### PR TITLE
Prevent provider-specific logic in carina-core (#155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
+  provider-agnostic:
+    name: Core Provider-Agnostic Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-core-provider-agnostic.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/scripts/check-core-provider-agnostic.sh
+++ b/scripts/check-core-provider-agnostic.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Check that carina-core remains provider-agnostic.
+# Fails if any non-test, non-comment Rust source in carina-core/src/
+# contains hardcoded provider-specific string literals.
+set -euo pipefail
+
+CORE_DIR="carina-core/src"
+
+# Provider-specific patterns to reject (regex for grep -E)
+# Matches string literals like "awscc.", "aws.", "awscc", "aws" used in format strings
+PATTERNS='"awscc\.|"aws\.|"awscc"|"aws"'
+
+violations=0
+
+for file in $(find "$CORE_DIR" -name '*.rs' -type f); do
+    in_test=false
+    line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Track #[cfg(test)] mod blocks
+        if echo "$line" | grep -q '#\[cfg(test)\]'; then
+            in_test=true
+            continue
+        fi
+
+        # Skip test code
+        if $in_test; then
+            continue
+        fi
+
+        # Skip comment lines
+        stripped=$(echo "$line" | sed 's/^[[:space:]]*//')
+        if echo "$stripped" | grep -q '^//'; then
+            continue
+        fi
+
+        # Check for provider-specific patterns
+        if echo "$line" | grep -qE "$PATTERNS"; then
+            echo "VIOLATION: $file:$line_num: $line"
+            violations=$((violations + 1))
+        fi
+    done < "$file"
+done
+
+if [ "$violations" -gt 0 ]; then
+    echo ""
+    echo "ERROR: Found $violations provider-specific string literal(s) in $CORE_DIR."
+    echo "carina-core must remain provider-agnostic."
+    echo "Move provider-specific logic to the appropriate provider crate."
+    exit 1
+fi
+
+echo "OK: No provider-specific string literals found in $CORE_DIR (excluding tests)."


### PR DESCRIPTION
## Summary
- Remove hardcoded `"awscc."` and `"aws."` string literals from `differ.rs` schema lookup, replacing with a generic provider-based lookup using `resource.id.provider`
- Add CI check script (`scripts/check-core-provider-agnostic.sh`) that scans `carina-core/src/` for provider-specific string literals in non-test code
- Add `provider-agnostic` CI job to prevent future violations

## Test plan
- [x] `cargo test -p carina-core` — all 151 tests pass (including updated `replace_with_provider_prefixed_schema_key` test)
- [x] `bash scripts/check-core-provider-agnostic.sh` — passes with no violations
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)