### PR TITLE
Fix apply/destroy returning exit code 0 on partial failure

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -1275,19 +1275,13 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                 .green()
                 .bold()
         );
+        Ok(())
     } else {
-        println!(
-            "{}",
-            format!(
-                "Apply failed. {} succeeded, {} failed.",
-                success_count, failure_count
-            )
-            .red()
-            .bold()
-        );
+        Err(format!(
+            "Apply failed. {} succeeded, {} failed.",
+            success_count, failure_count
+        ))
     }
-
-    Ok(())
 }
 
 async fn run_destroy(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
@@ -1576,19 +1570,13 @@ async fn run_destroy(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                 .green()
                 .bold()
         );
+        Ok(())
     } else {
-        println!(
-            "{}",
-            format!(
-                "Destroy failed. {} succeeded, {} failed.",
-                success_count, failure_count
-            )
-            .red()
-            .bold()
-        );
+        Err(format!(
+            "Destroy failed. {} succeeded, {} failed.",
+            success_count, failure_count
+        ))
     }
-
-    Ok(())
 }
 
 /// Get identifier from state file for a resource


### PR DESCRIPTION
## Summary
- `run_apply()` and `run_destroy()` now return `Err` when `failure_count > 0`, causing `main()` to exit with code 1
- Previously both functions returned `Ok(())` unconditionally, making partial failures invisible to CI/CD and scripts

Closes #75

## Test plan
- [x] All existing tests pass (`cargo test`)
- [ ] Manual test: apply with a resource that fails → verify exit code is 1
- [ ] Manual test: successful apply → verify exit code is still 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)