### PR TITLE
Fix sidebar to show resource types on AWS provider pages

### DIFF
--- a/docs/theme/sidebar-filter.js
+++ b/docs/theme/sidebar-filter.js
@@ -102,6 +102,9 @@
             }
         });
 
+        // Remove empty categories (from other providers' sections in the TOC)
+        links = links.filter(function (cat) { return cat.resources.length > 0; });
+
         // Build header (title + filter) outside scrollbox
         var header = document.createElement("div");
         header.className = "sidebar-header";


### PR DESCRIPTION
## Summary
- The sidebar JS (`sidebar-filter.js`) was hardcoded for AWSCC only — AWS provider pages were treated as non-provider pages, hiding all nested resource items
- Extract a `detectProvider()` function that recognizes both `/providers/awscc/` and `/providers/aws/` paths
- Make `setupProviderSidebar()` use the detected provider info instead of hardcoded AWSCC values
- `detectProvider()` checks `awscc` before `aws` since `/providers/awscc/` contains `/providers/aws/` as a substring

Closes #283

## Test plan
- [ ] Visit https://carina-rs.github.io/providers/aws/index.html — sidebar should show "AWS" title with EC2 and S3 categories and resource links
- [ ] Visit https://carina-rs.github.io/providers/awscc/index.html — sidebar should still show "AWSCC" title with all resource links (no regression)
- [ ] Visit https://carina-rs.github.io/introduction.html — sidebar should show top-level providers only (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)