### PR TITLE
Fix codegen CIDR detection for CidrIp properties

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -41,7 +41,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("security_group_egress", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "Egress".to_string(),
                     fields: vec![
-                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("destination_prefix_list_id", AttributeType::String).with_provider_name("DestinationPrefixListId"),
@@ -58,7 +58,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("security_group_ingress", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "Ingress".to_string(),
                     fields: vec![
-                    StructField::new("cidr_ip", AttributeType::String).with_provider_name("CidrIp"),
+                    StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -29,7 +29,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_security_group_egress")
         .with_description("Adds the specified outbound (egress) rule to a security group.  An outbound rule permits instances to send traffic to the specified IPv4 or IPv6 address range, the IP addresses that are specified by a...")
         .attribute(
-            AttributeSchema::new("cidr_ip", AttributeType::String)
+            AttributeSchema::new("cidr_ip", types::ipv4_cidr())
                 .with_description("The IPv4 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``Des...")
                 .with_provider_name("CidrIp"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -29,7 +29,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_security_group_ingress")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroupIngress")
         .attribute(
-            AttributeSchema::new("cidr_ip", AttributeType::String)
+            AttributeSchema::new("cidr_ip", types::ipv4_cidr())
                 .with_description("The IPv4 ranges")
                 .with_provider_name("CidrIp"),
         )


### PR DESCRIPTION
## Summary

- Fix codegen bug where `CidrIp` properties were incorrectly typed as `String` instead of `types::ipv4_cidr()`
- Root cause: lowercased PascalCase `"cidrip"` was compared against snake_case `"cidr_ip"`, which never matched
- Simplify CIDR detection logic: any property containing "cidr" is a CIDR field (IPv6 if also contains "ipv6", otherwise IPv4)
- Regenerated affected schemas: `security_group.rs`, `security_group_ingress.rs`, `security_group_egress.rs`

## Test plan

- [x] Added unit tests for `CidrIp` → `types::ipv4_cidr()` and `CidrIpv6` → `types::ipv6_cidr()` detection
- [x] Regenerated schemas and verified `cidr_ip` fields now use `types::ipv4_cidr()`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)