### PR TITLE
Add Union type to fix gateway_id type mismatch

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -749,7 +749,7 @@ impl CompletionProvider {
             AttributeType::Custom { name, .. } if name == "IpProtocol" => {
                 self.ip_protocol_completions(resource_type)
             }
-            AttributeType::String | AttributeType::Custom { .. } => {
+            AttributeType::Union(_) | AttributeType::String | AttributeType::Custom { .. } => {
                 vec![CompletionItem {
                     label: "env".to_string(),
                     kind: Some(CompletionItemKind::FUNCTION),

--- a/carina-provider-awscc/src/schemas/generated/ec2_route.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_route.rs
@@ -54,7 +54,7 @@ pub fn ec2_route_config() -> AwsccSchemaConfig {
                 .with_provider_name("EgressOnlyInternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("gateway_id", super::aws_resource_id())
+            AttributeSchema::new("gateway_id", super::gateway_id())
                 .with_description("The ID of an internet gateway or virtual private gateway attached to your VPC.")
                 .with_provider_name("GatewayId"),
         )

--- a/docs/src/providers/awscc/ec2_route.md
+++ b/docs/src/providers/awscc/ec2_route.md
@@ -52,7 +52,7 @@ The ID of a prefix list used for the destination match.
 
 ### `gateway_id`
 
-- **Type:** AwsResourceId
+- **Type:** GatewayId
 - **Required:** No
 
 The ID of an internet gateway or virtual private gateway attached to your VPC.


### PR DESCRIPTION
## Summary

Closes #158

- Add `AttributeType::Union(Vec<AttributeType>)` variant so a single attribute can accept multiple specific types
- Type `ec2_route.gateway_id` as `InternetGatewayId | VpnGatewayId` instead of generic `AwsResourceId`
- Resource references like `igw.internet_gateway_id` (type `InternetGatewayId`) now pass type checking against `gateway_id`

## Changes

- **carina-core**: Add `Union` variant with `validate()` (any member match), `type_name()` (`A | B` format), and `accepts_type_name()` for type compatibility checks
- **carina-provider-awscc**: Add `gateway_id()` union type and codegen override for `AWS::EC2::Route.GatewayId`
- **carina-cli**: Use `accepts_type_name()` in `validate_resource_ref_types()` to handle Union types; add Union arm to `is_string_compatible_type()`
- **carina-lsp**: Add Union + ResourceRef diagnostic match arm; add Union to completion handler
- Regenerated schemas and docs

## Test plan

- [x] `cargo test` — all existing tests pass
- [x] New unit tests for Union validate, type_name, accepts_type_name
- [x] New test for gateway_id() union type (igw-*, vgw-*, rejection of other prefixes)
- [x] Codegen override tests pass
- [ ] Acceptance test: `run-tests.sh full ec2_route`

🤖 Generated with [Claude Code](https://claude.com/claude-code)