### PR TITLE
Handle namespace-expanded form in validate_availability_zone()

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -908,6 +908,12 @@ mod tests {
             ))
             .is_ok()
         );
+        // Underscored form without namespace (consistent with other enum types
+        // accepting underscore-to-hyphen conversion via find_matching_enum_value)
+        assert!(
+            t.validate(&Value::String("ap_northeast_1a".to_string()))
+                .is_ok()
+        );
         assert!(t.validate(&Value::String("us-east-1".to_string())).is_err());
         assert!(t.validate(&Value::String("invalid".to_string())).is_err());
         assert!(t.validate(&Value::Int(42)).is_err());


### PR DESCRIPTION
## Summary

- Add namespace validation to `availability_zone()` type's validate closure using `validate_enum_namespace()` + `extract_enum_value()`, consistent with how other enum types use `validate_namespaced_enum()`
- Wrong namespace prefixes (e.g., `wrong.AvailabilityZone.us_east_1a`) are now rejected
- Both `"ap-northeast-1a"` (AWS format) and `"awscc.AvailabilityZone.ap_northeast_1a"` (namespace-expanded form) pass validation
- `validate_availability_zone()` remains a pure AWS-format validator (no namespace awareness)
- Added tests for namespace-expanded valid/invalid cases including wrong namespace rejection

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)