### PR TITLE
Reduce visibility of canonicalize_enum_value to pub(crate)

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -57,7 +57,7 @@ fn find_matching_enum_value<'a>(input: &str, valid_values: &[&'a str]) -> Option
 
 /// Canonicalize an enum value by matching against valid values.
 /// Handles exact match, case-insensitive match, and underscore-to-hyphen conversion.
-pub fn canonicalize_enum_value(raw: &str, valid_values: &[&str]) -> String {
+pub(crate) fn canonicalize_enum_value(raw: &str, valid_values: &[&str]) -> String {
     find_matching_enum_value(raw, valid_values)
         .unwrap_or(raw)
         .to_string()


### PR DESCRIPTION
## Summary

- Change `canonicalize_enum_value` from `pub` to `pub(crate)` since its only external caller (`provider.rs`) is within the same crate

Closes #235

## Test plan

- [x] `cargo build` succeeds
- [x] All tests pass (pre-commit hooks verified)
- [x] No external crate references this function

🤖 Generated with [Claude Code](https://claude.com/claude-code)