### PR TITLE
Remove hardcoded provider-specific completions from LSP

### DIFF
--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -495,7 +495,7 @@ impl CompletionProvider {
                 return completions;
             }
             // Fall back to type-based completions
-            completions.extend(self.completions_for_type(&attr_schema.attr_type, resource_type));
+            completions.extend(self.completions_for_type(&attr_schema.attr_type));
             return completions;
         }
 
@@ -578,11 +578,7 @@ impl CompletionProvider {
         bindings
     }
 
-    fn completions_for_type(
-        &self,
-        attr_type: &AttributeType,
-        resource_type: &str,
-    ) -> Vec<CompletionItem> {
+    fn completions_for_type(&self, attr_type: &AttributeType) -> Vec<CompletionItem> {
         match attr_type {
             AttributeType::Bool => {
                 vec![
@@ -618,13 +614,6 @@ impl CompletionProvider {
                 {
                     return self.region_completions();
                 }
-                // Check if this is a protocol enum
-                if variants
-                    .iter()
-                    .any(|v| v == "tcp" || v == "udp" || v == "icmp")
-                {
-                    return self.protocol_completions();
-                }
                 // Generic enum completions - wrap in quotes since they're string values
                 variants
                     .iter()
@@ -649,15 +638,6 @@ impl CompletionProvider {
                 self.ipv6_cidr_completions()
             }
             AttributeType::Custom { name, .. } if name == "Arn" => self.arn_completions(),
-            AttributeType::Custom { name, .. } if name == "VersioningStatus" => {
-                self.versioning_status_completions()
-            }
-            AttributeType::Custom { name, .. } if name == "InstanceTenancy" => {
-                self.instance_tenancy_completions(resource_type)
-            }
-            AttributeType::Custom { name, .. } if name == "IpProtocol" => {
-                self.ip_protocol_completions(resource_type)
-            }
             AttributeType::Union(_) | AttributeType::String | AttributeType::Custom { .. } => {
                 vec![CompletionItem {
                     label: "env".to_string(),
@@ -744,7 +724,7 @@ impl CompletionProvider {
             && let Some(fields) = self.extract_struct_fields(&attr_schema.attr_type)
             && let Some(field) = fields.iter().find(|f| f.name == field_name)
         {
-            self.completions_for_type(&field.field_type, resource_type)
+            self.completions_for_type(&field.field_type)
         } else {
             vec![]
         }
@@ -792,26 +772,6 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::ENUM_MEMBER),
                 detail: Some(c.description.clone()),
                 insert_text: Some(c.value.clone()),
-                ..Default::default()
-            })
-            .collect()
-    }
-
-    fn protocol_completions(&self) -> Vec<CompletionItem> {
-        let protocols = vec![
-            ("tcp", "Transmission Control Protocol"),
-            ("udp", "User Datagram Protocol"),
-            ("icmp", "Internet Control Message Protocol"),
-            ("all", "All protocols (-1)"),
-        ];
-
-        protocols
-            .into_iter()
-            .map(|(code, description)| CompletionItem {
-                label: format!("aws.Protocol.{}", code),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some(description.to_string()),
-                insert_text: Some(format!("aws.Protocol.{}", code)),
                 ..Default::default()
             })
             .collect()
@@ -872,80 +832,6 @@ impl CompletionProvider {
             detail: Some("ARN format: arn:partition:service:region:account:resource".to_string()),
             ..Default::default()
         }]
-    }
-
-    fn versioning_status_completions(&self) -> Vec<CompletionItem> {
-        vec![
-            CompletionItem {
-                label: "aws.s3.bucket.VersioningStatus.Enabled".to_string(),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some("Enable versioning".to_string()),
-                insert_text: Some("aws.s3.bucket.VersioningStatus.Enabled".to_string()),
-                ..Default::default()
-            },
-            CompletionItem {
-                label: "aws.s3.bucket.VersioningStatus.Suspended".to_string(),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some("Suspend versioning".to_string()),
-                insert_text: Some("aws.s3.bucket.VersioningStatus.Suspended".to_string()),
-                ..Default::default()
-            },
-        ]
-    }
-
-    fn instance_tenancy_completions(&self, resource_type: &str) -> Vec<CompletionItem> {
-        // Determine prefix based on resource type
-        let prefix = if resource_type.starts_with("awscc") {
-            "awscc.ec2.vpc.InstanceTenancy"
-        } else {
-            "aws.ec2.vpc.InstanceTenancy"
-        };
-
-        vec![
-            CompletionItem {
-                label: format!("{}.default", prefix),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some("Instances can have any tenancy".to_string()),
-                insert_text: Some(format!("{}.default", prefix)),
-                ..Default::default()
-            },
-            CompletionItem {
-                label: format!("{}.dedicated", prefix),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some("Instances will be dedicated tenancy".to_string()),
-                insert_text: Some(format!("{}.dedicated", prefix)),
-                ..Default::default()
-            },
-            CompletionItem {
-                label: format!("{}.host", prefix),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some("Instances will run on dedicated hosts".to_string()),
-                insert_text: Some(format!("{}.host", prefix)),
-                ..Default::default()
-            },
-        ]
-    }
-
-    fn ip_protocol_completions(&self, resource_type: &str) -> Vec<CompletionItem> {
-        let prefix = format!("{}.IpProtocol", resource_type);
-        let protocols = vec![
-            ("tcp", "Transmission Control Protocol"),
-            ("udp", "User Datagram Protocol"),
-            ("icmp", "Internet Control Message Protocol"),
-            ("icmpv6", "Internet Control Message Protocol v6"),
-            ("all", "All protocols (-1)"),
-        ];
-
-        protocols
-            .into_iter()
-            .map(|(code, description)| CompletionItem {
-                label: format!("{}.{}", prefix, code),
-                kind: Some(CompletionItemKind::ENUM_MEMBER),
-                detail: Some(description.to_string()),
-                insert_text: Some(format!("{}.{}", prefix, code)),
-                ..Default::default()
-            })
-            .collect()
     }
 
     fn ref_type_completions(&self) -> Vec<CompletionItem> {

--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -520,6 +520,9 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         .unwrap_or(res.name);
     let mut schema_imports = vec!["AttributeSchema", "ResourceSchema"];
     schema_imports.insert(1, "AttributeType");
+    if attrs.iter().any(|a| a.enum_info.is_some()) {
+        schema_imports.push("CompletionValue");
+    }
     if needs_struct_field {
         schema_imports.push("StructField");
     }
@@ -743,10 +746,45 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         }
 
         attr_code.push_str(&format!(
-            "\n\x20               .with_provider_name(\"{}\"),",
+            "\n\x20               .with_provider_name(\"{}\")",
             attr.provider_name
         ));
-        attr_code.push_str("\n\x20       )\n");
+
+        // Generate .with_completions() for enum attributes
+        if let Some(ref ei) = attr.enum_info {
+            let has_hyphens = ei.values.iter().any(|v| v.contains('-'));
+            let snake = attr.provider_name.to_snake_case();
+            let prop_aliases = enum_alias_map.get(snake.as_str());
+            let completion_entries: Vec<String> = ei
+                .values
+                .iter()
+                .map(|value| {
+                    let dsl_value = if let Some(alias_list) = prop_aliases {
+                        if let Some((_, alias)) =
+                            alias_list.iter().find(|(c, _)| *c == value.as_str())
+                        {
+                            alias.to_string()
+                        } else if has_hyphens {
+                            value.replace('-', "_")
+                        } else {
+                            value.clone()
+                        }
+                    } else if has_hyphens {
+                        value.replace('-', "_")
+                    } else {
+                        value.clone()
+                    };
+                    let dsl_id = format!("{}.{}.{}", namespace, ei.type_name, dsl_value);
+                    format!("CompletionValue::new(\"{}\", \"{}\")", dsl_id, value)
+                })
+                .collect();
+            attr_code.push_str(&format!(
+                "\n\x20               .with_completions(vec![{}])",
+                completion_entries.join(", ")
+            ));
+        }
+
+        attr_code.push_str(",\n\x20       )\n");
         code.push_str(&attr_code);
     }
 

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
@@ -133,7 +133,17 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("Not supported. Use IP permissions instead.")
-                .with_provider_name("IpProtocol"),
+                .with_provider_name("IpProtocol")
+                .with_completions(vec![
+                    CompletionValue::new("aws.ec2.security_group_egress.IpProtocol.tcp", "tcp"),
+                    CompletionValue::new("aws.ec2.security_group_egress.IpProtocol.udp", "udp"),
+                    CompletionValue::new("aws.ec2.security_group_egress.IpProtocol.icmp", "icmp"),
+                    CompletionValue::new(
+                        "aws.ec2.security_group_egress.IpProtocol.icmpv6",
+                        "icmpv6",
+                    ),
+                    CompletionValue::new("aws.ec2.security_group_egress.IpProtocol.all", "-1"),
+                ]),
             )
             .attribute(
                 AttributeSchema::new("source_security_group_name", AttributeType::String)

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
@@ -7,7 +7,7 @@
 use super::AwsSchemaConfig;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
@@ -123,7 +123,8 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("The IP protocol name (tcp, udp, icmp) or number (see Protocol Numbers). To specify all protocols, use -1. To specify icmpv6, use IP permissions instea...")
-                .with_provider_name("IpProtocol"),
+                .with_provider_name("IpProtocol")
+                .with_completions(vec![CompletionValue::new("aws.ec2.security_group_ingress.IpProtocol.tcp", "tcp"), CompletionValue::new("aws.ec2.security_group_ingress.IpProtocol.udp", "udp"), CompletionValue::new("aws.ec2.security_group_ingress.IpProtocol.icmp", "icmp"), CompletionValue::new("aws.ec2.security_group_ingress.IpProtocol.icmpv6", "icmpv6"), CompletionValue::new("aws.ec2.security_group_ingress.IpProtocol.all", "-1")]),
         )
         .attribute(
             AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())

--- a/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
@@ -8,7 +8,7 @@ use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_INSTANCE_TENANCY: &[&str] = &["dedicated", "default", "host"];
@@ -85,7 +85,8 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
             })
                 .create_only()
                 .with_description("The tenancy options for instances launched into the VPC. For default, instances are launched with shared tenancy by default. You can launch instances ...")
-                .with_provider_name("InstanceTenancy"),
+                .with_provider_name("InstanceTenancy")
+                .with_completions(vec![CompletionValue::new("aws.ec2.vpc.InstanceTenancy.dedicated", "dedicated"), CompletionValue::new("aws.ec2.vpc.InstanceTenancy.default", "default"), CompletionValue::new("aws.ec2.vpc.InstanceTenancy.host", "host")]),
         )
         .attribute(
             AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())

--- a/carina-provider-aws/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3_bucket.rs
@@ -8,7 +8,7 @@ use super::AwsSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema};
 
 #[allow(dead_code)]
 const VALID_VERSIONING_STATUS: &[&str] = &["Enabled", "Suspended"];
@@ -58,7 +58,11 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
                     },
                 )
                 .with_description("The versioning state of the bucket.")
-                .with_provider_name("VersioningStatus"),
+                .with_provider_name("VersioningStatus")
+                .with_completions(vec![
+                    CompletionValue::new("aws.s3.bucket.VersioningStatus.Enabled", "Enabled"),
+                    CompletionValue::new("aws.s3.bucket.VersioningStatus.Suspended", "Suspended"),
+                ]),
             )
             .attribute(
                 AttributeSchema::new("tags", tags_type())

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -914,6 +914,9 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
     if needs_attribute_type {
         schema_imports.insert(1, "AttributeType");
     }
+    if schema.properties.keys().any(|k| enums.contains_key(k)) {
+        schema_imports.push("CompletionValue");
+    }
     if needs_struct_field {
         schema_imports.push("StructField");
     }
@@ -1145,6 +1148,38 @@ pub fn {}() -> AwsccSchemaConfig {{
             "\n                .with_provider_name(\"{}\")",
             prop_name
         ));
+
+        // Generate .with_completions() for enum attributes
+        if let Some(enum_info) = enums.get(prop_name) {
+            let has_hyphens = enum_info.values.iter().any(|v| v.contains('-'));
+            let aliases = known_enum_aliases();
+            let prop_aliases = aliases.get(prop_name.as_str());
+            let completion_entries: Vec<String> = enum_info
+                .values
+                .iter()
+                .map(|value| {
+                    let dsl_value = if let Some(alias_list) = prop_aliases {
+                        if let Some((_, alias)) = alias_list.iter().find(|(c, _)| c == value) {
+                            alias.to_string()
+                        } else if has_hyphens {
+                            value.replace('-', "_")
+                        } else {
+                            value.clone()
+                        }
+                    } else if has_hyphens {
+                        value.replace('-', "_")
+                    } else {
+                        value.clone()
+                    };
+                    let dsl_id = format!("{}.{}.{}", namespace, enum_info.type_name, dsl_value);
+                    format!("CompletionValue::new(\"{}\", \"{}\")", dsl_id, value)
+                })
+                .collect();
+            attr_code.push_str(&format!(
+                "\n                .with_completions(vec![{}])",
+                completion_entries.join(", ")
+            ));
+        }
 
         attr_code.push_str(",\n        )\n");
         code.push_str(&attr_code);

--- a/carina-provider-awscc/src/schemas/generated/ec2_eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_eip.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_DOMAIN: &[&str] = &["vpc", "standard"];
@@ -52,7 +52,8 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("The network (``vpc``). If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a depend...")
-                .with_provider_name("Domain"),
+                .with_provider_name("Domain")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.eip.Domain.vpc", "vpc"), CompletionValue::new("awscc.ec2.eip.Domain.standard", "standard")]),
         )
         .attribute(
             AttributeSchema::new("instance_id", super::aws_resource_id())

--- a/carina-provider-awscc/src/schemas/generated/ec2_flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_flow_log.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField,
+};
 
 #[allow(dead_code)]
 const VALID_LOG_DESTINATION_TYPE: &[&str] = &["cloud-watch-logs", "s3", "kinesis-data-firehose"];
@@ -130,7 +132,8 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3.")
-                .with_provider_name("LogDestinationType"),
+                .with_provider_name("LogDestinationType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.flow_log.LogDestinationType.cloud_watch_logs", "cloud-watch-logs"), CompletionValue::new("awscc.ec2.flow_log.LogDestinationType.s3", "s3"), CompletionValue::new("awscc.ec2.flow_log.LogDestinationType.kinesis_data_firehose", "kinesis-data-firehose")]),
         )
         .attribute(
             AttributeSchema::new("log_format", AttributeType::String)
@@ -168,7 +171,8 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("The type of resource for which to create the flow log. For example, if you specified a VPC ID for the ResourceId property, specify VPC for this proper...")
-                .with_provider_name("ResourceType"),
+                .with_provider_name("ResourceType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.flow_log.ResourceType.NetworkInterface", "NetworkInterface"), CompletionValue::new("awscc.ec2.flow_log.ResourceType.Subnet", "Subnet"), CompletionValue::new("awscc.ec2.flow_log.ResourceType.VPC", "VPC"), CompletionValue::new("awscc.ec2.flow_log.ResourceType.TransitGateway", "TransitGateway"), CompletionValue::new("awscc.ec2.flow_log.ResourceType.TransitGatewayAttachment", "TransitGatewayAttachment"), CompletionValue::new("awscc.ec2.flow_log.ResourceType.RegionalNatGateway", "RegionalNatGateway")]),
         )
         .attribute(
             AttributeSchema::new("tags", tags_type())
@@ -185,7 +189,8 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.")
-                .with_provider_name("TrafficType"),
+                .with_provider_name("TrafficType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.flow_log.TrafficType.ACCEPT", "ACCEPT"), CompletionValue::new("awscc.ec2.flow_log.TrafficType.ALL", "ALL"), CompletionValue::new("awscc.ec2.flow_log.TrafficType.REJECT", "REJECT")]),
         )
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2_ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_ipam.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField,
+};
 
 #[allow(dead_code)]
 const VALID_METERED_ACCOUNT: &[&str] = &["ipam-owner", "resource-owner"];
@@ -100,7 +102,8 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("A metered account is an account that is charged for active IP addresses managed in IPAM")
-                .with_provider_name("MeteredAccount"),
+                .with_provider_name("MeteredAccount")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam.MeteredAccount.ipam_owner", "ipam-owner"), CompletionValue::new("awscc.ec2.ipam.MeteredAccount.resource_owner", "resource-owner")]),
         )
         .attribute(
             AttributeSchema::new("operating_regions", AttributeType::List(Box::new(AttributeType::Struct {
@@ -146,7 +149,8 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("The tier of the IPAM.")
-                .with_provider_name("Tier"),
+                .with_provider_name("Tier")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam.Tier.free", "free"), CompletionValue::new("awscc.ec2.ipam.Tier.advanced", "advanced")]),
         )
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2_ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_ipam_pool.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField,
+};
 
 #[allow(dead_code)]
 const VALID_ADDRESS_FAMILY: &[&str] = &["IPv4", "IPv6"];
@@ -130,7 +132,8 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("The address family of the address space in this pool. Either IPv4 or IPv6.")
-                .with_provider_name("AddressFamily"),
+                .with_provider_name("AddressFamily")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam_pool.AddressFamily.IPv4", "IPv4"), CompletionValue::new("awscc.ec2.ipam_pool.AddressFamily.IPv6", "IPv6")]),
         )
         .attribute(
             AttributeSchema::new("allocation_default_netmask_length", AttributeType::Int)
@@ -172,7 +175,8 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("Limits which service in Amazon Web Services that the pool can be used in.")
-                .with_provider_name("AwsService"),
+                .with_provider_name("AwsService")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam_pool.AwsService.ec2", "ec2"), CompletionValue::new("awscc.ec2.ipam_pool.AwsService.global_services", "global-services")]),
         )
         .attribute(
             AttributeSchema::new("description", AttributeType::String)
@@ -209,7 +213,8 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("Determines whether this scope contains publicly routable space or space for a private network (read-only)")
-                .with_provider_name("IpamScopeType"),
+                .with_provider_name("IpamScopeType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam_pool.IpamScopeType.public", "public"), CompletionValue::new("awscc.ec2.ipam_pool.IpamScopeType.private", "private")]),
         )
         .attribute(
             AttributeSchema::new("locale", AttributeType::String)
@@ -242,7 +247,8 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Default is `byoip`.")
-                .with_provider_name("PublicIpSource"),
+                .with_provider_name("PublicIpSource")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam_pool.PublicIpSource.byoip", "byoip"), CompletionValue::new("awscc.ec2.ipam_pool.PublicIpSource.amazon", "amazon")]),
         )
         .attribute(
             AttributeSchema::new("publicly_advertisable", AttributeType::Bool)
@@ -278,7 +284,8 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("The state of this pool. This can be one of the following values: \"create-in-progress\", \"create-complete\", \"modify-in-progress\", \"modify-complet... (read-only)")
-                .with_provider_name("State"),
+                .with_provider_name("State")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.ipam_pool.State.create_in_progress", "create-in-progress"), CompletionValue::new("awscc.ec2.ipam_pool.State.create_complete", "create-complete"), CompletionValue::new("awscc.ec2.ipam_pool.State.modify_in_progress", "modify-in-progress"), CompletionValue::new("awscc.ec2.ipam_pool.State.modify_complete", "modify-complete"), CompletionValue::new("awscc.ec2.ipam_pool.State.delete_in_progress", "delete-in-progress"), CompletionValue::new("awscc.ec2.ipam_pool.State.delete_complete", "delete-complete")]),
         )
         .attribute(
             AttributeSchema::new("state_message", AttributeType::String)

--- a/carina-provider-awscc/src/schemas/generated/ec2_nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_nat_gateway.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField, types,
+};
 
 #[allow(dead_code)]
 const VALID_AVAILABILITY_MODE: &[&str] = &["zonal", "regional"];
@@ -84,7 +86,8 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway. A zonal NAT gateway is a NAT Gateway that provides redundancy and sc...")
-                .with_provider_name("AvailabilityMode"),
+                .with_provider_name("AvailabilityMode")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.nat_gateway.AvailabilityMode.zonal", "zonal"), CompletionValue::new("awscc.ec2.nat_gateway.AvailabilityMode.regional", "regional")]),
         )
         .attribute(
             AttributeSchema::new("availability_zone_addresses", AttributeType::List(Box::new(AttributeType::Struct {
@@ -108,7 +111,8 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity.")
-                .with_provider_name("ConnectivityType"),
+                .with_provider_name("ConnectivityType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.nat_gateway.ConnectivityType.public", "public"), CompletionValue::new("awscc.ec2.nat_gateway.ConnectivityType.private", "private")]),
         )
         .attribute(
             AttributeSchema::new("eni_id", super::aws_resource_id())

--- a/carina-provider-awscc/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_security_group_egress.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
@@ -125,7 +125,8 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Protocol Numbers](https://docs.aws.amazon.com/http://www.iana.org/assign...")
-                .with_provider_name("IpProtocol"),
+                .with_provider_name("IpProtocol")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.security_group_egress.IpProtocol.tcp", "tcp"), CompletionValue::new("awscc.ec2.security_group_egress.IpProtocol.udp", "udp"), CompletionValue::new("awscc.ec2.security_group_egress.IpProtocol.icmp", "icmp"), CompletionValue::new("awscc.ec2.security_group_egress.IpProtocol.icmpv6", "icmpv6"), CompletionValue::new("awscc.ec2.security_group_egress.IpProtocol.all", "-1")]),
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {

--- a/carina-provider-awscc/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_security_group_ingress.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
@@ -118,7 +118,8 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .required()
                 .create_only()
                 .with_description("The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers). [VPC only] Use -1 to specify all protocols. When authorizing security ...")
-                .with_provider_name("IpProtocol"),
+                .with_provider_name("IpProtocol")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.security_group_ingress.IpProtocol.tcp", "tcp"), CompletionValue::new("awscc.ec2.security_group_ingress.IpProtocol.udp", "udp"), CompletionValue::new("awscc.ec2.security_group_ingress.IpProtocol.icmp", "icmp"), CompletionValue::new("awscc.ec2.security_group_ingress.IpProtocol.icmpv6", "icmpv6"), CompletionValue::new("awscc.ec2.security_group_ingress.IpProtocol.all", "-1")]),
         )
         .attribute(
             AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())

--- a/carina-provider-awscc/src/schemas/generated/ec2_transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_transit_gateway.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_AUTO_ACCEPT_SHARED_ATTACHMENTS: &[&str] = &["enable", "disable"];
@@ -204,7 +204,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("AutoAcceptSharedAttachments"),
+                .with_provider_name("AutoAcceptSharedAttachments")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.AutoAcceptSharedAttachments.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.AutoAcceptSharedAttachments.disable",
+                        "disable",
+                    ),
+                ]),
             )
             .attribute(
                 AttributeSchema::new(
@@ -217,7 +227,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("DefaultRouteTableAssociation"),
+                .with_provider_name("DefaultRouteTableAssociation")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.DefaultRouteTableAssociation.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.DefaultRouteTableAssociation.disable",
+                        "disable",
+                    ),
+                ]),
             )
             .attribute(
                 AttributeSchema::new(
@@ -230,7 +250,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("DefaultRouteTablePropagation"),
+                .with_provider_name("DefaultRouteTablePropagation")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.DefaultRouteTablePropagation.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.DefaultRouteTablePropagation.disable",
+                        "disable",
+                    ),
+                ]),
             )
             .attribute(
                 AttributeSchema::new("description", AttributeType::String)
@@ -247,7 +277,11 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("DnsSupport"),
+                .with_provider_name("DnsSupport")
+                .with_completions(vec![
+                    CompletionValue::new("awscc.ec2.transit_gateway.DnsSupport.enable", "enable"),
+                    CompletionValue::new("awscc.ec2.transit_gateway.DnsSupport.disable", "disable"),
+                ]),
             )
             .attribute(
                 AttributeSchema::new(
@@ -260,7 +294,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("EncryptionSupport"),
+                .with_provider_name("EncryptionSupport")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.EncryptionSupport.disable",
+                        "disable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.EncryptionSupport.enable",
+                        "enable",
+                    ),
+                ]),
             )
             .attribute(
                 AttributeSchema::new("encryption_support_state", AttributeType::String)
@@ -284,7 +328,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     },
                 )
                 .create_only()
-                .with_provider_name("MulticastSupport"),
+                .with_provider_name("MulticastSupport")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.MulticastSupport.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.MulticastSupport.disable",
+                        "disable",
+                    ),
+                ]),
             )
             .attribute(
                 AttributeSchema::new(
@@ -304,7 +358,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("SecurityGroupReferencingSupport"),
+                .with_provider_name("SecurityGroupReferencingSupport")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.SecurityGroupReferencingSupport.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.SecurityGroupReferencingSupport.disable",
+                        "disable",
+                    ),
+                ]),
             )
             .attribute(AttributeSchema::new("tags", tags_type()).with_provider_name("Tags"))
             .attribute(
@@ -330,7 +394,17 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         to_dsl: None,
                     },
                 )
-                .with_provider_name("VpnEcmpSupport"),
+                .with_provider_name("VpnEcmpSupport")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.VpnEcmpSupport.enable",
+                        "enable",
+                    ),
+                    CompletionValue::new(
+                        "awscc.ec2.transit_gateway.VpnEcmpSupport.disable",
+                        "disable",
+                    ),
+                ]),
             ),
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2_vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_vpc.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema, types};
 
 #[allow(dead_code)]
 const VALID_INSTANCE_TENANCY: &[&str] = &["default", "dedicated", "host"];
@@ -90,7 +90,8 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("The allowed tenancy of instances launched into the VPC.  + ``default``: An instance launched into the VPC runs on shared hardware by default, unless y...")
-                .with_provider_name("InstanceTenancy"),
+                .with_provider_name("InstanceTenancy")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.vpc.InstanceTenancy.default", "default"), CompletionValue::new("awscc.ec2.vpc.InstanceTenancy.dedicated", "dedicated"), CompletionValue::new("awscc.ec2.vpc.InstanceTenancy.host", "host")]),
         )
         .attribute(
             AttributeSchema::new("ipv4_ipam_pool_id", super::ipam_pool_id())

--- a/carina-provider-awscc/src/schemas/generated/ec2_vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_vpc_endpoint.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField,
+};
 
 #[allow(dead_code)]
 const VALID_DNS_RECORD_IP_TYPE: &[&str] = &[
@@ -194,7 +196,8 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("The supported IP address types.")
-                .with_provider_name("IpAddressType"),
+                .with_provider_name("IpAddressType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.vpc_endpoint.IpAddressType.ipv4", "ipv4"), CompletionValue::new("awscc.ec2.vpc_endpoint.IpAddressType.ipv6", "ipv6"), CompletionValue::new("awscc.ec2.vpc_endpoint.IpAddressType.dualstack", "dualstack"), CompletionValue::new("awscc.ec2.vpc_endpoint.IpAddressType.not_specified", "not-specified")]),
         )
         .attribute(
             AttributeSchema::new("network_interface_ids", AttributeType::List(Box::new(super::aws_resource_id())))
@@ -265,7 +268,8 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
             })
                 .create_only()
                 .with_description("The type of endpoint. Default: Gateway")
-                .with_provider_name("VpcEndpointType"),
+                .with_provider_name("VpcEndpointType")
+                .with_completions(vec![CompletionValue::new("awscc.ec2.vpc_endpoint.VpcEndpointType.Interface", "Interface"), CompletionValue::new("awscc.ec2.vpc_endpoint.VpcEndpointType.Gateway", "Gateway"), CompletionValue::new("awscc.ec2.vpc_endpoint.VpcEndpointType.GatewayLoadBalancer", "GatewayLoadBalancer"), CompletionValue::new("awscc.ec2.vpc_endpoint.VpcEndpointType.ServiceNetwork", "ServiceNetwork"), CompletionValue::new("awscc.ec2.vpc_endpoint.VpcEndpointType.Resource", "Resource")]),
         )
         .attribute(
             AttributeSchema::new("vpc_id", super::vpc_id())

--- a/carina-provider-awscc/src/schemas/generated/logs_log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs_log_group.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema};
 
 #[allow(dead_code)]
 const VALID_LOG_GROUP_CLASS: &[&str] = &["STANDARD", "INFREQUENT_ACCESS", "DELIVERY"];
@@ -72,7 +72,8 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("Specifies the log group class for this log group. There are two classes:  + The ``Standard`` log class supports all CWL features.  + The ``Infrequent ...")
-                .with_provider_name("LogGroupClass"),
+                .with_provider_name("LogGroupClass")
+                .with_completions(vec![CompletionValue::new("awscc.logs.log_group.LogGroupClass.STANDARD", "STANDARD"), CompletionValue::new("awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS", "INFREQUENT_ACCESS"), CompletionValue::new("awscc.logs.log_group.LogGroupClass.DELIVERY", "DELIVERY")]),
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::String)

--- a/carina-provider-awscc/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3_bucket.rs
@@ -8,7 +8,9 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_namespaced_enum;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, CompletionValue, ResourceSchema, StructField,
+};
 
 #[allow(dead_code)]
 const VALID_ABAC_STATUS: &[&str] = &["Enabled", "Disabled"];
@@ -398,7 +400,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general p...")
-                .with_provider_name("AbacStatus"),
+                .with_provider_name("AbacStatus")
+                .with_completions(vec![CompletionValue::new("awscc.s3.bucket.AbacStatus.Enabled", "Enabled"), CompletionValue::new("awscc.s3.bucket.AbacStatus.Disabled", "Disabled")]),
         )
         .attribute(
             AttributeSchema::new("accelerate_configuration", AttributeType::Struct {
@@ -425,7 +428,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             })
                 .with_description("This is a legacy property, and it is not recommended for most use cases. A majority of modern use cases in Amazon S3 no longer require the use of ACLs...")
-                .with_provider_name("AccessControl"),
+                .with_provider_name("AccessControl")
+                .with_completions(vec![CompletionValue::new("awscc.s3.bucket.AccessControl.AuthenticatedRead", "AuthenticatedRead"), CompletionValue::new("awscc.s3.bucket.AccessControl.AwsExecRead", "AwsExecRead"), CompletionValue::new("awscc.s3.bucket.AccessControl.BucketOwnerFullControl", "BucketOwnerFullControl"), CompletionValue::new("awscc.s3.bucket.AccessControl.BucketOwnerRead", "BucketOwnerRead"), CompletionValue::new("awscc.s3.bucket.AccessControl.LogDeliveryWrite", "LogDeliveryWrite"), CompletionValue::new("awscc.s3.bucket.AccessControl.Private", "Private"), CompletionValue::new("awscc.s3.bucket.AccessControl.PublicRead", "PublicRead"), CompletionValue::new("awscc.s3.bucket.AccessControl.PublicReadWrite", "PublicReadWrite")]),
         )
         .attribute(
             AttributeSchema::new("analytics_configurations", AttributeType::List(Box::new(AttributeType::Struct {


### PR DESCRIPTION
## Summary

- Generate `.with_completions()` in both codegens (smithy_codegen and codegen) for enum attributes, populating `AttributeSchema.completions` with DSL identifiers computed from enum values, aliases, and hyphen-to-underscore conversions
- Remove 4 hardcoded LSP methods: `protocol_completions`, `versioning_status_completions`, `instance_tenancy_completions`, `ip_protocol_completions`
- Remove their call sites in `completions_for_type()` and the dead `Enum` protocol detection branch
- Remove unused `resource_type` parameter from `completions_for_type()`

Closes #365

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo test` — all 517 tests pass (including `instance_tenancy_completion_for_aws_vpc` and `versioning_status_completion_for_s3_bucket`)
- [x] Pre-commit hooks pass (clippy, formatting, tests)
- [x] Verified generated schemas have `.with_completions()` for enum attributes (e.g., `s3_bucket.rs` for VersioningStatus, `ec2_vpc.rs` for InstanceTenancy, `ec2_security_group_ingress.rs` for IpProtocol with `-1` → `all` alias)
- [x] Verified LSP `completion.rs` has zero provider-specific strings in non-test code

🤖 Generated with [Claude Code](https://claude.com/claude-code)