### PR TITLE
Trim extra trailing newlines in formatter

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -90,10 +90,9 @@ impl Formatter {
             self.write_newline();
         }
 
-        // Ensure file ends with a newline
-        if !self.output.ends_with('\n') {
-            self.write_newline();
-        }
+        // Ensure file ends with exactly one newline (trim extra trailing newlines)
+        let trimmed = self.output.trim_end();
+        self.output = format!("{}\n", trimmed);
     }
 
     fn format_node(&mut self, node: &CstNode) {

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -158,9 +158,12 @@ impl LanguageServer for Backend {
                     }
 
                     // Calculate the range covering the entire document
-                    let lines: Vec<&str> = text.lines().collect();
-                    let last_line = lines.len().saturating_sub(1) as u32;
-                    let last_char = lines.last().map(|l| l.len() as u32).unwrap_or(0);
+                    // Note: lines() doesn't include trailing empty lines, so we count newlines manually
+                    let line_count = text.chars().filter(|&c| c == '\n').count();
+                    let last_line = line_count as u32;
+                    let last_char = text.lines().last().map(|l| l.len() as u32).unwrap_or(0);
+                    // If text ends with newline, last line is empty
+                    let last_char = if text.ends_with('\n') { 0 } else { last_char };
 
                     let edit = TextEdit {
                         range: Range {


### PR DESCRIPTION
## Summary
- Ensure files end with exactly one newline by trimming any extra trailing whitespace/newlines before adding a single newline

## Test plan
- [x] Existing formatter tests pass
- [x] Manual test: Save file with multiple trailing newlines, verify only one remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)