### PR TITLE
Fix run-tests.sh full: prevent worker subshell silent abort

### DIFF
--- a/carina-provider-awscc/acceptance-tests/run-tests.sh
+++ b/carina-provider-awscc/acceptance-tests/run-tests.sh
@@ -112,6 +112,7 @@ if [ "$COMMAND" = "full" ]; then
         mkdir -p "$STATE_DIR"
 
         (
+            set +e
             PASSED=0
             FAILED=0
 


### PR DESCRIPTION
## Summary
- Add `set +e` to worker subshells in `run-tests.sh full` mode to prevent silent abort on test failure
- Without this fix, worker subshells inherit `set -e` from the parent script and exit on the first test failure, skipping all remaining tests and cleanup

## Impact
Before fix: Only **4/43** tests were reported (most workers died silently)
After fix: All **43/43** tests executed properly with correct pass/fail reporting

Closes #170

## Test plan
- [x] Ran `run-tests.sh full` before fix: 4 passed, 0 failed (of 43) — most tests silently skipped
- [x] Ran `run-tests.sh full` after fix: 22 passed, 21 failed (of 43) — all tests reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)