### PR TITLE
Add provider name to ResourceId for full resource identifiers (closes #99)

### DIFF
--- a/carina-core/src/differ.rs
+++ b/carina-core/src/differ.rs
@@ -17,7 +17,7 @@ pub enum Diff {
     /// Resource exists with differences -> needs update
     Update {
         id: ResourceId,
-        from: State,
+        from: Box<State>,
         to: Resource,
         changed_attributes: Vec<String>,
     },
@@ -47,7 +47,7 @@ pub fn diff(desired: &Resource, current: &State) -> Diff {
     } else {
         Diff::Update {
             id: desired.id.clone(),
-            from: current.clone(),
+            from: Box::new(current.clone()),
             to: desired.clone(),
             changed_attributes: changed,
         }

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -17,7 +17,7 @@ pub enum Effect {
     /// Update an existing resource
     Update {
         id: ResourceId,
-        from: State,
+        from: Box<State>,
         to: Resource,
     },
 

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -208,7 +208,11 @@ impl ModuleResolver {
 
             // Prefix the resource name with instance prefix
             let new_name = format!("{}_{}", instance_prefix, new_resource.id.name);
-            new_resource.id = ResourceId::new(&new_resource.id.resource_type, new_name.clone());
+            new_resource.id = ResourceId::with_provider(
+                &new_resource.id.provider,
+                &new_resource.id.resource_type,
+                new_name.clone(),
+            );
 
             // Update name attribute
             new_resource

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -578,7 +578,7 @@ fn parse_anonymous_resource(
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
 
     Ok(Resource {
-        id: ResourceId::new(resource_type, resource_name),
+        id: ResourceId::with_provider(provider, resource_type, resource_name),
         attributes,
         read_only: false,
     })
@@ -693,7 +693,7 @@ fn parse_resource_expr(
     );
 
     Ok(Resource {
-        id: ResourceId::new(resource_type, resource_name),
+        id: ResourceId::with_provider(provider, resource_type, resource_name),
         attributes,
         read_only: false,
     })
@@ -752,7 +752,7 @@ fn parse_read_resource_expr(
     attributes.insert("_data_source".to_string(), Value::Bool(true));
 
     Ok(Resource {
-        id: ResourceId::new(resource_type, resource_name),
+        id: ResourceId::with_provider(provider, resource_type, resource_name),
         attributes,
         read_only: true,
     })

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -251,13 +251,10 @@ impl ModularPlan {
 /// Format an effect briefly for display
 fn format_effect_brief(effect: &Effect) -> String {
     match effect {
-        Effect::Create(r) => format!("+ {}.{}", r.id.resource_type, r.id.name),
-        Effect::Update { id, .. } => format!("~ {}.{}", id.resource_type, id.name),
-        Effect::Delete(id) => format!("- {}.{}", id.resource_type, id.name),
-        Effect::Read { resource } => format!(
-            "<= {}.{} (data source)",
-            resource.id.resource_type, resource.id.name
-        ),
+        Effect::Create(r) => format!("+ {}", r.id),
+        Effect::Update { id, .. } => format!("~ {}", id),
+        Effect::Delete(id) => format!("- {}", id),
+        Effect::Read { resource } => format!("<= {} (data source)", resource.id),
     }
 }
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -7,6 +7,8 @@ use crate::parser::ResourceTypePath;
 /// Unique identifier for a resource
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ResourceId {
+    /// Provider name (e.g., "aws", "awscc")
+    pub provider: String,
     /// Resource type (e.g., "s3_bucket", "ec2_instance")
     pub resource_type: String,
     /// Resource name (identifier specified in DSL)
@@ -16,8 +18,40 @@ pub struct ResourceId {
 impl ResourceId {
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
+            provider: String::new(),
             resource_type: resource_type.into(),
             name: name.into(),
+        }
+    }
+
+    pub fn with_provider(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            resource_type: resource_type.into(),
+            name: name.into(),
+        }
+    }
+
+    /// Returns the display type including provider prefix if available
+    pub fn display_type(&self) -> String {
+        if self.provider.is_empty() {
+            self.resource_type.clone()
+        } else {
+            format!("{}.{}", self.provider, self.resource_type)
+        }
+    }
+}
+
+impl std::fmt::Display for ResourceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.provider.is_empty() {
+            write!(f, "{}.{}", self.resource_type, self.name)
+        } else {
+            write!(f, "{}.{}.{}", self.provider, self.resource_type, self.name)
         }
     }
 }
@@ -63,6 +97,18 @@ impl Resource {
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: ResourceId::new(resource_type, name),
+            attributes: HashMap::new(),
+            read_only: false,
+        }
+    }
+
+    pub fn with_provider(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: ResourceId::with_provider(provider, resource_type, name),
             attributes: HashMap::new(),
             read_only: false,
         }

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -164,7 +164,7 @@ impl AwsProvider {
 
     /// Read an S3 bucket
     async fn read_s3_bucket(&self, name: &str) -> ProviderResult<State> {
-        let id = ResourceId::new("s3.bucket", name);
+        let id = ResourceId::with_provider("aws", "s3.bucket", name);
 
         match self.s3_client.head_bucket().bucket(name).send().await {
             Ok(_) => {
@@ -456,7 +456,7 @@ impl AwsProvider {
     async fn read_ec2_vpc(&self, name: &str) -> ProviderResult<State> {
         use aws_sdk_ec2::types::Filter;
 
-        let id = ResourceId::new("vpc", name);
+        let id = ResourceId::with_provider("aws", "vpc", name);
 
         let filter = Filter::builder().name("tag:Name").values(name).build();
 
@@ -744,7 +744,7 @@ impl AwsProvider {
     async fn read_ec2_subnet(&self, name: &str) -> ProviderResult<State> {
         use aws_sdk_ec2::types::Filter;
 
-        let id = ResourceId::new("subnet", name);
+        let id = ResourceId::with_provider("aws", "subnet", name);
 
         let filter = Filter::builder().name("tag:Name").values(name).build();
 
@@ -900,7 +900,7 @@ impl AwsProvider {
     async fn read_ec2_internet_gateway(&self, name: &str) -> ProviderResult<State> {
         use aws_sdk_ec2::types::Filter;
 
-        let id = ResourceId::new("internet_gateway", name);
+        let id = ResourceId::with_provider("aws", "internet_gateway", name);
 
         let filter = Filter::builder().name("tag:Name").values(name).build();
 
@@ -1101,7 +1101,7 @@ impl AwsProvider {
     async fn read_ec2_route_table(&self, name: &str) -> ProviderResult<State> {
         use aws_sdk_ec2::types::Filter;
 
-        let id = ResourceId::new("route_table", name);
+        let id = ResourceId::with_provider("aws", "route_table", name);
 
         let filter = Filter::builder().name("tag:Name").values(name).build();
 
@@ -1292,7 +1292,7 @@ impl AwsProvider {
         // Routes don't have a "name" in AWS - we use the name for identification
         // The actual route is identified by route_table_id + destination_cidr_block
         // For read, we return not_found since we can't look up by name alone
-        let id = ResourceId::new("route", name);
+        let id = ResourceId::with_provider("aws", "route", name);
         Ok(State::not_found(id))
     }
 
@@ -1303,7 +1303,7 @@ impl AwsProvider {
         route_table_id: &str,
         destination_cidr_block: &str,
     ) -> ProviderResult<State> {
-        let id = ResourceId::new("route", name);
+        let id = ResourceId::with_provider("aws", "route", name);
 
         // Describe the route table to get its routes
         let result = self
@@ -1485,7 +1485,7 @@ impl AwsProvider {
     async fn read_ec2_security_group(&self, name: &str) -> ProviderResult<State> {
         use aws_sdk_ec2::types::Filter;
 
-        let id = ResourceId::new("security_group", name);
+        let id = ResourceId::with_provider("aws", "security_group", name);
 
         let filter = Filter::builder().name("tag:Name").values(name).build();
 
@@ -1673,7 +1673,7 @@ impl AwsProvider {
         } else {
             "security_group.egress_rule"
         };
-        let id = ResourceId::new(resource_type, name);
+        let id = ResourceId::with_provider("aws", resource_type, name);
 
         let rules = self
             .find_security_group_rules_by_name(name, is_ingress)

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -220,7 +220,7 @@ impl AwsccProvider {
         name: &str,
         identifier: Option<&str>,
     ) -> ProviderResult<State> {
-        let id = ResourceId::new(resource_type, name);
+        let id = ResourceId::with_provider("awscc", resource_type, name);
 
         let config = get_schema_config(resource_type).ok_or_else(|| {
             ProviderError::new(format!("Unknown resource type: {}", resource_type))


### PR DESCRIPTION
## Summary
- Added `provider` field to `ResourceId` struct with `with_provider()` constructor and `Display` impl
- Parser now sets provider name when creating ResourceIds from DSL
- All plan/apply/destroy display output now shows full identifiers like `awscc.ec2_vpc.name` instead of `ec2_vpc.name`
- Provider read operations (`aws`, `awscc`) now create ResourceIds with their provider name
- Boxed `State` in `Update` variants of `Effect` and `Diff` enums to satisfy clippy `large_enum_variant` lint triggered by the added field

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all 215 tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatting clean
- [ ] Verify plan output shows provider prefix with a real `.crn` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)