### PR TITLE
Show original input in availability_zone validation errors

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -903,6 +903,25 @@ mod tests {
     }
 
     #[test]
+    fn validate_availability_zone_underscored_error_shows_original_input() {
+        let t = availability_zone();
+        // Underscored form without namespace - error should show original, not normalized
+        let result = t.validate(&Value::String("us_east_1".to_string()));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("us_east_1"),
+            "Error should show original input, got: {}",
+            err_msg
+        );
+        assert!(
+            !err_msg.contains("'us-east-1'"),
+            "Error should not show normalized form, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
     fn validate_availability_zone_invalid() {
         assert!(validate_availability_zone("us-east-1").is_err()); // no zone letter
         assert!(validate_availability_zone("US-EAST-1A").is_err()); // uppercase


### PR DESCRIPTION
## Summary
- Fix `availability_zone()` validation error messages to show the original user input (e.g., `awscc.AvailabilityZone.us_east_1`) instead of the normalized form (e.g., `us-east-1`)
- Change `validate_availability_zone()` to return just the failure reason (e.g., `"must end with a zone letter (a-z)"`) without embedding the input value
- The caller adds context via `map_err`, cleanly separating the error cause from the display value
- Add tests to verify error messages contain original input for both namespaced and non-namespaced forms

Closes #225

## Test plan
- [x] New test `validate_availability_zone_namespace_expanded_error_shows_original_input` verifies namespaced form (e.g., `awscc.AvailabilityZone.us_east_1`) shows original input
- [x] New test `validate_availability_zone_underscored_error_shows_original_input` verifies non-namespaced underscored form (e.g., `us_east_1`) shows original input
- [x] All existing `validate_availability_zone` tests continue to pass
- [x] Full test suite passes (352 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)