### PR TITLE
Remove hardcoded normalize_instance_tenancy and normalize_region special cases

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -16,7 +16,7 @@ pub mod utils;
 
 // Re-export main types
 pub use provider::AwsccProvider;
-pub use utils::{convert_enum_value, normalize_instance_tenancy, normalize_region};
+pub use utils::convert_enum_value;
 
 use carina_core::provider::{BoxFuture, Provider, ProviderResult};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State};

--- a/carina-provider-awscc/src/utils.rs
+++ b/carina-provider-awscc/src/utils.rs
@@ -1,24 +1,5 @@
 //! Utility functions for value normalization and conversion
 
-/// Normalize region value (e.g., "aws.Region.ap_northeast_1" -> "ap-northeast-1")
-pub fn normalize_region(s: &str) -> String {
-    let region_part = if s.contains('.') {
-        s.split('.').next_back().unwrap_or(s)
-    } else {
-        s
-    };
-    region_part.replace('_', "-")
-}
-
-/// Normalize instance tenancy value (e.g., "awscc.ec2_vpc.InstanceTenancy.default" -> "default")
-pub fn normalize_instance_tenancy(s: &str) -> String {
-    if s.contains('.') {
-        s.split('.').next_back().unwrap_or(s).to_string()
-    } else {
-        s.to_string()
-    }
-}
-
 /// Convert DSL enum value to AWS SDK format
 /// e.g., "aws.Region.ap_northeast_1" -> "ap-northeast-1"
 /// e.g., "awscc.ec2_ipam.Tier.advanced" -> "advanced"
@@ -64,21 +45,6 @@ pub fn convert_enum_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_normalize_region() {
-        assert_eq!(normalize_region("ap_northeast_1"), "ap-northeast-1");
-        assert_eq!(normalize_region("aws.Region.us_east_1"), "us-east-1");
-    }
-
-    #[test]
-    fn test_normalize_instance_tenancy() {
-        assert_eq!(normalize_instance_tenancy("default"), "default");
-        assert_eq!(
-            normalize_instance_tenancy("awscc.ec2_vpc.InstanceTenancy.dedicated"),
-            "dedicated"
-        );
-    }
 
     #[test]
     fn test_convert_enum_value() {


### PR DESCRIPTION
## Summary

- Remove the `"instance_tenancy"` hardcoded match arm from `dsl_value_to_aws()` in the AWSCC provider, letting it fall through to the generic `Custom` type path via `convert_enum_value()` which produces the same result
- Remove `normalize_instance_tenancy()` and `normalize_region()` from `carina-provider-awscc/src/utils.rs` and their re-exports from `lib.rs` — these are redundant with the generic `convert_enum_value()` and already exist locally in `carina-provider-aws`
- Remove the now-unused `dsl_name` parameter from `dsl_value_to_aws()`

Closes #199

## Test plan

- [x] All existing tests pass (316 tests)
- [x] `convert_enum_value("awscc.ec2_vpc.InstanceTenancy.default")` already returns `"default"` — same as `normalize_instance_tenancy()`
- [x] `carina-provider-aws` already has its own local `normalize_region()` and `normalize_instance_tenancy()` — no external consumers of the AWSCC versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)