### PR TITLE
Add FlowLog schema, fix enum value handling, and fix example errors

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -26,6 +26,7 @@ RESOURCE_TYPES=(
     "AWS::EC2::SecurityGroupEgress"
     "AWS::EC2::VPCEndpoint"
     "AWS::EC2::VPCGatewayAttachment"
+    "AWS::EC2::FlowLog"
 )
 
 echo "Generating awscc provider schemas..."
@@ -161,7 +162,12 @@ pub fn validate_namespaced_enum(
         }
 
         let normalized = normalize_namespaced_enum(s);
-        if valid_values.contains(&normalized.as_str()) {
+        // Accept both underscore (DSL identifier) and hyphen (AWS value) forms
+        // e.g., "cloud_watch_logs" matches "cloud-watch-logs"
+        let hyphenated = normalized.replace('_', "-");
+        if valid_values.contains(&normalized.as_str())
+            || valid_values.contains(&hyphenated.as_str())
+        {
             Ok(())
         } else {
             Err(format!(

--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -1,0 +1,143 @@
+//! flow_log schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::EC2::FlowLog
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_namespaced_enum;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "s3", "kinesis-data-firehose"];
+
+fn validate_log_destination_type(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "LogDestinationType",
+        "awscc.ec2_flow_log",
+        VALID_LOG_DESTINATION_TYPE,
+    )
+}
+
+const VALID_RESOURCE_TYPE: &[&str] = &[
+    "NetworkInterface",
+    "Subnet",
+    "VPC",
+    "TransitGateway",
+    "TransitGatewayAttachment",
+    "RegionalNatGateway",
+];
+
+fn validate_resource_type(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "ResourceType",
+        "awscc.ec2_flow_log",
+        VALID_RESOURCE_TYPE,
+    )
+}
+
+const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
+
+fn validate_traffic_type(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "TrafficType",
+        "awscc.ec2_flow_log",
+        VALID_TRAFFIC_TYPE,
+    )
+}
+
+/// Returns the schema config for ec2_flow_log (AWS::EC2::FlowLog)
+pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::EC2::FlowLog",
+        resource_type_name: "ec2_flow_log",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.ec2_flow_log")
+        .with_description("Specifies a VPC flow log, which enables you to capture IP traffic for a specific network interface, subnet, or VPC.")
+        .attribute(
+            AttributeSchema::new("deliver_cross_account_role", AttributeType::String)
+                .with_description("The ARN of the IAM role that allows Amazon EC2 to publish flow logs across accounts.")
+                .with_provider_name("DeliverCrossAccountRole"),
+        )
+        .attribute(
+            AttributeSchema::new("deliver_logs_permission_arn", AttributeType::String)
+                .with_description("The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a CloudWatch Logs log group in your account. If you specify LogDestinationTyp...")
+                .with_provider_name("DeliverLogsPermissionArn"),
+        )
+        .attribute(
+            AttributeSchema::new("destination_options", AttributeType::Map(Box::new(AttributeType::String)))
+                .with_provider_name("DestinationOptions"),
+        )
+        .attribute(
+            AttributeSchema::new("id", AttributeType::String)
+                .with_description("The Flow Log ID (read-only)")
+                .with_provider_name("Id"),
+        )
+        .attribute(
+            AttributeSchema::new("log_destination", AttributeType::String)
+                .with_description("Specifies the destination to which the flow log data is to be published. Flow log data can be published to a CloudWatch Logs log group, an Amazon S3 b...")
+                .with_provider_name("LogDestination"),
+        )
+        .attribute(
+            AttributeSchema::new("log_destination_type", AttributeType::Custom {
+                name: "LogDestinationType".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_log_destination_type,
+                namespace: Some("awscc.ec2_flow_log".to_string()),
+            })
+                .with_description("Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3.")
+                .with_provider_name("LogDestinationType"),
+        )
+        .attribute(
+            AttributeSchema::new("log_format", AttributeType::String)
+                .with_description("The fields to include in the flow log record, in the order in which they should appear.")
+                .with_provider_name("LogFormat"),
+        )
+        .attribute(
+            AttributeSchema::new("log_group_name", AttributeType::String)
+                .with_description("The name of a new or existing CloudWatch Logs log group where Amazon EC2 publishes your flow logs. If you specify LogDestinationType as s3 or kinesis-...")
+                .with_provider_name("LogGroupName"),
+        )
+        .attribute(
+            AttributeSchema::new("max_aggregation_interval", AttributeType::Int)
+                .with_description("The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1 minute) o...")
+                .with_provider_name("MaxAggregationInterval"),
+        )
+        .attribute(
+            AttributeSchema::new("resource_id", AttributeType::String)
+                .required()
+                .with_description("The ID of the subnet, network interface, or VPC for which you want to create a flow log.")
+                .with_provider_name("ResourceId"),
+        )
+        .attribute(
+            AttributeSchema::new("resource_type", AttributeType::Custom {
+                name: "ResourceType".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_resource_type,
+                namespace: Some("awscc.ec2_flow_log".to_string()),
+            })
+                .required()
+                .with_description("The type of resource for which to create the flow log. For example, if you specified a VPC ID for the ResourceId property, specify VPC for this proper...")
+                .with_provider_name("ResourceType"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("The tags to apply to the flow logs.")
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("traffic_type", AttributeType::Custom {
+                name: "TrafficType".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_traffic_type,
+                namespace: Some("awscc.ec2_flow_log".to_string()),
+            })
+                .with_description("The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.")
+                .with_provider_name("TrafficType"),
+        )
+    }
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -86,7 +86,12 @@ pub fn validate_namespaced_enum(
         }
 
         let normalized = normalize_namespaced_enum(s);
-        if valid_values.contains(&normalized.as_str()) {
+        // Accept both underscore (DSL identifier) and hyphen (AWS value) forms
+        // e.g., "cloud_watch_logs" matches "cloud-watch-logs"
+        let hyphenated = normalized.replace('_', "-");
+        if valid_values.contains(&normalized.as_str())
+            || valid_values.contains(&hyphenated.as_str())
+        {
             Ok(())
         } else {
             Err(format!(
@@ -101,6 +106,7 @@ pub fn validate_namespaced_enum(
 }
 
 pub mod eip;
+pub mod flow_log;
 pub mod internet_gateway;
 pub mod nat_gateway;
 pub mod route;
@@ -130,6 +136,7 @@ pub fn configs() -> Vec<AwsccSchemaConfig> {
         security_group_egress::ec2_security_group_egress_config(),
         vpc_endpoint::ec2_vpc_endpoint_config(),
         vpc_gateway_attachment::ec2_vpc_gateway_attachment_config(),
+        flow_log::ec2_flow_log_config(),
     ]
 }
 

--- a/examples/awscc-vpc/main.crn
+++ b/examples/awscc-vpc/main.crn
@@ -37,8 +37,13 @@ let vpc = awscc.ec2_vpc {
 # ========================================
 
 let igw = awscc.ec2_internet_gateway {
-  name   = "main"
-  vpc_id = vpc.vpc_id
+  name = "main"
+}
+
+awscc.ec2_vpc_gateway_attachment {
+  name                = "main"
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
 }
 
 # ========================================
@@ -292,13 +297,13 @@ let vpc_endpoint_sg = awscc.ec2_security_group {
 }
 
 awscc.ec2_security_group_ingress {
-  name              = "vpc-endpoint-https"
-  security_group_id = vpc_endpoint_sg.group_id
-  description       = "Allow access to 443 port"
-  ip_protocol       = "tcp"
-  from_port         = 443
-  to_port           = 443
-  cidr_ip           = "10.0.0.0/16"
+  name        = "vpc-endpoint-https"
+  group_id    = vpc_endpoint_sg.group_id
+  description = "Allow access to 443 port"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
 }
 
 awscc.ec2_security_group_egress {

--- a/examples/modules/awscc-vpc-module/main.crn
+++ b/examples/modules/awscc-vpc-module/main.crn
@@ -53,8 +53,13 @@ let vpc = awscc.ec2_vpc {
 # ========================================
 
 let igw = awscc.ec2_internet_gateway {
-  name   = input.name
-  vpc_id = vpc.vpc_id
+  name = input.name
+}
+
+awscc.ec2_vpc_gateway_attachment {
+  name                = input.name
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
 }
 
 # ========================================
@@ -368,11 +373,11 @@ let vpc_endpoint_sg = awscc.ec2_security_group {
 }
 
 awscc.ec2_security_group_ingress {
-  name              = "${input.name}-vpc-endpoint-https"
-  security_group_id = vpc_endpoint_sg.group_id
-  description       = "Allow access to 443 port"
-  ip_protocol       = "tcp"
-  from_port         = 443
+  name        = "${input.name}-vpc-endpoint-https"
+  group_id    = vpc_endpoint_sg.group_id
+  description = "Allow access to 443 port"
+  ip_protocol = "tcp"
+  from_port   = 443
   to_port           = 443
   cidr_ip           = input.cidr_block
 }


### PR DESCRIPTION
## Summary

- Add `AWS::EC2::FlowLog` to generated schemas with enum types (`LogDestinationType`, `ResourceType`, `TrafficType`)
- Fix provider `dsl_value_to_aws` to handle `Custom` (enum) types: converts `Value::UnresolvedIdent` bare identifiers and applies underscore-to-hyphen mapping for AWS API values
- Fix `validate_namespaced_enum` to accept underscore forms of hyphenated AWS values (e.g., `cloud_watch_logs` matches `cloud-watch-logs`)
- Fix examples: use `ec2_vpc_gateway_attachment` for IGW attachment, use `group_id` instead of `security_group_id` for SecurityGroupIngress

## Test plan

- [x] All 171 tests pass
- [x] `cargo clippy` clean
- [x] Apply `examples/awscc-vpc/main.crn` — 45/45 resources created with 0 failures
- [x] Destroy — 45/45 resources destroyed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)