### PR TITLE
Change S3 versioning from Bool to Enum (Enabled/Suspended)

### DIFF
--- a/carina-provider-aws/src/schemas/s3.rs
+++ b/carina-provider-aws/src/schemas/s3.rs
@@ -1,6 +1,6 @@
 //! S3 bucket schema definition
 
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 
 use super::types as aws_types;
 
@@ -22,8 +22,8 @@ pub fn bucket_schema() -> ResourceSchema {
                 .with_description("The canned ACL for the bucket"),
         )
         .attribute(
-            AttributeSchema::new("versioning", AttributeType::Bool)
-                .with_description("Enable versioning for the bucket"),
+            AttributeSchema::new("versioning", aws_types::versioning_status())
+                .with_description("Versioning status for the bucket (Enabled or Suspended)"),
         )
         .attribute(
             AttributeSchema::new("expiration_days", types::positive_int())
@@ -50,7 +50,10 @@ mod tests {
             "region".to_string(),
             Value::String("Region.ap_northeast_1".to_string()),
         );
-        attrs.insert("versioning".to_string(), Value::Bool(true));
+        attrs.insert(
+            "versioning".to_string(),
+            Value::String("Enabled".to_string()),
+        );
 
         assert!(schema.validate(&attrs).is_ok());
     }

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -66,3 +66,10 @@ fn normalize_region(s: &str) -> String {
     // Convert underscores to hyphens
     region_part.replace('_', "-")
 }
+
+/// S3 bucket versioning status
+/// - Enabled: Versioning is enabled
+/// - Suspended: Versioning is suspended (previously enabled)
+pub fn versioning_status() -> AttributeType {
+    AttributeType::Enum(vec!["Enabled".to_string(), "Suspended".to_string()])
+}


### PR DESCRIPTION
## Summary
- Add `versioning_status()` type to aws_types
- Update s3.bucket schema to use versioning_status enum
- Values: `Enabled`, `Suspended`

## Test plan
- [x] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)