### PR TITLE
Add named resource reference support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,8 @@ The parser uses [pest](https://pest.rs/) grammar defined in `carina-core/src/par
 The DSL uses `aws.Region.ap_northeast_1` format, but AWS SDK uses `ap-northeast-1`. Conversion happens in:
 - `carina-provider-aws/src/lib.rs`: `convert_region_value()` for DSL→SDK
 - Provider read operations return DSL format for consistent state comparison
+
+## Code Style
+
+- **Commit messages**: Write in English
+- **Code comments**: Write in English

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -1,39 +1,39 @@
 // Carina DSL Grammar
 
-// エントリーポイント
+// Entry point
 file = { SOI ~ statement* ~ EOI }
 
 statement = { provider_block | let_binding | anonymous_resource }
 
-// 匿名リソース: aws.s3.bucket { ... }（トップレベル）
+// Anonymous resource: aws.s3.bucket { ... } (top-level)
 anonymous_resource = { namespaced_id ~ "{" ~ attribute* ~ "}" }
 
-// providerブロック: provider aws { ... }
+// Provider block: provider aws { ... }
 provider_block = {
     "provider" ~ identifier ~ "{" ~ attribute* ~ "}"
 }
 
-// 変数/リソース定義: let name = value
+// Variable/resource definition: let name = value
 let_binding = { "let" ~ identifier ~ "=" ~ expression }
 
-// 属性: key = value
+// Attribute: key = value
 attribute = { identifier ~ "=" ~ expression }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
-// 名前空間付き識別子: aws.s3.bucket, aws.Region.ap_northeast_1
+// Namespaced identifier: aws.s3.bucket, aws.Region.ap_northeast_1
 namespaced_id = @{ identifier ~ ("." ~ identifier)+ }
 
-// 式
+// Expression
 expression = { pipe_expr }
 
-// パイプ演算子: value |> func |> func
+// Pipe operator: value |> func |> func
 pipe_expr = { primary ~ ("|>" ~ function_call)* }
 
-// 関数呼び出し: func(args)
+// Function call: func(args)
 function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 
-// 基本値
+// Primary value
 primary = {
     env_var
   | resource_expr
@@ -45,16 +45,16 @@ primary = {
   | "(" ~ expression ~ ")"
 }
 
-// 環境変数: env("VAR_NAME")
+// Environment variable: env("VAR_NAME")
 env_var = { "env" ~ "(" ~ string ~ ")" }
 
-// リソース式: aws.s3.bucket { ... }
+// Resource expression: aws.s3.bucket { ... }
 resource_expr = { namespaced_id ~ "{" ~ attribute* ~ "}" }
 
-// 変数参照
-variable_ref = { identifier }
+// Variable reference (with optional member access: bucket.name)
+variable_ref = { identifier ~ ("." ~ identifier)? }
 
-// リテラル
+// Literals
 boolean = { "true" | "false" }
 number = @{ "-"? ~ ASCII_DIGIT+ }
 string = ${ "\"" ~ inner_string ~ "\"" }
@@ -64,8 +64,8 @@ char = {
   | "\\" ~ ("\"" | "\\" | "n" | "r" | "t")
 }
 
-// 空白（自動スキップ）
+// Whitespace (auto-skip)
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 
-// コメント（自動スキップ）
+// Comment (auto-skip)
 COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -28,6 +28,8 @@ pub enum Value {
     Bool(bool),
     List(Vec<Value>),
     Map(HashMap<String, Value>),
+    /// Reference to another resource's attribute (binding_name, attribute_name)
+    ResourceRef(String, String),
 }
 
 /// Desired state declared in DSL

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -128,6 +128,7 @@ impl Value {
             Value::Bool(_) => "Bool".to_string(),
             Value::List(_) => "List".to_string(),
             Value::Map(_) => "Map".to_string(),
+            Value::ResourceRef(binding, attr) => format!("ResourceRef({}.{})", binding, attr),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Enable referencing attributes of named resources using dot notation (e.g., `bucket.name`)
- This allows resources to reference values from other resources defined with `let` bindings

## Changes

- Add `ResourceRef(binding_name, attr_name)` variant to `Value` enum
- Update grammar to support member access syntax in variable_ref
- Track resource bindings in ParseContext during parsing
- Add `resolve_resource_refs()` to resolve references to actual values
- Add `parse_and_resolve()` convenience function
- Update CLI to use parse_and_resolve for proper reference resolution
- Add code style guidelines to CLAUDE.md

## Example

```
let bucket = aws.s3.bucket {
    name = "my-bucket"
    region = aws.Region.ap_northeast_1
}

let policy = aws.s3.bucket_policy {
    name = "my-policy"
    bucket_name = bucket.name        # resolves to "my-bucket"
    bucket_region = bucket.region    # resolves to "aws.Region.ap_northeast_1"
}
```

## Test plan

- [x] All existing tests pass
- [x] New tests for resource reference parsing
- [x] New tests for reference resolution
- [x] CLI correctly resolves references in plan output

🤖 Generated with [Claude Code](https://claude.ai/code)