### PR TITLE
Move resolve_enum_identifiers() and restore_create_only_attrs() to Provider layer

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -15,8 +15,10 @@ pub mod schemas;
 // Re-export main types
 pub use provider::AwsccProvider;
 
+use std::collections::HashMap;
+
 use carina_core::provider::{BoxFuture, Provider, ProviderResult};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State};
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 
 use resources::resource_types;
 
@@ -74,5 +76,17 @@ impl Provider for AwsccProvider {
         let identifier = identifier.to_string();
         let lifecycle = lifecycle.clone();
         Box::pin(async move { self.delete_resource(&id, &identifier, &lifecycle).await })
+    }
+
+    fn resolve_enum_identifiers(&self, resources: &mut [Resource]) {
+        crate::provider::resolve_enum_identifiers_impl(resources);
+    }
+
+    fn restore_create_only_attrs(
+        &self,
+        current_states: &mut HashMap<ResourceId, State>,
+        saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
+    ) {
+        crate::provider::restore_create_only_attrs_impl(current_states, saved_attrs);
     }
 }


### PR DESCRIPTION
## Summary

- Move `resolve_enum_identifiers()` and `restore_create_only_attrs_from_state()` from CLI to the Provider trait, making CLI provider-agnostic
- Add default no-op implementations so non-AWSCC providers (AwsProvider, FileProvider, etc.) need no changes
- Add `build_saved_attrs_from_state()` helper in CLI to convert `StateFile` to the provider-agnostic `HashMap` format

Closes #185

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo test` — all 385 tests pass
- [x] Pre-commit hooks (fmt, clippy, tests) all pass
- [x] New tests for `resolve_enum_identifiers_impl` (bare ident, TypeName.value, skips non-awscc)
- [x] New tests for `restore_create_only_attrs_impl` (basic restoration, skips non-awscc, skips already-present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)