### PR TITLE
Remove unused re-export of convert_enum_value from carina-provider-awscc

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -13,7 +13,6 @@ pub mod resources;
 pub mod schemas;
 
 // Re-export main types
-pub use carina_core::utils::convert_enum_value;
 pub use provider::AwsccProvider;
 
 use carina_core::provider::{BoxFuture, Provider, ProviderResult};


### PR DESCRIPTION
## Summary

- Remove unused `pub use carina_core::utils::convert_enum_value;` re-export from `carina-provider-awscc/src/lib.rs`
- After #204 consolidated `convert_enum_value` into `carina-core::utils`, all callers import directly from `carina_core::utils`, making this re-export unnecessary

Closes #206

## Test plan

- [x] `cargo build` succeeds
- [x] All tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)