### PR TITLE
Add type compatibility for resource reference type checking

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -20,6 +20,7 @@ use carina_core::schema::ResourceSchema;
 use carina_core::schema::validate_cidr;
 use carina_provider_aws::schemas;
 use carina_provider_awscc::AwsccProvider;
+use carina_provider_awscc::schemas::awscc_types::are_custom_types_compatible;
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
     StateFile, create_backend, create_local_backend,
@@ -363,11 +364,15 @@ fn validate_resource_ref_types(resources: &[Resource]) -> Result<(), String> {
             // Type compatibility check:
             // - Same type -> OK
             // - Either is "String" -> OK (String is the base type for Custom types)
+            // - Types in the same family -> OK (e.g., Arn and IamRoleArn)
             // - Different Custom types -> Error
             if expected_type_name == ref_type_name {
                 continue;
             }
             if expected_type_name == "String" || ref_type_name == "String" {
+                continue;
+            }
+            if are_custom_types_compatible(&expected_type_name, &ref_type_name) {
                 continue;
             }
 

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -7,7 +7,7 @@ use carina_core::parser::{InputParameter, ParseError, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
 use carina_core::schema::{validate_cidr, validate_ipv6_cidr};
 use carina_provider_aws::schemas::{s3, types as aws_types, vpc};
-use carina_provider_awscc::schemas::awscc_types;
+use carina_provider_awscc::schemas::awscc_types::{self, are_custom_types_compatible};
 use carina_provider_awscc::schemas::generated::flow_log as awscc_flow_log;
 use carina_provider_awscc::schemas::generated::nat_gateway as awscc_nat_gateway;
 use carina_provider_awscc::schemas::generated::security_group as awscc_security_group;
@@ -226,6 +226,10 @@ impl DiagnosticEngine {
                                                 ref_attr_schema.attr_type.type_name();
                                             if ref_type_name != *expected_name
                                                 && ref_type_name != "String"
+                                                && !are_custom_types_compatible(
+                                                    expected_name,
+                                                    &ref_type_name,
+                                                )
                                             {
                                                 Some(format!(
                                                     "Type mismatch: expected {}, got {} (from {}.{})",


### PR DESCRIPTION
## Summary

- Add `are_custom_types_compatible()` function that recognizes type families for resource reference checking
- ARN family: `Arn`, `IamRoleArn`, `IamPolicyArn`, `KmsKeyArn` are compatible with each other
- Resource ID family: `AwsResourceId`, `VpcId`, `SubnetId`, `InternetGatewayId`, etc. are compatible with each other
- Updated both CLI validation and LSP diagnostics to use the compatibility check

Closes #260

## Test plan

- [x] Unit tests for `are_custom_types_compatible()` covering same-family, cross-family, and unknown types
- [x] `cargo run --bin carina -- validate` passes for `ec2_flow_log/cloudwatch.crn` (the failing case from #260)
- [x] `cargo run --bin carina -- validate` passes for `ec2_route/igw.crn` (related #158 case)
- [x] Existing `resource_ref_type_mismatch` LSP test still correctly rejects `AwsResourceId` where `IpamPoolId` is expected
- [x] All 386 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)