### PR TITLE
Improve end-to-end support for repeated blocks (closes #126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ instance_tenancy = dedicated
 
 ### Nested Objects (Struct Types)
 
-Some resources support nested objects for inline configuration:
+Some resources support nested objects for inline configuration. Use repeated blocks for multiple items:
 
 ```hcl
 awscc.ec2_security_group {
@@ -188,21 +188,33 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Web server security group"
 
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+```
+
+Array syntax is also supported:
+
+```hcl
   security_group_ingress = [
     {
       ip_protocol = "tcp"
       from_port   = 80
       to_port     = 80
       cidr_ip     = "0.0.0.0/0"
-    },
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ip     = "0.0.0.0/0"
     }
   ]
-}
 ```
 
 ### Modules

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -1698,6 +1698,45 @@ simple {
     }
 
     #[test]
+    fn struct_field_completion_inside_second_repeated_block() {
+        let provider = CompletionProvider::new();
+        let doc = create_document(
+            r#"awscc.ec2_security_group {
+    group_description = "test"
+    security_group_ingress {
+        ip_protocol = "tcp"
+        from_port = 80
+        to_port = 80
+        cidr_ip = "0.0.0.0/0"
+    }
+    security_group_ingress {
+
+    }
+}"#,
+        );
+        // Cursor inside the second nested block (line 9)
+        let position = Position {
+            line: 9,
+            character: 8,
+        };
+
+        let completions = provider.complete(&doc, position, None);
+
+        // Should have struct field completions in the second block too
+        let ip_protocol = completions.iter().find(|c| c.label == "ip_protocol");
+        assert!(
+            ip_protocol.is_some(),
+            "Should have ip_protocol field completion in second repeated block"
+        );
+
+        let from_port = completions.iter().find(|c| c.label == "from_port");
+        assert!(
+            from_port.is_some(),
+            "Should have from_port field completion in second repeated block"
+        );
+    }
+
+    #[test]
     fn context_detection_returns_struct_context() {
         let provider = CompletionProvider::new();
         let text = r#"awscc.ec2_security_group {

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -16,23 +16,19 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - IPv6 rules"
 
-  security_group_ingress = [
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ipv6   = "::/0"
-      description = "Allow HTTPS from IPv6"
-    }
-  ]
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ipv6   = "::/0"
+    description = "Allow HTTPS from IPv6"
+  }
 
-  security_group_egress = [
-    {
-      ip_protocol = "-1"
-      cidr_ipv6   = "::/0"
-      description = "Allow all IPv6 outbound"
-    }
-  ]
+  security_group_egress {
+    ip_protocol = "-1"
+    cidr_ipv6   = "::/0"
+    description = "Allow all IPv6 outbound"
+  }
 
   tags = {
     Environment = "acceptance-test"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
@@ -16,20 +16,19 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - egress rules"
 
-  security_group_egress = [
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ip     = "0.0.0.0/0"
-      description = "Allow HTTPS outbound"
-    },
-    {
-      ip_protocol = "-1"
-      cidr_ip     = "10.0.0.0/8"
-      description = "Allow all to private ranges"
-    }
-  ]
+  security_group_egress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+    description = "Allow HTTPS outbound"
+  }
+
+  security_group_egress {
+    ip_protocol = "-1"
+    cidr_ip     = "10.0.0.0/8"
+    description = "Allow all to private ranges"
+  }
 
   tags = {
     Environment = "acceptance-test"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -16,22 +16,21 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - ingress rules"
 
-  security_group_ingress = [
-    {
-      ip_protocol = "tcp"
-      from_port   = 80
-      to_port     = 80
-      cidr_ip     = "0.0.0.0/0"
-      description = "Allow HTTP"
-    },
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ip     = "0.0.0.0/0"
-      description = "Allow HTTPS"
-    }
-  ]
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+    description = "Allow HTTP"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+    description = "Allow HTTPS"
+  }
 
   tags = {
     Environment = "acceptance-test"

--- a/carina-provider-awscc/examples/ec2_security_group/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group/main.crn
@@ -16,20 +16,19 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 
-  security_group_ingress = [
-    {
-      ip_protocol = "tcp"
-      from_port   = 80
-      to_port     = 80
-      cidr_ip     = "0.0.0.0/0"
-    },
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ip     = "0.0.0.0/0"
-    }
-  ]
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+  }
 
   tags = {
     Environment = "example"

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -103,20 +103,19 @@ awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 
-  security_group_ingress = [
-    {
-      ip_protocol = "tcp"
-      from_port   = 80
-      to_port     = 80
-      cidr_ip     = "0.0.0.0/0"
-    },
-    {
-      ip_protocol = "tcp"
-      from_port   = 443
-      to_port     = 443
-      cidr_ip     = "0.0.0.0/0"
-    }
-  ]
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+  }
 
   tags = {
     Environment = "example"


### PR DESCRIPTION
## Summary

- **Plan display**: Multi-line formatting for list-of-struct attributes with per-item `+`/`-`/`~` diff markers instead of unreadable inline `[{...}, {...}]`
- **LSP diagnostics**: Validate all repeated block occurrences with correct position mapping (errors in 2nd+ blocks now point to the right location)
- **LSP semantic tokens**: Highlight nested block names (e.g., `security_group_ingress {`) as PROPERTY
- **LSP completion**: Verified and tested completions work inside 2nd+ repeated blocks
- **Differ**: Added list-of-map diff detection test
- **Examples/tests/docs**: Converted `.crn` files and README from `attr = [{ ... }]` to repeated block syntax

## Test plan

- [x] `cargo test` — all 250 tests pass
- [x] `cargo build` — clean build, no warnings
- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [ ] Manual: verify plan display with a security group `.crn` file containing repeated blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)