### PR TITLE
Add unknown resource type error detection

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -130,13 +130,21 @@ fn validate_resources(resources: &[Resource]) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
     for resource in resources {
-        if let Some(schema) = schemas.get(&resource.id.resource_type)
-            && let Err(errors) = schema.validate(&resource.attributes)
-        {
-            for error in errors {
+        match schemas.get(&resource.id.resource_type) {
+            Some(schema) => {
+                if let Err(errors) = schema.validate(&resource.attributes) {
+                    for error in errors {
+                        all_errors.push(format!(
+                            "{}.{}: {}",
+                            resource.id.resource_type, resource.id.name, error
+                        ));
+                    }
+                }
+            }
+            None => {
                 all_errors.push(format!(
-                    "{}.{}: {}",
-                    resource.id.resource_type, resource.id.name, error
+                    "Unknown resource type: aws.{}",
+                    resource.id.resource_type
                 ));
             }
         }

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -227,12 +227,8 @@ impl DiagnosticEngine {
 
     fn find_resource_position(&self, doc: &Document, resource_type: &str) -> Option<(u32, u32)> {
         let text = doc.text();
-        // Convert resource_type back to DSL format: vpc -> aws.vpc, s3_bucket -> aws.s3.bucket
-        let dsl_type = if resource_type == "s3_bucket" {
-            "aws.s3.bucket".to_string()
-        } else {
-            format!("aws.{}", resource_type.replace('_', "."))
-        };
+        // Convert resource_type back to DSL format: vpc -> aws.vpc, s3.bucket -> aws.s3.bucket
+        let dsl_type = format!("aws.{}", resource_type.replace('_', "."));
 
         for (line_idx, line) in text.lines().enumerate() {
             if let Some(col) = line.find(&dsl_type) {


### PR DESCRIPTION
## Summary
- CLI: Report error for unknown resource types like `aws.aws.s3.bucket`
- LSP: Remove obsolete `s3_bucket` special case in `find_resource_position`

## Before
```
$ cargo run --bin carina -- validate test.crn
Validating...
✓ 1 resources validated successfully.
  • aws.s3.bucket.bucket-name
```

## After
```
$ cargo run --bin carina -- validate test.crn
Validating...
Error: Unknown resource type: aws.aws.s3.bucket
```

## Test plan
- [x] `cargo test` passes
- [x] `aws.aws.s3.bucket` now shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)