### PR TITLE
Standardize validate_namespaced_enum to bare-reason pattern

### DIFF
--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -100,7 +100,7 @@ pub fn convert_enum_value(value: &str) -> String {
 ///
 /// # Returns
 /// * `Ok(())` if namespace is valid or string has no dots
-/// * `Err(String)` with descriptive message if namespace is invalid
+/// * `Err(String)` with bare reason string (without the input value) if namespace is invalid
 ///
 /// # Examples
 ///
@@ -132,8 +132,8 @@ pub fn validate_enum_namespace(s: &str, type_name: &str, namespace: &str) -> Res
         2 => {
             if parts[0] != type_name {
                 return Err(format!(
-                    "Invalid format '{}', expected {}.value or {}.{}.value",
-                    s, type_name, namespace, type_name
+                    "expected format {}.value or {}.{}.value",
+                    type_name, namespace, type_name
                 ));
             }
         }
@@ -141,23 +141,17 @@ pub fn validate_enum_namespace(s: &str, type_name: &str, namespace: &str) -> Res
             // Full namespaced form: namespace.TypeName.value
             for (i, &expected) in ns_parts.iter().enumerate() {
                 if parts[i] != expected {
-                    return Err(format!(
-                        "Invalid format '{}', expected {}.{}.value",
-                        s, namespace, type_name
-                    ));
+                    return Err(format!("expected format {}.{}.value", namespace, type_name));
                 }
             }
             if parts[ns_parts.len()] != type_name {
-                return Err(format!(
-                    "Invalid format '{}', expected {}.{}.value",
-                    s, namespace, type_name
-                ));
+                return Err(format!("expected format {}.{}.value", namespace, type_name));
             }
         }
         _ => {
             return Err(format!(
-                "Invalid format '{}', expected one of: value, {}.value, or {}.{}.value",
-                s, type_name, namespace, type_name
+                "expected format: value, {}.value, or {}.{}.value",
+                type_name, namespace, type_name
             ));
         }
     }

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -36,7 +36,8 @@ pub fn aws_region() -> AttributeType {
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
-                validate_enum_namespace(s, "Region", "aws")?;
+                validate_enum_namespace(s, "Region", "aws")
+                    .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 // Normalize the input to AWS format (hyphens)
                 let normalized = extract_enum_value(s).replace('_', "-");
                 if VALID_REGIONS.contains(&normalized.as_str()) {
@@ -71,7 +72,8 @@ pub fn versioning_status() -> AttributeType {
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
-                validate_enum_namespace(s, "VersioningStatus", "aws.s3")?;
+                validate_enum_namespace(s, "VersioningStatus", "aws.s3")
+                    .map_err(|reason| format!("Invalid versioning status '{}': {}", s, reason))?;
                 let normalized = extract_enum_value(s);
                 if VALID_VERSIONING_STATUS.contains(&normalized) {
                     Ok(())

--- a/carina-provider-aws/src/schemas/vpc.rs
+++ b/carina-provider-aws/src/schemas/vpc.rs
@@ -122,7 +122,8 @@ pub fn instance_tenancy() -> AttributeType {
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
-                validate_enum_namespace(s, "InstanceTenancy", "aws.vpc")?;
+                validate_enum_namespace(s, "InstanceTenancy", "aws.vpc")
+                    .map_err(|reason| format!("Invalid instance tenancy '{}': {}", s, reason))?;
                 let normalized = extract_enum_value(s);
                 if VALID_INSTANCE_TENANCY.contains(&normalized) {
                     Ok(())

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -833,10 +833,17 @@ use super::AwsccSchemaConfig;
         code.push_str(&format!(
             r#"fn {}(value: &Value) -> Result<(), String> {{
     validate_namespaced_enum(value, "{}", "{}", {})
+        .map_err(|reason| {{
+            if let Value::String(s) = value {{
+                format!("Invalid {} '{{}}': {{}}", s, reason)
+            }} else {{
+                reason
+            }}
+        }})
 }}
 
 "#,
-            fn_name, enum_info.type_name, namespace, const_name
+            fn_name, enum_info.type_name, namespace, const_name, enum_info.type_name
         ));
     }
 

--- a/carina-provider-awscc/src/schemas/generated/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/bucket.rs
@@ -13,7 +13,15 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, Struct
 const VALID_ABAC_STATUS: &[&str] = &["Enabled", "Disabled"];
 
 fn validate_abac_status(value: &Value) -> Result<(), String> {
-    validate_namespaced_enum(value, "AbacStatus", "awscc.s3_bucket", VALID_ABAC_STATUS)
+    validate_namespaced_enum(value, "AbacStatus", "awscc.s3_bucket", VALID_ABAC_STATUS).map_err(
+        |reason| {
+            if let Value::String(s) = value {
+                format!("Invalid AbacStatus '{}': {}", s, reason)
+            } else {
+                reason
+            }
+        },
+    )
 }
 
 const VALID_ACCESS_CONTROL: &[&str] = &[
@@ -34,6 +42,13 @@ fn validate_access_control(value: &Value) -> Result<(), String> {
         "awscc.s3_bucket",
         VALID_ACCESS_CONTROL,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid AccessControl '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for s3_bucket (AWS::S3::Bucket)

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -13,7 +13,13 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types}
 const VALID_DOMAIN: &[&str] = &["vpc", "standard"];
 
 fn validate_domain(value: &Value) -> Result<(), String> {
-    validate_namespaced_enum(value, "Domain", "awscc.ec2_eip", VALID_DOMAIN)
+    validate_namespaced_enum(value, "Domain", "awscc.ec2_eip", VALID_DOMAIN).map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid Domain '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_eip (AWS::EC2::EIP)

--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -19,6 +19,13 @@ fn validate_log_destination_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_flow_log",
         VALID_LOG_DESTINATION_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid LogDestinationType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_RESOURCE_TYPE: &[&str] = &[
@@ -37,6 +44,13 @@ fn validate_resource_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_flow_log",
         VALID_RESOURCE_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid ResourceType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
@@ -48,6 +62,13 @@ fn validate_traffic_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_flow_log",
         VALID_TRAFFIC_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid TrafficType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_flow_log (AWS::EC2::FlowLog)

--- a/carina-provider-awscc/src/schemas/generated/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam.rs
@@ -19,12 +19,25 @@ fn validate_metered_account(value: &Value) -> Result<(), String> {
         "awscc.ec2_ipam",
         VALID_METERED_ACCOUNT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid MeteredAccount '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_TIER: &[&str] = &["free", "advanced"];
 
 fn validate_tier(value: &Value) -> Result<(), String> {
-    validate_namespaced_enum(value, "Tier", "awscc.ec2_ipam", VALID_TIER)
+    validate_namespaced_enum(value, "Tier", "awscc.ec2_ipam", VALID_TIER).map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid Tier '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_ipam (AWS::EC2::IPAM)

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -19,6 +19,13 @@ fn validate_address_family(value: &Value) -> Result<(), String> {
         "awscc.ec2_ipam_pool",
         VALID_ADDRESS_FAMILY,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid AddressFamily '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_AWS_SERVICE: &[&str] = &["ec2", "global-services"];
@@ -30,6 +37,13 @@ fn validate_aws_service(value: &Value) -> Result<(), String> {
         "awscc.ec2_ipam_pool",
         VALID_AWS_SERVICE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid AwsService '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_IPAM_SCOPE_TYPE: &[&str] = &["public", "private"];
@@ -41,6 +55,13 @@ fn validate_ipam_scope_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_ipam_pool",
         VALID_IPAM_SCOPE_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid IpamScopeType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_PUBLIC_IP_SOURCE: &[&str] = &["byoip", "amazon"];
@@ -52,6 +73,13 @@ fn validate_public_ip_source(value: &Value) -> Result<(), String> {
         "awscc.ec2_ipam_pool",
         VALID_PUBLIC_IP_SOURCE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid PublicIpSource '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_STATE: &[&str] = &[
@@ -64,7 +92,13 @@ const VALID_STATE: &[&str] = &[
 ];
 
 fn validate_state(value: &Value) -> Result<(), String> {
-    validate_namespaced_enum(value, "State", "awscc.ec2_ipam_pool", VALID_STATE)
+    validate_namespaced_enum(value, "State", "awscc.ec2_ipam_pool", VALID_STATE).map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid State '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_ipam_pool (AWS::EC2::IPAMPool)

--- a/carina-provider-awscc/src/schemas/generated/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/log_group.rs
@@ -19,6 +19,13 @@ fn validate_log_group_class(value: &Value) -> Result<(), String> {
         "awscc.logs_log_group",
         VALID_LOG_GROUP_CLASS,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid LogGroupClass '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for logs_log_group (AWS::Logs::LogGroup)

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -19,6 +19,13 @@ fn validate_availability_mode(value: &Value) -> Result<(), String> {
         "awscc.ec2_nat_gateway",
         VALID_AVAILABILITY_MODE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid AvailabilityMode '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_CONNECTIVITY_TYPE: &[&str] = &["public", "private"];
@@ -30,6 +37,13 @@ fn validate_connectivity_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_nat_gateway",
         VALID_CONNECTIVITY_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid ConnectivityType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_nat_gateway (AWS::EC2::NatGateway)

--- a/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_egress.rs
@@ -18,6 +18,13 @@ fn validate_ip_protocol(value: &Value) -> Result<(), String> {
         "awscc.ec2_security_group_egress",
         VALID_IP_PROTOCOL,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid IpProtocol '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -18,6 +18,13 @@ fn validate_ip_protocol(value: &Value) -> Result<(), String> {
         "awscc.ec2_security_group_ingress",
         VALID_IP_PROTOCOL,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid IpProtocol '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
@@ -19,6 +19,13 @@ fn validate_auto_accept_shared_attachments(value: &Value) -> Result<(), String> 
         "awscc.ec2_transit_gateway",
         VALID_AUTO_ACCEPT_SHARED_ATTACHMENTS,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid AutoAcceptSharedAttachments '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_DEFAULT_ROUTE_TABLE_ASSOCIATION: &[&str] = &["enable", "disable"];
@@ -30,6 +37,13 @@ fn validate_default_route_table_association(value: &Value) -> Result<(), String>
         "awscc.ec2_transit_gateway",
         VALID_DEFAULT_ROUTE_TABLE_ASSOCIATION,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid DefaultRouteTableAssociation '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_DEFAULT_ROUTE_TABLE_PROPAGATION: &[&str] = &["enable", "disable"];
@@ -41,6 +55,13 @@ fn validate_default_route_table_propagation(value: &Value) -> Result<(), String>
         "awscc.ec2_transit_gateway",
         VALID_DEFAULT_ROUTE_TABLE_PROPAGATION,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid DefaultRouteTablePropagation '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_DNS_SUPPORT: &[&str] = &["enable", "disable"];
@@ -52,6 +73,13 @@ fn validate_dns_support(value: &Value) -> Result<(), String> {
         "awscc.ec2_transit_gateway",
         VALID_DNS_SUPPORT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid DnsSupport '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_ENCRYPTION_SUPPORT: &[&str] = &["disable", "enable"];
@@ -63,6 +91,13 @@ fn validate_encryption_support(value: &Value) -> Result<(), String> {
         "awscc.ec2_transit_gateway",
         VALID_ENCRYPTION_SUPPORT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid EncryptionSupport '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_MULTICAST_SUPPORT: &[&str] = &["enable", "disable"];
@@ -74,6 +109,13 @@ fn validate_multicast_support(value: &Value) -> Result<(), String> {
         "awscc.ec2_transit_gateway",
         VALID_MULTICAST_SUPPORT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid MulticastSupport '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_SECURITY_GROUP_REFERENCING_SUPPORT: &[&str] = &["enable", "disable"];
@@ -85,6 +127,16 @@ fn validate_security_group_referencing_support(value: &Value) -> Result<(), Stri
         "awscc.ec2_transit_gateway",
         VALID_SECURITY_GROUP_REFERENCING_SUPPORT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!(
+                "Invalid SecurityGroupReferencingSupport '{}': {}",
+                s, reason
+            )
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_VPN_ECMP_SUPPORT: &[&str] = &["enable", "disable"];
@@ -96,6 +148,13 @@ fn validate_vpn_ecmp_support(value: &Value) -> Result<(), String> {
         "awscc.ec2_transit_gateway",
         VALID_VPN_ECMP_SUPPORT,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid VpnEcmpSupport '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_transit_gateway (AWS::EC2::TransitGateway)

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -19,6 +19,13 @@ fn validate_instance_tenancy(value: &Value) -> Result<(), String> {
         "awscc.ec2_vpc",
         VALID_INSTANCE_TENANCY,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid InstanceTenancy '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -19,6 +19,13 @@ fn validate_ip_address_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_vpc_endpoint",
         VALID_IP_ADDRESS_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid IpAddressType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
@@ -36,6 +43,13 @@ fn validate_vpc_endpoint_type(value: &Value) -> Result<(), String> {
         "awscc.ec2_vpc_endpoint",
         VALID_VPC_ENDPOINT_TYPE,
     )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid VpcEndpointType '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
 }
 
 /// Returns the schema config for ec2_vpc_endpoint (AWS::EC2::VPCEndpoint)


### PR DESCRIPTION
## Summary

- Change `validate_namespaced_enum` and `validate_enum_namespace` to return bare reason strings without embedding input values
- Callers now add context via `map_err`, consistent with the pattern established in #228
- Update codegen to generate `map_err` wrapping in validator functions
- Regenerate all schema files

**Before:**
```
Invalid value 'foo', expected one of: IPv4, IPv6
```

**After (in generated code):**
```
Invalid AddressFamily 'foo': expected one of: IPv4, IPv6
```

## Changes

- `validate_enum_namespace` (carina-core): remove input value from error messages
- `validate_namespaced_enum` (awscc_types): return bare "expected one of: ..." reason
- Update all callers in aws/awscc providers to wrap namespace errors with `map_err`
- Update codegen template to generate `map_err` wrapping
- Regenerate all 17 affected schema files

## Test plan

- [x] All existing tests pass (400+ tests across all crates)
- [x] Updated test assertion for `validate_namespaced_enum_invalid_value` to match new bare-reason format
- [x] Verified regenerated schema files contain correct `map_err` wrapping

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)