### PR TITLE
Fix codegen to use egress_only_internet_gateway_id() for eigw attributes

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1335,13 +1335,13 @@ fn get_resource_id_type(prop_name: &str) -> &'static str {
     if (lower.contains("securitygroup") || lower.contains("groupid")) && lower.ends_with("id") {
         return "super::security_group_id()";
     }
+    // Egress Only Internet Gateway IDs (must be checked before Internet Gateway IDs)
+    if lower.contains("egressonlyinternetgateway") && lower.ends_with("id") {
+        return "super::egress_only_internet_gateway_id()";
+    }
     // Internet Gateway IDs
     if lower.contains("internetgateway") && lower.ends_with("id") {
         return "super::internet_gateway_id()";
-    }
-    // Egress Only Internet Gateway IDs
-    if lower.contains("egressonlyinternetgateway") && lower.ends_with("id") {
-        return "super::egress_only_internet_gateway_id()";
     }
     // Route Table IDs
     if lower.contains("routetable") && lower.ends_with("id") {

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -49,7 +49,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("DestinationPrefixListId"),
         )
         .attribute(
-            AttributeSchema::new("egress_only_internet_gateway_id", super::internet_gateway_id())
+            AttributeSchema::new("egress_only_internet_gateway_id", super::egress_only_internet_gateway_id())
                 .with_description("[IPv6 traffic only] The ID of an egress-only internet gateway.")
                 .with_provider_name("EgressOnlyInternetGatewayId"),
         )


### PR DESCRIPTION
## Summary

- Reorder codegen pattern matching so egress-only internet gateway check comes before the general internet gateway check
- The string `egressonlyinternetgatewayid` contains `internetgateway`, so the broader pattern was matching first, causing `egress_only_internet_gateway_id` attributes to incorrectly use `internet_gateway_id()` (validates `igw-` prefix) instead of `egress_only_internet_gateway_id()` (validates `eigw-` prefix)
- Regenerated schema files to apply the fix

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Verified `route.rs` now uses `super::egress_only_internet_gateway_id()` instead of `super::internet_gateway_id()`
- [x] Regenerated all schemas and docs

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)