### PR TITLE
Improve documentation for AttributeType::Struct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,20 @@ Enum values use namespaced identifiers like `aws.s3.VersioningStatus.Enabled` or
 
 5. **Always test with actual values** - Don't assume pattern matching works; write a quick test to verify
 
+### Struct Types
+
+`AttributeType::Struct` represents nested objects with typed fields.
+
+**Key points:**
+- Defined in `carina-core/src/schema.rs` as `Struct { name, fields: Vec<StructField> }`
+- Each `StructField` has: `name`, `field_type` (recursive AttributeType), `required`, `description`
+- AWSCC provider converts between DSL snake_case and CloudFormation PascalCase (see `carina-provider-awscc/src/provider.rs`)
+- Codegen resolves CloudFormation `$ref` and inline object definitions into Struct types
+
+**LSP integration:**
+- When adding Struct validation, update `carina-lsp/src/diagnostics.rs` to validate nested fields
+- Completion should work recursively for struct fields
+
 ### Module Loading
 
 Directory-based modules (e.g., `modules/web_tier/`) require special handling:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,33 @@ versioning = Enabled
 instance_tenancy = dedicated
 ```
 
+### Nested Objects (Struct Types)
+
+Some resources support nested objects for inline configuration:
+
+```hcl
+awscc.ec2_security_group {
+  name              = "web-sg"
+  vpc_id            = vpc.vpc_id
+  group_description = "Web server security group"
+
+  security_group_ingress = [
+    {
+      ip_protocol = "tcp"
+      from_port   = 80
+      to_port     = 80
+      cidr_ip     = "0.0.0.0/0"
+    },
+    {
+      ip_protocol = "tcp"
+      from_port   = 443
+      to_port     = 443
+      cidr_ip     = "0.0.0.0/0"
+    }
+  ]
+}
+```
+
 ### Modules
 
 Modules enable reusable infrastructure components with typed inputs and outputs.

--- a/carina-provider-awscc/examples/ec2_security_group/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group/main.crn
@@ -16,6 +16,21 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 
+  security_group_ingress = [
+    {
+      ip_protocol = "tcp"
+      from_port   = 80
+      to_port     = 80
+      cidr_ip     = "0.0.0.0/0"
+    },
+    {
+      ip_protocol = "tcp"
+      from_port   = 443
+      to_port     = 443
+      cidr_ip     = "0.0.0.0/0"
+    }
+  ]
+
   tags = {
     Environment = "example"
   }

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -53,7 +53,7 @@ The private IPv4 address to assign to the NAT gateway. If you don't provide an a
 
 ### `secondary_allocation_ids`
 
-- **Type:** List
+- **Type:** List<String>
 - **Required:** No
 
 Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-working-with.html) in the *Amazon VPC User Guide*.
@@ -67,7 +67,7 @@ Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](h
 
 ### `secondary_private_ip_addresses`
 
-- **Type:** List
+- **Type:** List<String>
 - **Required:** No
 
 Secondary private IPv4 addresses. For more information about secondary addresses, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-creating) in the *Amazon Virtual Private Cloud User Guide*. ``SecondaryPrivateIpAddressCount`` and ``SecondaryPrivateIpAddresses`` cannot be set at the same time.
@@ -132,7 +132,7 @@ Shorthand formats: `public` or `ConnectivityType.public`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `allocation_ids` | List | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
+| `allocation_ids` | List<String> | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
 | `availability_zone` | AvailabilityZone | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
 | `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
 

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -103,6 +103,21 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 
+  security_group_ingress = [
+    {
+      ip_protocol = "tcp"
+      from_port   = 80
+      to_port     = 80
+      cidr_ip     = "0.0.0.0/0"
+    },
+    {
+      ip_protocol = "tcp"
+      from_port   = 443
+      to_port     = 443
+      cidr_ip     = "0.0.0.0/0"
+    }
+  ]
+
   tags = {
     Environment = "example"
   }

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -135,7 +135,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 ### `ipv6_cidr_blocks`
 
-- **Type:** List
+- **Type:** List<String>
 
 ### `network_acl_association_id`
 

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -61,7 +61,7 @@ The tags for the VPC.
 
 ### `cidr_block_associations`
 
-- **Type:** List
+- **Type:** List<String>
 
 ### `default_network_acl`
 
@@ -73,7 +73,7 @@ The tags for the VPC.
 
 ### `ipv6_cidr_blocks`
 
-- **Type:** List
+- **Type:** List<String>
 
 ### `vpc_id`
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -46,14 +46,14 @@ The Amazon Resource Name (ARN) of the resource configuration.
 
 ### `route_table_ids`
 
-- **Type:** List
+- **Type:** List<String>
 - **Required:** No
 
 The IDs of the route tables. Routing is supported only for gateway endpoints.
 
 ### `security_group_ids`
 
-- **Type:** List
+- **Type:** List<String>
 - **Required:** No
 
 The IDs of the security groups to associate with the endpoint network interfaces. If this parameter is not specified, we use the default security group for the VPC. Security groups are supported only for interface endpoints.
@@ -81,7 +81,7 @@ Describes a Region.
 
 ### `subnet_ids`
 
-- **Type:** List
+- **Type:** List<String>
 - **Required:** No
 
 The IDs of the subnets in which to create endpoint network interfaces. You must specify this property for an interface endpoint or a Gateway Load Balancer endpoint. You can't specify this property for a gateway endpoint. For a Gateway Load Balancer endpoint, you can specify only one subnet.
@@ -115,7 +115,7 @@ The ID of the VPC.
 
 ### `dns_entries`
 
-- **Type:** List
+- **Type:** List<String>
 
 ### `id`
 
@@ -123,7 +123,7 @@ The ID of the VPC.
 
 ### `network_interface_ids`
 
-- **Type:** List
+- **Type:** List<String>
 
 ## Enum Values
 
@@ -159,7 +159,7 @@ Shorthand formats: `Interface` or `VpcEndpointType.Interface`
 | `dns_record_ip_type` | String | No | The DNS records created for the endpoint. |
 | `private_dns_only_for_inbound_resolver_endpoint` | String | No | Indicates whether to enable private DNS only for inbound endpoints. This option is available only fo... |
 | `private_dns_preference` | String | No | The preference for which private domains have a private hosted zone created for and associated with ... |
-| `private_dns_specified_domains` | List | No | Indicates which of the private domains to create private hosted zones for and associate with the spe... |
+| `private_dns_specified_domains` | List<String> | No | Indicates which of the private domains to create private hosted zones for and associate with the spe... |
 
 
 


### PR DESCRIPTION
## Summary

- Fix codegen to display `List<String>`, `List<Int>`, `List<Bool>` instead of bare `List` for primitive element types in generated docs
- Add Struct usage examples (nested objects) to README.md DSL Syntax section
- Add Struct implementation guidelines to CLAUDE.md
- Update ec2_security_group example to demonstrate `security_group_ingress` with inline struct syntax
- Regenerate docs with corrected List element types

Closes #61

## Test plan

- [x] All existing tests pass (203 tests)
- [x] New `test_list_element_type_display` test added for the helper function
- [x] Regenerated docs verified: no bare `List` types remain
- [x] Pre-commit hooks (fmt, clippy, tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)