### PR TITLE
Convert String types to stricter Enum types in AWSCC codegen

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -921,6 +921,14 @@ fn known_enum_overrides() -> HashMap<&'static str, Vec<&'static str>> {
     let mut m = HashMap::new();
     m.insert("IpProtocol", vec!["tcp", "udp", "icmp", "icmpv6", "-1"]);
     m.insert("ConnectivityType", vec!["public", "private"]);
+    m.insert("AvailabilityMode", vec!["zonal", "regional"]);
+    m.insert("AddressFamily", vec!["IPv4", "IPv6"]);
+    m.insert("Domain", vec!["vpc", "standard"]);
+    m.insert(
+        "InternetGatewayBlockMode",
+        vec!["off", "block-bidirectional", "block-ingress"],
+    );
+    m.insert("HostnameType", vec!["ip-name", "resource-name"]);
     m
 }
 
@@ -947,9 +955,15 @@ fn is_aws_resource_id_property(prop_name: &str) -> bool {
     if lower.contains("owner") || lower.contains("availabilityzone") || lower == "resourceid" {
         return false;
     }
+    // Strip trailing "s" for plural forms (e.g., "RouteTableIds" -> "routetableid")
+    let singular = if lower.ends_with("ids") {
+        &lower[..lower.len() - 1]
+    } else {
+        &lower
+    };
     resource_id_suffixes
         .iter()
-        .any(|suffix| lower.ends_with(suffix))
+        .any(|suffix| lower.ends_with(suffix) || singular.ends_with(suffix))
 }
 
 /// Check if a property name represents an IPAM Pool ID

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -6,7 +6,15 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
+use super::validate_namespaced_enum;
+use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+
+const VALID_DOMAIN: &[&str] = &["vpc", "standard"];
+
+fn validate_domain(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(value, "Domain", "awscc.ec2_eip", VALID_DOMAIN)
+}
 
 /// Returns the schema config for ec2_eip (AWS::EC2::EIP)
 pub fn ec2_eip_config() -> AwsccSchemaConfig {
@@ -27,7 +35,12 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("AllocationId"),
         )
         .attribute(
-            AttributeSchema::new("domain", AttributeType::String)
+            AttributeSchema::new("domain", AttributeType::Custom {
+                name: "Domain".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_domain,
+                namespace: Some("awscc.ec2_eip".to_string()),
+            })
                 .with_description("The network (``vpc``). If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a depend...")
                 .with_provider_name("Domain"),
         )

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -10,6 +10,17 @@ use super::validate_namespaced_enum;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
+const VALID_ADDRESS_FAMILY: &[&str] = &["IPv4", "IPv6"];
+
+fn validate_address_family(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "AddressFamily",
+        "awscc.ec2_ipam_pool",
+        VALID_ADDRESS_FAMILY,
+    )
+}
+
 const VALID_AWS_SERVICE: &[&str] = &["ec2", "global-services"];
 
 fn validate_aws_service(value: &Value) -> Result<(), String> {
@@ -65,7 +76,12 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2_ipam_pool")
         .with_description("Resource Schema of AWS::EC2::IPAMPool Type")
         .attribute(
-            AttributeSchema::new("address_family", AttributeType::String)
+            AttributeSchema::new("address_family", AttributeType::Custom {
+                name: "AddressFamily".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_address_family,
+                namespace: Some("awscc.ec2_ipam_pool".to_string()),
+            })
                 .required()
                 .with_description("The address family of the address space in this pool. Either IPv4 or IPv6.")
                 .with_provider_name("AddressFamily"),

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -10,6 +10,17 @@ use super::validate_namespaced_enum;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
+const VALID_AVAILABILITY_MODE: &[&str] = &["zonal", "regional"];
+
+fn validate_availability_mode(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "AvailabilityMode",
+        "awscc.ec2_nat_gateway",
+        VALID_AVAILABILITY_MODE,
+    )
+}
+
 const VALID_CONNECTIVITY_TYPE: &[&str] = &["public", "private"];
 
 fn validate_connectivity_type(value: &Value) -> Result<(), String> {
@@ -45,7 +56,12 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("AutoScalingIps"),
         )
         .attribute(
-            AttributeSchema::new("availability_mode", AttributeType::String)
+            AttributeSchema::new("availability_mode", AttributeType::Custom {
+                name: "AvailabilityMode".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_availability_mode,
+                namespace: Some("awscc.ec2_nat_gateway".to_string()),
+            })
                 .with_description("Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway. A zonal NAT gateway is a NAT Gateway that provides redundancy and sc...")
                 .with_provider_name("AvailabilityMode"),
         )
@@ -53,7 +69,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
             AttributeSchema::new("availability_zone_addresses", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "AvailabilityZoneAddress".to_string(),
                     fields: vec![
-                    StructField::new("allocation_ids", AttributeType::List(Box::new(AttributeType::String))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
+                    StructField::new("allocation_ids", AttributeType::List(Box::new(super::aws_resource_id()))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
                     StructField::new("availability_zone", super::availability_zone()).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
                     StructField::new("availability_zone_id", AttributeType::String).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
                     ],
@@ -97,7 +113,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
-            AttributeSchema::new("secondary_allocation_ids", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("secondary_allocation_ids", AttributeType::List(Box::new(super::aws_resource_id())))
                 .with_description("Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-working-wi...")
                 .with_provider_name("SecondaryAllocationIds"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -35,7 +35,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
             AttributeSchema::new("block_public_access_states", AttributeType::Struct {
                     name: "BlockPublicAccessStates".to_string(),
                     fields: vec![
-                    StructField::new("internet_gateway_block_mode", AttributeType::String).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
+                    StructField::new("internet_gateway_block_mode", AttributeType::Enum(vec!["off".to_string(), "block-bidirectional".to_string(), "block-ingress".to_string()])).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
                     ],
                 })
                 .with_description(" (read-only)")
@@ -112,7 +112,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("enable_resource_name_dns_aaaa_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsAAAARecord"),
                     StructField::new("enable_resource_name_dns_a_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsARecord"),
-                    StructField::new("hostname_type", AttributeType::String).with_provider_name("HostnameType")
+                    StructField::new("hostname_type", AttributeType::Enum(vec!["ip-name".to_string(), "resource-name".to_string()])).with_provider_name("HostnameType")
                     ],
                 })
                 .with_description("The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more infor...")

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -85,7 +85,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpAddressType"),
         )
         .attribute(
-            AttributeSchema::new("network_interface_ids", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("network_interface_ids", AttributeType::List(Box::new(super::aws_resource_id())))
                 .with_description(" (read-only)")
                 .with_provider_name("NetworkInterfaceIds"),
         )
@@ -105,12 +105,12 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("ResourceConfigurationArn"),
         )
         .attribute(
-            AttributeSchema::new("route_table_ids", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("route_table_ids", AttributeType::List(Box::new(super::aws_resource_id())))
                 .with_description("The IDs of the route tables. Routing is supported only for gateway endpoints.")
                 .with_provider_name("RouteTableIds"),
         )
         .attribute(
-            AttributeSchema::new("security_group_ids", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("security_group_ids", AttributeType::List(Box::new(super::aws_resource_id())))
                 .with_description("The IDs of the security groups to associate with the endpoint network interfaces. If this parameter is not specified, we use the default security grou...")
                 .with_provider_name("SecurityGroupIds"),
         )
@@ -130,7 +130,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("ServiceRegion"),
         )
         .attribute(
-            AttributeSchema::new("subnet_ids", AttributeType::List(Box::new(AttributeType::String)))
+            AttributeSchema::new("subnet_ids", AttributeType::List(Box::new(super::aws_resource_id())))
                 .with_description("The IDs of the subnets in which to create endpoint network interfaces. You must specify this property for an interface endpoint or a Gateway Load Bala...")
                 .with_provider_name("SubnetIds"),
         )

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -17,7 +17,7 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
 
 ### `domain`
 
-- **Type:** String
+- **Type:** [Enum (Domain)](#domain-domain)
 - **Required:** No
 
 The network (``vpc``). If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a dependency on the VPC-gateway attachment by using the [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) on this resource.
@@ -73,6 +73,17 @@ The Elastic IP address you are accepting for transfer. You can only accept one t
 ### `public_ip`
 
 - **Type:** Ipv4Address
+
+## Enum Values
+
+### domain (Domain)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `vpc` | `awscc.ec2_eip.Domain.vpc` |
+| `standard` | `awscc.ec2_eip.Domain.standard` |
+
+Shorthand formats: `vpc` or `Domain.vpc`
 
 
 

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -8,7 +8,7 @@ Resource Schema of AWS::EC2::IPAMPool Type
 
 ### `address_family`
 
-- **Type:** String
+- **Type:** [Enum (AddressFamily)](#address_family-addressfamily)
 - **Required:** Yes
 
 The address family of the address space in this pool. Either IPv4 or IPv6.
@@ -149,6 +149,15 @@ An array of key-value pairs to apply to this resource.
 - **Type:** String
 
 ## Enum Values
+
+### address_family (AddressFamily)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `IPv4` | `awscc.ec2_ipam_pool.AddressFamily.IPv4` |
+| `IPv6` | `awscc.ec2_ipam_pool.AddressFamily.IPv6` |
+
+Shorthand formats: `IPv4` or `AddressFamily.IPv4`
 
 ### aws_service (AwsService)
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -18,7 +18,7 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
 
 ### `availability_mode`
 
-- **Type:** String
+- **Type:** [Enum (AvailabilityMode)](#availability_mode-availabilitymode)
 - **Required:** No
 
 Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway. A zonal NAT gateway is a NAT Gateway that provides redundancy and scalability within a single availability zone. A regional NAT gateway is a single NAT Gateway that works across multiple availability zones (AZs) in your VPC, providing redundancy, scalability and availability across all the AZs in a Region. For more information, see [Regional NAT gateways for automatic multi-AZ expansion](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateways-regional.html) in the *Amazon VPC User Guide*.
@@ -116,6 +116,15 @@ The ID of the VPC in which the NAT gateway is located.
 - **Type:** AwsResourceId
 
 ## Enum Values
+
+### availability_mode (AvailabilityMode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `zonal` | `awscc.ec2_nat_gateway.AvailabilityMode.zonal` |
+| `regional` | `awscc.ec2_nat_gateway.AvailabilityMode.regional` |
+
+Shorthand formats: `zonal` or `AvailabilityMode.zonal`
 
 ### connectivity_type (ConnectivityType)
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -151,7 +151,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `internet_gateway_block_mode` | String | No | The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress  |
+| `internet_gateway_block_mode` | Enum | No | The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress  |
 
 ### PrivateDnsNameOptionsOnLaunch
 
@@ -159,7 +159,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 |-------|------|----------|-------------|
 | `enable_resource_name_dns_aaaa_record` | Bool | No |  |
 | `enable_resource_name_dns_a_record` | Bool | No |  |
-| `hostname_type` | String | No |  |
+| `hostname_type` | Enum | No |  |
 
 
 


### PR DESCRIPTION
## Summary

- Add enum overrides for 5 attributes whose CloudFormation schemas lack `enum` fields: `AvailabilityMode`, `AddressFamily`, `Domain`, `InternetGatewayBlockMode`, `HostnameType`
- Fix plural ID suffix matching in `is_aws_resource_id_property()` so `List(String)` arrays like `RouteTableIds` become `List(aws_resource_id())`
- Add mod.rs tests to `generate-schemas.sh` template so they survive regeneration

Closes #95

## Changes

| File | Attribute | Before | After |
|------|-----------|--------|-------|
| nat_gateway.rs | `availability_mode` | String | Custom enum (zonal, regional) |
| ipam_pool.rs | `address_family` | String | Custom enum (IPv4, IPv6) |
| eip.rs | `domain` | String | Custom enum (vpc, standard) |
| subnet.rs | `internet_gateway_block_mode` | String (in struct) | Enum (in struct) |
| subnet.rs | `hostname_type` | String (in struct) | Enum (in struct) |
| vpc_endpoint.rs | `route_table_ids` | List(String) | List(aws_resource_id()) |
| vpc_endpoint.rs | `security_group_ids` | List(String) | List(aws_resource_id()) |
| vpc_endpoint.rs | `subnet_ids` | List(String) | List(aws_resource_id()) |
| vpc_endpoint.rs | `network_interface_ids` | List(String) | List(aws_resource_id()) |
| nat_gateway.rs | `secondary_allocation_ids` | List(String) | List(aws_resource_id()) |
| nat_gateway.rs | `allocation_ids` (in struct) | List(String) | List(aws_resource_id()) |

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 220 tests pass
- [x] Pre-commit hooks (fmt, clippy, tests) pass
- [x] Acceptance test `.crn` files are compatible with new types
- [x] Generated files match expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)