### PR TITLE
Accept AWS format region strings in provider validation

### DIFF
--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -3,8 +3,10 @@
 use carina_core::schema::AttributeType;
 
 /// AWS region enum type
+/// Accepts both DSL format (ap_northeast_1) and AWS format (ap-northeast-1)
 pub fn aws_region() -> AttributeType {
     AttributeType::Enum(vec![
+        // DSL format (underscores)
         "ap_northeast_1".to_string(),
         "ap_northeast_2".to_string(),
         "ap_northeast_3".to_string(),
@@ -22,5 +24,23 @@ pub fn aws_region() -> AttributeType {
         "eu_north_1".to_string(),
         "ca_central_1".to_string(),
         "sa_east_1".to_string(),
+        // AWS format (hyphens)
+        "ap-northeast-1".to_string(),
+        "ap-northeast-2".to_string(),
+        "ap-northeast-3".to_string(),
+        "ap-southeast-1".to_string(),
+        "ap-southeast-2".to_string(),
+        "ap-south-1".to_string(),
+        "us-east-1".to_string(),
+        "us-east-2".to_string(),
+        "us-west-1".to_string(),
+        "us-west-2".to_string(),
+        "eu-west-1".to_string(),
+        "eu-west-2".to_string(),
+        "eu-west-3".to_string(),
+        "eu-central-1".to_string(),
+        "eu-north-1".to_string(),
+        "ca-central-1".to_string(),
+        "sa-east-1".to_string(),
     ])
 }


### PR DESCRIPTION
## Summary
- Allow both DSL format (`ap_northeast_1`) and AWS format (`ap-northeast-1`) for provider region values
- Fixes issue where `region = "ap-northeast-1"` caused validation error

## Test plan
- [x] `cargo test` passes
- [x] `region = "ap-northeast-1"` is now accepted
- [x] DSL format still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)