### PR TITLE
Fix anonymous resource identifier collision across regions (#153)

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -190,6 +190,14 @@ pub trait ProviderFactory: Send + Sync {
     fn format_schema_key(&self, resource_type: &str) -> String {
         format!("{}.{}", self.name(), resource_type)
     }
+
+    /// Attribute names (beyond schema create-only properties) that contribute
+    /// to anonymous resource identity. For example, AWS providers return
+    /// `["region"]` because the same resource type in different regions must
+    /// produce different identifiers.
+    fn identity_attributes(&self) -> Vec<&str> {
+        vec![]
+    }
 }
 
 /// Provider implementation for Box<dyn Provider>

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -68,6 +68,10 @@ impl ProviderFactory for AwsProviderFactory {
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
         schemas::all_schemas()
     }
+
+    fn identity_attributes(&self) -> Vec<&str> {
+        vec!["region"]
+    }
 }
 
 /// S3 Bucket resource type

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -76,6 +76,10 @@ impl ProviderFactory for AwsccProviderFactory {
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
         schemas::all_schemas()
     }
+
+    fn identity_attributes(&self) -> Vec<&str> {
+        vec!["region"]
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Add `identity_attributes()` method to `ProviderFactory` trait so providers can declare extra attributes (beyond schema create-only properties) that contribute to anonymous resource identity
- AWS and AWSCC providers return `["region"]`, ensuring the same resource type with identical create-only properties in different regions produces different identifiers
- Add collision detection that errors when two anonymous resources hash to the same identifier, suggesting `let` bindings

Closes #153

## Test plan

- [x] `test_anonymous_id_different_regions_produce_different_identifiers` — same type + same create-only properties + different regions → different identifiers
- [x] `test_anonymous_id_same_region_same_create_only_collides` — same type + same create-only properties + same region → collision error
- [x] `test_anonymous_id_different_create_only_same_region_no_collision` — same type + different create-only properties + same region → no collision
- [x] `test_anonymous_id_named_resources_are_skipped` — named resources are not processed
- [x] Full test suite passes (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)