### PR TITLE
Add support for mutually exclusive required fields in schema validation (closes #92)

### DIFF
--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -375,6 +375,29 @@ impl DiagnosticEngine {
                             }
                         }
                     }
+
+                    // Run resource-level validator (e.g., mutually exclusive required fields)
+                    if let Err(errors) = schema.validate(&resource.attributes) {
+                        for error in errors {
+                            if let Some((line, _col)) =
+                                self.find_resource_position(doc, &resource.id.resource_type)
+                            {
+                                diagnostics.push(Diagnostic {
+                                    range: Range {
+                                        start: Position { line, character: 0 },
+                                        end: Position {
+                                            line: line + 1,
+                                            character: 0,
+                                        },
+                                    },
+                                    severity: Some(DiagnosticSeverity::ERROR),
+                                    source: Some("carina".to_string()),
+                                    message: error.to_string(),
+                                    ..Default::default()
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR implements resource-level validators to support complex validation patterns like mutually exclusive required fields, addressing issue #92.

## Problem

The current schema system only supports simple required field validation using `.required()`. However, some AWS resources require mutually exclusive fields where exactly one of multiple fields must be specified.

For example, AWS EC2 Subnet requires either `cidr_block` OR `ipv4_ipam_pool_id` to be specified, but not both and not neither:
- When using IPAM: specify `ipv4_ipam_pool_id` (and optionally `ipv4_netmask_length`)
- When not using IPAM: specify `cidr_block`

## Solution

Added resource-level validators that execute after standard attribute validation:

1. **`ResourceValidator` type alias** - Clean type definition for validator functions
2. **`ResourceSchema.validator` field** - Optional validator function for cross-attribute validation
3. **`validators::validate_exclusive_required()` helper** - Reusable helper for mutually exclusive field validation
4. **EC2 Subnet validator** - Applied to require exactly one of `cidr_block` or `ipv4_ipam_pool_id`
5. **LSP integration** - Diagnostics engine now calls resource validators for real-time validation

## Changes

- `carina-core/src/schema.rs`:
  - Add `ResourceValidator` type alias
  - Add `validator` field to `ResourceSchema`
  - Add `with_validator()` builder method
  - Update `validate()` to execute custom validators
  - Add `validators::validate_exclusive_required()` helper
  - Comprehensive tests

- `carina-provider-awscc/src/schemas/generated/subnet.rs`:
  - Add `validate_subnet()` function
  - Apply validator to subnet schema
  - Test demonstrating the validation

- `carina-lsp/src/diagnostics.rs`:
  - Call `schema.validate()` for resource-level validation
  - Display validation errors in editor

## Test Coverage

- ✅ Unit tests for `ResourceSchema.validator`
- ✅ Unit tests for `validators::validate_exclusive_required()`
- ✅ Integration test for EC2 Subnet validation
- ✅ All existing tests pass

## Future Work

This pattern can be applied to other resources with mutually exclusive fields or other complex validation requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)