### PR TITLE
Update docs for Ipv4Cidr and Ipv6Cidr types

### DIFF
--- a/docs/src/providers/awscc/ec2_route.md
+++ b/docs/src/providers/awscc/ec2_route.md
@@ -17,7 +17,7 @@ The ID of the carrier gateway. You can only use this option when the VPC contain
 
 ### `cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv4Cidr
 - **Read-only**
 
 ### `core_network_arn`
@@ -29,14 +29,14 @@ The Amazon Resource Name (ARN) of the core network.
 
 ### `destination_cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv4Cidr
 - **Required:** No
 
 The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match. We modify the specified CIDR block to its canonical form; for example, if you specify ``100.68.0.18/18``, we modify it to ``100.68.0.0/18``.
 
 ### `destination_ipv6_cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv6Cidr
 - **Required:** No
 
 The IPv6 CIDR block used for the destination match. Routing decisions are based on the most specific match.

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -64,8 +64,8 @@ The ID of the VPC for the security group.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `cidr_ip` | String | No |  |
-| `cidr_ipv6` | String | No |  |
+| `cidr_ip` | Ipv4Cidr | No |  |
+| `cidr_ipv6` | Ipv6Cidr | No |  |
 | `description` | String | No |  |
 | `destination_prefix_list_id` | String | No |  |
 | `destination_security_group_id` | String | No |  |
@@ -77,8 +77,8 @@ The ID of the VPC for the security group.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `cidr_ip` | String | No |  |
-| `cidr_ipv6` | String | No |  |
+| `cidr_ip` | Ipv4Cidr | No |  |
+| `cidr_ipv6` | Ipv6Cidr | No |  |
 | `description` | String | No |  |
 | `from_port` | Int | No |  |
 | `ip_protocol` | String | Yes |  |

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -12,14 +12,14 @@ Adds the specified outbound (egress) rule to a security group.
 
 ### `cidr_ip`
 
-- **Type:** String
+- **Type:** Ipv4Cidr
 - **Required:** No
 
 The IPv4 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSecurityGroupId``. For examples of rules that you can add to security groups for specific access scenarios, see [Security group rules for different use cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html) in the *User Guide*.
 
 ### `cidr_ipv6`
 
-- **Type:** String
+- **Type:** Ipv6Cidr
 - **Required:** No
 
 The IPv6 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSecurityGroupId``. For examples of rules that you can add to security groups for specific access scenarios, see [Security group rules for different use cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html) in the *User Guide*.

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -8,14 +8,14 @@ Resource Type definition for AWS::EC2::SecurityGroupIngress
 
 ### `cidr_ip`
 
-- **Type:** String
+- **Type:** Ipv4Cidr
 - **Required:** No
 
 The IPv4 ranges
 
 ### `cidr_ipv6`
 
-- **Type:** String
+- **Type:** Ipv6Cidr
 - **Required:** No
 
 [VPC only] The IPv6 ranges

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -36,7 +36,7 @@ The AZ ID of the subnet.
 
 ### `cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv4Cidr
 - **Required:** No
 
 The IPv4 CIDR block assigned to the subnet. If you update this property, we create a new subnet, and then delete the existing one.
@@ -71,7 +71,7 @@ An IPv4 netmask length for the subnet.
 
 ### `ipv6_cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv6Cidr
 - **Required:** No
 
 The IPv6 CIDR block. If you specify ``AssignIpv6AddressOnCreation``, you must also specify an IPv6 CIDR block.

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -10,7 +10,7 @@ Specifies a virtual private cloud (VPC).
 
 ### `cidr_block`
 
-- **Type:** CIDR
+- **Type:** Ipv4Cidr
 - **Required:** No
 
 The IPv4 network range for the VPC, in CIDR notation. For example, ``10.0.0.0/16``. We modify the specified CIDR block to its canonical form; for example, if you specify ``100.68.0.18/18``, we modify it to ``100.68.0.0/18``. You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``.


### PR DESCRIPTION
## Summary

- Update attribute type annotations in awscc resource docs to reflect the separated CIDR types from #64
- `cidr_block`, `destination_cidr_block`, `cidr_ip`: CIDR/String → Ipv4Cidr
- `ipv6_cidr_block`, `destination_ipv6_cidr_block`, `cidr_ipv6`: CIDR/String → Ipv6Cidr

## Affected docs

- `ec2_vpc.md`
- `ec2_subnet.md`
- `ec2_route.md`
- `ec2_security_group.md`
- `ec2_security_group_egress.md`
- `ec2_security_group_ingress.md`

## Test plan

- [x] No code changes, documentation only
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)