### PR TITLE
Propagate IGW detach error instead of silently ignoring it

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -712,9 +712,15 @@ impl AwsccProvider {
                 && !attachments.is_empty()
             {
                 let patch_ops = vec![json!({"op": "remove", "path": "/Attachments"})];
-                let _ = self
-                    .cc_update_resource(config.aws_type_name, identifier, patch_ops)
-                    .await;
+                self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
+                    .await
+                    .map_err(|e| {
+                        ProviderError::new(format!(
+                            "Failed to detach Internet Gateway from VPC before deletion: {}",
+                            e
+                        ))
+                        .for_resource(id.clone())
+                    })?;
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

- Replace `let _ = ...` with proper error propagation in `pre_delete_operations()` for Internet Gateway VPC detach
- Errors now include a clear message: "Failed to detach Internet Gateway from VPC before deletion"
- Closes #136

## Test plan

- [x] `cargo build` compiles successfully
- [x] All 281 tests pass
- [x] Clippy passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)