### PR TITLE
Stop using name attribute as resource identifier for AWS provider

### DIFF
--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -214,18 +214,6 @@ impl ModuleResolver {
                 new_name.clone(),
             );
 
-            // Update name attribute for aws provider only
-            // Non-aws providers don't use name as a resource property
-            let is_aws_provider = new_resource
-                .attributes
-                .get("_provider")
-                .is_some_and(|v| matches!(v, Value::String(s) if s == "aws"));
-            if is_aws_provider {
-                new_resource
-                    .attributes
-                    .insert("name".to_string(), Value::String(new_name));
-            }
-
             // Add module source info
             new_resource.attributes.insert(
                 "_module".to_string(),

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -367,7 +367,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.vpc {\n    name       = \"${1:vpc-name}\"\n    cidr_block = \"${2:10.0.0.0/16}\"\n}".to_string(),
+                    new_text: "aws.vpc {\n    cidr_block = \"${1:10.0.0.0/16}\"\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("VPC resource".to_string()),
@@ -378,7 +378,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.subnet {\n    name              = \"${1:subnet-name}\"\n    vpc_id            = ${2:vpc.id}\n    cidr_block        = \"${3:10.0.1.0/24}\"\n    availability_zone = aws.AvailabilityZone.${4:ap_northeast_1a}\n}".to_string(),
+                    new_text: "aws.subnet {\n    vpc_id            = ${1:vpc.id}\n    cidr_block        = \"${2:10.0.1.0/24}\"\n    availability_zone = aws.AvailabilityZone.${3:ap_northeast_1a}\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Subnet resource".to_string()),
@@ -389,7 +389,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.internet_gateway {\n    name   = \"${1:igw-name}\"\n    vpc_id = ${2:vpc.id}\n}".to_string(),
+                    new_text: "aws.internet_gateway {\n    vpc_id = ${1:vpc.id}\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Internet Gateway resource".to_string()),
@@ -400,7 +400,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.route_table {\n    name   = \"${1:rt-name}\"\n    vpc_id = ${2:vpc.id}\n}".to_string(),
+                    new_text: "aws.route_table {\n    vpc_id = ${1:vpc.id}\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Route Table resource".to_string()),
@@ -411,7 +411,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.route {\n    name                   = \"${1:route-name}\"\n    route_table_id         = ${2:rt.id}\n    destination_cidr_block = \"${3:0.0.0.0/0}\"\n    gateway_id             = ${4:igw.id}\n}".to_string(),
+                    new_text: "aws.route {\n    route_table_id         = ${1:rt.id}\n    destination_cidr_block = \"${2:0.0.0.0/0}\"\n    gateway_id             = ${3:igw.id}\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Route in a Route Table".to_string()),
@@ -422,7 +422,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.security_group {\n    name        = \"${1:sg-name}\"\n    vpc_id      = ${2:vpc.id}\n    description = \"${3:Security group description}\"\n}".to_string(),
+                    new_text: "aws.security_group {\n    vpc_id      = ${1:vpc.id}\n    description = \"${2:Security group description}\"\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Security Group resource".to_string()),
@@ -433,7 +433,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.security_group.ingress_rule {\n    name              = \"${1:rule-name}\"\n    security_group_id = ${2:sg.id}\n    protocol          = aws.Protocol.${3:tcp}\n    from_port         = ${4:80}\n    to_port           = ${5:80}\n    cidr              = \"${6:0.0.0.0/0}\"\n}".to_string(),
+                    new_text: "aws.security_group.ingress_rule {\n    security_group_id = ${1:sg.id}\n    protocol          = aws.Protocol.${2:tcp}\n    from_port         = ${3:80}\n    to_port           = ${4:80}\n    cidr              = \"${5:0.0.0.0/0}\"\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Security Group Ingress Rule".to_string()),
@@ -444,7 +444,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,
-                    new_text: "aws.security_group.egress_rule {\n    name              = \"${1:rule-name}\"\n    security_group_id = ${2:sg.id}\n    protocol          = aws.Protocol.${3:all}\n    from_port         = ${4:0}\n    to_port           = ${5:0}\n    cidr              = \"${6:0.0.0.0/0}\"\n}".to_string(),
+                    new_text: "aws.security_group.egress_rule {\n    security_group_id = ${1:sg.id}\n    protocol          = aws.Protocol.${2:all}\n    from_port         = ${3:0}\n    to_port           = ${4:0}\n    cidr              = \"${5:0.0.0.0/0}\"\n}".to_string(),
                 })),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Security Group Egress Rule".to_string()),

--- a/carina-provider-aws/src/schemas/s3.rs
+++ b/carina-provider-aws/src/schemas/s3.rs
@@ -10,6 +10,7 @@ pub fn bucket_schema() -> ResourceSchema {
         .with_description("An S3 bucket for object storage")
         .attribute(
             AttributeSchema::new("name", aws_types::s3_bucket_name())
+                .create_only()
                 .with_description("Override bucket name (defaults to resource name)"),
         )
         .attribute(

--- a/carina-provider-aws/src/schemas/vpc.rs
+++ b/carina-provider-aws/src/schemas/vpc.rs
@@ -197,8 +197,7 @@ pub fn vpc_schema() -> ResourceSchema {
         // ========== Carina-specific attributes ==========
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
-                .with_description("VPC name (Name tag) - Carina identifier"),
+                .with_description("VPC name (Name tag)"),
         )
         .attribute(
             AttributeSchema::new("region", aws_types::aws_region()).with_description(
@@ -208,6 +207,7 @@ pub fn vpc_schema() -> ResourceSchema {
         // ========== CloudFormation input properties ==========
         .attribute(
             AttributeSchema::new("cidr_block", types::cidr())
+                .create_only()
                 .with_description("The IPv4 network range for the VPC, in CIDR notation. Required if not using Ipv4IpamPoolId."),
         )
         .attribute(
@@ -220,6 +220,7 @@ pub fn vpc_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("instance_tenancy", instance_tenancy())
+                .create_only()
                 .with_description("The allowed tenancy of instances launched into the VPC. Values: default, dedicated, host")
                 .with_completions(vec![
                     CompletionValue::new("default", "Instances can have any tenancy"),
@@ -272,7 +273,6 @@ pub fn subnet_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Subnet name (Name tag)"),
         )
         .attribute(
@@ -283,15 +283,18 @@ pub fn subnet_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("vpc_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("VPC ID to create the subnet in"),
         )
         .attribute(
             AttributeSchema::new("cidr_block", types::cidr())
                 .required()
+                .create_only()
                 .with_description("The IPv4 CIDR block for the subnet"),
         )
         .attribute(
             AttributeSchema::new("availability_zone", availability_zone())
+                .create_only()
                 .with_description("The availability zone for the subnet"),
         )
 }
@@ -306,7 +309,6 @@ pub fn internet_gateway_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Internet Gateway name (Name tag)"),
         )
         .attribute(
@@ -329,7 +331,6 @@ pub fn route_table_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Route Table name (Name tag)"),
         )
         .attribute(
@@ -340,6 +341,7 @@ pub fn route_table_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("vpc_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("VPC ID for the Route Table"),
         )
 }
@@ -350,7 +352,6 @@ pub fn route_schema() -> ResourceSchema {
         .with_description("A route in an AWS VPC Route Table")
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Route name (for identification)"),
         )
         .attribute(
@@ -360,11 +361,13 @@ pub fn route_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("route_table_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("Route Table ID"),
         )
         .attribute(
             AttributeSchema::new("destination_cidr_block", types::cidr())
                 .required()
+                .create_only()
                 .with_description("Destination CIDR block"),
         )
         .attribute(
@@ -387,7 +390,6 @@ pub fn security_group_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Security Group name (Name tag)"),
         )
         .attribute(
@@ -398,6 +400,7 @@ pub fn security_group_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("vpc_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("VPC ID for the Security Group"),
         )
         .attribute(
@@ -416,7 +419,6 @@ pub fn security_group_ingress_rule_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Rule name (for identification)"),
         )
         .attribute(
@@ -426,21 +428,25 @@ pub fn security_group_ingress_rule_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("security_group_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("Security Group ID"),
         )
         .attribute(
             AttributeSchema::new("protocol", protocol())
                 .required()
+                .create_only()
                 .with_description("Protocol (tcp, udp, icmp, or -1 for all)"),
         )
         .attribute(
             AttributeSchema::new("from_port", port_number())
                 .required()
+                .create_only()
                 .with_description("Start of port range"),
         )
         .attribute(
             AttributeSchema::new("to_port", port_number())
                 .required()
+                .create_only()
                 .with_description("End of port range"),
         )
         .attribute(
@@ -459,7 +465,6 @@ pub fn security_group_egress_rule_schema() -> ResourceSchema {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::String)
-                .required()
                 .with_description("Rule name (for identification)"),
         )
         .attribute(
@@ -469,21 +474,25 @@ pub fn security_group_egress_rule_schema() -> ResourceSchema {
         .attribute(
             AttributeSchema::new("security_group_id", AttributeType::String)
                 .required()
+                .create_only()
                 .with_description("Security Group ID"),
         )
         .attribute(
             AttributeSchema::new("protocol", protocol())
                 .required()
+                .create_only()
                 .with_description("Protocol (tcp, udp, icmp, or -1 for all)"),
         )
         .attribute(
             AttributeSchema::new("from_port", port_number())
                 .required()
+                .create_only()
                 .with_description("Start of port range"),
         )
         .attribute(
             AttributeSchema::new("to_port", port_number())
                 .required()
+                .create_only()
                 .with_description("End of port range"),
         )
         .attribute(
@@ -588,6 +597,7 @@ mod tests {
 
     #[test]
     fn vpc_missing_name() {
+        // name is optional (not required) - VPC can be identified by vpc-id
         let schema = vpc_schema();
         let mut attrs = HashMap::new();
         attrs.insert(
@@ -596,7 +606,7 @@ mod tests {
         );
 
         let result = schema.validate(&attrs);
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Decouple the `name` attribute from resource identity for the `aws` provider, matching the approach from PR #151 (AWSCC provider)
- `let` bindings now use the binding name as `ResourceId.name` instead of the `name` attribute value
- Anonymous resources get hash-based identifiers from create-only properties via `compute_anonymous_identifiers()`
- Provider read/update/delete methods use the `identifier` parameter for AWS resource lookups (supports both AWS resource IDs like `vpc-xxx` and Name tag lookups)

closes #152

## Changes
- **Parser** (`carina-core/src/parser/mod.rs`): Remove aws-specific branches in `parse_anonymous_resource`, `parse_resource_expr`, `parse_read_resource_expr` - all providers now use binding name for identity
- **Schemas** (`carina-provider-aws/src/schemas/`): Add `.create_only()` markers to immutable properties (cidr_block, vpc_id, etc.), make `name` optional for all VPC resources
- **CLI** (`carina-cli/src/main.rs`): Enable `compute_anonymous_identifiers()` for aws provider, add name attribute fallback in `get_identifier_from_state()`
- **Provider** (`carina-provider-aws/src/lib.rs`): All read/update/delete methods use `identifier` parameter with prefix-based detection (vpc-, subnet-, igw-, rtb-, sg-, sgr-) for ID vs Name tag lookup
- **Module Resolver** (`carina-core/src/module_resolver.rs`): Remove aws-specific name insertion in `expand_module_call()`
- **LSP** (`carina-lsp/src/completion.rs`): Update completion snippets to remove `name` as first attribute for VPC resources

## Test plan
- [x] `cargo test -p carina-core` - 108 tests pass (parser, formatter, module resolver)
- [x] `cargo test -p carina-provider-aws` - 41 tests pass (schema validation)
- [x] `cargo test -p carina-lsp` - 27 tests pass (completion, diagnostics, semantic tokens, integration)
- [x] `cargo build` - clean build with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)