### PR TITLE
Add shorthand enum value support with schema-based namespace resolution

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -2214,6 +2214,10 @@ fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             attribute_name,
             ..
         } => format!("{}.{}", binding_name, attribute_name),
+        Value::UnresolvedIdent(name, member) => match member {
+            Some(m) => format!("{}.{}", name, m),
+            None => name.clone(),
+        },
     }
 }
 
@@ -2295,6 +2299,10 @@ fn value_to_json(value: &Value) -> serde_json::Value {
             attribute_name,
             ..
         } => serde_json::Value::String(format!("${{{}.{}}}", binding_name, attribute_name)),
+        Value::UnresolvedIdent(name, member) => match member {
+            Some(m) => serde_json::Value::String(format!("{}.{}", name, m)),
+            None => serde_json::Value::String(name.clone()),
+        },
     }
 }
 
@@ -2501,6 +2509,11 @@ impl FileProvider {
                 attribute_name,
                 ..
             } => serde_json::Value::String(format!("${{{}.{}}}", binding_name, attribute_name)),
+            // UnresolvedIdent should be resolved before reaching here, but handle it as a string
+            Value::UnresolvedIdent(name, member) => match member {
+                Some(m) => serde_json::Value::String(format!("{}.{}", name, m)),
+                None => serde_json::Value::String(name.clone()),
+            },
         }
     }
 

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -150,6 +150,10 @@ fn format_value(value: &Value) -> String {
             attribute_name,
             ..
         } => format!("{}.{}", binding_name, attribute_name),
+        Value::UnresolvedIdent(name, member) => match member {
+            Some(m) => format!("{}.{}", name, m),
+            None => name.clone(),
+        },
     }
 }
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -41,6 +41,13 @@ pub enum Value {
         /// Optional resource type for type checking (e.g., aws.vpc)
         resource_type: Option<ResourceTypePath>,
     },
+    /// Unresolved identifier that will be resolved during schema validation
+    /// This allows shorthand enum values like `dedicated` to be resolved to
+    /// `aws.vpc.InstanceTenancy.dedicated` based on schema context.
+    /// The tuple contains (identifier, optional_member) for forms like:
+    /// - `dedicated` -> ("dedicated", None)
+    /// - `InstanceTenancy.dedicated` -> ("InstanceTenancy", Some("dedicated"))
+    UnresolvedIdent(String, Option<String>),
 }
 
 /// Desired state declared in DSL

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -1368,22 +1368,17 @@ simple {
 
         let completions = provider.complete(&doc, position, None);
 
-        // Should have aws.vpc.InstanceTenancy completions
-        let default_completion = completions
-            .iter()
-            .find(|c| c.label == "aws.vpc.InstanceTenancy.default");
+        // Should have shorthand instance_tenancy completions
+        let default_completion = completions.iter().find(|c| c.label == "default");
         assert!(
             default_completion.is_some(),
-            "Should have aws.vpc.InstanceTenancy.default completion"
+            "Should have 'default' completion"
         );
 
-        // Should NOT have awscc completions
-        let awscc_completion = completions
-            .iter()
-            .find(|c| c.label.contains("awscc.vpc.InstanceTenancy"));
+        let dedicated_completion = completions.iter().find(|c| c.label == "dedicated");
         assert!(
-            awscc_completion.is_none(),
-            "Should NOT have awscc.vpc.InstanceTenancy completion for aws.vpc resource"
+            dedicated_completion.is_some(),
+            "Should have 'dedicated' completion"
         );
     }
 
@@ -1404,22 +1399,17 @@ simple {
 
         let completions = provider.complete(&doc, position, None);
 
-        // Should have awscc.vpc.InstanceTenancy completions
-        let default_completion = completions
-            .iter()
-            .find(|c| c.label == "awscc.vpc.InstanceTenancy.default");
+        // Should have shorthand instance_tenancy completions
+        let default_completion = completions.iter().find(|c| c.label == "default");
         assert!(
             default_completion.is_some(),
-            "Should have awscc.vpc.InstanceTenancy.default completion"
+            "Should have 'default' completion"
         );
 
-        // Should NOT have aws completions
-        let aws_completion = completions
-            .iter()
-            .find(|c| c.label == "aws.vpc.InstanceTenancy.default");
+        let dedicated_completion = completions.iter().find(|c| c.label == "dedicated");
         assert!(
-            aws_completion.is_none(),
-            "Should NOT have aws.vpc.InstanceTenancy completion for awscc.vpc resource"
+            dedicated_completion.is_some(),
+            "Should have 'dedicated' completion"
         );
     }
 
@@ -1440,21 +1430,17 @@ simple {
 
         let completions = provider.complete(&doc, position, None);
 
-        // Should have aws.s3.VersioningStatus completions
-        let enabled_completion = completions
-            .iter()
-            .find(|c| c.label == "aws.s3.VersioningStatus.Enabled");
+        // Should have shorthand versioning status completions
+        let enabled_completion = completions.iter().find(|c| c.label == "Enabled");
         assert!(
             enabled_completion.is_some(),
-            "Should have aws.s3.VersioningStatus.Enabled completion"
+            "Should have 'Enabled' completion"
         );
 
-        let suspended_completion = completions
-            .iter()
-            .find(|c| c.label == "aws.s3.VersioningStatus.Suspended");
+        let suspended_completion = completions.iter().find(|c| c.label == "Suspended");
         assert!(
             suspended_completion.is_some(),
-            "Should have aws.s3.VersioningStatus.Suspended completion"
+            "Should have 'Suspended' completion"
         );
     }
 }

--- a/carina-provider-aws/src/schemas/s3.rs
+++ b/carina-provider-aws/src/schemas/s3.rs
@@ -25,14 +25,8 @@ pub fn bucket_schema() -> ResourceSchema {
             AttributeSchema::new("versioning", aws_types::versioning_status())
                 .with_description("Versioning status for the bucket (Enabled or Suspended)")
                 .with_completions(vec![
-                    CompletionValue::new(
-                        "aws.s3.VersioningStatus.Enabled",
-                        "Enable versioning for the bucket",
-                    ),
-                    CompletionValue::new(
-                        "aws.s3.VersioningStatus.Suspended",
-                        "Suspend versioning for the bucket",
-                    ),
+                    CompletionValue::new("Enabled", "Enable versioning for the bucket"),
+                    CompletionValue::new("Suspended", "Suspend versioning for the bucket"),
                 ]),
         )
         .attribute(

--- a/examples/aws-s3/main.crn
+++ b/examples/aws-s3/main.crn
@@ -19,7 +19,7 @@ backend s3 {
 # Application bucket
 aws.s3.bucket {
   name       = "my-app-bucket"
-  versioning = aws.s3.VersioningStatus.Enabled
+  versioning = Enabled
 }
 
 # Log bucket with expiration

--- a/examples/aws-vpc/main.crn
+++ b/examples/aws-vpc/main.crn
@@ -17,7 +17,7 @@ let main_vpc = aws.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = aws.vpc.InstanceTenancy.dedicated
+  instance_tenancy     = dedicated
 }
 
 # Public Subnet 1
@@ -82,6 +82,5 @@ aws.security_group.ingress_rule {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
 }
-
 # Note: AWS Security Groups allow all outbound traffic by default,
 # so we don't need to explicitly define an egress rule for 0.0.0.0/0

--- a/examples/awscc-vpc/main.crn
+++ b/examples/awscc-vpc/main.crn
@@ -17,7 +17,7 @@ awscc.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
-  instance_tenancy     = awscc.vpc.InstanceTenancy.dedicated
+  instance_tenancy     = dedicated
 
   tags = {
     Environment = "development"


### PR DESCRIPTION
## Summary

- Allow enum values to be written in shorthand forms that are automatically resolved to their full namespace based on schema context
- Add `Value::UnresolvedIdent` variant to hold unresolved identifiers during parsing
- Add `namespace` field to `AttributeType::Custom` for resolution context
- LSP completions now suggest 1-part shorthand values (e.g., `dedicated` instead of `aws.vpc.InstanceTenancy.dedicated`)
- LSP diagnostics properly handle `UnresolvedIdent` expansion

### Supported formats

```crn
# All valid - resolved to aws.vpc.InstanceTenancy.dedicated based on schema
instance_tenancy = aws.vpc.InstanceTenancy.dedicated  # Full format
instance_tenancy = InstanceTenancy.dedicated           # Type.value format
instance_tenancy = dedicated                           # Value only (recommended)
```

## Test plan

- [x] `cargo test` passes
- [x] `cargo run -- validate examples/aws-vpc` works with shorthand values
- [x] LSP completions show 1-part values
- [x] LSP diagnostics don't show errors for shorthand enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)