### PR TITLE
Use types::cidr() for VPC cidr_block attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,12 @@ The DSL uses `aws.Region.ap_northeast_1` format, but AWS SDK uses `ap-northeast-
 - `carina-provider-aws/src/lib.rs`: `convert_region_value()` for DSL→SDK
 - Provider read operations return DSL format for consistent state comparison
 
+### LSP Integration
+
+When modifying resource schemas (`carina-provider-aws/src/schemas/`), also update the LSP:
+- **Completion** (`carina-lsp/src/completion.rs`): Add value completions for new types
+- **Diagnostics** (`carina-lsp/src/diagnostics.rs`): Add type validation for new types
+
 ## Code Style
 
 - **Commit messages**: Write in English

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -567,6 +567,7 @@ impl CompletionProvider {
             AttributeType::Int => {
                 vec![] // No specific completions for integers
             }
+            AttributeType::Custom { name, .. } if name == "Cidr" => self.cidr_completions(),
             AttributeType::String | AttributeType::Custom { .. } => {
                 vec![CompletionItem {
                     label: "env".to_string(),
@@ -663,6 +664,29 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::ENUM_MEMBER),
                 detail: Some(description.to_string()),
                 insert_text: Some(format!("aws.Protocol.{}", code)),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    fn cidr_completions(&self) -> Vec<CompletionItem> {
+        let cidrs = vec![
+            ("10.0.0.0/16", "VPC CIDR (65,536 IPs)"),
+            ("10.0.0.0/24", "Subnet CIDR (256 IPs)"),
+            ("10.0.1.0/24", "Subnet CIDR (256 IPs)"),
+            ("10.0.2.0/24", "Subnet CIDR (256 IPs)"),
+            ("172.16.0.0/16", "VPC CIDR (65,536 IPs)"),
+            ("192.168.0.0/16", "VPC CIDR (65,536 IPs)"),
+            ("0.0.0.0/0", "All IPv4 addresses"),
+        ];
+
+        cidrs
+            .into_iter()
+            .map(|(cidr, description)| CompletionItem {
+                label: format!("\"{}\"", cidr),
+                kind: Some(CompletionItemKind::VALUE),
+                detail: Some(description.to_string()),
+                insert_text: Some(format!("\"{}\"", cidr)),
                 ..Default::default()
             })
             .collect()

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -148,6 +148,11 @@ impl DiagnosticEngine {
                                         s
                                     ))
                                 }
+                                // CIDR type validation
+                                (
+                                    carina_core::schema::AttributeType::Custom { name, .. },
+                                    Value::String(s),
+                                ) if name == "Cidr" => validate_cidr(s).err(),
                                 // String type - check for bare resource binding
                                 (carina_core::schema::AttributeType::String, Value::String(s)) => {
                                     if let Some(binding) =


### PR DESCRIPTION
## Summary

- Remove duplicate `cidr_block()` function from `vpc.rs` and use `types::cidr()` from carina-core
- Add CIDR type completions and validation in LSP
- Document LSP integration requirements in CLAUDE.md

## Test plan

- [x] `cargo test` passes
- [x] LSP provides CIDR value completions for `cidr_block` attributes
- [x] LSP validates CIDR format and shows errors for invalid values

🤖 Generated with [Claude Code](https://claude.com/claude-code)