### PR TITLE
Move AWS-specific types from carina-core to carina-provider-awscc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ When modifying the DSL or resource schemas, also update the LSP:
 
 ### Provider-Specific Types
 
-AWS-specific type definitions (e.g., region validation, versioning status) belong in `carina-provider-aws/src/schemas/types.rs`, NOT in `carina-core`. Keep `carina-core` provider-agnostic.
+AWS-specific type definitions (e.g., region validation, versioning status) belong in `carina-provider-aws/src/schemas/types.rs` and `carina-provider-awscc/src/schemas/generated/mod.rs`, NOT in `carina-core`. Keep `carina-core` provider-agnostic.
 
 ### Resource Type Mapping
 

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -405,7 +405,9 @@ impl ResourceSchema {
     }
 }
 
-/// Helper functions for common types
+/// Provider-agnostic types only. AWS-specific types (arn, aws_resource_id,
+/// availability_zone, etc.) belong in provider crates.
+/// See carina-provider-awscc/src/schemas/generated/mod.rs for AWS types.
 pub mod types {
     use super::*;
 
@@ -461,22 +463,6 @@ pub mod types {
         }
     }
 
-    /// ARN type (e.g., "arn:aws:s3:::my-bucket")
-    pub fn arn() -> AttributeType {
-        AttributeType::Custom {
-            name: "Arn".to_string(),
-            base: Box::new(AttributeType::String),
-            validate: |value| {
-                if let Value::String(s) = value {
-                    validate_arn(s)
-                } else {
-                    Err("Expected string".to_string())
-                }
-            },
-            namespace: None,
-        }
-    }
-
     /// IPv4 address type (e.g., "10.0.1.5", "192.168.0.1")
     pub fn ipv4_address() -> AttributeType {
         AttributeType::Custom {
@@ -501,40 +487,6 @@ pub mod types {
             validate: |value| {
                 if let Value::String(s) = value {
                     validate_ipv6_address(s)
-                } else {
-                    Err("Expected string".to_string())
-                }
-            },
-            namespace: None,
-        }
-    }
-
-    /// Availability Zone type (e.g., "us-east-1a", "ap-northeast-1c")
-    /// Validates format: region + single letter zone identifier
-    pub fn availability_zone() -> AttributeType {
-        AttributeType::Custom {
-            name: "AvailabilityZone".to_string(),
-            base: Box::new(AttributeType::String),
-            validate: |value| {
-                if let Value::String(s) = value {
-                    validate_availability_zone(s)
-                } else {
-                    Err("Expected string".to_string())
-                }
-            },
-            namespace: None,
-        }
-    }
-
-    /// AWS resource ID type (e.g., "vpc-1a2b3c4d", "subnet-0123456789abcdef0")
-    /// Validates format: {prefix}-{hex} where hex is 8+ hex digits
-    pub fn aws_resource_id() -> AttributeType {
-        AttributeType::Custom {
-            name: "AwsResourceId".to_string(),
-            base: Box::new(AttributeType::String),
-            validate: |value| {
-                if let Value::String(s) = value {
-                    validate_aws_resource_id(s)
                 } else {
                     Err("Expected string".to_string())
                 }
@@ -612,110 +564,6 @@ pub fn validate_ipv4_cidr(cidr: &str) -> Result<(), String> {
 /// Backward-compatible alias for `validate_ipv4_cidr`
 pub fn validate_cidr(cidr: &str) -> Result<(), String> {
     validate_ipv4_cidr(cidr)
-}
-
-/// Validate ARN format (e.g., "arn:aws:s3:::my-bucket")
-/// Validate AWS resource ID format (e.g., "vpc-1a2b3c4d", "subnet-0123456789abcdef0")
-/// Generic format: {prefix}-{hex} where prefix is lowercase/digits and hex is 8+ hex chars
-pub fn validate_aws_resource_id(id: &str) -> Result<(), String> {
-    let Some(dash_pos) = id.find('-') else {
-        return Err(format!(
-            "Invalid resource ID '{}': expected format 'prefix-hexdigits'",
-            id
-        ));
-    };
-
-    let prefix = &id[..dash_pos];
-    let hex_part = &id[dash_pos + 1..];
-
-    if prefix.is_empty()
-        || !prefix
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
-    {
-        return Err(format!(
-            "Invalid resource ID '{}': prefix must be lowercase alphanumeric",
-            id
-        ));
-    }
-
-    if hex_part.len() < 8 {
-        return Err(format!(
-            "Invalid resource ID '{}': ID part must be at least 8 characters after prefix",
-            id
-        ));
-    }
-
-    if !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(format!(
-            "Invalid resource ID '{}': ID part must contain only hex digits",
-            id
-        ));
-    }
-
-    Ok(())
-}
-
-pub fn validate_arn(arn: &str) -> Result<(), String> {
-    if !arn.starts_with("arn:") {
-        return Err(format!("Invalid ARN '{}': must start with 'arn:'", arn));
-    }
-    let parts: Vec<&str> = arn.splitn(6, ':').collect();
-    if parts.len() < 6 {
-        return Err(format!(
-            "Invalid ARN '{}': must have at least 6 colon-separated parts (arn:partition:service:region:account:resource)",
-            arn
-        ));
-    }
-    Ok(())
-}
-
-/// Validate Availability Zone format (e.g., "us-east-1a", "ap-northeast-1c")
-/// Format: {area}-{subarea}-{number}{zone_letter}
-/// where zone_letter is a single lowercase letter
-pub fn validate_availability_zone(az: &str) -> Result<(), String> {
-    // Must end with a single lowercase letter (zone identifier)
-    let zone_letter = az.chars().last();
-    if !zone_letter.is_some_and(|c| c.is_ascii_lowercase()) {
-        return Err(format!(
-            "Invalid availability zone '{}': must end with a zone letter (a-z)",
-            az
-        ));
-    }
-
-    // Region part is everything except the last character
-    let region = &az[..az.len() - 1];
-
-    // Region must match pattern: lowercase-lowercase-digit
-    // e.g., "us-east-1", "ap-northeast-1", "eu-west-2"
-    let parts: Vec<&str> = region.split('-').collect();
-    if parts.len() < 3 {
-        return Err(format!(
-            "Invalid availability zone '{}': expected format like 'us-east-1a'",
-            az
-        ));
-    }
-
-    // Last part of region must be a number
-    let last = parts.last().unwrap();
-    if last.parse::<u8>().is_err() {
-        return Err(format!(
-            "Invalid availability zone '{}': region must end with a number",
-            az
-        ));
-    }
-
-    // All other parts must be lowercase alphabetic
-    for part in &parts[..parts.len() - 1] {
-        if part.is_empty() || !part.chars().all(|c| c.is_ascii_lowercase()) {
-            return Err(format!(
-                "Invalid availability zone '{}': expected format like 'us-east-1a'",
-                az
-            ));
-        }
-    }
-
-    Ok(())
 }
 
 /// Validate IPv6 CIDR block format (e.g., "2001:db8::/32", "::/0")
@@ -1069,12 +917,6 @@ mod tests {
             .is_ok()
         );
 
-        let arn = types::arn();
-        assert!(
-            arn.validate(&Value::ResourceRef("role".to_string(), "arn".to_string()))
-                .is_ok()
-        );
-
         // TypedResourceRef should also be accepted
         assert!(
             ipv4.validate(&Value::TypedResourceRef {
@@ -1084,40 +926,6 @@ mod tests {
             })
             .is_ok()
         );
-    }
-
-    #[test]
-    fn validate_arn_type() {
-        let t = types::arn();
-
-        // Valid ARNs
-        assert!(
-            t.validate(&Value::String("arn:aws:s3:::my-bucket".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String(
-                "arn:aws:iam::123456789012:role/MyRole".to_string()
-            ))
-            .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String(
-                "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-1234".to_string()
-            ))
-            .is_ok()
-        );
-
-        // Invalid ARNs
-        assert!(
-            t.validate(&Value::String("not-an-arn".to_string()))
-                .is_err()
-        );
-        assert!(
-            t.validate(&Value::String("arn:aws:s3".to_string()))
-                .is_err()
-        ); // too few parts
-        assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
     }
 
     #[test]
@@ -1176,115 +984,29 @@ mod tests {
     }
 
     #[test]
-    fn validate_arn_function_directly() {
-        // Valid
-        assert!(validate_arn("arn:aws:s3:::my-bucket").is_ok());
-        assert!(validate_arn("arn:aws:iam::123456789012:role/MyRole").is_ok());
-        assert!(validate_arn("arn:aws-cn:s3:::my-bucket").is_ok());
-        assert!(validate_arn("arn:aws:ec2:us-east-1:123456789012:vpc/vpc-1234").is_ok());
-
-        // Invalid
-        assert!(validate_arn("not-an-arn").is_err());
-        assert!(validate_arn("arn:aws:s3").is_err());
-        assert!(validate_arn("arn:aws").is_err());
-        assert!(validate_arn("").is_err());
-    }
-
-    #[test]
-    fn validate_availability_zone_type() {
-        let t = types::availability_zone();
-
-        // Valid availability zones
-        assert!(t.validate(&Value::String("us-east-1a".to_string())).is_ok());
-        assert!(
-            t.validate(&Value::String("ap-northeast-1c".to_string()))
-                .is_ok()
-        );
-        assert!(t.validate(&Value::String("eu-west-2b".to_string())).is_ok());
-        assert!(
-            t.validate(&Value::String("ap-south-1a".to_string()))
-                .is_ok()
-        );
-        assert!(t.validate(&Value::String("us-west-2d".to_string())).is_ok());
-
-        // Invalid availability zones
-        assert!(t.validate(&Value::String("us-east-1".to_string())).is_err()); // missing zone letter
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
-        assert!(t.validate(&Value::String("us-east-a".to_string())).is_err()); // no number
-        assert!(t.validate(&Value::String("".to_string())).is_err());
-        assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
-    }
-
-    #[test]
-    fn validate_availability_zone_function_directly() {
-        // Valid
-        assert!(validate_availability_zone("us-east-1a").is_ok());
-        assert!(validate_availability_zone("ap-northeast-1c").is_ok());
-        assert!(validate_availability_zone("eu-central-1b").is_ok());
-        assert!(validate_availability_zone("me-south-1a").is_ok());
-
-        // Invalid
-        assert!(validate_availability_zone("us-east-1").is_err()); // no zone letter
-        assert!(validate_availability_zone("US-EAST-1A").is_err()); // uppercase
-        assert!(validate_availability_zone("us-east").is_err()); // no number
-        assert!(validate_availability_zone("1a").is_err()); // too short
-        assert!(validate_availability_zone("").is_err()); // empty
-    }
-
-    #[test]
-    fn validate_aws_resource_id_type() {
-        let t = types::aws_resource_id();
-
-        // Valid resource IDs
-        assert!(
-            t.validate(&Value::String("vpc-1a2b3c4d".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String("subnet-0123456789abcdef0".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String("sg-12345678".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String("rtb-abcdef12".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String("eipalloc-0123456789abcdef0".to_string()))
-                .is_ok()
-        );
-        assert!(
-            t.validate(&Value::String("igw-12345678".to_string()))
-                .is_ok()
-        );
-
-        // Invalid resource IDs
-        assert!(
-            t.validate(&Value::String("not-a-valid-id".to_string()))
-                .is_err()
-        ); // hex part too short
-        assert!(t.validate(&Value::String("vpc".to_string())).is_err()); // no dash
-        assert!(t.validate(&Value::String("vpc-short".to_string())).is_err()); // hex part < 8
-        assert!(
-            t.validate(&Value::String("vpc-1234567".to_string()))
-                .is_err()
-        ); // only 7 chars
-        assert!(
-            t.validate(&Value::String("VPC-12345678".to_string()))
-                .is_err()
-        ); // uppercase prefix
-        assert!(t.validate(&Value::Int(42)).is_err()); // wrong type
-
-        // ResourceRef should be accepted
-        assert!(
-            t.validate(&Value::ResourceRef(
-                "my_vpc".to_string(),
-                "vpc_id".to_string()
-            ))
-            .is_ok()
-        );
+    fn types_module_has_no_aws_specific_types() {
+        // Verify that AWS-specific types are not defined in carina-core.
+        // These belong in provider crates (e.g., carina-provider-awscc).
+        let source = include_str!("schema.rs");
+        let aws_keywords = [
+            "fn arn()",
+            "fn aws_resource_id()",
+            "fn availability_zone()",
+            "validate_arn",
+            "validate_aws_resource_id",
+            "validate_availability_zone",
+        ];
+        for keyword in &aws_keywords {
+            // Exclude this test function itself from the check
+            let occurrences: Vec<_> = source.match_indices(keyword).collect();
+            // Each keyword appears once in the aws_keywords array literal above
+            // If it appears more than once, it means it's also defined elsewhere
+            assert!(
+                occurrences.len() <= 1,
+                "Found AWS-specific type '{}' in carina-core/src/schema.rs. \
+                 AWS-specific types belong in provider crates.",
+                keyword
+            );
+        }
     }
 }

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -5,12 +5,13 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use crate::document::Document;
 use carina_core::parser::{InputParameter, ParseError, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
-use carina_core::schema::{validate_arn, validate_cidr, validate_ipv6_cidr};
+use carina_core::schema::{validate_cidr, validate_ipv6_cidr};
 use carina_provider_aws::schemas::{s3, types as aws_types, vpc};
 use carina_provider_awscc::schemas::generated::flow_log as awscc_flow_log;
 use carina_provider_awscc::schemas::generated::nat_gateway as awscc_nat_gateway;
 use carina_provider_awscc::schemas::generated::security_group as awscc_security_group;
 use carina_provider_awscc::schemas::generated::subnet as awscc_subnet;
+use carina_provider_awscc::schemas::generated::validate_arn;
 use carina_provider_awscc::schemas::generated::vpc as awscc_vpc;
 use carina_provider_awscc::schemas::generated::vpc_endpoint as awscc_vpc_endpoint;
 

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1054,7 +1054,7 @@ fn cfn_type_to_carina_type_with_enum(
 
             // AWS resource IDs with known prefix-hex format
             if is_aws_resource_id_property(prop_name) {
-                return ("types::aws_resource_id()".to_string(), None);
+                return ("super::aws_resource_id()".to_string(), None);
             }
 
             // Other IDs are plain strings (AZ IDs, owner IDs, etc.)
@@ -1064,13 +1064,13 @@ fn cfn_type_to_carina_type_with_enum(
 
             // ARNs use validated Arn type
             if prop_lower.ends_with("arn") || prop_lower.contains("_arn") {
-                return ("types::arn()".to_string(), None);
+                return ("super::arn()".to_string(), None);
             }
 
             // Availability zone uses format validation (e.g., "us-east-1a")
             // but AvailabilityZoneId stays as String (e.g., "use1-az1")
             if prop_lower == "availabilityzone" {
-                return ("types::availability_zone()".to_string(), None);
+                return ("super::availability_zone()".to_string(), None);
             }
 
             // Other zone/region fields are strings
@@ -1460,9 +1460,9 @@ mod tests {
             tagging: None,
         };
 
-        // AvailabilityZone should use types::availability_zone()
+        // AvailabilityZone should use super::availability_zone()
         let (type_str, _) = cfn_type_to_carina_type_with_enum(&prop, "AvailabilityZone", &schema);
-        assert_eq!(type_str, "types::availability_zone()");
+        assert_eq!(type_str, "super::availability_zone()");
 
         // AvailabilityZoneId should stay String
         let (type_str, _) = cfn_type_to_carina_type_with_enum(&prop, "AvailabilityZoneId", &schema);

--- a/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2_egress_only_internet_gateway (AWS::EC2::EgressOnlyInternetGateway)
 pub fn ec2_egress_only_internet_gateway_config() -> AwsccSchemaConfig {
@@ -29,7 +29,7 @@ pub fn ec2_egress_only_internet_gateway_config() -> AwsccSchemaConfig {
                     .with_provider_name("Tags"),
             )
             .attribute(
-                AttributeSchema::new("vpc_id", types::aws_resource_id())
+                AttributeSchema::new("vpc_id", super::aws_resource_id())
                     .required()
                     .with_description(
                         "The ID of the VPC for which to create the egress-only internet gateway.",

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -22,7 +22,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("Address"),
         )
         .attribute(
-            AttributeSchema::new("allocation_id", types::aws_resource_id())
+            AttributeSchema::new("allocation_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("AllocationId"),
         )
@@ -32,7 +32,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("Domain"),
         )
         .attribute(
-            AttributeSchema::new("instance_id", types::aws_resource_id())
+            AttributeSchema::new("instance_id", super::aws_resource_id())
                 .with_description("The ID of the instance.  Updates to the ``InstanceId`` property may require *some interruptions*. Updates on an EIP reassociates the address on its as...")
                 .with_provider_name("InstanceId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "s3", "kinesis-data-firehose"];
 
@@ -64,7 +64,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 .with_provider_name("DeliverCrossAccountRole"),
         )
         .attribute(
-            AttributeSchema::new("deliver_logs_permission_arn", types::arn())
+            AttributeSchema::new("deliver_logs_permission_arn", super::arn())
                 .with_description("The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a CloudWatch Logs log group in your account. If you specify LogDestinationTyp...")
                 .with_provider_name("DeliverLogsPermissionArn"),
         )

--- a/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2_internet_gateway (AWS::EC2::InternetGateway)
 pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
@@ -17,7 +17,7 @@ pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_internet_gateway")
         .with_description("Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.")
         .attribute(
-            AttributeSchema::new("internet_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("internet_gateway_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("InternetGatewayId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_METERED_ACCOUNT: &[&str] = &["ipam-owner", "resource-owner"];
 
@@ -36,7 +36,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_ipam")
         .with_description("Resource Schema of AWS::EC2::IPAM Type")
         .attribute(
-            AttributeSchema::new("arn", types::arn())
+            AttributeSchema::new("arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the IPAM. (read-only)")
                 .with_provider_name("Arn"),
         )

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_AWS_SERVICE: &[&str] = &["ec2", "global-services"];
 
@@ -91,7 +91,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("AllocationResourceTags"),
         )
         .attribute(
-            AttributeSchema::new("arn", types::arn())
+            AttributeSchema::new("arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the IPAM Pool. (read-only)")
                 .with_provider_name("Arn"),
         )
@@ -115,7 +115,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("ipam_arn", types::arn())
+            AttributeSchema::new("ipam_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the IPAM this pool is a part of. (read-only)")
                 .with_provider_name("IpamArn"),
         )
@@ -125,7 +125,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpamPoolId"),
         )
         .attribute(
-            AttributeSchema::new("ipam_scope_arn", types::arn())
+            AttributeSchema::new("ipam_scope_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the scope this pool is a part of. (read-only)")
                 .with_provider_name("IpamScopeArn"),
         )

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -30,7 +30,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_nat_gateway")
         .with_description("Specifies a network address translation (NAT) gateway in the specified subnet. You can create either a public NAT gateway or a private NAT gateway. The default is a public NAT gateway. If you create a...")
         .attribute(
-            AttributeSchema::new("allocation_id", types::aws_resource_id())
+            AttributeSchema::new("allocation_id", super::aws_resource_id())
                 .with_description("[Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public N...")
                 .with_provider_name("AllocationId"),
         )
@@ -54,7 +54,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                     name: "AvailabilityZoneAddress".to_string(),
                     fields: vec![
                     StructField::new("allocation_ids", AttributeType::List(Box::new(AttributeType::String))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
-                    StructField::new("availability_zone", types::availability_zone()).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
+                    StructField::new("availability_zone", super::availability_zone()).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
                     StructField::new("availability_zone_id", AttributeType::String).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
                     ],
                 })))
@@ -72,7 +72,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("ConnectivityType"),
         )
         .attribute(
-            AttributeSchema::new("eni_id", types::aws_resource_id())
+            AttributeSchema::new("eni_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("EniId"),
         )
@@ -82,7 +82,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("MaxDrainDurationSeconds"),
         )
         .attribute(
-            AttributeSchema::new("nat_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("nat_gateway_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("NatGatewayId"),
         )
@@ -92,7 +92,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrivateIpAddress"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", types::aws_resource_id())
+            AttributeSchema::new("route_table_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("RouteTableId"),
         )
@@ -112,7 +112,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("SecondaryPrivateIpAddresses"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", types::aws_resource_id())
+            AttributeSchema::new("subnet_id", super::aws_resource_id())
                 .with_description("The ID of the subnet in which the NAT gateway is located.")
                 .with_provider_name("SubnetId"),
         )
@@ -122,7 +122,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .with_description("The ID of the VPC in which the NAT gateway is located.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -16,7 +16,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_route")
         .with_description("Specifies a route in a route table. For more information, see [Routes](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#route-table-routes) in the *Amazon VPC User Guide*.  You m...")
         .attribute(
-            AttributeSchema::new("carrier_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("carrier_gateway_id", super::aws_resource_id())
                 .with_description("The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.")
                 .with_provider_name("CarrierGatewayId"),
         )
@@ -26,7 +26,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("core_network_arn", types::arn())
+            AttributeSchema::new("core_network_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the core network.")
                 .with_provider_name("CoreNetworkArn"),
         )
@@ -41,58 +41,58 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("DestinationIpv6CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("destination_prefix_list_id", types::aws_resource_id())
+            AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
                 .with_description("The ID of a prefix list used for the destination match.")
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("egress_only_internet_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("egress_only_internet_gateway_id", super::aws_resource_id())
                 .with_description("[IPv6 traffic only] The ID of an egress-only internet gateway.")
                 .with_provider_name("EgressOnlyInternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("gateway_id", types::aws_resource_id())
+            AttributeSchema::new("gateway_id", super::aws_resource_id())
                 .with_description("The ID of an internet gateway or virtual private gateway attached to your VPC.")
                 .with_provider_name("GatewayId"),
         )
         .attribute(
-            AttributeSchema::new("instance_id", types::aws_resource_id())
+            AttributeSchema::new("instance_id", super::aws_resource_id())
                 .with_description("The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.")
                 .with_provider_name("InstanceId"),
         )
         .attribute(
-            AttributeSchema::new("local_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("local_gateway_id", super::aws_resource_id())
                 .with_description("The ID of the local gateway.")
                 .with_provider_name("LocalGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("nat_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("nat_gateway_id", super::aws_resource_id())
                 .with_description("[IPv4 traffic only] The ID of a NAT gateway.")
                 .with_provider_name("NatGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("network_interface_id", types::aws_resource_id())
+            AttributeSchema::new("network_interface_id", super::aws_resource_id())
                 .with_description("The ID of a network interface.")
                 .with_provider_name("NetworkInterfaceId"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", types::aws_resource_id())
+            AttributeSchema::new("route_table_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the route table for the route.")
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
-            AttributeSchema::new("transit_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("transit_gateway_id", super::aws_resource_id())
                 .with_description("The ID of a transit gateway.")
                 .with_provider_name("TransitGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_endpoint_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_endpoint_id", super::aws_resource_id())
                 .with_description("The ID of a VPC endpoint. Supported for Gateway Load Balancer endpoints only.")
                 .with_provider_name("VpcEndpointId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_peering_connection_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_peering_connection_id", super::aws_resource_id())
                 .with_description("The ID of a VPC peering connection.")
                 .with_provider_name("VpcPeeringConnectionId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2_route_table (AWS::EC2::RouteTable)
 pub fn ec2_route_table_config() -> AwsccSchemaConfig {
@@ -17,7 +17,7 @@ pub fn ec2_route_table_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_route_table")
         .with_description("Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.  For more information, see [Route tables](https://docs.aws.amaz...")
         .attribute(
-            AttributeSchema::new("route_table_id", types::aws_resource_id())
+            AttributeSchema::new("route_table_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("RouteTableId"),
         )
@@ -27,7 +27,7 @@ pub fn ec2_route_table_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -23,7 +23,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("GroupDescription"),
         )
         .attribute(
-            AttributeSchema::new("group_id", types::aws_resource_id())
+            AttributeSchema::new("group_id", super::aws_resource_id())
                 .with_description("The group ID of the specified security group. (read-only)")
                 .with_provider_name("GroupId"),
         )
@@ -44,8 +44,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("cidr_ip", types::ipv4_cidr()).with_provider_name("CidrIp"),
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
-                    StructField::new("destination_prefix_list_id", types::aws_resource_id()).with_provider_name("DestinationPrefixListId"),
-                    StructField::new("destination_security_group_id", types::aws_resource_id()).with_provider_name("DestinationSecurityGroupId"),
+                    StructField::new("destination_prefix_list_id", super::aws_resource_id()).with_provider_name("DestinationPrefixListId"),
+                    StructField::new("destination_security_group_id", super::aws_resource_id()).with_provider_name("DestinationSecurityGroupId"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Enum(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string()])).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
@@ -63,8 +63,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Int).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Enum(vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string()])).required().with_provider_name("IpProtocol"),
-                    StructField::new("source_prefix_list_id", types::aws_resource_id()).with_provider_name("SourcePrefixListId"),
-                    StructField::new("source_security_group_id", types::aws_resource_id()).with_provider_name("SourceSecurityGroupId"),
+                    StructField::new("source_prefix_list_id", super::aws_resource_id()).with_provider_name("SourcePrefixListId"),
+                    StructField::new("source_security_group_id", super::aws_resource_id()).with_provider_name("SourceSecurityGroupId"),
                     StructField::new("source_security_group_name", AttributeType::String).with_provider_name("SourceSecurityGroupName"),
                     StructField::new("source_security_group_owner_id", AttributeType::String).with_provider_name("SourceSecurityGroupOwnerId"),
                     StructField::new("to_port", AttributeType::Int).with_provider_name("ToPort")
@@ -79,7 +79,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .with_description("The ID of the VPC for the security group.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -44,12 +44,12 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("destination_prefix_list_id", types::aws_resource_id())
+            AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
                 .with_description("The prefix list IDs for an AWS service. This is the AWS service to access through a VPC endpoint from instances associated with the security group. Yo...")
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("destination_security_group_id", types::aws_resource_id())
+            AttributeSchema::new("destination_security_group_id", super::aws_resource_id())
                 .with_description("The ID of the security group. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSe...")
                 .with_provider_name("DestinationSecurityGroupId"),
         )
@@ -59,7 +59,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", types::aws_resource_id())
+            AttributeSchema::new("group_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -49,7 +49,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", types::aws_resource_id())
+            AttributeSchema::new("group_id", super::aws_resource_id())
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),
         )
@@ -75,12 +75,12 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
-            AttributeSchema::new("source_prefix_list_id", types::aws_resource_id())
+            AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())
                 .with_description("[EC2-VPC only] The ID of a prefix list. ")
                 .with_provider_name("SourcePrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("source_security_group_id", types::aws_resource_id())
+            AttributeSchema::new("source_security_group_id", super::aws_resource_id())
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name. For security groups in a nondefault VPC, you m...")
                 .with_provider_name("SourceSecurityGroupId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -22,7 +22,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("AssignIpv6AddressOnCreation"),
         )
         .attribute(
-            AttributeSchema::new("availability_zone", types::availability_zone())
+            AttributeSchema::new("availability_zone", super::availability_zone())
                 .with_description("The Availability Zone of the subnet. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("AvailabilityZone"),
         )
@@ -102,7 +102,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("NetworkAclAssociationId"),
         )
         .attribute(
-            AttributeSchema::new("outpost_arn", types::arn())
+            AttributeSchema::new("outpost_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the Outpost.")
                 .with_provider_name("OutpostArn"),
         )
@@ -119,7 +119,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrivateDnsNameOptionsOnLaunch"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", types::aws_resource_id())
+            AttributeSchema::new("subnet_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("SubnetId"),
         )
@@ -129,7 +129,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2_subnet_route_table_association (AWS::EC2::SubnetRouteTableAssociation)
 pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
@@ -21,13 +21,13 @@ pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("route_table_id", types::aws_resource_id())
+            AttributeSchema::new("route_table_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the route table. The physical ID changes when the route table ID is changed.")
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
-            AttributeSchema::new("subnet_id", types::aws_resource_id())
+            AttributeSchema::new("subnet_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the subnet.")
                 .with_provider_name("SubnetId"),

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
@@ -36,7 +36,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             .attribute(
                 AttributeSchema::new(
                     "association_default_route_table_id",
-                    types::aws_resource_id(),
+                    super::aws_resource_id(),
                 )
                 .with_provider_name("AssociationDefaultRouteTableId"),
             )
@@ -89,7 +89,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             .attribute(
                 AttributeSchema::new(
                     "propagation_default_route_table_id",
-                    types::aws_resource_id(),
+                    super::aws_resource_id(),
                 )
                 .with_provider_name("PropagationDefaultRouteTableId"),
             )
@@ -99,7 +99,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             )
             .attribute(AttributeSchema::new("tags", tags_type()).with_provider_name("Tags"))
             .attribute(
-                AttributeSchema::new("transit_gateway_arn", types::arn())
+                AttributeSchema::new("transit_gateway_arn", super::arn())
                     .with_description("(read-only)")
                     .with_provider_name("TransitGatewayArn"),
             )

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -90,7 +90,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
 const VALID_IP_ADDRESS_TYPE: &[&str] = &["ipv4", "ipv6", "dualstack", "not-specified"];
 
@@ -100,7 +100,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrivateDnsEnabled"),
         )
         .attribute(
-            AttributeSchema::new("resource_configuration_arn", types::arn())
+            AttributeSchema::new("resource_configuration_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the resource configuration.")
                 .with_provider_name("ResourceConfigurationArn"),
         )
@@ -120,7 +120,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("ServiceName"),
         )
         .attribute(
-            AttributeSchema::new("service_network_arn", types::arn())
+            AttributeSchema::new("service_network_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the service network.")
                 .with_provider_name("ServiceNetworkArn"),
         )
@@ -150,7 +150,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("VpcEndpointType"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2_vpc_gateway_attachment (AWS::EC2::VPCGatewayAttachment)
 pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
@@ -21,18 +21,18 @@ pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
                 .with_provider_name("AttachmentType"),
         )
         .attribute(
-            AttributeSchema::new("internet_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("internet_gateway_id", super::aws_resource_id())
                 .with_description("The ID of the internet gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.")
                 .with_provider_name("InternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )
         .attribute(
-            AttributeSchema::new("vpn_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("vpn_gateway_id", super::aws_resource_id())
                 .with_description("The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both.")
                 .with_provider_name("VpnGatewayId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2_vpc_peering_connection (AWS::EC2::VPCPeeringConnection)
 pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
@@ -32,12 +32,12 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
                 .with_provider_name("PeerRegion"),
         )
         .attribute(
-            AttributeSchema::new("peer_role_arn", types::arn())
+            AttributeSchema::new("peer_role_arn", super::arn())
                 .with_description("The Amazon Resource Name (ARN) of the VPC peer role for the peering connection in another AWS account.")
                 .with_provider_name("PeerRoleArn"),
         )
         .attribute(
-            AttributeSchema::new("peer_vpc_id", types::aws_resource_id())
+            AttributeSchema::new("peer_vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC with which you are creating the VPC peering connection. You must specify this parameter in the request.")
                 .with_provider_name("PeerVpcId"),
@@ -47,7 +47,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("vpc_id", types::aws_resource_id())
+            AttributeSchema::new("vpc_id", super::aws_resource_id())
                 .required()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),

--- a/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
 /// Returns the schema config for ec2_vpn_gateway (AWS::EC2::VPNGateway)
 pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
@@ -33,7 +33,7 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("Type"),
         )
         .attribute(
-            AttributeSchema::new("vpn_gateway_id", types::aws_resource_id())
+            AttributeSchema::new("vpn_gateway_id", super::aws_resource_id())
                 .with_description(" (read-only)")
                 .with_provider_name("VPNGatewayId"),
         )


### PR DESCRIPTION
## Summary

- Move `arn()`, `aws_resource_id()`, `availability_zone()` type functions and their validators from `carina-core/src/schema.rs` to `carina-provider-awscc/src/schemas/generated/mod.rs`, keeping `carina-core` provider-agnostic
- Update codegen to generate `super::` references instead of `types::` for moved types
- Update all 20 generated schema files to use `super::` for the moved types
- Update LSP diagnostics to import `validate_arn` from `carina-provider-awscc`
- Add regression prevention test in `carina-core` to prevent AWS-specific types from being reintroduced
- Update `generate-schemas.sh` heredoc template so regeneration preserves the moved types

Closes #83

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test -p carina-core` — 93 tests pass (including new regression prevention test)
- [x] `cargo test -p carina-provider-awscc` — 33 tests pass (including new type validation tests)
- [x] `cargo test -p carina-lsp` — 23 tests pass
- [x] `cargo test` — all 206 tests pass
- [x] Pre-commit hooks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)