### PR TITLE
Remove AWS-specific name attribute handling from parser

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -561,10 +561,6 @@ fn parse_anonymous_resource(
 
     // Add provider information to attributes
     let mut attributes = attributes;
-    // Strip name from attributes for non-aws providers (name is not a resource property)
-    if provider != "aws" {
-        attributes.remove("name");
-    }
     attributes.insert("_provider".to_string(), Value::String(provider.to_string()));
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
 
@@ -659,11 +655,6 @@ fn parse_resource_expr(
     let mut attributes = parse_block_contents(inner, ctx)?;
 
     // All providers: use binding name as identifier.
-    // Strip name from attributes for non-aws providers (name is not a resource property).
-    // For aws, keep name in attributes (it's a real property: bucket name, Name tag, etc.)
-    if provider != "aws" {
-        attributes.remove("name");
-    }
     let resource_name = binding_name.to_string();
 
     // Add provider information to attributes
@@ -705,10 +696,6 @@ fn parse_read_resource_expr(
     let mut attributes = parse_block_contents(inner, ctx)?;
 
     // All providers: use binding name as identifier.
-    // Strip name from attributes for non-aws providers.
-    if provider != "aws" {
-        attributes.remove("name");
-    }
     let resource_name = binding_name.to_string();
 
     // Add provider information to attributes


### PR DESCRIPTION
## Summary
- Remove `if provider != "aws"` branches from the parser that stripped `name` attribute for non-aws providers
- The core parser is now fully provider-agnostic as intended by the architecture
- Provider-specific attribute handling belongs in provider crates, not in `carina-core`

closes #154

## Changes
- **`carina-core/src/parser/mod.rs`**: Remove three `if provider != "aws" { attributes.remove("name"); }` blocks from `parse_anonymous_resource`, `parse_resource_expr`, and `parse_read_resource_expr`

## Why this is safe
- AWSCC `.crn` files don't use `name` attribute (no impact)
- The AWSCC provider only processes schema-defined attributes, so unknown attributes like `name` are silently ignored
- The differ skips `_`-prefixed internal attributes but checks user attributes; if a user mistakenly adds `name` to an AWSCC resource, it would show up as a diff — but this is correct behavior (the user provided an attribute the provider doesn't support)

## Test plan
- [x] All 284 tests pass across all crates
- [x] Clean build with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)