### PR TITLE
Add formatter command (similar to terraform fmt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "clap",
  "colored",
  "serde_json",
+ "similar",
  "tokio",
 ]
 
@@ -2230,6 +2231,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -15,3 +15,4 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 colored = "3"
 serde_json = "1"
+similar = "2"

--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -1,0 +1,98 @@
+// Carina DSL Grammar for Formatting
+// Unlike the semantic parser, this grammar captures whitespace and comments
+
+// Entry point - captures everything including trivia
+file = { SOI ~ file_content* ~ EOI }
+file_content = _{ trivia | statement }
+
+// Trivia: whitespace and comments that we want to preserve
+trivia = { ws | comment | newline }
+ws = @{ (" " | "\t")+ }
+newline = @{ NEWLINE }
+comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
+
+statement = { provider_block | let_binding | anonymous_resource }
+
+// Anonymous resource: aws.s3.bucket { ... }
+anonymous_resource = {
+    namespaced_id ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+}
+
+// Provider block: provider aws { ... }
+provider_block = {
+    kw_provider ~ trivia+ ~ identifier ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+}
+
+// Variable/resource definition: let name = value
+let_binding = {
+    kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ expression
+}
+
+// Block content: attributes, trivia, or nested elements
+block_content = _{ trivia | attribute }
+
+// Attribute: key = value
+attribute = { identifier ~ trivia* ~ equals ~ trivia* ~ expression }
+
+identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+
+// Namespaced identifier: aws.s3.bucket, aws.Region.ap_northeast_1
+namespaced_id = @{ identifier ~ ("." ~ identifier)+ }
+
+// Expression
+expression = { pipe_expr }
+
+// Pipe operator: value |> func |> func
+pipe_expr = { primary ~ (trivia* ~ pipe_op ~ trivia* ~ function_call)* }
+
+// Function call: func(args)
+function_call = {
+    identifier ~ open_paren ~ (trivia* ~ expression ~ (trivia* ~ comma ~ trivia* ~ expression)*)? ~ trivia* ~ close_paren
+}
+
+// Primary value
+primary = {
+    env_var
+  | resource_expr
+  | namespaced_id
+  | boolean
+  | number
+  | string
+  | variable_ref
+  | open_paren ~ trivia* ~ expression ~ trivia* ~ close_paren
+}
+
+// Environment variable: env("VAR_NAME")
+env_var = { kw_env ~ open_paren ~ trivia* ~ string ~ trivia* ~ close_paren }
+
+// Resource expression: aws.s3.bucket { ... }
+resource_expr = {
+    namespaced_id ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+}
+
+// Variable reference (with optional member access: bucket.name)
+variable_ref = { identifier ~ ("." ~ identifier)? }
+
+// Literals
+boolean = { "true" | "false" }
+number = @{ "-"? ~ ASCII_DIGIT+ }
+string = ${ "\"" ~ inner_string ~ "\"" }
+inner_string = @{ char* }
+char = {
+    !("\"" | "\\") ~ ANY
+  | "\\" ~ ("\"" | "\\" | "n" | "r" | "t")
+}
+
+// Tokens (for easier identification in CST)
+open_brace = { "{" }
+close_brace = { "}" }
+open_paren = { "(" }
+close_paren = { ")" }
+equals = { "=" }
+comma = { "," }
+pipe_op = { "|>" }
+
+// Keywords
+kw_provider = { "provider" }
+kw_let = { "let" }
+kw_env = { "env" }

--- a/carina-core/src/formatter/config.rs
+++ b/carina-core/src/formatter/config.rs
@@ -1,0 +1,68 @@
+//! Formatting configuration
+
+/// Formatting options
+#[derive(Debug, Clone)]
+pub struct FormatConfig {
+    /// Number of spaces for indentation (default: 4)
+    pub indent_size: usize,
+
+    /// Use tabs instead of spaces for indentation
+    pub use_tabs: bool,
+
+    /// Number of blank lines between top-level blocks (default: 1)
+    pub blank_lines_between_blocks: usize,
+
+    /// Align attribute values in a block
+    pub align_attributes: bool,
+}
+
+impl Default for FormatConfig {
+    fn default() -> Self {
+        Self {
+            indent_size: 4,
+            use_tabs: false,
+            blank_lines_between_blocks: 1,
+            align_attributes: true,
+        }
+    }
+}
+
+impl FormatConfig {
+    /// Get the string to use for a single level of indentation
+    pub fn indent_string(&self) -> String {
+        if self.use_tabs {
+            "\t".to_string()
+        } else {
+            " ".repeat(self.indent_size)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = FormatConfig::default();
+        assert_eq!(config.indent_size, 4);
+        assert!(!config.use_tabs);
+        assert_eq!(config.blank_lines_between_blocks, 1);
+        assert!(config.align_attributes);
+    }
+
+    #[test]
+    fn test_indent_string_spaces() {
+        let config = FormatConfig::default();
+        assert_eq!(config.indent_string(), "    ");
+    }
+
+    #[test]
+    fn test_indent_string_tabs() {
+        let config = FormatConfig {
+            use_tabs: true,
+            ..Default::default()
+        };
+        assert_eq!(config.indent_string(), "\t");
+    }
+}

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -1,0 +1,137 @@
+//! Concrete Syntax Tree for formatting
+//! Preserves all source information including trivia (whitespace and comments)
+
+// Allow dead code for fields/methods that may be used in future enhancements
+#![allow(dead_code)]
+
+/// Source location information
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+/// Trivia types (whitespace and comments)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Trivia {
+    /// Spaces and tabs (not including newlines)
+    Whitespace(String),
+    /// Single newline
+    Newline,
+    /// Line comment including the # prefix
+    LineComment(String),
+}
+
+impl Trivia {
+    pub fn text(&self) -> &str {
+        match self {
+            Trivia::Whitespace(s) => s,
+            Trivia::Newline => "\n",
+            Trivia::LineComment(s) => s,
+        }
+    }
+}
+
+/// A token with its text and position
+#[derive(Debug, Clone)]
+pub struct Token {
+    pub text: String,
+    pub span: Span,
+}
+
+impl Token {
+    pub fn new(text: String, span: Span) -> Self {
+        Self { text, span }
+    }
+}
+
+/// CST node kinds
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeKind {
+    File,
+    ProviderBlock,
+    LetBinding,
+    AnonymousResource,
+    ResourceExpr,
+    Attribute,
+    Expression,
+    PipeExpr,
+    FunctionCall,
+    EnvVar,
+    VariableRef,
+    NamespacedId,
+    Identifier,
+    String,
+    Number,
+    Boolean,
+    // Delimiters
+    OpenBrace,
+    CloseBrace,
+    OpenParen,
+    CloseParen,
+    Equals,
+    PipeOperator,
+    Comma,
+    // Keywords
+    KwProvider,
+    KwLet,
+    KwEnv,
+}
+
+/// CST node - preserves all source information
+#[derive(Debug, Clone)]
+pub struct CstNode {
+    pub kind: NodeKind,
+    pub span: Span,
+    pub children: Vec<CstChild>,
+}
+
+impl CstNode {
+    pub fn new(kind: NodeKind, span: Span) -> Self {
+        Self {
+            kind,
+            span,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn with_children(kind: NodeKind, span: Span, children: Vec<CstChild>) -> Self {
+        Self {
+            kind,
+            span,
+            children,
+        }
+    }
+}
+
+/// Child of a CST node - can be a node, token, or trivia
+#[derive(Debug, Clone)]
+pub enum CstChild {
+    Node(CstNode),
+    Token(Token),
+    Trivia(Trivia),
+}
+
+/// Complete CST for a file
+#[derive(Debug)]
+pub struct Cst {
+    pub root: CstNode,
+    pub source: String,
+}
+
+impl Cst {
+    pub fn new(root: CstNode, source: String) -> Self {
+        Self { root, source }
+    }
+
+    /// Get the source text for a span
+    pub fn text(&self, span: &Span) -> &str {
+        &self.source[span.start..span.end]
+    }
+}

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -1,0 +1,177 @@
+//! Build CST from pest parse tree
+
+use pest::iterators::Pair;
+
+use super::cst::{Cst, CstChild, CstNode, NodeKind, Span, Token, Trivia};
+use super::parser::Rule;
+
+/// Build a CST from pest parse result
+pub fn build_cst(source: &str, pairs: pest::iterators::Pairs<'_, Rule>) -> Cst {
+    let builder = CstBuilder::new(source);
+    builder.build(pairs)
+}
+
+struct CstBuilder<'a> {
+    source: &'a str,
+}
+
+impl<'a> CstBuilder<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source }
+    }
+
+    fn build(self, pairs: pest::iterators::Pairs<'a, Rule>) -> Cst {
+        let mut children = Vec::new();
+
+        for pair in pairs {
+            if pair.as_rule() == Rule::file {
+                for inner in pair.into_inner() {
+                    if let Some(child) = self.build_child(inner) {
+                        children.push(child);
+                    }
+                }
+            }
+        }
+
+        let root =
+            CstNode::with_children(NodeKind::File, Span::new(0, self.source.len()), children);
+
+        Cst::new(root, self.source.to_string())
+    }
+
+    fn build_child(&self, pair: Pair<'a, Rule>) -> Option<CstChild> {
+        let span = self.pair_span(&pair);
+
+        match pair.as_rule() {
+            Rule::EOI => None,
+
+            // Trivia
+            Rule::trivia => {
+                let inner = pair.into_inner().next()?;
+                self.build_child(inner)
+            }
+            Rule::ws => Some(CstChild::Trivia(Trivia::Whitespace(
+                pair.as_str().to_string(),
+            ))),
+            Rule::newline => Some(CstChild::Trivia(Trivia::Newline)),
+            Rule::comment => Some(CstChild::Trivia(Trivia::LineComment(
+                pair.as_str().to_string(),
+            ))),
+
+            // Statements
+            Rule::statement => {
+                let inner = pair.into_inner().next()?;
+                self.build_child(inner)
+            }
+            Rule::provider_block => Some(CstChild::Node(
+                self.build_node(NodeKind::ProviderBlock, pair),
+            )),
+            Rule::let_binding => Some(CstChild::Node(self.build_node(NodeKind::LetBinding, pair))),
+            Rule::anonymous_resource => Some(CstChild::Node(
+                self.build_node(NodeKind::AnonymousResource, pair),
+            )),
+            Rule::resource_expr => Some(CstChild::Node(
+                self.build_node(NodeKind::ResourceExpr, pair),
+            )),
+            Rule::attribute => Some(CstChild::Node(self.build_node(NodeKind::Attribute, pair))),
+
+            // Expressions
+            Rule::expression => {
+                let inner = pair.into_inner().next()?;
+                self.build_child(inner)
+            }
+            Rule::pipe_expr => Some(CstChild::Node(self.build_node(NodeKind::PipeExpr, pair))),
+            Rule::function_call => Some(CstChild::Node(
+                self.build_node(NodeKind::FunctionCall, pair),
+            )),
+            Rule::primary => {
+                let inner = pair.into_inner().next()?;
+                self.build_child(inner)
+            }
+            Rule::env_var => Some(CstChild::Node(self.build_node(NodeKind::EnvVar, pair))),
+            Rule::variable_ref => {
+                Some(CstChild::Node(self.build_node(NodeKind::VariableRef, pair)))
+            }
+
+            // Atoms - these become tokens
+            Rule::namespaced_id => {
+                Some(CstChild::Token(Token::new(pair.as_str().to_string(), span)))
+            }
+            Rule::identifier => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::string => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::number => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::boolean => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::inner_string | Rule::char => None,
+
+            // Delimiters and operators
+            Rule::open_brace => Some(CstChild::Token(Token::new("{".to_string(), span))),
+            Rule::close_brace => Some(CstChild::Token(Token::new("}".to_string(), span))),
+            Rule::open_paren => Some(CstChild::Token(Token::new("(".to_string(), span))),
+            Rule::close_paren => Some(CstChild::Token(Token::new(")".to_string(), span))),
+            Rule::equals => Some(CstChild::Token(Token::new("=".to_string(), span))),
+            Rule::comma => Some(CstChild::Token(Token::new(",".to_string(), span))),
+            Rule::pipe_op => Some(CstChild::Token(Token::new("|>".to_string(), span))),
+
+            // Keywords
+            Rule::kw_provider => Some(CstChild::Token(Token::new("provider".to_string(), span))),
+            Rule::kw_let => Some(CstChild::Token(Token::new("let".to_string(), span))),
+            Rule::kw_env => Some(CstChild::Token(Token::new("env".to_string(), span))),
+
+            // Skip file_content (it's a silent rule wrapper)
+            Rule::file_content => None,
+            Rule::block_content => None,
+
+            Rule::file => None,
+        }
+    }
+
+    fn build_node(&self, kind: NodeKind, pair: Pair<'a, Rule>) -> CstNode {
+        let span = self.pair_span(&pair);
+        let mut children = Vec::new();
+
+        for inner in pair.into_inner() {
+            if let Some(child) = self.build_child(inner) {
+                children.push(child);
+            }
+        }
+
+        CstNode::with_children(kind, span, children)
+    }
+
+    fn pair_span(&self, pair: &Pair<'a, Rule>) -> Span {
+        let pest_span = pair.as_span();
+        Span::new(pest_span.start(), pest_span.end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatter::parser;
+
+    #[test]
+    fn test_build_simple_cst() {
+        let input = "provider aws {}\n";
+        let pairs = parser::parse(input).unwrap();
+        let cst = build_cst(input, pairs);
+
+        assert_eq!(cst.root.kind, NodeKind::File);
+        assert!(!cst.root.children.is_empty());
+    }
+
+    #[test]
+    fn test_build_cst_with_comment() {
+        let input = "# Comment\nprovider aws {}\n";
+        let pairs = parser::parse(input).unwrap();
+        let cst = build_cst(input, pairs);
+
+        // First child should be the comment
+        let first_child = &cst.root.children[0];
+        match first_child {
+            CstChild::Trivia(Trivia::LineComment(s)) => {
+                assert_eq!(s, "# Comment");
+            }
+            _ => panic!("Expected comment trivia"),
+        }
+    }
+}

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -1,0 +1,579 @@
+//! Main formatting logic
+
+use super::config::FormatConfig;
+use super::cst::{Cst, CstChild, CstNode, NodeKind, Trivia};
+use super::cst_builder::build_cst;
+use super::parser::{self, FormatParseError};
+
+/// Format a .crn file
+pub fn format(source: &str, config: &FormatConfig) -> Result<String, FormatParseError> {
+    let pairs = parser::parse(source)?;
+    let cst = build_cst(source, pairs);
+    let formatter = Formatter::new(config.clone());
+    Ok(formatter.format(&cst))
+}
+
+/// Check if a file needs formatting
+pub fn needs_format(source: &str, config: &FormatConfig) -> Result<bool, FormatParseError> {
+    let formatted = format(source, config)?;
+    Ok(formatted != source)
+}
+
+struct Formatter {
+    config: FormatConfig,
+    output: String,
+    current_indent: usize,
+}
+
+impl Formatter {
+    fn new(config: FormatConfig) -> Self {
+        Self {
+            config,
+            output: String::new(),
+            current_indent: 0,
+        }
+    }
+
+    fn format(mut self, cst: &Cst) -> String {
+        self.format_file(&cst.root);
+        self.output
+    }
+
+    fn format_file(&mut self, node: &CstNode) {
+        let mut prev_was_block = false;
+        let mut pending_comments: Vec<&Trivia> = Vec::new();
+        let mut blank_line_count = 0;
+
+        for child in &node.children {
+            match child {
+                CstChild::Trivia(trivia) => match trivia {
+                    Trivia::LineComment(_) => {
+                        pending_comments.push(trivia);
+                        blank_line_count = 0;
+                    }
+                    Trivia::Newline => {
+                        blank_line_count += 1;
+                    }
+                    Trivia::Whitespace(_) => {
+                        // Normalize whitespace
+                    }
+                },
+                CstChild::Node(child_node) => {
+                    // Add blank lines between blocks
+                    if prev_was_block {
+                        self.write_newlines(self.config.blank_lines_between_blocks);
+                    }
+
+                    // Write pending comments before the block
+                    if !pending_comments.is_empty() {
+                        for comment in pending_comments.drain(..) {
+                            self.write_trivia(comment);
+                            self.write_newline();
+                        }
+                        // Add blank line after comments if there was one in the original
+                        if blank_line_count > 1 {
+                            self.write_newline();
+                        }
+                    }
+
+                    self.format_node(child_node);
+                    prev_was_block = true;
+                    blank_line_count = 0;
+                }
+                CstChild::Token(_) => {}
+            }
+        }
+
+        // Write any remaining comments at end of file
+        for comment in pending_comments {
+            self.write_trivia(comment);
+            self.write_newline();
+        }
+
+        // Ensure file ends with a newline
+        if !self.output.ends_with('\n') {
+            self.write_newline();
+        }
+    }
+
+    fn format_node(&mut self, node: &CstNode) {
+        match node.kind {
+            NodeKind::ProviderBlock => self.format_provider_block(node),
+            NodeKind::LetBinding => self.format_let_binding(node),
+            NodeKind::AnonymousResource => self.format_anonymous_resource(node),
+            NodeKind::ResourceExpr => self.format_resource_expr(node),
+            NodeKind::Attribute => self.format_attribute(node, 0),
+            NodeKind::PipeExpr => self.format_pipe_expr(node),
+            NodeKind::FunctionCall => self.format_function_call(node),
+            NodeKind::EnvVar => self.format_env_var(node),
+            NodeKind::VariableRef => self.format_variable_ref(node),
+            _ => self.format_default(node),
+        }
+    }
+
+    fn format_provider_block(&mut self, node: &CstNode) {
+        self.write_indent();
+        self.write("provider ");
+
+        // Find and write provider name
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && self.is_identifier(&token.text)
+                && token.text != "provider"
+            {
+                self.write(&token.text);
+                break;
+            }
+        }
+
+        self.write(" {");
+        self.write_newline();
+        self.current_indent += 1;
+
+        self.format_block_attributes(node);
+
+        self.current_indent -= 1;
+        self.write_indent();
+        self.write("}");
+        self.write_newline();
+    }
+
+    fn format_let_binding(&mut self, node: &CstNode) {
+        self.write_indent();
+        self.write("let ");
+
+        let mut found_name = false;
+        let mut found_equals = false;
+
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if token.text == "let" {
+                        continue;
+                    }
+                    if token.text == "=" {
+                        self.write(" = ");
+                        found_equals = true;
+                        continue;
+                    }
+                    if !found_name && self.is_identifier(&token.text) {
+                        self.write(&token.text);
+                        found_name = true;
+                        continue;
+                    }
+                    if found_equals {
+                        self.write(&token.text);
+                    }
+                }
+                CstChild::Node(n) => {
+                    if found_equals {
+                        self.format_node(n);
+                    }
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+
+        self.write_newline();
+    }
+
+    fn format_anonymous_resource(&mut self, node: &CstNode) {
+        self.write_indent();
+
+        // Write resource type (namespaced_id)
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && token.text.contains('.')
+            {
+                self.write(&token.text);
+                break;
+            }
+        }
+
+        self.write(" {");
+        self.write_newline();
+        self.current_indent += 1;
+
+        self.format_block_attributes(node);
+
+        self.current_indent -= 1;
+        self.write_indent();
+        self.write("}");
+        self.write_newline();
+    }
+
+    fn format_resource_expr(&mut self, node: &CstNode) {
+        // Write resource type (namespaced_id)
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && token.text.contains('.')
+            {
+                self.write(&token.text);
+                break;
+            }
+        }
+
+        self.write(" {");
+        self.write_newline();
+        self.current_indent += 1;
+
+        self.format_block_attributes(node);
+
+        self.current_indent -= 1;
+        self.write_indent();
+        self.write("}");
+    }
+
+    fn format_block_attributes(&mut self, node: &CstNode) {
+        // Collect attributes and comments
+        let mut attributes: Vec<&CstNode> = Vec::new();
+        let mut inline_comments: std::collections::HashMap<usize, &Trivia> =
+            std::collections::HashMap::new();
+        let mut pending_comments: Vec<&Trivia> = Vec::new();
+
+        let mut attr_index = 0;
+        for child in &node.children {
+            match child {
+                CstChild::Node(n) if n.kind == NodeKind::Attribute => {
+                    // Write any pending standalone comments
+                    for comment in pending_comments.drain(..) {
+                        self.write_indent();
+                        self.write_trivia(comment);
+                        self.write_newline();
+                    }
+                    attributes.push(n);
+                    attr_index += 1;
+                }
+                CstChild::Trivia(Trivia::LineComment(s)) => {
+                    // Check if this is an inline comment (on same line as previous attribute)
+                    // For simplicity, we treat comments after a newline as standalone
+                    if !attributes.is_empty() && !s.is_empty() {
+                        // Store as potential inline comment for previous attribute
+                        inline_comments.insert(
+                            attr_index - 1,
+                            match child {
+                                CstChild::Trivia(t) => t,
+                                _ => unreachable!(),
+                            },
+                        );
+                    } else {
+                        pending_comments.push(match child {
+                            CstChild::Trivia(t) => t,
+                            _ => unreachable!(),
+                        });
+                    }
+                }
+                CstChild::Trivia(Trivia::Newline) => {
+                    // Newline means pending comments become standalone
+                }
+                _ => {}
+            }
+        }
+
+        // Calculate max key length for alignment
+        let max_key_len = if self.config.align_attributes {
+            attributes
+                .iter()
+                .filter_map(|attr| self.get_attribute_key(attr))
+                .map(|k| k.len())
+                .max()
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // Format each attribute
+        for (i, attr) in attributes.iter().enumerate() {
+            let inline_comment = inline_comments.get(&i);
+            self.format_attribute_aligned(attr, max_key_len, inline_comment.copied());
+        }
+
+        // Write any trailing standalone comments
+        for comment in pending_comments {
+            self.write_indent();
+            self.write_trivia(comment);
+            self.write_newline();
+        }
+    }
+
+    fn get_attribute_key(&self, node: &CstNode) -> Option<String> {
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && self.is_identifier(&token.text)
+            {
+                return Some(token.text.clone());
+            }
+        }
+        None
+    }
+
+    fn format_attribute(&mut self, node: &CstNode, align_to: usize) {
+        self.format_attribute_aligned(node, align_to, None);
+    }
+
+    fn format_attribute_aligned(
+        &mut self,
+        node: &CstNode,
+        align_to: usize,
+        inline_comment: Option<&Trivia>,
+    ) {
+        self.write_indent();
+
+        let mut key_len: usize;
+        let mut wrote_key = false;
+        let mut wrote_equals = false;
+
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if !wrote_key && self.is_identifier(&token.text) {
+                        key_len = token.text.len();
+                        self.write(&token.text);
+                        wrote_key = true;
+
+                        // Add padding for alignment
+                        if align_to > 0 && key_len < align_to {
+                            let padding = align_to - key_len;
+                            self.write(&" ".repeat(padding));
+                        }
+                    } else if token.text == "=" && !wrote_equals {
+                        self.write(" = ");
+                        wrote_equals = true;
+                    } else if wrote_equals {
+                        self.write(&token.text);
+                    }
+                }
+                CstChild::Node(n) => {
+                    if wrote_equals {
+                        self.format_node(n);
+                    }
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+
+        // Write inline comment if present
+        if let Some(comment) = inline_comment {
+            self.write("  ");
+            self.write_trivia(comment);
+        }
+
+        self.write_newline();
+    }
+
+    fn format_pipe_expr(&mut self, node: &CstNode) {
+        let mut first = true;
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if token.text == "|>" {
+                        self.write(" |> ");
+                    } else {
+                        self.write(&token.text);
+                    }
+                }
+                CstChild::Node(n) => {
+                    if !first && n.kind == NodeKind::FunctionCall {
+                        self.format_function_call(n);
+                    } else {
+                        self.format_node(n);
+                    }
+                    first = false;
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+    }
+
+    fn format_function_call(&mut self, node: &CstNode) {
+        let mut in_args = false;
+        let mut first_arg = true;
+
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    if token.text == "(" {
+                        self.write("(");
+                        in_args = true;
+                    } else if token.text == ")" {
+                        self.write(")");
+                        in_args = false;
+                    } else if token.text == "," {
+                        self.write(", ");
+                    } else {
+                        self.write(&token.text);
+                    }
+                }
+                CstChild::Node(n) => {
+                    if in_args {
+                        if !first_arg {
+                            // comma already handled
+                        }
+                        self.format_node(n);
+                        first_arg = false;
+                    }
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+    }
+
+    fn format_env_var(&mut self, node: &CstNode) {
+        self.write("env(");
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && token.text.starts_with('"')
+            {
+                self.write(&token.text);
+                break;
+            }
+        }
+        self.write(")");
+    }
+
+    fn format_variable_ref(&mut self, node: &CstNode) {
+        let mut parts: Vec<&str> = Vec::new();
+        for child in &node.children {
+            if let CstChild::Token(token) = child
+                && self.is_identifier(&token.text)
+            {
+                parts.push(&token.text);
+            }
+        }
+        self.write(&parts.join("."));
+    }
+
+    fn format_default(&mut self, node: &CstNode) {
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    self.write(&token.text);
+                }
+                CstChild::Node(n) => {
+                    self.format_node(n);
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+    }
+
+    // Helper methods
+
+    fn write(&mut self, s: &str) {
+        self.output.push_str(s);
+    }
+
+    fn write_indent(&mut self) {
+        let indent = self.config.indent_string().repeat(self.current_indent);
+        self.output.push_str(&indent);
+    }
+
+    fn write_newline(&mut self) {
+        self.output.push('\n');
+    }
+
+    fn write_newlines(&mut self, count: usize) {
+        for _ in 0..count {
+            self.write_newline();
+        }
+    }
+
+    fn write_trivia(&mut self, trivia: &Trivia) {
+        match trivia {
+            Trivia::LineComment(s) => self.write(s),
+            Trivia::Newline => self.write_newline(),
+            Trivia::Whitespace(s) => self.write(s),
+        }
+    }
+
+    fn is_identifier(&self, s: &str) -> bool {
+        let mut chars = s.chars();
+        chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_provider_block() {
+        let input = "provider aws {\nregion=aws.Region.ap_northeast_1\n}";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(result.contains("provider aws {"));
+        assert!(result.contains("    region = aws.Region.ap_northeast_1"));
+    }
+
+    #[test]
+    fn test_format_preserves_comments() {
+        let input = "# Header comment\nprovider aws {}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(result.contains("# Header comment"));
+    }
+
+    #[test]
+    fn test_format_normalizes_indentation() {
+        let input = "aws.s3.bucket {\n  name = \"test\"\n}";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(result.contains("    name = \"test\""));
+    }
+
+    #[test]
+    fn test_format_aligns_attributes() {
+        let input = "aws.s3.bucket {\nname = \"test\"\nversioning = true\n}";
+        let config = FormatConfig {
+            align_attributes: true,
+            ..Default::default()
+        };
+        let result = format(input, &config).unwrap();
+
+        // Both "=" should be at the same column
+        let lines: Vec<&str> = result.lines().collect();
+        let name_eq_pos = lines.iter().find(|l| l.contains("name")).unwrap().find('=');
+        let vers_eq_pos = lines
+            .iter()
+            .find(|l| l.contains("versioning"))
+            .unwrap()
+            .find('=');
+
+        assert_eq!(name_eq_pos, vers_eq_pos);
+    }
+
+    #[test]
+    fn test_format_idempotent() {
+        let input = "provider aws {\n    region = aws.Region.ap_northeast_1\n}\n";
+        let config = FormatConfig::default();
+
+        let first = format(input, &config).unwrap();
+        let second = format(&first, &config).unwrap();
+
+        assert_eq!(first, second, "Formatting should be idempotent");
+    }
+
+    #[test]
+    fn test_format_let_binding() {
+        let input = "let bucket=aws.s3.bucket {\nname=\"test\"\n}";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(result.contains("let bucket = aws.s3.bucket {"));
+    }
+
+    #[test]
+    fn test_needs_format() {
+        let config = FormatConfig::default();
+
+        let formatted = "provider aws {\n    region = aws.Region.ap_northeast_1\n}\n";
+        assert!(!needs_format(formatted, &config).unwrap());
+
+        let unformatted = "provider aws {\nregion=aws.Region.ap_northeast_1\n}";
+        assert!(needs_format(unformatted, &config).unwrap());
+    }
+}

--- a/carina-core/src/formatter/mod.rs
+++ b/carina-core/src/formatter/mod.rs
@@ -1,0 +1,26 @@
+//! Code formatter for Carina DSL
+//!
+//! Provides formatting similar to `terraform fmt` for .crn files.
+//! Preserves comments and normalizes whitespace.
+//!
+//! # Example
+//!
+//! ```
+//! use carina_core::formatter::{format, FormatConfig};
+//!
+//! let source = "provider aws {\nregion=aws.Region.ap_northeast_1\n}";
+//! let config = FormatConfig::default();
+//! let formatted = format(source, &config).unwrap();
+//!
+//! assert!(formatted.contains("    region = aws.Region.ap_northeast_1"));
+//! ```
+
+mod config;
+mod cst;
+mod cst_builder;
+mod format;
+mod parser;
+
+pub use config::FormatConfig;
+pub use format::{format, needs_format};
+pub use parser::FormatParseError;

--- a/carina-core/src/formatter/parser.rs
+++ b/carina-core/src/formatter/parser.rs
@@ -1,0 +1,66 @@
+//! Pest parser for the formatter grammar
+
+use pest::Parser;
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "formatter/carina_fmt.pest"]
+pub struct CarinaFmtParser;
+
+/// Error type for format parsing
+#[derive(Debug)]
+pub struct FormatParseError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for FormatParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Parse error at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for FormatParseError {}
+
+impl From<pest::error::Error<Rule>> for FormatParseError {
+    fn from(err: pest::error::Error<Rule>) -> Self {
+        let (line, column) = match err.line_col {
+            pest::error::LineColLocation::Pos((l, c)) => (l, c),
+            pest::error::LineColLocation::Span((l, c), _) => (l, c),
+        };
+        FormatParseError {
+            message: err.variant.message().to_string(),
+            line,
+            column,
+        }
+    }
+}
+
+/// Parse source code for formatting
+pub fn parse(source: &str) -> Result<pest::iterators::Pairs<'_, Rule>, FormatParseError> {
+    CarinaFmtParser::parse(Rule::file, source).map_err(FormatParseError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_provider() {
+        let input = "provider aws {\n    region = aws.Region.ap_northeast_1\n}\n";
+        let result = parse(input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_with_comment() {
+        let input = "# Header comment\nprovider aws {}\n";
+        let result = parse(input);
+        assert!(result.is_ok());
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod differ;
 pub mod effect;
+pub mod formatter;
 pub mod interpreter;
 pub mod parser;
 pub mod plan;


### PR DESCRIPTION
## Summary
- Implements a code formatter for `.crn` files similar to `terraform fmt`
- Preserves comments (header, inline, and block comments)
- Normalizes indentation and aligns attribute values within blocks
- Adds CLI `fmt` subcommand with `--check`, `--diff`, and `-r` flags

## Test plan
- [x] `cargo test -p carina-core` passes (14 new formatter tests)
- [x] `cargo run --bin carina -- fmt --diff example.crn` shows expected changes
- [x] `cargo run --bin carina -- fmt --check example.crn` returns error for unformatted files
- [x] Formatting is idempotent (running twice produces same output)

🤖 Generated with [Claude Code](https://claude.ai/code)