### PR TITLE
Fix inconsistent table column widths in documentation

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -10,4 +10,4 @@ build-dir = "book"
 [output.html]
 default-theme = "latte"
 preferred-dark-theme = "mocha"
-additional-css = ["./theme/catppuccin.css"]
+additional-css = ["./theme/catppuccin.css", "./theme/custom.css"]

--- a/docs/theme/custom.css
+++ b/docs/theme/custom.css
@@ -1,0 +1,44 @@
+/* Standardize table column widths for documentation */
+
+/* All tables: consistent base styling */
+table {
+    table-layout: fixed;
+    width: 100%;
+}
+
+/* Enum values tables (2 columns: Value | DSL Identifier) */
+table:has(th:first-child:last-child + th) {
+    table-layout: fixed;
+}
+table:has(th:first-child:last-child + th) th:first-child,
+table:has(th:first-child:last-child + th) td:first-child {
+    width: 30%;
+}
+table:has(th:first-child:last-child + th) th:last-child,
+table:has(th:first-child:last-child + th) td:last-child {
+    width: 70%;
+}
+
+/* Struct field tables (4 columns: Field | Type | Required | Description) */
+table:has(th:nth-child(4):last-child) th:nth-child(1),
+table:has(th:nth-child(4):last-child) td:nth-child(1) {
+    width: 25%;
+}
+table:has(th:nth-child(4):last-child) th:nth-child(2),
+table:has(th:nth-child(4):last-child) td:nth-child(2) {
+    width: 20%;
+}
+table:has(th:nth-child(4):last-child) th:nth-child(3),
+table:has(th:nth-child(4):last-child) td:nth-child(3) {
+    width: 10%;
+}
+table:has(th:nth-child(4):last-child) th:nth-child(4),
+table:has(th:nth-child(4):last-child) td:nth-child(4) {
+    width: 45%;
+}
+
+/* Ensure cell content wraps properly with fixed layout */
+td, th {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}


### PR DESCRIPTION
## Summary
- Added `docs/theme/custom.css` with fixed column widths for enum values tables (30%/70%) and struct field tables (25%/20%/10%/45%)
- Updated `docs/book.toml` to include the custom CSS
- Uses `table-layout: fixed` with CSS `:has()` selector to target tables by column count

Closes #117

## Test plan
- [ ] Build mdbook and verify enum values tables have consistent column widths across pages
- [ ] Verify struct field tables have consistent column widths across pages
- [ ] Check that table content wraps properly with fixed layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)