### PR TITLE
Add Struct variant to AttributeType for nested object schemas

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "s3", "kinesis-data-firehose"];
 
@@ -69,7 +69,14 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 .with_provider_name("DeliverLogsPermissionArn"),
         )
         .attribute(
-            AttributeSchema::new("destination_options", AttributeType::Map(Box::new(AttributeType::String)))
+            AttributeSchema::new("destination_options", AttributeType::Struct {
+                    name: "DestinationOptions".to_string(),
+                    fields: vec![
+                    StructField::new("file_format", AttributeType::Enum(vec!["plain-text".to_string(), "parquet".to_string()])).required().with_provider_name("FileFormat"),
+                    StructField::new("hive_compatible_partitions", AttributeType::Bool).required().with_provider_name("HiveCompatiblePartitions"),
+                    StructField::new("per_hour_partition", AttributeType::Bool).required().with_provider_name("PerHourPartition")
+                    ],
+                })
                 .with_provider_name("DestinationOptions"),
         )
         .attribute(

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 /// Returns the schema config for ec2_nat_gateway (AWS::EC2::NatGateway)
 pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
@@ -37,7 +37,14 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("AvailabilityMode"),
         )
         .attribute(
-            AttributeSchema::new("availability_zone_addresses", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("availability_zone_addresses", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "AvailabilityZoneAddress".to_string(),
+                    fields: vec![
+                    StructField::new("allocation_ids", AttributeType::List(Box::new(AttributeType::String))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
+                    StructField::new("availability_zone", AttributeType::String).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
+                    StructField::new("availability_zone_id", AttributeType::String).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
+                    ],
+                })))
                 .with_description("For regional NAT gateways only: Specifies which Availability Zones you want the NAT gateway to support and the Elastic IP addresses (EIPs) to use in e...")
                 .with_provider_name("AvailabilityZoneAddresses"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 /// Returns the schema config for ec2_security_group (AWS::EC2::SecurityGroup)
 pub fn ec2_security_group_config() -> AwsccSchemaConfig {
@@ -38,12 +38,38 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("security_group_egress", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("security_group_egress", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Egress".to_string(),
+                    fields: vec![
+                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ipv6", AttributeType::String).with_provider_name("CidrIpv6"),
+                    StructField::new("description", AttributeType::String).with_provider_name("Description"),
+                    StructField::new("destination_prefix_list_id", AttributeType::String).with_provider_name("DestinationPrefixListId"),
+                    StructField::new("destination_security_group_id", AttributeType::String).with_provider_name("DestinationSecurityGroupId"),
+                    StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
+                    StructField::new("ip_protocol", AttributeType::String).required().with_provider_name("IpProtocol"),
+                    StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
+                    ],
+                })))
                 .with_description("[VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.")
                 .with_provider_name("SecurityGroupEgress"),
         )
         .attribute(
-            AttributeSchema::new("security_group_ingress", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("security_group_ingress", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Ingress".to_string(),
+                    fields: vec![
+                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ipv6", AttributeType::String).with_provider_name("CidrIpv6"),
+                    StructField::new("description", AttributeType::String).with_provider_name("Description"),
+                    StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
+                    StructField::new("ip_protocol", AttributeType::String).required().with_provider_name("IpProtocol"),
+                    StructField::new("source_prefix_list_id", AttributeType::String).with_provider_name("SourcePrefixListId"),
+                    StructField::new("source_security_group_id", AttributeType::String).with_provider_name("SourceSecurityGroupId"),
+                    StructField::new("source_security_group_name", AttributeType::String).with_provider_name("SourceSecurityGroupName"),
+                    StructField::new("source_security_group_owner_id", AttributeType::String).with_provider_name("SourceSecurityGroupOwnerId"),
+                    StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
+                    ],
+                })))
                 .with_description("The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.")
                 .with_provider_name("SecurityGroupIngress"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 /// Returns the schema config for ec2_subnet (AWS::EC2::Subnet)
 pub fn ec2_subnet_config() -> AwsccSchemaConfig {
@@ -32,7 +32,12 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("AvailabilityZoneId"),
         )
         .attribute(
-            AttributeSchema::new("block_public_access_states", AttributeType::Map(Box::new(AttributeType::String)))
+            AttributeSchema::new("block_public_access_states", AttributeType::Struct {
+                    name: "BlockPublicAccessStates".to_string(),
+                    fields: vec![
+                    StructField::new("internet_gateway_block_mode", AttributeType::String).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
+                    ],
+                })
                 .with_description(" (read-only)")
                 .with_provider_name("BlockPublicAccessStates"),
         )
@@ -102,7 +107,14 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("OutpostArn"),
         )
         .attribute(
-            AttributeSchema::new("private_dns_name_options_on_launch", AttributeType::Map(Box::new(AttributeType::String)))
+            AttributeSchema::new("private_dns_name_options_on_launch", AttributeType::Struct {
+                    name: "PrivateDnsNameOptionsOnLaunch".to_string(),
+                    fields: vec![
+                    StructField::new("enable_resource_name_dns_aaaa_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsAAAARecord"),
+                    StructField::new("enable_resource_name_dns_a_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsARecord"),
+                    StructField::new("hostname_type", AttributeType::String).with_provider_name("HostnameType")
+                    ],
+                })
                 .with_description("The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more infor...")
                 .with_provider_name("PrivateDnsNameOptionsOnLaunch"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_IP_ADDRESS_TYPE: &[&str] = &["ipv4", "ipv6", "dualstack", "not-specified"];
 
@@ -57,7 +57,15 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("DnsEntries"),
         )
         .attribute(
-            AttributeSchema::new("dns_options", AttributeType::String)
+            AttributeSchema::new("dns_options", AttributeType::Struct {
+                    name: "DnsOptionsSpecification".to_string(),
+                    fields: vec![
+                    StructField::new("dns_record_ip_type", AttributeType::Enum(vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string(), "service-defined".to_string(), "not-specified".to_string()])).with_description("The DNS records created for the endpoint.").with_provider_name("DnsRecordIpType"),
+                    StructField::new("private_dns_only_for_inbound_resolver_endpoint", AttributeType::Enum(vec!["OnlyInboundResolver".to_string(), "AllResolvers".to_string(), "NotSpecified".to_string()])).with_description("Indicates whether to enable private DNS only for inbound endpoints. This option is available only for services that support both gateway and interface...").with_provider_name("PrivateDnsOnlyForInboundResolverEndpoint"),
+                    StructField::new("private_dns_preference", AttributeType::Enum(vec!["VERIFIED_DOMAINS_ONLY".to_string(), "ALL_DOMAINS".to_string(), "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "SPECIFIED_DOMAINS_ONLY".to_string()])).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS...").with_provider_name("PrivateDnsPreference"),
+                    StructField::new("private_dns_specified_domains", AttributeType::List(Box::new(AttributeType::String))).with_description("Indicates which of the private domains to create private hosted zones for and associate with the specified VPC. Only supported when private DNS is ena...").with_provider_name("PrivateDnsSpecifiedDomains")
+                    ],
+                })
                 .with_description("Describes the DNS options for an endpoint.")
                 .with_provider_name("DnsOptions"),
         )

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -22,7 +22,7 @@ The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a Cloud
 
 ### `destination_options`
 
-- **Type:** Map
+- **Type:** Struct(DestinationOptions)
 - **Required:** No
 
 ### `id`
@@ -127,6 +127,16 @@ Shorthand formats: `NetworkInterface` or `ResourceType.NetworkInterface`
 | `REJECT` | `awscc.ec2_flow_log.TrafficType.REJECT` |
 
 Shorthand formats: `ACCEPT` or `TrafficType.ACCEPT`
+
+## Struct Definitions
+
+### DestinationOptions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `file_format` | String | Yes |  |
+| `hive_compatible_partitions` | Bool | Yes |  |
+| `per_hour_partition` | Bool | Yes |  |
 
 
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -35,7 +35,7 @@ Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway
 
 ### `availability_zone_addresses`
 
-- **Type:** List
+- **Type:** List<AvailabilityZoneAddress>
 - **Required:** No
 
 For regional NAT gateways only: Specifies which Availability Zones you want the NAT gateway to support and the Elastic IP addresses (EIPs) to use in each AZ. The regional NAT gateway uses these EIPs to handle outbound NAT traffic from their respective AZs. If not specified, the NAT gateway will automatically expand to new AZs and associate EIPs upon detection of an elastic network interface. If you specify this parameter, auto-expansion is disabled and you must manually manage AZ coverage. A regional NAT gateway is a single NAT Gateway that works across multiple availability zones (AZs) in your VPC, providing redundancy, scalability and availability across all the AZs in a Region. For more information, see [Regional NAT gateways for automatic multi-AZ expansion](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateways-regional.html) in the *Amazon VPC User Guide*.
@@ -117,6 +117,16 @@ The tags for the NAT gateway.
 - **Required:** No
 
 The ID of the VPC in which the NAT gateway is located.
+
+## Struct Definitions
+
+### AvailabilityZoneAddress
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `allocation_ids` | List | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
+| `availability_zone` | String | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
+| `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -32,14 +32,14 @@ The name of the security group.
 
 ### `security_group_egress`
 
-- **Type:** List
+- **Type:** List<Egress>
 - **Required:** No
 
 [VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.
 
 ### `security_group_ingress`
 
-- **Type:** List
+- **Type:** List<Ingress>
 - **Required:** No
 
 The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.
@@ -57,6 +57,36 @@ Any tags assigned to the security group.
 - **Required:** No
 
 The ID of the VPC for the security group.
+
+## Struct Definitions
+
+### Egress
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cidr_ip` | String | No |  |
+| `cidr_ipv6` | String | No |  |
+| `description` | String | No |  |
+| `destination_prefix_list_id` | String | No |  |
+| `destination_security_group_id` | String | No |  |
+| `from_port` | Int | No |  |
+| `ip_protocol` | String | Yes |  |
+| `to_port` | Int | No |  |
+
+### Ingress
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cidr_ip` | String | No |  |
+| `cidr_ipv6` | String | No |  |
+| `description` | String | No |  |
+| `from_port` | Int | No |  |
+| `ip_protocol` | String | Yes |  |
+| `source_prefix_list_id` | String | No |  |
+| `source_security_group_id` | String | No |  |
+| `source_security_group_name` | String | No |  |
+| `source_security_group_owner_id` | String | No |  |
+| `to_port` | Int | No |  |
 
 
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -31,7 +31,7 @@ The AZ ID of the subnet.
 
 ### `block_public_access_states`
 
-- **Type:** Map
+- **Type:** Struct(BlockPublicAccessStates)
 - **Read-only**
 
 ### `cidr_block`
@@ -123,7 +123,7 @@ The Amazon Resource Name (ARN) of the Outpost.
 
 ### `private_dns_name_options_on_launch`
 
-- **Type:** Map
+- **Type:** Struct(PrivateDnsNameOptionsOnLaunch)
 - **Required:** No
 
 The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more information, see [Amazon EC2 instance hostname types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html) in the *User Guide*. Available options:  + EnableResourceNameDnsAAAARecord (true | false)  + EnableResourceNameDnsARecord (true | false)  + HostnameType (ip-name | resource-name)
@@ -146,6 +146,22 @@ Any tags assigned to the subnet.
 - **Required:** Yes
 
 The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.
+
+## Struct Definitions
+
+### BlockPublicAccessStates
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `internet_gateway_block_mode` | String | No | The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress  |
+
+### PrivateDnsNameOptionsOnLaunch
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enable_resource_name_dns_aaaa_record` | Bool | No |  |
+| `enable_resource_name_dns_a_record` | Bool | No |  |
+| `hostname_type` | String | No |  |
 
 
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -21,7 +21,7 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
 
 ### `dns_options`
 
-- **Type:** String
+- **Type:** Struct(DnsOptionsSpecification)
 - **Required:** No
 
 Describes the DNS options for an endpoint.
@@ -151,6 +151,17 @@ Shorthand formats: `ipv4` or `IpAddressType.ipv4`
 | `Resource` | `awscc.ec2_vpc_endpoint.VpcEndpointType.Resource` |
 
 Shorthand formats: `Interface` or `VpcEndpointType.Interface`
+
+## Struct Definitions
+
+### DnsOptionsSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dns_record_ip_type` | String | No | The DNS records created for the endpoint. |
+| `private_dns_only_for_inbound_resolver_endpoint` | String | No | Indicates whether to enable private DNS only for inbound endpoints. This option is available only fo... |
+| `private_dns_preference` | String | No | The preference for which private domains have a private hosted zone created for and associated with ... |
+| `private_dns_specified_domains` | List | No | Indicates which of the private domains to create private hosted zones for and associate with the spe... |
 
 
 


### PR DESCRIPTION
## Summary

- Add `StructField` struct and `AttributeType::Struct` variant to `carina-core` for typed nested objects
- Update codegen to resolve CloudFormation `$ref` and inline object definitions into `Struct` types instead of falling back to `String`/`Map`
- Add `Value::Map` ↔ `serde_json::Value::Object` conversion in the AWSCC provider (with snake_case/PascalCase key conversion)

## Key changes

| Before | After |
|--------|-------|
| `security_group_ingress: List(String)` | `security_group_ingress: List(Struct{Ingress})` |
| `destination_options: Map(String)` | `destination_options: Struct{DestinationOptions}` |
| `dns_options: Map(String)` | `dns_options: Struct{DnsOptionsSpecification}` |

Docs now include a **Struct Definitions** section with field tables for each resolved struct type.

## Test plan

- [x] `cargo test` — all 173 tests pass (including 2 new Struct validation tests)
- [x] `cargo clippy` — no warnings
- [x] Regenerated schemas compile and match expected Struct types
- [x] Regenerated docs contain Struct Definitions sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)