### PR TITLE
Standardize validate_* error messages to bare reason strings

### DIFF
--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -299,7 +299,11 @@ impl DiagnosticEngine {
                                         }
                                     } else if name == "Arn" {
                                         if let Value::String(s) = &resolved_value {
-                                            validate_arn(s).err()
+                                            validate_arn(s)
+                                                .map_err(|reason| {
+                                                    format!("Invalid ARN '{}': {}", s, reason)
+                                                })
+                                                .err()
                                         } else {
                                             None
                                         }


### PR DESCRIPTION
## Summary
- Standardize all `validate_*` functions in `awscc_types.rs` to return bare reason strings (e.g., `"must start with 'arn:'"`) instead of embedding the input value
- Each caller's closure now adds context via `map_err` with the pattern `"Invalid <TypeName> '<input>': <reason>"`
- Reduce visibility of `validate_availability_zone`, `validate_aws_resource_id`, and `validate_ipam_pool_id` to private
- Update LSP's `validate_arn` caller to wrap bare reasons with context

## Test plan
- [x] All existing tests pass without modification (bare reason functions are tested directly, callers tested via type validators)
- [x] `validate_prefix_mismatch_error_messages` test verifies the caller still includes both the input value and expected format
- [x] `validate_availability_zone_*_error_shows_original_input` tests verify the original input is shown (not normalized)
- [x] Pre-commit hooks pass (fmt, clippy, full test suite)

Closes #228
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)