### PR TITLE
Remove provider-specific logic from carina-cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Enum values use namespaced identifiers like `aws.s3.VersioningStatus.Enabled` or
    resource.chars().all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
    ```
 
-2. **Update `is_dsl_enum_format()` in `carina-cli/src/main.rs`** for new patterns (e.g., 4-part identifiers like `provider.resource.TypeName.value`)
+2. **Update `is_dsl_enum_format()` in `carina-core/src/utils.rs`** for new patterns (e.g., 4-part identifiers like `provider.resource.TypeName.value`)
 
 3. **Plan display should not quote namespaced identifiers** - They are identifiers, not strings
 

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -20,6 +20,7 @@ use carina_core::provider::{
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::schema::ResourceSchema;
 use carina_core::schema::validate_ipv4_cidr;
+use carina_core::utils::is_dsl_enum_format;
 use carina_provider_aws::AwsProviderFactory;
 use carina_provider_awscc::AwsccProviderFactory;
 use carina_state::{
@@ -1077,7 +1078,9 @@ async fn run_plan(path: &PathBuf, out: Option<&PathBuf>) -> Result<bool, String>
                 })
                 .ok_or("Backend bucket name not specified")?;
 
-            let backend_resource_type = backend.resource_type().unwrap_or("s3.bucket");
+            let backend_resource_type = backend
+                .resource_type()
+                .ok_or("Backend does not specify a resource type")?;
             let has_bucket_resource = parsed.resources.iter().any(|r| {
                 r.id.resource_type == backend_resource_type
                     && r.attributes
@@ -1119,8 +1122,12 @@ async fn run_plan(path: &PathBuf, out: Option<&PathBuf>) -> Result<bool, String>
 
     // Show bootstrap plan if needed
     if will_create_state_bucket {
-        let backend_provider = plan_backend.provider_name().unwrap_or("aws");
-        let backend_resource_type = plan_backend.resource_type().unwrap_or("s3.bucket");
+        let backend_provider = plan_backend
+            .provider_name()
+            .ok_or("Backend does not specify a provider name")?;
+        let backend_resource_type = plan_backend
+            .resource_type()
+            .ok_or("Backend does not specify a resource type")?;
         println!("{}", "Bootstrap Plan:".cyan().bold());
         println!(
             "  {} {} (state bucket with versioning enabled)",
@@ -1258,7 +1265,9 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                 .ok_or("Missing bucket name in backend configuration")?;
 
             // Check if there's a bucket resource defined with matching name
-            let backend_resource_type = backend.resource_type().unwrap_or("s3.bucket");
+            let backend_resource_type = backend
+                .resource_type()
+                .ok_or("Backend does not specify a resource type")?;
             if let Some(bucket_resource) =
                 find_state_bucket_resource(&parsed, &bucket_name, backend_resource_type)
             {
@@ -1269,7 +1278,9 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                 );
 
                 // Create the bucket resource using the factory pattern
-                let backend_provider_name = backend.provider_name().unwrap_or("aws");
+                let backend_provider_name = backend
+                    .provider_name()
+                    .ok_or("Backend does not specify a provider name")?;
                 let factories = provider_factories();
                 let factory = find_factory(&factories, backend_provider_name).ok_or_else(|| {
                     format!("No provider factory found for '{}'", backend_provider_name)
@@ -1310,7 +1321,9 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                     println!("  {} Created state bucket", "✓".green());
 
                     // Get region from backend config using factory
-                    let backend_provider_name = backend.provider_name().unwrap_or("aws");
+                    let backend_provider_name = backend
+                        .provider_name()
+                        .ok_or("Backend does not specify a provider name")?;
                     let factories = provider_factories();
                     let factory =
                         find_factory(&factories, backend_provider_name).ok_or_else(|| {
@@ -1344,7 +1357,9 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                     );
 
                     // Create a protected ResourceState for the auto-created bucket
-                    let backend_resource_type = backend.resource_type().unwrap_or("s3.bucket");
+                    let backend_resource_type = backend
+                        .resource_type()
+                        .ok_or("Backend does not specify a resource type")?;
                     let bucket_state = ResourceState::new(
                         backend_resource_type,
                         &bucket_name,
@@ -2908,7 +2923,7 @@ fn get_identifier_from_state(
     {
         return resource_state.identifier.clone();
     }
-    // Fallback: use name attribute for initial lookup (aws provider)
+    // Fallback: use name attribute for initial lookup
     if let Some(Value::String(name)) = resource.attributes.get("name") {
         return Some(name.clone());
     }
@@ -3571,57 +3586,6 @@ fn format_effect(effect: &Effect) -> String {
     }
 }
 
-/// Check if a string is in DSL enum format
-/// Patterns:
-/// - provider.TypeName.value (e.g., aws.Region.ap_northeast_1, gcp.Region.us_central1)
-/// - TypeName.value (e.g., Region.ap_northeast_1)
-/// - provider.resource.TypeName.value (e.g., aws.s3.VersioningStatus.Enabled)
-/// - provider.service.resource.TypeName.value (e.g., awscc.ec2.vpc.InstanceTenancy.default)
-fn is_dsl_enum_format(s: &str) -> bool {
-    let parts: Vec<&str> = s.split('.').collect();
-
-    match parts.len() {
-        // TypeName.value
-        2 => parts[0].chars().next().is_some_and(|c| c.is_uppercase()),
-        // provider.TypeName.value
-        3 => {
-            let provider = parts[0];
-            let type_name = parts[1];
-            // provider should be lowercase, TypeName should start with uppercase
-            provider.chars().all(|c| c.is_lowercase())
-                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
-        }
-        // provider.resource.TypeName.value (e.g., aws.s3.VersioningStatus.Enabled)
-        4 => {
-            let provider = parts[0];
-            let resource = parts[1];
-            let type_name = parts[2];
-            // provider and resource should be lowercase/digits, TypeName should start with uppercase
-            provider.chars().all(|c| c.is_lowercase())
-                && resource
-                    .chars()
-                    .all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
-                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
-        }
-        // provider.service.resource.TypeName.value (e.g., awscc.ec2.vpc.InstanceTenancy.default)
-        5 => {
-            let provider = parts[0];
-            let service = parts[1];
-            let resource = parts[2];
-            let type_name = parts[3];
-            provider.chars().all(|c| c.is_lowercase())
-                && service
-                    .chars()
-                    .all(|c| c.is_lowercase() || c.is_ascii_digit())
-                && resource
-                    .chars()
-                    .all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
-                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
-        }
-        _ => false,
-    }
-}
-
 /// Check if a value is a list of maps (list-of-struct)
 fn is_list_of_maps(value: &Value) -> bool {
     if let Value::List(items) = value {
@@ -3922,14 +3886,7 @@ fn resource_to_state(
     state: &State,
     existing_state: Option<&ResourceState>,
 ) -> ResourceState {
-    let provider = resource
-        .attributes
-        .get("_provider")
-        .and_then(|v| match v {
-            Value::String(s) => Some(s.clone()),
-            _ => None,
-        })
-        .unwrap_or_else(|| "aws".to_string());
+    let provider = resource.id.provider.clone();
 
     let mut resource_state =
         ResourceState::new(&resource.id.resource_type, &resource.id.name, provider);
@@ -4155,8 +4112,12 @@ async fn run_state_bucket_delete(
         .map_err(|e| format!("Failed to create backend: {}", e))?;
 
     // Get provider metadata from backend
-    let backend_provider_name = backend.provider_name().unwrap_or("aws");
-    let backend_resource_type = backend.resource_type().unwrap_or("s3.bucket");
+    let backend_provider_name = backend
+        .provider_name()
+        .ok_or("Backend does not specify a provider name")?;
+    let backend_resource_type = backend
+        .resource_type()
+        .ok_or("Backend does not specify a resource type")?;
     let factories = provider_factories();
     let factory = find_factory(&factories, backend_provider_name)
         .ok_or_else(|| format!("No provider factory found for '{}'", backend_provider_name))?;

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -96,6 +96,71 @@ pub fn convert_enum_value(value: &str) -> String {
     raw_value.replace('_', "-")
 }
 
+/// Check if a string is in DSL enum format (a namespaced identifier).
+///
+/// Recognizes the following patterns:
+/// - `TypeName.value` (2-part, e.g., `Region.ap_northeast_1`)
+/// - `provider.TypeName.value` (3-part, e.g., `aws.Region.ap_northeast_1`)
+/// - `provider.resource.TypeName.value` (4-part, e.g., `aws.s3.VersioningStatus.Enabled`)
+/// - `provider.service.resource.TypeName.value` (5-part, e.g., `awscc.ec2.vpc.InstanceTenancy.default`)
+///
+/// # Examples
+///
+/// ```
+/// use carina_core::utils::is_dsl_enum_format;
+///
+/// assert!(is_dsl_enum_format("Region.ap_northeast_1"));
+/// assert!(is_dsl_enum_format("aws.Region.ap_northeast_1"));
+/// assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Enabled"));
+/// assert!(is_dsl_enum_format("awscc.ec2.vpc.InstanceTenancy.default"));
+/// assert!(!is_dsl_enum_format("my-bucket"));
+/// assert!(!is_dsl_enum_format("some.random.string"));
+/// ```
+pub fn is_dsl_enum_format(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+
+    match parts.len() {
+        // TypeName.value
+        2 => parts[0].chars().next().is_some_and(|c| c.is_uppercase()),
+        // provider.TypeName.value
+        3 => {
+            let provider = parts[0];
+            let type_name = parts[1];
+            // provider should be lowercase, TypeName should start with uppercase
+            provider.chars().all(|c| c.is_lowercase())
+                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
+        }
+        // provider.resource.TypeName.value (e.g., aws.s3.VersioningStatus.Enabled)
+        4 => {
+            let provider = parts[0];
+            let resource = parts[1];
+            let type_name = parts[2];
+            // provider and resource should be lowercase/digits, TypeName should start with uppercase
+            provider.chars().all(|c| c.is_lowercase())
+                && resource
+                    .chars()
+                    .all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
+                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
+        }
+        // provider.service.resource.TypeName.value (e.g., awscc.ec2.vpc.InstanceTenancy.default)
+        5 => {
+            let provider = parts[0];
+            let service = parts[1];
+            let resource = parts[2];
+            let type_name = parts[3];
+            provider.chars().all(|c| c.is_lowercase())
+                && service
+                    .chars()
+                    .all(|c| c.is_lowercase() || c.is_ascii_digit())
+                && resource
+                    .chars()
+                    .all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
+                && type_name.chars().next().is_some_and(|c| c.is_uppercase())
+        }
+        _ => false,
+    }
+}
+
 /// Validate namespace format for an enum identifier.
 ///
 /// Handles the following formats:
@@ -413,5 +478,47 @@ mod tests {
         assert!(
             validate_enum_namespace("a.b.c.d.e.f", "VersioningStatus", "aws.s3.bucket").is_err()
         );
+    }
+
+    // is_dsl_enum_format tests
+
+    #[test]
+    fn test_is_dsl_enum_format_2_part() {
+        assert!(is_dsl_enum_format("Region.ap_northeast_1"));
+        assert!(is_dsl_enum_format("VersioningStatus.Enabled"));
+        // lowercase first part → not a TypeName
+        assert!(!is_dsl_enum_format("region.ap_northeast_1"));
+    }
+
+    #[test]
+    fn test_is_dsl_enum_format_3_part() {
+        assert!(is_dsl_enum_format("aws.Region.ap_northeast_1"));
+        assert!(is_dsl_enum_format("gcp.Region.us_central1"));
+        // uppercase provider → not valid
+        assert!(!is_dsl_enum_format("AWS.Region.ap_northeast_1"));
+        // lowercase TypeName → not valid
+        assert!(!is_dsl_enum_format("aws.region.ap_northeast_1"));
+    }
+
+    #[test]
+    fn test_is_dsl_enum_format_4_part() {
+        assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Enabled"));
+        assert!(is_dsl_enum_format("aws.ec2.IpProtocol.tcp"));
+        // resource with digits
+        assert!(is_dsl_enum_format("aws.s3.VersioningStatus.Suspended"));
+    }
+
+    #[test]
+    fn test_is_dsl_enum_format_5_part() {
+        assert!(is_dsl_enum_format("awscc.ec2.vpc.InstanceTenancy.default"));
+        assert!(is_dsl_enum_format("awscc.ec2.ipam_pool.AddressFamily.IPv4"));
+    }
+
+    #[test]
+    fn test_is_dsl_enum_format_non_matching() {
+        assert!(!is_dsl_enum_format("my-bucket"));
+        assert!(!is_dsl_enum_format("ap-northeast-1"));
+        assert!(!is_dsl_enum_format("some.random.string"));
+        assert!(!is_dsl_enum_format("a.b.c.d.e.f"));
     }
 }


### PR DESCRIPTION
## Summary

- Move `is_dsl_enum_format()` from `carina-cli` to `carina-core/src/utils.rs` where it belongs alongside other enum utility functions
- Replace 9 hardcoded `unwrap_or("aws")` / `unwrap_or("s3.bucket")` fallbacks with proper `.ok_or(...)? ` error handling
- Replace `_provider` attribute lookup in `resource_to_state()` with `resource.id.provider.clone()` (the parser always sets this field)
- Fix misleading comment and update CLAUDE.md reference

Closes #334

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test -p carina-core` — new `is_dsl_enum_format` tests + doc-tests pass
- [x] `cargo test -p carina-cli` — all 38 existing CLI tests pass
- [x] Pre-commit hooks pass (formatting, clippy, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)