### PR TITLE
Fix LSP schema lookup for S3 bucket key format mismatch

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -234,7 +234,7 @@ impl CompletionProvider {
                 "aws.ec2_security_group_egress",
             ),
             ("aws.ec2_security_group", "aws.ec2_security_group"),
-            ("aws.s3_bucket", "aws.s3_bucket"),
+            ("aws.s3.bucket", "aws.s3.bucket"),
             // awscc resources
             ("awscc.ec2_vpc", "awscc.ec2_vpc"),
             (


### PR DESCRIPTION
## Summary

- Fix `valid_resource_types` and `get_schema_for_type()` in diagnostics.rs to use `"aws.s3.bucket"` (dot notation) matching the parser output, instead of `"aws.s3_bucket"` (underscore format) which silently failed
- Fix `extract_resource_type()` in completion.rs to match DSL text `aws.s3.bucket` correctly
- Add test verifying S3 bucket schema lookup works with dot notation (resource type recognized, unknown attributes detected)

Closes #134

## Test plan

- [x] New test `s3_bucket_schema_lookup_with_dot_notation` verifies resource type is recognized and attribute validation works
- [x] All existing LSP tests pass (26 unit + 4 integration)
- [x] Full test suite passes (all crates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)