### PR TITLE
Add IpamPoolId dedicated type (closes #81)

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -187,6 +187,42 @@ pub fn validate_namespaced_enum(
     }
 }
 
+/// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
+/// Validates format: ipam-pool-{hex} where hex is 8+ hex digits
+pub fn ipam_pool_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "IpamPoolId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_ipam_pool_id(s)
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+    }
+}
+
+pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
+    let Some(hex_part) = id.strip_prefix("ipam-pool-") else {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': expected format 'ipam-pool-{{hex}}'", id
+        ));
+    };
+    if hex_part.len() < 8 {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': hex part must be at least 8 characters", id
+        ));
+    }
+    if !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': hex part must contain only hex digits", id
+        ));
+    }
+    Ok(())
+}
+
 EOF
 
 # Add module declarations

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -37,7 +37,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("InstanceId"),
         )
         .attribute(
-            AttributeSchema::new("ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("ipam_pool_id", super::ipam_pool_id())
                 .with_description("")
                 .with_provider_name("IpamPoolId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -120,7 +120,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpamArn"),
         )
         .attribute(
-            AttributeSchema::new("ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("ipam_pool_id", super::ipam_pool_id())
                 .with_description("Id of the IPAM Pool. (read-only)")
                 .with_provider_name("IpamPoolId"),
         )
@@ -181,7 +181,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("PubliclyAdvertisable"),
         )
         .attribute(
-            AttributeSchema::new("source_ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("source_ipam_pool_id", super::ipam_pool_id())
                 .with_description("The Id of this pool's source. If set, all space provisioned in this pool must be free space provisioned in the parent pool.")
                 .with_provider_name("SourceIpamPoolId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -105,6 +105,45 @@ pub fn validate_namespaced_enum(
     }
 }
 
+/// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
+/// Validates format: ipam-pool-{hex} where hex is 8+ hex digits
+pub fn ipam_pool_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "IpamPoolId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_ipam_pool_id(s)
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+    }
+}
+
+pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
+    let Some(hex_part) = id.strip_prefix("ipam-pool-") else {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': expected format 'ipam-pool-{{hex}}'",
+            id
+        ));
+    };
+    if hex_part.len() < 8 {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': hex part must be at least 8 characters",
+            id
+        ));
+    }
+    if !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "Invalid IPAM Pool ID '{}': hex part must contain only hex digits",
+            id
+        ));
+    }
+    Ok(())
+}
+
 pub mod egress_only_internet_gateway;
 pub mod eip;
 pub mod flow_log;

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -57,7 +57,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("EnableLniAtDeviceIndex"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())
                 .with_description("An IPv4 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv4IpamPoolId"),
         )
@@ -77,7 +77,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("Ipv6CidrBlocks"),
         )
         .attribute(
-            AttributeSchema::new("ipv6_ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("ipv6_ipam_pool_id", super::ipam_pool_id())
                 .with_description("An IPv6 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv6IpamPoolId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -70,7 +70,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_provider_name("InstanceTenancy"),
         )
         .attribute(
-            AttributeSchema::new("ipv4_ipam_pool_id", types::aws_resource_id())
+            AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())
                 .with_description("The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc...")
                 .with_provider_name("Ipv4IpamPoolId"),
         )

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -31,7 +31,7 @@ The ID of the instance.  Updates to the ``InstanceId`` property may require *som
 
 ### `ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 - **Required:** No
 
 

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -97,7 +97,7 @@ Determines whether or not address space from this pool is publicly advertised. M
 
 ### `source_ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 - **Required:** No
 
 The Id of this pool's source. If set, all space provisioned in this pool must be free space provisioned in the parent pool.
@@ -126,7 +126,7 @@ An array of key-value pairs to apply to this resource.
 
 ### `ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 
 ### `ipam_scope_arn`
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -52,7 +52,7 @@ Indicates the device position for local network interfaces in this subnet. For e
 
 ### `ipv4_ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 - **Required:** No
 
 An IPv4 IPAM pool ID for the subnet.
@@ -73,7 +73,7 @@ The IPv6 CIDR block. If you specify ``AssignIpv6AddressOnCreation``, you must al
 
 ### `ipv6_ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 - **Required:** No
 
 An IPv6 IPAM pool ID for the subnet.

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -38,7 +38,7 @@ The allowed tenancy of instances launched into the VPC.  + ``default``: An insta
 
 ### `ipv4_ipam_pool_id`
 
-- **Type:** AwsResourceId
+- **Type:** IpamPoolId
 - **Required:** No
 
 The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc/latest/ipam/what-is-it-ipam.html) in the *Amazon VPC IPAM User Guide*. You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``.


### PR DESCRIPTION
## Summary

- Introduce `IpamPoolId` custom type that validates `ipam-pool-{hex}` format (8+ hex digits)
- Remove `poolid` from `AwsResourceId` suffix list to avoid false matches
- Add `is_ipam_pool_id_property()` in codegen to detect IPAM Pool ID properties
- Regenerate schemas and docs to reflect the type change

## Affected attributes

| Resource | Attribute | Before | After |
|----------|-----------|--------|-------|
| `ec2_ipam_pool` | `ipam_pool_id` | AwsResourceId | IpamPoolId |
| `ec2_ipam_pool` | `source_ipam_pool_id` | AwsResourceId | IpamPoolId |
| `ec2_eip` | `ipam_pool_id` | AwsResourceId | IpamPoolId |
| `ec2_subnet` | `ipv4_ipam_pool_id` | AwsResourceId | IpamPoolId |
| `ec2_subnet` | `ipv6_ipam_pool_id` | AwsResourceId | IpamPoolId |
| `ec2_vpc` | `ipv4_ipam_pool_id` | AwsResourceId | IpamPoolId |

## Test plan

- [x] `cargo test` — all 205 tests pass
- [x] `carina validate` — both IPAM acceptance tests pass
- [x] `carina plan` — both IPAM acceptance tests pass
- [x] `carina apply` — VPC with IPAM: 3/3 success; Subnet with IPAM: 3/4 success (subnet failure is known IPAM Pool CIDR propagation issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)