### PR TITLE
Add resource reference type mismatch detection (closes #84)

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -202,7 +202,7 @@ impl AttributeType {
         }
     }
 
-    fn type_name(&self) -> String {
+    pub fn type_name(&self) -> String {
         match self {
             AttributeType::String => "String".to_string(),
             AttributeType::Int => "Int".to_string(),


### PR DESCRIPTION
## Summary

- Detect type mismatches in resource references (e.g., `vpc.vpc_id` used where `IpamPoolId` is expected)
- Add `validate_resource_ref_types()` to CLI, called from validate/plan/apply commands
- Add ResourceRef type check match arms to LSP diagnostics for editor warnings
- Make `AttributeType::type_name()` public for cross-crate type name comparison

## Type compatibility rules

- Same type name → OK
- Either side is `String` → OK (String is the base type for Custom types)
- Different Custom types → Error (e.g., `IpamPoolId` ≠ `AwsResourceId`)

## Test plan

- [x] New LSP test: `resource_ref_type_mismatch` — verifies `vpc.vpc_id` in `ipv4_ipam_pool_id` field produces WARNING
- [x] New LSP test: `resource_ref_compatible_type` — verifies `vpc.vpc_id` in `vpc_id` field produces no warning
- [x] CLI: `validate /tmp/type_mismatch_test.crn` correctly reports type mismatch error
- [x] CLI: `validate carina-provider-awscc/acceptance-tests/ec2_vpc/with_ipam.crn` passes (valid IPAM reference)
- [x] All 202 existing tests pass
- [x] Pre-commit checks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)