### PR TITLE
Fix false struct diffs when AWS returns extra fields (#172)

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -1469,7 +1469,13 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
     provider.resolve_enum_identifiers(&mut resources_for_plan);
     let lifecycles = build_lifecycles_from_state(&state_file);
     let schemas = get_schemas();
-    let plan = create_plan(&resources_for_plan, &current_states, &lifecycles, &schemas);
+    let plan = create_plan(
+        &resources_for_plan,
+        &current_states,
+        &lifecycles,
+        &schemas,
+        &saved_attrs,
+    );
 
     if plan.is_empty() {
         println!("{}", "No changes needed.".green());
@@ -3116,7 +3122,13 @@ async fn create_plan_from_parsed(
     let lifecycles = build_lifecycles_from_state(state_file);
 
     let schemas = get_schemas();
-    let plan = create_plan(&resources, &current_states, &lifecycles, &schemas);
+    let plan = create_plan(
+        &resources,
+        &current_states,
+        &lifecycles,
+        &schemas,
+        &saved_attrs,
+    );
     Ok(PlanContext {
         plan,
         sorted_resources,


### PR DESCRIPTION
## Summary
- Fix false plan diffs when AWS returns extra fields in a struct that weren't specified in the `.crn` file (e.g., `private_dns_name_options_on_launch` returning 3 fields when only 2 were declared)
- Add `merge_with_saved()` function that merges desired values with saved state before comparison, filling in unmanaged nested fields while preserving drift detection
- Thread saved state through `create_plan()` → `diff()` → `find_changed_attributes()` so the differ can use it

## Test plan
- [x] Unit tests for `merge_with_saved()`: map fills extra keys, desired wins on conflicts, list-of-maps merging, scalar passthrough
- [x] Unit tests for differ: no false diff with saved state, drift detection on unmanaged fields, backward compatibility without saved state
- [x] All existing tests pass (487+ across all crates)
- [ ] Acceptance test: `ec2_subnet/with_dns_options` plan-verify step should show no changes

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)