### PR TITLE
Use custom type for region validation with normalized format

### DIFF
--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -1,46 +1,68 @@
 //! AWS-specific type definitions
 
+use carina_core::resource::Value;
 use carina_core::schema::AttributeType;
 
-/// AWS region enum type
-/// Accepts both DSL format (ap_northeast_1) and AWS format (ap-northeast-1)
+/// Valid AWS regions (in AWS format with hyphens)
+const VALID_REGIONS: &[&str] = &[
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-south-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "eu-central-1",
+    "eu-north-1",
+    "ca-central-1",
+    "sa-east-1",
+];
+
+/// AWS region type with custom validation
+/// Accepts:
+/// - DSL format: aws.Region.ap_northeast_1
+/// - AWS string format: "ap-northeast-1"
 pub fn aws_region() -> AttributeType {
-    AttributeType::Enum(vec![
-        // DSL format (underscores)
-        "ap_northeast_1".to_string(),
-        "ap_northeast_2".to_string(),
-        "ap_northeast_3".to_string(),
-        "ap_southeast_1".to_string(),
-        "ap_southeast_2".to_string(),
-        "ap_south_1".to_string(),
-        "us_east_1".to_string(),
-        "us_east_2".to_string(),
-        "us_west_1".to_string(),
-        "us_west_2".to_string(),
-        "eu_west_1".to_string(),
-        "eu_west_2".to_string(),
-        "eu_west_3".to_string(),
-        "eu_central_1".to_string(),
-        "eu_north_1".to_string(),
-        "ca_central_1".to_string(),
-        "sa_east_1".to_string(),
-        // AWS format (hyphens)
-        "ap-northeast-1".to_string(),
-        "ap-northeast-2".to_string(),
-        "ap-northeast-3".to_string(),
-        "ap-southeast-1".to_string(),
-        "ap-southeast-2".to_string(),
-        "ap-south-1".to_string(),
-        "us-east-1".to_string(),
-        "us-east-2".to_string(),
-        "us-west-1".to_string(),
-        "us-west-2".to_string(),
-        "eu-west-1".to_string(),
-        "eu-west-2".to_string(),
-        "eu-west-3".to_string(),
-        "eu-central-1".to_string(),
-        "eu-north-1".to_string(),
-        "ca-central-1".to_string(),
-        "sa-east-1".to_string(),
-    ])
+    AttributeType::Custom {
+        name: "Region".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                // Normalize the input to AWS format (hyphens)
+                let normalized = normalize_region(s);
+                if VALID_REGIONS.contains(&normalized.as_str()) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "Invalid region '{}', expected one of: {} or DSL format like aws.Region.ap_northeast_1",
+                        s,
+                        VALID_REGIONS.join(", ")
+                    ))
+                }
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+    }
+}
+
+/// Normalize region string to AWS format (hyphens)
+/// - "aws.Region.ap_northeast_1" -> "ap-northeast-1"
+/// - "ap_northeast_1" -> "ap-northeast-1"
+/// - "ap-northeast-1" -> "ap-northeast-1"
+fn normalize_region(s: &str) -> String {
+    // Extract region part from DSL format (aws.Region.xxx)
+    let region_part = if s.contains('.') {
+        s.split('.').next_back().unwrap_or(s)
+    } else {
+        s
+    };
+    // Convert underscores to hyphens
+    region_part.replace('_', "-")
 }


### PR DESCRIPTION
## Summary
- Replace Enum with Custom type for better validation
- Normalize input to AWS format before validation
- Show AWS format regions (`ap-northeast-1`) in error messages instead of internal format (`ap_northeast_1`)
- Accept both DSL format (`aws.Region.ap_northeast_1`) and AWS format (`"ap-northeast-1"`)

## Test plan
- [x] `cargo test` passes
- [x] DSL format `aws.Region.ap_northeast_1` works
- [x] AWS format `"ap-northeast-1"` works
- [x] Invalid region shows proper error message with AWS format

🤖 Generated with [Claude Code](https://claude.com/claude-code)