### PR TITLE
Add EC2 TransitGatewayAttachment, S3 Bucket, IAM Role, and Logs LogGroup resource types

### DIFF
--- a/carina-provider-awscc/scripts/generate-docs.sh
+++ b/carina-provider-awscc/scripts/generate-docs.sh
@@ -34,6 +34,10 @@ RESOURCE_TYPES=(
     "AWS::EC2::TransitGateway"
     "AWS::EC2::VPCPeeringConnection"
     "AWS::EC2::EgressOnlyInternetGateway"
+    "AWS::EC2::TransitGatewayAttachment"
+    "AWS::S3::Bucket"
+    "AWS::IAM::Role"
+    "AWS::Logs::LogGroup"
 )
 
 echo "Generating awscc provider documentation..."

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -33,6 +33,10 @@ RESOURCE_TYPES=(
     "AWS::EC2::TransitGateway"
     "AWS::EC2::VPCPeeringConnection"
     "AWS::EC2::EgressOnlyInternetGateway"
+    "AWS::EC2::TransitGatewayAttachment"
+    "AWS::S3::Bucket"
+    "AWS::IAM::Role"
+    "AWS::Logs::LogGroup"
 )
 
 echo "Generating awscc provider schemas..."

--- a/carina-provider-awscc/src/schemas/generated/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/bucket.rs
@@ -1,0 +1,696 @@
+//! bucket schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::S3::Bucket
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_namespaced_enum;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+const VALID_ABAC_STATUS: &[&str] = &["Enabled", "Disabled"];
+
+fn validate_abac_status(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(value, "AbacStatus", "awscc.s3_bucket", VALID_ABAC_STATUS)
+}
+
+const VALID_ACCESS_CONTROL: &[&str] = &[
+    "AuthenticatedRead",
+    "AwsExecRead",
+    "BucketOwnerFullControl",
+    "BucketOwnerRead",
+    "LogDeliveryWrite",
+    "Private",
+    "PublicRead",
+    "PublicReadWrite",
+];
+
+fn validate_access_control(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "AccessControl",
+        "awscc.s3_bucket",
+        VALID_ACCESS_CONTROL,
+    )
+}
+
+/// Returns the schema config for s3_bucket (AWS::S3::Bucket)
+pub fn s3_bucket_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::S3::Bucket",
+        resource_type_name: "s3_bucket",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.s3_bucket")
+        .with_description("The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Region where you create the AWS CloudFormation stack.  To control how AWS CloudFormation handles the bucket when the stack ...")
+        .attribute(
+            AttributeSchema::new("abac_status", AttributeType::Custom {
+                name: "AbacStatus".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_abac_status,
+                namespace: Some("awscc.s3_bucket".to_string()),
+            })
+                .with_description("The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general p...")
+                .with_provider_name("AbacStatus"),
+        )
+        .attribute(
+            AttributeSchema::new("accelerate_configuration", AttributeType::Struct {
+                    name: "AccelerateConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("acceleration_status", AttributeType::Enum(vec!["Enabled".to_string(), "Suspended".to_string()])).required().with_description("Specifies the transfer acceleration status of the bucket.").with_provider_name("AccelerationStatus")
+                    ],
+                })
+                .with_description("Configures the transfer acceleration state for an Amazon S3 bucket. For more information, see [Amazon S3 Transfer Acceleration](https://docs.aws.amazo...")
+                .with_provider_name("AccelerateConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("access_control", AttributeType::Custom {
+                name: "AccessControl".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_access_control,
+                namespace: Some("awscc.s3_bucket".to_string()),
+            })
+                .with_description("This is a legacy property, and it is not recommended for most use cases. A majority of modern use cases in Amazon S3 no longer require the use of ACLs...")
+                .with_provider_name("AccessControl"),
+        )
+        .attribute(
+            AttributeSchema::new("analytics_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "AnalyticsConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("id", AttributeType::String).required().with_description("The ID that identifies the analytics configuration.").with_provider_name("Id"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix that an object must have to be included in the analytics results.").with_provider_name("Prefix"),
+                    StructField::new("storage_class_analysis", AttributeType::Struct {
+                    name: "StorageClassAnalysis".to_string(),
+                    fields: vec![
+                    StructField::new("data_export", AttributeType::Struct {
+                    name: "DataExport".to_string(),
+                    fields: vec![
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "Destination".to_string(),
+                    fields: vec![
+                    StructField::new("bucket_account_id", AttributeType::String).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data.  Although this val...").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
+                    StructField::new("format", AttributeType::Enum(vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()])).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
+                    ],
+                }).required().with_description("The place to store the data for an analysis.").with_provider_name("Destination"),
+                    StructField::new("output_schema_version", AttributeType::String).required().with_description("The version of the output schema to use when exporting data. Must be ``V_1``.").with_provider_name("OutputSchemaVersion")
+                    ],
+                }).with_description("Specifies how data related to the storage class analysis for an Amazon S3 bucket should be exported.").with_provider_name("DataExport")
+                    ],
+                }).required().with_description("Contains data related to access patterns to be collected and made available to analyze the tradeoffs between different storage classes.").with_provider_name("StorageClassAnalysis"),
+                    StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("The tags to use when evaluating an analytics filter. The analytics only includes objects that meet the filter's criteria. If no filter is specified, a...").with_provider_name("TagFilters")
+                    ],
+                })))
+                .with_description("Specifies the configuration and any analyses for the analytics filter of an Amazon S3 bucket.")
+                .with_provider_name("AnalyticsConfigurations"),
+        )
+        .attribute(
+            AttributeSchema::new("arn", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_encryption", AttributeType::Struct {
+                    name: "BucketEncryption".to_string(),
+                    fields: vec![
+                    StructField::new("server_side_encryption_configuration", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "ServerSideEncryptionRule".to_string(),
+                    fields: vec![
+                    StructField::new("blocked_encryption_types", AttributeType::Struct {
+                    name: "BlockedEncryptionTypes".to_string(),
+                    fields: vec![
+                    StructField::new("encryption_type", AttributeType::String).with_description("The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket.  Currently, this parameter only supports blockin...").with_provider_name("EncryptionType")
+                    ],
+                }).with_description("A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryp...").with_provider_name("BlockedEncryptionTypes"),
+                    StructField::new("bucket_key_enabled", AttributeType::Bool).with_description("Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. Existing object...").with_provider_name("BucketKeyEnabled"),
+                    StructField::new("server_side_encryption_by_default", AttributeType::Struct {
+                    name: "ServerSideEncryptionByDefault".to_string(),
+                    fields: vec![
+                    StructField::new("kms_master_key_id", AttributeType::String).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption.   + *General purpose buckets* - This parameter is allowed ...").with_provider_name("KMSMasterKeyID"),
+                    StructField::new("sse_algorithm", AttributeType::Enum(vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()])).required().with_description("Server-side encryption algorithm to use for the default encryption.  For directory buckets, there are only two supported values for server-side encryp...").with_provider_name("SSEAlgorithm")
+                    ],
+                }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption...").with_provider_name("ServerSideEncryptionByDefault")
+                    ],
+                }))).required().with_description("Specifies the default server-side-encryption configuration.").with_provider_name("ServerSideEncryptionConfiguration")
+                    ],
+                })
+                .with_description("Specifies default encryption for a bucket using server-side encryption with Amazon S3-managed keys (SSE-S3), AWS KMS-managed keys (SSE-KMS), or dual-l...")
+                .with_provider_name("BucketEncryption"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_name", AttributeType::String)
+                .with_description("A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name mus...")
+                .with_provider_name("BucketName"),
+        )
+        .attribute(
+            AttributeSchema::new("cors_configuration", AttributeType::Struct {
+                    name: "CorsConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("cors_rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "CorsRule".to_string(),
+                    fields: vec![
+                    StructField::new("allowed_headers", AttributeType::List(Box::new(AttributeType::String))).with_description("Headers that are specified in the ``Access-Control-Request-Headers`` header. These headers are allowed in a preflight OPTIONS request. In response to ...").with_provider_name("AllowedHeaders"),
+                    StructField::new("allowed_methods", AttributeType::List(Box::new(AttributeType::String))).required().with_description("An HTTP method that you allow the origin to run. *Allowed values*: ``GET`` | ``PUT`` | ``HEAD`` | ``POST`` | ``DELETE``").with_provider_name("AllowedMethods"),
+                    StructField::new("allowed_origins", AttributeType::List(Box::new(AttributeType::String))).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
+                    StructField::new("exposed_headers", AttributeType::List(Box::new(AttributeType::String))).with_description("One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript ``XMLHttpRequ...").with_provider_name("ExposedHeaders"),
+                    StructField::new("id", AttributeType::String).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
+                    StructField::new("max_age", AttributeType::Int).with_description("The time in seconds that your browser is to cache the preflight response for the specified resource.").with_provider_name("MaxAge")
+                    ],
+                }))).required().with_description("A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.").with_provider_name("CorsRules")
+                    ],
+                })
+                .with_description("Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource Sharing]...")
+                .with_provider_name("CorsConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("domain_name", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("DomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("dual_stack_domain_name", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("DualStackDomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("intelligent_tiering_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "IntelligentTieringConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the S3 Intelligent-Tiering configuration.").with_provider_name("Id"),
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.").with_provider_name("Prefix"),
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).required().with_description("Specifies the status of the configuration.").with_provider_name("Status"),
+                    StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("A container for a key-value pair.").with_provider_name("TagFilters"),
+                    StructField::new("tierings", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Tiering".to_string(),
+                    fields: vec![
+                    StructField::new("access_tier", AttributeType::Enum(vec!["ARCHIVE_ACCESS".to_string(), "DEEP_ARCHIVE_ACCESS".to_string()])).required().with_description("S3 Intelligent-Tiering access tier. See [Storage class for automatically optimizing frequently and infrequently accessed objects](https://docs.aws.ama...").with_provider_name("AccessTier"),
+                    StructField::new("days", AttributeType::Int).required().with_description("The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of...").with_provider_name("Days")
+                    ],
+                }))).required().with_description("Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one tier must be defined in the list. At most, you can s...").with_provider_name("Tierings")
+                    ],
+                })))
+                .with_description("Defines how Amazon S3 handles Intelligent-Tiering storage.")
+                .with_provider_name("IntelligentTieringConfigurations"),
+        )
+        .attribute(
+            AttributeSchema::new("inventory_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "InventoryConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "Destination".to_string(),
+                    fields: vec![
+                    StructField::new("bucket_account_id", AttributeType::String).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data.  Although this val...").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
+                    StructField::new("format", AttributeType::Enum(vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()])).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
+                    ],
+                }).required().with_description("Contains information about where to publish the inventory results.").with_provider_name("Destination"),
+                    StructField::new("enabled", AttributeType::Bool).required().with_description("Specifies whether the inventory is enabled or disabled. If set to ``True``, an inventory list is generated. If set to ``False``, no inventory list is ...").with_provider_name("Enabled"),
+                    StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the inventory configuration.").with_provider_name("Id"),
+                    StructField::new("included_object_versions", AttributeType::Enum(vec!["All".to_string(), "Current".to_string()])).required().with_description("Object versions to include in the inventory list. If set to ``All``, the list includes all the object versions, which adds the version-related fields ...").with_provider_name("IncludedObjectVersions"),
+                    StructField::new("optional_fields", AttributeType::List(Box::new(AttributeType::String))).with_description("Contains the optional fields that are included in the inventory results.").with_provider_name("OptionalFields"),
+                    StructField::new("prefix", AttributeType::String).with_description("Specifies the inventory filter prefix.").with_provider_name("Prefix"),
+                    StructField::new("schedule_frequency", AttributeType::Enum(vec!["Daily".to_string(), "Weekly".to_string()])).required().with_description("Specifies the schedule for generating inventory results.").with_provider_name("ScheduleFrequency")
+                    ],
+                })))
+                .with_description("Specifies the S3 Inventory configuration for an Amazon S3 bucket. For more information, see [GET Bucket inventory](https://docs.aws.amazon.com/AmazonS...")
+                .with_provider_name("InventoryConfigurations"),
+        )
+        .attribute(
+            AttributeSchema::new("lifecycle_configuration", AttributeType::Struct {
+                    name: "LifecycleConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Rule".to_string(),
+                    fields: vec![
+                    StructField::new("abort_incomplete_multipart_upload", AttributeType::Struct {
+                    name: "AbortIncompleteMultipartUpload".to_string(),
+                    fields: vec![
+                    StructField::new("days_after_initiation", AttributeType::Int).required().with_description("Specifies the number of days after which Amazon S3 stops an incomplete multipart upload.").with_provider_name("DaysAfterInitiation")
+                    ],
+                }).with_description("Specifies a lifecycle rule that stops incomplete multipart uploads to an Amazon S3 bucket.").with_provider_name("AbortIncompleteMultipartUpload"),
+                    StructField::new("expiration_date", AttributeType::String).with_description("Indicates when objects are deleted from Amazon S3 and Amazon S3 Glacier. The date value must be in ISO 8601 format. The time is always midnight UTC. I...").with_provider_name("ExpirationDate"),
+                    StructField::new("expiration_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon S3 Glacier. If you specify an expiration and transition...").with_provider_name("ExpirationInDays"),
+                    StructField::new("expired_object_delete_marker", AttributeType::Bool).with_description("Indicates whether Amazon S3 will remove a delete marker without any noncurrent versions. If set to true, the delete marker will be removed if there ar...").with_provider_name("ExpiredObjectDeleteMarker"),
+                    StructField::new("id", AttributeType::String).with_description("Unique identifier for the rule. The value can't be longer than 255 characters.").with_provider_name("Id"),
+                    StructField::new("noncurrent_version_expiration", AttributeType::Struct {
+                    name: "NoncurrentVersionExpiration".to_string(),
+                    fields: vec![
+                    StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For...").with_provider_name("NewerNoncurrentVersions"),
+                    StructField::new("noncurrent_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before S3 can perform the associated action. For information about the noncurrent days calculatio...").with_provider_name("NoncurrentDays")
+                    ],
+                }).with_description("Specifies when noncurrent object versions expire. Upon expiration, S3 permanently deletes the noncurrent object versions. You set this lifecycle confi...").with_provider_name("NoncurrentVersionExpiration"),
+                    StructField::new("noncurrent_version_expiration_in_days", AttributeType::Int).with_description("(Deprecated.) For buckets with versioning enabled (or suspended), specifies the time, in days, between when a new version of the object is uploaded to...").with_provider_name("NoncurrentVersionExpirationInDays"),
+                    StructField::new("noncurrent_version_transition", AttributeType::Struct {
+                    name: "NoncurrentVersionTransition".to_string(),
+                    fields: vec![
+                    StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For...").with_provider_name("NewerNoncurrentVersions"),
+                    StructField::new("storage_class", AttributeType::Enum(vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "Glacier".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()])).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
+                    StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days cal...").with_provider_name("TransitionInDays")
+                    ],
+                }).with_description("(Deprecated.) For buckets with versioning enabled (or suspended), specifies when non-current objects transition to a specified storage class. If you s...").with_provider_name("NoncurrentVersionTransition"),
+                    StructField::new("noncurrent_version_transitions", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "NoncurrentVersionTransition".to_string(),
+                    fields: vec![
+                    StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For...").with_provider_name("NewerNoncurrentVersions"),
+                    StructField::new("storage_class", AttributeType::Enum(vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "Glacier".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()])).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
+                    StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days cal...").with_provider_name("TransitionInDays")
+                    ],
+                }))).with_description("For buckets with versioning enabled (or suspended), one or more transition rules that specify when non-current objects transition to a specified stora...").with_provider_name("NoncurrentVersionTransitions"),
+                    StructField::new("object_size_greater_than", AttributeType::String).with_description("Specifies the minimum object size in bytes for this rule to apply to. Objects must be larger than this value in bytes. For more information about size...").with_provider_name("ObjectSizeGreaterThan"),
+                    StructField::new("object_size_less_than", AttributeType::String).with_description("Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than this value in bytes. For more information about siz...").with_provider_name("ObjectSizeLessThan"),
+                    StructField::new("prefix", AttributeType::String).with_description("Object key prefix that identifies one or more objects to which this rule applies.  Replacement must be made for object keys containing special charact...").with_provider_name("Prefix"),
+                    StructField::new("status", AttributeType::Enum(vec!["Enabled".to_string(), "Disabled".to_string()])).required().with_description("If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied.").with_provider_name("Status"),
+                    StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("Tags to use to identify a subset of objects to which the lifecycle rule applies.").with_provider_name("TagFilters"),
+                    StructField::new("transition", AttributeType::Struct {
+                    name: "Transition".to_string(),
+                    fields: vec![
+                    StructField::new("storage_class", AttributeType::Enum(vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "Glacier".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()])).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
+                    StructField::new("transition_date", AttributeType::String).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
+                    StructField::new("transition_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are transitioned to the specified storage class. If the specified storage class is ``INTELLIG...").with_provider_name("TransitionInDays")
+                    ],
+                }).with_description("(Deprecated.) Specifies when an object transitions to a specified storage class. If you specify an expiration and transition time, you must use the sa...").with_provider_name("Transition"),
+                    StructField::new("transitions", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Transition".to_string(),
+                    fields: vec![
+                    StructField::new("storage_class", AttributeType::Enum(vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "Glacier".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()])).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
+                    StructField::new("transition_date", AttributeType::String).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
+                    StructField::new("transition_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are transitioned to the specified storage class. If the specified storage class is ``INTELLIG...").with_provider_name("TransitionInDays")
+                    ],
+                }))).with_description("One or more transition rules that specify when an object transitions to a specified storage class. If you specify an expiration and transition time, y...").with_provider_name("Transitions")
+                    ],
+                }))).required().with_description("A lifecycle rule for individual objects in an Amazon S3 bucket.").with_provider_name("Rules"),
+                    StructField::new("transition_default_minimum_object_size", AttributeType::Enum(vec!["varies_by_storage_class".to_string(), "all_storage_classes_128K".to_string()])).with_description("Indicates which default minimum object size behavior is applied to the lifecycle configuration.  This parameter applies to general purpose buckets onl...").with_provider_name("TransitionDefaultMinimumObjectSize")
+                    ],
+                })
+                .with_description("Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.ama...")
+                .with_provider_name("LifecycleConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("logging_configuration", AttributeType::Struct {
+                    name: "LoggingConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("destination_bucket_name", AttributeType::String).with_description("The name of the bucket where Amazon S3 should store server access log files. You can store log files in any bucket that you own. By default, logs are ...").with_provider_name("DestinationBucketName"),
+                    StructField::new("log_file_prefix", AttributeType::String).with_description("A prefix for all log object keys. If you store log files from multiple Amazon S3 buckets in a single bucket, you can use a prefix to distinguish which...").with_provider_name("LogFilePrefix"),
+                    StructField::new("target_object_key_format", AttributeType::String).with_description("Amazon S3 key format for log objects. Only one format, either PartitionedPrefix or SimplePrefix, is allowed.").with_provider_name("TargetObjectKeyFormat")
+                    ],
+                })
+                .with_description("Settings that define where logs are stored.")
+                .with_provider_name("LoggingConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metadata_configuration", AttributeType::Struct {
+                    name: "MetadataConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "MetadataDestination".to_string(),
+                    fields: vec![
+                    StructField::new("table_bucket_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored.").with_provider_name("TableBucketArn"),
+                    StructField::new("table_bucket_type", AttributeType::Enum(vec!["aws".to_string(), "customer".to_string()])).required().with_description("The type of the table bucket where the metadata configuration is stored. The ``aws`` value indicates an AWS managed table bucket, and the ``customer``...").with_provider_name("TableBucketType"),
+                    StructField::new("table_namespace", AttributeType::String).with_description("The namespace in the table bucket where the metadata tables for a metadata configuration are stored.").with_provider_name("TableNamespace")
+                    ],
+                }).with_description("The destination information for the S3 Metadata configuration.").with_provider_name("Destination"),
+                    StructField::new("inventory_table_configuration", AttributeType::Struct {
+                    name: "InventoryTableConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("configuration_state", AttributeType::Enum(vec!["ENABLED".to_string(), "DISABLED".to_string()])).required().with_description("The configuration state of the inventory table, indicating whether the inventory table is enabled or disabled.").with_provider_name("ConfigurationState"),
+                    StructField::new("encryption_configuration", AttributeType::Struct {
+                    name: "MetadataTableEncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("kms_key_arn", super::arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must speci...").with_provider_name("KmsKeyArn"),
+                    StructField::new("sse_algorithm", AttributeType::Enum(vec!["aws:kms".to_string(), "AES256".to_string()])).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To...").with_provider_name("SseAlgorithm")
+                    ],
+                }).with_description("The encryption configuration for the inventory table.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the inventory table.").with_provider_name("TableArn"),
+                    StructField::new("table_name", AttributeType::String).with_description("The name of the inventory table.").with_provider_name("TableName")
+                    ],
+                }).with_description("The inventory table configuration for a metadata configuration.").with_provider_name("InventoryTableConfiguration"),
+                    StructField::new("journal_table_configuration", AttributeType::Struct {
+                    name: "JournalTableConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("encryption_configuration", AttributeType::Struct {
+                    name: "MetadataTableEncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("kms_key_arn", super::arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must speci...").with_provider_name("KmsKeyArn"),
+                    StructField::new("sse_algorithm", AttributeType::Enum(vec!["aws:kms".to_string(), "AES256".to_string()])).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To...").with_provider_name("SseAlgorithm")
+                    ],
+                }).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("record_expiration", AttributeType::Struct {
+                    name: "RecordExpiration".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("If you enable journal table record expiration, you can set the number of days to retain your journal table records. Journal table records must be reta...").with_provider_name("Days"),
+                    StructField::new("expiration", AttributeType::Enum(vec!["ENABLED".to_string(), "DISABLED".to_string()])).required().with_description("Specifies whether journal table record expiration is enabled or disabled.").with_provider_name("Expiration")
+                    ],
+                }).required().with_description("The journal table record expiration settings for the journal table.").with_provider_name("RecordExpiration"),
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the journal table.").with_provider_name("TableArn"),
+                    StructField::new("table_name", AttributeType::String).with_description("The name of the journal table.").with_provider_name("TableName")
+                    ],
+                }).required().with_description("The journal table configuration for a metadata configuration.").with_provider_name("JournalTableConfiguration")
+                    ],
+                })
+                .with_description("The S3 Metadata configuration for a general purpose bucket.")
+                .with_provider_name("MetadataConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metadata_table_configuration", AttributeType::Struct {
+                    name: "MetadataTableConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("s3_tables_destination", AttributeType::Struct {
+                    name: "S3TablesDestination".to_string(),
+                    fields: vec![
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the metadata table in the metadata table configuration. The specified metadata table name must be unique within the...").with_provider_name("TableArn"),
+                    StructField::new("table_bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) for the table bucket that's specified as the destination in the metadata table configuration. The destination table buc...").with_provider_name("TableBucketArn"),
+                    StructField::new("table_name", AttributeType::String).required().with_description("The name for the metadata table in your metadata table configuration. The specified metadata table name must be unique within the ``aws_s3_metadata`` ...").with_provider_name("TableName"),
+                    StructField::new("table_namespace", AttributeType::String).with_description("The table bucket namespace for the metadata table in your metadata table configuration. This value is always ``aws_s3_metadata``.").with_provider_name("TableNamespace")
+                    ],
+                }).required().with_description("The destination information for the metadata table configuration. The destination table bucket must be in the same Region and AWS-account as the gener...").with_provider_name("S3TablesDestination")
+                    ],
+                })
+                .with_description("The metadata table configuration of an S3 general purpose bucket.")
+                .with_provider_name("MetadataTableConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metrics_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "MetricsConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("access_point_arn", super::arn()).with_description("The access point that was used while performing operations on the object. The metrics configuration only includes objects that meet the filter's crite...").with_provider_name("AccessPointArn"),
+                    StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the metrics configuration. This can be any value you choose that helps you identify your metrics configuration.").with_provider_name("Id"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix that an object must have to be included in the metrics results.").with_provider_name("Prefix"),
+                    StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration includes only objects that meet the filter's crite...").with_provider_name("TagFilters")
+                    ],
+                })))
+                .with_description("Specifies a metrics configuration for the CloudWatch request metrics (specified by the metrics configuration ID) from an Amazon S3 bucket. If you're u...")
+                .with_provider_name("MetricsConfigurations"),
+        )
+        .attribute(
+            AttributeSchema::new("notification_configuration", AttributeType::Struct {
+                    name: "NotificationConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event_bridge_configuration", AttributeType::Struct {
+                    name: "EventBridgeConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event_bridge_enabled", AttributeType::Bool).required().with_description("Enables delivery of events to Amazon EventBridge.").with_provider_name("EventBridgeEnabled")
+                    ],
+                }).with_description("Enables delivery of events to Amazon EventBridge.").with_provider_name("EventBridgeConfiguration"),
+                    StructField::new("lambda_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "LambdaConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event", AttributeType::String).required().with_description("The Amazon S3 bucket event for which to invoke the LAMlong function. For more information, see [Supported Event Types](https://docs.aws.amazon.com/Ama...").with_provider_name("Event"),
+                    StructField::new("filter", AttributeType::Struct {
+                    name: "NotificationFilter".to_string(),
+                    fields: vec![
+                    StructField::new("s3_key", AttributeType::Struct {
+                    name: "S3KeyFilter".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "FilterRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
+                    ],
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                    ],
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                    ],
+                }).with_description("The filtering rules that determine which objects invoke the AWS Lambda function. For example, you can create a filter so that only image files with a ...").with_provider_name("Filter"),
+                    StructField::new("function", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified event type occurs.").with_provider_name("Function")
+                    ],
+                }))).with_description("Describes the LAMlong functions to invoke and the events for which to invoke them.").with_provider_name("LambdaConfigurations"),
+                    StructField::new("queue_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "QueueConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event", AttributeType::String).required().with_description("The Amazon S3 bucket event about which you want to publish messages to Amazon SQS. For more information, see [Supported Event Types](https://docs.aws....").with_provider_name("Event"),
+                    StructField::new("filter", AttributeType::Struct {
+                    name: "NotificationFilter".to_string(),
+                    fields: vec![
+                    StructField::new("s3_key", AttributeType::Struct {
+                    name: "S3KeyFilter".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "FilterRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
+                    ],
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                    ],
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                    ],
+                }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications onl...").with_provider_name("Filter"),
+                    StructField::new("queue", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queue...").with_provider_name("Queue")
+                    ],
+                }))).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations"),
+                    StructField::new("topic_configurations", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "TopicConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event", AttributeType::String).required().with_description("The Amazon S3 bucket event about which to send notifications. For more information, see [Supported Event Types](https://docs.aws.amazon.com/AmazonS3/l...").with_provider_name("Event"),
+                    StructField::new("filter", AttributeType::Struct {
+                    name: "NotificationFilter".to_string(),
+                    fields: vec![
+                    StructField::new("s3_key", AttributeType::Struct {
+                    name: "S3KeyFilter".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "FilterRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
+                    ],
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                    ],
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                    ],
+                }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications...").with_provider_name("Filter"),
+                    StructField::new("topic", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
+                    ],
+                }))).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations")
+                    ],
+                })
+                .with_description("Configuration that defines how Amazon S3 handles bucket notifications.")
+                .with_provider_name("NotificationConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("object_lock_configuration", AttributeType::Struct {
+                    name: "ObjectLockConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("object_lock_enabled", AttributeType::String).with_description("Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a b...").with_provider_name("ObjectLockEnabled"),
+                    StructField::new("rule", AttributeType::Struct {
+                    name: "ObjectLockRule".to_string(),
+                    fields: vec![
+                    StructField::new("default_retention", AttributeType::Struct {
+                    name: "DefaultRetention".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("The number of days that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify eithe...").with_provider_name("Days"),
+                    StructField::new("mode", AttributeType::Enum(vec!["COMPLIANCE".to_string(), "GOVERNANCE".to_string()])).with_description("The default Object Lock retention mode you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, you must specify ...").with_provider_name("Mode"),
+                    StructField::new("years", AttributeType::Int).with_description("The number of years that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify eith...").with_provider_name("Years")
+                    ],
+                }).with_description("The default Object Lock retention mode and period that you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, b...").with_provider_name("DefaultRetention")
+                    ],
+                }).with_description("Specifies the Object Lock rule for the specified object. Enable this rule when you apply ``ObjectLockConfiguration`` to a bucket. If Object Lock is tu...").with_provider_name("Rule")
+                    ],
+                })
+                .with_description("This operation is not supported for directory buckets.  Places an Object Lock configuration on the specified bucket. The rule specified in the Object ...")
+                .with_provider_name("ObjectLockConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("object_lock_enabled", AttributeType::Bool)
+                .with_description("Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a b...")
+                .with_provider_name("ObjectLockEnabled"),
+        )
+        .attribute(
+            AttributeSchema::new("ownership_controls", AttributeType::Struct {
+                    name: "OwnershipControls".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "OwnershipControlsRule".to_string(),
+                    fields: vec![
+                    StructField::new("object_ownership", AttributeType::Enum(vec!["ObjectWriter".to_string(), "BucketOwnerPreferred".to_string(), "BucketOwnerEnforced".to_string()])).with_description("Specifies an object ownership rule.").with_provider_name("ObjectOwnership")
+                    ],
+                }))).required().with_description("Specifies the container element for Object Ownership rules.").with_provider_name("Rules")
+                    ],
+                })
+                .with_description("Configuration that defines how Amazon S3 handles Object Ownership rules.")
+                .with_provider_name("OwnershipControls"),
+        )
+        .attribute(
+            AttributeSchema::new("public_access_block_configuration", AttributeType::Struct {
+                    name: "PublicAccessBlockConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("block_public_acls", AttributeType::Bool).with_description("Specifies whether Amazon S3 should block public access control lists (ACLs) for this bucket and objects in this bucket. Setting this element to ``TRUE...").with_provider_name("BlockPublicAcls"),
+                    StructField::new("block_public_policy", AttributeType::Bool).with_description("Specifies whether Amazon S3 should block public bucket policies for this bucket. Setting this element to ``TRUE`` causes Amazon S3 to reject calls to ...").with_provider_name("BlockPublicPolicy"),
+                    StructField::new("ignore_public_acls", AttributeType::Bool).with_description("Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this bucket. Setting this element to ``TRUE`` causes Amazon S3 to...").with_provider_name("IgnorePublicAcls"),
+                    StructField::new("restrict_public_buckets", AttributeType::Bool).with_description("Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this element to ``TRUE`` restricts access to this bucket t...").with_provider_name("RestrictPublicBuckets")
+                    ],
+                })
+                .with_description("Configuration that defines how Amazon S3 handles public access.")
+                .with_provider_name("PublicAccessBlockConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("regional_domain_name", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("RegionalDomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("replication_configuration", AttributeType::Struct {
+                    name: "ReplicationConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("role", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating objects. For more information, see [How to Set Up Rep...").with_provider_name("Role"),
+                    StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "ReplicationRule".to_string(),
+                    fields: vec![
+                    StructField::new("delete_marker_replication", AttributeType::Struct {
+                    name: "DeleteMarkerReplication".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).with_description("Indicates whether to replicate delete markers.").with_provider_name("Status")
+                    ],
+                }).with_description("Specifies whether Amazon S3 replicates delete markers. If you specify a ``Filter`` in your replication configuration, you must also include a ``Delete...").with_provider_name("DeleteMarkerReplication"),
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "ReplicationDestination".to_string(),
+                    fields: vec![
+                    StructField::new("access_control_translation", AttributeType::Struct {
+                    name: "AccessControlTranslation".to_string(),
+                    fields: vec![
+                    StructField::new("owner", AttributeType::String).required().with_description("Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucket...").with_provider_name("Owner")
+                    ],
+                }).with_description("Specify this only in a cross-account scenario (where source and destination bucket owners are not the same), and you want to change replica ownership ...").with_provider_name("AccessControlTranslation"),
+                    StructField::new("account", AttributeType::String).with_description("Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to change replica ownership to the AWS-account that owns the...").with_provider_name("Account"),
+                    StructField::new("bucket", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the bucket where you want Amazon S3 to store the results.").with_provider_name("Bucket"),
+                    StructField::new("encryption_configuration", AttributeType::Struct {
+                    name: "EncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("replica_kms_key_id", AttributeType::String).required().with_description("Specifies the ID (Key ARN or Alias ARN) of the customer managed AWS KMS key stored in AWS Key Management Service (KMS) for the destination bucket. Ama...").with_provider_name("ReplicaKmsKeyID")
+                    ],
+                }).with_description("Specifies encryption-related information.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("metrics", AttributeType::Struct {
+                    name: "Metrics".to_string(),
+                    fields: vec![
+                    StructField::new("event_threshold", AttributeType::Struct {
+                    name: "ReplicationTimeValue".to_string(),
+                    fields: vec![
+                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes.  Valid value: 15").with_provider_name("Minutes")
+                    ],
+                }).with_description("A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold`` event.").with_provider_name("EventThreshold"),
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
+                    ],
+                }).with_description("A container specifying replication metrics-related settings enabling replication metrics and events.").with_provider_name("Metrics"),
+                    StructField::new("replication_time", AttributeType::Struct {
+                    name: "ReplicationTime".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
+                    StructField::new("time", AttributeType::Struct {
+                    name: "ReplicationTimeValue".to_string(),
+                    fields: vec![
+                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes.  Valid value: 15").with_provider_name("Minutes")
+                    ],
+                }).required().with_description("A container specifying the time by which replication should be complete for all objects and operations on objects.").with_provider_name("Time")
+                    ],
+                }).with_description("A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time when all objects and operations on objec...").with_provider_name("ReplicationTime"),
+                    StructField::new("storage_class", AttributeType::Enum(vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()])).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the sour...").with_provider_name("StorageClass")
+                    ],
+                }).required().with_description("A container for information about the replication destination and its configurations including enabling the S3 Replication Time Control (S3 RTC).").with_provider_name("Destination"),
+                    StructField::new("filter", AttributeType::Struct {
+                    name: "ReplicationRuleFilter".to_string(),
+                    fields: vec![
+                    StructField::new("and", AttributeType::Struct {
+                    name: "ReplicationRuleAndOperator".to_string(),
+                    fields: vec![
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.").with_provider_name("Prefix"),
+                    StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("An array of tags containing key and value pairs.").with_provider_name("TagFilters")
+                    ],
+                }).with_description("A container for specifying rule filters. The filters determine the subset of objects to which the rule applies. This element is required only if you s...").with_provider_name("And"),
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.  Replacement must be made for object keys containing specia...").with_provider_name("Prefix"),
+                    StructField::new("tag_filter", tags_type()).with_description("A container for specifying a tag key and value.  The rule applies only to objects that have the tag in their tag set.").with_provider_name("TagFilter")
+                    ],
+                }).with_description("A filter that identifies the subset of objects to which the replication rule applies. A ``Filter`` must specify exactly one ``Prefix``, ``TagFilter``,...").with_provider_name("Filter"),
+                    StructField::new("id", AttributeType::String).with_description("A unique identifier for the rule. The maximum value is 255 characters. If you don't specify a value, AWS CloudFormation generates a random ID. When us...").with_provider_name("Id"),
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the object or objects to which the rule applies. The maximum prefix length is 1,024 characters. To include a...").with_provider_name("Prefix"),
+                    StructField::new("priority", AttributeType::Int).with_description("The priority indicates which rule has precedence whenever two or more replication rules conflict. Amazon S3 will attempt to replicate objects accordin...").with_provider_name("Priority"),
+                    StructField::new("source_selection_criteria", AttributeType::Struct {
+                    name: "SourceSelectionCriteria".to_string(),
+                    fields: vec![
+                    StructField::new("replica_modifications", AttributeType::Struct {
+                    name: "ReplicaModifications".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::Enum(vec!["Enabled".to_string(), "Disabled".to_string()])).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
+                    ],
+                }).with_description("A filter that you can specify for selection for modifications on replicas.").with_provider_name("ReplicaModifications"),
+                    StructField::new("sse_kms_encrypted_objects", AttributeType::Struct {
+                    name: "SseKmsEncryptedObjects".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
+                    ],
+                }).with_description("A container for filter information for the selection of Amazon S3 objects encrypted with AWS KMS.").with_provider_name("SseKmsEncryptedObjects")
+                    ],
+                }).with_description("A container that describes additional filters for identifying the source objects that you want to replicate. You can choose to enable or disable the r...").with_provider_name("SourceSelectionCriteria"),
+                    StructField::new("status", AttributeType::Enum(vec!["Disabled".to_string(), "Enabled".to_string()])).required().with_description("Specifies whether the rule is enabled.").with_provider_name("Status")
+                    ],
+                }))).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules")
+                    ],
+                })
+                .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration``...")
+                .with_provider_name("ReplicationConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("An arbitrary set of tags (key-value pairs) for this S3 bucket.")
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("versioning_configuration", AttributeType::Struct {
+                    name: "VersioningConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::Enum(vec!["Enabled".to_string(), "Suspended".to_string()])).required().with_description("The versioning state of the bucket.").with_provider_name("Status")
+                    ],
+                })
+                .with_description("Enables multiple versions of all objects in this bucket. You might enable versioning to prevent objects from being deleted or overwritten by mistake o...")
+                .with_provider_name("VersioningConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("website_configuration", AttributeType::Struct {
+                    name: "WebsiteConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("error_document", AttributeType::String).with_description("The name of the error document for the website.").with_provider_name("ErrorDocument"),
+                    StructField::new("index_document", AttributeType::String).with_description("The name of the index document for the website.").with_provider_name("IndexDocument"),
+                    StructField::new("redirect_all_requests_to", AttributeType::Struct {
+                    name: "RedirectAllRequestsTo".to_string(),
+                    fields: vec![
+                    StructField::new("host_name", AttributeType::String).required().with_description("Name of the host where requests are redirected.").with_provider_name("HostName"),
+                    StructField::new("protocol", AttributeType::Enum(vec!["http".to_string(), "https".to_string()])).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol")
+                    ],
+                }).with_description("The redirect behavior for every request to this bucket's website endpoint.  If you specify this property, you can't specify any other property.").with_provider_name("RedirectAllRequestsTo"),
+                    StructField::new("routing_rules", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "RoutingRule".to_string(),
+                    fields: vec![
+                    StructField::new("redirect_rule", AttributeType::Struct {
+                    name: "RedirectRule".to_string(),
+                    fields: vec![
+                    StructField::new("host_name", AttributeType::String).with_description("The host name to use in the redirect request.").with_provider_name("HostName"),
+                    StructField::new("http_redirect_code", AttributeType::String).with_description("The HTTP redirect code to use on the response. Not required if one of the siblings is present.").with_provider_name("HttpRedirectCode"),
+                    StructField::new("protocol", AttributeType::Enum(vec!["http".to_string(), "https".to_string()])).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol"),
+                    StructField::new("replace_key_prefix_with", AttributeType::Enum(vec!["docs/".to_string(), "documents/".to_string(), "/documents".to_string()])).with_description("The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix ``docs/`` (objects in the ``docs/`` ...").with_provider_name("ReplaceKeyPrefixWith"),
+                    StructField::new("replace_key_with", AttributeType::String).with_description("The specific object key to use in the redirect request. For example, redirect request to ``error.html``. Not required if one of the siblings is presen...").with_provider_name("ReplaceKeyWith")
+                    ],
+                }).required().with_description("Container for redirect information. You can redirect requests to another host, to another page, or with another protocol. In the event of an error, yo...").with_provider_name("RedirectRule"),
+                    StructField::new("routing_rule_condition", AttributeType::Struct {
+                    name: "RoutingRuleCondition".to_string(),
+                    fields: vec![
+                    StructField::new("http_error_code_returned_equals", AttributeType::String).with_description("The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applie...").with_provider_name("HttpErrorCodeReturnedEquals"),
+                    StructField::new("key_prefix_equals", AttributeType::String).with_description("The object key name prefix when the redirect is applied. For example, to redirect requests for ``ExamplePage.html``, the key prefix will be ``ExampleP...").with_provider_name("KeyPrefixEquals")
+                    ],
+                }).with_description("A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the ``/docs`` ...").with_provider_name("RoutingRuleCondition")
+                    ],
+                }))).with_description("Rules that define when a redirect is applied and the redirect behavior.").with_provider_name("RoutingRules")
+                    ],
+                })
+                .with_description("Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/Am...")
+                .with_provider_name("WebsiteConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("website_url", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("WebsiteURL"),
+        )
+    }
+}

--- a/carina-provider-awscc/src/schemas/generated/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/log_group.rs
@@ -1,0 +1,88 @@
+//! log_group schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::Logs::LogGroup
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_namespaced_enum;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+const VALID_LOG_GROUP_CLASS: &[&str] = &["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"];
+
+fn validate_log_group_class(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "LogGroupClass",
+        "awscc.logs_log_group",
+        VALID_LOG_GROUP_CLASS,
+    )
+}
+
+/// Returns the schema config for logs_log_group (AWS::Logs::LogGroup)
+pub fn logs_log_group_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::Logs::LogGroup",
+        resource_type_name: "logs_log_group",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.logs_log_group")
+        .with_description("The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines common properties for log streams, such as their retention and access control rules. Each log stream must belong to one ...")
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .with_description(" (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("data_protection_policy", AttributeType::Map(Box::new(AttributeType::String)))
+                .with_description("Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the lo...")
+                .with_provider_name("DataProtectionPolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("deletion_protection_enabled", AttributeType::Bool)
+                .with_description("Indicates whether deletion protection is enabled for this log group. When enabled, deletion protection blocks all deletion operations until it is expl...")
+                .with_provider_name("DeletionProtectionEnabled"),
+        )
+        .attribute(
+            AttributeSchema::new("field_index_policies", AttributeType::List(Box::new(AttributeType::Map(Box::new(AttributeType::String)))))
+                .with_description("Creates or updates a *field index policy* for the specified log group. Only log groups in the Standard log class support field index policies. For mor...")
+                .with_provider_name("FieldIndexPolicies"),
+        )
+        .attribute(
+            AttributeSchema::new("kms_key_id", AttributeType::String)
+                .with_description("The Amazon Resource Name (ARN) of the KMS key to use when encrypting log data. To associate an KMS key with the log group, specify the ARN of that KMS...")
+                .with_provider_name("KmsKeyId"),
+        )
+        .attribute(
+            AttributeSchema::new("log_group_class", AttributeType::Custom {
+                name: "LogGroupClass".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_log_group_class,
+                namespace: Some("awscc.logs_log_group".to_string()),
+            })
+                .with_description("Specifies the log group class for this log group. There are two classes:  + The ``Standard`` log class supports all CWL features.  + The ``Infrequent ...")
+                .with_provider_name("LogGroupClass"),
+        )
+        .attribute(
+            AttributeSchema::new("log_group_name", AttributeType::String)
+                .with_description("The name of the log group. If you don't specify a name, CFNlong generates a unique ID for the log group.")
+                .with_provider_name("LogGroupName"),
+        )
+        .attribute(
+            AttributeSchema::new("resource_policy_document", AttributeType::Map(Box::new(AttributeType::String)))
+                .with_description("Creates or updates a resource policy for the specified log group that allows other services to put log events to this account. A LogGroup can have 1 r...")
+                .with_provider_name("ResourcePolicyDocument"),
+        )
+        .attribute(
+            AttributeSchema::new("retention_in_days", AttributeType::Int)
+                .with_description("The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545,...")
+                .with_provider_name("RetentionInDays"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("An array of key-value pairs to apply to the log group. For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/...")
+                .with_provider_name("Tags"),
+        )
+    }
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -481,13 +481,16 @@ pub fn validate_availability_zone(az: &str) -> Result<(), String> {
     Ok(())
 }
 
+pub mod bucket;
 pub mod egress_only_internet_gateway;
 pub mod eip;
 pub mod flow_log;
 pub mod internet_gateway;
 pub mod ipam;
 pub mod ipam_pool;
+pub mod log_group;
 pub mod nat_gateway;
+pub mod role;
 pub mod route;
 pub mod route_table;
 pub mod security_group;
@@ -496,6 +499,7 @@ pub mod security_group_ingress;
 pub mod subnet;
 pub mod subnet_route_table_association;
 pub mod transit_gateway;
+pub mod transit_gateway_attachment;
 pub mod vpc;
 pub mod vpc_endpoint;
 pub mod vpc_gateway_attachment;
@@ -525,6 +529,10 @@ pub fn configs() -> Vec<AwsccSchemaConfig> {
         transit_gateway::ec2_transit_gateway_config(),
         vpc_peering_connection::ec2_vpc_peering_connection_config(),
         egress_only_internet_gateway::ec2_egress_only_internet_gateway_config(),
+        transit_gateway_attachment::ec2_transit_gateway_attachment_config(),
+        bucket::s3_bucket_config(),
+        role::iam_role_config(),
+        log_group::logs_log_group_config(),
     ]
 }
 

--- a/carina-provider-awscc/src/schemas/generated/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/role.rs
@@ -1,0 +1,82 @@
+//! role schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::IAM::Role
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+/// Returns the schema config for iam_role (AWS::IAM::Role)
+pub fn iam_role_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::IAM::Role",
+        resource_type_name: "iam_role",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.iam_role")
+        .with_description("Creates a new role for your AWS-account.   For more information about roles, see [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *IAM User Guide*. For information ab...")
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .with_description(" (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("assume_role_policy_document", AttributeType::Map(Box::new(AttributeType::String)))
+                .required()
+                .with_description("The trust policy that is associated with this role. Trust policies define which entities can assume the role. You can associate only one trust policy ...")
+                .with_provider_name("AssumeRolePolicyDocument"),
+        )
+        .attribute(
+            AttributeSchema::new("description", AttributeType::String)
+                .with_description("A description of the role that you provide.")
+                .with_provider_name("Description"),
+        )
+        .attribute(
+            AttributeSchema::new("managed_policy_arns", AttributeType::List(Box::new(AttributeType::String)))
+                .with_description("A list of Amazon Resource Names (ARNs) of the IAM managed policies that you want to attach to the role. For more information about ARNs, see [Amazon R...")
+                .with_provider_name("ManagedPolicyArns"),
+        )
+        .attribute(
+            AttributeSchema::new("max_session_duration", AttributeType::Int)
+                .with_description("The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default val...")
+                .with_provider_name("MaxSessionDuration"),
+        )
+        .attribute(
+            AttributeSchema::new("path", AttributeType::String)
+                .with_description("The path to the role. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)...")
+                .with_provider_name("Path"),
+        )
+        .attribute(
+            AttributeSchema::new("permissions_boundary", AttributeType::String)
+                .with_description("The ARN of the policy used to set the permissions boundary for the role. For more information about permissions boundaries, see [Permissions boundarie...")
+                .with_provider_name("PermissionsBoundary"),
+        )
+        .attribute(
+            AttributeSchema::new("policies", AttributeType::List(Box::new(AttributeType::Struct {
+                    name: "Policy".to_string(),
+                    fields: vec![
+                    StructField::new("policy_document", AttributeType::String).required().with_description("The entire contents of the policy that defines permissions. For more information, see [Overview of JSON policies](https://docs.aws.amazon.com/IAM/late...").with_provider_name("PolicyDocument"),
+                    StructField::new("policy_name", AttributeType::String).required().with_description("The friendly name (not ARN) identifying the policy.").with_provider_name("PolicyName")
+                    ],
+                })))
+                .with_description("Adds or updates an inline policy document that is embedded in the specified IAM role. When you embed an inline policy in a role, the inline policy is ...")
+                .with_provider_name("Policies"),
+        )
+        .attribute(
+            AttributeSchema::new("role_id", AttributeType::String)
+                .with_description(" (read-only)")
+                .with_provider_name("RoleId"),
+        )
+        .attribute(
+            AttributeSchema::new("role_name", AttributeType::String)
+                .with_description("A name for the IAM role, up to 64 characters in length. For valid values, see the ``RoleName`` parameter for the [CreateRole](https://docs.aws.amazon....")
+                .with_provider_name("RoleName"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("A list of tags that are attached to the role. For more information about tagging, see [Tagging IAM resources](https://docs.aws.amazon.com/IAM/latest/U...")
+                .with_provider_name("Tags"),
+        )
+    }
+}

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
@@ -1,0 +1,57 @@
+//! transit_gateway_attachment schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::EC2::TransitGatewayAttachment
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+/// Returns the schema config for ec2_transit_gateway_attachment (AWS::EC2::TransitGatewayAttachment)
+pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::EC2::TransitGatewayAttachment",
+        resource_type_name: "ec2_transit_gateway_attachment",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.ec2_transit_gateway_attachment")
+        .with_description("Resource Type definition for AWS::EC2::TransitGatewayAttachment")
+        .attribute(
+            AttributeSchema::new("id", AttributeType::String)
+                .with_description("(read-only)")
+                .with_provider_name("Id"),
+        )
+        .attribute(
+            AttributeSchema::new("options", AttributeType::Struct {
+                    name: "Options".to_string(),
+                    fields: vec![
+                    StructField::new("appliance_mode_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("ApplianceModeSupport"),
+                    StructField::new("dns_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable DNS Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("DnsSupport"),
+                    StructField::new("ipv6_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("Ipv6Support"),
+                    StructField::new("security_group_referencing_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Security Group referencing support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("SecurityGroupReferencingSupport")
+                    ],
+                })
+                .with_description("The options for the transit gateway vpc attachment.")
+                .with_provider_name("Options"),
+        )
+        .attribute(
+            AttributeSchema::new("subnet_ids", AttributeType::List(Box::new(super::aws_resource_id())))
+                .required()
+                .with_provider_name("SubnetIds"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("transit_gateway_id", super::transit_gateway_id())
+                .required()
+                .with_provider_name("TransitGatewayId"),
+        )
+        .attribute(
+            AttributeSchema::new("vpc_id", super::vpc_id())
+                .required()
+                .with_provider_name("VpcId"),
+        )
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,3 +25,7 @@
   - [awscc.ec2_transit_gateway](providers/awscc/ec2_transit_gateway.md)
   - [awscc.ec2_vpc_peering_connection](providers/awscc/ec2_vpc_peering_connection.md)
   - [awscc.ec2_egress_only_internet_gateway](providers/awscc/ec2_egress_only_internet_gateway.md)
+  - [awscc.ec2_transit_gateway_attachment](providers/awscc/ec2_transit_gateway_attachment.md)
+  - [awscc.s3_bucket](providers/awscc/s3_bucket.md)
+  - [awscc.iam_role](providers/awscc/iam_role.md)
+  - [awscc.logs_log_group](providers/awscc/logs_log_group.md)

--- a/docs/src/providers/awscc/ec2_transit_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway_attachment.md
@@ -1,0 +1,53 @@
+# awscc.ec2_transit_gateway_attachment
+
+CloudFormation Type: `AWS::EC2::TransitGatewayAttachment`
+
+Resource Type definition for AWS::EC2::TransitGatewayAttachment
+
+## Argument Reference
+
+### `options`
+
+- **Type:** [Struct(Options)](#options)
+- **Required:** No
+
+The options for the transit gateway vpc attachment.
+
+### `subnet_ids`
+
+- **Type:** `List<SubnetId>`
+- **Required:** Yes
+
+### `tags`
+
+- **Type:** Map
+- **Required:** No
+
+### `transit_gateway_id`
+
+- **Type:** TransitGatewayId
+- **Required:** Yes
+
+### `vpc_id`
+
+- **Type:** VpcId
+- **Required:** Yes
+
+## Struct Definitions
+
+### Options
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `appliance_mode_support` | String | No | Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable |
+| `dns_support` | String | No | Indicates whether to enable DNS Support for Vpc Attachment. Valid Values: enable | disable |
+| `ipv6_support` | String | No | Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable |
+| `security_group_referencing_support` | String | No | Indicates whether to enable Security Group referencing support for Vpc Attachment. Valid Values: ena... |
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
+
+

--- a/docs/src/providers/awscc/iam_role.md
+++ b/docs/src/providers/awscc/iam_role.md
@@ -1,0 +1,92 @@
+# awscc.iam_role
+
+CloudFormation Type: `AWS::IAM::Role`
+
+Creates a new role for your AWS-account.
+  For more information about roles, see [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *IAM User Guide*. For information about quotas for role names and the number of roles you can create, see [IAM and quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in the *IAM User Guide*.
+
+## Argument Reference
+
+### `assume_role_policy_document`
+
+- **Type:** Map
+- **Required:** Yes
+
+The trust policy that is associated with this role. Trust policies define which entities can assume the role. You can associate only one trust policy with a role. For an example of a policy that can be used to assume a role, see [Template Examples](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#aws-resource-iam-role--examples). For more information about the elements that you can use in an IAM policy, see [Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in the *User Guide*.
+
+### `description`
+
+- **Type:** String
+- **Required:** No
+
+A description of the role that you provide.
+
+### `managed_policy_arns`
+
+- **Type:** `List<Arn>`
+- **Required:** No
+
+A list of Amazon Resource Names (ARNs) of the IAM managed policies that you want to attach to the role. For more information about ARNs, see [Amazon Resource Names (ARNs) and Service Namespaces](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) in the *General Reference*.
+
+### `max_session_duration`
+
+- **Type:** Int
+- **Required:** No
+
+The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default value of one hour is applied. This setting can have a value from 1 hour to 12 hours. Anyone who assumes the role from the CLI or API can use the ``DurationSeconds`` API parameter or the ``duration-seconds``CLI parameter to request a longer session. The ``MaxSessionDuration`` setting determines the maximum duration that can be requested using the ``DurationSeconds`` parameter. If users don't specify a value for the ``DurationSeconds`` parameter, their security credentials are valid for one hour by default. This applies when you use the ``AssumeRole*`` API operations or the ``assume-role*``CLI operations but does not apply when you use those operations to create a console URL. For more information, see [Using IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) in the *IAM User Guide*.
+
+### `path`
+
+- **Type:** String
+- **Required:** No
+
+The path to the role. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the *IAM User Guide*. This parameter is optional. If it is not included, it defaults to a slash (/). This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (``\u0021``) through the DEL character (``\u007F``), including most punctuation characters, digits, and upper and lowercased letters.
+
+### `permissions_boundary`
+
+- **Type:** String
+- **Required:** No
+
+The ARN of the policy used to set the permissions boundary for the role. For more information about permissions boundaries, see [Permissions boundaries for IAM identities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) in the *IAM User Guide*.
+
+### `policies`
+
+- **Type:** [List\<Policy\>](#policy)
+- **Required:** No
+
+Adds or updates an inline policy document that is embedded in the specified IAM role. When you embed an inline policy in a role, the inline policy is used as part of the role's access (permissions) policy. The role's trust policy is created at the same time as the role. You can update a role's trust policy later. For more information about IAM roles, go to [Using Roles to Delegate Permissions and Federate Identities](https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html). A role can also have an attached managed policy. For information about policies, see [Managed Policies and Inline Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html) in the *User Guide*. For information about limits on the number of inline policies that you can embed with a role, see [Limitations on Entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/LimitationsOnEntities.html) in the *User Guide*.  If an external policy (such as ``AWS::IAM::Policy`` or ``AWS::IAM::ManagedPolicy``) has a ``Ref`` to a role and if a resource (such as ``AWS::ECS::Service``) also has a ``Ref`` to the same role, add a ``DependsOn`` attribute to the resource to make the resource depend on the external policy. This dependency ensures that the role's policy is available throughout the resource's lifecycle. For example, when you delete a stack with an ``AWS::ECS::Service`` resource, the ``DependsOn`` attribute ensures that CFN deletes the ``AWS::ECS::Service`` resource before deleting its role's policy.
+
+### `role_name`
+
+- **Type:** String
+- **Required:** No
+
+A name for the IAM role, up to 64 characters in length. For valid values, see the ``RoleName`` parameter for the [CreateRole](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateRole.html) action in the *User Guide*. This parameter allows (per its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-. The role name must be unique within the account. Role names are not distinguished by case. For example, you cannot create roles named both "Role1" and "role1". If you don't specify a name, CFN generates a unique physical ID and uses that ID for the role name. If you specify a name, you must specify the ``CAPABILITY_NAMED_IAM`` value to acknowledge your template's capabilities. For more information, see [Acknowledging Resources in Templates](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#using-iam-capabilities).  Naming an IAM resource can cause an unrecoverable error if you reuse the same template in multiple Regions. To prevent this, we recommend using ``Fn::Join`` and ``AWS::Region`` to create a Region-specific name, as in the following example: ``{"Fn::Join": ["", [{"Ref": "AWS::Region"}, {"Ref": "MyResourceName"}]]}``.
+
+### `tags`
+
+- **Type:** Map
+- **Required:** No
+
+A list of tags that are attached to the role. For more information about tagging, see [Tagging IAM resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the *IAM User Guide*.
+
+## Struct Definitions
+
+### Policy
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `policy_document` | String | Yes | The entire contents of the policy that defines permissions. For more information, see [Overview of J... |
+| `policy_name` | String | Yes | The friendly name (not ARN) identifying the policy. |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+### `role_id`
+
+- **Type:** String
+
+

--- a/docs/src/providers/awscc/logs_log_group.md
+++ b/docs/src/providers/awscc/logs_log_group.md
@@ -1,0 +1,94 @@
+# awscc.logs_log_group
+
+CloudFormation Type: `AWS::Logs::LogGroup`
+
+The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines common properties for log streams, such as their retention and access control rules. Each log stream must belong to one log group.
+ You can create up to 1,000,000 log groups per Region per account. You must use the following guidelines when naming a log group:
+  +  Log group names must be unique within a Region for an AWS account.
+  +  Log group names can be between 1 and 512 characters long.
+  +  Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).
+
+## Argument Reference
+
+### `data_protection_policy`
+
+- **Type:** Map
+- **Required:** No
+
+Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the log group by auditing and masking the sensitive log data. When a user who does not have permission to view masked data views a log event that includes masked data, the sensitive data is replaced by asterisks.
+
+### `deletion_protection_enabled`
+
+- **Type:** Bool
+- **Required:** No
+
+Indicates whether deletion protection is enabled for this log group. When enabled, deletion protection blocks all deletion operations until it is explicitly disabled.
+
+### `field_index_policies`
+
+- **Type:** `List<String>`
+- **Required:** No
+
+Creates or updates a *field index policy* for the specified log group. Only log groups in the Standard log class support field index policies. For more information about log classes, see [Log classes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html). You can use field index policies to create *field indexes* on fields found in log events in the log group. Creating field indexes lowers the costs for CWL Insights queries that reference those field indexes, because these queries attempt to skip the processing of log events that are known to not match the indexed field. Good fields to index are fields that you often need to query for and fields that have high cardinality of values Common examples of indexes include request ID, session ID, userID, and instance IDs. For more information, see [Create field indexes to improve query performance and reduce costs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogs-Field-Indexing.html). Currently, this array supports only one field index policy object.
+
+### `kms_key_id`
+
+- **Type:** String
+- **Required:** No
+
+The Amazon Resource Name (ARN) of the KMS key to use when encrypting log data. To associate an KMS key with the log group, specify the ARN of that KMS key here. If you do so, ingested data is encrypted using this key. This association is stored as long as the data encrypted with the KMS key is still within CWL. This enables CWL to decrypt this data whenever it is requested. If you attempt to associate a KMS key with the log group but the KMS key doesn't exist or is deactivated, you will receive an ``InvalidParameterException`` error. Log group data is always encrypted in CWL. If you omit this key, the encryption does not use KMS. For more information, see [Encrypt log data in using](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)
+
+### `log_group_class`
+
+- **Type:** [Enum (LogGroupClass)](#log_group_class-loggroupclass)
+- **Required:** No
+
+Specifies the log group class for this log group. There are two classes:  + The ``Standard`` log class supports all CWL features.  + The ``Infrequent Access`` log class supports a subset of CWL features and incurs lower costs.   For details about the features supported by each class, see [Log classes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html)
+
+### `log_group_name`
+
+- **Type:** String
+- **Required:** No
+
+The name of the log group. If you don't specify a name, CFNlong generates a unique ID for the log group.
+
+### `resource_policy_document`
+
+- **Type:** Map
+- **Required:** No
+
+Creates or updates a resource policy for the specified log group that allows other services to put log events to this account. A LogGroup can have 1 resource policy.
+
+### `retention_in_days`
+
+- **Type:** Int
+- **Required:** No
+
+The number of days to retain the log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, and 3653. To set a log group so that its log events do not expire, do not specify this property.
+
+### `tags`
+
+- **Type:** Map
+- **Required:** No
+
+An array of key-value pairs to apply to the log group. For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).
+
+## Enum Values
+
+### log_group_class (LogGroupClass)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `STANDARD` | `awscc.logs_log_group.LogGroupClass.STANDARD` |
+| `INFREQUENT_ACCESS` | `awscc.logs_log_group.LogGroupClass.INFREQUENT_ACCESS` |
+| `DELIVERY` | `awscc.logs_log_group.LogGroupClass.DELIVERY` |
+
+Shorthand formats: `STANDARD` or `LogGroupClass.STANDARD`
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -1,0 +1,362 @@
+# awscc.s3_bucket
+
+CloudFormation Type: `AWS::S3::Bucket`
+
+The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Region where you create the AWS CloudFormation stack.
+ To control how AWS CloudFormation handles the bucket when the stack is deleted, you can set a deletion policy for your bucket. You can choose to *retain* the bucket or to *delete* the bucket. For more information, see [DeletionPolicy Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html).
+  You can only delete empty buckets. Deletion fails for buckets that have contents.
+
+## Argument Reference
+
+### `abac_status`
+
+- **Type:** [Enum (AbacStatus)](#abac_status-abacstatus)
+- **Required:** No
+
+The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see [Using tags with S3 general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html).
+
+### `accelerate_configuration`
+
+- **Type:** [Struct(AccelerateConfiguration)](#accelerateconfiguration)
+- **Required:** No
+
+Configures the transfer acceleration state for an Amazon S3 bucket. For more information, see [Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html) in the *Amazon S3 User Guide*.
+
+### `access_control`
+
+- **Type:** [Enum (AccessControl)](#access_control-accesscontrol)
+- **Required:** No
+
+This is a legacy property, and it is not recommended for most use cases. A majority of modern use cases in Amazon S3 no longer require the use of ACLs, and we recommend that you keep ACLs disabled. For more information, see [Controlling object ownership](https://docs.aws.amazon.com//AmazonS3/latest/userguide/about-object-ownership.html) in the *Amazon S3 User Guide*.  A canned access control list (ACL) that grants predefined permissions to the bucket. For more information about canned ACLs, see [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) in the *Amazon S3 User Guide*.  S3 buckets are created with ACLs disabled by default. Therefore, unless you explicitly set the [AWS::S3::OwnershipControls](https://docs.aws.amazon.com//AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-ownershipcontrols.html) property to enable ACLs, your resource will fail to deploy with any value other than Private. Use cases requiring ACLs are uncommon.  The majority of access control configurations can be successfully and more easily achieved with bucket policies. For more information, see [AWS::S3::BucketPolicy](https://docs.aws.amazon.com//AWSCloudFormation/latest/UserGuide/aws-properties-s3-policy.html). For examples of common policy configurations, including S3 Server Access Logs buckets and more, see [Bucket policy examples](https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html) in the *Amazon S3 User Guide*.
+
+### `analytics_configurations`
+
+- **Type:** [List\<AnalyticsConfiguration\>](#analyticsconfiguration)
+- **Required:** No
+
+Specifies the configuration and any analyses for the analytics filter of an Amazon S3 bucket.
+
+### `bucket_encryption`
+
+- **Type:** [Struct(BucketEncryption)](#bucketencryption)
+- **Required:** No
+
+Specifies default encryption for a bucket using server-side encryption with Amazon S3-managed keys (SSE-S3), AWS KMS-managed keys (SSE-KMS), or dual-layer server-side encryption with KMS-managed keys (DSSE-KMS). For information about the Amazon S3 default encryption feature, see [Amazon S3 Default Encryption for S3 Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) in the *Amazon S3 User Guide*.
+
+### `bucket_name`
+
+- **Type:** String
+- **Required:** No
+
+A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*.  If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.
+
+### `cors_configuration`
+
+- **Type:** [Struct(CorsConfiguration)](#corsconfiguration)
+- **Required:** No
+
+Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) in the *Amazon S3 User Guide*.
+
+### `intelligent_tiering_configurations`
+
+- **Type:** [List\<IntelligentTieringConfiguration\>](#intelligenttieringconfiguration)
+- **Required:** No
+
+Defines how Amazon S3 handles Intelligent-Tiering storage.
+
+### `inventory_configurations`
+
+- **Type:** [List\<InventoryConfiguration\>](#inventoryconfiguration)
+- **Required:** No
+
+Specifies the S3 Inventory configuration for an Amazon S3 bucket. For more information, see [GET Bucket inventory](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html) in the *Amazon S3 API Reference*.
+
+### `lifecycle_configuration`
+
+- **Type:** [Struct(LifecycleConfiguration)](#lifecycleconfiguration)
+- **Required:** No
+
+Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) in the *Amazon S3 User Guide*.
+
+### `logging_configuration`
+
+- **Type:** [Struct(LoggingConfiguration)](#loggingconfiguration)
+- **Required:** No
+
+Settings that define where logs are stored.
+
+### `metadata_configuration`
+
+- **Type:** [Struct(MetadataConfiguration)](#metadataconfiguration)
+- **Required:** No
+
+The S3 Metadata configuration for a general purpose bucket.
+
+### `metadata_table_configuration`
+
+- **Type:** [Struct(MetadataTableConfiguration)](#metadatatableconfiguration)
+- **Required:** No
+
+The metadata table configuration of an S3 general purpose bucket.
+
+### `metrics_configurations`
+
+- **Type:** [List\<MetricsConfiguration\>](#metricsconfiguration)
+- **Required:** No
+
+Specifies a metrics configuration for the CloudWatch request metrics (specified by the metrics configuration ID) from an Amazon S3 bucket. If you're updating an existing metrics configuration, note that this is a full replacement of the existing metrics configuration. If you don't include the elements you want to keep, they are erased. For more information, see [PutBucketMetricsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html).
+
+### `notification_configuration`
+
+- **Type:** [Struct(NotificationConfiguration)](#notificationconfiguration)
+- **Required:** No
+
+Configuration that defines how Amazon S3 handles bucket notifications.
+
+### `object_lock_configuration`
+
+- **Type:** [Struct(ObjectLockConfiguration)](#objectlockconfiguration)
+- **Required:** No
+
+This operation is not supported for directory buckets.  Places an Object Lock configuration on the specified bucket. The rule specified in the Object Lock configuration will be applied by default to every new object placed in the specified bucket. For more information, see [Locking Objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html).   + The ``DefaultRetention`` settings require both a mode and a period.  + The ``DefaultRetention`` period can be either ``Days`` or ``Years`` but you must select one. You cannot specify ``Days`` and ``Years`` at the same time.  + You can enable Object Lock for new or existing buckets. For more information, see [Configuring Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html).    You must URL encode any signed header values that contain spaces. For example, if your header value is ``my file.txt``, containing two spaces after ``my``, you must URL encode this value to ``my%20%20file.txt``.
+
+### `object_lock_enabled`
+
+- **Type:** Bool
+- **Required:** No
+
+Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a bucket.
+
+### `ownership_controls`
+
+- **Type:** [Struct(OwnershipControls)](#ownershipcontrols)
+- **Required:** No
+
+Configuration that defines how Amazon S3 handles Object Ownership rules.
+
+### `public_access_block_configuration`
+
+- **Type:** [Struct(PublicAccessBlockConfiguration)](#publicaccessblockconfiguration)
+- **Required:** No
+
+Configuration that defines how Amazon S3 handles public access.
+
+### `replication_configuration`
+
+- **Type:** [Struct(ReplicationConfiguration)](#replicationconfiguration)
+- **Required:** No
+
+Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration`` property. Amazon S3 can store replicated objects in a single destination bucket or multiple destination buckets. The destination bucket or buckets must already exist.
+
+### `tags`
+
+- **Type:** Map
+- **Required:** No
+
+An arbitrary set of tags (key-value pairs) for this S3 bucket.
+
+### `versioning_configuration`
+
+- **Type:** [Struct(VersioningConfiguration)](#versioningconfiguration)
+- **Required:** No
+
+Enables multiple versions of all objects in this bucket. You might enable versioning to prevent objects from being deleted or overwritten by mistake or to archive objects so that you can retrieve previous versions of them.  When you enable versioning on a bucket for the first time, it might take a short amount of time for the change to be fully propagated. We recommend that you wait for 15 minutes after enabling versioning before issuing write operations (``PUT`` or ``DELETE``) on objects in the bucket.
+
+### `website_configuration`
+
+- **Type:** [Struct(WebsiteConfiguration)](#websiteconfiguration)
+- **Required:** No
+
+Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html).
+
+## Enum Values
+
+### abac_status (AbacStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Enabled` | `awscc.s3_bucket.AbacStatus.Enabled` |
+| `Disabled` | `awscc.s3_bucket.AbacStatus.Disabled` |
+
+Shorthand formats: `Enabled` or `AbacStatus.Enabled`
+
+### access_control (AccessControl)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `AuthenticatedRead` | `awscc.s3_bucket.AccessControl.AuthenticatedRead` |
+| `AwsExecRead` | `awscc.s3_bucket.AccessControl.AwsExecRead` |
+| `BucketOwnerFullControl` | `awscc.s3_bucket.AccessControl.BucketOwnerFullControl` |
+| `BucketOwnerRead` | `awscc.s3_bucket.AccessControl.BucketOwnerRead` |
+| `LogDeliveryWrite` | `awscc.s3_bucket.AccessControl.LogDeliveryWrite` |
+| `Private` | `awscc.s3_bucket.AccessControl.Private` |
+| `PublicRead` | `awscc.s3_bucket.AccessControl.PublicRead` |
+| `PublicReadWrite` | `awscc.s3_bucket.AccessControl.PublicReadWrite` |
+
+Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
+
+## Struct Definitions
+
+### AccelerateConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `acceleration_status` | String | Yes | Specifies the transfer acceleration status of the bucket. |
+
+### AnalyticsConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | String | Yes | The ID that identifies the analytics configuration. |
+| `prefix` | String | No | The prefix that an object must have to be included in the analytics results. |
+| `storage_class_analysis` | String | Yes | Contains data related to access patterns to be collected and made available to analyze the tradeoffs... |
+| `tag_filters` | `List<String>` | No | The tags to use when evaluating an analytics filter. The analytics only includes objects that meet t... |
+
+### BucketEncryption
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `server_side_encryption_configuration` | `List<String>` | Yes | Specifies the default server-side-encryption configuration. |
+
+### CorsConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cors_rules` | `List<String>` | Yes | A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rul... |
+
+### IntelligentTieringConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | String | Yes | The ID used to identify the S3 Intelligent-Tiering configuration. |
+| `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. |
+| `status` | String | Yes | Specifies the status of the configuration. |
+| `tag_filters` | `List<String>` | No | A container for a key-value pair. |
+| `tierings` | `List<String>` | Yes | Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one ti... |
+
+### InventoryConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination` | String | Yes | Contains information about where to publish the inventory results. |
+| `enabled` | Bool | Yes | Specifies whether the inventory is enabled or disabled. If set to ``True``, an inventory list is gen... |
+| `id` | String | Yes | The ID used to identify the inventory configuration. |
+| `included_object_versions` | String | Yes | Object versions to include in the inventory list. If set to ``All``, the list includes all the objec... |
+| `optional_fields` | `List<String>` | No | Contains the optional fields that are included in the inventory results. |
+| `prefix` | String | No | Specifies the inventory filter prefix. |
+| `schedule_frequency` | String | Yes | Specifies the schedule for generating inventory results. |
+
+### LifecycleConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rules` | `List<String>` | Yes | A lifecycle rule for individual objects in an Amazon S3 bucket. |
+| `transition_default_minimum_object_size` | String | No | Indicates which default minimum object size behavior is applied to the lifecycle configuration.  Thi... |
+
+### LoggingConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination_bucket_name` | String | No | The name of the bucket where Amazon S3 should store server access log files. You can store log files... |
+| `log_file_prefix` | String | No | A prefix for all log object keys. If you store log files from multiple Amazon S3 buckets in a single... |
+| `target_object_key_format` | String | No | Amazon S3 key format for log objects. Only one format, either PartitionedPrefix or SimplePrefix, is ... |
+
+### MetadataConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination` | String | No | The destination information for the S3 Metadata configuration. |
+| `inventory_table_configuration` | String | No | The inventory table configuration for a metadata configuration. |
+| `journal_table_configuration` | String | Yes | The journal table configuration for a metadata configuration. |
+
+### MetadataTableConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `s3_tables_destination` | String | Yes | The destination information for the metadata table configuration. The destination table bucket must ... |
+
+### MetricsConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `access_point_arn` | Arn | No | The access point that was used while performing operations on the object. The metrics configuration ... |
+| `id` | String | Yes | The ID used to identify the metrics configuration. This can be any value you choose that helps you i... |
+| `prefix` | String | No | The prefix that an object must have to be included in the metrics results. |
+| `tag_filters` | `List<String>` | No | Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration ... |
+
+### NotificationConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event_bridge_configuration` | String | No | Enables delivery of events to Amazon EventBridge. |
+| `lambda_configurations` | `List<String>` | No | Describes the LAMlong functions to invoke and the events for which to invoke them. |
+| `queue_configurations` | `List<String>` | No | The Amazon Simple Queue Service queues to publish messages to and the events for which to publish me... |
+| `topic_configurations` | `List<String>` | No | The topic to which notifications are sent and the events for which notifications are generated. |
+
+### ObjectLockConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `object_lock_enabled` | String | No | Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled``... |
+| `rule` | String | No | Specifies the Object Lock rule for the specified object. Enable this rule when you apply ``ObjectLoc... |
+
+### OwnershipControls
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rules` | `List<String>` | Yes | Specifies the container element for Object Ownership rules. |
+
+### PublicAccessBlockConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `block_public_acls` | Bool | No | Specifies whether Amazon S3 should block public access control lists (ACLs) for this bucket and obje... |
+| `block_public_policy` | Bool | No | Specifies whether Amazon S3 should block public bucket policies for this bucket. Setting this elemen... |
+| `ignore_public_acls` | Bool | No | Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this bucket. Se... |
+| `restrict_public_buckets` | Bool | No | Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this ele... |
+
+### ReplicationConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `role` | String | Yes | The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating obj... |
+| `rules` | `List<String>` | Yes | A container for one or more replication rules. A replication configuration must have at least one ru... |
+
+### VersioningConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | String | Yes | The versioning state of the bucket. |
+
+### WebsiteConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `error_document` | String | No | The name of the error document for the website. |
+| `index_document` | String | No | The name of the index document for the website. |
+| `redirect_all_requests_to` | String | No | The redirect behavior for every request to this bucket's website endpoint.  If you specify this prop... |
+| `routing_rules` | `List<String>` | No | Rules that define when a redirect is applied and the redirect behavior. |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** String
+
+### `domain_name`
+
+- **Type:** String
+
+### `dual_stack_domain_name`
+
+- **Type:** String
+
+### `regional_domain_name`
+
+- **Type:** String
+
+### `website_url`
+
+- **Type:** String
+
+


### PR DESCRIPTION
## Summary

- Adds 4 new AWS resource types to the AWSCC provider: `AWS::EC2::TransitGatewayAttachment`, `AWS::S3::Bucket`, `AWS::IAM::Role`, and `AWS::Logs::LogGroup`
- Generates Rust schema code and markdown documentation for all new resource types via `generate-schemas.sh` and `generate-docs.sh`
- Updates generation scripts and SUMMARY.md to include the new resource types

Closes #78
Closes #79

## New Resource Types

| Resource Type | Schema File | Description |
|---|---|---|
| `awscc.ec2_transit_gateway_attachment` | `transit_gateway_attachment.rs` (57 lines) | VPC attachments to Transit Gateways |
| `awscc.s3_bucket` | `bucket.rs` (696 lines) | S3 bucket management with full schema |
| `awscc.iam_role` | `role.rs` (82 lines) | IAM role creation and management |
| `awscc.logs_log_group` | `log_group.rs` (88 lines) | CloudWatch Logs log group management |

## Notes

- The existing `ec2_route/transit_gateway.crn` acceptance test has a `validate-only` comment noting it needs a TransitGatewayAttachment. Now that the resource type exists, a follow-up could enable the full test, but it also requires subnet creation so was left as-is.
- Integer enum values (e.g., `RetentionInDays` in LogGroup) are handled correctly by the codegen -- they fall back to `AttributeType::Int` instead of generating invalid enum code.
- The `looks_like_enum_value()` filter in codegen prevents false enum detection from IAM Role descriptions containing unicode escapes and JSON examples.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes (257 tests, 0 failures)
- [x] Pre-commit hooks pass (formatting, clippy, tests)
- [ ] Verify new resource types appear in documentation
- [ ] Smoke test: write a `.crn` file using `awscc.iam_role` or `awscc.logs_log_group` and run `validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)