### PR TITLE
Add lifecycle { force_delete } meta-argument for S3 buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-cloudcontrol",
+ "aws-sdk-s3",
  "carina-core",
  "clap",
  "heck",

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::resource::{Resource, ResourceId, State};
+use crate::resource::{LifecycleConfig, Resource, ResourceId, State};
 
 /// Effect representing an operation on a resource
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -24,7 +24,12 @@ pub enum Effect {
     },
 
     /// Delete a resource
-    Delete { id: ResourceId, identifier: String },
+    Delete {
+        id: ResourceId,
+        identifier: String,
+        #[serde(default)]
+        lifecycle: LifecycleConfig,
+    },
 }
 
 impl Effect {
@@ -106,6 +111,7 @@ mod tests {
             Effect::Delete {
                 id: ResourceId::new("s3_bucket", "old-bucket"),
                 identifier: "old-bucket".to_string(),
+                lifecycle: LifecycleConfig::default(),
             },
         ];
 

--- a/carina-core/src/interpreter.rs
+++ b/carina-core/src/interpreter.rs
@@ -119,8 +119,12 @@ impl<P: Provider> Interpreter<P> {
                 let state = self.provider.update(id, identifier, from, to).await?;
                 Ok(EffectOutcome::Updated { state })
             }
-            Effect::Delete { id, identifier } => {
-                self.provider.delete(id, identifier).await?;
+            Effect::Delete {
+                id,
+                identifier,
+                lifecycle,
+            } => {
+                self.provider.delete(id, identifier, lifecycle).await?;
                 Ok(EffectOutcome::Deleted)
             }
         }
@@ -131,7 +135,7 @@ impl<P: Provider> Interpreter<P> {
 mod tests {
     use super::*;
     use crate::provider::BoxFuture;
-    use crate::resource::{Resource, ResourceId};
+    use crate::resource::{LifecycleConfig, Resource, ResourceId};
 
     struct TestProvider;
 
@@ -170,7 +174,12 @@ mod tests {
             Box::pin(async move { Ok(state) })
         }
 
-        fn delete(&self, _id: &ResourceId, _identifier: &str) -> BoxFuture<'_, ProviderResult<()>> {
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _lifecycle: &LifecycleConfig,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
     }

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -297,6 +297,7 @@ pub fn get_parsed_file(path: &Path) -> Result<ParsedFile, ModuleError> {
 mod tests {
     use super::*;
     use crate::parser::{InputParameter, TypeExpr};
+    use crate::resource::LifecycleConfig;
 
     fn create_test_module() -> ParsedFile {
         ParsedFile {
@@ -317,6 +318,7 @@ mod tests {
                     attrs
                 },
                 read_only: false,
+                lifecycle: LifecycleConfig::default(),
             }],
             variables: HashMap::new(),
             imports: vec![],

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -280,6 +280,7 @@ mod tests {
         plan.add(Effect::Delete {
             id: crate::resource::ResourceId::new("s3_bucket", "c"),
             identifier: String::new(),
+            lifecycle: crate::resource::LifecycleConfig::default(),
         });
 
         let summary = plan.summary();
@@ -358,6 +359,7 @@ mod tests {
         plan.add(Effect::Delete {
             id: ResourceId::new("s3_bucket", "b"),
             identifier: "b-id".to_string(),
+            lifecycle: crate::resource::LifecycleConfig::default(),
         });
 
         let json = serde_json::to_string(&plan).unwrap();

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -86,6 +86,15 @@ pub enum Value {
     UnresolvedIdent(String, Option<String>),
 }
 
+/// Lifecycle configuration for a resource
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct LifecycleConfig {
+    /// If true, force-delete the resource (e.g., empty S3 bucket before deletion)
+    #[serde(default)]
+    pub force_delete: bool,
+    // Future: create_before_destroy, prevent_destroy (issue #150)
+}
+
 /// Desired state declared in DSL
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Resource {
@@ -93,6 +102,9 @@ pub struct Resource {
     pub attributes: HashMap<String, Value>,
     /// If true, this is a data source (read-only) that won't be modified
     pub read_only: bool,
+    /// Lifecycle meta-argument configuration
+    #[serde(default)]
+    pub lifecycle: LifecycleConfig,
 }
 
 impl Resource {
@@ -101,6 +113,7 @@ impl Resource {
             id: ResourceId::new(resource_type, name),
             attributes: HashMap::new(),
             read_only: false,
+            lifecycle: LifecycleConfig::default(),
         }
     }
 
@@ -113,6 +126,7 @@ impl Resource {
             id: ResourceId::with_provider(provider, resource_type, name),
             attributes: HashMap::new(),
             read_only: false,
+            lifecycle: LifecycleConfig::default(),
         }
     }
 

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -12,7 +12,7 @@ use aws_sdk_s3::Client as S3Client;
 use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderResult, ResourceSchema, ResourceType,
 };
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 
 /// S3 Bucket resource type
 pub struct S3BucketType;
@@ -2160,7 +2160,12 @@ impl Provider for AwsProvider {
         })
     }
 
-    fn delete(&self, id: &ResourceId, identifier: &str) -> BoxFuture<'_, ProviderResult<()>> {
+    fn delete(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        _lifecycle: &LifecycleConfig,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         let identifier = identifier.to_string();
         Box::pin(async move {

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/bin/codegen.rs"
 carina-core = { path = "../carina-core" }
 aws-config = "1"
 aws-sdk-cloudcontrol = "1"
+aws-sdk-s3 = "1"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
@@ -12,6 +12,9 @@ let vpc = awscc.ec2_vpc {
 }
 
 let bucket = awscc.s3_bucket {
+  lifecycle {
+    force_delete = true
+  }
 }
 
 let flow_log = awscc.ec2_flow_log {

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -21,7 +21,7 @@ pub use utils::{
 };
 
 use carina_core::provider::{BoxFuture, Provider, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, State};
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State};
 
 use resources::resource_types;
 
@@ -69,9 +69,15 @@ impl Provider for AwsccProvider {
         Box::pin(async move { self.update_resource(id, &identifier, to).await })
     }
 
-    fn delete(&self, id: &ResourceId, identifier: &str) -> BoxFuture<'_, ProviderResult<()>> {
+    fn delete(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        lifecycle: &LifecycleConfig,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         let identifier = identifier.to_string();
-        Box::pin(async move { self.delete_resource(&id, &identifier).await })
+        let lifecycle = lifecycle.clone();
+        Box::pin(async move { self.delete_resource(&id, &identifier, &lifecycle).await })
     }
 }

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -1,5 +1,6 @@
 //! State file structures for persisting infrastructure state
 
+use carina_core::resource::LifecycleConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -116,6 +117,9 @@ pub struct ResourceState {
     /// Whether this resource is protected from deletion (e.g., state bucket)
     #[serde(default)]
     pub protected: bool,
+    /// Lifecycle configuration persisted from DSL
+    #[serde(default)]
+    pub lifecycle: LifecycleConfig,
 }
 
 impl ResourceState {
@@ -132,6 +136,7 @@ impl ResourceState {
             identifier: None,
             attributes: HashMap::new(),
             protected: false,
+            lifecycle: LifecycleConfig::default(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `lifecycle { force_delete = true }` meta-argument that empties S3 buckets before deletion via CloudControl API
- Introduces `LifecycleConfig` struct threaded through Resource → Effect → Provider for lifecycle-aware operations
- Persists lifecycle config in state file for orphaned resource deletion

Closes #160

## Changes
- **carina-core**: `LifecycleConfig` struct, parser extraction, `Effect::Delete` lifecycle field, `Provider::delete` signature, `create_plan` lifecycle map
- **carina-state**: `ResourceState.lifecycle` persistence
- **carina-provider-awscc**: S3 bucket emptying logic (paginated `list_object_versions` + batch `delete_objects`), `aws-sdk-s3` dependency
- **carina-provider-aws**: Signature update (unused)
- **carina-cli**: Lifecycle state save/load, lifecycle threading through apply/destroy flows

## Test plan
- [x] All 291 existing tests pass
- [x] 3 new parser tests for lifecycle extraction
- [ ] Acceptance test: `ec2_flow_log/s3.crn` with `lifecycle { force_delete = true }` apply+destroy cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)