### PR TITLE
Standardize AWS provider enum validators to bare-reason pattern

### DIFF
--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -330,4 +330,60 @@ mod tests {
                 .is_err()
         );
     }
+
+    // Error message format consistency tests
+
+    #[test]
+    fn region_error_format_consistent_for_namespace_and_value() {
+        let region_type = aws_region();
+        // Namespace error: wrong provider prefix
+        let ns_err = region_type
+            .validate(&Value::String("gcp.Region.ap_northeast_1".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            ns_err.contains("Invalid region 'gcp.Region.ap_northeast_1':"),
+            "Namespace error should use 'Invalid region '<value>':' format, got: {}",
+            ns_err
+        );
+
+        // Value error: invalid region value
+        let val_err = region_type
+            .validate(&Value::String("invalid-region".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            val_err.contains("Invalid region 'invalid-region':"),
+            "Value error should use 'Invalid region '<value>':' format, got: {}",
+            val_err
+        );
+    }
+
+    #[test]
+    fn versioning_error_format_consistent_for_namespace_and_value() {
+        let versioning = versioning_status();
+        // Namespace error: wrong provider
+        let ns_err = versioning
+            .validate(&Value::String(
+                "awscc.s3.VersioningStatus.Enabled".to_string(),
+            ))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            ns_err.contains("Invalid versioning status 'awscc.s3.VersioningStatus.Enabled':"),
+            "Namespace error should use consistent format, got: {}",
+            ns_err
+        );
+
+        // Value error: invalid value
+        let val_err = versioning
+            .validate(&Value::String("Disabled".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            val_err.contains("Invalid versioning status 'Disabled':"),
+            "Value error should use consistent format, got: {}",
+            val_err
+        );
+    }
 }

--- a/carina-provider-aws/src/schemas/vpc.rs
+++ b/carina-provider-aws/src/schemas/vpc.rs
@@ -756,4 +756,32 @@ mod tests {
 
         assert!(schema.validate(&attrs).is_ok());
     }
+
+    #[test]
+    fn instance_tenancy_error_format_consistent_for_namespace_and_value() {
+        let tenancy = instance_tenancy();
+        // Namespace error: wrong provider
+        let ns_err = tenancy
+            .validate(&Value::String(
+                "awscc.vpc.InstanceTenancy.default".to_string(),
+            ))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            ns_err.contains("Invalid instance tenancy 'awscc.vpc.InstanceTenancy.default':"),
+            "Namespace error should use consistent format, got: {}",
+            ns_err
+        );
+
+        // Value error: invalid value
+        let val_err = tenancy
+            .validate(&Value::String("shared".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            val_err.contains("Invalid instance tenancy 'shared':"),
+            "Value error should use consistent format, got: {}",
+            val_err
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Refactored `aws_region()`, `versioning_status()`, and `instance_tenancy()` validators to consistently return bare reason strings
- Removed `map_err` wrappers that embedded the input value in namespace error messages
- Changed value-validation errors to use bare reasons (e.g., `"expected one of: ..."`) instead of the old pattern (`"Invalid region '...', expected one of: ..."`)
- This makes them consistent with `validate_namespaced_enum` used by the AWSCC provider

Closes #249

## Test plan

- [x] All existing tests pass (375+ tests across all crates)
- [x] Updated `region_rejects_invalid_region` test to match new error format
- [x] Pre-commit checks (formatting, clippy, tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)