### PR TITLE
Add provider region validation

### DIFF
--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -1,6 +1,7 @@
 //! AWS resource schema definitions
 
 pub mod s3;
+pub mod types;
 pub mod vpc;
 
 use carina_core::schema::ResourceSchema;

--- a/carina-provider-aws/src/schemas/s3.rs
+++ b/carina-provider-aws/src/schemas/s3.rs
@@ -2,6 +2,8 @@
 
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
+use super::types as aws_types;
+
 /// Returns the schema for S3 buckets
 pub fn bucket_schema() -> ResourceSchema {
     ResourceSchema::new("s3.bucket")
@@ -11,7 +13,7 @@ pub fn bucket_schema() -> ResourceSchema {
                 .with_description("Override bucket name (defaults to resource name)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region()).with_description(
+            AttributeSchema::new("region", aws_types::aws_region()).with_description(
                 "The AWS region for the bucket (inherited from provider if not specified)",
             ),
         )

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -1,0 +1,26 @@
+//! AWS-specific type definitions
+
+use carina_core::schema::AttributeType;
+
+/// AWS region enum type
+pub fn aws_region() -> AttributeType {
+    AttributeType::Enum(vec![
+        "ap_northeast_1".to_string(),
+        "ap_northeast_2".to_string(),
+        "ap_northeast_3".to_string(),
+        "ap_southeast_1".to_string(),
+        "ap_southeast_2".to_string(),
+        "ap_south_1".to_string(),
+        "us_east_1".to_string(),
+        "us_east_2".to_string(),
+        "us_west_1".to_string(),
+        "us_west_2".to_string(),
+        "eu_west_1".to_string(),
+        "eu_west_2".to_string(),
+        "eu_west_3".to_string(),
+        "eu_central_1".to_string(),
+        "eu_north_1".to_string(),
+        "ca_central_1".to_string(),
+        "sa_east_1".to_string(),
+    ])
+}

--- a/carina-provider-aws/src/schemas/vpc.rs
+++ b/carina-provider-aws/src/schemas/vpc.rs
@@ -3,6 +3,8 @@
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
+use super::types as aws_types;
+
 /// Port number type (with validation)
 pub fn port_number() -> AttributeType {
     AttributeType::Custom {
@@ -117,7 +119,7 @@ pub fn vpc_schema() -> ResourceSchema {
                 .with_description("VPC name (Name tag)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region()).with_description(
+            AttributeSchema::new("region", aws_types::aws_region()).with_description(
                 "The AWS region for the VPC (inherited from provider if not specified)",
             ),
         )
@@ -150,7 +152,7 @@ pub fn subnet_schema() -> ResourceSchema {
                 .with_description("Subnet name (Name tag)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region()).with_description(
+            AttributeSchema::new("region", aws_types::aws_region()).with_description(
                 "The AWS region for the subnet (inherited from provider if not specified)",
             ),
         )
@@ -184,7 +186,7 @@ pub fn internet_gateway_schema() -> ResourceSchema {
                 .with_description("Internet Gateway name (Name tag)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region())
+            AttributeSchema::new("region", aws_types::aws_region())
                 .with_description("The AWS region for the Internet Gateway (inherited from provider if not specified)"),
         )
         .attribute(
@@ -207,7 +209,7 @@ pub fn route_table_schema() -> ResourceSchema {
                 .with_description("Route Table name (Name tag)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region()).with_description(
+            AttributeSchema::new("region", aws_types::aws_region()).with_description(
                 "The AWS region for the Route Table (inherited from provider if not specified)",
             ),
         )
@@ -228,7 +230,7 @@ pub fn route_schema() -> ResourceSchema {
                 .with_description("Route name (for identification)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region())
+            AttributeSchema::new("region", aws_types::aws_region())
                 .with_description("The AWS region (inherited from provider if not specified)"),
         )
         .attribute(
@@ -265,7 +267,7 @@ pub fn security_group_schema() -> ResourceSchema {
                 .with_description("Security Group name (Name tag)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region()).with_description(
+            AttributeSchema::new("region", aws_types::aws_region()).with_description(
                 "The AWS region for the Security Group (inherited from provider if not specified)",
             ),
         )
@@ -294,7 +296,7 @@ pub fn security_group_ingress_rule_schema() -> ResourceSchema {
                 .with_description("Rule name (for identification)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region())
+            AttributeSchema::new("region", aws_types::aws_region())
                 .with_description("The AWS region (inherited from provider if not specified)"),
         )
         .attribute(
@@ -337,7 +339,7 @@ pub fn security_group_egress_rule_schema() -> ResourceSchema {
                 .with_description("Rule name (for identification)"),
         )
         .attribute(
-            AttributeSchema::new("region", types::aws_region())
+            AttributeSchema::new("region", aws_types::aws_region())
                 .with_description("The AWS region (inherited from provider if not specified)"),
         )
         .attribute(


### PR DESCRIPTION
## Summary
- Create AWS-specific types module in carina-provider-aws with `aws_region()`
- Add 4 new regions: `eu_west_3`, `eu_north_1`, `ca_central_1`, `sa_east_1`
- Add `validate_provider_region()` to CLI for validate/plan/apply/destroy commands
- Add provider region diagnostics to LSP for editor warnings
- Move aws_region type from carina-core to carina-provider-aws (AWS-specific types should live in provider crate)

## Test plan
- [x] `cargo test` passes
- [x] Invalid region in provider block causes single clear error message
- [x] Valid regions (including new ones) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)