### PR TITLE
Add `all` alias for IpProtocol `-1` enum value

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -237,6 +237,14 @@ impl CompletionProvider {
             ("aws.security_group", "security_group"),
             // awscc resources
             ("awscc.ec2_vpc", "awscc.ec2_vpc"),
+            (
+                "awscc.ec2_security_group_ingress",
+                "awscc.ec2_security_group_ingress",
+            ),
+            (
+                "awscc.ec2_security_group_egress",
+                "awscc.ec2_security_group_egress",
+            ),
             ("awscc.ec2_security_group", "awscc.ec2_security_group"),
             ("awscc.ec2_flow_log", "awscc.ec2_flow_log"),
             ("awscc.ec2_nat_gateway", "awscc.ec2_nat_gateway"),
@@ -746,6 +754,9 @@ impl CompletionProvider {
             AttributeType::Custom { name, .. } if name == "InstanceTenancy" => {
                 self.instance_tenancy_completions(resource_type)
             }
+            AttributeType::Custom { name, .. } if name == "IpProtocol" => {
+                self.ip_protocol_completions(resource_type)
+            }
             AttributeType::String | AttributeType::Custom { .. } => {
                 vec![CompletionItem {
                     label: "env".to_string(),
@@ -1035,6 +1046,28 @@ impl CompletionProvider {
                 ..Default::default()
             },
         ]
+    }
+
+    fn ip_protocol_completions(&self, resource_type: &str) -> Vec<CompletionItem> {
+        let prefix = format!("{}.IpProtocol", resource_type);
+        let protocols = vec![
+            ("tcp", "Transmission Control Protocol"),
+            ("udp", "User Datagram Protocol"),
+            ("icmp", "Internet Control Message Protocol"),
+            ("icmpv6", "Internet Control Message Protocol v6"),
+            ("all", "All protocols (-1)"),
+        ];
+
+        protocols
+            .into_iter()
+            .map(|(code, description)| CompletionItem {
+                label: format!("{}.{}", prefix, code),
+                kind: Some(CompletionItemKind::ENUM_MEMBER),
+                detail: Some(description.to_string()),
+                insert_text: Some(format!("{}.{}", prefix, code)),
+                ..Default::default()
+            })
+            .collect()
     }
 
     fn ref_type_completions(&self) -> Vec<CompletionItem> {

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -18,6 +18,6 @@ let sg = awscc.ec2_security_group {
 let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound"
-  ip_protocol = "-1"
+  ip_protocol = all
   cidr_ip     = "0.0.0.0/0"
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -18,6 +18,6 @@ let sg = awscc.ec2_security_group {
 let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all IPv6 outbound"
-  ip_protocol = "-1"
+  ip_protocol = all
   cidr_ipv6   = "::/0"
 }

--- a/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
@@ -19,6 +19,6 @@ let sg = awscc.ec2_security_group {
 let egress = awscc.ec2_security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound traffic"
-  ip_protocol = "-1"
+  ip_protocol = all
   cidr_ip     = "0.0.0.0/0"
 }

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -182,6 +182,26 @@ cat >> "$OUTPUT_DIR/mod.rs" << 'EOF'
     }
     None
 }
+
+/// Maps DSL alias values back to canonical AWS values.
+/// Dispatches to per-module enum_alias_reverse() functions.
+pub fn get_enum_alias_reverse(resource_type: &str, attr_name: &str, value: &str) -> Option<&'static str> {
+EOF
+
+# Add enum_alias_reverse() dispatches dynamically
+for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
+    MODNAME=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-module-name)
+    FULL_RESOURCE=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-full-resource-name)
+    cat >> "$OUTPUT_DIR/mod.rs" << INNEREOF
+    if resource_type == "${FULL_RESOURCE}" {
+        return ${MODNAME}::enum_alias_reverse(attr_name, value);
+    }
+INNEREOF
+done
+
+cat >> "$OUTPUT_DIR/mod.rs" << 'EOF'
+    None
+}
 EOF
 
 echo ""

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -1836,4 +1836,89 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Expected string");
     }
+
+    #[test]
+    fn validate_ip_protocol_alias_all() {
+        // "all" should be accepted as a valid IpProtocol value (alias for "-1")
+        let valid_values = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+        let result = validate_namespaced_enum(
+            &Value::String("all".to_string()),
+            "IpProtocol",
+            "awscc.ec2_security_group_egress",
+            valid_values,
+        );
+        assert!(result.is_ok(), "all should be accepted: {:?}", result);
+    }
+
+    #[test]
+    fn validate_ip_protocol_canonical_minus_one() {
+        // "-1" should still be accepted
+        let valid_values = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+        let result = validate_namespaced_enum(
+            &Value::String("-1".to_string()),
+            "IpProtocol",
+            "awscc.ec2_security_group_egress",
+            valid_values,
+        );
+        assert!(result.is_ok(), "-1 should still be accepted: {:?}", result);
+    }
+
+    #[test]
+    fn validate_ip_protocol_namespaced_all() {
+        // Full namespaced form: awscc.ec2_security_group_egress.IpProtocol.all
+        let valid_values = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+        let result = validate_namespaced_enum(
+            &Value::String("awscc.ec2_security_group_egress.IpProtocol.all".to_string()),
+            "IpProtocol",
+            "awscc.ec2_security_group_egress",
+            valid_values,
+        );
+        assert!(
+            result.is_ok(),
+            "Namespaced all should be accepted: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn auto_generated_get_enum_alias_reverse() {
+        use crate::schemas::generated::get_enum_alias_reverse;
+        // "all" maps to "-1" for ip_protocol on security_group_egress
+        assert_eq!(
+            get_enum_alias_reverse("ec2_security_group_egress", "ip_protocol", "all"),
+            Some("-1")
+        );
+        // "all" maps to "-1" for ip_protocol on security_group_ingress
+        assert_eq!(
+            get_enum_alias_reverse("ec2_security_group_ingress", "ip_protocol", "all"),
+            Some("-1")
+        );
+        // "tcp" has no alias mapping
+        assert_eq!(
+            get_enum_alias_reverse("ec2_security_group_egress", "ip_protocol", "tcp"),
+            None
+        );
+        // Unknown resource has no alias mapping
+        assert_eq!(
+            get_enum_alias_reverse("ec2_vpc", "instance_tenancy", "default"),
+            None
+        );
+    }
+
+    #[test]
+    fn auto_generated_ip_protocol_valid_values_include_all() {
+        use crate::schemas::generated::get_enum_valid_values;
+        // VALID_IP_PROTOCOL should include "all" as an alias
+        let values = get_enum_valid_values("ec2_security_group_egress", "ip_protocol").unwrap();
+        assert!(
+            values.contains(&"all"),
+            "VALID_IP_PROTOCOL should include 'all', got: {:?}",
+            values
+        );
+        assert!(
+            values.contains(&"-1"),
+            "VALID_IP_PROTOCOL should still include '-1', got: {:?}",
+            values
+        );
+    }
 }

--- a/carina-provider-awscc/src/schemas/generated/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/bucket.rs
@@ -726,3 +726,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/egress_only_internet_gateway.rs
@@ -47,3 +47,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_egress_only_internet_gateway", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/eip.rs
@@ -100,3 +100,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_eip", &[("domain", VALID_DOMAIN)])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/flow_log.rs
@@ -198,3 +198,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/internet_gateway.rs
@@ -36,3 +36,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_internet_gateway", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam.rs
@@ -160,3 +160,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ipam_pool.rs
@@ -299,3 +299,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/log_group.rs
@@ -106,3 +106,10 @@ pub fn enum_valid_values() -> (
         &[("log_group_class", VALID_LOG_GROUP_CLASS)],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -116,3 +116,85 @@ pub fn get_enum_valid_values(
     }
     None
 }
+
+/// Maps DSL alias values back to canonical AWS values.
+/// Dispatches to per-module enum_alias_reverse() functions.
+pub fn get_enum_alias_reverse(
+    resource_type: &str,
+    attr_name: &str,
+    value: &str,
+) -> Option<&'static str> {
+    if resource_type == "ec2_vpc" {
+        return vpc::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_subnet" {
+        return subnet::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_internet_gateway" {
+        return internet_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_route_table" {
+        return route_table::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_route" {
+        return route::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_subnet_route_table_association" {
+        return subnet_route_table_association::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_eip" {
+        return eip::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_nat_gateway" {
+        return nat_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_security_group" {
+        return security_group::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_security_group_ingress" {
+        return security_group_ingress::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_security_group_egress" {
+        return security_group_egress::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_vpc_endpoint" {
+        return vpc_endpoint::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_vpc_gateway_attachment" {
+        return vpc_gateway_attachment::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_flow_log" {
+        return flow_log::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_ipam" {
+        return ipam::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_ipam_pool" {
+        return ipam_pool::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_vpn_gateway" {
+        return vpn_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_transit_gateway" {
+        return transit_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_vpc_peering_connection" {
+        return vpc_peering_connection::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_egress_only_internet_gateway" {
+        return egress_only_internet_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2_transit_gateway_attachment" {
+        return transit_gateway_attachment::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "s3_bucket" {
+        return bucket::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "iam_role" {
+        return role::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "logs_log_group" {
+        return log_group::enum_alias_reverse(attr_name, value);
+    }
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/nat_gateway.rs
@@ -180,3 +180,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/role.rs
@@ -109,3 +109,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("iam_role", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/route.rs
@@ -110,3 +110,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_route", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/route_table.rs
@@ -43,3 +43,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_route_table", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group.rs
@@ -145,3 +145,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_security_group", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/security_group_ingress.rs
@@ -9,7 +9,7 @@ use super::validate_namespaced_enum;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1"];
+const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
 fn validate_ip_protocol(value: &Value) -> Result<(), String> {
     validate_namespaced_enum(
@@ -111,7 +111,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 base: Box::new(AttributeType::String),
                 validate: validate_ip_protocol,
                 namespace: Some("awscc.ec2_security_group_ingress".to_string()),
-                to_dsl: Some(|s: &str| s.replace('-', "_")),
+                to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             })
                 .required()
                 .create_only()
@@ -166,4 +166,13 @@ pub fn enum_valid_values() -> (
         "ec2_security_group_ingress",
         &[("ip_protocol", VALID_IP_PROTOCOL)],
     )
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    match (attr_name, value) {
+        ("ip_protocol", "all") => Some("-1"),
+        _ => None,
+    }
 }

--- a/carina-provider-awscc/src/schemas/generated/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet.rs
@@ -191,3 +191,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_subnet", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/subnet_route_table_association.rs
@@ -44,3 +44,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_subnet_route_table_association", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway.rs
@@ -350,3 +350,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/transit_gateway_attachment.rs
@@ -65,3 +65,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_transit_gateway_attachment", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc.rs
@@ -133,3 +133,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_vpc", &[("instance_tenancy", VALID_INSTANCE_TENANCY)])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_endpoint.rs
@@ -193,3 +193,10 @@ pub fn enum_valid_values() -> (
         ],
     )
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_gateway_attachment.rs
@@ -47,3 +47,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_vpc_gateway_attachment", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpc_peering_connection.rs
@@ -67,3 +67,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_vpc_peering_connection", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/vpn_gateway.rs
@@ -49,3 +49,10 @@ pub fn enum_valid_values() -> (
 ) {
     ("ec2_vpn_gateway", &[])
 }
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -83,7 +83,7 @@ If the protocol is TCP or UDP, this is the end of the port range. If the protoco
 | `udp` | `awscc.ec2_security_group_egress.IpProtocol.udp` |
 | `icmp` | `awscc.ec2_security_group_egress.IpProtocol.icmp` |
 | `icmpv6` | `awscc.ec2_security_group_egress.IpProtocol.icmpv6` |
-| `-1` | `awscc.ec2_security_group_egress.IpProtocol._1` |
+| `-1` | `awscc.ec2_security_group_egress.IpProtocol.all` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
 

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -100,7 +100,7 @@ The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A v
 | `udp` | `awscc.ec2_security_group_ingress.IpProtocol.udp` |
 | `icmp` | `awscc.ec2_security_group_ingress.IpProtocol.icmp` |
 | `icmpv6` | `awscc.ec2_security_group_ingress.IpProtocol.icmpv6` |
-| `-1` | `awscc.ec2_security_group_ingress.IpProtocol._1` |
+| `-1` | `awscc.ec2_security_group_ingress.IpProtocol.all` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
 


### PR DESCRIPTION
## Summary

- Allow `ip_protocol = all` as a human-readable alias for `-1` (all protocols) on `ec2_security_group_ingress` and `ec2_security_group_egress` resources
- Add registry-based enum alias system in codegen (`known_enum_aliases()`)
- Generate per-module `enum_alias_reverse()` functions and dispatcher in `mod.rs`
- Update `dsl_value_to_aws()` write path to resolve aliases back to canonical AWS values
- Update `to_dsl` closures so plan output shows `IpProtocol.all` instead of `IpProtocol._1`
- Add IpProtocol completions in LSP with `all` option
- Add `ec2_security_group_ingress`/`ec2_security_group_egress` to LSP resource type detection
- Backward compatible: `ip_protocol = "-1"` still works
- Created follow-up issue #267 for struct field enum alias support (inline ingress/egress in `ec2_security_group`)

Closes #266

## Test plan

- [x] `cargo test` - all existing + new tests pass (9 new tests added)
- [x] `cargo run -- validate` with `ip_protocol = all` succeeds
- [x] Backward compat: `ip_protocol = "-1"` still validates
- [ ] Run acceptance tests: `run-tests.sh full security_group_egress`

🤖 Generated with [Claude Code](https://claude.com/claude-code)