### PR TITLE
Implement identifier-based resource management

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -2204,6 +2204,9 @@ fn resource_to_state(
     let mut resource_state =
         ResourceState::new(&resource.id.resource_type, &resource.id.name, provider);
 
+    // Copy identifier from state
+    resource_state.identifier = state.identifier.clone();
+
     // Set attributes directly (not nested)
     for (k, v) in &state.attributes {
         resource_state

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -556,6 +556,7 @@ fn parse_anonymous_resource(
     let attributes = parse_block_contents(inner, ctx)?;
 
     // Get resource name from name attribute
+    // Anonymous resources (not bound with let) require a name attribute for identification
     // In module context, name can be input.param which is a ResourceRef
     let resource_name = match attributes.get("name") {
         Some(Value::String(s)) => s.clone(),
@@ -566,7 +567,7 @@ fn parse_anonymous_resource(
         _ => {
             return Err(ParseError::InvalidExpression {
                 line: 0,
-                message: "Anonymous resource must have a 'name' attribute".to_string(),
+                message: "Anonymous resource must have a 'name' attribute for identification. Use 'let' binding instead if you don't want to specify a name.".to_string(),
             });
         }
     };
@@ -668,6 +669,7 @@ fn parse_resource_expr(
 
     // Get resource name from name attribute (same as anonymous resources)
     // In module context, name can be input.param which is a ResourceRef
+    // If name attribute is not provided, use the binding name as the resource identifier
     let resource_name = match attributes.get("name") {
         Some(Value::String(s)) => s.clone(),
         Some(Value::ResourceRef(ref_name, ref_attr)) if ctx.in_module && ref_name == "input" => {
@@ -676,13 +678,8 @@ fn parse_resource_expr(
             format!("__input_ref__:{}", ref_attr)
         }
         _ => {
-            return Err(ParseError::InvalidExpression {
-                line: 0,
-                message: format!(
-                    "Resource bound to '{}' must have a 'name' attribute",
-                    binding_name
-                ),
-            });
+            // Use binding name as the resource identifier when name attribute is not provided
+            binding_name.to_string()
         }
     };
 

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -27,6 +27,7 @@ macro_rules! define_resource_type {
 define_resource_type!(VpcType, "vpc");
 define_resource_type!(SubnetType, "subnet");
 define_resource_type!(InternetGatewayType, "internet_gateway");
+define_resource_type!(VpcGatewayAttachmentType, "vpc_gateway_attachment");
 define_resource_type!(RouteTableType, "route_table");
 define_resource_type!(RouteType, "route");
 define_resource_type!(RouteTableAssociationType, "route_table_association");
@@ -42,6 +43,7 @@ pub fn resource_types() -> Vec<Box<dyn ResourceType>> {
         Box::new(VpcType),
         Box::new(SubnetType),
         Box::new(InternetGatewayType),
+        Box::new(VpcGatewayAttachmentType),
         Box::new(RouteTableType),
         Box::new(RouteType),
         Box::new(RouteTableAssociationType),
@@ -77,6 +79,7 @@ pub struct ResourceConfig {
 pub const VPC_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::VPC",
     attributes: &[
+        ("vpc_id", "VpcId", false), // Read-only identifier
         ("cidr_block", "CidrBlock", true),
         ("enable_dns_hostnames", "EnableDnsHostnames", false),
         ("enable_dns_support", "EnableDnsSupport", false),
@@ -88,6 +91,7 @@ pub const VPC_CONFIG: ResourceConfig = ResourceConfig {
 pub const SUBNET_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::Subnet",
     attributes: &[
+        ("subnet_id", "SubnetId", false), // Read-only identifier
         ("vpc_id", "VpcId", true),
         ("cidr_block", "CidrBlock", true),
         ("availability_zone", "AvailabilityZone", false),
@@ -98,8 +102,20 @@ pub const SUBNET_CONFIG: ResourceConfig = ResourceConfig {
 
 pub const INTERNET_GATEWAY_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::InternetGateway",
-    attributes: &[],
+    attributes: &[
+        ("internet_gateway_id", "InternetGatewayId", false), // Read-only identifier
+    ],
     has_tags: true,
+};
+
+pub const VPC_GATEWAY_ATTACHMENT_CONFIG: ResourceConfig = ResourceConfig {
+    aws_type_name: "AWS::EC2::VPCGatewayAttachment",
+    attributes: &[
+        ("vpc_id", "VpcId", true),
+        ("internet_gateway_id", "InternetGatewayId", false),
+        ("vpn_gateway_id", "VpnGatewayId", false),
+    ],
+    has_tags: false,
 };
 
 // =============================================================================
@@ -108,7 +124,10 @@ pub const INTERNET_GATEWAY_CONFIG: ResourceConfig = ResourceConfig {
 
 pub const ROUTE_TABLE_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::RouteTable",
-    attributes: &[("vpc_id", "VpcId", true)],
+    attributes: &[
+        ("route_table_id", "RouteTableId", false), // Read-only identifier
+        ("vpc_id", "VpcId", true),
+    ],
     has_tags: true,
 };
 
@@ -126,6 +145,7 @@ pub const ROUTE_CONFIG: ResourceConfig = ResourceConfig {
 pub const ROUTE_TABLE_ASSOCIATION_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::SubnetRouteTableAssociation",
     attributes: &[
+        ("id", "Id", false), // Read-only identifier
         ("subnet_id", "SubnetId", true),
         ("route_table_id", "RouteTableId", true),
     ],
@@ -139,6 +159,7 @@ pub const ROUTE_TABLE_ASSOCIATION_CONFIG: ResourceConfig = ResourceConfig {
 pub const EIP_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::EIP",
     attributes: &[
+        ("allocation_id", "AllocationId", false), // Read-only identifier
         ("domain", "Domain", false),
         ("public_ip", "PublicIp", false),
     ],
@@ -148,6 +169,7 @@ pub const EIP_CONFIG: ResourceConfig = ResourceConfig {
 pub const NAT_GATEWAY_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::NatGateway",
     attributes: &[
+        ("nat_gateway_id", "NatGatewayId", false), // Read-only identifier
         ("subnet_id", "SubnetId", true),
         ("allocation_id", "AllocationId", false),
         ("connectivity_type", "ConnectivityType", false),
@@ -162,6 +184,7 @@ pub const NAT_GATEWAY_CONFIG: ResourceConfig = ResourceConfig {
 pub const SECURITY_GROUP_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::SecurityGroup",
     attributes: &[
+        ("group_id", "GroupId", false), // Read-only identifier (security group ID)
         ("vpc_id", "VpcId", true),
         ("description", "GroupDescription", false),
         ("group_name", "GroupName", false),
@@ -188,6 +211,7 @@ pub const SECURITY_GROUP_INGRESS_CONFIG: ResourceConfig = ResourceConfig {
 pub const VPC_ENDPOINT_CONFIG: ResourceConfig = ResourceConfig {
     aws_type_name: "AWS::EC2::VPCEndpoint",
     attributes: &[
+        ("vpc_endpoint_id", "Id", false), // Read-only identifier
         ("vpc_id", "VpcId", true),
         ("service_name", "ServiceName", true),
         ("vpc_endpoint_type", "VpcEndpointType", false),
@@ -205,6 +229,7 @@ pub fn get_resource_config(resource_type: &str) -> Option<&'static ResourceConfi
         "vpc" => Some(&VPC_CONFIG),
         "subnet" => Some(&SUBNET_CONFIG),
         "internet_gateway" => Some(&INTERNET_GATEWAY_CONFIG),
+        "vpc_gateway_attachment" => Some(&VPC_GATEWAY_ATTACHMENT_CONFIG),
         "route_table" => Some(&ROUTE_TABLE_CONFIG),
         "route" => Some(&ROUTE_CONFIG),
         "route_table_association" => Some(&ROUTE_TABLE_ASSOCIATION_CONFIG),

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -20,6 +20,7 @@ pub mod security_group;
 pub mod subnet;
 pub mod vpc;
 pub mod vpc_endpoint;
+pub mod vpc_gateway_attachment;
 
 /// Returns all generated schemas
 pub fn schemas() -> Vec<ResourceSchema> {
@@ -34,5 +35,6 @@ pub fn schemas() -> Vec<ResourceSchema> {
         nat_gateway::nat_gateway_schema(),
         security_group::security_group_schema(),
         vpc_endpoint::vpc_endpoint_schema(),
+        vpc_gateway_attachment::vpc_gateway_attachment_schema(),
     ]
 }

--- a/carina-provider-awscc/src/schemas/generated/route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table_association.rs
@@ -8,7 +8,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema for subnet_route_table_association (AWS::EC2::SubnetRouteTableAssociation)
 pub fn subnet_route_table_association_schema() -> ResourceSchema {
-    ResourceSchema::new("awscc.subnet_route_table_association")
+    ResourceSchema::new("awscc.route_table_association")
         .with_description("Associates a subnet with a route table. The subnet and route table must be in the same VPC. This association causes traffic originating from the subnet to be routed according to the routes in the rout...")
         .attribute(
             AttributeSchema::new("route_table_id", AttributeType::String)

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -1,0 +1,26 @@
+//! vpc_gateway_attachment schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::EC2::VPCGatewayAttachment
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema for vpc_gateway_attachment (AWS::EC2::VPCGatewayAttachment)
+pub fn vpc_gateway_attachment_schema() -> ResourceSchema {
+    ResourceSchema::new("awscc.vpc_gateway_attachment")
+        .with_description("Attaches an internet gateway, or a virtual private gateway to a VPC, enabling connectivity between the internet and the VPC.")
+        .attribute(
+            AttributeSchema::new("vpc_id", AttributeType::String)
+                .required()
+                .with_description("The ID of the VPC."),
+        )
+        .attribute(
+            AttributeSchema::new("internet_gateway_id", AttributeType::String)
+                .with_description("The ID of the internet gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both."),
+        )
+        .attribute(
+            AttributeSchema::new("vpn_gateway_id", AttributeType::String)
+                .with_description("The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both."),
+        )
+}

--- a/examples/awscc-simple-test/main.crn
+++ b/examples/awscc-simple-test/main.crn
@@ -1,0 +1,67 @@
+# Simple test for awscc provider
+# Creates a VPC and Internet Gateway only (no cost resources)
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = awscc.vpc {
+  cidr_block           = "10.99.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = "default"
+
+  tags = {
+    Name        = "carina-test"
+    Environment = "test"
+    ManagedBy   = "carina"
+  }
+}
+
+let igw = awscc.internet_gateway {
+  tags = {
+    Name        = "carina-test"
+    Environment = "test"
+    ManagedBy   = "carina"
+  }
+}
+
+let igw_attachment = awscc.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let public_subnet = awscc.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.99.0.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "carina-test-public"
+    Environment = "test"
+    ManagedBy   = "carina"
+  }
+}
+
+let public_rt = awscc.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name        = "carina-test-public"
+    Environment = "test"
+    ManagedBy   = "carina"
+  }
+}
+
+let internet_route = awscc.route {
+  route_table_id         = public_rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  # Reference through igw_attachment to ensure IGW is attached before route creation
+  gateway_id             = igw_attachment.internet_gateway_id
+}
+
+let public_rt_assoc = awscc.route_table_association {
+  subnet_id      = public_subnet.subnet_id
+  route_table_id = public_rt.route_table_id
+}


### PR DESCRIPTION
## Summary

- Fix CLI to copy identifier from State to ResourceState when saving state
- Add read-only identifier attributes to all awscc resource configs (vpc_id, subnet_id, internet_gateway_id, route_table_id, etc.)
- Add vpc_gateway_attachment resource type for attaching Internet Gateway to VPC
- Fix route_table_association schema name to match DSL type
- Fix parser to use binding name when name attribute is not provided
- Add awscc-simple-test example with full VPC infrastructure

## Details

Resources are now managed by AWS internal identifiers (vpc-xxx, subnet-xxx, etc.) stored in state file, enabling proper read/update/delete operations.

### Key Changes

1. **CLI (`carina-cli/src/main.rs`)**: Copy `identifier` from provider's State to ResourceState when saving

2. **Resource Configs (`carina-provider-awscc/src/resources.rs`)**: Added read-only identifier attributes:
   - VPC: `vpc_id`
   - Subnet: `subnet_id`
   - Internet Gateway: `internet_gateway_id`
   - Route Table: `route_table_id`
   - Route Table Association: `id`
   - EIP: `allocation_id`
   - NAT Gateway: `nat_gateway_id`
   - Security Group: `group_id`
   - VPC Endpoint: `vpc_endpoint_id`

3. **New Resource Type**: `vpc_gateway_attachment` to attach IGW to VPC before routes can use it

4. **Parser Fix**: Use binding name as resource identifier when `name` attribute is not provided

## Test plan

- [x] All tests pass (163 tests)
- [x] Full validate/plan/apply/destroy cycle works on awscc-simple-test example
- [x] Identifiers properly saved to state file
- [x] Resources correctly deleted using identifiers from state

🤖 Generated with [Claude Code](https://claude.com/claude-code)