### PR TITLE
Add AWS provider documentation to site navigation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,18 @@
 
 # Providers
 
+- [AWS Provider](providers/aws/index.md)
+  - [EC2]()
+    - [aws.ec2_vpc](providers/aws/ec2_vpc.md)
+    - [aws.ec2_subnet](providers/aws/ec2_subnet.md)
+    - [aws.ec2_internet_gateway](providers/aws/ec2_internet_gateway.md)
+    - [aws.ec2_route_table](providers/aws/ec2_route_table.md)
+    - [aws.ec2_route](providers/aws/ec2_route.md)
+    - [aws.ec2_security_group](providers/aws/ec2_security_group.md)
+    - [aws.ec2_security_group_ingress](providers/aws/ec2_security_group_ingress.md)
+    - [aws.ec2_security_group_egress](providers/aws/ec2_security_group_egress.md)
+  - [S3]()
+    - [aws.s3_bucket](providers/aws/s3_bucket.md)
 - [AWSCC Provider](providers/awscc/index.md)
   - [EC2]()
     - [awscc.ec2_vpc](providers/awscc/ec2_vpc.md)

--- a/docs/src/providers/aws/index.md
+++ b/docs/src/providers/aws/index.md
@@ -1,0 +1,44 @@
+# AWS Provider
+
+The `aws` provider manages AWS resources through native AWS SDK APIs (EC2, S3).
+
+## Configuration
+
+```crn
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+```
+
+## Usage
+
+Resources are defined using the `aws.<resource_type>` syntax:
+
+```crn
+let vpc = aws.ec2_vpc {
+  name       = "my-vpc"
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Environment = "production"
+  }
+}
+```
+
+Named resources (using `let`) can be referenced by other resources:
+
+```crn
+let subnet = aws.ec2_subnet {
+  name              = "my-subnet"
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+```
+
+## Enum Values
+
+Some attributes accept enum values. These can be specified in three formats:
+
+- **Bare value**: `instance_tenancy = default`
+- **TypeName.value**: `instance_tenancy = InstanceTenancy.default`
+- **Full namespace**: `instance_tenancy = aws.ec2_vpc.InstanceTenancy.default`


### PR DESCRIPTION
## Summary
- Add `index.md` for the AWS provider with configuration and usage examples
- Add all 9 existing AWS provider doc pages (EC2 and S3 resources) to `docs/src/SUMMARY.md`
- AWS provider now appears in the documentation site navigation alongside AWSCC

Closes #283

## Test plan
- [x] `mdbook build` succeeds
- [ ] Verify the AWS provider section appears in the documentation site navigation
- [ ] Verify all 9 resource pages are accessible from the navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)