### PR TITLE
Reduce visibility of validate_namespaced_enum to pub(crate)

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -65,7 +65,7 @@ pub fn canonicalize_enum_value(raw: &str, valid_values: &[&str]) -> String {
 
 /// Validate a namespaced enum value.
 /// Returns Ok(()) if valid, Err with message if invalid.
-pub fn validate_namespaced_enum(
+pub(crate) fn validate_namespaced_enum(
     value: &Value,
     type_name: &str,
     namespace: &str,


### PR DESCRIPTION
## Summary
- Change `validate_namespaced_enum` from `pub` to `pub(crate)` so it's no longer part of the public API while remaining accessible to generated schema files within the crate

Closes #233

## Test plan
- [x] `cargo build` succeeds
- [x] All 373 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)