### PR TITLE
Add internal links from Enum type references to Enum Values section

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -237,7 +237,12 @@ fn type_display_string(
     enums: &BTreeMap<String, EnumInfo>,
 ) -> String {
     if enums.contains_key(prop_name) {
-        format!("Enum ({})", enums[prop_name].type_name)
+        format!(
+            "[Enum ({})](#{}-{})",
+            enums[prop_name].type_name,
+            prop_name.to_snake_case(),
+            enums[prop_name].type_name.to_lowercase()
+        )
     } else if prop_name == "Tags" {
         "Map".to_string()
     } else if let Some(ref_path) = &prop.ref_path {

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -34,7 +34,7 @@ Specifies the destination to which the flow log data is to be published. Flow lo
 
 ### `log_destination_type`
 
-- **Type:** Enum (LogDestinationType)
+- **Type:** [Enum (LogDestinationType)](#log_destination_type-logdestinationtype)
 - **Required:** No
 
 Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3.
@@ -69,7 +69,7 @@ The ID of the subnet, network interface, or VPC for which you want to create a f
 
 ### `resource_type`
 
-- **Type:** Enum (ResourceType)
+- **Type:** [Enum (ResourceType)](#resource_type-resourcetype)
 - **Required:** Yes
 
 The type of resource for which to create the flow log. For example, if you specified a VPC ID for the ResourceId property, specify VPC for this property.
@@ -83,7 +83,7 @@ The tags to apply to the flow logs.
 
 ### `traffic_type`
 
-- **Type:** Enum (TrafficType)
+- **Type:** [Enum (TrafficType)](#traffic_type-traffictype)
 - **Required:** No
 
 The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.

--- a/docs/src/providers/awscc/ec2_ipam.md
+++ b/docs/src/providers/awscc/ec2_ipam.md
@@ -27,7 +27,7 @@ Enable provisioning of GUA space in private pools.
 
 ### `metered_account`
 
-- **Type:** Enum (MeteredAccount)
+- **Type:** [Enum (MeteredAccount)](#metered_account-meteredaccount)
 - **Required:** No
 
 A metered account is an account that is charged for active IP addresses managed in IPAM
@@ -48,7 +48,7 @@ An array of key-value pairs to apply to this resource.
 
 ### `tier`
 
-- **Type:** Enum (Tier)
+- **Type:** [Enum (Tier)](#tier-tier)
 - **Required:** No
 
 The tier of the IPAM.

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -50,7 +50,7 @@ Determines what to do if IPAM discovers resources that haven't been assigned an 
 
 ### `aws_service`
 
-- **Type:** Enum (AwsService)
+- **Type:** [Enum (AwsService)](#aws_service-awsservice)
 - **Required:** No
 
 Limits which service in Amazon Web Services that the pool can be used in.
@@ -83,7 +83,7 @@ A list of cidrs representing the address space available for allocation in this 
 
 ### `public_ip_source`
 
-- **Type:** Enum (PublicIpSource)
+- **Type:** [Enum (PublicIpSource)](#public_ip_source-publicipsource)
 - **Required:** No
 
 The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Default is `byoip`.
@@ -134,7 +134,7 @@ An array of key-value pairs to apply to this resource.
 
 ### `ipam_scope_type`
 
-- **Type:** Enum (IpamScopeType)
+- **Type:** [Enum (IpamScopeType)](#ipam_scope_type-ipamscopetype)
 
 ### `pool_depth`
 
@@ -142,7 +142,7 @@ An array of key-value pairs to apply to this resource.
 
 ### `state`
 
-- **Type:** Enum (State)
+- **Type:** [Enum (State)](#state-state)
 
 ### `state_message`
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -32,7 +32,7 @@ For regional NAT gateways only: Specifies which Availability Zones you want the 
 
 ### `connectivity_type`
 
-- **Type:** Enum (ConnectivityType)
+- **Type:** [Enum (ConnectivityType)](#connectivity_type-connectivitytype)
 - **Required:** No
 
 Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity.

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -61,7 +61,7 @@ The ID of the security group. You must specify either the security group ID or t
 
 ### `ip_protocol`
 
-- **Type:** Enum (IpProtocol)
+- **Type:** [Enum (IpProtocol)](#ip_protocol-ipprotocol)
 - **Required:** Yes
 
 The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Protocol Numbers](https://docs.aws.amazon.com/http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)). Use ``-1`` to specify all protocols. When authorizing security group rules, specifying ``-1`` or a protocol number other than ``tcp``, ``udp``, ``icmp``, or ``icmpv6`` allows traffic on all ports, regardless of any port range you specify. For ``tcp``, ``udp``, and ``icmp``, you must specify a port range. For ``icmpv6``, the port range is optional; if you omit the port range, traffic for all types and codes is allowed.

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -50,7 +50,7 @@ The name of the security group.
 
 ### `ip_protocol`
 
-- **Type:** Enum (IpProtocol)
+- **Type:** [Enum (IpProtocol)](#ip_protocol-ipprotocol)
 - **Required:** Yes
 
 The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers). [VPC only] Use -1 to specify all protocols. When authorizing security group rules, specifying -1 or a protocol number other than tcp, udp, icmp, or icmpv6 allows traffic on all ports, regardless of any port range you specify. For tcp, udp, and icmp, you must specify a port range. For icmpv6, the port range is optional; if you omit the port range, traffic for all types and codes is allowed.

--- a/docs/src/providers/awscc/ec2_transit_gateway.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway.md
@@ -43,7 +43,7 @@ Resource Type definition for AWS::EC2::TransitGateway
 
 ### `encryption_support`
 
-- **Type:** Enum (EncryptionSupport)
+- **Type:** [Enum (EncryptionSupport)](#encryption_support-encryptionsupport)
 - **Required:** No
 
 ### `multicast_support`

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -31,7 +31,7 @@ Indicates whether the DNS resolution is supported for the VPC. If enabled, queri
 
 ### `instance_tenancy`
 
-- **Type:** Enum (InstanceTenancy)
+- **Type:** [Enum (InstanceTenancy)](#instance_tenancy-instancetenancy)
 - **Required:** No
 
 The allowed tenancy of instances launched into the VPC.  + ``default``: An instance launched into the VPC runs on shared hardware by default, unless you explicitly specify a different tenancy during instance launch.  + ``dedicated``: An instance launched into the VPC runs on dedicated hardware by default, unless you explicitly specify a tenancy of ``host`` during instance launch. You cannot specify a tenancy of ``default`` during instance launch.   Updating ``InstanceTenancy`` requires no replacement only if you are updating its value from ``dedicated`` to ``default``. Updating ``InstanceTenancy`` from ``default`` to ``dedicated`` requires replacement.

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -18,7 +18,7 @@ Describes the DNS options for an endpoint.
 
 ### `ip_address_type`
 
-- **Type:** Enum (IpAddressType)
+- **Type:** [Enum (IpAddressType)](#ip_address_type-ipaddresstype)
 - **Required:** No
 
 The supported IP address types.
@@ -95,7 +95,7 @@ The tags to associate with the endpoint.
 
 ### `vpc_endpoint_type`
 
-- **Type:** Enum (VpcEndpointType)
+- **Type:** [Enum (VpcEndpointType)](#vpc_endpoint_type-vpcendpointtype)
 - **Required:** No
 
 The type of endpoint. Default: Gateway


### PR DESCRIPTION
## Summary

- Enum type references in generated docs (e.g., `Enum (InstanceTenancy)`) now link to the corresponding Enum Values section on the same page
- Updated `type_display_string()` in codegen to generate markdown links with anchors
- Regenerated all affected documentation files

Closes #74

## Test plan

- [x] `cargo build -p carina-provider-awscc` builds successfully
- [x] All 206 tests pass
- [x] Generated docs contain correct links (verified in `ec2_vpc.md` and other files)
- [ ] Verify links work correctly in mdBook rendered output (`cd docs && mdbook serve`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)