### PR TITLE
Stop using name attribute as resource identifier for AWSCC provider

### DIFF
--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -214,10 +214,17 @@ impl ModuleResolver {
                 new_name.clone(),
             );
 
-            // Update name attribute
-            new_resource
+            // Update name attribute for aws provider only
+            // Non-aws providers don't use name as a resource property
+            let is_aws_provider = new_resource
                 .attributes
-                .insert("name".to_string(), Value::String(new_name));
+                .get("_provider")
+                .is_some_and(|v| matches!(v, Value::String(s) if s == "aws"));
+            if is_aws_provider {
+                new_resource
+                    .attributes
+                    .insert("name".to_string(), Value::String(new_name));
+            }
 
             // Add module source info
             new_resource.attributes.insert(

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -370,6 +370,8 @@ pub struct AttributeSchema {
     pub completions: Option<Vec<CompletionValue>>,
     /// Provider-side property name (e.g., "VpcId" for AWS Cloud Control)
     pub provider_name: Option<String>,
+    /// Whether this attribute is create-only (immutable after creation)
+    pub create_only: bool,
 }
 
 impl AttributeSchema {
@@ -382,11 +384,17 @@ impl AttributeSchema {
             description: None,
             completions: None,
             provider_name: None,
+            create_only: false,
         }
     }
 
     pub fn required(mut self) -> Self {
         self.required = true;
+        self
+    }
+
+    pub fn create_only(mut self) -> Self {
+        self.create_only = true;
         self
     }
 
@@ -445,6 +453,15 @@ impl ResourceSchema {
     pub fn with_validator(mut self, validator: ResourceValidator) -> Self {
         self.validator = Some(validator);
         self
+    }
+
+    /// Returns the names of create-only (immutable) attributes
+    pub fn create_only_attributes(&self) -> Vec<&str> {
+        self.attributes
+            .iter()
+            .filter(|(_, schema)| schema.create_only)
+            .map(|(name, _)| name.as_str())
+            .collect()
     }
 
     /// Validate resource attributes

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -456,7 +456,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "awscc.ec2_vpc {\n    name                 = \"${1:vpc-name}\"\n    cidr_block           = \"${2:10.0.0.0/16}\"\n    enable_dns_support   = true\n    enable_dns_hostnames = true\n}".to_string(),
+                    new_text: "let ${1:vpc} = awscc.ec2_vpc {\n    cidr_block           = \"${2:10.0.0.0/16}\"\n    enable_dns_support   = true\n    enable_dns_hostnames = true\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("VPC resource (Cloud Control API)".to_string()),
@@ -1669,16 +1669,15 @@ simple {
         let provider = CompletionProvider::new();
         // flow_log's destination_options has Bool fields
         let doc = create_document(
-            r#"awscc.ec2_flow_log {
-    name = "test"
+            r#"let flow_log = awscc.ec2_flow_log {
     destination_options {
         hive_compatible_partitions =
     }
 }"#,
         );
-        // Cursor after "hive_compatible_partitions = " (line 3)
+        // Cursor after "hive_compatible_partitions = " (line 2)
         let position = Position {
-            line: 3,
+            line: 2,
             character: 37,
         };
 

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -1220,8 +1220,7 @@ mod tests {
     region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_security_group {
-    name = "test-sg"
+let sg = awscc.ec2_security_group {
     group_description = "Test security group"
     security_group_ingress {
         ip_protocol = "tcp"
@@ -1250,8 +1249,7 @@ awscc.ec2_security_group {
     region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_security_group {
-    name = "test-sg"
+let sg = awscc.ec2_security_group {
     group_description = "Test security group"
     security_group_ingress {
         ip_protocol = "tcp"
@@ -1282,12 +1280,10 @@ awscc.ec2_security_group {
 }
 
 let vpc = awscc.ec2_vpc {
-    name = "test-vpc"
     cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_vpc {
-    name = "test-vpc-2"
+let vpc2 = awscc.ec2_vpc {
     ipv4_ipam_pool_id = vpc.vpc_id
 }"#,
         );
@@ -1315,12 +1311,10 @@ awscc.ec2_vpc {
 }
 
 let vpc = awscc.ec2_vpc {
-    name = "test-vpc"
     cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_subnet {
-    name = "test-subnet"
+let subnet = awscc.ec2_subnet {
     vpc_id = vpc.vpc_id
     cidr_block = "10.0.1.0/24"
 }"#,
@@ -1346,8 +1340,7 @@ awscc.ec2_subnet {
     region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_security_group {
-    name = "test-sg"
+let sg = awscc.ec2_security_group {
     group_description = "Test security group"
     security_group_ingress {
         ip_protocol = "tcp"
@@ -1377,11 +1370,11 @@ awscc.ec2_security_group {
         );
 
         // The diagnostic should point to the second block, not the first.
-        // LSP uses 0-indexed lines, so line 18 = line 19 in 1-indexed.
+        // LSP uses 0-indexed lines, so line 17 = line 18 in 1-indexed.
         let diag = bad_field_diag.unwrap();
         assert_eq!(
-            diag.range.start.line, 18,
-            "Diagnostic should point to line 18 (0-indexed, in second block), got line {}",
+            diag.range.start.line, 17,
+            "Diagnostic should point to line 17 (0-indexed, in second block), got line {}",
             diag.range.start.line
         );
     }

--- a/carina-provider-awscc/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-eoigw"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_egress_only_internet_gateway {
-  name   = "acceptance-test-eoigw"
+let eoigw = awscc.ec2_egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_eip/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_eip/basic.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_eip {
-  name   = "acceptance-test-eip"
+let eip = awscc.ec2_eip {
   domain = "vpc"
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_eip/with_network_border.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_eip/with_network_border.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_eip {
-  name                 = "acceptance-test-eip-border"
+let eip = awscc.ec2_eip {
   domain               = "vpc"
   network_border_group = "ap-northeast-1"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -8,18 +8,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-flowlog-cw"
   cidr_block = "10.0.0.0/16"
 }
 
 let log_group = awscc.logs_log_group {
-  name              = "acceptance-test-log-group-flowlog-cw"
   log_group_name    = "/acceptance-test/vpc-flow-logs"
   retention_in_days = 1
 }
 
 let flow_log_role = awscc.iam_role {
-  name      = "acceptance-test-flow-log-role"
   role_name = "acceptance-test-flow-log-role"
   assume_role_policy_document = {
     version = "2012-10-17"
@@ -33,8 +30,7 @@ let flow_log_role = awscc.iam_role {
   }
 }
 
-awscc.ec2_flow_log {
-  name                        = "acceptance-test-flowlog-cw"
+let flow_log = awscc.ec2_flow_log {
   resource_id                 = vpc.vpc_id
   resource_type               = VPC
   traffic_type                = ALL

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
@@ -8,16 +8,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-flowlog-s3"
   cidr_block = "10.0.0.0/16"
 }
 
 let bucket = awscc.s3_bucket {
-  name = "acceptance-test-flowlog-s3-bucket"
 }
 
-awscc.ec2_flow_log {
-  name                 = "acceptance-test-flowlog-s3"
+let flow_log = awscc.ec2_flow_log {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/carina-provider-awscc/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -6,9 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_internet_gateway {
-  name = "acceptance-test-igw"
-
+let igw = awscc.ec2_internet_gateway {
   tags = {
     Environment = "acceptance-test"
   }

--- a/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_ipam {
-  name        = "acceptance-test-ipam"
+let ipam = awscc.ec2_ipam {
   description = "Acceptance test IPAM"
   tier        = free
 

--- a/carina-provider-awscc/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -8,7 +8,6 @@ provider awscc {
 }
 
 let ipam = awscc.ec2_ipam {
-  name = "acceptance-test-ipam-pool-parent"
   tier = advanced
 
   operating_regions = [
@@ -18,8 +17,7 @@ let ipam = awscc.ec2_ipam {
   ]
 }
 
-awscc.ec2_ipam_pool {
-  name           = "acceptance-test-ipam-pool"
+let ipam_pool = awscc.ec2_ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"

--- a/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/private.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/private.crn
@@ -7,19 +7,16 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-natgw-private"
   cidr_block = "10.0.0.0/16"
 }
 
 let private_subnet = awscc.ec2_subnet {
-  name              = "acceptance-test-subnet-natgw-private"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
-awscc.ec2_nat_gateway {
-  name               = "acceptance-test-natgw-private"
+let nat_gw = awscc.ec2_nat_gateway {
   subnet_id          = private_subnet.subnet_id
   connectivity_type  = private
   private_ip_address = "10.0.1.100"

--- a/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/public.crn
@@ -7,24 +7,20 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-natgw-public"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "acceptance-test-igw-natgw-public"
 }
 
 let igw_attach = awscc.ec2_vpc_gateway_attachment {
-  name                = "acceptance-test-igw-attach-natgw-public"
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 let public_subnet = awscc.ec2_subnet {
-  name                    = "acceptance-test-subnet-natgw-public"
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"
@@ -32,12 +28,10 @@ let public_subnet = awscc.ec2_subnet {
 }
 
 let eip = awscc.ec2_eip {
-  name   = "acceptance-test-eip-natgw-public"
   domain = "vpc"
 }
 
-awscc.ec2_nat_gateway {
-  name          = "acceptance-test-natgw-public"
+let nat_gw = awscc.ec2_nat_gateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/carina-provider-awscc/acceptance-tests/ec2_route/igw.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/igw.crn
@@ -7,27 +7,22 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-route-igw"
   cidr_block = "10.0.0.0/16"
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "acceptance-test-igw-route"
 }
 
 let igw_attachment = awscc.ec2_vpc_gateway_attachment {
-  name                = "acceptance-test-igw-attach-route"
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-igw"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_route {
-  name                   = "acceptance-test-route-igw"
+let route = awscc.ec2_route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw_attachment.internet_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/ipv6.crn
@@ -8,22 +8,18 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-route-ipv6"
   cidr_block = "10.0.0.0/16"
 }
 
 let eoigw = awscc.ec2_egress_only_internet_gateway {
-  name   = "acceptance-test-eoigw-route"
   vpc_id = vpc.vpc_id
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-ipv6"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_route {
-  name                            = "acceptance-test-route-ipv6"
+let route = awscc.ec2_route {
   route_table_id                  = rt.route_table_id
   destination_ipv6_cidr_block     = "::/0"
   egress_only_internet_gateway_id = eoigw.id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/nat_gateway.crn
@@ -7,24 +7,20 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-route-nat"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "acceptance-test-igw-route-nat"
 }
 
 let igw_attach = awscc.ec2_vpc_gateway_attachment {
-  name                = "acceptance-test-igw-attach-route-nat"
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 let public_subnet = awscc.ec2_subnet {
-  name                    = "acceptance-test-public-subnet-nat"
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"
@@ -32,23 +28,19 @@ let public_subnet = awscc.ec2_subnet {
 }
 
 let eip = awscc.ec2_eip {
-  name   = "acceptance-test-eip-nat-route"
   domain = "vpc"
 }
 
 let nat_gw = awscc.ec2_nat_gateway {
-  name          = "acceptance-test-nat-gw-route"
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-nat"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_route {
-  name                   = "acceptance-test-route-nat"
+let route = awscc.ec2_route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
@@ -8,36 +8,30 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-route-tgw"
   cidr_block = "10.0.0.0/16"
 }
 
 let subnet = awscc.ec2_subnet {
-  name              = "acceptance-test-subnet-route-tgw"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
 let tgw = awscc.ec2_transit_gateway {
-  name        = "acceptance-test-tgw-route"
   description = "Transit Gateway for route test"
 }
 
 let tgw_attach = awscc.ec2_transit_gateway_attachment {
-  name               = "acceptance-test-tgw-attach-route"
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id
   subnet_ids         = [subnet.subnet_id]
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-tgw"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_route {
-  name                   = "acceptance-test-route-tgw"
+let route = awscc.ec2_route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "10.1.0.0/16"
   transit_gateway_id     = tgw_attach.transit_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/vpc_peering.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/vpc_peering.crn
@@ -8,28 +8,23 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc1-route-peer"
   cidr_block = "10.0.0.0/16"
 }
 
 let vpc2 = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc2-route-peer"
   cidr_block = "10.1.0.0/16"
 }
 
 let peering = awscc.ec2_vpc_peering_connection {
-  name        = "acceptance-test-peering-route"
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-peer"
   vpc_id = vpc1.vpc_id
 }
 
-awscc.ec2_route {
-  name                       = "acceptance-test-route-peer"
+let route = awscc.ec2_route {
   route_table_id             = rt.route_table_id
   destination_cidr_block     = "10.1.0.0/16"
   vpc_peering_connection_id  = peering.id

--- a/carina-provider-awscc/acceptance-tests/ec2_route_table/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route_table/basic.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-rt"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_route_table {
-  name   = "acceptance-test-rt"
+let rt = awscc.ec2_route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sg-ipv6"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_security_group {
-  name              = "acceptance-test-sg-ipv6"
+let sg = awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - IPv6 rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sg-egress"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_security_group {
-  name              = "acceptance-test-sg-egress"
+let sg = awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - egress rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sg-ingress"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_security_group {
-  name              = "acceptance-test-sg-ingress"
+let sg = awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - ingress rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -7,18 +7,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sge-basic"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "acceptance-test-sg-for-egress"
   vpc_id            = vpc.vpc_id
   group_description = "SG for egress rule test"
 }
 
-awscc.ec2_security_group_egress {
-  name        = "acceptance-test-egress-basic"
+let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound"
   ip_protocol = "-1"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -7,24 +7,20 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sge-destsg"
   cidr_block = "10.0.0.0/16"
 }
 
 let source_sg = awscc.ec2_security_group {
-  name              = "acceptance-test-src-sg-egress"
   vpc_id            = vpc.vpc_id
   group_description = "Source security group"
 }
 
 let dest_sg = awscc.ec2_security_group {
-  name              = "acceptance-test-dest-sg-egress"
   vpc_id            = vpc.vpc_id
   group_description = "Destination security group"
 }
 
-awscc.ec2_security_group_egress {
-  name                         = "acceptance-test-egress-destsg"
+let egress = awscc.ec2_security_group_egress {
   group_id                     = source_sg.group_id
   description                  = "Allow HTTPS to destination SG"
   ip_protocol                  = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -7,18 +7,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sge-ipv6"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "acceptance-test-sg-for-egress-ipv6"
   vpc_id            = vpc.vpc_id
   group_description = "SG for IPv6 egress rule test"
 }
 
-awscc.ec2_security_group_egress {
-  name        = "acceptance-test-egress-ipv6"
+let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all IPv6 outbound"
   ip_protocol = "-1"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -7,18 +7,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sgi-basic"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "acceptance-test-sg-for-ingress"
   vpc_id            = vpc.vpc_id
   group_description = "SG for ingress rule test"
 }
 
-awscc.ec2_security_group_ingress {
-  name        = "acceptance-test-ingress-basic"
+let ingress = awscc.ec2_security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -7,18 +7,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sgi-ipv6"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "acceptance-test-sg-for-ingress-ipv6"
   vpc_id            = vpc.vpc_id
   group_description = "SG for IPv6 ingress rule test"
 }
 
-awscc.ec2_security_group_ingress {
-  name        = "acceptance-test-ingress-ipv6"
+let ingress = awscc.ec2_security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from IPv6"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -7,24 +7,20 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-sgi-srcsg"
   cidr_block = "10.0.0.0/16"
 }
 
 let source_sg = awscc.ec2_security_group {
-  name              = "acceptance-test-source-sg"
   vpc_id            = vpc.vpc_id
   group_description = "Source security group"
 }
 
 let dest_sg = awscc.ec2_security_group {
-  name              = "acceptance-test-dest-sg"
   vpc_id            = vpc.vpc_id
   group_description = "Destination security group"
 }
 
-awscc.ec2_security_group_ingress {
-  name                     = "acceptance-test-ingress-srcsg"
+let ingress = awscc.ec2_security_group_ingress {
   group_id                 = dest_sg.group_id
   description              = "Allow HTTPS from source SG"
   ip_protocol              = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/basic.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-subnet-basic"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_subnet {
-  name                    = "acceptance-test-subnet-basic"
+let subnet = awscc.ec2_subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/ipv6.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-subnet-ipv6"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_subnet {
-  name                            = "acceptance-test-subnet-ipv6"
+let subnet = awscc.ec2_subnet {
   vpc_id                          = vpc.vpc_id
   cidr_block                      = "10.0.1.0/24"
   availability_zone               = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -7,14 +7,12 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-subnet-dns"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2_subnet {
-  name              = "acceptance-test-subnet-dns"
+let subnet = awscc.ec2_subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -13,7 +13,6 @@ provider awscc {
 }
 
 let ipam = awscc.ec2_ipam {
-  name = "acceptance-test-ipam-subnet"
   tier = advanced
 
   operating_regions = [
@@ -24,7 +23,6 @@ let ipam = awscc.ec2_ipam {
 }
 
 let ipam_pool = awscc.ec2_ipam_pool {
-  name           = "acceptance-test-ipam-pool-subnet"
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"
@@ -37,13 +35,11 @@ let ipam_pool = awscc.ec2_ipam_pool {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                = "acceptance-test-vpc-subnet-ipam"
   ipv4_ipam_pool_id   = ipam_pool.ipam_pool_id
   ipv4_netmask_length = 16
 }
 
-awscc.ec2_subnet {
-  name                = "acceptance-test-subnet-ipam"
+let subnet = awscc.ec2_subnet {
   vpc_id              = vpc.vpc_id
   ipv4_ipam_pool_id   = ipam_pool.ipam_pool_id
   ipv4_netmask_length = 24

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -7,24 +7,20 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-rt-assoc"
   cidr_block = "10.0.0.0/16"
 }
 
 let subnet = awscc.ec2_subnet {
-  name              = "acceptance-test-subnet-rt-assoc"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-assoc"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_subnet_route_table_association {
-  name           = "acceptance-test-rt-association"
+let rt_assoc = awscc.ec2_subnet_route_table_association {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_transit_gateway {
-  name        = "acceptance-test-tgw"
+let tgw = awscc.ec2_transit_gateway {
   description = "Acceptance test Transit Gateway"
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc/basic.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-basic"
+let vpc = awscc.ec2_vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc/with_ipam.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc/with_ipam.crn
@@ -12,7 +12,6 @@ provider awscc {
 }
 
 let ipam = awscc.ec2_ipam {
-  name = "acceptance-test-ipam-vpc"
   tier = advanced
 
   operating_regions = [
@@ -23,7 +22,6 @@ let ipam = awscc.ec2_ipam {
 }
 
 let ipam_pool = awscc.ec2_ipam_pool {
-  name           = "acceptance-test-ipam-pool-vpc"
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"
@@ -35,8 +33,7 @@ let ipam_pool = awscc.ec2_ipam_pool {
   ]
 }
 
-awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-ipam"
+let vpc = awscc.ec2_vpc {
   ipv4_ipam_pool_id    = ipam_pool.ipam_pool_id
   ipv4_netmask_length  = 16
   enable_dns_support   = true

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -7,17 +7,14 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-endpoint-gw"
   cidr_block = "10.0.0.0/16"
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "acceptance-test-rt-endpoint-gw"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_vpc_endpoint {
-  name              = "acceptance-test-endpoint-gw"
+let vpc_endpoint = awscc.ec2_vpc_endpoint {
   vpc_id            = vpc.vpc_id
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = Gateway

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -8,27 +8,23 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "acceptance-test-vpc-endpoint-iface"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2_subnet {
-  name              = "acceptance-test-subnet-endpoint-iface"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.100.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "acceptance-test-sg-endpoint-iface"
   vpc_id            = vpc.vpc_id
   group_description = "SG for VPC Endpoint"
 }
 
-awscc.ec2_security_group_ingress {
-  name        = "acceptance-test-endpoint-https"
+let ingress = awscc.ec2_security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"
@@ -37,8 +33,7 @@ awscc.ec2_security_group_ingress {
   cidr_ip     = "10.0.0.0/16"
 }
 
-awscc.ec2_vpc_endpoint {
-  name                = "acceptance-test-endpoint-iface"
+let vpc_endpoint = awscc.ec2_vpc_endpoint {
   vpc_id              = vpc.vpc_id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = Interface

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
@@ -7,16 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-gw-attach-igw"
   cidr_block = "10.0.0.0/16"
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "acceptance-test-igw-attach"
 }
 
-awscc.ec2_vpc_gateway_attachment {
-  name                = "acceptance-test-igw-attachment"
+let igw_attachment = awscc.ec2_vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -8,17 +8,14 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-gw-attach-vpn"
   cidr_block = "10.0.0.0/16"
 }
 
 let vpn_gw = awscc.ec2_vpn_gateway {
-  name = "acceptance-test-vpn-gw"
   type = "ipsec.1"
 }
 
-awscc.ec2_vpc_gateway_attachment {
-  name           = "acceptance-test-vpn-attachment"
+let vpn_attachment = awscc.ec2_vpc_gateway_attachment {
   vpc_id         = vpc.vpc_id
   vpn_gateway_id = vpn_gw.vpn_gateway_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -7,17 +7,14 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-peer1"
   cidr_block = "10.0.0.0/16"
 }
 
 let vpc2 = awscc.ec2_vpc {
-  name       = "acceptance-test-vpc-peer2"
   cidr_block = "10.1.0.0/16"
 }
 
-awscc.ec2_vpc_peering_connection {
-  name        = "acceptance-test-peering"
+let peering = awscc.ec2_vpc_peering_connection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/carina-provider-awscc/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_vpn_gateway {
-  name = "acceptance-test-vpn-gw"
+let vpn_gw = awscc.ec2_vpn_gateway {
   type = "ipsec.1"
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_egress_only_internet_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_egress_only_internet_gateway/main.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "example-vpc-eoigw"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_egress_only_internet_gateway {
-  name   = "example-eoigw"
+let eoigw = awscc.ec2_egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_eip/main.crn
+++ b/carina-provider-awscc/examples/ec2_eip/main.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_eip {
-  name   = "example-eip"
+let eip = awscc.ec2_eip {
   domain = "vpc"
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_flow_log/main.crn
+++ b/carina-provider-awscc/examples/ec2_flow_log/main.crn
@@ -8,12 +8,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "example-vpc"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_flow_log {
-  name                 = "example-flow-log"
+let flow_log = awscc.ec2_flow_log {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/carina-provider-awscc/examples/ec2_internet_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_internet_gateway/main.crn
@@ -6,9 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_internet_gateway {
-  name = "example-igw"
-
+let igw = awscc.ec2_internet_gateway {
   tags = {
     Environment = "example"
   }

--- a/carina-provider-awscc/examples/ec2_ipam/main.crn
+++ b/carina-provider-awscc/examples/ec2_ipam/main.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_ipam {
-  name        = "example-ipam"
+let ipam = awscc.ec2_ipam {
   description = "Example IPAM"
   tier        = free
 

--- a/carina-provider-awscc/examples/ec2_ipam_pool/main.crn
+++ b/carina-provider-awscc/examples/ec2_ipam_pool/main.crn
@@ -7,7 +7,6 @@ provider awscc {
 }
 
 let ipam = awscc.ec2_ipam {
-  name        = "example-ipam"
   description = "Example IPAM"
   tier        = free
 
@@ -18,8 +17,7 @@ let ipam = awscc.ec2_ipam {
   ]
 }
 
-awscc.ec2_ipam_pool {
-  name           = "example-ipam-pool"
+let ipam_pool = awscc.ec2_ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"

--- a/carina-provider-awscc/examples/ec2_nat_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_nat_gateway/main.crn
@@ -7,14 +7,12 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let public_subnet = awscc.ec2_subnet {
-  name                    = "example-public-subnet"
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"
@@ -22,12 +20,10 @@ let public_subnet = awscc.ec2_subnet {
 }
 
 let eip = awscc.ec2_eip {
-  name   = "example-nat-eip"
   domain = "vpc"
 }
 
-awscc.ec2_nat_gateway {
-  name          = "example-nat-gw"
+let nat_gw = awscc.ec2_nat_gateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/carina-provider-awscc/examples/ec2_route/main.crn
+++ b/carina-provider-awscc/examples/ec2_route/main.crn
@@ -8,29 +8,24 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "example-igw"
 }
 
 let igw_attachment = awscc.ec2_vpc_gateway_attachment {
-  name                = "example-igw-attachment"
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "example-public-rt"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_route {
-  name                   = "example-internet-route"
+let route = awscc.ec2_route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw_attachment.internet_gateway_id

--- a/carina-provider-awscc/examples/ec2_route_table/main.crn
+++ b/carina-provider-awscc/examples/ec2_route_table/main.crn
@@ -7,14 +7,12 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2_route_table {
-  name   = "example-public-rt"
+let rt = awscc.ec2_route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_security_group/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group/main.crn
@@ -7,12 +7,10 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "example-vpc"
   cidr_block = "10.0.0.0/16"
 }
 
-awscc.ec2_security_group {
-  name              = "example-sg"
+let sg = awscc.ec2_security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 

--- a/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
@@ -8,18 +8,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "example-vpc"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "example-sg"
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 }
 
-awscc.ec2_security_group_egress {
-  name        = "example-all-outbound"
+let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound traffic"
   ip_protocol = "-1"

--- a/carina-provider-awscc/examples/ec2_security_group_ingress/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group_ingress/main.crn
@@ -8,18 +8,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name       = "example-vpc"
   cidr_block = "10.0.0.0/16"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "example-sg"
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 }
 
-awscc.ec2_security_group_ingress {
-  name        = "example-https-ingress"
+let ingress = awscc.ec2_security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/examples/ec2_subnet/main.crn
+++ b/carina-provider-awscc/examples/ec2_subnet/main.crn
@@ -7,14 +7,12 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2_subnet {
-  name                    = "example-public-subnet"
+let subnet = awscc.ec2_subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"

--- a/carina-provider-awscc/examples/ec2_subnet_route_table_association/main.crn
+++ b/carina-provider-awscc/examples/ec2_subnet_route_table_association/main.crn
@@ -8,26 +8,22 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2_subnet {
-  name              = "example-subnet"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
 let rt = awscc.ec2_route_table {
-  name   = "example-rt"
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2_subnet_route_table_association {
-  name           = "example-subnet-rt-assoc"
+let rt_assoc = awscc.ec2_subnet_route_table_association {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/carina-provider-awscc/examples/ec2_transit_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_transit_gateway/main.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_transit_gateway {
-  name        = "example-tgw"
+let tgw = awscc.ec2_transit_gateway {
   description = "Example Transit Gateway"
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_vpc/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc/main.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_vpc {
-  name                 = "example-vpc"
+let vpc = awscc.ec2_vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/examples/ec2_vpc_endpoint/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_endpoint/main.crn
@@ -8,27 +8,23 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2_subnet {
-  name              = "example-private-subnet"
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.100.0/24"
   availability_zone = "ap-northeast-1a"
 }
 
 let sg = awscc.ec2_security_group {
-  name              = "example-endpoint-sg"
   vpc_id            = vpc.vpc_id
   group_description = "SG for VPC Endpoint"
 }
 
-awscc.ec2_security_group_ingress {
-  name        = "example-endpoint-https"
+let ingress = awscc.ec2_security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"
@@ -37,8 +33,7 @@ awscc.ec2_security_group_ingress {
   cidr_ip     = "10.0.0.0/16"
 }
 
-awscc.ec2_vpc_endpoint {
-  name                = "example-ecr-dkr"
+let vpc_endpoint = awscc.ec2_vpc_endpoint {
   vpc_id              = vpc.vpc_id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = "Interface"

--- a/carina-provider-awscc/examples/ec2_vpc_gateway_attachment/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_gateway_attachment/main.crn
@@ -7,18 +7,15 @@ provider awscc {
 }
 
 let vpc = awscc.ec2_vpc {
-  name                 = "example-vpc"
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let igw = awscc.ec2_internet_gateway {
-  name = "example-igw"
 }
 
-awscc.ec2_vpc_gateway_attachment {
-  name                = "example-igw-attachment"
+let igw_attachment = awscc.ec2_vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/carina-provider-awscc/examples/ec2_vpc_peering_connection/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_peering_connection/main.crn
@@ -7,17 +7,14 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2_vpc {
-  name       = "example-vpc-peer-1"
   cidr_block = "10.0.0.0/16"
 }
 
 let vpc2 = awscc.ec2_vpc {
-  name       = "example-vpc-peer-2"
   cidr_block = "10.1.0.0/16"
 }
 
-awscc.ec2_vpc_peering_connection {
-  name        = "example-vpc-peering"
+let peering = awscc.ec2_vpc_peering_connection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/carina-provider-awscc/examples/ec2_vpn_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpn_gateway/main.crn
@@ -6,8 +6,7 @@ provider awscc {
   region = aws.Region.ap_northeast_1
 }
 
-awscc.ec2_vpn_gateway {
-  name = "example-vpn-gw"
+let vpn_gw = awscc.ec2_vpn_gateway {
   type = "ipsec.1"
 
   tags = {

--- a/carina-provider-awscc/src/schemas/generated/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/bucket.rs
@@ -141,6 +141,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("bucket_name", AttributeType::String)
+                .create_only()
                 .with_description("A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name mus...")
                 .with_provider_name("BucketName"),
         )

--- a/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
@@ -31,6 +31,7 @@ pub fn ec2_egress_only_internet_gateway_config() -> AwsccSchemaConfig {
             .attribute(
                 AttributeSchema::new("vpc_id", super::vpc_id())
                     .required()
+                    .create_only()
                     .with_description(
                         "The ID of the VPC for which to create the egress-only internet gateway.",
                     )

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -26,6 +26,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
         .with_description("Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool c...")
         .attribute(
             AttributeSchema::new("address", AttributeType::String)
+                .create_only()
                 .with_description("")
                 .with_provider_name("Address"),
         )
@@ -51,11 +52,13 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipam_pool_id", super::ipam_pool_id())
+                .create_only()
                 .with_description("")
                 .with_provider_name("IpamPoolId"),
         )
         .attribute(
             AttributeSchema::new("network_border_group", AttributeType::String)
+                .create_only()
                 .with_description("A unique set of Availability Zones, Local Zones, or Wavelength Zones from which AWS advertises IP addresses. Use this parameter to limit the IP addres...")
                 .with_provider_name("NetworkBorderGroup"),
         )
@@ -76,6 +79,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("transfer_address", AttributeType::String)
+                .create_only()
                 .with_description("The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfe...")
                 .with_provider_name("TransferAddress"),
         )

--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -60,11 +60,13 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
         .with_description("Specifies a VPC flow log, which enables you to capture IP traffic for a specific network interface, subnet, or VPC.")
         .attribute(
             AttributeSchema::new("deliver_cross_account_role", AttributeType::String)
+                .create_only()
                 .with_description("The ARN of the IAM role that allows Amazon EC2 to publish flow logs across accounts.")
                 .with_provider_name("DeliverCrossAccountRole"),
         )
         .attribute(
             AttributeSchema::new("deliver_logs_permission_arn", super::arn())
+                .create_only()
                 .with_description("The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a CloudWatch Logs log group in your account. If you specify LogDestinationTyp...")
                 .with_provider_name("DeliverLogsPermissionArn"),
         )
@@ -77,6 +79,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                     StructField::new("per_hour_partition", AttributeType::Bool).required().with_provider_name("PerHourPartition")
                     ],
                 })
+                .create_only()
                 .with_provider_name("DestinationOptions"),
         )
         .attribute(
@@ -86,6 +89,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("log_destination", AttributeType::String)
+                .create_only()
                 .with_description("Specifies the destination to which the flow log data is to be published. Flow log data can be published to a CloudWatch Logs log group, an Amazon S3 b...")
                 .with_provider_name("LogDestination"),
         )
@@ -96,27 +100,32 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 validate: validate_log_destination_type,
                 namespace: Some("awscc.ec2_flow_log".to_string()),
             })
+                .create_only()
                 .with_description("Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3.")
                 .with_provider_name("LogDestinationType"),
         )
         .attribute(
             AttributeSchema::new("log_format", AttributeType::String)
+                .create_only()
                 .with_description("The fields to include in the flow log record, in the order in which they should appear.")
                 .with_provider_name("LogFormat"),
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::String)
+                .create_only()
                 .with_description("The name of a new or existing CloudWatch Logs log group where Amazon EC2 publishes your flow logs. If you specify LogDestinationType as s3 or kinesis-...")
                 .with_provider_name("LogGroupName"),
         )
         .attribute(
             AttributeSchema::new("max_aggregation_interval", AttributeType::Int)
+                .create_only()
                 .with_description("The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1 minute) o...")
                 .with_provider_name("MaxAggregationInterval"),
         )
         .attribute(
             AttributeSchema::new("resource_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("The ID of the subnet, network interface, or VPC for which you want to create a flow log.")
                 .with_provider_name("ResourceId"),
         )
@@ -128,6 +137,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 namespace: Some("awscc.ec2_flow_log".to_string()),
             })
                 .required()
+                .create_only()
                 .with_description("The type of resource for which to create the flow log. For example, if you specified a VPC ID for the ResourceId property, specify VPC for this proper...")
                 .with_provider_name("ResourceType"),
         )
@@ -143,6 +153,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 validate: validate_traffic_type,
                 namespace: Some("awscc.ec2_flow_log".to_string()),
             })
+                .create_only()
                 .with_description("The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.")
                 .with_provider_name("TrafficType"),
         )

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -83,6 +83,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 namespace: Some("awscc.ec2_ipam_pool".to_string()),
             })
                 .required()
+                .create_only()
                 .with_description("The address family of the address space in this pool. Either IPv4 or IPv6.")
                 .with_provider_name("AddressFamily"),
         )
@@ -123,6 +124,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_aws_service,
                 namespace: Some("awscc.ec2_ipam_pool".to_string()),
             })
+                .create_only()
                 .with_description("Limits which service in Amazon Web Services that the pool can be used in.")
                 .with_provider_name("AwsService"),
         )
@@ -148,6 +150,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("ipam_scope_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("The Id of the scope this pool is a part of.")
                 .with_provider_name("IpamScopeId"),
         )
@@ -163,6 +166,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("locale", AttributeType::String)
+                .create_only()
                 .with_description("The region of this pool. If not set, this will default to \"None\" which will disable non-custom allocations. If the locale has been specified for the...")
                 .with_provider_name("Locale"),
         )
@@ -188,16 +192,19 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_public_ip_source,
                 namespace: Some("awscc.ec2_ipam_pool".to_string()),
             })
+                .create_only()
                 .with_description("The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Default is `byoip`.")
                 .with_provider_name("PublicIpSource"),
         )
         .attribute(
             AttributeSchema::new("publicly_advertisable", AttributeType::Bool)
+                .create_only()
                 .with_description("Determines whether or not address space from this pool is publicly advertised. Must be set if and only if the pool is IPv6.")
                 .with_provider_name("PubliclyAdvertisable"),
         )
         .attribute(
             AttributeSchema::new("source_ipam_pool_id", super::ipam_pool_id())
+                .create_only()
                 .with_description("The Id of this pool's source. If set, all space provisioned in this pool must be free space provisioned in the parent pool.")
                 .with_provider_name("SourceIpamPoolId"),
         )
@@ -211,6 +218,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                     StructField::new("resource_type", AttributeType::String).required().with_provider_name("ResourceType")
                     ],
                 })
+                .create_only()
                 .with_provider_name("SourceResource"),
         )
         .attribute(

--- a/carina-provider-awscc/src/schemas/generated/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/log_group.rs
@@ -66,6 +66,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::String)
+                .create_only()
                 .with_description("The name of the log group. If you don't specify a name, CFNlong generates a unique ID for the log group.")
                 .with_provider_name("LogGroupName"),
         )

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -42,6 +42,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         .with_description("Specifies a network address translation (NAT) gateway in the specified subnet. You can create either a public NAT gateway or a private NAT gateway. The default is a public NAT gateway. If you create a...")
         .attribute(
             AttributeSchema::new("allocation_id", super::aws_resource_id())
+                .create_only()
                 .with_description("[Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public N...")
                 .with_provider_name("AllocationId"),
         )
@@ -62,6 +63,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 validate: validate_availability_mode,
                 namespace: Some("awscc.ec2_nat_gateway".to_string()),
             })
+                .create_only()
                 .with_description("Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway. A zonal NAT gateway is a NAT Gateway that provides redundancy and sc...")
                 .with_provider_name("AvailabilityMode"),
         )
@@ -84,6 +86,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 validate: validate_connectivity_type,
                 namespace: Some("awscc.ec2_nat_gateway".to_string()),
             })
+                .create_only()
                 .with_description("Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity.")
                 .with_provider_name("ConnectivityType"),
         )
@@ -104,6 +107,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("private_ip_address", types::ipv4_address())
+                .create_only()
                 .with_description("The private IPv4 address to assign to the NAT gateway. If you don't provide an address, a private IPv4 address will be automatically assigned.")
                 .with_provider_name("PrivateIpAddress"),
         )
@@ -129,6 +133,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("subnet_id", super::subnet_id())
+                .create_only()
                 .with_description("The ID of the subnet in which the NAT gateway is located.")
                 .with_provider_name("SubnetId"),
         )
@@ -139,6 +144,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
+                .create_only()
                 .with_description("The ID of the VPC in which the NAT gateway is located.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/role.rs
@@ -44,6 +44,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("path", AttributeType::String)
+                .create_only()
                 .with_description("The path to the role. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html)...")
                 .with_provider_name("Path"),
         )
@@ -70,6 +71,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("role_name", AttributeType::String)
+                .create_only()
                 .with_description("A name for the IAM role, up to 64 characters in length. For valid values, see the ``RoleName`` parameter for the [CreateRole](https://docs.aws.amazon....")
                 .with_provider_name("RoleName"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -32,16 +32,19 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("destination_cidr_block", types::ipv4_cidr())
+                .create_only()
                 .with_description("The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match. We modify the specified CIDR block...")
                 .with_provider_name("DestinationCidrBlock"),
         )
         .attribute(
             AttributeSchema::new("destination_ipv6_cidr_block", types::ipv6_cidr())
+                .create_only()
                 .with_description("The IPv6 CIDR block used for the destination match. Routing decisions are based on the most specific match.")
                 .with_provider_name("DestinationIpv6CidrBlock"),
         )
         .attribute(
             AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
+                .create_only()
                 .with_description("The ID of a prefix list used for the destination match.")
                 .with_provider_name("DestinationPrefixListId"),
         )
@@ -78,6 +81,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("route_table_id", super::route_table_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the route table for the route.")
                 .with_provider_name("RouteTableId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table.rs
@@ -29,6 +29,7 @@ pub fn ec2_route_table_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -19,6 +19,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("group_description", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("A description for the security group.")
                 .with_provider_name("GroupDescription"),
         )
@@ -29,6 +30,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("group_name", AttributeType::String)
+                .create_only()
                 .with_description("The name of the security group.")
                 .with_provider_name("GroupName"),
         )
@@ -80,6 +82,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
+                .create_only()
                 .with_description("The ID of the VPC for the security group.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -30,11 +30,13 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         .with_description("Adds the specified outbound (egress) rule to a security group.  An outbound rule permits instances to send traffic to the specified IPv4 or IPv6 address range, the IP addresses that are specified by a...")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())
+                .create_only()
                 .with_description("The IPv4 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``Des...")
                 .with_provider_name("CidrIp"),
         )
         .attribute(
             AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
+                .create_only()
                 .with_description("The IPv6 address range, in CIDR format. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``Des...")
                 .with_provider_name("CidrIpv6"),
         )
@@ -45,22 +47,26 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
+                .create_only()
                 .with_description("The prefix list IDs for an AWS service. This is the AWS service to access through a VPC endpoint from instances associated with the security group. Yo...")
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
             AttributeSchema::new("destination_security_group_id", super::security_group_id())
+                .create_only()
                 .with_description("The ID of the security group. You must specify exactly one of the following: ``CidrIp``, ``CidrIpv6``, ``DestinationPrefixListId``, or ``DestinationSe...")
                 .with_provider_name("DestinationSecurityGroupId"),
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Int)
+                .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP type or -1 (all ICMP types).")
                 .with_provider_name("FromPort"),
         )
         .attribute(
             AttributeSchema::new("group_id", super::security_group_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),
         )
@@ -77,11 +83,13 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 namespace: Some("awscc.ec2_security_group_egress".to_string()),
             })
                 .required()
+                .create_only()
                 .with_description("The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Protocol Numbers](https://docs.aws.amazon.com/http://www.iana.org/assign...")
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Int)
+                .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP code or -1 (all ICMP codes). If ...")
                 .with_provider_name("ToPort"),
         )

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -30,11 +30,13 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for AWS::EC2::SecurityGroupIngress")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())
+                .create_only()
                 .with_description("The IPv4 ranges")
                 .with_provider_name("CidrIp"),
         )
         .attribute(
             AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
+                .create_only()
                 .with_description("[VPC only] The IPv6 ranges")
                 .with_provider_name("CidrIpv6"),
         )
@@ -45,16 +47,19 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Int)
+                .create_only()
                 .with_description("The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. A value of -1 indicates all ICMP/ICMPv6 types. If you specify al...")
                 .with_provider_name("FromPort"),
         )
         .attribute(
             AttributeSchema::new("group_id", super::security_group_id())
+                .create_only()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondef...")
                 .with_provider_name("GroupId"),
         )
         .attribute(
             AttributeSchema::new("group_name", AttributeType::String)
+                .create_only()
                 .with_description("The name of the security group.")
                 .with_provider_name("GroupName"),
         )
@@ -71,31 +76,37 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 namespace: Some("awscc.ec2_security_group_ingress".to_string()),
             })
                 .required()
+                .create_only()
                 .with_description("The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers). [VPC only] Use -1 to specify all protocols. When authorizing security ...")
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
             AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())
+                .create_only()
                 .with_description("[EC2-VPC only] The ID of a prefix list. ")
                 .with_provider_name("SourcePrefixListId"),
         )
         .attribute(
             AttributeSchema::new("source_security_group_id", super::security_group_id())
+                .create_only()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name. For security groups in a nondefault VPC, you m...")
                 .with_provider_name("SourceSecurityGroupId"),
         )
         .attribute(
             AttributeSchema::new("source_security_group_name", AttributeType::String)
+                .create_only()
                 .with_description("[EC2-Classic, default VPC] The name of the source security group. You must specify the GroupName property or the GroupId property. For security groups...")
                 .with_provider_name("SourceSecurityGroupName"),
         )
         .attribute(
             AttributeSchema::new("source_security_group_owner_id", AttributeType::String)
+                .create_only()
                 .with_description("[nondefault VPC] The AWS account ID that owns the source security group. You can't specify this property with an IP address range. If you specify Sour...")
                 .with_provider_name("SourceSecurityGroupOwnerId"),
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Int)
+                .create_only()
                 .with_description("The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type...")
                 .with_provider_name("ToPort"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -23,11 +23,13 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("availability_zone", super::availability_zone())
+                .create_only()
                 .with_description("The Availability Zone of the subnet. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("AvailabilityZone"),
         )
         .attribute(
             AttributeSchema::new("availability_zone_id", AttributeType::String)
+                .create_only()
                 .with_description("The AZ ID of the subnet.")
                 .with_provider_name("AvailabilityZoneId"),
         )
@@ -43,6 +45,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("cidr_block", types::ipv4_cidr())
+                .create_only()
                 .with_description("The IPv4 CIDR block assigned to the subnet. If you update this property, we create a new subnet, and then delete the existing one.")
                 .with_provider_name("CidrBlock"),
         )
@@ -58,11 +61,13 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())
+                .create_only()
                 .with_description("An IPv4 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv4IpamPoolId"),
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Int)
+                .create_only()
                 .with_description("An IPv4 netmask length for the subnet.")
                 .with_provider_name("Ipv4NetmaskLength"),
         )
@@ -78,16 +83,19 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv6_ipam_pool_id", super::ipam_pool_id())
+                .create_only()
                 .with_description("An IPv6 IPAM pool ID for the subnet.")
                 .with_provider_name("Ipv6IpamPoolId"),
         )
         .attribute(
             AttributeSchema::new("ipv6_native", AttributeType::Bool)
+                .create_only()
                 .with_description("Indicates whether this is an IPv6 only subnet. For more information, see [Subnet basics](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets....")
                 .with_provider_name("Ipv6Native"),
         )
         .attribute(
             AttributeSchema::new("ipv6_netmask_length", AttributeType::Int)
+                .create_only()
                 .with_description("An IPv6 netmask length for the subnet.")
                 .with_provider_name("Ipv6NetmaskLength"),
         )
@@ -103,6 +111,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("outpost_arn", super::arn())
+                .create_only()
                 .with_description("The Amazon Resource Name (ARN) of the Outpost.")
                 .with_provider_name("OutpostArn"),
         )
@@ -131,6 +140,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC the subnet is in. If you update this property, you must also update the ``CidrBlock`` property.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
@@ -23,12 +23,14 @@ pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("route_table_id", super::route_table_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the route table. The physical ID changes when the route table ID is changed.")
                 .with_provider_name("RouteTableId"),
         )
         .attribute(
             AttributeSchema::new("subnet_id", super::subnet_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the subnet.")
                 .with_provider_name("SubnetId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
@@ -31,6 +31,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             .with_description("Resource Type definition for AWS::EC2::TransitGateway")
             .attribute(
                 AttributeSchema::new("amazon_side_asn", AttributeType::Int)
+                    .create_only()
                     .with_provider_name("AmazonSideAsn"),
             )
             .attribute(
@@ -84,6 +85,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             )
             .attribute(
                 AttributeSchema::new("multicast_support", AttributeType::String)
+                    .create_only()
                     .with_provider_name("MulticastSupport"),
             )
             .attribute(

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
@@ -46,11 +46,13 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("transit_gateway_id", super::transit_gateway_id())
                 .required()
+                .create_only()
                 .with_provider_name("TransitGatewayId"),
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_provider_name("VpcId"),
         )
     }

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -31,6 +31,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
         .with_description("Specifies a virtual private cloud (VPC).  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrbloc...")
         .attribute(
             AttributeSchema::new("cidr_block", types::ipv4_cidr())
+                .create_only()
                 .with_description("The IPv4 network range for the VPC, in CIDR notation. For example, ``10.0.0.0/16``. We modify the specified CIDR block to its canonical form; for exam...")
                 .with_provider_name("CidrBlock"),
         )
@@ -71,11 +72,13 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())
+                .create_only()
                 .with_description("The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc...")
                 .with_provider_name("Ipv4IpamPoolId"),
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Int)
+                .create_only()
                 .with_description("The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPA...")
                 .with_provider_name("Ipv4NetmaskLength"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -101,6 +101,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("resource_configuration_arn", super::arn())
+                .create_only()
                 .with_description("The Amazon Resource Name (ARN) of the resource configuration.")
                 .with_provider_name("ResourceConfigurationArn"),
         )
@@ -116,16 +117,19 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("service_name", AttributeType::String)
+                .create_only()
                 .with_description("The name of the endpoint service.")
                 .with_provider_name("ServiceName"),
         )
         .attribute(
             AttributeSchema::new("service_network_arn", super::arn())
+                .create_only()
                 .with_description("The Amazon Resource Name (ARN) of the service network.")
                 .with_provider_name("ServiceNetworkArn"),
         )
         .attribute(
             AttributeSchema::new("service_region", AttributeType::String)
+                .create_only()
                 .with_description("Describes a Region.")
                 .with_provider_name("ServiceRegion"),
         )
@@ -146,12 +150,14 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_vpc_endpoint_type,
                 namespace: Some("awscc.ec2_vpc_endpoint".to_string()),
             })
+                .create_only()
                 .with_description("The type of endpoint. Default: Gateway")
                 .with_provider_name("VpcEndpointType"),
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -28,6 +28,7 @@ pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
@@ -23,22 +23,26 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("peer_owner_id", AttributeType::String)
+                .create_only()
                 .with_description("The AWS account ID of the owner of the accepter VPC.")
                 .with_provider_name("PeerOwnerId"),
         )
         .attribute(
             AttributeSchema::new("peer_region", AttributeType::String)
+                .create_only()
                 .with_description("The Region code for the accepter VPC, if the accepter VPC is located in a Region other than the Region in which you make the request.")
                 .with_provider_name("PeerRegion"),
         )
         .attribute(
             AttributeSchema::new("peer_role_arn", super::arn())
+                .create_only()
                 .with_description("The Amazon Resource Name (ARN) of the VPC peer role for the peering connection in another AWS account.")
                 .with_provider_name("PeerRoleArn"),
         )
         .attribute(
             AttributeSchema::new("peer_vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC with which you are creating the VPC peering connection. You must specify this parameter in the request.")
                 .with_provider_name("PeerVpcId"),
         )
@@ -49,6 +53,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())
                 .required()
+                .create_only()
                 .with_description("The ID of the VPC.")
                 .with_provider_name("VpcId"),
         )

--- a/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
@@ -18,6 +18,7 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
         .with_description("Specifies a virtual private gateway. A virtual private gateway is the endpoint on the VPC side of your VPN connection. You can create a virtual private gateway before creating the VPC itself.  For mor...")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Int)
+                .create_only()
                 .with_description("The private Autonomous System Number (ASN) for the Amazon side of a BGP session.")
                 .with_provider_name("AmazonSideAsn"),
         )
@@ -29,6 +30,7 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("type", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("The type of VPN connection the virtual private gateway supports.")
                 .with_provider_name("Type"),
         )


### PR DESCRIPTION
## Summary

- Decouples the `name` attribute from resource identity for the AWSCC provider, fixing false diffs caused by AWS not returning `name` on reads (#146)
- Adds `create_only` flag to `AttributeSchema` and propagates `createOnlyProperties` from CloudFormation schemas via codegen
- Anonymous resources get stable identifiers computed from create-only property hashes (e.g., `ec2_vpc_a3f2b1c8`)
- Let-bound resources use their binding name as identifier
- Updates all 59 AWSCC example and acceptance test `.crn` files to use `let` bindings instead of `name`

Closes #148

## Test plan
- [x] All 283 existing tests pass (`cargo test`)
- [x] Pre-commit hooks pass (formatting, clippy, tests)
- [ ] Manual verification with `cargo run -- plan` on AWSCC examples (no false `name` diff)
- [ ] Acceptance tests with real AWS resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)