### PR TITLE
Make schema key formatting provider-agnostic via ProviderFactory trait

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -184,6 +184,12 @@ pub trait ProviderFactory: Send + Sync {
 
     /// Get all resource schemas for this provider.
     fn schemas(&self) -> Vec<crate::schema::ResourceSchema>;
+
+    /// Format a schema lookup key from a resource type.
+    /// Default: prepends provider name (e.g., "awscc" + "ec2_vpc" → "awscc.ec2_vpc").
+    fn format_schema_key(&self, resource_type: &str) -> String {
+        format!("{}.{}", self.name(), resource_type)
+    }
 }
 
 /// Provider implementation for Box<dyn Provider>

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -67,6 +67,10 @@ impl ProviderFactory for AwsProviderFactory {
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
         schemas::all_schemas()
     }
+
+    fn format_schema_key(&self, resource_type: &str) -> String {
+        resource_type.to_string()
+    }
 }
 
 /// S3 Bucket resource type


### PR DESCRIPTION
## Summary

- Add `format_schema_key()` method to `ProviderFactory` trait with a default implementation that prepends provider name (e.g., `"awscc"` + `"ec2_vpc"` → `"awscc.ec2_vpc"`)
- Override in `AwsProviderFactory` to return resource type as-is (no prefix)
- Replace 5 hardcoded `provider != "aws"` / `provider == "aws"` checks in `carina-cli/src/main.rs` with a `schema_key_for_resource()` helper

Closes #272

## Test plan

- [x] `cargo build` compiles successfully
- [x] `cargo test` — all 399 tests pass
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Verified no remaining hardcoded provider name checks for schema key construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)