### PR TITLE
Add AwsResourceId type for resource ID format validation

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -22,7 +22,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("Address"),
         )
         .attribute(
-            AttributeSchema::new("allocation_id", AttributeType::String)
+            AttributeSchema::new("allocation_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("AllocationId"),
         )
@@ -32,12 +32,12 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("Domain"),
         )
         .attribute(
-            AttributeSchema::new("instance_id", AttributeType::String)
+            AttributeSchema::new("instance_id", types::aws_resource_id())
                 .with_description("The ID of the instance.  Updates to the ``InstanceId`` property may require *some interruptions*. Updates on an EIP reassociates the address on its as...")
                 .with_provider_name("InstanceId"),
         )
         .attribute(
-            AttributeSchema::new("ipam_pool_id", AttributeType::String)
+            AttributeSchema::new("ipam_pool_id", types::aws_resource_id())
                 .with_description("")
                 .with_provider_name("IpamPoolId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 
 /// Returns the schema config for ec2_internet_gateway (AWS::EC2::InternetGateway)
 pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
@@ -17,7 +17,7 @@ pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_internet_gateway")
         .with_description("Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.")
         .attribute(
-            AttributeSchema::new("internet_gateway_id", AttributeType::String)
+            AttributeSchema::new("internet_gateway_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("InternetGatewayId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -30,7 +30,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_nat_gateway")
         .with_description("Specifies a network address translation (NAT) gateway in the specified subnet. You can create either a public NAT gateway or a private NAT gateway. The default is a public NAT gateway. If you create a...")
         .attribute(
-            AttributeSchema::new("allocation_id", AttributeType::String)
+            AttributeSchema::new("allocation_id", types::aws_resource_id())
                 .with_description("[Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public N...")
                 .with_provider_name("AllocationId"),
         )
@@ -72,7 +72,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("ConnectivityType"),
         )
         .attribute(
-            AttributeSchema::new("eni_id", AttributeType::String)
+            AttributeSchema::new("eni_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("EniId"),
         )
@@ -82,7 +82,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("MaxDrainDurationSeconds"),
         )
         .attribute(
-            AttributeSchema::new("nat_gateway_id", AttributeType::String)
+            AttributeSchema::new("nat_gateway_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("NatGatewayId"),
         )
@@ -92,7 +92,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrivateIpAddress"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", AttributeType::String)
+            AttributeSchema::new("route_table_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("RouteTableId"),
         )
@@ -112,7 +112,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("SecondaryPrivateIpAddresses"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", AttributeType::String)
+            AttributeSchema::new("subnet_id", types::aws_resource_id())
                 .with_description("The ID of the subnet in which the NAT gateway is located.")
                 .with_provider_name("SubnetId"),
         )
@@ -122,7 +122,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .with_description("The ID of the VPC in which the NAT gateway is located.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 
 /// Returns the schema config for ec2_route (AWS::EC2::Route)
 pub fn ec2_route_config() -> AwsccSchemaConfig {
@@ -16,7 +16,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_route")
         .with_description("Specifies a route in a route table. For more information, see [Routes](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#route-table-routes) in the *Amazon VPC User Guide*.  You m...")
         .attribute(
-            AttributeSchema::new("carrier_gateway_id", AttributeType::String)
+            AttributeSchema::new("carrier_gateway_id", types::aws_resource_id())
                 .with_description("The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.")
                 .with_provider_name("CarrierGatewayId"),
         )
@@ -41,58 +41,58 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("DestinationIpv6CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("destination_prefix_list_id", AttributeType::String)
+            AttributeSchema::new("destination_prefix_list_id", types::aws_resource_id())
                 .with_description("The ID of a prefix list used for the destination match.")
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("egress_only_internet_gateway_id", AttributeType::String)
+            AttributeSchema::new("egress_only_internet_gateway_id", types::aws_resource_id())
                 .with_description("[IPv6 traffic only] The ID of an egress-only internet gateway.")
                 .with_provider_name("EgressOnlyInternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("gateway_id", AttributeType::String)
+            AttributeSchema::new("gateway_id", types::aws_resource_id())
                 .with_description("The ID of an internet gateway or virtual private gateway attached to your VPC.")
                 .with_provider_name("GatewayId"),
         )
         .attribute(
-            AttributeSchema::new("instance_id", AttributeType::String)
+            AttributeSchema::new("instance_id", types::aws_resource_id())
                 .with_description("The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.")
                 .with_provider_name("InstanceId"),
         )
         .attribute(
-            AttributeSchema::new("local_gateway_id", AttributeType::String)
+            AttributeSchema::new("local_gateway_id", types::aws_resource_id())
                 .with_description("The ID of the local gateway.")
                 .with_provider_name("LocalGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("nat_gateway_id", AttributeType::String)
+            AttributeSchema::new("nat_gateway_id", types::aws_resource_id())
                 .with_description("[IPv4 traffic only] The ID of a NAT gateway.")
                 .with_provider_name("NatGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("network_interface_id", AttributeType::String)
+            AttributeSchema::new("network_interface_id", types::aws_resource_id())
                 .with_description("The ID of a network interface.")
                 .with_provider_name("NetworkInterfaceId"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", AttributeType::String)
+            AttributeSchema::new("route_table_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the route table for the route.")
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
-            AttributeSchema::new("transit_gateway_id", AttributeType::String)
+            AttributeSchema::new("transit_gateway_id", types::aws_resource_id())
                 .with_description("The ID of a transit gateway.")
                 .with_provider_name("TransitGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_endpoint_id", AttributeType::String)
+            AttributeSchema::new("vpc_endpoint_id", types::aws_resource_id())
                 .with_description("The ID of a VPC endpoint. Supported for Gateway Load Balancer endpoints only.")
                 .with_provider_name("VpcEndpointId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_peering_connection_id", AttributeType::String)
+            AttributeSchema::new("vpc_peering_connection_id", types::aws_resource_id())
                 .with_description("The ID of a VPC peering connection.")
                 .with_provider_name("VpcPeeringConnectionId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 
 /// Returns the schema config for ec2_route_table (AWS::EC2::RouteTable)
 pub fn ec2_route_table_config() -> AwsccSchemaConfig {
@@ -17,7 +17,7 @@ pub fn ec2_route_table_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_route_table")
         .with_description("Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.  For more information, see [Route tables](https://docs.aws.amaz...")
         .attribute(
-            AttributeSchema::new("route_table_id", AttributeType::String)
+            AttributeSchema::new("route_table_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("RouteTableId"),
         )
@@ -27,7 +27,7 @@ pub fn ec2_route_table_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -23,7 +23,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("GroupDescription"),
         )
         .attribute(
-            AttributeSchema::new("group_id", AttributeType::String)
+            AttributeSchema::new("group_id", types::aws_resource_id())
                 .with_description("The group ID of the specified security group. (read-only)")
                 .with_provider_name("GroupId"),
         )
@@ -44,8 +44,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
-                    StructField::new("destination_prefix_list_id", AttributeType::String).with_provider_name("DestinationPrefixListId"),
-                    StructField::new("destination_security_group_id", AttributeType::String).with_provider_name("DestinationSecurityGroupId"),
+                    StructField::new("destination_prefix_list_id", types::aws_resource_id()).with_provider_name("DestinationPrefixListId"),
+                    StructField::new("destination_security_group_id", types::aws_resource_id()).with_provider_name("DestinationSecurityGroupId"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Enum(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string()])).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
@@ -63,8 +63,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Enum(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string()])).required().with_provider_name("IpProtocol"),
-                    StructField::new("source_prefix_list_id", AttributeType::String).with_provider_name("SourcePrefixListId"),
-                    StructField::new("source_security_group_id", AttributeType::String).with_provider_name("SourceSecurityGroupId"),
+                    StructField::new("source_prefix_list_id", types::aws_resource_id()).with_provider_name("SourcePrefixListId"),
+                    StructField::new("source_security_group_id", types::aws_resource_id()).with_provider_name("SourceSecurityGroupId"),
                     StructField::new("source_security_group_name", AttributeType::String).with_provider_name("SourceSecurityGroupName"),
                     StructField::new("source_security_group_owner_id", AttributeType::String).with_provider_name("SourceSecurityGroupOwnerId"),
                     StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
@@ -79,7 +79,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .with_description("The ID of the VPC for the security group.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -44,12 +44,12 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("destination_prefix_list_id", AttributeType::String)
+            AttributeSchema::new("destination_prefix_list_id", types::aws_resource_id())
                 .with_description("The prefix list IDs for an AWS service. This is the AWS service to access through a VPC endpoint from instances associated with the security group. Yo...")
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("destination_security_group_id", AttributeType::String)
+            AttributeSchema::new("destination_security_group_id", types::aws_resource_id())
                 .with_description("The ID of the security group. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSe...")
                 .with_provider_name("DestinationSecurityGroupId"),
         )
@@ -59,7 +59,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", AttributeType::String)
+            AttributeSchema::new("group_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -49,7 +49,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", AttributeType::String)
+            AttributeSchema::new("group_id", types::aws_resource_id())
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),
         )
@@ -75,12 +75,12 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
-            AttributeSchema::new("source_prefix_list_id", AttributeType::String)
+            AttributeSchema::new("source_prefix_list_id", types::aws_resource_id())
                 .with_description("[EC2-VPC only] The ID of a prefix list. ")
                 .with_provider_name("SourcePrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("source_security_group_id", AttributeType::String)
+            AttributeSchema::new("source_security_group_id", types::aws_resource_id())
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name. For security groups in a nondefault VPC, you m...")
                 .with_provider_name("SourceSecurityGroupId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -57,7 +57,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("EnableLniAtDeviceIndex"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_ipam_pool_id", AttributeType::String)
+            AttributeSchema::new("ipv4_ipam_pool_id", types::aws_resource_id())
                 .with_description("An IPv4 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv4IpamPoolId"),
         )
@@ -77,7 +77,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("Ipv6CidrBlocks"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_ipam_pool_id", AttributeType::String)
+            AttributeSchema::new("ipv6_ipam_pool_id", types::aws_resource_id())
                 .with_description("An IPv6 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv6IpamPoolId"),
         )
@@ -119,7 +119,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrivateDnsNameOptionsOnLaunch"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", AttributeType::String)
+            AttributeSchema::new("subnet_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("SubnetId"),
         )
@@ -129,7 +129,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for ec2_subnet_route_table_association (AWS::EC2::SubnetRouteTableAssociation)
 pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
@@ -21,13 +21,13 @@ pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", AttributeType::String)
+            AttributeSchema::new("route_table_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the route table. The physical ID changes when the route table ID is changed.")
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", AttributeType::String)
+            AttributeSchema::new("subnet_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the subnet.")
                 .with_provider_name("SubnetId"),

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -70,7 +70,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_provider_name("InstanceTenancy"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_ipam_pool_id", AttributeType::String)
+            AttributeSchema::new("ipv4_ipam_pool_id", types::aws_resource_id())
                 .with_description("The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc...")
                 .with_provider_name("Ipv4IpamPoolId"),
         )
@@ -90,7 +90,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -150,7 +150,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("VpcEndpointType"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for ec2_vpc_gateway_attachment (AWS::EC2::VPCGatewayAttachment)
 pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
@@ -21,18 +21,18 @@ pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
                 .with_provider_name("AttachmentType"),
         )
         .attribute(
-            AttributeSchema::new("internet_gateway_id", AttributeType::String)
+            AttributeSchema::new("internet_gateway_id", types::aws_resource_id())
                 .with_description("The ID of the internet gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.")
                 .with_provider_name("InternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", AttributeType::String)
+            AttributeSchema::new("vpc_id", types::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )
         .attribute(
-            AttributeSchema::new("vpn_gateway_id", AttributeType::String)
+            AttributeSchema::new("vpn_gateway_id", types::aws_resource_id())
                 .with_description("The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.")
                 .with_provider_name("VpnGatewayId"),
         )

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -24,14 +24,14 @@ The network (``vpc``). If you define an Elastic IP address and associate it with
 
 ### `instance_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the instance.  Updates to the ``InstanceId`` property may require *some interruptions*. Updates on an EIP reassociates the address on its associated resource.
 
 ### `ipam_pool_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 
@@ -68,7 +68,7 @@ The Elastic IP address you are accepting for transfer. You can only accept one t
 
 ### `allocation_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ### `public_ip`
 

--- a/docs/src/providers/awscc/ec2_internet_gateway.md
+++ b/docs/src/providers/awscc/ec2_internet_gateway.md
@@ -17,7 +17,7 @@ Any tags to assign to the internet gateway.
 
 ### `internet_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -11,7 +11,7 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
 
 ### `allocation_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 [Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public NAT gateway and cannot be specified with a private NAT gateway.
@@ -74,7 +74,7 @@ Secondary private IPv4 addresses. For more information about secondary addresses
 
 ### `subnet_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the subnet in which the NAT gateway is located.
@@ -88,7 +88,7 @@ The tags for the NAT gateway.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the VPC in which the NAT gateway is located.
@@ -105,15 +105,15 @@ The ID of the VPC in which the NAT gateway is located.
 
 ### `eni_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ### `nat_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ### `route_table_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_route.md
+++ b/docs/src/providers/awscc/ec2_route.md
@@ -10,7 +10,7 @@ Specifies a route in a route table. For more information, see [Routes](https://d
 
 ### `carrier_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.
@@ -38,77 +38,77 @@ The IPv6 CIDR block used for the destination match. Routing decisions are based 
 
 ### `destination_prefix_list_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a prefix list used for the destination match.
 
 ### `egress_only_internet_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 [IPv6 traffic only] The ID of an egress-only internet gateway.
 
 ### `gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of an internet gateway or virtual private gateway attached to your VPC.
 
 ### `instance_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.
 
 ### `local_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the local gateway.
 
 ### `nat_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 [IPv4 traffic only] The ID of a NAT gateway.
 
 ### `network_interface_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a network interface.
 
 ### `route_table_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the route table for the route.
 
 ### `transit_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a transit gateway.
 
 ### `vpc_endpoint_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a VPC endpoint. Supported for Gateway Load Balancer endpoints only.
 
 ### `vpc_peering_connection_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of a VPC peering connection.

--- a/docs/src/providers/awscc/ec2_route_table.md
+++ b/docs/src/providers/awscc/ec2_route_table.md
@@ -16,7 +16,7 @@ Any tags assigned to the route table.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the VPC.
@@ -25,7 +25,7 @@ The ID of the VPC.
 
 ### `route_table_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -43,7 +43,7 @@ Any tags assigned to the security group.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the VPC for the security group.
@@ -52,7 +52,7 @@ The ID of the VPC for the security group.
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ### `id`
 
@@ -67,8 +67,8 @@ The ID of the VPC for the security group.
 | `cidr_ip` | Ipv4Cidr | No |  |
 | `cidr_ipv6` | Ipv6Cidr | No |  |
 | `description` | String | No |  |
-| `destination_prefix_list_id` | String | No |  |
-| `destination_security_group_id` | String | No |  |
+| `destination_prefix_list_id` | AwsResourceId | No |  |
+| `destination_security_group_id` | AwsResourceId | No |  |
 | `from_port` | Int | No |  |
 | `ip_protocol` | Enum | Yes |  |
 | `to_port` | Int | No |  |
@@ -82,8 +82,8 @@ The ID of the VPC for the security group.
 | `description` | String | No |  |
 | `from_port` | Int | No |  |
 | `ip_protocol` | Enum | Yes |  |
-| `source_prefix_list_id` | String | No |  |
-| `source_security_group_id` | String | No |  |
+| `source_prefix_list_id` | AwsResourceId | No |  |
+| `source_security_group_id` | AwsResourceId | No |  |
 | `source_security_group_name` | String | No |  |
 | `source_security_group_owner_id` | String | No |  |
 | `to_port` | Int | No |  |

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -33,14 +33,14 @@ The description of an egress (outbound) security group rule. Constraints: Up to 
 
 ### `destination_prefix_list_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The prefix list IDs for an AWS service. This is the AWS service to access through a VPC endpoint from instances associated with the security group. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSecurityGroupId``.
 
 ### `destination_security_group_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the security group. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSecurityGroupId``.
@@ -54,7 +54,7 @@ If the protocol is TCP or UDP, this is the start of the port range. If the proto
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID.

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -36,7 +36,7 @@ The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type nu
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID. You must specify the GroupName property or the GroupId property. For security groups that are in a VPC, you must use the GroupId property.
@@ -57,14 +57,14 @@ The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers). 
 
 ### `source_prefix_list_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 [EC2-VPC only] The ID of a prefix list. 
 
 ### `source_security_group_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the security group. You must specify either the security group ID or the security group name. For security groups in a nondefault VPC, you must specify the security group ID.

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -52,7 +52,7 @@ Indicates the device position for local network interfaces in this subnet. For e
 
 ### `ipv4_ipam_pool_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 An IPv4 IPAM pool ID for the subnet.
@@ -73,7 +73,7 @@ The IPv6 CIDR block. If you specify ``AssignIpv6AddressOnCreation``, you must al
 
 ### `ipv6_ipam_pool_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 An IPv6 IPAM pool ID for the subnet.
@@ -122,7 +122,7 @@ Any tags assigned to the subnet.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.
@@ -143,7 +143,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 ### `subnet_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ## Struct Definitions
 

--- a/docs/src/providers/awscc/ec2_subnet_route_table_association.md
+++ b/docs/src/providers/awscc/ec2_subnet_route_table_association.md
@@ -8,14 +8,14 @@ Associates a subnet with a route table. The subnet and route table must be in th
 
 ### `route_table_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the route table. The physical ID changes when the route table ID is changed.
 
 ### `subnet_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the subnet.

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -38,7 +38,7 @@ The allowed tenancy of instances launched into the VPC.  + ``default``: An insta
 
 ### `ipv4_ipam_pool_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc/latest/ipam/what-is-it-ipam.html) in the *Amazon VPC IPAM User Guide*. You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``.
@@ -77,7 +77,7 @@ The tags for the VPC.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 
 ## Enum Values
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -102,7 +102,7 @@ The type of endpoint. Default: Gateway
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the VPC.

--- a/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
@@ -8,21 +8,21 @@ Resource Type definition for AWS::EC2::VPCGatewayAttachment
 
 ### `internet_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the internet gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.
 
 ### `vpc_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** Yes
 
 The ID of the VPC.
 
 ### `vpn_gateway_id`
 
-- **Type:** String
+- **Type:** AwsResourceId
 - **Required:** No
 
 The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.


### PR DESCRIPTION
## Summary

- Add `types::aws_resource_id()` to carina-core that validates the standard AWS resource ID format (`prefix-hexdigits`, e.g., `vpc-1a2b3c4d`, `subnet-0123456789abcdef0`)
- Add `is_aws_resource_id_property()` to codegen for detecting known resource ID properties (VpcId, SubnetId, GroupId, RouteTableId, GatewayId, AllocationId, etc.)
- Exclude non-standard ID properties: AvailabilityZoneId, OwnerId, ResourceId
- Improve codegen import generation to conditionally include `AttributeType` only when used
- ResourceRef values are still accepted (skipped by Custom type validation)
- Regenerated all schemas and docs (28 files changed)

## Test plan

- [x] Added unit tests for `types::aws_resource_id()` validation (valid/invalid IDs, ResourceRef acceptance)
- [x] Added codegen test for `is_aws_resource_id_property()` detection
- [x] All existing tests pass
- [x] No unused import warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)