### PR TITLE
Fix #173: Preserve all unreturned attrs, not just create-only

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -1440,9 +1440,9 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
         current_states.insert(resource.id.clone(), state);
     }
 
-    // Restore create-only attributes from state file (CloudControl doesn't return them)
+    // Restore unreturned attributes from state file (CloudControl doesn't always return them)
     let saved_attrs = build_saved_attrs_from_state(&state_file);
-    provider.restore_create_only_attrs(&mut current_states, &saved_attrs);
+    provider.restore_unreturned_attrs(&mut current_states, &saved_attrs);
 
     // Build initial binding map for reference resolution
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -3109,9 +3109,9 @@ async fn create_plan_from_parsed(
         current_states.insert(resource.id.clone(), state);
     }
 
-    // Restore create-only attributes from state file (CloudControl doesn't return them)
+    // Restore unreturned attributes from state file (CloudControl doesn't always return them)
     let saved_attrs = build_saved_attrs_from_state(state_file);
-    provider.restore_create_only_attrs(&mut current_states, &saved_attrs);
+    provider.restore_unreturned_attrs(&mut current_states, &saved_attrs);
 
     // Resolve ResourceRef values and enum identifiers using AWS state
     let mut resources = sorted_resources.clone();
@@ -4016,7 +4016,7 @@ fn json_to_dsl_value(json: &serde_json::Value) -> Value {
 
 /// Build a map of saved attributes from a state file, converting JSON values to DSL values.
 ///
-/// This is used to pass saved attribute data to the provider's `restore_create_only_attrs` method.
+/// This is used to pass saved attribute data to the provider's `restore_unreturned_attrs` method.
 fn build_saved_attrs_from_state(
     state_file: &Option<StateFile>,
 ) -> HashMap<ResourceId, HashMap<String, Value>> {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -139,12 +139,13 @@ pub trait Provider: Send + Sync {
     /// Default implementation is a no-op for providers without enum types.
     fn resolve_enum_identifiers(&self, _resources: &mut [Resource]) {}
 
-    /// Restore create-only attributes from saved state into current read states.
+    /// Restore unreturned attributes from saved state into current read states.
     ///
-    /// Some APIs (e.g., CloudControl) don't return create-only properties in read responses.
+    /// Some APIs (e.g., CloudControl) don't return certain properties in read responses
+    /// (create-only properties, or normal properties like `description` on some resources).
     /// This method carries them forward from previously saved attribute values.
     /// Default implementation is a no-op.
-    fn restore_create_only_attrs(
+    fn restore_unreturned_attrs(
         &self,
         _current_states: &mut HashMap<ResourceId, State>,
         _saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
@@ -246,12 +247,12 @@ impl Provider for Box<dyn Provider> {
         (**self).resolve_enum_identifiers(resources)
     }
 
-    fn restore_create_only_attrs(
+    fn restore_unreturned_attrs(
         &self,
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     ) {
-        (**self).restore_create_only_attrs(current_states, saved_attrs)
+        (**self).restore_unreturned_attrs(current_states, saved_attrs)
     }
 }
 

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -142,11 +142,11 @@ impl Provider for AwsccProvider {
         crate::provider::resolve_enum_identifiers_impl(resources);
     }
 
-    fn restore_create_only_attrs(
+    fn restore_unreturned_attrs(
         &self,
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     ) {
-        crate::provider::restore_create_only_attrs_impl(current_states, saved_attrs);
+        crate::provider::restore_unreturned_attrs_impl(current_states, saved_attrs);
     }
 }


### PR DESCRIPTION
## Summary

- Generalize attribute preservation to ALL attributes not returned by CloudControl API, not just `create_only` properties
- Fix false plan diff for `description` on `EC2::SecurityGroupEgress` (and similar cases on other resources)
- Add preservation logic to `update_resource` (previously only `create_resource` had it)
- Rename `restore_create_only_attrs` → `restore_unreturned_attrs` across trait, implementation, and call sites

Closes #173

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — all unit tests pass (including new `test_restore_unreturned_attrs_impl_non_create_only`)
- [ ] `run-tests.sh full ec2_security_group_egress` — plan-verify should show no false diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)