### PR TITLE
Refactor: Extract dependency graph into carina-core::deps module

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -8,6 +8,10 @@ use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
 
+use carina_core::deps::{
+    build_dependents_map, find_failed_dependency, find_failed_dependent, get_resource_dependencies,
+    sort_resources_by_dependencies,
+};
 use carina_core::differ::create_plan;
 use carina_core::effect::Effect;
 use carina_core::formatter::{self, FormatConfig};
@@ -1604,7 +1608,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
             );
             skip_count += 1;
             // Propagate failure to this binding so transitive dependents are also skipped
-            if let Some(binding) = get_effect_binding_name(effect) {
+            if let Some(binding) = effect.binding_name() {
                 failed_bindings.insert(binding);
             }
             continue;
@@ -1642,7 +1646,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                     Err(e) => {
                         println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                         failure_count += 1;
-                        if let Some(binding) = get_effect_binding_name(effect) {
+                        if let Some(binding) = effect.binding_name() {
                             failed_bindings.insert(binding);
                         }
                     }
@@ -1679,7 +1683,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                     Err(e) => {
                         println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                         failure_count += 1;
-                        if let Some(binding) = get_effect_binding_name(effect) {
+                        if let Some(binding) = effect.binding_name() {
                             failed_bindings.insert(binding);
                         }
                     }
@@ -1725,7 +1729,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                                 Err(e) => {
                                     println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                                     failure_count += 1;
-                                    if let Some(binding) = get_effect_binding_name(effect) {
+                                    if let Some(binding) = effect.binding_name() {
                                         failed_bindings.insert(binding);
                                     }
                                 }
@@ -1734,7 +1738,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                         Err(e) => {
                             println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                             failure_count += 1;
-                            if let Some(binding) = get_effect_binding_name(effect) {
+                            if let Some(binding) = effect.binding_name() {
                                 failed_bindings.insert(binding);
                             }
                         }
@@ -1773,7 +1777,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                                 Err(e) => {
                                     println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                                     failure_count += 1;
-                                    if let Some(binding) = get_effect_binding_name(effect) {
+                                    if let Some(binding) = effect.binding_name() {
                                         failed_bindings.insert(binding);
                                     }
                                 }
@@ -1782,7 +1786,7 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                         Err(e) => {
                             println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                             failure_count += 1;
-                            if let Some(binding) = get_effect_binding_name(effect) {
+                            if let Some(binding) = effect.binding_name() {
                                 failed_bindings.insert(binding);
                             }
                         }
@@ -2181,7 +2185,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
             );
             skip_count += 1;
             // Propagate failure to this binding so transitive dependents are also skipped
-            if let Some(binding) = get_effect_binding_name(effect) {
+            if let Some(binding) = effect.binding_name() {
                 failed_bindings.insert(binding);
             }
             continue;
@@ -2215,7 +2219,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                     Err(e) => {
                         println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                         failure_count += 1;
-                        if let Some(binding) = get_effect_binding_name(effect) {
+                        if let Some(binding) = effect.binding_name() {
                             failed_bindings.insert(binding);
                         }
                     }
@@ -2247,7 +2251,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                     Err(e) => {
                         println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                         failure_count += 1;
-                        if let Some(binding) = get_effect_binding_name(effect) {
+                        if let Some(binding) = effect.binding_name() {
                             failed_bindings.insert(binding);
                         }
                     }
@@ -2292,7 +2296,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                                 Err(e) => {
                                     println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                                     failure_count += 1;
-                                    if let Some(binding) = get_effect_binding_name(effect) {
+                                    if let Some(binding) = effect.binding_name() {
                                         failed_bindings.insert(binding);
                                     }
                                 }
@@ -2301,7 +2305,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                         Err(e) => {
                             println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                             failure_count += 1;
-                            if let Some(binding) = get_effect_binding_name(effect) {
+                            if let Some(binding) = effect.binding_name() {
                                 failed_bindings.insert(binding);
                             }
                         }
@@ -2336,7 +2340,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                                 Err(e) => {
                                     println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                                     failure_count += 1;
-                                    if let Some(binding) = get_effect_binding_name(effect) {
+                                    if let Some(binding) = effect.binding_name() {
                                         failed_bindings.insert(binding);
                                     }
                                 }
@@ -2345,7 +2349,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
                         Err(e) => {
                             println!("  {} {} - {}", "✗".red(), format_effect(effect), e);
                             failure_count += 1;
-                            if let Some(binding) = get_effect_binding_name(effect) {
+                            if let Some(binding) = effect.binding_name() {
                                 failed_bindings.insert(binding);
                             }
                         }
@@ -3030,101 +3034,6 @@ fn resolve_ref_value(
     }
 }
 
-/// Extract binding names that a resource depends on
-fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
-    let mut deps = HashSet::new();
-    for value in resource.attributes.values() {
-        collect_dependencies(value, &mut deps);
-    }
-    deps
-}
-
-fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
-    match value {
-        Value::ResourceRef { binding_name, .. } => {
-            deps.insert(binding_name.clone());
-        }
-        Value::List(items) => {
-            for item in items {
-                collect_dependencies(item, deps);
-            }
-        }
-        Value::Map(map) => {
-            for v in map.values() {
-                collect_dependencies(v, deps);
-            }
-        }
-        _ => {}
-    }
-}
-
-/// Sort resources topologically based on dependencies
-fn sort_resources_by_dependencies(resources: &[Resource]) -> Vec<Resource> {
-    // Build binding name to resource mapping
-    let mut binding_to_resource: HashMap<String, &Resource> = HashMap::new();
-    for resource in resources {
-        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
-            binding_to_resource.insert(binding_name.clone(), resource);
-        }
-    }
-
-    // Build dependency graph
-    let mut sorted = Vec::new();
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut visiting: HashSet<String> = HashSet::new();
-
-    fn visit<'a>(
-        resource: &'a Resource,
-        binding_to_resource: &HashMap<String, &'a Resource>,
-        visited: &mut HashSet<String>,
-        visiting: &mut HashSet<String>,
-        sorted: &mut Vec<Resource>,
-    ) {
-        let binding_name = resource
-            .attributes
-            .get("_binding")
-            .and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
-
-        if visited.contains(&binding_name) {
-            return;
-        }
-        if visiting.contains(&binding_name) {
-            // Circular dependency - just continue
-            return;
-        }
-
-        visiting.insert(binding_name.clone());
-
-        // Visit dependencies first
-        let deps = get_resource_dependencies(resource);
-        for dep in deps {
-            if let Some(dep_resource) = binding_to_resource.get(&dep) {
-                visit(dep_resource, binding_to_resource, visited, visiting, sorted);
-            }
-        }
-
-        visiting.remove(&binding_name);
-        visited.insert(binding_name);
-        sorted.push(resource.clone());
-    }
-
-    for resource in resources {
-        visit(
-            resource,
-            &binding_to_resource,
-            &mut visited,
-            &mut visiting,
-            &mut sorted,
-        );
-    }
-
-    sorted
-}
-
 async fn create_plan_from_parsed(
     parsed: &ParsedFile,
     state_file: &Option<StateFile>,
@@ -3547,35 +3456,6 @@ fn print_plan(plan: &Plan) {
     }
     parts.push(format!("{} to destroy", summary.delete.to_string().red()));
     println!("Plan: {}.", parts.join(", "));
-}
-
-/// Get the resource from an effect for dependency checking
-fn get_effect_resource(effect: &Effect) -> Option<&Resource> {
-    match effect {
-        Effect::Create(resource) => Some(resource),
-        Effect::Update { to, .. } => Some(to),
-        Effect::Replace { to, .. } => Some(to),
-        Effect::Read { resource } => Some(resource),
-        Effect::Delete { .. } => None,
-    }
-}
-
-/// Get the binding name for an effect's resource
-fn get_effect_binding_name(effect: &Effect) -> Option<String> {
-    get_effect_resource(effect).and_then(|r| {
-        r.attributes.get("_binding").and_then(|v| match v {
-            Value::String(s) => Some(s.clone()),
-            _ => None,
-        })
-    })
-}
-
-/// Check if an effect has any dependency on failed bindings.
-/// Returns the name of the first failed dependency found, or None.
-fn find_failed_dependency(effect: &Effect, failed_bindings: &HashSet<String>) -> Option<String> {
-    let resource = get_effect_resource(effect)?;
-    let deps = get_resource_dependencies(resource);
-    deps.into_iter().find(|dep| failed_bindings.contains(dep))
 }
 
 fn format_effect(effect: &Effect) -> String {
@@ -4481,53 +4361,6 @@ fn find_crn_files_in_dir(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
     Ok(files)
 }
 
-/// Build a reverse dependency map: for each binding, which bindings depend on it.
-/// If resource A depends on resource B, then `dependents_map["b"]` contains "a".
-fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<String>> {
-    let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-    for resource in resources {
-        let binding = resource
-            .attributes
-            .get("_binding")
-            .and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
-
-        let deps = get_resource_dependencies(resource);
-        for dep in deps {
-            dependents_map
-                .entry(dep)
-                .or_default()
-                .insert(binding.clone());
-        }
-    }
-    dependents_map
-}
-
-/// Check if any dependent of the given binding has failed (is in failed_bindings).
-/// Returns the first failed dependent found, if any.
-fn find_failed_dependent<'a>(
-    binding: &str,
-    dependents_map: &'a HashMap<String, HashSet<String>>,
-    failed_bindings: &'a HashSet<String>,
-) -> Option<&'a String> {
-    // Check direct dependents
-    if let Some(dependents) = dependents_map.get(binding) {
-        for dep in dependents {
-            if failed_bindings.contains(dep) {
-                return Some(dep);
-            }
-            // Check transitive: if a dependent of this binding has a dependent that failed
-            if let Some(failed) = find_failed_dependent(dep, dependents_map, failed_bindings) {
-                return Some(failed);
-            }
-        }
-    }
-    None
-}
-
 fn print_diff(file: &Path, original: &str, formatted: &str) {
     println!("\n{} {}:", "Diff for".cyan().bold(), file.display());
 
@@ -4682,94 +4515,6 @@ fn run_lint(path: &PathBuf) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn make_resource(binding: &str, deps: &[&str]) -> Resource {
-        let mut r = Resource::new("test", binding);
-        r.attributes
-            .insert("_binding".to_string(), Value::String(binding.to_string()));
-        for dep in deps {
-            r.attributes.insert(
-                format!("ref_{}", dep),
-                Value::ResourceRef {
-                    binding_name: dep.to_string(),
-                    attribute_name: "id".to_string(),
-                },
-            );
-        }
-        r
-    }
-
-    #[test]
-    fn test_build_dependents_map() {
-        // A depends on B
-        let a = make_resource("a", &["b"]);
-        let b = make_resource("b", &[]);
-        let resources: Vec<&Resource> = vec![&a, &b];
-
-        let map = build_dependents_map(&resources);
-
-        // b's dependents should contain "a"
-        assert!(map.get("b").unwrap().contains("a"));
-        // a should have no dependents
-        assert!(!map.contains_key("a"));
-    }
-
-    #[test]
-    fn test_find_failed_dependent() {
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let mut failed_bindings = HashSet::new();
-        failed_bindings.insert("a".to_string());
-
-        // b has a dependent (a) that failed
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependent_none() {
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let failed_bindings: HashSet<String> = HashSet::new();
-
-        // No failed dependents
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_transitive_chain() {
-        // A depends on B, B depends on C
-        // dependents_map: c -> {b}, b -> {a}
-        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
-        dependents_map
-            .entry("c".to_string())
-            .or_default()
-            .insert("b".to_string());
-        dependents_map
-            .entry("b".to_string())
-            .or_default()
-            .insert("a".to_string());
-
-        let mut failed_bindings = HashSet::new();
-        failed_bindings.insert("a".to_string());
-
-        // a failed -> b is blocked (a is a direct dependent of b)
-        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
-
-        // a failed -> c is also blocked (transitively through b -> a)
-        let result = find_failed_dependent("c", &dependents_map, &failed_bindings);
-        assert_eq!(result, Some(&"a".to_string()));
-    }
 
     #[test]
     fn plan_file_serde_round_trip() {
@@ -5196,114 +4941,6 @@ mod tests {
 
         // Name should remain unchanged
         assert_eq!(resources[0].id.name, "my_vpc");
-    }
-
-    #[test]
-    fn test_get_effect_resource_create() {
-        let resource = make_resource("a", &[]);
-        let effect = Effect::Create(resource.clone());
-        assert_eq!(get_effect_resource(&effect).unwrap().id, resource.id);
-    }
-
-    #[test]
-    fn test_get_effect_resource_delete_returns_none() {
-        let effect = Effect::Delete {
-            id: ResourceId::new("test", "a"),
-            identifier: "id-123".to_string(),
-            lifecycle: LifecycleConfig::default(),
-        };
-        assert!(get_effect_resource(&effect).is_none());
-    }
-
-    #[test]
-    fn test_get_effect_binding_name() {
-        let resource = make_resource("my_binding", &[]);
-        let effect = Effect::Create(resource);
-        assert_eq!(
-            get_effect_binding_name(&effect),
-            Some("my_binding".to_string())
-        );
-    }
-
-    #[test]
-    fn test_get_effect_binding_name_no_binding() {
-        let mut resource = Resource::new("test", "no_binding");
-        // No _binding attribute
-        resource
-            .attributes
-            .insert("name".to_string(), Value::String("test".to_string()));
-        let effect = Effect::Create(resource);
-        assert_eq!(get_effect_binding_name(&effect), None);
-    }
-
-    #[test]
-    fn test_find_failed_dependency_direct() {
-        // resource "b" depends on "a"
-        let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource);
-
-        let mut failed = HashSet::new();
-        failed.insert("a".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, Some("a".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependency_none() {
-        let resource = make_resource("b", &["a"]);
-        let effect = Effect::Create(resource);
-
-        let failed: HashSet<String> = HashSet::new();
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_failed_dependency_no_deps() {
-        let resource = make_resource("a", &[]);
-        let effect = Effect::Create(resource);
-
-        let mut failed = HashSet::new();
-        failed.insert("x".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_find_failed_dependency_transitive_propagation() {
-        // Simulates the apply loop behavior:
-        // c depends on b, b depends on a
-        // a fails -> b gets added to failed_bindings (by apply loop)
-        // c should be skipped because b is in failed_bindings
-        let resource_c = make_resource("c", &["b"]);
-        let effect_c = Effect::Create(resource_c);
-
-        let mut failed = HashSet::new();
-        // "a" failed initially, "b" was added when skipped (simulating apply loop propagation)
-        failed.insert("a".to_string());
-        failed.insert("b".to_string());
-
-        let result = find_failed_dependency(&effect_c, &failed);
-        assert_eq!(result, Some("b".to_string()));
-    }
-
-    #[test]
-    fn test_find_failed_dependency_delete_effect() {
-        // Delete effects have no resource, so no dependencies to check
-        let effect = Effect::Delete {
-            id: ResourceId::new("test", "a"),
-            identifier: "id-123".to_string(),
-            lifecycle: LifecycleConfig::default(),
-        };
-
-        let mut failed = HashSet::new();
-        failed.insert("some_binding".to_string());
-
-        let result = find_failed_dependency(&effect, &failed);
-        assert_eq!(result, None);
     }
 
     #[test]

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -1,0 +1,345 @@
+//! Dependency graph utilities for resource ordering and failure propagation
+
+use std::collections::{HashMap, HashSet};
+
+use crate::effect::Effect;
+use crate::resource::{Resource, Value};
+
+/// Extract binding names that a resource depends on
+pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
+    let mut deps = HashSet::new();
+    for value in resource.attributes.values() {
+        collect_dependencies(value, &mut deps);
+    }
+    deps
+}
+
+/// Recursively collect resource reference dependencies from a value
+fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
+    match value {
+        Value::ResourceRef { binding_name, .. } => {
+            deps.insert(binding_name.clone());
+        }
+        Value::List(items) => {
+            for item in items {
+                collect_dependencies(item, deps);
+            }
+        }
+        Value::Map(map) => {
+            for v in map.values() {
+                collect_dependencies(v, deps);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Sort resources topologically based on dependencies
+pub fn sort_resources_by_dependencies(resources: &[Resource]) -> Vec<Resource> {
+    // Build binding name to resource mapping
+    let mut binding_to_resource: HashMap<String, &Resource> = HashMap::new();
+    for resource in resources {
+        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
+            binding_to_resource.insert(binding_name.clone(), resource);
+        }
+    }
+
+    // Build dependency graph
+    let mut sorted = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut visiting: HashSet<String> = HashSet::new();
+
+    fn visit<'a>(
+        resource: &'a Resource,
+        binding_to_resource: &HashMap<String, &'a Resource>,
+        visited: &mut HashSet<String>,
+        visiting: &mut HashSet<String>,
+        sorted: &mut Vec<Resource>,
+    ) {
+        let binding_name = resource
+            .attributes
+            .get("_binding")
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+
+        if visited.contains(&binding_name) {
+            return;
+        }
+        if visiting.contains(&binding_name) {
+            // Circular dependency - just continue
+            return;
+        }
+
+        visiting.insert(binding_name.clone());
+
+        // Visit dependencies first
+        let deps = get_resource_dependencies(resource);
+        for dep in deps {
+            if let Some(dep_resource) = binding_to_resource.get(&dep) {
+                visit(dep_resource, binding_to_resource, visited, visiting, sorted);
+            }
+        }
+
+        visiting.remove(&binding_name);
+        visited.insert(binding_name);
+        sorted.push(resource.clone());
+    }
+
+    for resource in resources {
+        visit(
+            resource,
+            &binding_to_resource,
+            &mut visited,
+            &mut visiting,
+            &mut sorted,
+        );
+    }
+
+    sorted
+}
+
+/// Build a reverse dependency map: for each binding, which bindings depend on it.
+/// If resource A depends on resource B, then `dependents_map["b"]` contains "a".
+pub fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<String>> {
+    let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
+    for resource in resources {
+        let binding = resource
+            .attributes
+            .get("_binding")
+            .and_then(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+
+        let deps = get_resource_dependencies(resource);
+        for dep in deps {
+            dependents_map
+                .entry(dep)
+                .or_default()
+                .insert(binding.clone());
+        }
+    }
+    dependents_map
+}
+
+/// Check if an effect has any dependency on failed bindings.
+/// Returns the name of the first failed dependency found, or None.
+pub fn find_failed_dependency(
+    effect: &Effect,
+    failed_bindings: &HashSet<String>,
+) -> Option<String> {
+    let resource = effect.resource()?;
+    let deps = get_resource_dependencies(resource);
+    deps.into_iter().find(|dep| failed_bindings.contains(dep))
+}
+
+/// Check if any dependent of the given binding has failed (is in failed_bindings).
+/// Returns the first failed dependent found, if any.
+pub fn find_failed_dependent<'a>(
+    binding: &str,
+    dependents_map: &'a HashMap<String, HashSet<String>>,
+    failed_bindings: &'a HashSet<String>,
+) -> Option<&'a String> {
+    // Check direct dependents
+    if let Some(dependents) = dependents_map.get(binding) {
+        for dep in dependents {
+            if failed_bindings.contains(dep) {
+                return Some(dep);
+            }
+            // Check transitive: if a dependent of this binding has a dependent that failed
+            if let Some(failed) = find_failed_dependent(dep, dependents_map, failed_bindings) {
+                return Some(failed);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::{LifecycleConfig, Resource, ResourceId, Value};
+
+    fn make_resource(binding: &str, deps: &[&str]) -> Resource {
+        let mut r = Resource::new("test", binding);
+        r.attributes
+            .insert("_binding".to_string(), Value::String(binding.to_string()));
+        for dep in deps {
+            r.attributes.insert(
+                format!("ref_{}", dep),
+                Value::ResourceRef {
+                    binding_name: dep.to_string(),
+                    attribute_name: "id".to_string(),
+                },
+            );
+        }
+        r
+    }
+
+    #[test]
+    fn test_get_resource_dependencies() {
+        let resource = make_resource("a", &["b", "c"]);
+        let deps = get_resource_dependencies(&resource);
+        assert!(deps.contains("b"));
+        assert!(deps.contains("c"));
+        assert_eq!(deps.len(), 2);
+    }
+
+    #[test]
+    fn test_get_resource_dependencies_no_deps() {
+        let resource = make_resource("a", &[]);
+        let deps = get_resource_dependencies(&resource);
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn test_sort_resources_by_dependencies() {
+        // b depends on a
+        let a = make_resource("a", &[]);
+        let b = make_resource("b", &["a"]);
+
+        // Even if b comes first in the input, a should come first in the output
+        let sorted = sort_resources_by_dependencies(&[b, a]);
+        let binding_order: Vec<_> = sorted
+            .iter()
+            .filter_map(|r| match r.attributes.get("_binding") {
+                Some(Value::String(s)) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(binding_order, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_build_dependents_map() {
+        // A depends on B
+        let a = make_resource("a", &["b"]);
+        let b = make_resource("b", &[]);
+        let resources: Vec<&Resource> = vec![&a, &b];
+
+        let map = build_dependents_map(&resources);
+
+        // b's dependents should contain "a"
+        assert!(map.get("b").unwrap().contains("a"));
+        // a should have no dependents
+        assert!(!map.contains_key("a"));
+    }
+
+    #[test]
+    fn test_find_failed_dependency_direct() {
+        let resource = make_resource("b", &["a"]);
+        let effect = Effect::Create(resource);
+
+        let mut failed = HashSet::new();
+        failed.insert("a".to_string());
+
+        let result = find_failed_dependency(&effect, &failed);
+        assert_eq!(result, Some("a".to_string()));
+    }
+
+    #[test]
+    fn test_find_failed_dependency_none() {
+        let resource = make_resource("b", &["a"]);
+        let effect = Effect::Create(resource);
+
+        let failed: HashSet<String> = HashSet::new();
+
+        let result = find_failed_dependency(&effect, &failed);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_failed_dependency_no_deps() {
+        let resource = make_resource("a", &[]);
+        let effect = Effect::Create(resource);
+
+        let mut failed = HashSet::new();
+        failed.insert("x".to_string());
+
+        let result = find_failed_dependency(&effect, &failed);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_failed_dependency_transitive_propagation() {
+        let resource_c = make_resource("c", &["b"]);
+        let effect_c = Effect::Create(resource_c);
+
+        let mut failed = HashSet::new();
+        failed.insert("a".to_string());
+        failed.insert("b".to_string());
+
+        let result = find_failed_dependency(&effect_c, &failed);
+        assert_eq!(result, Some("b".to_string()));
+    }
+
+    #[test]
+    fn test_find_failed_dependency_delete_effect() {
+        let effect = Effect::Delete {
+            id: ResourceId::new("test", "a"),
+            identifier: "id-123".to_string(),
+            lifecycle: LifecycleConfig::default(),
+        };
+
+        let mut failed = HashSet::new();
+        failed.insert("some_binding".to_string());
+
+        let result = find_failed_dependency(&effect, &failed);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_failed_dependent() {
+        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
+        dependents_map
+            .entry("b".to_string())
+            .or_default()
+            .insert("a".to_string());
+
+        let mut failed_bindings = HashSet::new();
+        failed_bindings.insert("a".to_string());
+
+        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
+        assert_eq!(result, Some(&"a".to_string()));
+    }
+
+    #[test]
+    fn test_find_failed_dependent_none() {
+        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
+        dependents_map
+            .entry("b".to_string())
+            .or_default()
+            .insert("a".to_string());
+
+        let failed_bindings: HashSet<String> = HashSet::new();
+
+        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_transitive_chain() {
+        let mut dependents_map: HashMap<String, HashSet<String>> = HashMap::new();
+        dependents_map
+            .entry("c".to_string())
+            .or_default()
+            .insert("b".to_string());
+        dependents_map
+            .entry("b".to_string())
+            .or_default()
+            .insert("a".to_string());
+
+        let mut failed_bindings = HashSet::new();
+        failed_bindings.insert("a".to_string());
+
+        let result = find_failed_dependent("b", &dependents_map, &failed_bindings);
+        assert_eq!(result, Some(&"a".to_string()));
+
+        let result = find_failed_dependent("c", &dependents_map, &failed_bindings);
+        assert_eq!(result, Some(&"a".to_string()));
+    }
+}

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -70,6 +70,29 @@ impl Effect {
             Effect::Delete { id, .. } => id,
         }
     }
+
+    /// Returns a reference to the resource for this effect, if it has one.
+    /// Delete effects have no resource.
+    pub fn resource(&self) -> Option<&Resource> {
+        match self {
+            Effect::Create(resource) => Some(resource),
+            Effect::Update { to, .. } => Some(to),
+            Effect::Replace { to, .. } => Some(to),
+            Effect::Read { resource } => Some(resource),
+            Effect::Delete { .. } => None,
+        }
+    }
+
+    /// Returns the binding name for this effect's resource, if it has one.
+    pub fn binding_name(&self) -> Option<String> {
+        use crate::resource::Value;
+        self.resource().and_then(|r| {
+            r.attributes.get("_binding").and_then(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+        })
+    }
 }
 
 #[cfg(test)]
@@ -97,6 +120,41 @@ mod tests {
             resource: resource.clone(),
         };
         assert_eq!(effect.resource_id(), &resource.id);
+    }
+
+    #[test]
+    fn resource_returns_some_for_create() {
+        let resource = Resource::new("s3.bucket", "my-bucket");
+        let effect = Effect::Create(resource.clone());
+        assert_eq!(effect.resource().unwrap().id, resource.id);
+    }
+
+    #[test]
+    fn resource_returns_none_for_delete() {
+        let effect = Effect::Delete {
+            id: ResourceId::new("test", "a"),
+            identifier: "id-123".to_string(),
+            lifecycle: LifecycleConfig::default(),
+        };
+        assert!(effect.resource().is_none());
+    }
+
+    #[test]
+    fn binding_name_returns_binding() {
+        use crate::resource::Value;
+        let resource = Resource::new("test", "my_binding")
+            .with_attribute("_binding", Value::String("my_binding".to_string()));
+        let effect = Effect::Create(resource);
+        assert_eq!(effect.binding_name(), Some("my_binding".to_string()));
+    }
+
+    #[test]
+    fn binding_name_returns_none_without_binding() {
+        use crate::resource::Value;
+        let resource = Resource::new("test", "no_binding")
+            .with_attribute("name", Value::String("test".to_string()));
+        let effect = Effect::Create(resource);
+        assert_eq!(effect.binding_name(), None);
     }
 
     #[test]

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Core library for an infrastructure management tool that treats side effects as values
 
+pub mod deps;
 pub mod differ;
 pub mod effect;
 pub mod formatter;


### PR DESCRIPTION
## Summary

- Extract dependency graph functions (`get_resource_dependencies`, `sort_resources_by_dependencies`, `build_dependents_map`, `find_failed_dependency`, `find_failed_dependent`) from `carina-cli/src/main.rs` into a new `carina-core::deps` module
- Add `resource()` and `binding_name()` methods to `Effect` (replacing free functions `get_effect_resource` and `get_effect_binding_name`)
- Move all related tests to `carina-core`

This is Phase 1 (partial) of #328 — focusing on the dependency graph function group.

Refs #328

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] New tests in `carina-core::deps` cover all moved functions
- [x] New tests in `carina-core::effect` cover `resource()` and `binding_name()` methods
- [x] Pre-commit hooks (fmt + clippy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)