### PR TITLE
Extract reference resolution into carina-core::resolver

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -21,6 +21,7 @@ use carina_core::plan::Plan;
 use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ResourceType,
 };
+use carina_core::resolver::{resolve_ref_value, resolve_refs_with_state};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::schema::validate_ipv4_cidr;
 use carina_core::schema::{ResourceSchema, resolve_block_names};
@@ -2961,77 +2962,6 @@ async fn get_provider(parsed: &ParsedFile) -> Box<dyn Provider> {
     // Use file-based mock for other cases
     println!("{}", "Using file-based mock provider".cyan());
     Box::new(FileProvider::new())
-}
-
-/// Resolve ResourceRef values using current AWS state
-fn resolve_refs_with_state(
-    resources: &mut [Resource],
-    current_states: &HashMap<ResourceId, State>,
-) {
-    // Build a map of binding_name -> attributes (merged from DSL and AWS state)
-    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
-
-    for resource in resources.iter() {
-        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
-            let mut attrs = resource.attributes.clone();
-
-            // Merge AWS state attributes (like `id`) if available
-            if let Some(state) = current_states.get(&resource.id)
-                && state.exists
-            {
-                for (k, v) in &state.attributes {
-                    if !attrs.contains_key(k) {
-                        attrs.insert(k.clone(), v.clone());
-                    }
-                }
-            }
-
-            binding_map.insert(binding_name.clone(), attrs);
-        }
-    }
-
-    // Resolve ResourceRef values in all resources
-    for resource in resources.iter_mut() {
-        let mut resolved_attrs = HashMap::new();
-        for (key, value) in &resource.attributes {
-            resolved_attrs.insert(key.clone(), resolve_ref_value(value, &binding_map));
-        }
-        resource.attributes = resolved_attrs;
-    }
-}
-
-fn resolve_ref_value(
-    value: &Value,
-    binding_map: &HashMap<String, HashMap<String, Value>>,
-) -> Value {
-    match value {
-        Value::ResourceRef {
-            binding_name,
-            attribute_name,
-            ..
-        } => {
-            if let Some(attrs) = binding_map.get(binding_name)
-                && let Some(attr_value) = attrs.get(attribute_name)
-            {
-                // Recursively resolve
-                return resolve_ref_value(attr_value, binding_map);
-            }
-            // Keep as-is if not found
-            value.clone()
-        }
-        Value::List(items) => Value::List(
-            items
-                .iter()
-                .map(|v| resolve_ref_value(v, binding_map))
-                .collect(),
-        ),
-        Value::Map(map) => Value::Map(
-            map.iter()
-                .map(|(k, v)| (k.clone(), resolve_ref_value(v, binding_map)))
-                .collect(),
-        ),
-        _ => value.clone(),
-    }
 }
 
 async fn create_plan_from_parsed(

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod module_resolver;
 pub mod parser;
 pub mod plan;
 pub mod provider;
+pub mod resolver;
 pub mod resource;
 pub mod schema;
 pub mod utils;

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -1,0 +1,230 @@
+//! Reference resolution for ResourceRef values
+//!
+//! Resolves `Value::ResourceRef` references by looking up bound resource attributes
+//! from both the DSL definition and current infrastructure state.
+
+use std::collections::HashMap;
+
+use crate::resource::{Resource, ResourceId, State, Value};
+
+/// Resolve all ResourceRef values in resources using current state.
+///
+/// Builds a binding map from resource attributes and state, then resolves
+/// all ResourceRef values across all resources.
+pub fn resolve_refs_with_state(
+    resources: &mut [Resource],
+    current_states: &HashMap<ResourceId, State>,
+) {
+    // Build a map of binding_name -> attributes (merged from DSL and AWS state)
+    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+    for resource in resources.iter() {
+        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
+            let mut attrs = resource.attributes.clone();
+
+            // Merge AWS state attributes (like `id`) if available
+            if let Some(state) = current_states.get(&resource.id)
+                && state.exists
+            {
+                for (k, v) in &state.attributes {
+                    if !attrs.contains_key(k) {
+                        attrs.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+
+            binding_map.insert(binding_name.clone(), attrs);
+        }
+    }
+
+    // Resolve ResourceRef values in all resources
+    for resource in resources.iter_mut() {
+        let mut resolved_attrs = HashMap::new();
+        for (key, value) in &resource.attributes {
+            resolved_attrs.insert(key.clone(), resolve_ref_value(value, &binding_map));
+        }
+        resource.attributes = resolved_attrs;
+    }
+}
+
+/// Recursively resolve a single Value, replacing ResourceRef with the referenced value.
+///
+/// If the referenced binding or attribute is not found, the value is returned as-is.
+pub fn resolve_ref_value(
+    value: &Value,
+    binding_map: &HashMap<String, HashMap<String, Value>>,
+) -> Value {
+    match value {
+        Value::ResourceRef {
+            binding_name,
+            attribute_name,
+            ..
+        } => {
+            if let Some(attrs) = binding_map.get(binding_name)
+                && let Some(attr_value) = attrs.get(attribute_name)
+            {
+                // Recursively resolve
+                return resolve_ref_value(attr_value, binding_map);
+            }
+            // Keep as-is if not found
+            value.clone()
+        }
+        Value::List(items) => Value::List(
+            items
+                .iter()
+                .map(|v| resolve_ref_value(v, binding_map))
+                .collect(),
+        ),
+        Value::Map(map) => Value::Map(
+            map.iter()
+                .map(|(k, v)| (k.clone(), resolve_ref_value(v, binding_map)))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::ResourceId;
+
+    fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
+        let mut attributes: HashMap<String, Value> =
+            attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
+        if let Some(b) = binding {
+            attributes.insert("_binding".to_string(), Value::String(b.to_string()));
+        }
+        let mut r = Resource::new("test.resource", name);
+        r.attributes = attributes;
+        r
+    }
+
+    #[test]
+    fn test_resolve_simple_resource_ref() {
+        let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut attrs = HashMap::new();
+        attrs.insert("id".to_string(), Value::String("vpc-123".to_string()));
+        binding_map.insert("my_vpc".to_string(), attrs);
+
+        let ref_value = Value::ResourceRef {
+            binding_name: "my_vpc".to_string(),
+            attribute_name: "id".to_string(),
+        };
+
+        let resolved = resolve_ref_value(&ref_value, &binding_map);
+        assert_eq!(resolved, Value::String("vpc-123".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_nested_refs_in_list() {
+        let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut attrs = HashMap::new();
+        attrs.insert("id".to_string(), Value::String("sg-456".to_string()));
+        binding_map.insert("my_sg".to_string(), attrs);
+
+        let list = Value::List(vec![
+            Value::String("static".to_string()),
+            Value::ResourceRef {
+                binding_name: "my_sg".to_string(),
+                attribute_name: "id".to_string(),
+            },
+        ]);
+
+        let resolved = resolve_ref_value(&list, &binding_map);
+        assert_eq!(
+            resolved,
+            Value::List(vec![
+                Value::String("static".to_string()),
+                Value::String("sg-456".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_resolve_nested_refs_in_map() {
+        let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut attrs = HashMap::new();
+        attrs.insert("id".to_string(), Value::String("subnet-789".to_string()));
+        binding_map.insert("my_subnet".to_string(), attrs);
+
+        let map = Value::Map(
+            vec![(
+                "subnet_id".to_string(),
+                Value::ResourceRef {
+                    binding_name: "my_subnet".to_string(),
+                    attribute_name: "id".to_string(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let resolved = resolve_ref_value(&map, &binding_map);
+        if let Value::Map(m) = resolved {
+            assert_eq!(
+                m.get("subnet_id"),
+                Some(&Value::String("subnet-789".to_string()))
+            );
+        } else {
+            panic!("Expected Map");
+        }
+    }
+
+    #[test]
+    fn test_unresolved_ref_stays_as_is() {
+        let binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+        let ref_value = Value::ResourceRef {
+            binding_name: "nonexistent".to_string(),
+            attribute_name: "id".to_string(),
+        };
+
+        let resolved = resolve_ref_value(&ref_value, &binding_map);
+        assert_eq!(resolved, ref_value);
+    }
+
+    #[test]
+    fn test_state_attributes_merged_into_binding_map() {
+        let rid = ResourceId::new("test.resource", "my-vpc");
+        let mut resources = vec![
+            make_resource(
+                "my-vpc",
+                Some("my_vpc"),
+                vec![("cidr_block", Value::String("10.0.0.0/16".to_string()))],
+            ),
+            make_resource(
+                "my-subnet",
+                None,
+                vec![(
+                    "vpc_id",
+                    Value::ResourceRef {
+                        binding_name: "my_vpc".to_string(),
+                        attribute_name: "vpc_id".to_string(),
+                    },
+                )],
+            ),
+        ];
+
+        let mut current_states = HashMap::new();
+        current_states.insert(
+            rid.clone(),
+            State {
+                id: rid,
+                identifier: None,
+                exists: true,
+                attributes: vec![("vpc_id".to_string(), Value::String("vpc-abc".to_string()))]
+                    .into_iter()
+                    .collect(),
+            },
+        );
+
+        resolve_refs_with_state(&mut resources, &current_states);
+
+        // The subnet's vpc_id should be resolved from state
+        assert_eq!(
+            resources[1].attributes.get("vpc_id"),
+            Some(&Value::String("vpc-abc".to_string()))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Move `resolve_refs_with_state` and `resolve_ref_value` from `carina-cli/src/main.rs` into new `carina-core::resolver` module
- Add unit tests for simple ref, nested refs (list/map), unresolved ref, and state attribute merging
- Part of #328 (extract domain logic from CLI into core)

## Test plan
- [x] `cargo test -p carina-core` passes (220 tests + 6 doctests)
- [x] `cargo test -p carina-cli` passes (26 tests)
- [x] `cargo build` succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)