### PR TITLE
Extract validation functions into carina-core::validation module

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -16,16 +16,16 @@ use carina_core::differ::create_plan;
 use carina_core::effect::Effect;
 use carina_core::formatter::{self, FormatConfig};
 use carina_core::module_resolver;
-use carina_core::parser::{self, BackendConfig, ParsedFile, ProviderConfig, TypeExpr};
+use carina_core::parser::{self, BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ResourceType,
 };
 use carina_core::resolver::{resolve_ref_value, resolve_refs_with_state};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use carina_core::schema::validate_ipv4_cidr;
 use carina_core::schema::{ResourceSchema, resolve_block_names};
 use carina_core::utils::is_dsl_enum_format;
+use carina_core::validation;
 use carina_provider_aws::AwsProviderFactory;
 use carina_provider_awscc::AwsccProviderFactory;
 use carina_state::{
@@ -301,128 +301,21 @@ fn get_schemas() -> HashMap<String, ResourceSchema> {
 fn validate_resources(resources: &[Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
-    let mut all_errors = Vec::new();
-
-    for resource in resources {
-        let schema_key = schema_key_for_resource(&factories, resource);
-
-        match schemas.get(&schema_key) {
-            Some(schema) => {
-                if schema.data_source && !resource.read_only {
-                    all_errors.push(format!(
-                        "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
-                        schema.resource_type, schema.resource_type
-                    ));
-                }
-                if let Err(errors) = schema.validate(&resource.attributes) {
-                    for error in errors {
-                        all_errors.push(format!("{}: {}", resource.id, error));
-                    }
-                }
-            }
-            None => {
-                all_errors.push(format!("Unknown resource type: {}", schema_key));
-            }
-        }
-    }
-
-    if all_errors.is_empty() {
-        Ok(())
-    } else {
-        Err(all_errors.join("\n"))
-    }
+    validation::validate_resources(resources, &schemas, &|r| {
+        schema_key_for_resource(&factories, r)
+    })
 }
 
-/// Validate that resource references have compatible types.
-/// For example, if `ipv4_ipam_pool_id` expects `IpamPoolId` type,
-/// a reference like `vpc.vpc_id` (which is `AwsResourceId`) should be an error.
 fn validate_resource_ref_types(resources: &[Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
-    let mut all_errors = Vec::new();
-
-    // Build binding_name -> resource map
-    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
-    for resource in resources {
-        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
-            binding_map.insert(binding_name.clone(), resource);
-        }
-    }
-
-    for resource in resources {
-        let schema_key = schema_key_for_resource(&factories, resource);
-
-        let Some(schema) = schemas.get(&schema_key) else {
-            continue;
-        };
-
-        for (attr_name, attr_value) in &resource.attributes {
-            if attr_name.starts_with('_') {
-                continue;
-            }
-
-            let (ref_binding, ref_attr) = match attr_value {
-                Value::ResourceRef {
-                    binding_name,
-                    attribute_name,
-                    ..
-                } => (binding_name, attribute_name),
-                _ => continue,
-            };
-
-            // Get the expected type for this attribute
-            let Some(attr_schema) = schema.attributes.get(attr_name) else {
-                continue;
-            };
-            let expected_type_name = attr_schema.attr_type.type_name();
-
-            // Look up the referenced binding's schema to get the type of the referenced attribute
-            let Some(ref_resource) = binding_map.get(ref_binding.as_str()) else {
-                continue; // Unknown binding, skip
-            };
-            let ref_schema_key_str = schema_key_for_resource(&factories, ref_resource);
-            let Some(ref_schema) = schemas.get(&ref_schema_key_str) else {
-                continue;
-            };
-            let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
-                continue; // Unknown attribute on referenced resource, skip
-            };
-            let ref_type_name = ref_attr_schema.attr_type.type_name();
-
-            // Type compatibility check:
-            // - Union type accepts any member type name -> OK
-            // - Same type -> OK
-            // - Either is "String" -> OK (String is the base type for Custom types)
-            // - Different Custom types -> Error
-            if attr_schema.attr_type.accepts_type_name(&ref_type_name) {
-                continue;
-            }
-            if expected_type_name == "String" || ref_type_name == "String" {
-                continue;
-            }
-
-            all_errors.push(format!(
-                "{}: type mismatch for '{}': expected {}, got {} (from {}.{})",
-                resource.id, attr_name, expected_type_name, ref_type_name, ref_binding, ref_attr,
-            ));
-        }
-    }
-
-    if all_errors.is_empty() {
-        Ok(())
-    } else {
-        Err(all_errors.join("\n"))
-    }
+    validation::validate_resource_ref_types(resources, &schemas, &|r| {
+        schema_key_for_resource(&factories, r)
+    })
 }
 
-/// Check if an AttributeType is string-compatible (can accept a string value).
 fn is_string_compatible_type(attr_type: &carina_core::schema::AttributeType) -> bool {
-    use carina_core::schema::AttributeType;
-    match attr_type {
-        AttributeType::String | AttributeType::Custom { .. } | AttributeType::Enum(_) => true,
-        AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
-        _ => false,
-    }
+    validation::is_string_compatible_type(attr_type)
 }
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
@@ -779,24 +672,12 @@ fn derive_module_name(path: &Path) -> String {
     file_stem.to_string()
 }
 
-/// Validate provider region attribute
 fn validate_provider_region(parsed: &ParsedFile) -> Result<(), String> {
     let factories = provider_factories();
-
-    for provider in &parsed.providers {
-        if let Some(factory) = find_factory(&factories, &provider.name) {
-            factory
-                .validate_config(&provider.attributes)
-                .map_err(|e| format!("provider {}: {}", provider.name, e))?;
-        }
-    }
-    Ok(())
+    validation::validate_provider_config(parsed, &factories)
 }
 
-/// Validate module call arguments against module input types
 fn validate_module_calls(parsed: &ParsedFile, base_dir: &Path) -> Result<(), String> {
-    let mut errors = Vec::new();
-
     // Build a map of imported modules: alias -> inputs
     let mut imported_modules = HashMap::new();
     for import in &parsed.imports {
@@ -806,27 +687,7 @@ fn validate_module_calls(parsed: &ParsedFile, base_dir: &Path) -> Result<(), Str
         }
     }
 
-    // Validate each module call
-    for call in &parsed.module_calls {
-        if let Some(module_inputs) = imported_modules.get(&call.module_name) {
-            for (arg_name, arg_value) in &call.arguments {
-                if let Some(input) = module_inputs.iter().find(|i| &i.name == arg_name)
-                    && let Some(error) = validate_module_arg_type(&input.type_expr, arg_value)
-                {
-                    errors.push(format!(
-                        "module {} argument '{}': {}",
-                        call.module_name, arg_name, error
-                    ));
-                }
-            }
-        }
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors.join("\n"))
-    }
+    validation::validate_module_calls(&parsed.module_calls, &imported_modules)
 }
 
 /// Load a module from a file or directory
@@ -974,33 +835,6 @@ fn get_base_dir(path: &Path) -> &Path {
         path.parent().unwrap_or(Path::new("."))
     } else {
         path
-    }
-}
-
-/// Validate a module argument value against its expected type
-fn validate_module_arg_type(type_expr: &TypeExpr, value: &Value) -> Option<String> {
-    match (type_expr, value) {
-        (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
-        (TypeExpr::List(inner), Value::List(items)) => {
-            if let TypeExpr::Cidr = inner.as_ref() {
-                for (i, item) in items.iter().enumerate() {
-                    if let Value::String(s) = item {
-                        if let Err(e) = validate_ipv4_cidr(s) {
-                            return Some(format!("element {}: {}", i, e));
-                        }
-                    } else {
-                        return Some(format!("element {}: expected string", i));
-                    }
-                }
-            }
-            None
-        }
-        (TypeExpr::Bool, Value::String(s)) => Some(format!(
-            "expected bool, got string \"{}\". Use true or false.",
-            s
-        )),
-        (TypeExpr::Int, Value::String(s)) => Some(format!("expected int, got string \"{}\".", s)),
-        _ => None,
     }
 }
 

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -16,3 +16,4 @@ pub mod resolver;
 pub mod resource;
 pub mod schema;
 pub mod utils;
+pub mod validation;

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -1,0 +1,216 @@
+//! Validation utilities for resources and modules
+
+use std::collections::HashMap;
+
+use crate::parser::{ModuleCall, ParsedFile, TypeExpr};
+use crate::provider::ProviderFactory;
+use crate::resource::{Resource, Value};
+use crate::schema::{AttributeType, ResourceSchema, validate_ipv4_cidr};
+
+/// Validate resources against their schemas.
+///
+/// Checks that each resource's type is known, data sources use the `read` keyword,
+/// and all attributes pass schema validation.
+pub fn validate_resources(
+    resources: &[Resource],
+    schemas: &HashMap<String, ResourceSchema>,
+    schema_key_fn: &dyn Fn(&Resource) -> String,
+) -> Result<(), String> {
+    let mut all_errors = Vec::new();
+
+    for resource in resources {
+        let schema_key = schema_key_fn(resource);
+
+        match schemas.get(&schema_key) {
+            Some(schema) => {
+                if schema.data_source && !resource.read_only {
+                    all_errors.push(format!(
+                        "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
+                        schema.resource_type, schema.resource_type
+                    ));
+                }
+                if let Err(errors) = schema.validate(&resource.attributes) {
+                    for error in errors {
+                        all_errors.push(format!("{}: {}", resource.id, error));
+                    }
+                }
+            }
+            None => {
+                all_errors.push(format!("Unknown resource type: {}", schema_key));
+            }
+        }
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(all_errors.join("\n"))
+    }
+}
+
+/// Validate that resource references have compatible types.
+///
+/// For example, if `ipv4_ipam_pool_id` expects `IpamPoolId` type,
+/// a reference like `vpc.vpc_id` (which is `AwsResourceId`) should be an error.
+pub fn validate_resource_ref_types(
+    resources: &[Resource],
+    schemas: &HashMap<String, ResourceSchema>,
+    schema_key_fn: &dyn Fn(&Resource) -> String,
+) -> Result<(), String> {
+    let mut all_errors = Vec::new();
+
+    // Build binding_name -> resource map
+    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
+    for resource in resources {
+        if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
+            binding_map.insert(binding_name.clone(), resource);
+        }
+    }
+
+    for resource in resources {
+        let schema_key = schema_key_fn(resource);
+
+        let Some(schema) = schemas.get(&schema_key) else {
+            continue;
+        };
+
+        for (attr_name, attr_value) in &resource.attributes {
+            if attr_name.starts_with('_') {
+                continue;
+            }
+
+            let (ref_binding, ref_attr) = match attr_value {
+                Value::ResourceRef {
+                    binding_name,
+                    attribute_name,
+                    ..
+                } => (binding_name, attribute_name),
+                _ => continue,
+            };
+
+            // Get the expected type for this attribute
+            let Some(attr_schema) = schema.attributes.get(attr_name) else {
+                continue;
+            };
+            let expected_type_name = attr_schema.attr_type.type_name();
+
+            // Look up the referenced binding's schema to get the type of the referenced attribute
+            let Some(ref_resource) = binding_map.get(ref_binding.as_str()) else {
+                continue; // Unknown binding, skip
+            };
+            let ref_schema_key_str = schema_key_fn(ref_resource);
+            let Some(ref_schema) = schemas.get(&ref_schema_key_str) else {
+                continue;
+            };
+            let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
+                continue; // Unknown attribute on referenced resource, skip
+            };
+            let ref_type_name = ref_attr_schema.attr_type.type_name();
+
+            // Type compatibility check:
+            // - Union type accepts any member type name -> OK
+            // - Same type -> OK
+            // - Either is "String" -> OK (String is the base type for Custom types)
+            // - Different Custom types -> Error
+            if attr_schema.attr_type.accepts_type_name(&ref_type_name) {
+                continue;
+            }
+            if expected_type_name == "String" || ref_type_name == "String" {
+                continue;
+            }
+
+            all_errors.push(format!(
+                "{}: type mismatch for '{}': expected {}, got {} (from {}.{})",
+                resource.id, attr_name, expected_type_name, ref_type_name, ref_binding, ref_attr,
+            ));
+        }
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(all_errors.join("\n"))
+    }
+}
+
+/// Check if an AttributeType is string-compatible (can accept a string value).
+pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
+    match attr_type {
+        AttributeType::String | AttributeType::Custom { .. } | AttributeType::Enum(_) => true,
+        AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
+        _ => false,
+    }
+}
+
+/// Validate provider configuration attributes via `ProviderFactory::validate_config()`.
+pub fn validate_provider_config(
+    parsed: &ParsedFile,
+    factories: &[Box<dyn ProviderFactory>],
+) -> Result<(), String> {
+    for provider in &parsed.providers {
+        if let Some(factory) = factories.iter().find(|f| f.name() == provider.name) {
+            factory
+                .validate_config(&provider.attributes)
+                .map_err(|e| format!("provider {}: {}", provider.name, e))?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate module call arguments against module input types.
+///
+/// `imported_modules` maps module alias to its input parameter definitions.
+pub fn validate_module_calls(
+    module_calls: &[ModuleCall],
+    imported_modules: &HashMap<String, Vec<crate::parser::InputParameter>>,
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    for call in module_calls {
+        if let Some(module_inputs) = imported_modules.get(&call.module_name) {
+            for (arg_name, arg_value) in &call.arguments {
+                if let Some(input) = module_inputs.iter().find(|i| &i.name == arg_name)
+                    && let Some(error) = validate_module_arg_type(&input.type_expr, arg_value)
+                {
+                    errors.push(format!(
+                        "module {} argument '{}': {}",
+                        call.module_name, arg_name, error
+                    ));
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
+/// Validate a module argument value against its expected type.
+pub fn validate_module_arg_type(type_expr: &TypeExpr, value: &Value) -> Option<String> {
+    match (type_expr, value) {
+        (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
+        (TypeExpr::List(inner), Value::List(items)) => {
+            if let TypeExpr::Cidr = inner.as_ref() {
+                for (i, item) in items.iter().enumerate() {
+                    if let Value::String(s) = item {
+                        if let Err(e) = validate_ipv4_cidr(s) {
+                            return Some(format!("element {}: {}", i, e));
+                        }
+                    } else {
+                        return Some(format!("element {}: expected string", i));
+                    }
+                }
+            }
+            None
+        }
+        (TypeExpr::Bool, Value::String(s)) => Some(format!(
+            "expected bool, got string \"{}\". Use true or false.",
+            s
+        )),
+        (TypeExpr::Int, Value::String(s)) => Some(format!("expected int, got string \"{}\".", s)),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary
- Extract 6 validation functions from `carina-cli/src/main.rs` into new `carina-core/src/validation.rs` module
- Functions accept core types as parameters (schemas, factories, closures) instead of calling CLI helpers internally
- CLI retains thin wrappers that provide the glue (factory creation, schema loading, module loading)

Part of #328.

## Test plan
- [x] `cargo build` succeeds with no warnings
- [x] `cargo test` — all 324 tests pass
- [x] Pre-commit hooks (formatting + clippy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)