### PR TITLE
Fix VPC Endpoint ID operator precedence issue in codegen

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1364,7 +1364,7 @@ fn get_resource_id_type(prop_name: &str) -> &'static str {
         return "super::vpn_gateway_id()";
     }
     // VPC Endpoint IDs
-    if lower.contains("vpcendpoint") && lower.ends_with("id") || lower.ends_with("endpointid") {
+    if lower.contains("vpcendpoint") && lower.ends_with("id") {
         return "super::vpc_endpoint_id()";
     }
 
@@ -1408,7 +1408,7 @@ fn get_resource_id_display_name(prop_name: &str) -> &'static str {
     if lower.contains("vpngateway") && lower.ends_with("id") {
         return "VpnGatewayId";
     }
-    if lower.contains("vpcendpoint") && lower.ends_with("id") || lower.ends_with("endpointid") {
+    if lower.contains("vpcendpoint") && lower.ends_with("id") {
         return "VpcEndpointId";
     }
 
@@ -2939,6 +2939,16 @@ mod tests {
     }
 
     #[test]
+    fn test_get_resource_id_type_non_vpc_endpoint_id() {
+        // Regression test for #244: ServiceEndpointId should NOT match VPC Endpoint ID
+        // Previously, due to operator precedence, anything ending with "endpointid" matched
+        assert_eq!(
+            get_resource_id_type("ServiceEndpointId"),
+            "super::aws_resource_id()"
+        );
+    }
+
+    #[test]
     fn test_get_resource_id_type_fallback() {
         assert_eq!(
             get_resource_id_type("SomeUnknownId"),
@@ -3021,6 +3031,15 @@ mod tests {
         assert_eq!(
             get_resource_id_display_name("VpcEndpointId"),
             "VpcEndpointId"
+        );
+    }
+
+    #[test]
+    fn test_get_resource_id_display_name_non_vpc_endpoint_id() {
+        // Regression test for #244: ServiceEndpointId should NOT match VPC Endpoint ID
+        assert_eq!(
+            get_resource_id_display_name("ServiceEndpointId"),
+            "AwsResourceId"
         );
     }
 


### PR DESCRIPTION
## Summary

- Remove redundant `|| lower.ends_with("endpointid")` from `get_resource_id_type()` and `get_resource_id_display_name()` to fix operator precedence bug where any property ending with `endpointid` (e.g., `ServiceEndpointId`) would incorrectly match as a VPC Endpoint ID
- Add regression tests for both functions verifying non-VPC endpoint IDs fall through to generic fallback

Closes #244

## Test plan

- [x] Regression tests added for `ServiceEndpointId` in both `get_resource_id_type()` and `get_resource_id_display_name()`
- [x] All existing tests pass (including `VpcEndpointId` matching)
- [x] Full `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)