### PR TITLE
Skip data source state reads during destroy and add test

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -5465,7 +5465,7 @@ awscc.ec2.security_group {
         let data_source = Resource::with_provider("awscc", "sts.caller_identity", "identity")
             .with_read_only(true);
 
-        let destroy_order = vec![managed.clone(), data_source.clone()];
+        let destroy_order = vec![managed, data_source];
 
         // Build current_states only for managed resources (data sources are skipped)
         let mut current_states: HashMap<ResourceId, State> = HashMap::new();


### PR DESCRIPTION
## Summary

- Skip unnecessary `provider.read()` API calls for data source (read-only) resources during destroy — they were being read even though the subsequent filtering already excluded them
- Add unit test `destroy_plan_excludes_data_sources` to verify data sources are excluded from the destroy plan

Closes #343

## Test plan

- [x] New unit test `destroy_plan_excludes_data_sources` passes
- [x] All existing tests pass
- [x] Pre-commit checks (formatting, clippy, tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)