### PR TITLE
Add internal links from Struct type references to Struct Definitions section (closes #89)

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -254,7 +254,7 @@ fn type_display_string(
                 .map(|p| !p.is_empty())
                 .unwrap_or(false)
         {
-            format!("Struct({})", def_name)
+            format!("[Struct({})](#{})", def_name, def_name.to_lowercase())
         } else {
             "String".to_string()
         }
@@ -304,7 +304,7 @@ fn type_display_string(
                                     .map(|p| !p.is_empty())
                                     .unwrap_or(false)
                             {
-                                format!("List<{}>", def_name)
+                                format!("[List\\<{}\\>](#{})", def_name, def_name.to_lowercase())
                             } else {
                                 "List".to_string()
                             }
@@ -322,7 +322,7 @@ fn type_display_string(
                 if let Some(props) = &prop.properties
                     && !props.is_empty()
                 {
-                    format!("Struct({})", prop_name)
+                    format!("[Struct({})](#{})", prop_name, prop_name.to_lowercase())
                 } else {
                     "Map".to_string()
                 }

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -22,7 +22,7 @@ The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a Cloud
 
 ### `destination_options`
 
-- **Type:** Struct(DestinationOptions)
+- **Type:** [Struct(DestinationOptions)](#destinationoptions)
 - **Required:** No
 
 ### `log_destination`

--- a/docs/src/providers/awscc/ec2_ipam.md
+++ b/docs/src/providers/awscc/ec2_ipam.md
@@ -8,7 +8,7 @@ Resource Schema of AWS::EC2::IPAM Type
 
 ### `default_resource_discovery_organizational_unit_exclusions`
 
-- **Type:** List<IpamOrganizationalUnitExclusion>
+- **Type:** [List\<IpamOrganizationalUnitExclusion\>](#ipamorganizationalunitexclusion)
 - **Required:** No
 
 A set of organizational unit (OU) exclusions for the default resource discovery, created with this IPAM.
@@ -34,7 +34,7 @@ A metered account is an account that is charged for active IP addresses managed 
 
 ### `operating_regions`
 
-- **Type:** List<IpamOperatingRegion>
+- **Type:** [List\<IpamOperatingRegion\>](#ipamoperatingregion)
 - **Required:** No
 
 The regions IPAM is enabled for. Allows pools to be created in these regions, as well as enabling monitoring

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -76,7 +76,7 @@ The region of this pool. If not set, this will default to "None" which will disa
 
 ### `provisioned_cidrs`
 
-- **Type:** List<ProvisionedCidr>
+- **Type:** [List\<ProvisionedCidr\>](#provisionedcidr)
 - **Required:** No
 
 A list of cidrs representing the address space available for allocation in this pool.
@@ -104,7 +104,7 @@ The Id of this pool's source. If set, all space provisioned in this pool must be
 
 ### `source_resource`
 
-- **Type:** Struct(SourceResource)
+- **Type:** [Struct(SourceResource)](#sourceresource)
 - **Required:** No
 
 ### `tags`

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -25,7 +25,7 @@ Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway
 
 ### `availability_zone_addresses`
 
-- **Type:** List<AvailabilityZoneAddress>
+- **Type:** [List\<AvailabilityZoneAddress\>](#availabilityzoneaddress)
 - **Required:** No
 
 For regional NAT gateways only: Specifies which Availability Zones you want the NAT gateway to support and the Elastic IP addresses (EIPs) to use in each AZ. The regional NAT gateway uses these EIPs to handle outbound NAT traffic from their respective AZs. If not specified, the NAT gateway will automatically expand to new AZs and associate EIPs upon detection of an elastic network interface. If you specify this parameter, auto-expansion is disabled and you must manually manage AZ coverage. A regional NAT gateway is a single NAT Gateway that works across multiple availability zones (AZs) in your VPC, providing redundancy, scalability and availability across all the AZs in a Region. For more information, see [Regional NAT gateways for automatic multi-AZ expansion](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateways-regional.html) in the *Amazon VPC User Guide*.

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -22,14 +22,14 @@ The name of the security group.
 
 ### `security_group_egress`
 
-- **Type:** List<Egress>
+- **Type:** [List\<Egress\>](#egress)
 - **Required:** No
 
 [VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.
 
 ### `security_group_ingress`
 
-- **Type:** List<Ingress>
+- **Type:** [List\<Ingress\>](#ingress)
 - **Required:** No
 
 The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -108,7 +108,7 @@ The Amazon Resource Name (ARN) of the Outpost.
 
 ### `private_dns_name_options_on_launch`
 
-- **Type:** Struct(PrivateDnsNameOptionsOnLaunch)
+- **Type:** [Struct(PrivateDnsNameOptionsOnLaunch)](#privatednsnameoptionsonlaunch)
 - **Required:** No
 
 The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more information, see [Amazon EC2 instance hostname types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html) in the *User Guide*. Available options:  + EnableResourceNameDnsAAAARecord (true | false)  + EnableResourceNameDnsARecord (true | false)  + HostnameType (ip-name | resource-name)
@@ -131,7 +131,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 ### `block_public_access_states`
 
-- **Type:** Struct(BlockPublicAccessStates)
+- **Type:** [Struct(BlockPublicAccessStates)](#blockpublicaccessstates)
 
 ### `ipv6_cidr_blocks`
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -11,7 +11,7 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
 
 ### `dns_options`
 
-- **Type:** Struct(DnsOptionsSpecification)
+- **Type:** [Struct(DnsOptionsSpecification)](#dnsoptionsspecification)
 - **Required:** No
 
 Describes the DNS options for an endpoint.


### PR DESCRIPTION
## Summary

- Add markdown internal links from `Struct(Name)` and `List<Name>` type references to the corresponding `### Name` headings in the Struct Definitions section
- Follows the same pattern as PR #88 (Enum internal links)
- Regenerated all documentation with updated codegen

## Test plan

- [x] `cargo build -p carina-provider-awscc` compiles successfully
- [x] `cargo test -p carina-provider-awscc` all tests pass
- [x] Pre-commit checks (formatting, clippy, full test suite) pass
- [x] Regenerated docs show correct links (e.g., `[Struct(DestinationOptions)](#destinationoptions)` in `ec2_flow_log.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)