### PR TITLE
Add Float(f64) support to fix silent truncation

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -67,7 +67,7 @@ type_expr = {
     type_ref | type_list | type_map | type_primitive
 }
 
-type_primitive = @{ "string" | "bool" | "int" | "cidr" }
+type_primitive = @{ "string" | "bool" | "int" | "float" | "cidr" }
 
 type_list = { kw_list ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ close_paren }
 
@@ -110,6 +110,7 @@ primary = {
   | map
   | namespaced_id
   | boolean
+  | float
   | number
   | string
   | variable_ref
@@ -144,6 +145,7 @@ variable_ref = { identifier ~ ("." ~ identifier)? }
 
 // Literals
 boolean = { "true" | "false" }
+float = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
 number = @{ "-"? ~ ASCII_DIGIT+ }
 string = ${ "\"" ~ inner_string ~ "\"" }
 inner_string = @{ char* }

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -123,6 +123,7 @@ impl<'a> CstBuilder<'a> {
             }
             Rule::identifier => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::string => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::float => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::number => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::boolean => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::inner_string | Rule::char => None,

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -126,6 +126,14 @@ fn format_value(value: &Value) -> String {
             }
         }
         Value::Int(n) => n.to_string(),
+        Value::Float(f) => {
+            let s = f.to_string();
+            if s.contains('.') {
+                s
+            } else {
+                format!("{}.0", s)
+            }
+        }
         Value::Bool(b) => b.to_string(),
         Value::List(items) => {
             if items.is_empty() {

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -25,9 +25,9 @@ output_param = {
     identifier ~ ":" ~ type_expr ~ ("=" ~ expression)?
 }
 
-// Type expression: string, bool, int, list(type), map(type), ref(resource_type)
+// Type expression: string, bool, int, float, list(type), map(type), ref(resource_type)
 type_expr = { type_ref | type_generic | type_simple }
-type_simple = @{ "string" | "bool" | "int" | "cidr" }
+type_simple = @{ "string" | "bool" | "int" | "float" | "cidr" }
 type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
 type_ref = { "ref" ~ "(" ~ resource_type_path ~ ")" }
 resource_type_path = @{ identifier ~ ("." ~ identifier)+ }
@@ -93,6 +93,7 @@ primary = {
   | map
   | namespaced_id
   | boolean
+  | float
   | number
   | string
   | variable_ref
@@ -122,6 +123,7 @@ variable_ref = { identifier ~ ("." ~ identifier)? }
 
 // Literals
 boolean = { "true" | "false" }
+float = @{ "-"? ~ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
 number = @{ "-"? ~ ASCII_DIGIT+ }
 string = ${ "\"" ~ inner_string ~ "\"" }
 inner_string = @{ char* }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -61,6 +61,7 @@ impl std::fmt::Display for ResourceId {
 pub enum Value {
     String(String),
     Int(i64),
+    Float(f64),
     Bool(bool),
     List(Vec<Value>),
     Map(HashMap<String, Value>),
@@ -191,6 +192,8 @@ mod tests {
         let values = vec![
             Value::String("hello".to_string()),
             Value::Int(42),
+            Value::Float(2.5),
+            Value::Float(-0.5),
             Value::Bool(true),
             Value::List(vec![Value::String("a".to_string()), Value::Int(1)]),
             Value::Map(HashMap::from([

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -741,6 +741,9 @@ impl CompletionProvider {
             AttributeType::Int => {
                 vec![] // No specific completions for integers
             }
+            AttributeType::Float => {
+                vec![] // No specific completions for floats
+            }
             AttributeType::Custom { name, .. } if name == "Cidr" || name == "Ipv4Cidr" => {
                 self.cidr_completions()
             }
@@ -1240,6 +1243,7 @@ impl CompletionProvider {
             parser::TypeExpr::String => "string".to_string(),
             parser::TypeExpr::Bool => "bool".to_string(),
             parser::TypeExpr::Int => "int".to_string(),
+            parser::TypeExpr::Float => "float".to_string(),
             parser::TypeExpr::Cidr => "cidr".to_string(),
             parser::TypeExpr::List(inner) => format!("list({})", self.format_type_expr(inner)),
             parser::TypeExpr::Map(inner) => format!("map({})", self.format_type_expr(inner)),

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -231,6 +231,13 @@ impl DiagnosticEngine {
                                         s
                                     ))
                                 }
+                                // Float type should not receive String
+                                (carina_core::schema::AttributeType::Float, Value::String(s)) => {
+                                    Some(format!(
+                                        "Type mismatch: expected Float, got String \"{}\".",
+                                        s
+                                    ))
+                                }
                                 // ResourceRef type check for Custom types
                                 (
                                     carina_core::schema::AttributeType::Custom {
@@ -582,6 +589,9 @@ impl DiagnosticEngine {
                             (carina_core::schema::AttributeType::Int, Value::String(s)) => Some(
                                 format!("Type mismatch: expected Int, got String \"{}\".", s),
                             ),
+                            (carina_core::schema::AttributeType::Float, Value::String(s)) => Some(
+                                format!("Type mismatch: expected Float, got String \"{}\".", s),
+                            ),
                             // Custom types with Int base (e.g., ranged integers)
                             (
                                 carina_core::schema::AttributeType::Custom { base, .. },
@@ -589,6 +599,16 @@ impl DiagnosticEngine {
                             ) if matches!(**base, carina_core::schema::AttributeType::Int) => Some(
                                 format!("Type mismatch: expected Int, got String \"{}\".", s),
                             ),
+                            // Custom types with Float base (e.g., ranged floats)
+                            (
+                                carina_core::schema::AttributeType::Custom { base, .. },
+                                Value::String(s),
+                            ) if matches!(**base, carina_core::schema::AttributeType::Float) => {
+                                Some(format!(
+                                    "Type mismatch: expected Float, got String \"{}\".",
+                                    s
+                                ))
+                            }
                             _ => None,
                         };
 
@@ -995,6 +1015,11 @@ impl DiagnosticEngine {
             // Int type validation
             (TypeExpr::Int, Value::String(s)) => Some(format!(
                 "Type mismatch: expected int, got string \"{}\".",
+                s
+            )),
+            // Float type validation
+            (TypeExpr::Float, Value::String(s)) => Some(format!(
+                "Type mismatch: expected float, got string \"{}\".",
                 s
             )),
             _ => None,

--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -835,7 +835,7 @@ fn resolve_type(
             }
         }
         Some(ShapeKind::Float) | Some(ShapeKind::Double) => {
-            ("AttributeType::Int".to_string(), None)
+            ("AttributeType::Float".to_string(), None)
         }
         Some(ShapeKind::Enum) => {
             // Get enum values from Smithy model
@@ -1557,7 +1557,7 @@ fn type_display_string_md<'a>(
                 "Int".to_string()
             }
         }
-        Some(ShapeKind::Float) | Some(ShapeKind::Double) => "Int".to_string(),
+        Some(ShapeKind::Float) | Some(ShapeKind::Double) => "Float".to_string(),
         Some(ShapeKind::Enum) => {
             if let Some(values) = model.enum_values(target) {
                 let type_name = field_name.to_string();

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -756,7 +756,7 @@ impl AwsccProvider {
                 if let Some(i) = n.as_i64() {
                     Some(Value::Int(i))
                 } else {
-                    n.as_f64().map(|f| Value::Int(f as i64))
+                    n.as_f64().map(Value::Float)
                 }
             }
             serde_json::Value::Array(arr) => {
@@ -881,6 +881,7 @@ impl AwsccProvider {
             Value::String(s) => Some(json!(s)),
             Value::Bool(b) => Some(json!(b)),
             Value::Int(i) => Some(json!(i)),
+            Value::Float(f) => Some(json!(f)),
             Value::List(items) => {
                 let arr: Vec<serde_json::Value> =
                     items.iter().filter_map(|v| self.value_to_json(v)).collect();


### PR DESCRIPTION
## Summary

- Fix silent truncation of floating-point numbers in AWSCC provider's `json_to_value()` which used `n.as_f64().map(|f| Value::Int(f as i64))`
- Add `Value::Float(f64)` variant and `AttributeType::Float` across the entire stack
- CF codegen now maps `"number"` to `AttributeType::Float` and `"integer"` to `AttributeType::Int`
- Smithy codegen maps `Float`/`Double` shapes to `AttributeType::Float`
- Float formatting preserves decimal point for whole numbers (`1.0`, not `1`)

## Test plan

- [x] `cargo build` succeeds
- [x] All 424 tests pass across all crates
- [x] Pre-commit checks pass (formatting, clippy, tests)
- [x] Parser correctly parses float literals (`2.5`, `-0.5`)
- [x] `AttributeType::Float` accepts both `Value::Float` and `Value::Int`
- [x] `AttributeType::Int` rejects `Value::Float` (strict typing preserved)
- [x] Serde round-trip works for Float values
- [x] Schemas regenerated (no diff — current CF schemas use "integer" not "number")

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)