### PR TITLE
Remove cargo test from pre-commit hook for faster commits

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -9,29 +9,12 @@ echo "Running pre-commit checks..."
 # Check formatting
 echo "Checking formatting..."
 cargo fmt --all -- --check
-if [ $? -ne 0 ]; then
-    echo "Formatting check failed. Run 'cargo fmt --all' to fix."
-    exit 1
-fi
 echo "Formatting OK"
 
 # Run clippy
 echo "Running clippy..."
 cargo clippy --all-targets --all-features -- -D warnings
-if [ $? -ne 0 ]; then
-    echo "Clippy check failed. Fix the warnings above."
-    exit 1
-fi
 echo "Clippy OK"
-
-# Run tests
-echo "Running tests..."
-cargo test --quiet
-if [ $? -ne 0 ]; then
-    echo "Tests failed."
-    exit 1
-fi
-echo "Tests OK"
 
 echo ""
 echo "All pre-commit checks passed!"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -12,4 +12,4 @@ cp "$SCRIPT_DIR/pre-commit" "$REPO_ROOT/.git/hooks/pre-commit"
 chmod +x "$REPO_ROOT/.git/hooks/pre-commit"
 
 echo "Git hooks installed successfully!"
-echo "Pre-commit hook will run: fmt, clippy, tests"
+echo "Pre-commit hook will run: fmt, clippy"


### PR DESCRIPTION
## Summary

- Remove `cargo test` from pre-commit hook — it takes over 2 minutes due to doctest compilation and should run in CI instead
- Remove redundant `if [ $? -ne 0 ]` error handling blocks since `set -e` already exits on failure
- Update `setup-hooks.sh` message to reflect the reduced scope

Closes #376

## Test plan

- [x] Verified the new pre-commit hook runs successfully on commit
- [ ] Confirm formatting check still catches issues (`cargo fmt` violations)
- [ ] Confirm clippy check still catches issues (clippy warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)