### PR TITLE
Wait for timed-out deletions before deleting parent resources (closes #80)

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -14,6 +14,7 @@ pub struct ProviderError {
     pub message: String,
     pub resource_id: Option<ResourceId>,
     pub cause: Option<Box<dyn std::error::Error + Send + Sync>>,
+    pub is_timeout: bool,
 }
 
 impl std::fmt::Display for ProviderError {
@@ -40,6 +41,7 @@ impl ProviderError {
             message: message.into(),
             resource_id: None,
             cause: None,
+            is_timeout: false,
         }
     }
 
@@ -50,6 +52,11 @@ impl ProviderError {
 
     pub fn with_cause(mut self, cause: impl std::error::Error + Send + Sync + 'static) -> Self {
         self.cause = Some(Box::new(cause));
+        self
+    }
+
+    pub fn timeout(mut self) -> Self {
+        self.is_timeout = true;
         self
     }
 }

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -206,7 +206,7 @@ impl AwsccProvider {
             }
         }
 
-        Err(ProviderError::new("Operation timed out"))
+        Err(ProviderError::new("Operation timed out").timeout())
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- Add `is_timeout` field to `ProviderError` to distinguish timeout from actual failure
- Mark Cloud Control API timeout errors with `is_timeout = true`
- Build a reverse dependency map during `carina destroy`
- If a dependent resource's deletion timed out, poll its state every 10s (up to 30 min) before attempting to delete the parent
- If a dependent resource actually failed (non-timeout), skip the parent with a clear message

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — all existing tests pass
- [x] 4 new unit tests for `build_dependents_map` and `find_failed_dependent`
- [x] Acceptance test: `ec2_vpc/with_ipam.crn` apply+destroy cycle succeeds — IPAM Pool timeout is handled correctly and IPAM deletion succeeds after extended wait

### Acceptance test output

```
Destroying resources...

  ✓ Delete ec2_vpc.acceptance-test-vpc-ipam
  ⏳ Delete ec2_ipam_pool.acceptance-test-ipam-pool-vpc - Operation timed out, waiting for completion...
  ⏳ Waiting for ec2_ipam_pool.acceptance-test-ipam-pool-vpc to be deleted...
  ✓ Delete ec2_ipam_pool.acceptance-test-ipam-pool-vpc (completed after extended wait)
  ✓ Delete ec2_ipam.acceptance-test-ipam-vpc

Destroy complete! 3 resources destroyed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)