### PR TITLE
Remove backward compatibility aliases and wrappers

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -19,7 +19,7 @@ use carina_core::provider::{
 };
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::schema::ResourceSchema;
-use carina_core::schema::validate_cidr;
+use carina_core::schema::validate_ipv4_cidr;
 use carina_provider_aws::AwsProviderFactory;
 use carina_provider_awscc::AwsccProviderFactory;
 use carina_state::{
@@ -964,12 +964,12 @@ fn get_base_dir(path: &Path) -> &Path {
 /// Validate a module argument value against its expected type
 fn validate_module_arg_type(type_expr: &TypeExpr, value: &Value) -> Option<String> {
     match (type_expr, value) {
-        (TypeExpr::Cidr, Value::String(s)) => validate_cidr(s).err(),
+        (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
         (TypeExpr::List(inner), Value::List(items)) => {
             if let TypeExpr::Cidr = inner.as_ref() {
                 for (i, item) in items.iter().enumerate() {
                     if let Value::String(s) = item {
-                        if let Err(e) = validate_cidr(s) {
+                        if let Err(e) = validate_ipv4_cidr(s) {
                             return Some(format!("element {}: {}", i, e));
                         }
                     } else {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -98,8 +98,7 @@ pub trait Provider: Send + Sync {
     /// Get the current state of a resource
     ///
     /// If identifier is provided, use it to read the resource directly.
-    /// Otherwise, fall back to name-based lookup (for backwards compatibility).
-    /// Returns `State::not_found()` if the resource does not exist.
+    /// Returns `State::not_found()` if no identifier is provided or the resource does not exist.
     fn read(
         &self,
         id: &ResourceId,

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -611,23 +611,6 @@ pub mod types {
         }
     }
 
-    /// CIDR block type — alias for `ipv4_cidr()` for backward compatibility
-    pub fn cidr() -> AttributeType {
-        AttributeType::Custom {
-            name: "Cidr".to_string(),
-            base: Box::new(AttributeType::String),
-            validate: |value| {
-                if let Value::String(s) = value {
-                    validate_ipv4_cidr(s)
-                } else {
-                    Err("Expected string".to_string())
-                }
-            },
-            namespace: None,
-            to_dsl: None,
-        }
-    }
-
     /// IPv4 address type (e.g., "10.0.1.5", "192.168.0.1")
     pub fn ipv4_address() -> AttributeType {
         AttributeType::Custom {
@@ -727,11 +710,6 @@ pub fn validate_ipv4_cidr(cidr: &str) -> Result<(), String> {
             prefix
         )),
     }
-}
-
-/// Backward-compatible alias for `validate_ipv4_cidr`
-pub fn validate_cidr(cidr: &str) -> Result<(), String> {
-    validate_ipv4_cidr(cidr)
 }
 
 /// Validate IPv6 CIDR block format (e.g., "2001:db8::/32", "::/0")
@@ -965,7 +943,7 @@ mod tests {
 
     #[test]
     fn validate_cidr_type() {
-        let t = types::cidr();
+        let t = types::ipv4_cidr();
 
         // Valid CIDRs
         assert!(

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use crate::document::Document;
 use carina_core::parser::{InputParameter, ParseError, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
-use carina_core::schema::{validate_cidr, validate_ipv6_cidr};
+use carina_core::schema::{validate_ipv4_cidr, validate_ipv6_cidr};
 use carina_provider_aws::schemas::{generated as aws_generated, types as aws_types};
 use carina_provider_awscc::schemas::awscc_types;
 use carina_provider_awscc::schemas::generated::ec2_flow_log as awscc_flow_log;
@@ -382,7 +382,7 @@ impl DiagnosticEngine {
 
                                     if name == "Cidr" || name == "Ipv4Cidr" {
                                         if let Value::String(s) = &resolved_value {
-                                            validate_cidr(s).err()
+                                            validate_ipv4_cidr(s).err()
                                         } else {
                                             None
                                         }
@@ -1148,13 +1148,13 @@ impl DiagnosticEngine {
     fn validate_module_arg_type(&self, type_expr: &TypeExpr, value: &Value) -> Option<String> {
         match (type_expr, value) {
             // CIDR type validation
-            (TypeExpr::Cidr, Value::String(s)) => validate_cidr(s).err(),
+            (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
             // List of CIDR type validation
             (TypeExpr::List(inner), Value::List(items)) => {
                 if let TypeExpr::Cidr = inner.as_ref() {
                     for (i, item) in items.iter().enumerate() {
                         if let Value::String(s) = item {
-                            if let Err(e) = validate_cidr(s) {
+                            if let Err(e) = validate_ipv4_cidr(s) {
                                 return Some(format!("Element {}: {}", i, e));
                             }
                         } else {

--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -1154,7 +1154,6 @@ fn generate_mod_rs(dsl_names: &[&str]) -> String {
          //!\n\
          //! DO NOT EDIT MANUALLY - regenerate with:\n\
          //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh\n\n\
-         use carina_core::schema::ResourceSchema;\n\n\
          // Re-export all types and validators from types so that\n\
          // generated schema files can use `super::` to access them.\n\
          pub use super::types::*;\n\n",
@@ -1181,10 +1180,6 @@ fn generate_mod_rs(dsl_names: &[&str]) -> String {
     }
     code.push_str(
         "\x20   ]\n\
-         }\n\n\
-         /// Returns all generated schemas (for backward compatibility)\n\
-         pub fn schemas() -> Vec<ResourceSchema> {\n\
-         \x20   configs().into_iter().map(|c| c.schema).collect()\n\
          }\n\n",
     );
 

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -3,8 +3,6 @@
 //! DO NOT EDIT MANUALLY - regenerate with:
 //!   ./carina-provider-aws/scripts/generate-schemas-smithy.sh
 
-use carina_core::schema::ResourceSchema;
-
 // Re-export all types and validators from types so that
 // generated schema files can use `super::` to access them.
 pub use super::types::*;
@@ -34,11 +32,6 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         s3_bucket::s3_bucket_config(),
         sts_caller_identity::sts_caller_identity_config(),
     ]
-}
-
-/// Returns all generated schemas (for backward compatibility)
-pub fn schemas() -> Vec<ResourceSchema> {
-    configs().into_iter().map(|c| c.schema).collect()
 }
 
 /// Get valid enum values for a given resource type and attribute name.

--- a/carina-provider-aws/src/schemas/mod.rs
+++ b/carina-provider-aws/src/schemas/mod.rs
@@ -7,5 +7,5 @@ use carina_core::schema::ResourceSchema;
 
 /// Returns all AWS schemas
 pub fn all_schemas() -> Vec<ResourceSchema> {
-    generated::schemas()
+    generated::configs().into_iter().map(|c| c.schema).collect()
 }

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -113,8 +113,6 @@ cat > "$OUTPUT_DIR/mod.rs" << 'EOF'
 //! DO NOT EDIT MANUALLY - regenerate with:
 //!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
 
-use carina_core::schema::ResourceSchema;
-
 // Re-export all types and validators from awscc_types so that
 // generated schema files can use `super::` to access them.
 pub use super::awscc_types::*;
@@ -145,11 +143,6 @@ done
 
 cat >> "$OUTPUT_DIR/mod.rs" << 'EOF'
     ]
-}
-
-/// Returns all generated schemas (for backward compatibility)
-pub fn schemas() -> Vec<ResourceSchema> {
-    configs().into_iter().map(|c| c.schema).collect()
 }
 
 /// Get valid enum values for a given resource type and attribute name.

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -3,8 +3,6 @@
 //! DO NOT EDIT MANUALLY - regenerate with:
 //!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
 
-use carina_core::schema::ResourceSchema;
-
 // Re-export all types and validators from awscc_types so that
 // generated schema files can use `super::` to access them.
 pub use super::awscc_types::*;
@@ -62,11 +60,6 @@ pub fn configs() -> Vec<AwsccSchemaConfig> {
         iam_role::iam_role_config(),
         logs_log_group::logs_log_group_config(),
     ]
-}
-
-/// Returns all generated schemas (for backward compatibility)
-pub fn schemas() -> Vec<ResourceSchema> {
-    configs().into_iter().map(|c| c.schema).collect()
 }
 
 /// Get valid enum values for a given resource type and attribute name.

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -8,5 +8,5 @@ use carina_core::schema::ResourceSchema;
 /// Returns all AWS Cloud Control schemas
 /// Auto-generated from CloudFormation schemas
 pub fn all_schemas() -> Vec<ResourceSchema> {
-    generated::schemas()
+    generated::configs().into_iter().map(|c| c.schema).collect()
 }


### PR DESCRIPTION
## Summary

- Remove `cidr()` alias (use `ipv4_cidr()` directly) and `validate_cidr()` alias (use `validate_ipv4_cidr()` directly) from carina-core schema
- Remove `schemas()` backward-compat wrapper from both aws and awscc generated mod.rs; update `all_schemas()` to use `configs()` directly
- Remove `schemas()` generation from smithy codegen and generate-schemas.sh
- Remove unused `ResourceSchema` import from generated mod.rs files and codegen
- Fix misleading "backwards compatibility" doc comment on `Provider::read()`

### Items from issue not removed (no backward-compat code found)
- **Item 6** (`cidr_blocks`/`cidr` dual support in security group rules): No dual support exists; the code consistently uses `cidr_ip` and `cidr_ipv6`
- **Item 7** (legacy 3-part format in semantic_tokens.rs): The 3-part `provider.service.resource` format is the current active format, not legacy
- **`cf_type_name()`**: Actively used for `aws_type_name` field in `AwsSchemaConfig`, not backward compat

Closes #303

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all crates)
- [x] Pre-commit hooks (format, clippy, tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)