### PR TITLE
Auto-derive resource_types() from generated schema configs

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -265,10 +265,11 @@ use super::AwsccSchemaConfig;
 pub fn {}() -> AwsccSchemaConfig {{
     AwsccSchemaConfig {{
         aws_type_name: "{}",
+        resource_type_name: "{}",
         has_tags: {},
         schema: ResourceSchema::new("{}")
 "#,
-        full_resource, type_name, config_fn_name, type_name, has_tags, schema_name
+        full_resource, type_name, config_fn_name, type_name, full_resource, has_tags, schema_name
     ));
 
     // Add description

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -1,59 +1,37 @@
 //! Resource type definitions for AWS Cloud Control API
 //!
-//! This module defines resource type definitions implementing the ResourceType trait.
+//! Resource types are automatically derived from generated schema configs.
 
 use carina_core::provider::{ResourceSchema, ResourceType};
 
-// =============================================================================
-// Resource Type Definitions
-// =============================================================================
+use crate::schemas::generated::configs;
 
-macro_rules! define_resource_type {
-    ($name:ident, $type_name:expr) => {
-        pub struct $name;
-        impl ResourceType for $name {
-            fn name(&self) -> &'static str {
-                $type_name
-            }
-            fn schema(&self) -> ResourceSchema {
-                ResourceSchema::default()
-            }
-        }
-    };
+/// A resource type backed by an AwsccSchemaConfig
+struct AwsccResourceType {
+    name: &'static str,
 }
 
-define_resource_type!(Ec2VpcType, "ec2_vpc");
-define_resource_type!(Ec2SubnetType, "ec2_subnet");
-define_resource_type!(Ec2InternetGatewayType, "ec2_internet_gateway");
-define_resource_type!(Ec2VpcGatewayAttachmentType, "ec2_vpc_gateway_attachment");
-define_resource_type!(Ec2RouteTableType, "ec2_route_table");
-define_resource_type!(Ec2RouteType, "ec2_route");
-define_resource_type!(
-    Ec2SubnetRouteTableAssociationType,
-    "ec2_subnet_route_table_association"
-);
-define_resource_type!(Ec2EipType, "ec2_eip");
-define_resource_type!(Ec2NatGatewayType, "ec2_nat_gateway");
-define_resource_type!(Ec2SecurityGroupType, "ec2_security_group");
-define_resource_type!(Ec2SecurityGroupIngressType, "ec2_security_group_ingress");
-define_resource_type!(Ec2VpcEndpointType, "ec2_vpc_endpoint");
+impl ResourceType for AwsccResourceType {
+    fn name(&self) -> &'static str {
+        self.name
+    }
 
-/// Returns all resource types supported by this provider
+    fn schema(&self) -> ResourceSchema {
+        ResourceSchema::default()
+    }
+}
+
+/// Returns all resource types supported by this provider.
+/// Automatically derived from generated schema configs.
 pub fn resource_types() -> Vec<Box<dyn ResourceType>> {
-    vec![
-        Box::new(Ec2VpcType),
-        Box::new(Ec2SubnetType),
-        Box::new(Ec2InternetGatewayType),
-        Box::new(Ec2VpcGatewayAttachmentType),
-        Box::new(Ec2RouteTableType),
-        Box::new(Ec2RouteType),
-        Box::new(Ec2SubnetRouteTableAssociationType),
-        Box::new(Ec2EipType),
-        Box::new(Ec2NatGatewayType),
-        Box::new(Ec2SecurityGroupType),
-        Box::new(Ec2SecurityGroupIngressType),
-        Box::new(Ec2VpcEndpointType),
-    ]
+    configs()
+        .into_iter()
+        .map(|c| {
+            Box::new(AwsccResourceType {
+                name: c.resource_type_name,
+            }) as Box<dyn ResourceType>
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_eip_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::EIP",
+        resource_type_name: "ec2_eip",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_eip")
         .with_description("Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool c...")

--- a/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
+        resource_type_name: "ec2_internet_gateway",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_internet_gateway")
         .with_description("Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.")

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -13,6 +13,8 @@ use carina_core::schema::{AttributeType, ResourceSchema};
 pub struct AwsccSchemaConfig {
     /// AWS CloudFormation type name (e.g., "AWS::EC2::VPC")
     pub aws_type_name: &'static str,
+    /// Resource type name used in DSL (e.g., "ec2_vpc")
+    pub resource_type_name: &'static str,
     /// Whether this resource type uses tags
     pub has_tags: bool,
     /// The resource schema with attribute definitions

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::NatGateway",
+        resource_type_name: "ec2_nat_gateway",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_nat_gateway")
         .with_description("Specifies a network address translation (NAT) gateway in the specified subnet. You can create either a public NAT gateway or a private NAT gateway. The default is a public NAT gateway. If you create a...")

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -11,6 +11,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types}
 pub fn ec2_route_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
+        resource_type_name: "ec2_route",
         has_tags: false,
         schema: ResourceSchema::new("awscc.ec2_route")
         .with_description("Specifies a route in a route table. For more information, see [Routes](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#route-table-routes) in the *Amazon VPC User Guide*.  You m...")

--- a/carina-provider-awscc/src/schemas/generated/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_route_table_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
+        resource_type_name: "ec2_route_table",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_route_table")
         .with_description("Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.  For more information, see [Route tables](https://docs.aws.amaz...")

--- a/carina-provider-awscc/src/schemas/generated/route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table_association.rs
@@ -11,6 +11,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SubnetRouteTableAssociation",
+        resource_type_name: "ec2_subnet_route_table_association",
         has_tags: false,
         schema: ResourceSchema::new("awscc.ec2_subnet_route_table_association")
         .with_description("Associates a subnet with a route table. The subnet and route table must be in the same VPC. This association causes traffic originating from the subnet to be routed according to the routes in the rout...")

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_security_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
+        resource_type_name: "ec2_security_group",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_security_group")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroup")

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -11,6 +11,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
+        resource_type_name: "ec2_security_group_ingress",
         has_tags: false,
         schema: ResourceSchema::new("awscc.ec2_security_group_ingress")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroupIngress")

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -12,6 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types}
 pub fn ec2_subnet_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
+        resource_type_name: "ec2_subnet",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_subnet")
         .with_description("Specifies a subnet for the specified VPC.  For an IPv4 only subnet, specify an IPv4 CIDR block. If the VPC has an IPv6 CIDR block, you can create an IPv6 only subnet or a dual stack subnet instead. Fo...")

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -25,6 +25,7 @@ fn validate_instance_tenancy(value: &Value) -> Result<(), String> {
 pub fn ec2_vpc_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
+        resource_type_name: "ec2_vpc",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_vpc")
         .with_description("Specifies a virtual private cloud (VPC).  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrbloc...")

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -42,6 +42,7 @@ fn validate_ip_address_type(value: &Value) -> Result<(), String> {
 pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPCEndpoint",
+        resource_type_name: "ec2_vpc_endpoint",
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2_vpc_endpoint")
         .with_description("Specifies a VPC endpoint. A VPC endpoint provides a private connection between your VPC and an endpoint service. You can use an endpoint service provided by AWS, an MKT Partner, or another AWS account...")

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -11,6 +11,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPCGatewayAttachment",
+        resource_type_name: "ec2_vpc_gateway_attachment",
         has_tags: false,
         schema: ResourceSchema::new("awscc.ec2_vpc_gateway_attachment")
         .with_description("Resource Type definition for AWS::EC2::VPCGatewayAttachment")

--- a/scripts/generate-awscc-schemas.sh
+++ b/scripts/generate-awscc-schemas.sh
@@ -97,6 +97,8 @@ use carina_core::schema::{AttributeType, ResourceSchema};
 pub struct AwsccSchemaConfig {
     /// AWS CloudFormation type name (e.g., "AWS::EC2::VPC")
     pub aws_type_name: &'static str,
+    /// Resource type name used in DSL (e.g., "ec2_vpc")
+    pub resource_type_name: &'static str,
     /// Whether this resource type uses tags
     pub has_tags: bool,
     /// The resource schema with attribute definitions


### PR DESCRIPTION
## Summary

- Add `resource_type_name` field to `AwsccSchemaConfig` so each config carries its DSL type name (e.g., `"ec2_vpc"`)
- Replace manual `define_resource_type!` macros and hand-maintained `resource_types()` listing with automatic derivation from `configs()`
- Adding a new resource type no longer requires updating `resources.rs` — only the schema generation is needed

## Test plan

- [x] All 171 tests pass
- [x] Formatting and clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)