### PR TITLE
Separate Argument Reference and Attribute Reference in docs

### DIFF
--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -6,7 +6,7 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool created from a public IPv4 address range that you have brought to AWS for use with your AWS resources using bring your own IP addresses (BYOIP). For more information, see [Bring Your Own IP Addresses (BYOIP)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-byoip.html) in the *Amazon EC2 User Guide*.
  For more information, see [Elastic IP Addresses](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) in the *Amazon EC2 User Guide*.
 
-## Attributes
+## Argument Reference
 
 ### `address`
 
@@ -14,11 +14,6 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
 - **Required:** No
 
 
-
-### `allocation_id`
-
-- **Type:** String
-- **Read-only**
 
 ### `domain`
 
@@ -48,11 +43,6 @@ The ID of the instance.  Updates to the ``InstanceId`` property may require *som
 
 A unique set of Availability Zones, Local Zones, or Wavelength Zones from which AWS advertises IP addresses. Use this parameter to limit the IP address to this location. IP addresses cannot move between network border groups. Use [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html) to view the network border groups.
 
-### `public_ip`
-
-- **Type:** String
-- **Read-only**
-
 ### `public_ipv4_pool`
 
 - **Type:** String
@@ -73,6 +63,16 @@ Any tags assigned to the Elastic IP address.  Updates to the ``Tags`` property m
 - **Required:** No
 
 The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfers, see [Transfer Elastic IP addresses](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#transfer-EIPs-intro) in the *Amazon Virtual Private Cloud User Guide*.
+
+## Attribute Reference
+
+### `allocation_id`
+
+- **Type:** String
+
+### `public_ip`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -4,7 +4,7 @@ CloudFormation Type: `AWS::EC2::FlowLog`
 
 Specifies a VPC flow log, which enables you to capture IP traffic for a specific network interface, subnet, or VPC.
 
-## Attributes
+## Argument Reference
 
 ### `deliver_cross_account_role`
 
@@ -24,11 +24,6 @@ The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a Cloud
 
 - **Type:** Struct(DestinationOptions)
 - **Required:** No
-
-### `id`
-
-- **Type:** String
-- **Read-only**
 
 ### `log_destination`
 
@@ -92,6 +87,12 @@ The tags to apply to the flow logs.
 - **Required:** No
 
 The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_internet_gateway.md
+++ b/docs/src/providers/awscc/ec2_internet_gateway.md
@@ -4,12 +4,7 @@ CloudFormation Type: `AWS::EC2::InternetGateway`
 
 Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.
 
-## Attributes
-
-### `internet_gateway_id`
-
-- **Type:** String
-- **Read-only**
+## Argument Reference
 
 ### `tags`
 
@@ -17,6 +12,12 @@ Allocates an internet gateway for use with a VPC. After creating the Internet ga
 - **Required:** No
 
 Any tags to assign to the internet gateway.
+
+## Attribute Reference
+
+### `internet_gateway_id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -7,7 +7,7 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
  If you add a default route (``AWS::EC2::Route`` resource) that points to a NAT gateway, specify the NAT gateway ID for the route's ``NatGatewayId`` property.
   When you associate an Elastic IP address or secondary Elastic IP address with a public NAT gateway, the network border group of the Elastic IP address must match the network border group of the Availability Zone (AZ) that the public NAT gateway is in. Otherwise, the NAT gateway fails to launch. You can see the network border group for the AZ by viewing the details of the subnet. Similarly, you can view the network border group for the Elastic IP address by viewing its details. For more information, see [Allocate an Elastic IP address](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#allocate-eip) in the *Amazon VPC User Guide*.
 
-## Attributes
+## Argument Reference
 
 ### `allocation_id`
 
@@ -15,16 +15,6 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
 - **Required:** No
 
 [Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public NAT gateway and cannot be specified with a private NAT gateway.
-
-### `auto_provision_zones`
-
-- **Type:** String
-- **Read-only**
-
-### `auto_scaling_ips`
-
-- **Type:** String
-- **Read-only**
 
 ### `availability_mode`
 
@@ -47,11 +37,6 @@ For regional NAT gateways only: Specifies which Availability Zones you want the 
 
 Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity.
 
-### `eni_id`
-
-- **Type:** String
-- **Read-only**
-
 ### `max_drain_duration_seconds`
 
 - **Type:** Int
@@ -59,22 +44,12 @@ Indicates whether the NAT gateway supports public or private connectivity. The d
 
 The maximum amount of time to wait (in seconds) before forcibly releasing the IP addresses if connections are still in progress. Default value is 350 seconds.
 
-### `nat_gateway_id`
-
-- **Type:** String
-- **Read-only**
-
 ### `private_ip_address`
 
 - **Type:** String
 - **Required:** No
 
 The private IPv4 address to assign to the NAT gateway. If you don't provide an address, a private IPv4 address will be automatically assigned.
-
-### `route_table_id`
-
-- **Type:** String
-- **Read-only**
 
 ### `secondary_allocation_ids`
 
@@ -117,6 +92,28 @@ The tags for the NAT gateway.
 - **Required:** No
 
 The ID of the VPC in which the NAT gateway is located.
+
+## Attribute Reference
+
+### `auto_provision_zones`
+
+- **Type:** String
+
+### `auto_scaling_ips`
+
+- **Type:** String
+
+### `eni_id`
+
+- **Type:** String
+
+### `nat_gateway_id`
+
+- **Type:** String
+
+### `route_table_id`
+
+- **Type:** String
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_route.md
+++ b/docs/src/providers/awscc/ec2_route.md
@@ -6,7 +6,7 @@ Specifies a route in a route table. For more information, see [Routes](https://d
  You must specify either a destination CIDR block or prefix list ID. You must also specify exactly one of the resources as the target.
  If you create a route that references a transit gateway in the same template where you create the transit gateway, you must declare a dependency on the transit gateway attachment. The route table cannot use the transit gateway until it has successfully attached to the VPC. Add a [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) in the ``AWS::EC2::Route`` resource to explicitly declare a dependency on the ``AWS::EC2::TransitGatewayAttachment`` resource.
 
-## Attributes
+## Argument Reference
 
 ### `carrier_gateway_id`
 
@@ -14,11 +14,6 @@ Specifies a route in a route table. For more information, see [Routes](https://d
 - **Required:** No
 
 The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.
-
-### `cidr_block`
-
-- **Type:** Ipv4Cidr
-- **Read-only**
 
 ### `core_network_arn`
 
@@ -117,6 +112,12 @@ The ID of a VPC endpoint. Supported for Gateway Load Balancer endpoints only.
 - **Required:** No
 
 The ID of a VPC peering connection.
+
+## Attribute Reference
+
+### `cidr_block`
+
+- **Type:** Ipv4Cidr
 
 
 

--- a/docs/src/providers/awscc/ec2_route_table.md
+++ b/docs/src/providers/awscc/ec2_route_table.md
@@ -5,12 +5,7 @@ CloudFormation Type: `AWS::EC2::RouteTable`
 Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.
  For more information, see [Route tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html) in the *Amazon VPC User Guide*.
 
-## Attributes
-
-### `route_table_id`
-
-- **Type:** String
-- **Read-only**
+## Argument Reference
 
 ### `tags`
 
@@ -25,6 +20,12 @@ Any tags assigned to the route table.
 - **Required:** Yes
 
 The ID of the VPC.
+
+## Attribute Reference
+
+### `route_table_id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -4,7 +4,7 @@ CloudFormation Type: `AWS::EC2::SecurityGroup`
 
 Resource Type definition for AWS::EC2::SecurityGroup
 
-## Attributes
+## Argument Reference
 
 ### `group_description`
 
@@ -13,22 +13,12 @@ Resource Type definition for AWS::EC2::SecurityGroup
 
 A description for the security group.
 
-### `group_id`
-
-- **Type:** String
-- **Read-only**
-
 ### `group_name`
 
 - **Type:** String
 - **Required:** No
 
 The name of the security group.
-
-### `id`
-
-- **Type:** String
-- **Read-only**
 
 ### `security_group_egress`
 
@@ -57,6 +47,16 @@ Any tags assigned to the security group.
 - **Required:** No
 
 The ID of the VPC for the security group.
+
+## Attribute Reference
+
+### `group_id`
+
+- **Type:** String
+
+### `id`
+
+- **Type:** String
 
 ## Struct Definitions
 

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -8,7 +8,7 @@ Adds the specified outbound (egress) rule to a security group.
  You must specify a protocol for each rule (for example, TCP). If the protocol is TCP or UDP, you must also specify a port or port range. If the protocol is ICMP or ICMPv6, you must also specify the ICMP/ICMPv6 type and code. To specify all types or all codes, use -1.
  Rule changes are propagated to instances associated with the security group as quickly as possible. However, a small delay might occur.
 
-## Attributes
+## Argument Reference
 
 ### `cidr_ip`
 
@@ -59,11 +59,6 @@ If the protocol is TCP or UDP, this is the start of the port range. If the proto
 
 The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID.
 
-### `id`
-
-- **Type:** String
-- **Read-only**
-
 ### `ip_protocol`
 
 - **Type:** Enum (IpProtocol)
@@ -77,6 +72,12 @@ The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Pr
 - **Required:** No
 
 If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP code or -1 (all ICMP codes). If the start port is -1 (all ICMP types), then the end port must be -1 (all ICMP codes).
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -4,7 +4,7 @@ CloudFormation Type: `AWS::EC2::SecurityGroupIngress`
 
 Resource Type definition for AWS::EC2::SecurityGroupIngress
 
-## Attributes
+## Argument Reference
 
 ### `cidr_ip`
 
@@ -48,11 +48,6 @@ The ID of the security group. You must specify either the security group ID or t
 
 The name of the security group.
 
-### `id`
-
-- **Type:** String
-- **Read-only**
-
 ### `ip_protocol`
 
 - **Type:** Enum (IpProtocol)
@@ -94,6 +89,12 @@ The ID of the security group. You must specify either the security group ID or t
 - **Required:** No
 
 The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type. If you specify all ICMP/ICMPv6 types, you must specify all codes. Use this for ICMP and any protocol that uses ports.
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -6,7 +6,7 @@ Specifies a subnet for the specified VPC.
  For an IPv4 only subnet, specify an IPv4 CIDR block. If the VPC has an IPv6 CIDR block, you can create an IPv6 only subnet or a dual stack subnet instead. For an IPv6 only subnet, specify an IPv6 CIDR block. For a dual stack subnet, specify both an IPv4 CIDR block and an IPv6 CIDR block.
  For more information, see [Subnets for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) in the *Amazon VPC User Guide*.
 
-## Attributes
+## Argument Reference
 
 ### `assign_ipv6_address_on_creation`
 
@@ -28,11 +28,6 @@ The Availability Zone of the subnet. If you update this property, you must also 
 - **Required:** No
 
 The AZ ID of the subnet.
-
-### `block_public_access_states`
-
-- **Type:** Struct(BlockPublicAccessStates)
-- **Read-only**
 
 ### `cidr_block`
 
@@ -76,11 +71,6 @@ An IPv4 netmask length for the subnet.
 
 The IPv6 CIDR block. If you specify ``AssignIpv6AddressOnCreation``, you must also specify an IPv6 CIDR block.
 
-### `ipv6_cidr_blocks`
-
-- **Type:** List
-- **Read-only**
-
 ### `ipv6_ipam_pool_id`
 
 - **Type:** String
@@ -109,11 +99,6 @@ An IPv6 netmask length for the subnet.
 
 Indicates whether instances launched in this subnet receive a public IPv4 address. The default value is ``false``. AWS charges for all public IPv4 addresses, including public IPv4 addresses associated with running instances and Elastic IP addresses. For more information, see the *Public IPv4 Address* tab on the [VPC pricing page](https://docs.aws.amazon.com/vpc/pricing/).
 
-### `network_acl_association_id`
-
-- **Type:** String
-- **Read-only**
-
 ### `outpost_arn`
 
 - **Type:** Arn
@@ -128,11 +113,6 @@ The Amazon Resource Name (ARN) of the Outpost.
 
 The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more information, see [Amazon EC2 instance hostname types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html) in the *User Guide*. Available options:  + EnableResourceNameDnsAAAARecord (true | false)  + EnableResourceNameDnsARecord (true | false)  + HostnameType (ip-name | resource-name)
 
-### `subnet_id`
-
-- **Type:** String
-- **Read-only**
-
 ### `tags`
 
 - **Type:** Map
@@ -146,6 +126,24 @@ Any tags assigned to the subnet.
 - **Required:** Yes
 
 The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.
+
+## Attribute Reference
+
+### `block_public_access_states`
+
+- **Type:** Struct(BlockPublicAccessStates)
+
+### `ipv6_cidr_blocks`
+
+- **Type:** List
+
+### `network_acl_association_id`
+
+- **Type:** String
+
+### `subnet_id`
+
+- **Type:** String
 
 ## Struct Definitions
 

--- a/docs/src/providers/awscc/ec2_subnet_route_table_association.md
+++ b/docs/src/providers/awscc/ec2_subnet_route_table_association.md
@@ -4,12 +4,7 @@ CloudFormation Type: `AWS::EC2::SubnetRouteTableAssociation`
 
 Associates a subnet with a route table. The subnet and route table must be in the same VPC. This association causes traffic originating from the subnet to be routed according to the routes in the route table. A route table can be associated with multiple subnets. To create a route table, see [AWS::EC2::RouteTable](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-routetable.html).
 
-## Attributes
-
-### `id`
-
-- **Type:** String
-- **Read-only**
+## Argument Reference
 
 ### `route_table_id`
 
@@ -24,6 +19,12 @@ The ID of the route table. The physical ID changes when the route table ID is ch
 - **Required:** Yes
 
 The ID of the subnet.
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -6,7 +6,7 @@ Specifies a virtual private cloud (VPC).
  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html).
  For more information, see [Virtual private clouds (VPC)](https://docs.aws.amazon.com/vpc/latest/userguide/configure-your-vpc.html) in the *Amazon VPC User Guide*.
 
-## Attributes
+## Argument Reference
 
 ### `cidr_block`
 
@@ -14,21 +14,6 @@ Specifies a virtual private cloud (VPC).
 - **Required:** No
 
 The IPv4 network range for the VPC, in CIDR notation. For example, ``10.0.0.0/16``. We modify the specified CIDR block to its canonical form; for example, if you specify ``100.68.0.18/18``, we modify it to ``100.68.0.0/18``. You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``.
-
-### `cidr_block_associations`
-
-- **Type:** List
-- **Read-only**
-
-### `default_network_acl`
-
-- **Type:** String
-- **Read-only**
-
-### `default_security_group`
-
-- **Type:** String
-- **Read-only**
 
 ### `enable_dns_hostnames`
 
@@ -65,11 +50,6 @@ The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For 
 
 The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPAM, see [What is IPAM?](https://docs.aws.amazon.com//vpc/latest/ipam/what-is-it-ipam.html) in the *Amazon VPC IPAM User Guide*.
 
-### `ipv6_cidr_blocks`
-
-- **Type:** List
-- **Read-only**
-
 ### `tags`
 
 - **Type:** Map
@@ -77,10 +57,27 @@ The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Ama
 
 The tags for the VPC.
 
+## Attribute Reference
+
+### `cidr_block_associations`
+
+- **Type:** List
+
+### `default_network_acl`
+
+- **Type:** String
+
+### `default_security_group`
+
+- **Type:** String
+
+### `ipv6_cidr_blocks`
+
+- **Type:** List
+
 ### `vpc_id`
 
 - **Type:** String
-- **Read-only**
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -7,17 +7,7 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
  An endpoint of type ``gateway`` serves as a target for a route in your route table for traffic destined for S3 or DDB. You can specify an endpoint policy for the endpoint, which controls access to the service from your VPC. You can also specify the VPC route tables that use the endpoint. For more information about connectivity to S3, see [Why can't I connect to an S3 bucket using a gateway VPC endpoint?](https://docs.aws.amazon.com/premiumsupport/knowledge-center/connect-s3-vpc-endpoint)
  An endpoint of type ``GatewayLoadBalancer`` provides private connectivity between your VPC and virtual appliances from a service provider.
 
-## Attributes
-
-### `creation_timestamp`
-
-- **Type:** String
-- **Read-only**
-
-### `dns_entries`
-
-- **Type:** List
-- **Read-only**
+## Argument Reference
 
 ### `dns_options`
 
@@ -26,22 +16,12 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
 
 Describes the DNS options for an endpoint.
 
-### `id`
-
-- **Type:** String
-- **Read-only**
-
 ### `ip_address_type`
 
 - **Type:** Enum (IpAddressType)
 - **Required:** No
 
 The supported IP address types.
-
-### `network_interface_ids`
-
-- **Type:** List
-- **Read-only**
 
 ### `policy_document`
 
@@ -126,6 +106,24 @@ The type of endpoint. Default: Gateway
 - **Required:** Yes
 
 The ID of the VPC.
+
+## Attribute Reference
+
+### `creation_timestamp`
+
+- **Type:** String
+
+### `dns_entries`
+
+- **Type:** List
+
+### `id`
+
+- **Type:** String
+
+### `network_interface_ids`
+
+- **Type:** List
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
@@ -4,12 +4,7 @@ CloudFormation Type: `AWS::EC2::VPCGatewayAttachment`
 
 Resource Type definition for AWS::EC2::VPCGatewayAttachment
 
-## Attributes
-
-### `attachment_type`
-
-- **Type:** String
-- **Read-only**
+## Argument Reference
 
 ### `internet_gateway_id`
 
@@ -31,6 +26,12 @@ The ID of the VPC.
 - **Required:** No
 
 The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.
+
+## Attribute Reference
+
+### `attachment_type`
+
+- **Type:** String
 
 
 


### PR DESCRIPTION
## Summary

- Split the single "Attributes" section into "Argument Reference" (writable) and "Attribute Reference" (read-only) in generated documentation, following Terraform-style conventions
- Extract type display logic into a reusable `type_display_string()` helper function in codegen
- Regenerate all awscc provider documentation files

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — all 192 tests pass
- [x] Pre-commit checks (formatting, clippy, tests) pass
- [x] Verify `ec2_vpc.md`: writable attrs (`cidr_block`, `enable_dns_*`, `instance_tenancy`, `tags`) under "Argument Reference"; read-only attrs (`vpc_id`, `default_network_acl`, `default_security_group`, `cidr_block_associations`, `ipv6_cidr_blocks`) under "Attribute Reference"

🤖 Generated with [Claude Code](https://claude.com/claude-code)