### PR TITLE
Move extract_enum_value into carina-core::utils

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use crate::resource::Value;
+use crate::utils::extract_enum_value;
 
 /// Type alias for resource validator functions
 pub type ResourceValidator = fn(&HashMap<String, Value>) -> Result<(), Vec<TypeError>>;
@@ -98,8 +99,7 @@ impl AttributeType {
             (AttributeType::Bool, Value::Bool(_)) => Ok(()),
 
             (AttributeType::Enum(variants), Value::String(s)) => {
-                // Extract variant from "Type.variant" format
-                let variant = s.split('.').next_back().unwrap_or(s);
+                let variant = extract_enum_value(s);
                 if variants.iter().any(|v| v == variant || s == v) {
                     Ok(())
                 } else {

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -1,5 +1,25 @@
 //! Shared utility functions for value normalization and conversion
 
+/// Extract the last dot-separated part from a namespaced identifier.
+/// Returns the original string if no dots are present.
+///
+/// # Examples
+///
+/// ```
+/// use carina_core::utils::extract_enum_value;
+///
+/// assert_eq!(extract_enum_value("aws.Region.ap_northeast_1"), "ap_northeast_1");
+/// assert_eq!(extract_enum_value("aws.s3.VersioningStatus.Enabled"), "Enabled");
+/// assert_eq!(extract_enum_value("Enabled"), "Enabled");
+/// ```
+pub fn extract_enum_value(s: &str) -> &str {
+    if s.contains('.') {
+        s.split('.').next_back().unwrap_or(s)
+    } else {
+        s
+    }
+}
+
 /// Convert DSL enum value to provider SDK format.
 ///
 /// Handles the following patterns:
@@ -65,6 +85,30 @@ pub fn convert_enum_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_extract_enum_value_with_dots() {
+        assert_eq!(
+            extract_enum_value("aws.Region.ap_northeast_1"),
+            "ap_northeast_1"
+        );
+        assert_eq!(
+            extract_enum_value("aws.s3.VersioningStatus.Enabled"),
+            "Enabled"
+        );
+        assert_eq!(
+            extract_enum_value("aws.vpc.InstanceTenancy.default"),
+            "default"
+        );
+        assert_eq!(extract_enum_value("InstanceTenancy.dedicated"), "dedicated");
+    }
+
+    #[test]
+    fn test_extract_enum_value_without_dots() {
+        assert_eq!(extract_enum_value("Enabled"), "Enabled");
+        assert_eq!(extract_enum_value("default"), "default");
+        assert_eq!(extract_enum_value("ap-northeast-1"), "ap-northeast-1");
+    }
 
     #[test]
     fn test_convert_enum_value_2_part() {

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -13,7 +13,7 @@ use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderResult, ResourceSchema, ResourceType,
 };
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use carina_core::utils::convert_enum_value;
+use carina_core::utils::{convert_enum_value, extract_enum_value};
 
 /// S3 Bucket resource type
 pub struct S3BucketType;
@@ -288,7 +288,7 @@ impl AwsProvider {
         // Configure versioning
         if let Some(Value::String(status)) = resource.attributes.get("versioning") {
             use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-            let normalized = schemas::types::extract_enum_value(status);
+            let normalized = extract_enum_value(status);
             let versioning_status = if normalized == "Enabled" {
                 BucketVersioningStatus::Enabled
             } else {
@@ -364,7 +364,7 @@ impl AwsProvider {
         // Update versioning configuration
         if let Some(Value::String(status)) = to.attributes.get("versioning") {
             use aws_sdk_s3::types::{BucketVersioningStatus, VersioningConfiguration};
-            let normalized = schemas::types::extract_enum_value(status);
+            let normalized = extract_enum_value(status);
             let versioning_status = if normalized == "Enabled" {
                 BucketVersioningStatus::Enabled
             } else {
@@ -585,7 +585,7 @@ impl AwsProvider {
         // Handle instance_tenancy if specified
         if let Some(Value::String(tenancy)) = resource.attributes.get("instance_tenancy") {
             // Convert DSL format (aws.vpc.InstanceTenancy.dedicated) to API value (dedicated)
-            let tenancy_value = schemas::types::extract_enum_value(tenancy);
+            let tenancy_value = extract_enum_value(tenancy);
 
             let tenancy_enum = match tenancy_value {
                 "dedicated" => aws_sdk_ec2::types::Tenancy::Dedicated,

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -2,6 +2,7 @@
 
 use carina_core::resource::Value;
 use carina_core::schema::AttributeType;
+use carina_core::utils::extract_enum_value;
 
 /// Valid AWS regions (in AWS format with hyphens)
 const VALID_REGIONS: &[&str] = &[
@@ -52,20 +53,6 @@ pub fn aws_region() -> AttributeType {
         },
         namespace: Some("aws".to_string()),
         to_dsl: None,
-    }
-}
-
-/// Extract the last dot-separated part from a namespaced identifier.
-/// Returns the original string if no dots are present.
-///
-/// - "aws.Region.ap_northeast_1" -> "ap_northeast_1"
-/// - "aws.s3.VersioningStatus.Enabled" -> "Enabled"
-/// - "Enabled" -> "Enabled"
-pub fn extract_enum_value(s: &str) -> &str {
-    if s.contains('.') {
-        s.split('.').next_back().unwrap_or(s)
-    } else {
-        s
     }
 }
 
@@ -341,31 +328,5 @@ mod tests {
                 .validate(&Value::String("aws.s3.Versioning.Enabled".to_string()))
                 .is_err()
         );
-    }
-
-    // extract_enum_value tests
-
-    #[test]
-    fn extract_enum_value_with_dots() {
-        assert_eq!(
-            extract_enum_value("aws.Region.ap_northeast_1"),
-            "ap_northeast_1"
-        );
-        assert_eq!(
-            extract_enum_value("aws.s3.VersioningStatus.Enabled"),
-            "Enabled"
-        );
-        assert_eq!(
-            extract_enum_value("aws.vpc.InstanceTenancy.default"),
-            "default"
-        );
-        assert_eq!(extract_enum_value("InstanceTenancy.dedicated"), "dedicated");
-    }
-
-    #[test]
-    fn extract_enum_value_without_dots() {
-        assert_eq!(extract_enum_value("Enabled"), "Enabled");
-        assert_eq!(extract_enum_value("default"), "default");
-        assert_eq!(extract_enum_value("ap-northeast-1"), "ap-northeast-1");
     }
 }

--- a/carina-provider-aws/src/schemas/vpc.rs
+++ b/carina-provider-aws/src/schemas/vpc.rs
@@ -2,6 +2,7 @@
 
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
+use carina_core::utils::extract_enum_value;
 
 use super::types as aws_types;
 
@@ -154,7 +155,7 @@ pub fn instance_tenancy() -> AttributeType {
                         }
                     }
                 }
-                let normalized = aws_types::extract_enum_value(s);
+                let normalized = extract_enum_value(s);
                 if VALID_INSTANCE_TENANCY.contains(&normalized) {
                     Ok(())
                 } else {


### PR DESCRIPTION
## Summary
- Moved `extract_enum_value()` from `carina-provider-aws/src/schemas/types.rs` into `carina-core/src/utils.rs` alongside the existing `convert_enum_value()`
- Replaced the inline `s.split('.').next_back().unwrap_or(s)` pattern in `carina-core/src/schema.rs` with a call to `extract_enum_value()`
- Updated all call sites in `carina-provider-aws` (`lib.rs`, `schemas/types.rs`, `schemas/vpc.rs`) to import from `carina_core::utils`

## Test plan
- [x] All existing tests pass (118 core + 36 provider-aws)
- [x] Tests for `extract_enum_value` moved to `carina-core/src/utils.rs`
- [x] Doc-tests pass for the new function location
- [x] Clippy clean

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)