### PR TITLE
Support block syntax for statement in IamPolicyDocument

### DIFF
--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -104,7 +104,7 @@ primary = {
 list = { "[" ~ (expression ~ ("," ~ expression)*)? ~ ","? ~ "]" }
 
 // Map: { key = value, ... } (commas are optional, newlines work too)
-map = { "{" ~ map_entry* ~ "}" }
+map = { "{" ~ (map_entry | nested_block)* ~ "}" }
 
 // Map entry: key = value (with optional trailing comma)
 map_entry = { identifier ~ "=" ~ expression ~ ","? }

--- a/carina-provider-awscc/acceptance-tests/iam_role/prefix.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/prefix.crn
@@ -13,12 +13,10 @@ let role = awscc.iam.role {
 
   assume_role_policy_document = {
     version = "2012-10-17"
-    statement = [
-      {
-        effect    = "Allow"
-        principal = { service = "lambda.amazonaws.com" }
-        action    = "sts:AssumeRole"
-      }
-    ]
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Extend PEG grammar to accept nested blocks (`statement { ... }`) inside map expressions, in addition to list literal syntax (`statement = [{ ... }]`)
- Update parser to collect nested blocks as list values within maps
- Replace hand-written `IamPolicyDocument` validation with Struct-based validation using properly typed fields (Union, List, Map)
- Keep `Custom` type wrapper to avoid `Value::Map` vs `Value::List` mismatch in provider conversion paths

Closes #168

## Test plan

- [x] Parser tests for block syntax inside maps (`parse_block_syntax_inside_map`)
- [x] Parser tests for multiple blocks (`parse_multiple_blocks_inside_map`)
- [x] Backward compatibility test (`parse_list_syntax_inside_map_still_works`)
- [x] Struct-based validation tests for IAM policy documents
- [x] All 460 existing tests pass
- [ ] Acceptance test: `run-tests.sh full iam_role`

🤖 Generated with [Claude Code](https://claude.com/claude-code)