### PR TITLE
Reorder doc sections so type definitions appear before Attribute Reference

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -396,27 +396,6 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
         }
     }
 
-    // Attribute Reference (read-only attributes)
-    let has_read_only = schema
-        .properties
-        .keys()
-        .any(|name| read_only.contains(name));
-    if has_read_only {
-        md.push_str("## Attribute Reference\n\n");
-
-        for (prop_name, prop) in &schema.properties {
-            if !read_only.contains(prop_name) {
-                continue;
-            }
-
-            let attr_name = prop_name.to_snake_case();
-            let type_display = type_display_string(prop_name, prop, schema, &enums);
-
-            md.push_str(&format!("### `{}`\n\n", attr_name));
-            md.push_str(&format!("- **Type:** {}\n\n", type_display));
-        }
-    }
-
     // Enum values section
     if !enums.is_empty() {
         md.push_str("## Enum Values\n\n");
@@ -522,6 +501,27 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
                 ));
             }
             md.push('\n');
+        }
+    }
+
+    // Attribute Reference (read-only attributes)
+    let has_read_only = schema
+        .properties
+        .keys()
+        .any(|name| read_only.contains(name));
+    if has_read_only {
+        md.push_str("## Attribute Reference\n\n");
+
+        for (prop_name, prop) in &schema.properties {
+            if !read_only.contains(prop_name) {
+                continue;
+            }
+
+            let attr_name = prop_name.to_snake_case();
+            let type_display = type_display_string(prop_name, prop, schema, &enums);
+
+            md.push_str(&format!("### `{}`\n\n", attr_name));
+            md.push_str(&format!("- **Type:** {}\n\n", type_display));
         }
     }
 

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -64,16 +64,6 @@ Any tags assigned to the Elastic IP address.  Updates to the ``Tags`` property m
 
 The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfers, see [Transfer Elastic IP addresses](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#transfer-EIPs-intro) in the *Amazon Virtual Private Cloud User Guide*.
 
-## Attribute Reference
-
-### `allocation_id`
-
-- **Type:** AwsResourceId
-
-### `public_ip`
-
-- **Type:** Ipv4Address
-
 ## Enum Values
 
 ### domain (Domain)
@@ -84,6 +74,16 @@ The Elastic IP address you are accepting for transfer. You can only accept one t
 | `standard` | `awscc.ec2_eip.Domain.standard` |
 
 Shorthand formats: `vpc` or `Domain.vpc`
+
+## Attribute Reference
+
+### `allocation_id`
+
+- **Type:** AwsResourceId
+
+### `public_ip`
+
+- **Type:** Ipv4Address
 
 
 

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -88,12 +88,6 @@ The tags to apply to the flow logs.
 
 The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.
 
-## Attribute Reference
-
-### `id`
-
-- **Type:** String
-
 ## Enum Values
 
 ### log_destination_type (LogDestinationType)
@@ -138,6 +132,12 @@ Shorthand formats: `ACCEPT` or `TrafficType.ACCEPT`
 | `file_format` | String | Yes |  |
 | `hive_compatible_partitions` | Bool | Yes |  |
 | `per_hour_partition` | Bool | Yes |  |
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_ipam.md
+++ b/docs/src/providers/awscc/ec2_ipam.md
@@ -53,40 +53,6 @@ An array of key-value pairs to apply to this resource.
 
 The tier of the IPAM.
 
-## Attribute Reference
-
-### `arn`
-
-- **Type:** Arn
-
-### `default_resource_discovery_association_id`
-
-- **Type:** String
-
-### `default_resource_discovery_id`
-
-- **Type:** String
-
-### `ipam_id`
-
-- **Type:** String
-
-### `private_default_scope_id`
-
-- **Type:** String
-
-### `public_default_scope_id`
-
-- **Type:** String
-
-### `resource_discovery_association_count`
-
-- **Type:** Int
-
-### `scope_count`
-
-- **Type:** Int
-
 ## Enum Values
 
 ### metered_account (MeteredAccount)
@@ -120,6 +86,40 @@ Shorthand formats: `free` or `Tier.free`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `organizations_entity_path` | String | Yes | An AWS Organizations entity path. Build the path for the OU(s) using AWS Organizations IDs separated... |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+### `default_resource_discovery_association_id`
+
+- **Type:** String
+
+### `default_resource_discovery_id`
+
+- **Type:** String
+
+### `ipam_id`
+
+- **Type:** String
+
+### `private_default_scope_id`
+
+- **Type:** String
+
+### `public_default_scope_id`
+
+- **Type:** String
+
+### `resource_discovery_association_count`
+
+- **Type:** Int
+
+### `scope_count`
+
+- **Type:** Int
 
 
 

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -114,40 +114,6 @@ The Id of this pool's source. If set, all space provisioned in this pool must be
 
 An array of key-value pairs to apply to this resource.
 
-## Attribute Reference
-
-### `arn`
-
-- **Type:** Arn
-
-### `ipam_arn`
-
-- **Type:** Arn
-
-### `ipam_pool_id`
-
-- **Type:** IpamPoolId
-
-### `ipam_scope_arn`
-
-- **Type:** Arn
-
-### `ipam_scope_type`
-
-- **Type:** [Enum (IpamScopeType)](#ipam_scope_type-ipamscopetype)
-
-### `pool_depth`
-
-- **Type:** Int
-
-### `state`
-
-- **Type:** [Enum (State)](#state-state)
-
-### `state_message`
-
-- **Type:** String
-
 ## Enum Values
 
 ### address_family (AddressFamily)
@@ -215,6 +181,40 @@ Shorthand formats: `create-in-progress` or `State.create-in-progress`
 | `resource_owner` | String | Yes |  |
 | `resource_region` | String | Yes |  |
 | `resource_type` | String | Yes |  |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+### `ipam_arn`
+
+- **Type:** Arn
+
+### `ipam_pool_id`
+
+- **Type:** IpamPoolId
+
+### `ipam_scope_arn`
+
+- **Type:** Arn
+
+### `ipam_scope_type`
+
+- **Type:** [Enum (IpamScopeType)](#ipam_scope_type-ipamscopetype)
+
+### `pool_depth`
+
+- **Type:** Int
+
+### `state`
+
+- **Type:** [Enum (State)](#state-state)
+
+### `state_message`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -93,28 +93,6 @@ The tags for the NAT gateway.
 
 The ID of the VPC in which the NAT gateway is located.
 
-## Attribute Reference
-
-### `auto_provision_zones`
-
-- **Type:** String
-
-### `auto_scaling_ips`
-
-- **Type:** String
-
-### `eni_id`
-
-- **Type:** AwsResourceId
-
-### `nat_gateway_id`
-
-- **Type:** AwsResourceId
-
-### `route_table_id`
-
-- **Type:** AwsResourceId
-
 ## Enum Values
 
 ### availability_mode (AvailabilityMode)
@@ -144,6 +122,28 @@ Shorthand formats: `public` or `ConnectivityType.public`
 | `allocation_ids` | List<String> | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
 | `availability_zone` | AvailabilityZone | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
 | `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
+
+## Attribute Reference
+
+### `auto_provision_zones`
+
+- **Type:** String
+
+### `auto_scaling_ips`
+
+- **Type:** String
+
+### `eni_id`
+
+- **Type:** AwsResourceId
+
+### `nat_gateway_id`
+
+- **Type:** AwsResourceId
+
+### `route_table_id`
+
+- **Type:** AwsResourceId
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -48,16 +48,6 @@ Any tags assigned to the security group.
 
 The ID of the VPC for the security group.
 
-## Attribute Reference
-
-### `group_id`
-
-- **Type:** AwsResourceId
-
-### `id`
-
-- **Type:** String
-
 ## Struct Definitions
 
 ### Egress
@@ -87,6 +77,16 @@ The ID of the VPC for the security group.
 | `source_security_group_name` | String | No |  |
 | `source_security_group_owner_id` | String | No |  |
 | `to_port` | Int | No |  |
+
+## Attribute Reference
+
+### `group_id`
+
+- **Type:** AwsResourceId
+
+### `id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -73,12 +73,6 @@ The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Pr
 
 If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP code or -1 (all ICMP codes). If the start port is -1 (all ICMP types), then the end port must be -1 (all ICMP codes).
 
-## Attribute Reference
-
-### `id`
-
-- **Type:** String
-
 ## Enum Values
 
 ### ip_protocol (IpProtocol)
@@ -92,6 +86,12 @@ If the protocol is TCP or UDP, this is the end of the port range. If the protoco
 | `-1` | `awscc.ec2_security_group_egress.IpProtocol.-1` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -90,12 +90,6 @@ The ID of the security group. You must specify either the security group ID or t
 
 The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type. If you specify all ICMP/ICMPv6 types, you must specify all codes. Use this for ICMP and any protocol that uses ports.
 
-## Attribute Reference
-
-### `id`
-
-- **Type:** String
-
 ## Enum Values
 
 ### ip_protocol (IpProtocol)
@@ -109,6 +103,12 @@ The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A v
 | `-1` | `awscc.ec2_security_group_ingress.IpProtocol.-1` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
 
 
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -127,6 +127,22 @@ Any tags assigned to the subnet.
 
 The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.
 
+## Struct Definitions
+
+### BlockPublicAccessStates
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `internet_gateway_block_mode` | Enum | No | The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress  |
+
+### PrivateDnsNameOptionsOnLaunch
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enable_resource_name_dns_aaaa_record` | Bool | No |  |
+| `enable_resource_name_dns_a_record` | Bool | No |  |
+| `hostname_type` | Enum | No |  |
+
 ## Attribute Reference
 
 ### `block_public_access_states`
@@ -144,22 +160,6 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 ### `subnet_id`
 
 - **Type:** AwsResourceId
-
-## Struct Definitions
-
-### BlockPublicAccessStates
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `internet_gateway_block_mode` | Enum | No | The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress  |
-
-### PrivateDnsNameOptionsOnLaunch
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `enable_resource_name_dns_aaaa_record` | Bool | No |  |
-| `enable_resource_name_dns_a_record` | Bool | No |  |
-| `hostname_type` | Enum | No |  |
 
 
 

--- a/docs/src/providers/awscc/ec2_transit_gateway.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway.md
@@ -76,6 +76,17 @@ Resource Type definition for AWS::EC2::TransitGateway
 - **Type:** String
 - **Required:** No
 
+## Enum Values
+
+### encryption_support (EncryptionSupport)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `disable` | `awscc.ec2_transit_gateway.EncryptionSupport.disable` |
+| `enable` | `awscc.ec2_transit_gateway.EncryptionSupport.enable` |
+
+Shorthand formats: `disable` or `EncryptionSupport.disable`
+
 ## Attribute Reference
 
 ### `encryption_support_state`
@@ -89,17 +100,6 @@ Resource Type definition for AWS::EC2::TransitGateway
 ### `transit_gateway_arn`
 
 - **Type:** Arn
-
-## Enum Values
-
-### encryption_support (EncryptionSupport)
-
-| Value | DSL Identifier |
-|-------|----------------|
-| `disable` | `awscc.ec2_transit_gateway.EncryptionSupport.disable` |
-| `enable` | `awscc.ec2_transit_gateway.EncryptionSupport.enable` |
-
-Shorthand formats: `disable` or `EncryptionSupport.disable`
 
 
 

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -57,6 +57,18 @@ The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Ama
 
 The tags for the VPC.
 
+## Enum Values
+
+### instance_tenancy (InstanceTenancy)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `default` | `awscc.ec2_vpc.InstanceTenancy.default` |
+| `dedicated` | `awscc.ec2_vpc.InstanceTenancy.dedicated` |
+| `host` | `awscc.ec2_vpc.InstanceTenancy.host` |
+
+Shorthand formats: `default` or `InstanceTenancy.default`
+
 ## Attribute Reference
 
 ### `cidr_block_associations`
@@ -78,18 +90,6 @@ The tags for the VPC.
 ### `vpc_id`
 
 - **Type:** AwsResourceId
-
-## Enum Values
-
-### instance_tenancy (InstanceTenancy)
-
-| Value | DSL Identifier |
-|-------|----------------|
-| `default` | `awscc.ec2_vpc.InstanceTenancy.default` |
-| `dedicated` | `awscc.ec2_vpc.InstanceTenancy.dedicated` |
-| `host` | `awscc.ec2_vpc.InstanceTenancy.host` |
-
-Shorthand formats: `default` or `InstanceTenancy.default`
 
 
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -107,24 +107,6 @@ The type of endpoint. Default: Gateway
 
 The ID of the VPC.
 
-## Attribute Reference
-
-### `creation_timestamp`
-
-- **Type:** String
-
-### `dns_entries`
-
-- **Type:** List<String>
-
-### `id`
-
-- **Type:** String
-
-### `network_interface_ids`
-
-- **Type:** List<String>
-
 ## Enum Values
 
 ### ip_address_type (IpAddressType)
@@ -160,6 +142,24 @@ Shorthand formats: `Interface` or `VpcEndpointType.Interface`
 | `private_dns_only_for_inbound_resolver_endpoint` | String | No | Indicates whether to enable private DNS only for inbound endpoints. This option is available only fo... |
 | `private_dns_preference` | String | No | The preference for which private domains have a private hosted zone created for and associated with ... |
 | `private_dns_specified_domains` | List<String> | No | Indicates which of the private domains to create private hosted zones for and associate with the spe... |
+
+## Attribute Reference
+
+### `creation_timestamp`
+
+- **Type:** String
+
+### `dns_entries`
+
+- **Type:** List<String>
+
+### `id`
+
+- **Type:** String
+
+### `network_interface_ids`
+
+- **Type:** List<String>
 
 
 


### PR DESCRIPTION
## Summary
- Reorder generated AWSCC provider doc sections so Enum Values and Struct Definitions appear before Attribute Reference, since they are referenced in Argument Reference (closes #100)
- Pure section reorder in `generate_markdown()` — no logic changes
- Regenerated all affected doc files

## Test plan
- [x] `cargo build -p carina-provider-awscc` compiles
- [x] `cargo test -p carina-provider-awscc` passes (all 38 tests)
- [x] Pre-commit hooks pass (formatting, clippy, full test suite)
- [x] Regenerated docs and verified section order in output files

🤖 Generated with [Claude Code](https://claude.com/claude-code)