### PR TITLE
Fix LSP completion schema type mapping

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -156,32 +156,26 @@ impl CompletionProvider {
         let trimmed = line.trim();
 
         // Pattern: "aws.xxx.yyy {" or "let name = aws.xxx.yyy {"
-        for pattern in [
-            "aws.s3.bucket",
-            "aws.vpc",
-            "aws.subnet",
-            "aws.internet_gateway",
-            "aws.route_table",
-            "aws.route",
-            "aws.security_group.ingress_rule",
-            "aws.security_group.egress_rule",
-            "aws.security_group",
+        // Maps DSL format to schema resource_type
+        for (pattern, schema_type) in [
+            ("aws.s3.bucket", "s3.bucket"),
+            ("aws.vpc", "vpc"),
+            ("aws.subnet", "subnet"),
+            ("aws.internet_gateway", "internet_gateway"),
+            ("aws.route_table", "route_table"),
+            ("aws.route", "route"),
+            (
+                "aws.security_group.ingress_rule",
+                "security_group.ingress_rule",
+            ),
+            (
+                "aws.security_group.egress_rule",
+                "security_group.egress_rule",
+            ),
+            ("aws.security_group", "security_group"),
         ] {
             if trimmed.contains(pattern) {
-                // Convert DSL format to internal format
-                let internal_type = match pattern {
-                    "aws.s3.bucket" => "s3_bucket",
-                    "aws.vpc" => "vpc",
-                    "aws.subnet" => "subnet",
-                    "aws.internet_gateway" => "internet_gateway",
-                    "aws.route_table" => "route_table",
-                    "aws.route" => "route",
-                    "aws.security_group.ingress_rule" => "security_group.ingress_rule",
-                    "aws.security_group.egress_rule" => "security_group.egress_rule",
-                    "aws.security_group" => "security_group",
-                    _ => continue,
-                };
-                return Some(internal_type.to_string());
+                return Some(schema_type.to_string());
             }
         }
         None


### PR DESCRIPTION
## Summary
- Fix `s3_bucket` to `s3.bucket` to match actual schema resource_type
- Simplify `extract_resource_type` with direct pattern-to-schema mapping

## Problem
When typing `versioning = ` in an `aws.s3.bucket` block, the completion showed `region` instead of `true`/`false`. This was because the resource type was mapped to `s3_bucket` but the schema uses `s3.bucket`.

## Test plan
- [x] `cargo test` passes
- [x] Completion now shows correct values for attribute types

🤖 Generated with [Claude Code](https://claude.com/claude-code)