### PR TITLE
Validate data source types require `read` keyword

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -302,6 +302,12 @@ fn validate_resources(resources: &[Resource]) -> Result<(), String> {
 
         match schemas.get(&schema_key) {
             Some(schema) => {
+                if schema.data_source && !resource.read_only {
+                    all_errors.push(format!(
+                        "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
+                        schema.resource_type, schema.resource_type
+                    ));
+                }
                 if let Err(errors) = schema.validate(&resource.attributes) {
                     for error in errors {
                         all_errors.push(format!("{}: {}", resource.id, error));
@@ -5398,5 +5404,52 @@ awscc.ec2.security_group {
 
         // Non-matching bucket name
         assert!(find_state_bucket_resource(&parsed, "other-bucket", "s3.bucket").is_none());
+    }
+
+    #[test]
+    fn validate_data_source_without_read_keyword_errors() {
+        let resource = Resource::with_provider("aws", "sts.caller_identity", "identity")
+            .with_attribute("_provider", Value::String("aws".to_string()));
+        // read_only defaults to false, simulating missing `read` keyword
+        let result = validate_resources(&[resource]);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("data source"),
+            "Error should mention 'data source': {}",
+            err
+        );
+        assert!(
+            err.contains("read"),
+            "Error should mention 'read' keyword: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_data_source_with_read_keyword_passes() {
+        let resource = Resource::with_provider("aws", "sts.caller_identity", "identity")
+            .with_attribute("_provider", Value::String("aws".to_string()))
+            .with_read_only(true);
+        let result = validate_resources(&[resource]);
+        assert!(
+            result.is_ok(),
+            "Data source with read keyword should pass: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_regular_resource_without_read_keyword_passes() {
+        let resource = Resource::with_provider("aws", "s3.bucket", "my-bucket")
+            .with_attribute("_provider", Value::String("aws".to_string()))
+            .with_attribute("name", Value::String("my-bucket".to_string()))
+            .with_attribute("region", Value::String("ap-northeast-1".to_string()));
+        let result = validate_resources(&[resource]);
+        assert!(
+            result.is_ok(),
+            "Regular resource without read should pass: {:?}",
+            result
+        );
     }
 }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -487,6 +487,8 @@ pub struct ResourceSchema {
     /// Optional validator function for cross-attribute validation
     /// (e.g., mutually exclusive required fields)
     pub validator: Option<ResourceValidator>,
+    /// If true, this resource type is a data source and must be used with `read`
+    pub data_source: bool,
 }
 
 impl ResourceSchema {
@@ -496,6 +498,7 @@ impl ResourceSchema {
             attributes: HashMap::new(),
             description: None,
             validator: None,
+            data_source: false,
         }
     }
 
@@ -511,6 +514,11 @@ impl ResourceSchema {
 
     pub fn with_validator(mut self, validator: ResourceValidator) -> Self {
         self.validator = Some(validator);
+        self
+    }
+
+    pub fn as_data_source(mut self) -> Self {
+        self.data_source = true;
         self
     }
 
@@ -876,6 +884,18 @@ fn validate_ipv6_group(group: &str, addr: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resource_schema_data_source_default_false() {
+        let schema = ResourceSchema::new("test.resource");
+        assert!(!schema.data_source);
+    }
+
+    #[test]
+    fn resource_schema_as_data_source_sets_flag() {
+        let schema = ResourceSchema::new("test.resource").as_data_source();
+        assert!(schema.data_source);
+    }
 
     #[test]
     fn validate_string_type() {

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -135,6 +135,37 @@ impl DiagnosticEngine {
 
                 // Semantic validation using schema
                 let schema = self.get_schema_for_type(&full_resource_type);
+                if let Some(schema) = &schema {
+                    // Check data source without `read` keyword
+                    if schema.data_source
+                        && !resource.read_only
+                        && let Some((line, col)) =
+                            self.find_resource_position(doc, &resource.id.resource_type)
+                    {
+                        diagnostics.push(Diagnostic {
+                            range: Range {
+                                start: Position {
+                                    line,
+                                    character: col,
+                                },
+                                end: Position {
+                                    line,
+                                    character: col
+                                        + resource.id.resource_type.len() as u32
+                                        + provider.len() as u32
+                                        + 1,
+                                },
+                            },
+                            severity: Some(DiagnosticSeverity::ERROR),
+                            source: Some("carina".to_string()),
+                            message: format!(
+                                "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
+                                full_resource_type, full_resource_type
+                            ),
+                            ..Default::default()
+                        });
+                    }
+                }
                 if let Some(schema) = schema {
                     for (attr_name, attr_value) in &resource.attributes {
                         if attr_name.starts_with('_') {
@@ -1784,6 +1815,77 @@ let sg = awscc.ec2.security_group {
         assert!(
             lint_diag.is_none(),
             "String attributes should NOT produce lint warning. Got diagnostics: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn data_source_without_read_keyword_errors() {
+        let engine = DiagnosticEngine::new();
+        let doc = create_document(
+            r#"provider aws {
+    region = aws.Region.ap_northeast_1
+}
+
+aws.sts.caller_identity {}"#,
+        );
+
+        let diagnostics = engine.analyze(&doc, None);
+
+        let data_source_diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("data source") && d.message.contains("read"));
+        assert!(
+            data_source_diag.is_some(),
+            "Should error when data source is used without `read`. Got diagnostics: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn data_source_with_read_keyword_no_error() {
+        let engine = DiagnosticEngine::new();
+        let doc = create_document(
+            r#"provider aws {
+    region = aws.Region.ap_northeast_1
+}
+
+let identity = read aws.sts.caller_identity {}"#,
+        );
+
+        let diagnostics = engine.analyze(&doc, None);
+
+        let data_source_diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("data source") && d.message.contains("read"));
+        assert!(
+            data_source_diag.is_none(),
+            "Should NOT error when data source is used with `read`. Got diagnostics: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn regular_resource_without_read_no_data_source_error() {
+        let engine = DiagnosticEngine::new();
+        let doc = create_document(
+            r#"provider aws {
+    region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.bucket {
+    name = "my-bucket"
+}"#,
+        );
+
+        let diagnostics = engine.analyze(&doc, None);
+
+        let data_source_diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("data source"));
+        assert!(
+            data_source_diag.is_none(),
+            "Regular resource should NOT trigger data source error. Got diagnostics: {:?}",
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -620,6 +620,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
          \x20       aws_type_name: \"{}\",\n\
          \x20       resource_type_name: \"{}\",\n\
          \x20       has_tags: {},\n\
+         \x20       data_source: {},\n\
          \x20       schema: ResourceSchema::new(\"{}\")\n",
         res.name,
         ns,
@@ -627,6 +628,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         cf_type_name(res.name),
         res.name,
         res.has_tags,
+        is_data_source,
         namespace,
     ));
 
@@ -645,6 +647,11 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
             "\x20       .with_description(\"{}\")\n",
             truncated
         ));
+    }
+
+    // Mark data sources
+    if is_data_source {
+        code.push_str("\x20       .as_data_source()\n");
     }
 
     // Inject carina-specific attributes (name, region) — skip for data sources

--- a/carina-provider-aws/src/schemas/generated/ec2_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_internet_gateway.rs
@@ -14,6 +14,7 @@ pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
         resource_type_name: "ec2.internet_gateway",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.internet_gateway")
             .with_description("Describes an internet gateway.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_route.rs
@@ -13,6 +13,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
         resource_type_name: "ec2.route",
         has_tags: false,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.route")
         .with_description("Describes a route in a route table.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_route_table.rs
@@ -14,6 +14,7 @@ pub fn ec2_route_table_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
         resource_type_name: "ec2.route_table",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.route_table")
             .with_description("Describes a route table.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group.rs
@@ -14,6 +14,7 @@ pub fn ec2_security_group_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
         resource_type_name: "ec2.security_group",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group")
         .with_description("Describes a security group.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
@@ -59,6 +59,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupEgress",
         resource_type_name: "ec2.security_group_egress",
         has_tags: false,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group_egress")
             .with_description("Describes a security group rule.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
@@ -59,6 +59,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
         resource_type_name: "ec2.security_group_ingress",
         has_tags: false,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group_ingress")
         .with_description("Describes a security group rule.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_subnet.rs
@@ -56,6 +56,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
         resource_type_name: "ec2.subnet",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.subnet")
         .with_description("Describes a subnet.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
@@ -48,6 +48,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
         resource_type_name: "ec2.vpc",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.ec2.vpc")
         .with_description("Describes a VPC.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3_bucket.rs
@@ -36,6 +36,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::S3::Bucket",
         resource_type_name: "s3.bucket",
         has_tags: true,
+        data_source: false,
         schema: ResourceSchema::new("aws.s3.bucket")
             .attribute(
                 AttributeSchema::new("name", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/sts_caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts_caller_identity.rs
@@ -13,7 +13,9 @@ pub fn sts_caller_identity_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::STS::CallerIdentity",
         resource_type_name: "sts.caller_identity",
         has_tags: false,
+        data_source: true,
         schema: ResourceSchema::new("aws.sts.caller_identity")
+        .as_data_source()
         .attribute(
             AttributeSchema::new("account_id", AttributeType::String)
                 .with_description("The Amazon Web Services account ID number of the account that owns or contains the calling entity. (read-only)")

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -19,6 +19,8 @@ pub struct AwsSchemaConfig {
     pub resource_type_name: &'static str,
     /// Whether this resource type uses tags
     pub has_tags: bool,
+    /// Whether this is a data source (read-only) resource type
+    pub data_source: bool,
     /// The resource schema with attribute definitions
     pub schema: ResourceSchema,
 }


### PR DESCRIPTION
## Summary

- Add `data_source: bool` field to `ResourceSchema` and `AwsSchemaConfig` to mark data source resource types
- Update smithy codegen to automatically set the flag for resources with no `create_op`
- Add early validation in CLI `validate_resources()` with a helpful error message suggesting correct syntax
- Add LSP diagnostic for real-time editor feedback
- Regenerate all AWS schemas (`sts_caller_identity` gets `data_source: true`, all others `false`)

Previously, writing `aws.sts.caller_identity {}` without `read` only produced a generic "Unknown resource type" error at the provider's `create()` method. Now the error is caught early:

```
aws.sts.caller_identity is a data source and must be used with the `read` keyword:
  let <name> = read aws.sts.caller_identity { }
```

## Test plan

- [x] `cargo test -p carina-core` — schema unit tests for `as_data_source()` builder
- [x] `cargo test -p carina-cli` — validation tests (missing `read` → error, with `read` → pass, regular resource → pass)
- [x] `cargo test -p carina-lsp` — diagnostic tests (same three cases)
- [x] `cargo test` — full suite passes (510 tests, 0 failures)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)