### PR TITLE
Show element types in List documentation (closes #93)

### DIFF
--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -36,7 +36,7 @@ The minimum allowed netmask length for allocations made from this pool.
 
 ### `allocation_resource_tags`
 
-- **Type:** List
+- **Type:** List<Map>
 - **Required:** No
 
 When specified, an allocation will not be allowed unless a resource has a matching set of tags.


### PR DESCRIPTION
## Summary

- Fix all code paths in `type_display_string()` and `list_element_type_display()` that returned bare `"List"` without element type information
- Tag `$ref` arrays now display `List<Map>` instead of `List`
- Unresolvable `$ref` and missing items default to `List<String>` instead of `List`
- Add regression guard tests that ensure no code path can return bare `"List"` in the future
- Regenerate documentation (`ec2_ipam_pool.md` updated)

## Test plan

- [x] All 21 codegen tests pass, including 2 new regression guard tests
- [x] Full test suite passes (216 tests)
- [x] Regenerated docs confirm no bare `List` types remain
- [x] `grep` for `"| List |"` and `"List$"` in docs returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)