### PR TITLE
Remove default provider dependency on factory ordering

### DIFF
--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -1838,31 +1838,21 @@ let bucket = aws.s3.bucket {
 }"#,
         );
 
-        // With normal order (aws first)
         let engine = test_engine();
-        let diags_normal = engine.analyze(&doc, None);
-        let unknown_type_normal = diags_normal
-            .iter()
-            .any(|d| d.message.contains("Unknown resource type"));
-
-        // With reversed order (awscc first)
         let engine_rev = test_engine_reversed();
+
+        let diags_normal = engine.analyze(&doc, None);
         let diags_reversed = engine_rev.analyze(&doc, None);
-        let unknown_type_reversed = diags_reversed
-            .iter()
-            .any(|d| d.message.contains("Unknown resource type"));
+
+        let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
+        let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
 
         assert_eq!(
-            unknown_type_normal,
-            unknown_type_reversed,
-            "aws.s3.bucket detection should not depend on factory order.\n\
-             Normal order diagnostics: {:?}\n\
-             Reversed order diagnostics: {:?}",
-            diags_normal.iter().map(|d| &d.message).collect::<Vec<_>>(),
-            diags_reversed
-                .iter()
-                .map(|d| &d.message)
-                .collect::<Vec<_>>()
+            messages_normal, messages_reversed,
+            "aws.s3.bucket diagnostics should not depend on factory order.\n\
+             Normal: {:?}\n\
+             Reversed: {:?}",
+            messages_normal, messages_reversed
         );
     }
 
@@ -1878,31 +1868,21 @@ let vpc = awscc.ec2.vpc {
 }"#,
         );
 
-        // With normal order (aws first)
         let engine = test_engine();
-        let diags_normal = engine.analyze(&doc, None);
-        let unknown_type_normal = diags_normal
-            .iter()
-            .any(|d| d.message.contains("Unknown resource type"));
-
-        // With reversed order (awscc first)
         let engine_rev = test_engine_reversed();
+
+        let diags_normal = engine.analyze(&doc, None);
         let diags_reversed = engine_rev.analyze(&doc, None);
-        let unknown_type_reversed = diags_reversed
-            .iter()
-            .any(|d| d.message.contains("Unknown resource type"));
+
+        let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
+        let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
 
         assert_eq!(
-            unknown_type_normal,
-            unknown_type_reversed,
-            "awscc.ec2.vpc detection should not depend on factory order.\n\
-             Normal order diagnostics: {:?}\n\
-             Reversed order diagnostics: {:?}",
-            diags_normal.iter().map(|d| &d.message).collect::<Vec<_>>(),
-            diags_reversed
-                .iter()
-                .map(|d| &d.message)
-                .collect::<Vec<_>>()
+            messages_normal, messages_reversed,
+            "awscc.ec2.vpc diagnostics should not depend on factory order.\n\
+             Normal: {:?}\n\
+             Reversed: {:?}",
+            messages_normal, messages_reversed
         );
     }
 


### PR DESCRIPTION
## Summary

- Removed the implicit "default provider" concept from `detect_resource_provider()` that depended on `provider_names.first()` (i.e., factory registration order)
- All providers are now checked equally in text matching, sorted by reverse length to match `awscc` before `aws`
- Added a schema-based fallback: when text matching fails, the function checks which provider's schema contains the resource type
- Added 3 tests verifying provider detection is consistent regardless of factory ordering

## Test plan

- [x] All existing LSP tests pass (37 unit + 4 integration)
- [x] New tests verify identical behavior with `[aws, awscc]` and `[awscc, aws]` factory order
- [x] Full `cargo test` passes across all crates

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)