### PR TITLE
Deduplicate namespace validation logic across enum validators

### DIFF
--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -82,6 +82,89 @@ pub fn convert_enum_value(value: &str) -> String {
     raw_value.replace('_', "-")
 }
 
+/// Validate namespace format for an enum identifier.
+///
+/// Handles the following formats:
+/// - No dots: passes through (not a namespaced identifier)
+/// - `TypeName.value` (2-part): validates that the first part matches `type_name`
+/// - Full namespaced form (N-part): validates namespace segments and type_name
+///
+/// The expected full form length is determined by the namespace:
+/// - `"aws"` (1 segment) → 3 parts: `aws.Region.value`
+/// - `"aws.s3"` (2 segments) → 4 parts: `aws.s3.VersioningStatus.value`
+///
+/// # Arguments
+/// * `s` - The input string to validate
+/// * `type_name` - Expected type name (e.g., `"Region"`, `"InstanceTenancy"`)
+/// * `namespace` - Expected namespace prefix (e.g., `"aws"`, `"aws.s3"`, `"awscc.ec2_vpc"`)
+///
+/// # Returns
+/// * `Ok(())` if namespace is valid or string has no dots
+/// * `Err(String)` with descriptive message if namespace is invalid
+///
+/// # Examples
+///
+/// ```
+/// use carina_core::utils::validate_enum_namespace;
+///
+/// // No dots — passes through
+/// assert!(validate_enum_namespace("Enabled", "VersioningStatus", "aws.s3").is_ok());
+///
+/// // 2-part: TypeName.value
+/// assert!(validate_enum_namespace("Region.ap_northeast_1", "Region", "aws").is_ok());
+/// assert!(validate_enum_namespace("Location.ap_northeast_1", "Region", "aws").is_err());
+///
+/// // Full namespaced form
+/// assert!(validate_enum_namespace("aws.Region.ap_northeast_1", "Region", "aws").is_ok());
+/// assert!(validate_enum_namespace("aws.s3.VersioningStatus.Enabled", "VersioningStatus", "aws.s3").is_ok());
+/// ```
+pub fn validate_enum_namespace(s: &str, type_name: &str, namespace: &str) -> Result<(), String> {
+    if !s.contains('.') {
+        return Ok(());
+    }
+
+    let parts: Vec<&str> = s.split('.').collect();
+    let ns_parts: Vec<&str> = namespace.split('.').collect();
+    let expected_full_len = ns_parts.len() + 2; // namespace segments + type_name + value
+
+    match parts.len() {
+        // 2-part: TypeName.value
+        2 => {
+            if parts[0] != type_name {
+                return Err(format!(
+                    "Invalid format '{}', expected {}.value or {}.{}.value",
+                    s, type_name, namespace, type_name
+                ));
+            }
+        }
+        n if n == expected_full_len => {
+            // Full namespaced form: namespace.TypeName.value
+            for (i, &expected) in ns_parts.iter().enumerate() {
+                if parts[i] != expected {
+                    return Err(format!(
+                        "Invalid format '{}', expected {}.{}.value",
+                        s, namespace, type_name
+                    ));
+                }
+            }
+            if parts[ns_parts.len()] != type_name {
+                return Err(format!(
+                    "Invalid format '{}', expected {}.{}.value",
+                    s, namespace, type_name
+                ));
+            }
+        }
+        _ => {
+            return Err(format!(
+                "Invalid format '{}', expected one of: value, {}.value, or {}.{}.value",
+                s, type_name, namespace, type_name
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +247,127 @@ mod tests {
         assert_eq!(convert_enum_value("region.us_east_1"), "region.us_east_1");
         // single value -> passthrough
         assert_eq!(convert_enum_value("Enabled"), "Enabled");
+    }
+
+    // validate_enum_namespace tests
+
+    #[test]
+    fn test_validate_namespace_no_dots() {
+        // Plain values pass through without validation
+        assert!(validate_enum_namespace("Enabled", "VersioningStatus", "aws.s3").is_ok());
+        assert!(validate_enum_namespace("ap-northeast-1", "Region", "aws").is_ok());
+        assert!(validate_enum_namespace("default", "InstanceTenancy", "aws.vpc").is_ok());
+    }
+
+    #[test]
+    fn test_validate_namespace_2_part_valid() {
+        assert!(validate_enum_namespace("Region.ap_northeast_1", "Region", "aws").is_ok());
+        assert!(
+            validate_enum_namespace("VersioningStatus.Enabled", "VersioningStatus", "aws.s3")
+                .is_ok()
+        );
+        assert!(
+            validate_enum_namespace("InstanceTenancy.default", "InstanceTenancy", "aws.vpc")
+                .is_ok()
+        );
+        assert!(
+            validate_enum_namespace(
+                "InstanceTenancy.default",
+                "InstanceTenancy",
+                "awscc.ec2_vpc"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_2_part_invalid() {
+        assert!(validate_enum_namespace("Location.ap_northeast_1", "Region", "aws").is_err());
+        assert!(
+            validate_enum_namespace("Versioning.Enabled", "VersioningStatus", "aws.s3").is_err()
+        );
+        assert!(validate_enum_namespace("Tenancy.default", "InstanceTenancy", "aws.vpc").is_err());
+    }
+
+    #[test]
+    fn test_validate_namespace_3_part_valid() {
+        // 3-part is valid for 1-segment namespace (e.g., "aws")
+        assert!(validate_enum_namespace("aws.Region.ap_northeast_1", "Region", "aws").is_ok());
+    }
+
+    #[test]
+    fn test_validate_namespace_3_part_invalid() {
+        // Wrong provider
+        assert!(validate_enum_namespace("gcp.Region.ap_northeast_1", "Region", "aws").is_err());
+        // Wrong type name
+        assert!(validate_enum_namespace("aws.Location.ap_northeast_1", "Region", "aws").is_err());
+        // 3-part is invalid for 2-segment namespace (e.g., "aws.s3")
+        assert!(
+            validate_enum_namespace("vpc.InstanceTenancy.default", "InstanceTenancy", "aws.vpc")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_4_part_valid() {
+        assert!(
+            validate_enum_namespace(
+                "aws.s3.VersioningStatus.Enabled",
+                "VersioningStatus",
+                "aws.s3"
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_enum_namespace(
+                "aws.vpc.InstanceTenancy.default",
+                "InstanceTenancy",
+                "aws.vpc"
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_enum_namespace(
+                "awscc.ec2_vpc.InstanceTenancy.default",
+                "InstanceTenancy",
+                "awscc.ec2_vpc"
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_4_part_invalid() {
+        // Wrong provider
+        assert!(
+            validate_enum_namespace(
+                "awscc.s3.VersioningStatus.Enabled",
+                "VersioningStatus",
+                "aws.s3"
+            )
+            .is_err()
+        );
+        // Wrong resource
+        assert!(
+            validate_enum_namespace(
+                "aws.s.VersioningStatus.Enabled",
+                "VersioningStatus",
+                "aws.s3"
+            )
+            .is_err()
+        );
+        // Wrong type name
+        assert!(
+            validate_enum_namespace("aws.s3.Versioning.Enabled", "VersioningStatus", "aws.s3")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_wrong_part_count() {
+        // Too many parts for 1-segment namespace
+        assert!(validate_enum_namespace("foo.bar.baz.ap_northeast_1", "Region", "aws").is_err());
+        // 5-part is invalid for 2-segment namespace
+        assert!(validate_enum_namespace("a.b.c.d.e", "VersioningStatus", "aws.s3").is_err());
     }
 }

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -2,7 +2,7 @@
 
 use carina_core::resource::Value;
 use carina_core::schema::AttributeType;
-use carina_core::utils::extract_enum_value;
+use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// Valid AWS regions (in AWS format with hyphens)
 const VALID_REGIONS: &[&str] = &[
@@ -36,37 +36,7 @@ pub fn aws_region() -> AttributeType {
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
-                // Check namespace format if it contains dots
-                if s.contains('.') {
-                    let parts: Vec<&str> = s.split('.').collect();
-                    match parts.len() {
-                        // 2-part: Region.value
-                        2 => {
-                            if parts[0] != "Region" {
-                                return Err(format!(
-                                    "Invalid region '{}', expected format: Region.ap_northeast_1 or aws.Region.ap_northeast_1",
-                                    s
-                                ));
-                            }
-                        }
-                        // 3-part: aws.Region.value
-                        3 => {
-                            if parts[0] != "aws" || parts[1] != "Region" {
-                                return Err(format!(
-                                    "Invalid region '{}', expected format: aws.Region.ap_northeast_1",
-                                    s
-                                ));
-                            }
-                        }
-                        _ => {
-                            return Err(format!(
-                                "Invalid region '{}', expected one of: {}, Region.ap_northeast_1, or aws.Region.ap_northeast_1",
-                                s,
-                                VALID_REGIONS.join(", ")
-                            ));
-                        }
-                    }
-                }
+                validate_enum_namespace(s, "Region", "aws")?;
                 // Normalize the input to AWS format (hyphens)
                 let normalized = extract_enum_value(s).replace('_', "-");
                 if VALID_REGIONS.contains(&normalized.as_str()) {
@@ -101,39 +71,7 @@ pub fn versioning_status() -> AttributeType {
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
-                // Check namespace format if it contains dots
-                if s.contains('.') {
-                    let parts: Vec<&str> = s.split('.').collect();
-                    match parts.len() {
-                        // 2-part: VersioningStatus.value
-                        2 => {
-                            if parts[0] != "VersioningStatus" {
-                                return Err(format!(
-                                    "Invalid versioning status '{}', expected format: VersioningStatus.Enabled or VersioningStatus.Suspended",
-                                    s
-                                ));
-                            }
-                        }
-                        // 4-part: aws.s3.VersioningStatus.value
-                        4 => {
-                            if parts[0] != "aws"
-                                || parts[1] != "s3"
-                                || parts[2] != "VersioningStatus"
-                            {
-                                return Err(format!(
-                                    "Invalid versioning status '{}', expected format: aws.s3.VersioningStatus.Enabled or aws.s3.VersioningStatus.Suspended",
-                                    s
-                                ));
-                            }
-                        }
-                        _ => {
-                            return Err(format!(
-                                "Invalid versioning status '{}', expected one of: Enabled, Suspended, VersioningStatus.Enabled, or aws.s3.VersioningStatus.Enabled",
-                                s
-                            ));
-                        }
-                    }
-                }
+                validate_enum_namespace(s, "VersioningStatus", "aws.s3")?;
                 let normalized = extract_enum_value(s);
                 if VALID_VERSIONING_STATUS.contains(&normalized) {
                     Ok(())


### PR DESCRIPTION
## Summary
- Extract shared `validate_enum_namespace()` helper into `carina-core::utils` that handles 2-part (`TypeName.value`) and full namespaced (`namespace.TypeName.value`) validation
- Replace duplicated namespace validation in `aws_region()`, `versioning_status()`, `instance_tenancy()`, and `validate_namespaced_enum()` with the shared helper
- The helper dynamically computes expected part count from namespace segments, supporting both 1-segment (`aws` → 3-part) and 2-segment (`aws.s3`, `awscc.ec2_vpc` → 4-part) namespaces

Closes #212

## Test plan
- [x] Added comprehensive unit tests for `validate_enum_namespace()` covering all namespace patterns
- [x] All existing tests pass (330+ tests across all crates)
- [x] Doc-tests pass for the new function
- [x] Pre-commit hooks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)