### PR TITLE
Add dependency tree view to plan command and directory module imports

### DIFF
--- a/examples/main_with_module.crn
+++ b/examples/main_with_module.crn
@@ -5,7 +5,7 @@ provider aws {
 }
 
 # Import the web tier module
-import "./modules/web_tier/main.crn" as web_tier
+import "./modules/web_tier" as web_tier
 
 # VPC for the application
 let main_vpc = aws.vpc {


### PR DESCRIPTION
## Summary
- Display resource dependencies in tree format with `└─` and `├─` connectors for better visibility
- Show resource type in cyan bold, name attribute in white bold for emphasis
- Sort attributes alphabetically with name first
- Support directory-based module imports (load all `.crn` files in directory)

## Example output
```
Execution Plan:

  + vpc
      name: "main-vpc"
      cidr_block: "10.0.0.0/16"
      └─ + security_group
            name: "web-sg"
            vpc_id: main_vpc.id
            ├─ + security_group.ingress_rule
            │     name: "http"
            │     from_port: 80
            └─ + security_group.ingress_rule
                  name: "https"
                  from_port: 443

Plan: 4 to add, 0 to change, 0 to destroy.
```

## Test plan
- [x] `cargo test` passes
- [x] `cargo run --bin carina -- validate examples/main_with_module.crn` works with directory import

🤖 Generated with [Claude Code](https://claude.com/claude-code)