### PR TITLE
Add IPv4/IPv6 address types for stricter IP validation

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for ec2_eip (AWS::EC2::EIP)
 pub fn ec2_eip_config() -> AwsccSchemaConfig {
@@ -47,7 +47,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("NetworkBorderGroup"),
         )
         .attribute(
-            AttributeSchema::new("public_ip", AttributeType::String)
+            AttributeSchema::new("public_ip", types::ipv4_address())
                 .with_description(" (read-only)")
                 .with_provider_name("PublicIp"),
         )

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
 const VALID_CONNECTIVITY_TYPE: &[&str] = &["public", "private"];
 
@@ -87,7 +87,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("NatGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("private_ip_address", AttributeType::String)
+            AttributeSchema::new("private_ip_address", types::ipv4_address())
                 .with_description("The private IPv4 address to assign to the NAT gateway. If you don't provide an address, a private IPv4 address will be automatically assigned.")
                 .with_provider_name("PrivateIpAddress"),
         )
@@ -107,7 +107,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("SecondaryPrivateIpAddressCount"),
         )
         .attribute(
-            AttributeSchema::new("secondary_private_ip_addresses", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("secondary_private_ip_addresses", AttributeType::List(Box::new(types::ipv4_address())))
                 .with_description("Secondary private IPv4 addresses. For more information about secondary addresses, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/us...")
                 .with_provider_name("SecondaryPrivateIpAddresses"),
         )

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -72,7 +72,7 @@ The Elastic IP address you are accepting for transfer. You can only accept one t
 
 ### `public_ip`
 
-- **Type:** String
+- **Type:** Ipv4Address
 
 
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -46,7 +46,7 @@ The maximum amount of time to wait (in seconds) before forcibly releasing the IP
 
 ### `private_ip_address`
 
-- **Type:** String
+- **Type:** Ipv4Address
 - **Required:** No
 
 The private IPv4 address to assign to the NAT gateway. If you don't provide an address, a private IPv4 address will be automatically assigned.


### PR DESCRIPTION
## Summary

- Add `types::ipv4_address()` and `types::ipv6_address()` to carina-core for validating standalone IP addresses (distinct from CIDR blocks)
- Refactor `validate_ipv4_cidr()` to reuse `validate_ipv4_address()`, make `validate_ipv6_address()` public
- Add IP address detection heuristics to codegen: properties containing "ipaddress" or ending with "ip" (excluding CIDR, count, type) are mapped to the appropriate IP address type
- Affected fields: `private_ip_address`, `secondary_private_ip_addresses` (NatGateway), `public_ip` (EIP)
- Regenerated schemas and docs

## Test plan

- [x] Added unit tests for `types::ipv4_address()` and `types::ipv6_address()` validation
- [x] Added codegen tests for IP address detection (PrivateIpAddress, PublicIp, SecondaryPrivateIpAddressCount stays Int)
- [x] All existing tests pass
- [x] Regenerated schemas and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)