### PR TITLE
Fix: Region attribute shows false diff after apply (#331)

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -46,7 +46,6 @@ const CREATE_RETRY_MAX_DELAY_SECS: u64 = 120;
 pub struct AwsccProvider {
     cloudcontrol_client: CloudControlClient,
     aws_config: aws_config::SdkConfig,
-    region: String,
 }
 
 impl AwsccProvider {
@@ -60,7 +59,6 @@ impl AwsccProvider {
         Self {
             cloudcontrol_client: CloudControlClient::new(&config),
             aws_config: config,
-            region: region.to_string(),
         }
     }
 
@@ -435,12 +433,6 @@ impl AwsccProvider {
         };
 
         let mut attributes = HashMap::new();
-
-        // Add region for VPC
-        if resource_type == "ec2.vpc" {
-            let region_dsl = format!("awscc.Region.{}", self.region.replace('-', "_"));
-            attributes.insert("region".to_string(), Value::String(region_dsl));
-        }
 
         // Map AWS attributes to DSL attributes using provider_name
         for (dsl_name, attr_schema) in &config.schema.attributes {


### PR DESCRIPTION
## Summary

- Remove `apply_default_region()` which copied the provider's region into each resource's attributes — CloudControl API doesn't return `region` in read-back, causing the differ to see `region` in desired but not current state
- Update `compute_anonymous_identifiers()` to source identity attribute values from provider config instead of resource attributes
- Remove VPC region hack from `AwsccProvider::read` that injected region into read-back attributes
- Remove unused `region` field from `AwsccProvider` struct

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo test -p carina-cli test_anonymous_id` — updated tests pass with provider-sourced identity values
- [ ] Acceptance test: `./run-tests.sh full ec2_vpc_endpoint` — verify no false diffs at plan-verify

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)