### PR TITLE
Add AvailabilityZone type with format validation

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -54,7 +54,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                     name: "AvailabilityZoneAddress".to_string(),
                     fields: vec![
                     StructField::new("allocation_ids", AttributeType::List(Box::new(AttributeType::String))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
-                    StructField::new("availability_zone", AttributeType::String).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
+                    StructField::new("availability_zone", types::availability_zone()).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
                     StructField::new("availability_zone_id", AttributeType::String).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
                     ],
                 })))

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -22,7 +22,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("AssignIpv6AddressOnCreation"),
         )
         .attribute(
-            AttributeSchema::new("availability_zone", AttributeType::String)
+            AttributeSchema::new("availability_zone", types::availability_zone())
                 .with_description("The Availability Zone of the subnet. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("AvailabilityZone"),
         )

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -133,7 +133,7 @@ Shorthand formats: `public` or `ConnectivityType.public`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `allocation_ids` | List | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
-| `availability_zone` | String | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
+| `availability_zone` | AvailabilityZone | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
 | `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
 
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -17,7 +17,7 @@ Indicates whether a network interface created in this subnet receives an IPv6 ad
 
 ### `availability_zone`
 
-- **Type:** String
+- **Type:** AvailabilityZone
 - **Required:** No
 
 The Availability Zone of the subnet. If you update this property, you must also update the ``CidrBlock`` property.


### PR DESCRIPTION
## Summary

- Add `types::availability_zone()` to carina-core that validates AZ format (e.g., `us-east-1a`) using pattern matching
- Unlike the AWS provider's hardcoded enum approach, this format-based validation works for all regions without maintenance
- Add AZ detection to codegen: `AvailabilityZone` properties use the validated type, `AvailabilityZoneId` stays as String
- Affected schemas: `subnet.rs` (top-level), `nat_gateway.rs` (struct field)
- Regenerated schemas and docs

## Test plan

- [x] Added unit tests for `types::availability_zone()` type validation
- [x] Added `validate_availability_zone()` function tests (valid/invalid formats)
- [x] Added codegen test verifying AvailabilityZone vs AvailabilityZoneId detection
- [x] All existing tests pass
- [x] Regenerated schemas and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)