### PR TITLE
Ensure resource cleanup even when apply fails mid-way

### DIFF
--- a/carina-provider-awscc/acceptance-tests/run-tests.sh
+++ b/carina-provider-awscc/acceptance-tests/run-tests.sh
@@ -126,7 +126,7 @@ if [ "$COMMAND" = "cleanup" ]; then
                 DESTROY_OUTPUT=$(cd "$STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$TEST_FILE" 2>&1)
                 DESTROY_RC=$?
                 if [ $DESTROY_RC -eq 0 ]; then
-                    if echo "$DESTROY_OUTPUT" | grep -q "No changes"; then
+                    if echo "$DESTROY_OUTPUT" | grep -q "No resources to destroy"; then
                         SKIPPED=$((SKIPPED + 1))
                     else
                         echo "DESTROYED $REL_PATH"


### PR DESCRIPTION
## Summary

- Add `trap` handlers in worker subshells to attempt `destroy` on SIGINT/SIGTERM, ensuring partially created resources are cleaned up even when tests are interrupted mid-way
- Add signal forwarding in the main process to propagate interrupts to all worker processes and wait for their cleanup to complete
- Add new `cleanup` command that runs `destroy` across all 10 accounts in parallel, allowing recovery from stuck states where orphaned resources remain from previous failed runs

## Changes

### Worker signal handling (`full` command)
- Each worker subshell now tracks `CURRENT_TEST_FILE` — the test currently being processed
- A `worker_cleanup` trap on INT/TERM attempts `destroy` for the current test before the worker exits
- After each long-running operation (apply, plan), the worker checks an `INTERRUPTED` flag and breaks out of the loop early

### Main process signal handling (`full` command)
- `cleanup_main` trap on INT/TERM forwards SIGTERM to all worker PIDs, then waits for them to finish cleanup before exiting

### New `cleanup` command
- `run-tests.sh cleanup [filter]` runs `destroy` across all 10 accounts in parallel
- Each account attempts to destroy all matching tests (since we don't know which account created which resources)
- Reports per-account results: resources destroyed vs already clean

## Test plan

- [ ] Run `run-tests.sh full` with a small filter and verify normal operation is unchanged
- [ ] Run `run-tests.sh full` and press Ctrl+C mid-test to verify workers attempt destroy before exiting
- [ ] Run `run-tests.sh cleanup` to verify it runs destroy across all accounts

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)