### PR TITLE
Upgrade acceptance tests to full apply+destroy cycle

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
@@ -2,9 +2,6 @@
 #
 # Tests: log_destination_type=s3, traffic_type, resource_type, resource_id,
 #        log_destination, destination_options (Struct)
-#
-# validate-only: Requires S3 bucket that cannot be created with current
-# awscc resource types.
 
 provider awscc {
   region = aws.Region.ap_northeast_1
@@ -15,13 +12,17 @@ let vpc = awscc.ec2_vpc {
   cidr_block = "10.0.0.0/16"
 }
 
+let bucket = awscc.s3_bucket {
+  name = "acceptance-test-flowlog-s3-bucket"
+}
+
 awscc.ec2_flow_log {
   name                 = "acceptance-test-flowlog-s3"
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL
   log_destination_type = s3
-  log_destination      = "arn:aws:s3:::acceptance-test-flow-logs-bucket"
+  log_destination      = bucket.arn
 
   destination_options = {
     file_format                = "plain-text"

--- a/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
@@ -1,10 +1,7 @@
 # EC2 Route - Transit Gateway test
 #
 # Tests: transit_gateway_id
-# Requires: Transit Gateway
-#
-# validate-only: Requires TransitGatewayAttachment to VPC before route
-# creation, which needs ec2_transit_gateway_attachment resource type.
+# Requires: Transit Gateway, TransitGatewayAttachment, Subnet
 
 provider awscc {
   region = aws.Region.ap_northeast_1
@@ -15,9 +12,23 @@ let vpc = awscc.ec2_vpc {
   cidr_block = "10.0.0.0/16"
 }
 
+let subnet = awscc.ec2_subnet {
+  name              = "acceptance-test-subnet-route-tgw"
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
 let tgw = awscc.ec2_transit_gateway {
   name        = "acceptance-test-tgw-route"
   description = "Transit Gateway for route test"
+}
+
+let tgw_attach = awscc.ec2_transit_gateway_attachment {
+  name               = "acceptance-test-tgw-attach-route"
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+  subnet_ids         = [subnet.subnet_id]
 }
 
 let rt = awscc.ec2_route_table {
@@ -29,5 +40,5 @@ awscc.ec2_route {
   name                   = "acceptance-test-route-tgw"
   route_table_id         = rt.route_table_id
   destination_cidr_block = "10.1.0.0/16"
-  transit_gateway_id     = tgw.id
+  transit_gateway_id     = tgw_attach.transit_gateway_id
 }


### PR DESCRIPTION
## Summary

- Upgrade `ec2_route/transit_gateway.crn` from validate-only to full apply+destroy by adding `ec2_subnet` and `ec2_transit_gateway_attachment` resources
- Upgrade `ec2_flow_log/s3.crn` from validate-only to full apply by replacing hardcoded bucket ARN with `awscc.s3_bucket` resource reference

Both tests verified with successful apply+destroy against AWS.

**Note:** S3 flow log test has a known destroy limitation - the bucket contains flow log data and CloudControl API cannot delete non-empty buckets. Manual cleanup with `aws s3 rb --force` is needed.

**Note:** `ec2_flow_log/cloudwatch.crn` remains validate-only because `iam_role` requires nested JSON in `assume_role_policy_document` which the current `Map<String>` type cannot express. Tracked in #114.

Closes #78, Closes #79

## Test plan

- [x] `cargo test` - all 257 tests pass
- [x] `ec2_route/transit_gateway.crn` - apply + destroy verified
- [x] `ec2_flow_log/s3.crn` - apply verified (destroy has known S3 limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)