### PR TITLE
Remove unused resource_type field from Value::ResourceRef

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -4146,7 +4146,6 @@ mod tests {
                 Value::ResourceRef {
                     binding_name: dep.to_string(),
                     attribute_name: "id".to_string(),
-                    resource_type: None,
                 },
             );
         }

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -414,11 +414,8 @@ impl RootConfigSignature {
             Value::ResourceRef {
                 binding_name,
                 attribute_name,
-                resource_type,
             } => {
-                let target_type = resource_type
-                    .clone()
-                    .or_else(|| binding_types.get(binding_name).cloned());
+                let target_type = binding_types.get(binding_name).cloned();
                 graph.add_edge(
                     from.to_string(),
                     TypedDependency {
@@ -829,21 +826,18 @@ impl ModuleSignature {
             Value::ResourceRef {
                 binding_name,
                 attribute_name,
-                resource_type,
             } => {
-                let target_type = resource_type.clone().or_else(|| {
-                    if binding_name == "input" {
-                        input_types.get(attribute_name).and_then(|t| {
-                            if let TypeExpr::Ref(path) = t {
-                                Some(path.clone())
-                            } else {
-                                None
-                            }
-                        })
-                    } else {
-                        binding_types.get(binding_name).cloned()
-                    }
-                });
+                let target_type = if binding_name == "input" {
+                    input_types.get(attribute_name).and_then(|t| {
+                        if let TypeExpr::Ref(path) = t {
+                            Some(path.clone())
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    binding_types.get(binding_name).cloned()
+                };
 
                 graph.add_edge(
                     from.to_string(),

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -309,7 +309,6 @@ mod tests {
                         Value::ResourceRef {
                             binding_name: "input".to_string(),
                             attribute_name: "vpc_id".to_string(),
-                            resource_type: None,
                         },
                     );
                     attrs.insert(
@@ -350,7 +349,6 @@ mod tests {
         let value = Value::ResourceRef {
             binding_name: "input".to_string(),
             attribute_name: "vpc_id".to_string(),
-            resource_type: None,
         };
         let result = substitute_inputs(&value, &inputs);
 
@@ -366,7 +364,6 @@ mod tests {
             Value::ResourceRef {
                 binding_name: "input".to_string(),
                 attribute_name: "port".to_string(),
-                resource_type: None,
             },
             Value::Int(443),
         ]);

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -830,7 +830,6 @@ fn parse_primary_value(
                     Ok(Value::ResourceRef {
                         binding_name: "input".to_string(),
                         attribute_name: parts[1].to_string(),
-                        resource_type: None,
                     })
                 } else if ctx.get_variable(parts[0]).is_some() && !ctx.is_resource_binding(parts[0])
                 {
@@ -847,7 +846,6 @@ fn parse_primary_value(
                     Ok(Value::ResourceRef {
                         binding_name: parts[0].to_string(),
                         attribute_name: parts[1].to_string(),
-                        resource_type: None,
                     })
                 } else {
                     // Unknown 2-part identifier: could be TypeName.value enum shorthand
@@ -888,7 +886,6 @@ fn parse_primary_value(
                     return Ok(Value::ResourceRef {
                         binding_name: "input".to_string(),
                         attribute_name: attr_name.to_string(),
-                        resource_type: None,
                     });
                 }
 
@@ -896,7 +893,6 @@ fn parse_primary_value(
                 Ok(Value::ResourceRef {
                     binding_name: first_ident.to_string(),
                     attribute_name: attr_name.to_string(),
-                    resource_type: None,
                 })
             } else {
                 // Simple variable reference
@@ -1241,7 +1237,6 @@ mod tests {
             Some(&Value::ResourceRef {
                 binding_name: "bucket".to_string(),
                 attribute_name: "name".to_string(),
-                resource_type: None,
             })
         );
     }
@@ -1465,7 +1460,6 @@ mod tests {
             Some(&Value::ResourceRef {
                 binding_name: "input".to_string(),
                 attribute_name: "vpc_id".to_string(),
-                resource_type: None,
             })
         );
     }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -4,8 +4,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::parser::ResourceTypePath;
-
 /// Unique identifier for a resource
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResourceId {
@@ -66,14 +64,12 @@ pub enum Value {
     Bool(bool),
     List(Vec<Value>),
     Map(HashMap<String, Value>),
-    /// Reference to another resource's attribute with optional type information
+    /// Reference to another resource's attribute
     ResourceRef {
         /// Binding name of the referenced resource (e.g., "vpc", "web_sg")
         binding_name: String,
         /// Attribute name being referenced (e.g., "id", "name")
         attribute_name: String,
-        /// Optional resource type for type checking (e.g., aws.vpc)
-        resource_type: Option<ResourceTypePath>,
     },
     /// Unresolved identifier that will be resolved during schema validation
     /// This allows shorthand enum values like `dedicated` to be resolved to
@@ -189,7 +185,6 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::ResourceTypePath;
 
     #[test]
     fn value_serde_round_trip() {
@@ -205,17 +200,14 @@ mod tests {
             Value::ResourceRef {
                 binding_name: "vpc".to_string(),
                 attribute_name: "id".to_string(),
-                resource_type: None,
             },
             Value::ResourceRef {
                 binding_name: "web_sg".to_string(),
                 attribute_name: "id".to_string(),
-                resource_type: Some(ResourceTypePath::new("aws", "security_group")),
             },
             Value::ResourceRef {
                 binding_name: "bucket".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             },
             Value::UnresolvedIdent("dedicated".to_string(), None),
             Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -1204,7 +1204,6 @@ mod tests {
             ipv4.validate(&Value::ResourceRef {
                 binding_name: "vpc".to_string(),
                 attribute_name: "cidr_block".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1214,17 +1213,6 @@ mod tests {
             ipv6.validate(&Value::ResourceRef {
                 binding_name: "subnet".to_string(),
                 attribute_name: "ipv6_cidr".to_string(),
-                resource_type: None,
-            })
-            .is_ok()
-        );
-
-        // ResourceRef with type info should also be accepted
-        assert!(
-            ipv4.validate(&Value::ResourceRef {
-                binding_name: "vpc".to_string(),
-                attribute_name: "cidr_block".to_string(),
-                resource_type: Some(crate::parser::ResourceTypePath::new("aws", "vpc")),
             })
             .is_ok()
         );

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -782,7 +782,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "role".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -821,7 +820,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "my_vpc".to_string(),
                 attribute_name: "vpc_id".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1218,7 +1216,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "role".to_string(),
                 attribute_name: "policy".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1382,7 +1379,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "role".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1430,7 +1426,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "policy".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1468,7 +1463,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "key".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );
@@ -1528,7 +1522,6 @@ mod tests {
             t.validate(&Value::ResourceRef {
                 binding_name: "key".to_string(),
                 attribute_name: "arn".to_string(),
-                resource_type: None,
             })
             .is_ok()
         );


### PR DESCRIPTION
## Summary

- Remove the `resource_type: Option<ResourceTypePath>` field from `Value::ResourceRef` — it was always `None` in production (parser never set it) and never read
- Simplify `module.rs` type resolution to use `binding_types` directly instead of the `or_else` fallback pattern
- Clean up all construction sites across 7 files (remove `resource_type: None` boilerplate)

Closes #252

## Test plan

- [x] `cargo build` compiles cleanly with no warnings
- [x] All tests pass (`cargo test`)
- [x] Pre-commit hooks pass (formatting, clippy, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)