### PR TITLE
Unify ResourceRef and TypedResourceRef into a single Value variant

### DIFF
--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -241,10 +241,7 @@ impl ModuleResolver {
 /// Substitute input references with actual values
 fn substitute_inputs(value: &Value, inputs: &HashMap<String, Value>) -> Value {
     match value {
-        Value::ResourceRef(binding, attr) if binding == "input" => {
-            inputs.get(attr).cloned().unwrap_or_else(|| value.clone())
-        }
-        Value::TypedResourceRef {
+        Value::ResourceRef {
             binding_name,
             attribute_name,
             ..
@@ -309,7 +306,11 @@ mod tests {
                     attrs.insert("name".to_string(), Value::String("sg".to_string()));
                     attrs.insert(
                         "vpc_id".to_string(),
-                        Value::ResourceRef("input".to_string(), "vpc_id".to_string()),
+                        Value::ResourceRef {
+                            binding_name: "input".to_string(),
+                            attribute_name: "vpc_id".to_string(),
+                            resource_type: None,
+                        },
                     );
                     attrs.insert(
                         "_type".to_string(),
@@ -346,7 +347,11 @@ mod tests {
         let mut inputs = HashMap::new();
         inputs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
 
-        let value = Value::ResourceRef("input".to_string(), "vpc_id".to_string());
+        let value = Value::ResourceRef {
+            binding_name: "input".to_string(),
+            attribute_name: "vpc_id".to_string(),
+            resource_type: None,
+        };
         let result = substitute_inputs(&value, &inputs);
 
         assert_eq!(result, Value::String("vpc-123".to_string()));
@@ -358,7 +363,11 @@ mod tests {
         inputs.insert("port".to_string(), Value::Int(8080));
 
         let value = Value::List(vec![
-            Value::ResourceRef("input".to_string(), "port".to_string()),
+            Value::ResourceRef {
+                binding_name: "input".to_string(),
+                attribute_name: "port".to_string(),
+                resource_type: None,
+            },
             Value::Int(443),
         ]);
         let result = substitute_inputs(&value, &inputs);

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -66,10 +66,8 @@ pub enum Value {
     Bool(bool),
     List(Vec<Value>),
     Map(HashMap<String, Value>),
-    /// Reference to another resource's attribute (binding_name, attribute_name)
-    ResourceRef(String, String),
-    /// Typed reference to another resource's attribute with optional type information
-    TypedResourceRef {
+    /// Reference to another resource's attribute with optional type information
+    ResourceRef {
         /// Binding name of the referenced resource (e.g., "vpc", "web_sg")
         binding_name: String,
         /// Attribute name being referenced (e.g., "id", "name")
@@ -204,13 +202,17 @@ mod tests {
                 ("key".to_string(), Value::String("val".to_string())),
                 ("num".to_string(), Value::Int(10)),
             ])),
-            Value::ResourceRef("vpc".to_string(), "id".to_string()),
-            Value::TypedResourceRef {
+            Value::ResourceRef {
+                binding_name: "vpc".to_string(),
+                attribute_name: "id".to_string(),
+                resource_type: None,
+            },
+            Value::ResourceRef {
                 binding_name: "web_sg".to_string(),
                 attribute_name: "id".to_string(),
                 resource_type: Some(ResourceTypePath::new("aws", "security_group")),
             },
-            Value::TypedResourceRef {
+            Value::ResourceRef {
                 binding_name: "bucket".to_string(),
                 attribute_name: "arn".to_string(),
                 resource_type: None,

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -209,14 +209,7 @@ impl DiagnosticEngine {
                                         name: expected_name,
                                         ..
                                     },
-                                    Value::ResourceRef(ref_binding, ref_attr),
-                                )
-                                | (
-                                    carina_core::schema::AttributeType::Custom {
-                                        name: expected_name,
-                                        ..
-                                    },
-                                    Value::TypedResourceRef {
+                                    Value::ResourceRef {
                                         binding_name: ref_binding,
                                         attribute_name: ref_attr,
                                         ..

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -779,8 +779,12 @@ mod tests {
         assert!(t.validate(&Value::Int(42)).is_err());
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef("role".to_string(), "arn".to_string()))
-                .is_ok()
+            t.validate(&Value::ResourceRef {
+                binding_name: "role".to_string(),
+                attribute_name: "arn".to_string(),
+                resource_type: None,
+            })
+            .is_ok()
         );
     }
 
@@ -814,10 +818,11 @@ mod tests {
         assert!(t.validate(&Value::Int(42)).is_err());
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef(
-                "my_vpc".to_string(),
-                "vpc_id".to_string()
-            ))
+            t.validate(&Value::ResourceRef {
+                binding_name: "my_vpc".to_string(),
+                attribute_name: "vpc_id".to_string(),
+                resource_type: None,
+            })
             .is_ok()
         );
     }
@@ -1210,10 +1215,11 @@ mod tests {
         let t = iam_policy_document();
         // ResourceRef should be accepted (via Custom type handling in schema.rs)
         assert!(
-            t.validate(&Value::ResourceRef(
-                "role".to_string(),
-                "policy".to_string()
-            ))
+            t.validate(&Value::ResourceRef {
+                binding_name: "role".to_string(),
+                attribute_name: "policy".to_string(),
+                resource_type: None,
+            })
             .is_ok()
         );
     }
@@ -1373,8 +1379,12 @@ mod tests {
         );
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef("role".to_string(), "arn".to_string()))
-                .is_ok()
+            t.validate(&Value::ResourceRef {
+                binding_name: "role".to_string(),
+                attribute_name: "arn".to_string(),
+                resource_type: None,
+            })
+            .is_ok()
         );
     }
 
@@ -1417,8 +1427,12 @@ mod tests {
         );
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef("policy".to_string(), "arn".to_string()))
-                .is_ok()
+            t.validate(&Value::ResourceRef {
+                binding_name: "policy".to_string(),
+                attribute_name: "arn".to_string(),
+                resource_type: None,
+            })
+            .is_ok()
         );
     }
 
@@ -1451,8 +1465,12 @@ mod tests {
         );
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef("key".to_string(), "arn".to_string()))
-                .is_ok()
+            t.validate(&Value::ResourceRef {
+                binding_name: "key".to_string(),
+                attribute_name: "arn".to_string(),
+                resource_type: None,
+            })
+            .is_ok()
         );
     }
 
@@ -1507,8 +1525,12 @@ mod tests {
         );
         // ResourceRef should be accepted
         assert!(
-            t.validate(&Value::ResourceRef("key".to_string(), "arn".to_string()))
-                .is_ok()
+            t.validate(&Value::ResourceRef {
+                binding_name: "key".to_string(),
+                attribute_name: "arn".to_string(),
+                resource_type: None,
+            })
+            .is_ok()
         );
     }
 


### PR DESCRIPTION
## Summary

- Remove the tuple-style `ResourceRef(String, String)` variant from the `Value` enum
- Rename `TypedResourceRef` to `ResourceRef` as a struct variant with `binding_name`, `attribute_name`, and `resource_type: Option<ResourceTypePath>`
- Eliminate duplicated match arms across 8 files — every `match` on `Value` previously had to handle both reference variants with identical logic

The net result is **-43 lines** (129 added, 172 removed) with cleaner, non-duplicated pattern matching throughout the codebase.

Closes #188

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — all 375 tests pass
- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)