### PR TITLE
Fix valid_resource_types to use s3.bucket instead of s3_bucket

### DIFF
--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -17,7 +17,7 @@ impl DiagnosticEngine {
         let mut valid_resource_types = HashSet::new();
 
         // S3 resources
-        valid_resource_types.insert("s3_bucket".to_string());
+        valid_resource_types.insert("s3.bucket".to_string());
 
         // VPC resources
         valid_resource_types.insert("vpc".to_string());


### PR DESCRIPTION
## Summary
Parser produces `s3.bucket` (with dot) but diagnostics had `s3_bucket` (with underscore). This caused invalid resource types like `aws.aws.s3.bucket` to not show errors.

## Test plan
- [x] `cargo test` passes
- [x] `aws.aws.s3.bucket` now shows error in editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)