### PR TITLE
Fix availability_zone format mismatch causing false updates

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -2789,9 +2789,19 @@ fn resolve_enum_identifiers(resources: &mut [Resource]) {
             None => continue,
         };
 
-        // Resolve enum attributes
+        // Resolve enum attributes and availability_zone
         let mut resolved_attrs = HashMap::new();
         for (key, value) in &resource.attributes {
+            // Resolve availability_zone: "ap-northeast-1a" → "aws.AvailabilityZone.ap_northeast_1a"
+            if key == "availability_zone"
+                && let Value::String(s) = value
+                && !s.contains('.')
+            {
+                let az_dsl = format!("aws.AvailabilityZone.{}", s.replace('-', "_"));
+                resolved_attrs.insert(key.clone(), Value::String(az_dsl));
+                continue;
+            }
+
             if let Some(attr_schema) = config.schema.attributes.get(key.as_str())
                 && let AttributeType::Custom {
                     name: type_name,


### PR DESCRIPTION
## Summary
- Fix false update detection for `availability_zone` attributes after apply (closes #145)
- Normalize desired `availability_zone` values to DSL identifier format (`"aws.AvailabilityZone.ap_northeast_1a"`) in `resolve_enum_identifiers`, matching the format `aws_value_to_dsl` uses for current state values
- Follows the same pattern established in #178 for enum attributes: both sides are normalized to the typed DSL format before diffing

## Changes
- **`carina-cli/src/main.rs`**: Add `availability_zone` handling in `resolve_enum_identifiers` to convert `"ap-northeast-1a"` → `"aws.AvailabilityZone.ap_northeast_1a"` (values already in DSL format are left as-is)
- **`carina-core/src/differ.rs`**: Add unit tests documenting the availability zone comparison behavior

## Test plan
- [x] All 310 unit tests pass
- [x] `ec2_vpc/basic` acceptance test passes (instance_tenancy enum)
- [x] `ec2_subnet/basic` acceptance test passes (availability_zone)
- [x] `ec2_nat_gateway/private` acceptance test passes (connectivity_type enum + availability_zone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)