### PR TITLE
Add missing fields to security group ingress/egress schemas

### DIFF
--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -312,6 +312,20 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
     }
 
+    // Add extra writable fields from read structure
+    for extra in &res.extra_writable {
+        if writable_fields.contains_key(extra.name) {
+            continue;
+        }
+        if let Some(source_field) = extra.read_source
+            && let Some(read_struct) = read_structure
+            && let Some(member_ref) = read_struct.members.get(source_field)
+        {
+            writable_fields.insert(extra.name.to_string(), member_ref);
+        }
+        // Synthetic fields (read_source = None) are handled after main attribute generation
+    }
+
     // Collect read-only fields from read structure
     let mut read_only_fields: BTreeMap<String, &carina_smithy::ShapeRef> = BTreeMap::new();
     if let Some(read_struct) = read_structure {
@@ -339,6 +353,15 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
     }
 
+    // Build extra_writable description override map
+    let extra_writable_descs: HashMap<&str, Option<&str>> = res
+        .extra_writable
+        .iter()
+        .map(|e| (e.name, e.description))
+        .collect();
+    // Set of field names that are from extra_writable (always create-only)
+    let extra_writable_names: HashSet<&str> = res.extra_writable.iter().map(|e| e.name).collect();
+
     // Build attribute list
     let mut attrs: Vec<AttrInfo> = Vec::new();
 
@@ -351,11 +374,18 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         let is_read_only = read_only_overrides.contains(name.as_str());
         let is_create_only = if is_read_only {
             false
+        } else if extra_writable_names.contains(name.as_str()) {
+            true // Extra writable fields are always create-only
         } else {
             create_only_overrides.contains(name.as_str())
                 || !updatable_fields.contains(name.as_str())
         };
-        let description = SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string());
+        // Use ExtraField description override if available, otherwise Smithy docs
+        let description = if let Some(Some(desc)) = extra_writable_descs.get(name.as_str()) {
+            Some(desc.to_string())
+        } else {
+            SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string())
+        };
 
         let (type_code, enum_info) = resolve_type(
             model,
@@ -378,6 +408,31 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             is_read_only,
             description,
             enum_info,
+        });
+    }
+
+    // Process synthetic extra writable fields (no read_source)
+    for extra in &res.extra_writable {
+        if extra.read_source.is_some() {
+            continue; // Already handled via writable_fields
+        }
+        let snake_name = extra.name.to_snake_case();
+        let type_code = if let Some(&override_type) = type_overrides.get(extra.name) {
+            override_type.to_string()
+        } else if let Some(inferred) = infer_string_type(extra.name) {
+            inferred
+        } else {
+            "AttributeType::String".to_string()
+        };
+        attrs.push(AttrInfo {
+            snake_name,
+            provider_name: extra.name.to_string(),
+            type_code,
+            is_required: false,
+            is_create_only: true,
+            is_read_only: false,
+            description: extra.description.map(|s| s.to_string()),
+            enum_info: None,
         });
     }
 
@@ -1244,6 +1299,19 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         }
     }
 
+    // Add extra writable fields from read structure
+    for extra in &res.extra_writable {
+        if writable_fields.contains_key(extra.name) {
+            continue;
+        }
+        if let Some(source_field) = extra.read_source
+            && let Some(read_struct) = read_structure
+            && let Some(member_ref) = read_struct.members.get(source_field)
+        {
+            writable_fields.insert(extra.name.to_string(), member_ref);
+        }
+    }
+
     // Read-only fields
     let mut read_only_fields: BTreeMap<String, &carina_smithy::ShapeRef> = BTreeMap::new();
     if let Some(read_struct) = read_structure {
@@ -1279,13 +1347,24 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
         description: Option<String>,
     }
 
+    // Build extra_writable description override map
+    let extra_writable_descs: HashMap<&str, Option<&str>> = res
+        .extra_writable
+        .iter()
+        .map(|e| (e.name, e.description))
+        .collect();
+
     let mut writable_attrs: Vec<MdAttrInfo> = Vec::new();
     for (name, member_ref) in &writable_fields {
         let snake_name = name.to_snake_case();
         let is_required = (SmithyModel::is_required(member_ref)
             || required_overrides.contains(name.as_str()))
             && !read_only_overrides.contains(name.as_str());
-        let description = SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string());
+        let description = if let Some(Some(desc)) = extra_writable_descs.get(name.as_str()) {
+            Some(desc.to_string())
+        } else {
+            SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string())
+        };
         let type_display = type_display_string_md(
             model,
             &member_ref.target,
@@ -1301,6 +1380,27 @@ fn generate_markdown_resource(res: &ResourceDef, model: &SmithyModel) -> Result<
             type_display,
             is_required,
             description,
+        });
+    }
+
+    // Add synthetic extra writable fields (no read_source) to markdown
+    for extra in &res.extra_writable {
+        if extra.read_source.is_some() {
+            continue;
+        }
+        let snake_name = extra.name.to_snake_case();
+        let type_display = if let Some(&override_type) = type_overrides.get(extra.name) {
+            type_code_to_display(override_type)
+        } else if is_aws_resource_id_property(extra.name) {
+            resource_id_display(extra.name)
+        } else {
+            "String".to_string()
+        };
+        writable_attrs.push(MdAttrInfo {
+            snake_name,
+            type_display,
+            is_required: false,
+            description: extra.description.map(|s| s.to_string()),
         });
     }
 

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -1779,6 +1779,47 @@ impl AwsProvider {
             attributes.insert("cidr_blocks".to_string(), Value::List(cidr_blocks));
         }
 
+        // IPv6 CIDR
+        if let Some(cidr_ipv6) = first_rule.cidr_ipv6() {
+            attributes.insert(
+                "cidr_ipv6".to_string(),
+                Value::String(cidr_ipv6.to_string()),
+            );
+        }
+
+        // Description
+        if let Some(description) = first_rule.description() {
+            attributes.insert(
+                "description".to_string(),
+                Value::String(description.to_string()),
+            );
+        }
+
+        // Prefix list ID (source for ingress, destination for egress)
+        if let Some(prefix_list_id) = first_rule.prefix_list_id() {
+            let attr_name = if is_ingress {
+                "source_prefix_list_id"
+            } else {
+                "destination_prefix_list_id"
+            };
+            attributes.insert(
+                attr_name.to_string(),
+                Value::String(prefix_list_id.to_string()),
+            );
+        }
+
+        // Referenced security group ID (source for ingress, destination for egress)
+        if let Some(ref_group) = first_rule.referenced_group_info()
+            && let Some(group_id) = ref_group.group_id()
+        {
+            let attr_name = if is_ingress {
+                "source_security_group_id"
+            } else {
+                "destination_security_group_id"
+            };
+            attributes.insert(attr_name.to_string(), Value::String(group_id.to_string()));
+        }
+
         let state = State::existing(id.clone(), attributes);
         Ok(if let Some(id_str) = rule_identifier {
             state.with_identifier(id_str)
@@ -1832,8 +1873,39 @@ impl AwsProvider {
                 .collect(),
             _ => match resource.attributes.get("cidr") {
                 Some(Value::String(s)) => vec![s.clone()],
-                _ => vec!["0.0.0.0/0".to_string()],
+                _ => vec![],
             },
+        };
+
+        // New schema fields
+        let cidr_ipv6 = match resource.attributes.get("cidr_ipv6") {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
+
+        let description = match resource.attributes.get("description") {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
+
+        let prefix_list_attr = if is_ingress {
+            "source_prefix_list_id"
+        } else {
+            "destination_prefix_list_id"
+        };
+        let prefix_list_id = match resource.attributes.get(prefix_list_attr) {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
+        };
+
+        let sg_ref_attr = if is_ingress {
+            "source_security_group_id"
+        } else {
+            "destination_security_group_id"
+        };
+        let ref_security_group_id = match resource.attributes.get(sg_ref_attr) {
+            Some(Value::String(s)) => Some(s.clone()),
+            _ => None,
         };
 
         let mut permission_builder = aws_sdk_ec2::types::IpPermission::builder()
@@ -1841,9 +1913,41 @@ impl AwsProvider {
             .from_port(from_port)
             .to_port(to_port);
 
+        // IPv4 CIDR ranges
         for cidr in &cidrs {
-            permission_builder = permission_builder
-                .ip_ranges(aws_sdk_ec2::types::IpRange::builder().cidr_ip(cidr).build());
+            let mut range_builder = aws_sdk_ec2::types::IpRange::builder().cidr_ip(cidr);
+            if let Some(ref desc) = description {
+                range_builder = range_builder.description(desc);
+            }
+            permission_builder = permission_builder.ip_ranges(range_builder.build());
+        }
+
+        // IPv6 CIDR range
+        if let Some(ref cidr_v6) = cidr_ipv6 {
+            let mut range_builder = aws_sdk_ec2::types::Ipv6Range::builder().cidr_ipv6(cidr_v6);
+            if let Some(ref desc) = description {
+                range_builder = range_builder.description(desc);
+            }
+            permission_builder = permission_builder.ipv6_ranges(range_builder.build());
+        }
+
+        // Prefix list
+        if let Some(ref pl_id) = prefix_list_id {
+            let mut pl_builder = aws_sdk_ec2::types::PrefixListId::builder().prefix_list_id(pl_id);
+            if let Some(ref desc) = description {
+                pl_builder = pl_builder.description(desc);
+            }
+            permission_builder = permission_builder.prefix_list_ids(pl_builder.build());
+        }
+
+        // Security group reference
+        if let Some(ref ref_sg_id) = ref_security_group_id {
+            let mut pair_builder =
+                aws_sdk_ec2::types::UserIdGroupPair::builder().group_id(ref_sg_id);
+            if let Some(ref desc) = description {
+                pair_builder = pair_builder.description(desc);
+            }
+            permission_builder = permission_builder.user_id_group_pairs(pair_builder.build());
         }
 
         let permission = permission_builder.build();

--- a/carina-provider-aws/src/resource_defs.rs
+++ b/carina-provider-aws/src/resource_defs.rs
@@ -3,6 +3,18 @@
 //! Each `ResourceDef` describes how to map AWS API operations to a Carina resource schema.
 //! These definitions are consumed by the `smithy-codegen` binary.
 
+/// An additional writable field not present in the create operation input.
+/// Used to add fields from the read structure or synthetic fields.
+pub struct ExtraField {
+    /// PascalCase name for the generated attribute (e.g., "CidrIpv6", "SourcePrefixListId")
+    pub name: &'static str,
+    /// If Some, the field type is resolved from this read structure member.
+    /// If None, type is inferred from the field name (e.g., resource ID patterns).
+    pub read_source: Option<&'static str>,
+    /// Manual description (used when read_source is None, or to override Smithy docs)
+    pub description: Option<&'static str>,
+}
+
 /// A read operation that retrieves specific fields from an API response.
 /// Used for resources that have no single "describe" structure (e.g., S3).
 pub struct ReadOp {
@@ -52,6 +64,9 @@ pub struct ResourceDef {
     pub extra_read_only: Vec<&'static str>,
     /// Fields to force as read-only even if they appear in create input
     pub read_only_overrides: Vec<&'static str>,
+    /// Extra writable fields to add as create-only attributes.
+    /// These are fields not present in the create operation input.
+    pub extra_writable: Vec<ExtraField>,
 }
 
 /// An update operation and the fields it can modify.
@@ -97,6 +112,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.subnet
         ResourceDef {
@@ -126,6 +142,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.internet_gateway
         ResourceDef {
@@ -146,6 +163,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.route_table
         ResourceDef {
@@ -166,6 +184,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.route
         ResourceDef {
@@ -201,6 +220,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.security_group
         ResourceDef {
@@ -221,6 +241,7 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
         // ec2.security_group_ingress
         ResourceDef {
@@ -249,6 +270,28 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["IpProtocol"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "CidrIpv6",
+                    read_source: Some("CidrIpv6"),
+                    description: None,
+                },
+                ExtraField {
+                    name: "Description",
+                    read_source: Some("Description"),
+                    description: None,
+                },
+                ExtraField {
+                    name: "SourcePrefixListId",
+                    read_source: Some("PrefixListId"),
+                    description: Some("The ID of the source prefix list."),
+                },
+                ExtraField {
+                    name: "SourceSecurityGroupId",
+                    read_source: None,
+                    description: Some("The ID of the source security group."),
+                },
+            ],
         },
         // ec2.security_group_egress
         ResourceDef {
@@ -277,6 +320,28 @@ pub fn ec2_resources() -> Vec<ResourceDef> {
             required_overrides: vec!["IpProtocol", "GroupId"],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![
+                ExtraField {
+                    name: "CidrIpv6",
+                    read_source: Some("CidrIpv6"),
+                    description: None,
+                },
+                ExtraField {
+                    name: "Description",
+                    read_source: Some("Description"),
+                    description: None,
+                },
+                ExtraField {
+                    name: "DestinationPrefixListId",
+                    read_source: Some("PrefixListId"),
+                    description: Some("The ID of the destination prefix list."),
+                },
+                ExtraField {
+                    name: "DestinationSecurityGroupId",
+                    read_source: None,
+                    description: Some("The ID of the destination security group."),
+                },
+            ],
         },
     ]
 }
@@ -324,6 +389,7 @@ pub fn s3_resources() -> Vec<ResourceDef> {
             required_overrides: vec![],
             extra_read_only: vec![],
             read_only_overrides: vec![],
+            extra_writable: vec![],
         },
     ]
 }

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
@@ -76,6 +76,24 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                     .with_provider_name("CidrIp"),
             )
             .attribute(
+                AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
+                    .create_only()
+                    .with_description("The IPv6 CIDR range.")
+                    .with_provider_name("CidrIpv6"),
+            )
+            .attribute(
+                AttributeSchema::new("description", AttributeType::String)
+                    .create_only()
+                    .with_description("The security group rule description.")
+                    .with_provider_name("Description"),
+            )
+            .attribute(
+                AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
+                    .create_only()
+                    .with_description("The ID of the destination prefix list.")
+                    .with_provider_name("DestinationPrefixListId"),
+            )
+            .attribute(
                 AttributeSchema::new(
                     "from_port",
                     AttributeType::Custom {
@@ -142,6 +160,12 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 .create_only()
                 .with_description("Not supported. Use IP permissions instead.")
                 .with_provider_name("ToPort"),
+            )
+            .attribute(
+                AttributeSchema::new("destination_security_group_id", super::security_group_id())
+                    .create_only()
+                    .with_description("The ID of the destination security group.")
+                    .with_provider_name("DestinationSecurityGroupId"),
             )
             .attribute(
                 AttributeSchema::new("security_group_rule_id", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
@@ -76,6 +76,18 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("CidrIp"),
         )
         .attribute(
+            AttributeSchema::new("cidr_ipv6", types::ipv6_cidr())
+                .create_only()
+                .with_description("The IPv6 CIDR range.")
+                .with_provider_name("CidrIpv6"),
+        )
+        .attribute(
+            AttributeSchema::new("description", AttributeType::String)
+                .create_only()
+                .with_description("The security group rule description.")
+                .with_provider_name("Description"),
+        )
+        .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
                 name: "Int(-1..=65535)".to_string(),
                 base: Box::new(AttributeType::Int),
@@ -113,6 +125,12 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
+            AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())
+                .create_only()
+                .with_description("The ID of the source prefix list.")
+                .with_provider_name("SourcePrefixListId"),
+        )
+        .attribute(
             AttributeSchema::new("source_security_group_name", AttributeType::String)
                 .create_only()
                 .with_description("[Default VPC] The name of the source security group. The rule grants full ICMP, UDP, and TCP access. To create a rule with a specific protocol and por...")
@@ -135,6 +153,12 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP, this is the ICMP code or -1 (all ICMP codes). If the start ...")
                 .with_provider_name("ToPort"),
+        )
+        .attribute(
+            AttributeSchema::new("source_security_group_id", super::security_group_id())
+                .create_only()
+                .with_description("The ID of the source security group.")
+                .with_provider_name("SourceSecurityGroupId"),
         )
         .attribute(
             AttributeSchema::new("security_group_rule_id", AttributeType::String)

--- a/docs/src/providers/aws/ec2_security_group_egress.md
+++ b/docs/src/providers/aws/ec2_security_group_egress.md
@@ -13,6 +13,27 @@ Describes a security group rule.
 
 Not supported. Use IP permissions instead.
 
+### `cidr_ipv6`
+
+- **Type:** Ipv6Cidr
+- **Required:** No
+
+The IPv6 CIDR range.
+
+### `description`
+
+- **Type:** String
+- **Required:** No
+
+The security group rule description.
+
+### `destination_prefix_list_id`
+
+- **Type:** AwsResourceId
+- **Required:** No
+
+The ID of the destination prefix list.
+
 ### `from_port`
 
 - **Type:** Int(-1..=65535)
@@ -54,6 +75,13 @@ Not supported. Use IP permissions instead.
 - **Required:** No
 
 Not supported. Use IP permissions instead.
+
+### `destination_security_group_id`
+
+- **Type:** SecurityGroupId
+- **Required:** No
+
+The ID of the destination security group.
 
 ## Enum Values
 

--- a/docs/src/providers/aws/ec2_security_group_ingress.md
+++ b/docs/src/providers/aws/ec2_security_group_ingress.md
@@ -13,6 +13,20 @@ Describes a security group rule.
 
 The IPv4 address range, in CIDR format.                    Amazon Web Services canonicalizes IPv4 and IPv6 CIDRs. For example, if you specify 100.68.0.18/18 for the CIDR block,        Amazon Web Services canonicalizes the CIDR block to 100.68.0.0/18. Any subsequent DescribeSecurityGroups and DescribeSecurityGroupRules calls will        return the canonicalized form of the CIDR block. Additionally, if you attempt to add another rule with the        non-canonical form of the CIDR (such as 100.68.0.18/18) and there is already a rule for the canonicalized        form of the CIDR block (such as 100.68.0.0/18), the API throws an duplicate rule error.          To specify an IPv6 address range, use IP permissions instead.     To specify multiple rules and descriptions for the rules, use IP permissions instead.
 
+### `cidr_ipv6`
+
+- **Type:** Ipv6Cidr
+- **Required:** No
+
+The IPv6 CIDR range.
+
+### `description`
+
+- **Type:** String
+- **Required:** No
+
+The security group rule description.
+
 ### `from_port`
 
 - **Type:** Int(-1..=65535)
@@ -41,6 +55,13 @@ The ID of the security group.
 
 The IP protocol name (tcp, udp, icmp) or number    (see Protocol Numbers). To specify all protocols, use -1.     To specify icmpv6, use IP permissions instead.     If you specify a protocol other than one of the supported values, traffic is allowed      on all ports, regardless of any ports that you specify.     To specify multiple rules and descriptions for the rules, use IP permissions instead.
 
+### `source_prefix_list_id`
+
+- **Type:** AwsResourceId
+- **Required:** No
+
+The ID of the source prefix list.
+
 ### `source_security_group_name`
 
 - **Type:** String
@@ -61,6 +82,13 @@ The Amazon Web Services account ID for the source security group, if the source 
 - **Required:** No
 
 If the protocol is TCP or UDP, this is the end of the port range.      If the protocol is ICMP, this is the ICMP code or -1 (all ICMP codes).       If the start port is -1 (all ICMP types), then the end port must be -1 (all ICMP codes).     To specify multiple rules and descriptions for the rules, use IP permissions instead.
+
+### `source_security_group_id`
+
+- **Type:** SecurityGroupId
+- **Required:** No
+
+The ID of the source security group.
 
 ## Enum Values
 


### PR DESCRIPTION
## Summary

Closes #290

- Add `ExtraField` mechanism to `ResourceDef` for including fields from the read structure (or synthetic fields) that aren't in the create operation input
- Add `cidr_ipv6`, `description`, `source_prefix_list_id`/`destination_prefix_list_id`, and `source_security_group_id`/`destination_security_group_id` fields to security group ingress/egress schemas
- Update the EC2 provider to handle these new fields when creating (via `IpPermission` builder) and reading security group rules
- Regenerate schemas and documentation

## Test plan

- [x] `cargo test` passes (all 493 tests)
- [x] `cargo clippy` passes
- [x] Regenerated schemas verified to contain new fields with correct types
- [x] Regenerated documentation verified
- [ ] Acceptance tests for security group rules with new fields (IPv6 CIDR, SG-to-SG reference, prefix list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)