### PR TITLE
Add shell completions command

### DIFF
--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -14,6 +14,7 @@ carina-provider-aws = { path = "../carina-provider-aws" }
 carina-provider-awscc = { path = "../carina-provider-awscc" }
 carina-state = { path = "../carina-state" }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 colored = "3"
 serde_json = "1"

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use colored::Colorize;
 use similar::{ChangeTag, TextDiff};
 
@@ -105,6 +106,12 @@ enum Commands {
         #[command(subcommand)]
         command: StateCommands,
     },
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
 }
 
 #[derive(Subcommand)]
@@ -151,6 +158,10 @@ async fn main() {
         Commands::Module { command } => run_module_command(command),
         Commands::ForceUnlock { lock_id, path } => run_force_unlock(&lock_id, &path).await,
         Commands::State { command } => run_state_command(command).await,
+        Commands::Completions { shell } => {
+            generate(shell, &mut Cli::command(), "carina", &mut std::io::stdout());
+            Ok(())
+        }
     };
 
     if let Err(e) = result {


### PR DESCRIPTION
## Summary

- Add `completions` subcommand to generate shell completions
- Supports bash, zsh, fish, powershell, and elvish

## Usage

```bash
# Bash
carina completions bash > ~/.local/share/bash-completion/completions/carina

# Zsh
carina completions zsh > ~/.zfunc/_carina

# Fish
carina completions fish > ~/.config/fish/completions/carina.fish

# PowerShell
carina completions powershell > $HOME\Documents\PowerShell\Modules\carina\carina.ps1
```

## Test plan

- [x] `carina completions --help` shows available shells
- [x] `carina completions bash` generates valid bash completions
- [x] `carina completions zsh` generates valid zsh completions
- [x] `carina completions fish` generates valid fish completions

🤖 Generated with [Claude Code](https://claude.ai/code)