### PR TITLE
Reduce visibility of validate_iam_policy_document to private

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -623,7 +623,7 @@ pub fn iam_policy_document() -> AttributeType {
     }
 }
 
-pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
+fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
     let Value::Map(map) = value else {
         return Err("Expected a map for IAM policy document".to_string());
     };


### PR DESCRIPTION
## Summary

- Change `pub fn validate_iam_policy_document` to `fn validate_iam_policy_document` since it has no callers outside `awscc_types.rs`
- Follows the same pattern applied in PR #229 for other validate functions

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)