### PR TITLE
Add identifier to Effect::Delete (closes #135)

### DIFF
--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -22,7 +22,7 @@ pub enum Effect {
     },
 
     /// Delete a resource
-    Delete(ResourceId),
+    Delete { id: ResourceId, identifier: String },
 }
 
 impl Effect {
@@ -32,7 +32,7 @@ impl Effect {
             Effect::Read { .. } => "read",
             Effect::Create(_) => "create",
             Effect::Update { .. } => "update",
-            Effect::Delete(_) => "delete",
+            Effect::Delete { .. } => "delete",
         }
     }
 
@@ -47,7 +47,7 @@ impl Effect {
             Effect::Read { resource } => &resource.id,
             Effect::Create(r) => &r.id,
             Effect::Update { id, .. } => id,
-            Effect::Delete(id) => id,
+            Effect::Delete { id, .. } => id,
         }
     }
 }

--- a/carina-core/src/interpreter.rs
+++ b/carina-core/src/interpreter.rs
@@ -119,10 +119,8 @@ impl<P: Provider> Interpreter<P> {
                 let state = self.provider.update(id, identifier, from, to).await?;
                 Ok(EffectOutcome::Updated { state })
             }
-            Effect::Delete(id) => {
-                // Delete without identifier - this won't work for identifier-based providers
-                // CLI handles identifier extraction from state directly
-                self.provider.delete(id, "").await?;
+            Effect::Delete { id, identifier } => {
+                self.provider.delete(id, identifier).await?;
                 Ok(EffectOutcome::Deleted)
             }
         }

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -45,7 +45,7 @@ impl Plan {
                 Effect::Read { .. } => summary.read += 1,
                 Effect::Create(_) => summary.create += 1,
                 Effect::Update { .. } => summary.update += 1,
-                Effect::Delete(_) => summary.delete += 1,
+                Effect::Delete { .. } => summary.delete += 1,
             }
         }
         summary
@@ -143,7 +143,7 @@ impl ModularPlan {
                 Effect::Create(r) => Self::extract_source(&r.attributes),
                 Effect::Update { to, .. } => Self::extract_source(&to.attributes),
                 Effect::Read { resource } => Self::extract_source(&resource.attributes),
-                Effect::Delete(_) => ModuleSource::Root,
+                Effect::Delete { .. } => ModuleSource::Root,
             };
             modular.effect_sources.insert(idx, source);
         }
@@ -253,7 +253,7 @@ fn format_effect_brief(effect: &Effect) -> String {
     match effect {
         Effect::Create(r) => format!("+ {}", r.id),
         Effect::Update { id, .. } => format!("~ {}", id),
-        Effect::Delete(id) => format!("- {}", id),
+        Effect::Delete { id, .. } => format!("- {}", id),
         Effect::Read { resource } => format!("<= {} (data source)", resource.id),
     }
 }
@@ -275,10 +275,10 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::Create(Resource::new("s3_bucket", "a")));
         plan.add(Effect::Create(Resource::new("s3_bucket", "b")));
-        plan.add(Effect::Delete(crate::resource::ResourceId::new(
-            "s3_bucket",
-            "c",
-        )));
+        plan.add(Effect::Delete {
+            id: crate::resource::ResourceId::new("s3_bucket", "c"),
+            identifier: String::new(),
+        });
 
         let summary = plan.summary();
         assert_eq!(summary.create, 2);


### PR DESCRIPTION
## Summary

- Changed `Effect::Delete(ResourceId)` to `Effect::Delete { id: ResourceId, identifier: String }` so delete effects carry the cloud provider identifier (e.g., `vpc-123abc`) directly
- `create_plan()` now extracts identifier from `current_states` when building Delete effects (both explicit deletions and orphan detection)
- Fixed the `Interpreter` which previously passed an empty string `""` for delete operations, causing silent failures for anyone using it directly instead of the CLI

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 277 tests pass
- [x] Pre-commit hooks pass (formatting, clippy, tests)
- [ ] Run acceptance tests against real AWS resources to verify delete operations work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)