### PR TITLE
Cache CloudFormation schema downloads in codegen scripts (closes #125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 
 # mdbook build output
 docs/book/
+
+# CloudFormation schema cache
+carina-provider-awscc/cfn-schema-cache/


### PR DESCRIPTION
## Summary

- Both `generate-schemas.sh` and `generate-docs.sh` now cache downloaded CloudFormation schemas in `carina-provider-awscc/cfn-schema-cache/` to avoid redundant API calls on subsequent runs
- Cache files are named using the type name with `::` replaced by `__` (e.g., `AWS__EC2__VPC.json`)
- Added `--refresh-cache` flag to force re-download when needed
- Added `carina-provider-awscc/cfn-schema-cache/` to `.gitignore`

## Test plan

- [ ] Run `generate-schemas.sh` with AWS credentials — first run downloads and caches schemas
- [ ] Run `generate-schemas.sh` again — should use cached schemas (prints "Using cached schema")
- [ ] Run `generate-schemas.sh --refresh-cache` — should re-download all schemas
- [ ] Run `generate-docs.sh` — should reuse schemas cached by `generate-schemas.sh`
- [ ] Verify generated output is identical to pre-cache output

🤖 Generated with [Claude Code](https://claude.com/claude-code)