### PR TITLE
Fix aws.vpc.vpc to aws.ec2.vpc in parser test

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1750,7 +1750,7 @@ mod tests {
                 versioning = "Enabled"
             }
 
-            aws.vpc.vpc {
+            aws.ec2.vpc {
                 name       = "main-vpc"
                 cidr_block = "10.0.0.0/16"
             }


### PR DESCRIPTION
## Summary
- Replace `aws.vpc.vpc` with `aws.ec2.vpc` in `parse_backend_block_with_resources` test
- The old format parsed to resource_type `vpc.vpc`, but the provider registers VPC as `ec2.vpc`

Closes #302

## Test plan
- [x] `cargo test -p carina-core parse_backend_block_with_resources` passes
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)