### PR TITLE
Apply property name-based type inference to List element types in docs (closes #110)

### DIFF
--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -53,7 +53,7 @@ The private IPv4 address to assign to the NAT gateway. If you don't provide an a
 
 ### `secondary_allocation_ids`
 
-- **Type:** `List<String>`
+- **Type:** `List<AwsResourceId>`
 - **Required:** No
 
 Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-working-with.html) in the *Amazon VPC User Guide*.
@@ -67,7 +67,7 @@ Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](h
 
 ### `secondary_private_ip_addresses`
 
-- **Type:** `List<String>`
+- **Type:** `List<Ipv4Address>`
 - **Required:** No
 
 Secondary private IPv4 addresses. For more information about secondary addresses, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-creating) in the *Amazon Virtual Private Cloud User Guide*. ``SecondaryPrivateIpAddressCount`` and ``SecondaryPrivateIpAddresses`` cannot be set at the same time.
@@ -119,7 +119,7 @@ Shorthand formats: `public` or `ConnectivityType.public`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `allocation_ids` | `List<String>` | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
+| `allocation_ids` | `List<AwsResourceId>` | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
 | `availability_zone` | AvailabilityZone | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
 | `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -151,7 +151,7 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 ### `ipv6_cidr_blocks`
 
-- **Type:** `List<String>`
+- **Type:** `List<Ipv6Cidr>`
 
 ### `network_acl_association_id`
 

--- a/docs/src/providers/awscc/ec2_transit_gateway.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway.md
@@ -68,7 +68,7 @@ Resource Type definition for AWS::EC2::TransitGateway
 
 ### `transit_gateway_cidr_blocks`
 
-- **Type:** `List<String>`
+- **Type:** `List<Ipv4Cidr>`
 - **Required:** No
 
 ### `vpn_ecmp_support`

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -73,7 +73,7 @@ Shorthand formats: `default` or `InstanceTenancy.default`
 
 ### `cidr_block_associations`
 
-- **Type:** `List<String>`
+- **Type:** `List<Ipv4Cidr>`
 
 ### `default_network_acl`
 
@@ -85,7 +85,7 @@ Shorthand formats: `default` or `InstanceTenancy.default`
 
 ### `ipv6_cidr_blocks`
 
-- **Type:** `List<String>`
+- **Type:** `List<Ipv6Cidr>`
 
 ### `vpc_id`
 

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -46,14 +46,14 @@ The Amazon Resource Name (ARN) of the resource configuration.
 
 ### `route_table_ids`
 
-- **Type:** `List<String>`
+- **Type:** `List<RouteTableId>`
 - **Required:** No
 
 The IDs of the route tables. Routing is supported only for gateway endpoints.
 
 ### `security_group_ids`
 
-- **Type:** `List<String>`
+- **Type:** `List<SecurityGroupId>`
 - **Required:** No
 
 The IDs of the security groups to associate with the endpoint network interfaces. If this parameter is not specified, we use the default security group for the VPC. Security groups are supported only for interface endpoints.
@@ -81,7 +81,7 @@ Describes a Region.
 
 ### `subnet_ids`
 
-- **Type:** `List<String>`
+- **Type:** `List<SubnetId>`
 - **Required:** No
 
 The IDs of the subnets in which to create endpoint network interfaces. You must specify this property for an interface endpoint or a Gateway Load Balancer endpoint. You can't specify this property for a gateway endpoint. For a Gateway Load Balancer endpoint, you can specify only one subnet.
@@ -159,7 +159,7 @@ Shorthand formats: `Interface` or `VpcEndpointType.Interface`
 
 ### `network_interface_ids`
 
-- **Type:** `List<String>`
+- **Type:** `List<AwsResourceId>`
 
 
 


### PR DESCRIPTION
## Summary

- Extracted shared `infer_string_type_display()` helper function so `list_element_type_display()` applies the same property name-based type inference as `type_display_string()` for scalar types
- List properties like `subnet_ids`, `security_group_ids`, `route_table_ids` now correctly display specific typed lists (e.g., `List<SubnetId>`, `List<SecurityGroupId>`) instead of generic `List<String>`
- Regenerated all documentation to reflect the improved type display

### Examples of fixed types

| Property | Before | After |
|----------|--------|-------|
| `route_table_ids` | `List<String>` | `List<RouteTableId>` |
| `security_group_ids` | `List<String>` | `List<SecurityGroupId>` |
| `subnet_ids` | `List<String>` | `List<SubnetId>` |
| `network_interface_ids` | `List<String>` | `List<AwsResourceId>` |
| `secondary_private_ip_addresses` | `List<String>` | `List<Ipv4Address>` |
| `ipv6_cidr_blocks` | `List<String>` | `List<Ipv6Cidr>` |
| `transit_gateway_cidr_blocks` | `List<String>` | `List<Ipv4Cidr>` |

Closes #110

## Test plan

- [x] Added `test_list_element_type_display_with_name_inference` test covering SubnetIds, SecurityGroupIds, RouteTableIds, NetworkInterfaceIds, VpcEndpointIds, RoleArns, CidrBlocks, Ipv6CidrBlocks, and generic Names
- [x] All 28 codegen tests pass
- [x] All 247 project tests pass
- [x] Clippy and formatting checks pass
- [x] Regenerated documentation verified (ec2_vpc_endpoint.md, ec2_nat_gateway.md, ec2_subnet.md, ec2_vpc.md, ec2_transit_gateway.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)