### PR TITLE
Support create_before_destroy lifecycle option (#150)

### DIFF
--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -263,7 +263,13 @@ fn format_effect_brief(effect: &Effect) -> String {
     match effect {
         Effect::Create(r) => format!("+ {}", r.id),
         Effect::Update { id, .. } => format!("~ {}", id),
-        Effect::Replace { id, .. } => format!("-/+ {}", id),
+        Effect::Replace { id, lifecycle, .. } => {
+            if lifecycle.create_before_destroy {
+                format!("+/- {}", id)
+            } else {
+                format!("-/+ {}", id)
+            }
+        }
         Effect::Delete { id, .. } => format!("- {}", id),
         Effect::Read { resource } => format!("<= {} (data source)", resource.id),
     }


### PR DESCRIPTION
## Summary

- Add `create_before_destroy` lifecycle option to reverse the default replace ordering: create the new resource first, then delete the old one
- Avoids downtime for resources that other resources depend on
- Plan display shows `+/-` (create-before-destroy) vs `-/+` (default delete-then-create)

Closes #150

## Changes

- **`carina-core/src/resource.rs`**: Add `create_before_destroy: bool` to `LifecycleConfig`
- **`carina-core/src/parser/mod.rs`**: Parse `create_before_destroy` in `extract_lifecycle_config()`
- **`carina-core/src/interpreter.rs`**: Branch execution order in `Effect::Replace` based on lifecycle flag
- **`carina-core/src/plan.rs`**: Show `+/-` vs `-/+` in `format_effect_brief()`
- **`carina-cli/src/main.rs`**: Update both apply loops, plan symbol, plan header, and `format_effect()`
- **`carina-core/src/differ.rs`**: Test that lifecycle config propagates to Replace effect

## DSL Syntax

```crn
let vpc = awscc.ec2.vpc {
  cidr_block = "10.0.0.0/16"
  lifecycle {
    create_before_destroy = true
  }
}
```

## Test plan

- [x] Serde round-trip for `LifecycleConfig` with `create_before_destroy: true`
- [x] Backward compatibility: deserialize old JSON without `create_before_destroy` field
- [x] `OrderTrackingProvider` verifies `["delete", "create"]` for default ordering
- [x] `OrderTrackingProvider` verifies `["create", "delete"]` for create-before-destroy
- [x] Parser: `create_before_destroy = true` in lifecycle block
- [x] Parser: both `force_delete` and `create_before_destroy` together
- [x] Differ: `create_before_destroy` lifecycle propagates to Replace effect
- [x] `cargo build` clean, `cargo clippy` clean, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)