### PR TITLE
Separate IPv4 and IPv6 CIDR types for strict validation

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -729,7 +729,12 @@ impl CompletionProvider {
             AttributeType::Int => {
                 vec![] // No specific completions for integers
             }
-            AttributeType::Custom { name, .. } if name == "Cidr" => self.cidr_completions(),
+            AttributeType::Custom { name, .. } if name == "Cidr" || name == "Ipv4Cidr" => {
+                self.cidr_completions()
+            }
+            AttributeType::Custom { name, .. } if name == "Ipv6Cidr" => {
+                self.ipv6_cidr_completions()
+            }
             AttributeType::Custom { name, .. } if name == "VersioningStatus" => {
                 self.versioning_status_completions()
             }
@@ -924,6 +929,27 @@ impl CompletionProvider {
             ("172.16.0.0/16", "VPC CIDR (65,536 IPs)"),
             ("192.168.0.0/16", "VPC CIDR (65,536 IPs)"),
             ("0.0.0.0/0", "All IPv4 addresses"),
+        ];
+
+        cidrs
+            .into_iter()
+            .map(|(cidr, description)| CompletionItem {
+                label: format!("\"{}\"", cidr),
+                kind: Some(CompletionItemKind::VALUE),
+                detail: Some(description.to_string()),
+                insert_text: Some(format!("\"{}\"", cidr)),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    fn ipv6_cidr_completions(&self) -> Vec<CompletionItem> {
+        let cidrs = vec![
+            ("::/0", "All IPv6 addresses"),
+            ("2001:db8::/32", "Documentation range"),
+            ("fe80::/10", "Link-local addresses"),
+            ("fc00::/7", "Unique local addresses"),
+            ("::1/128", "Loopback address"),
         ];
 
         cidrs

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use crate::document::Document;
 use carina_core::parser::{InputParameter, ParseError, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
-use carina_core::schema::validate_cidr;
+use carina_core::schema::{validate_cidr, validate_ipv6_cidr};
 use carina_provider_aws::schemas::{s3, types as aws_types, vpc};
 use carina_provider_awscc::schemas::generated::flow_log as awscc_flow_log;
 use carina_provider_awscc::schemas::generated::nat_gateway as awscc_nat_gateway;
@@ -219,9 +219,15 @@ impl DiagnosticEngine {
                                         _ => value.clone(),
                                     };
 
-                                    if name == "Cidr" {
+                                    if name == "Cidr" || name == "Ipv4Cidr" {
                                         if let Value::String(s) = &resolved_value {
                                             validate_cidr(s).err()
+                                        } else {
+                                            None
+                                        }
+                                    } else if name == "Ipv6Cidr" {
+                                        if let Value::String(s) = &resolved_value {
+                                            validate_ipv6_cidr(s).err()
                                         } else {
                                             None
                                         }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -845,9 +845,18 @@ fn cfn_type_to_carina_type_with_enum(
             // Check property name for specific types
             let prop_lower = prop_name.to_lowercase();
 
-            // CIDR type - only for properties that are actually CIDRs
-            if prop_lower.contains("cidrblock") || prop_lower == "cidr_block" {
-                return ("types::cidr()".to_string(), None);
+            // CIDR types - differentiate IPv4 vs IPv6 based on property name
+            if prop_lower.contains("cidr") {
+                if prop_lower.contains("ipv6") {
+                    return ("types::ipv6_cidr()".to_string(), None);
+                }
+                if prop_lower.contains("cidrblock")
+                    || prop_lower == "cidr_block"
+                    || prop_lower == "cidr_ip"
+                    || prop_lower == "destination_cidr_block"
+                {
+                    return ("types::ipv4_cidr()".to_string(), None);
+                }
             }
 
             // IDs are always strings

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -21,7 +21,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("CarrierGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("cidr_block", types::cidr())
+            AttributeSchema::new("cidr_block", types::ipv4_cidr())
                 .with_description(" (read-only)")
                 .with_provider_name("CidrBlock"),
         )
@@ -31,12 +31,12 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("CoreNetworkArn"),
         )
         .attribute(
-            AttributeSchema::new("destination_cidr_block", types::cidr())
+            AttributeSchema::new("destination_cidr_block", types::ipv4_cidr())
                 .with_description("The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match. We modify the specified CIDR block...")
                 .with_provider_name("DestinationCidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("destination_ipv6_cidr_block", types::cidr())
+            AttributeSchema::new("destination_ipv6_cidr_block", types::ipv6_cidr())
                 .with_description("The IPv6 CIDR block used for the destination match. Routing decisions are based on the most specific match.")
                 .with_provider_name("DestinationIpv6CidrBlock"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 /// Returns the schema config for ec2_security_group (AWS::EC2::SecurityGroup)
 pub fn ec2_security_group_config() -> AwsccSchemaConfig {
@@ -41,8 +41,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("security_group_egress", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "Egress".to_string(),
                     fields: vec![
-                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
-                    StructField::new("cidr_ipv6", AttributeType::String).with_provider_name("CidrIpv6"),
+                    StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("destination_prefix_list_id", AttributeType::String).with_provider_name("DestinationPrefixListId"),
                     StructField::new("destination_security_group_id", AttributeType::String).with_provider_name("DestinationSecurityGroupId"),
@@ -58,8 +58,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("security_group_ingress", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "Ingress".to_string(),
                     fields: vec![
-                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
-                    StructField::new("cidr_ipv6", AttributeType::String).with_provider_name("CidrIpv6"),
+                    StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::String).required().with_provider_name("IpProtocol"),

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1"];
 
@@ -29,12 +29,12 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_security_group_egress")
         .with_description("Adds the specified outbound (egress) rule to a security group.  An outbound rule permits instances to send traffic to the specified IPv4 or IPv6 address range, the IP addresses that are specified by a...")
         .attribute(
-            AttributeSchema::new("cidr_ip", AttributeType::String)
+            AttributeSchema::new("cidr_ip", types::ipv4_cidr())
                 .with_description("The IPv4 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``Des...")
                 .with_provider_name("CidrIp"),
         )
         .attribute(
-            AttributeSchema::new("cidr_ipv6", AttributeType::String)
+            AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
                 .with_description("The IPv6 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``Des...")
                 .with_provider_name("CidrIpv6"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for ec2_security_group_ingress (AWS::EC2::SecurityGroupIngress)
 pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
@@ -16,12 +16,12 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_security_group_ingress")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroupIngress")
         .attribute(
-            AttributeSchema::new("cidr_ip", AttributeType::String)
+            AttributeSchema::new("cidr_ip", types::ipv4_cidr())
                 .with_description("The IPv4 ranges")
                 .with_provider_name("CidrIp"),
         )
         .attribute(
-            AttributeSchema::new("cidr_ipv6", AttributeType::String)
+            AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
                 .with_description("[VPC only] The IPv6 ranges")
                 .with_provider_name("CidrIpv6"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -42,7 +42,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("BlockPublicAccessStates"),
         )
         .attribute(
-            AttributeSchema::new("cidr_block", types::cidr())
+            AttributeSchema::new("cidr_block", types::ipv4_cidr())
                 .with_description("The IPv4 CIDR block assigned to the subnet. If you update this property, we create a new subnet, and then delete the existing one.")
                 .with_provider_name("CidrBlock"),
         )
@@ -67,12 +67,12 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("Ipv4NetmaskLength"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_cidr_block", types::cidr())
+            AttributeSchema::new("ipv6_cidr_block", types::ipv6_cidr())
                 .with_description("The IPv6 CIDR block. If you specify ``AssignIpv6AddressOnCreation``, you must also specify an IPv6 CIDR block.")
                 .with_provider_name("Ipv6CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_cidr_blocks", AttributeType::List(Box::new(types::cidr())))
+            AttributeSchema::new("ipv6_cidr_blocks", AttributeType::List(Box::new(types::ipv6_cidr())))
                 .with_description(" (read-only)")
                 .with_provider_name("Ipv6CidrBlocks"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -30,12 +30,12 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_vpc")
         .with_description("Specifies a virtual private cloud (VPC).  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrbloc...")
         .attribute(
-            AttributeSchema::new("cidr_block", types::cidr())
+            AttributeSchema::new("cidr_block", types::ipv4_cidr())
                 .with_description("The IPv4 network range for the VPC, in CIDR notation. For example, ``10.0.0.0/16``. We modify the specified CIDR block to its canonical form; for exam...")
                 .with_provider_name("CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("cidr_block_associations", AttributeType::List(Box::new(types::cidr())))
+            AttributeSchema::new("cidr_block_associations", AttributeType::List(Box::new(types::ipv4_cidr())))
                 .with_description(" (read-only)")
                 .with_provider_name("CidrBlockAssociations"),
         )
@@ -80,7 +80,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_provider_name("Ipv4NetmaskLength"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_cidr_blocks", AttributeType::List(Box::new(types::cidr())))
+            AttributeSchema::new("ipv6_cidr_blocks", AttributeType::List(Box::new(types::ipv6_cidr())))
                 .with_description(" (read-only)")
                 .with_provider_name("Ipv6CidrBlocks"),
         )


### PR DESCRIPTION
## Summary

- Add distinct `Ipv4Cidr` and `Ipv6Cidr` types in `carina-core` with dedicated validation functions (`validate_ipv4_cidr`, `validate_ipv6_cidr`)
- Update codegen to detect IPv6 properties (`cidr_ipv6`, `ipv6_cidr_block`, `destination_ipv6_cidr_block`) and map them to `types::ipv6_cidr()` instead of `types::cidr()`
- Update LSP diagnostics and completions to handle both new type names, with IPv6-specific completion suggestions

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 185 tests pass including new tests for:
  - Valid IPv6 CIDRs: `::/0`, `2001:db8::/32`, `fe80::/10`, `::1/128`
  - Invalid IPv6 CIDRs: prefix >128, missing prefix, invalid hex, double `::`
  - `types::ipv4_cidr()` behaves same as old `types::cidr()`
- [x] Pre-commit hooks pass (fmt, clippy, tests)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)