### PR TITLE
Add <attr>_prefix support for resource naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "serde_json",
  "similar",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -21,3 +21,4 @@ colored = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = "2"
+uuid = { version = "1", features = ["v4"] }

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -319,6 +319,7 @@ mod tests {
                 },
                 read_only: false,
                 lifecycle: LifecycleConfig::default(),
+                prefixes: HashMap::new(),
             }],
             variables: HashMap::new(),
             imports: vec![],

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -572,6 +572,7 @@ fn parse_anonymous_resource(
         attributes,
         read_only: false,
         lifecycle,
+        prefixes: HashMap::new(),
     })
 }
 
@@ -692,6 +693,7 @@ fn parse_resource_expr(
         attributes,
         read_only: false,
         lifecycle,
+        prefixes: HashMap::new(),
     })
 }
 
@@ -739,6 +741,7 @@ fn parse_read_resource_expr(
         attributes,
         read_only: true,
         lifecycle,
+        prefixes: HashMap::new(),
     })
 }
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -105,6 +105,10 @@ pub struct Resource {
     /// Lifecycle meta-argument configuration
     #[serde(default)]
     pub lifecycle: LifecycleConfig,
+    /// Attribute prefixes: maps attribute name -> prefix string
+    /// e.g., {"bucket_name": "my-app-"} from `bucket_name_prefix = "my-app-"`
+    #[serde(default)]
+    pub prefixes: HashMap<String, String>,
 }
 
 impl Resource {
@@ -114,6 +118,7 @@ impl Resource {
             attributes: HashMap::new(),
             read_only: false,
             lifecycle: LifecycleConfig::default(),
+            prefixes: HashMap::new(),
         }
     }
 
@@ -127,6 +132,7 @@ impl Resource {
             attributes: HashMap::new(),
             read_only: false,
             lifecycle: LifecycleConfig::default(),
+            prefixes: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `<attr>_prefix` meta-argument support that generates unique resource names by appending a random 8-char hex suffix (e.g., `bucket_name_prefix = "my-app-"` creates `my-app-a1b2c3d4`)
- Only activates when base attribute exists in schema as a String-compatible type; otherwise treated as a regular attribute
- Reconciles with existing state to preserve generated names across runs (same prefix reuses state name; changed prefix generates new name)
- Persists prefix metadata in state file for reliable reconciliation

Closes #161

## Test plan

- [x] `resolve_attr_prefixes` extracts `*_prefix`, generates name, stores in `resource.prefixes`
- [x] `resolve_attr_prefixes` leaves non-matching `*_prefix` attrs alone (base attr not in schema)
- [x] `resolve_attr_prefixes` errors when both `bucket_name_prefix` and `bucket_name` are set
- [x] `resolve_attr_prefixes` errors on empty prefix value
- [x] `reconcile_prefixed_names` reuses state name when prefix matches
- [x] `reconcile_prefixed_names` generates new name when prefix changes
- [x] `reconcile_prefixed_names` keeps generated name when no state exists
- [x] `ResourceState` with `prefixes` field serializes/deserializes correctly
- [x] Backward compatibility: old state files without `prefixes` deserialize with empty map
- [x] All 296 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)