### PR TITLE
Improve IAM Policy Document type handling (closes #124)

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -334,7 +334,13 @@ fn type_display_string(
         }
     } else {
         match prop.prop_type.as_ref().and_then(|t| t.as_str()) {
-            Some("string") => infer_string_type_display(prop_name),
+            Some("string") => {
+                if prop_name.ends_with("PolicyDocument") {
+                    "IamPolicyDocument".to_string()
+                } else {
+                    infer_string_type_display(prop_name)
+                }
+            }
             Some("boolean") => "Bool".to_string(),
             Some("integer") | Some("number") => {
                 if let (Some(min), Some(max)) = (prop.minimum, prop.maximum) {
@@ -486,7 +492,13 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
                     "Enum".to_string()
                 } else {
                     match field_prop.prop_type.as_ref().and_then(|t| t.as_str()) {
-                        Some("string") => infer_string_type_display(field_name),
+                        Some("string") => {
+                            if field_name.ends_with("PolicyDocument") {
+                                "IamPolicyDocument".to_string()
+                            } else {
+                                infer_string_type_display(field_name)
+                            }
+                        }
                         Some("boolean") => "Bool".to_string(),
                         Some("integer") | Some("number") => {
                             if let (Some(min), Some(max)) = (field_prop.minimum, field_prop.maximum)
@@ -1301,6 +1313,11 @@ fn cfn_type_to_carina_type_with_enum(
     // Handle type
     match prop.prop_type.as_ref().and_then(|t| t.as_str()) {
         Some("string") => {
+            // Check if this is a policy document field (CFN sometimes types these as "string")
+            if prop_name.ends_with("PolicyDocument") {
+                return ("super::iam_policy_document()".to_string(), None);
+            }
+
             // Check property name for specific types
             let prop_lower = prop_name.to_lowercase();
 

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -529,6 +529,86 @@ pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
                     i, e
                 ));
             }
+
+            // Validate Sid if present (must be a string)
+            if let Some(sid) = stmt_map.get("sid")
+                && !matches!(sid, Value::String(_))
+            {
+                return Err(format!("Statement[{}] 'sid' must be a string", i));
+            }
+
+            // Validate Action / NotAction if present (must be string or list of strings)
+            for key in &["action", "not_action"] {
+                if let Some(action) = stmt_map.get(*key) {
+                    match action {
+                        Value::String(_) => {}
+                        Value::List(items) => {
+                            for (j, item) in items.iter().enumerate() {
+                                if !matches!(item, Value::String(_)) {
+                                    return Err(format!(
+                                        "Statement[{}] '{}[{}]' must be a string",
+                                        i, key, j
+                                    ));
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(format!(
+                                "Statement[{}] '{}' must be a string or list of strings",
+                                i, key
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Validate Resource / NotResource if present (must be string or list of strings)
+            for key in &["resource", "not_resource"] {
+                if let Some(resource) = stmt_map.get(*key) {
+                    match resource {
+                        Value::String(_) => {}
+                        Value::List(items) => {
+                            for (j, item) in items.iter().enumerate() {
+                                if !matches!(item, Value::String(_)) {
+                                    return Err(format!(
+                                        "Statement[{}] '{}[{}]' must be a string",
+                                        i, key, j
+                                    ));
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(format!(
+                                "Statement[{}] '{}' must be a string or list of strings",
+                                i, key
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Validate Principal / NotPrincipal if present (must be string "*" or a map)
+            for key in &["principal", "not_principal"] {
+                if let Some(principal) = stmt_map.get(*key) {
+                    match principal {
+                        Value::String(_) => {}
+                        Value::Map(_) => {}
+                        _ => {
+                            return Err(format!(
+                                "Statement[{}] '{}' must be a string or a map",
+                                i, key
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // Validate Condition if present (must be a map)
+            if let Some(condition) = stmt_map.get("condition")
+                && !matches!(condition, Value::Map(_))
+            {
+                return Err(format!("Statement[{}] 'condition' must be a map", i));
+            }
         }
     }
 
@@ -968,6 +1048,144 @@ mod tests {
             ))
             .is_ok()
         );
+    }
+
+    #[test]
+    fn validate_iam_policy_document_valid_with_all_fields() {
+        let doc = Value::Map(
+            vec![
+                (
+                    "version".to_string(),
+                    Value::String("2012-10-17".to_string()),
+                ),
+                (
+                    "statement".to_string(),
+                    Value::List(vec![Value::Map(
+                        vec![
+                            (
+                                "sid".to_string(),
+                                Value::String("AllowS3Access".to_string()),
+                            ),
+                            ("effect".to_string(), Value::String("Allow".to_string())),
+                            (
+                                "principal".to_string(),
+                                Value::Map(
+                                    vec![(
+                                        "service".to_string(),
+                                        Value::String("ec2.amazonaws.com".to_string()),
+                                    )]
+                                    .into_iter()
+                                    .collect(),
+                                ),
+                            ),
+                            (
+                                "action".to_string(),
+                                Value::List(vec![
+                                    Value::String("s3:GetObject".to_string()),
+                                    Value::String("s3:PutObject".to_string()),
+                                ]),
+                            ),
+                            ("resource".to_string(), Value::String("*".to_string())),
+                            (
+                                "condition".to_string(),
+                                Value::Map(
+                                    vec![(
+                                        "string_equals".to_string(),
+                                        Value::Map(
+                                            vec![(
+                                                "aws:RequestedRegion".to_string(),
+                                                Value::String("us-east-1".to_string()),
+                                            )]
+                                            .into_iter()
+                                            .collect(),
+                                        ),
+                                    )]
+                                    .into_iter()
+                                    .collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        assert!(validate_iam_policy_document(&doc).is_ok());
+    }
+
+    #[test]
+    fn validate_iam_policy_document_invalid_principal() {
+        let doc = Value::Map(
+            vec![(
+                "statement".to_string(),
+                Value::List(vec![Value::Map(
+                    vec![
+                        ("effect".to_string(), Value::String("Allow".to_string())),
+                        (
+                            "principal".to_string(),
+                            Value::List(vec![Value::String("not-valid".to_string())]),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let result = validate_iam_policy_document(&doc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("principal"));
+    }
+
+    #[test]
+    fn validate_iam_policy_document_invalid_action() {
+        let doc = Value::Map(
+            vec![(
+                "statement".to_string(),
+                Value::List(vec![Value::Map(
+                    vec![
+                        ("effect".to_string(), Value::String("Allow".to_string())),
+                        ("action".to_string(), Value::Int(42)),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let result = validate_iam_policy_document(&doc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("action"));
+    }
+
+    #[test]
+    fn validate_iam_policy_document_invalid_condition() {
+        let doc = Value::Map(
+            vec![(
+                "statement".to_string(),
+                Value::List(vec![Value::Map(
+                    vec![
+                        ("effect".to_string(), Value::String("Allow".to_string())),
+                        (
+                            "condition".to_string(),
+                            Value::String("not-a-map".to_string()),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )]),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let result = validate_iam_policy_document(&doc);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("condition"));
     }
 
     #[test]

--- a/carina-provider-awscc/src/schemas/generated/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/role.rs
@@ -56,7 +56,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
             AttributeSchema::new("policies", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "Policy".to_string(),
                     fields: vec![
-                    StructField::new("policy_document", AttributeType::String).required().with_description("The entire contents of the policy that defines permissions. For more information, see [Overview of JSON policies](https://docs.aws.amazon.com/IAM/late...").with_provider_name("PolicyDocument"),
+                    StructField::new("policy_document", super::iam_policy_document()).required().with_description("The entire contents of the policy that defines permissions. For more information, see [Overview of JSON policies](https://docs.aws.amazon.com/IAM/late...").with_provider_name("PolicyDocument"),
                     StructField::new("policy_name", AttributeType::String).required().with_description("The friendly name (not ARN) identifying the policy.").with_provider_name("PolicyName")
                     ],
                 })))

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -90,7 +90,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("NetworkInterfaceIds"),
         )
         .attribute(
-            AttributeSchema::new("policy_document", AttributeType::String)
+            AttributeSchema::new("policy_document", super::iam_policy_document())
                 .with_description("An endpoint policy, which controls access to the service from the VPC. The default endpoint policy allows full access to the service. Endpoint policie...")
                 .with_provider_name("PolicyDocument"),
         )

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -25,7 +25,7 @@ The supported IP address types.
 
 ### `policy_document`
 
-- **Type:** String
+- **Type:** IamPolicyDocument
 - **Required:** No
 
 An endpoint policy, which controls access to the service from the VPC. The default endpoint policy allows full access to the service. Endpoint policies are supported only for gateway and interface endpoints. For CloudFormation templates in YAML, you can provide the policy in JSON or YAML format. For example, if you have a JSON policy, you can convert it to YAML before including it in the YAML template, and CFNlong converts the policy to JSON format before calling the API actions for privatelink. Alternatively, you can include the JSON directly in the YAML, as shown in the following ``Properties`` section: ``Properties: VpcEndpointType: 'Interface' ServiceName: !Sub 'com.amazonaws.${AWS::Region}.logs' PolicyDocument: '{ "Version":"2012-10-17", "Statement": [{ "Effect":"Allow", "Principal":"*", "Action":["logs:Describe*","logs:Get*","logs:List*","logs:FilterLogEvents"], "Resource":"*" }] }'``

--- a/docs/src/providers/awscc/iam_role.md
+++ b/docs/src/providers/awscc/iam_role.md
@@ -76,7 +76,7 @@ A list of tags that are attached to the role. For more information about tagging
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `policy_document` | String | Yes | The entire contents of the policy that defines permissions. For more information, see [Overview of J... |
+| `policy_document` | IamPolicyDocument | Yes | The entire contents of the policy that defines permissions. For more information, see [Overview of J... |
 | `policy_name` | String | Yes | The friendly name (not ARN) identifying the policy. |
 
 ## Attribute Reference


### PR DESCRIPTION
## Summary

- **Fix codegen detection**: PolicyDocument fields typed as `"string"` in CloudFormation schemas (e.g., `ec2_vpc_endpoint.policy_document`, `iam_role.policies[].policy_document`) are now correctly mapped to `IamPolicyDocument` instead of plain `String`
- **Enhance validation**: `validate_iam_policy_document()` now validates statement fields: `sid`, `action`/`not_action`, `resource`/`not_resource`, `principal`/`not_principal`, and `condition`
- **Regenerate schemas and docs**: All generated files updated to reflect the type changes

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 270 tests pass (including 4 new validation tests)
- [x] `cargo clippy` — no warnings
- [x] Verified `vpc_endpoint.rs` uses `super::iam_policy_document()` for `policy_document`
- [x] Verified `role.rs` uses `super::iam_policy_document()` for both `assume_role_policy_document` and `policies[].policy_document`
- [x] Verified docs show `IamPolicyDocument` type for these fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)