### PR TITLE
Extract prefix & identifier handling into carina-core::identifier module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,6 @@ dependencies = [
  "serde_json",
  "similar",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -697,6 +696,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -21,4 +21,3 @@ colored = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = "2"
-uuid = { version = "1", features = ["v4"] }

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -15,6 +15,7 @@ use carina_core::deps::{
 use carina_core::differ::create_plan;
 use carina_core::effect::Effect;
 use carina_core::formatter::{self, FormatConfig};
+use carina_core::identifier::{self, PrefixStateInfo};
 use carina_core::module_resolver;
 use carina_core::parser::{self, BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
@@ -317,17 +318,6 @@ fn validate_resource_ref_types(resources: &[Resource]) -> Result<(), String> {
     })
 }
 
-fn is_string_compatible_type(attr_type: &carina_core::schema::AttributeType) -> bool {
-    validation::is_string_compatible_type(attr_type)
-}
-
-/// Generate a random 8-character lowercase hex suffix using UUID v4.
-fn generate_random_suffix() -> String {
-    let uuid = uuid::Uuid::new_v4();
-    let hex = uuid.as_simple().to_string();
-    hex[..8].to_string()
-}
-
 /// Resolve block name aliases and attribute prefixes in one step.
 fn resolve_names(resources: &mut [Resource]) -> Result<(), String> {
     let factories = provider_factories();
@@ -338,239 +328,55 @@ fn resolve_names(resources: &mut [Resource]) -> Result<(), String> {
     resolve_attr_prefixes(resources)
 }
 
-/// Resolve `<attr>_prefix` meta-attributes in resources.
-///
-/// For each resource attribute ending in `_prefix`, checks if the base attribute
-/// (without `_prefix`) exists in the schema as a string-compatible type. If so:
-/// - Removes the `_prefix` attribute
-/// - Stores the prefix in `resource.prefixes`
-/// - Generates a temporary name: `prefix + random_suffix`
-///
-/// Errors if both `<attr>_prefix` and `<attr>` are specified, or if prefix is empty.
 fn resolve_attr_prefixes(resources: &mut [Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
-    let mut all_errors = Vec::new();
-
-    for resource in resources.iter_mut() {
-        let schema_key = schema_key_for_resource(&factories, resource);
-
-        let schema = match schemas.get(&schema_key) {
-            Some(s) => s,
-            None => continue, // Unknown resource type; validate_resources will catch this
-        };
-
-        // Collect prefix attributes to process
-        let prefix_attrs: Vec<(String, String)> = resource
-            .attributes
-            .iter()
-            .filter_map(|(key, value)| {
-                if let Some(base_attr) = key.strip_suffix("_prefix")
-                    && let Value::String(prefix_value) = value
-                    && let Some(attr_schema) = schema.attributes.get(base_attr)
-                    && is_string_compatible_type(&attr_schema.attr_type)
-                {
-                    return Some((base_attr.to_string(), prefix_value.clone()));
-                }
-                None
-            })
-            .collect();
-
-        for (base_attr, prefix_value) in prefix_attrs {
-            let prefix_key = format!("{}_prefix", base_attr);
-
-            // Error if prefix is empty
-            if prefix_value.is_empty() {
-                all_errors.push(format!("{}: '{}' cannot be empty", resource.id, prefix_key));
-                continue;
-            }
-
-            // Error if both prefix and base attribute are specified
-            if resource.attributes.contains_key(&base_attr) {
-                all_errors.push(format!(
-                    "{}: cannot specify both '{}' and '{}'",
-                    resource.id, prefix_key, base_attr
-                ));
-                continue;
-            }
-
-            // Remove the _prefix attribute
-            resource.attributes.remove(&prefix_key);
-
-            // Store prefix
-            resource
-                .prefixes
-                .insert(base_attr.clone(), prefix_value.clone());
-
-            // Generate temporary name
-            let generated_name = format!("{}{}", prefix_value, generate_random_suffix());
-            resource
-                .attributes
-                .insert(base_attr, Value::String(generated_name));
-        }
-    }
-
-    if all_errors.is_empty() {
-        Ok(())
-    } else {
-        Err(all_errors.join("\n"))
-    }
+    identifier::resolve_attr_prefixes(resources, &schemas, &|r| {
+        schema_key_for_resource(&factories, r)
+    })
 }
 
-/// Reconcile prefixed names with existing state.
-///
-/// For resources that have prefixes and a matching entry in state (same prefix),
-/// reuses the existing name from state instead of the temporarily generated one.
-/// If the prefix has changed or there's no state match, keeps the new generated name.
 fn reconcile_prefixed_names(resources: &mut [Resource], state_file: &Option<StateFile>) {
     let state_file = match state_file {
         Some(sf) => sf,
         None => return,
     };
 
-    for resource in resources.iter_mut() {
-        if resource.prefixes.is_empty() {
-            continue;
-        }
-
-        // Find matching resource in state
-        let state_resource =
-            state_file.find_resource(&resource.id.resource_type, &resource.id.name);
-        let state_resource = match state_resource {
-            Some(sr) => sr,
-            None => continue,
-        };
-
-        for (attr_name, prefix) in &resource.prefixes {
-            // Check if state has the same prefix for this attribute
-            if let Some(state_prefix) = state_resource.prefixes.get(attr_name)
-                && state_prefix == prefix
-            {
-                // Same prefix: reuse the existing name from state
-                if let Some(state_value) = state_resource.attributes.get(attr_name)
-                    && let Some(name_str) = state_value.as_str()
-                {
-                    resource
-                        .attributes
-                        .insert(attr_name.clone(), Value::String(name_str.to_string()));
-                }
-            }
-            // If prefix changed or no state prefix exists, keep the newly generated name
-        }
-    }
+    identifier::reconcile_prefixed_names(resources, &|resource_type, name| {
+        let sr = state_file.find_resource(resource_type, name)?;
+        Some(PrefixStateInfo {
+            prefixes: sr.prefixes.clone(),
+            attribute_values: sr
+                .attributes
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect(),
+        })
+    });
 }
 
-/// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
-/// Uses create-only properties and provider identity attributes to generate a deterministic hash.
 fn compute_anonymous_identifiers(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Result<(), String> {
-    use std::collections::BTreeMap;
-    use std::hash::{Hash, Hasher};
-
     let factories = provider_factories();
     let schemas = get_schemas();
-
-    // First pass: compute identifiers and detect collisions
-    let mut computed: Vec<(usize, String)> = Vec::new();
-
-    for (idx, resource) in resources.iter().enumerate() {
-        if !resource.id.name.is_empty() {
-            continue;
-        }
-
-        // Look up schema for this resource's provider (skip if no _provider set)
-        let Some(Value::String(provider_name)) = resource.attributes.get("_provider") else {
-            continue;
-        };
-        let schema_key = schema_key_for_resource(&factories, resource);
-
-        let Some(schema) = schemas.get(&schema_key) else {
-            continue;
-        };
-
-        let create_only_attrs = schema.create_only_attributes();
-        if create_only_attrs.is_empty() {
-            return Err(format!(
-                "Anonymous resource '{}' has no create-only properties. Use `let` binding for identification.",
-                resource.id.display_type()
-            ));
-        }
-
-        // Collect identity attribute values (e.g., region) from provider config
-        let mut identity_values: BTreeMap<&str, String> = BTreeMap::new();
-        if let Some(factory) = find_factory(&factories, provider_name)
-            && let Some(pc) = providers.iter().find(|p| p.name == *provider_name)
-        {
-            for attr_name in factory.identity_attributes() {
-                if let Some(value) = pc.attributes.get(attr_name) {
-                    identity_values.insert(attr_name, format!("{:?}", value));
-                }
-            }
-        }
-
-        // Collect create-only values in sorted order for deterministic hashing
-        let mut create_only_values: BTreeMap<&str, String> = BTreeMap::new();
-        for attr_name in &create_only_attrs {
-            if let Some(value) = resource.attributes.get(*attr_name) {
-                create_only_values.insert(attr_name, format!("{:?}", value));
-            }
-        }
-
-        if create_only_values.is_empty() {
-            return Err(format!(
-                "Anonymous resource '{}' has no create-only property values set. Use `let` binding for identification.",
-                resource.id.display_type()
-            ));
-        }
-
-        // Compute deterministic hash: identity attributes first, then create-only values
-        let mut hasher = std::hash::DefaultHasher::new();
-        for (k, v) in &identity_values {
-            k.hash(&mut hasher);
-            v.hash(&mut hasher);
-        }
-        for (k, v) in &create_only_values {
-            k.hash(&mut hasher);
-            v.hash(&mut hasher);
-        }
-        let hash = hasher.finish();
-        let hash_str = format!("{:08x}", hash & 0xFFFFFFFF); // 8 hex chars
-
-        // Build identifier: resource_type_hash (e.g., ec2_vpc_a3f2b1c8)
-        let identifier = format!(
-            "{}_{}",
-            resource.id.resource_type.replace('.', "_"),
-            hash_str
-        );
-
-        computed.push((idx, identifier));
-    }
-
-    // Detect collisions
-    let mut seen: HashMap<String, usize> = HashMap::new();
-    for (idx, identifier) in &computed {
-        if let Some(first_idx) = seen.get(identifier) {
-            return Err(format!(
-                "Anonymous resource identifier collision: '{}' and '{}' produce the same identifier '{}'. \
-                 Use `let` bindings to give them distinct names.",
-                resources[*first_idx].id.display_type(),
-                resources[*idx].id.display_type(),
-                identifier,
-            ));
-        }
-        seen.insert(identifier.clone(), *idx);
-    }
-
-    // Second pass: apply identifiers
-    for (idx, identifier) in computed {
-        let provider = resources[idx].id.provider.clone();
-        let resource_type = resources[idx].id.resource_type.clone();
-        resources[idx].id = ResourceId::with_provider(&provider, &resource_type, identifier);
-    }
-
-    Ok(())
+    identifier::compute_anonymous_identifiers(
+        resources,
+        providers,
+        &schemas,
+        &|r| schema_key_for_resource(&factories, r),
+        &|name| {
+            find_factory(&factories, name)
+                .map(|f| {
+                    f.identity_attributes()
+                        .into_iter()
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        },
+    )
 }
 
 fn run_module_command(command: ModuleCommands) -> Result<(), String> {
@@ -4370,13 +4176,6 @@ mod tests {
             resources[0].attributes.get("bucket_name"),
             Some(&Value::String("my-app-abcd1234".to_string()))
         );
-    }
-
-    #[test]
-    fn test_generate_random_suffix_format() {
-        let suffix = generate_random_suffix();
-        assert_eq!(suffix.len(), 8);
-        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -10,6 +10,7 @@ pest_derive = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -1,0 +1,472 @@
+//! Identifier and prefix handling for resources
+//!
+//! Functions for generating random suffixes, resolving attribute prefixes,
+//! reconciling prefixed names with state, and computing anonymous resource identifiers.
+
+use std::collections::HashMap;
+
+use crate::parser::ProviderConfig;
+use crate::resource::{Resource, ResourceId, Value};
+use crate::schema::ResourceSchema;
+use crate::validation::is_string_compatible_type;
+
+/// Generate a random 8-character lowercase hex suffix using UUID v4.
+pub fn generate_random_suffix() -> String {
+    let uuid = uuid::Uuid::new_v4();
+    let hex = uuid.as_simple().to_string();
+    hex[..8].to_string()
+}
+
+/// Resolve `<attr>_prefix` meta-attributes in resources.
+///
+/// For each resource attribute ending in `_prefix`, checks if the base attribute
+/// (without `_prefix`) exists in the schema as a string-compatible type. If so:
+/// - Removes the `_prefix` attribute
+/// - Stores the prefix in `resource.prefixes`
+/// - Generates a temporary name: `prefix + random_suffix`
+///
+/// Errors if both `<attr>_prefix` and `<attr>` are specified, or if prefix is empty.
+pub fn resolve_attr_prefixes(
+    resources: &mut [Resource],
+    schemas: &HashMap<String, ResourceSchema>,
+    schema_key_fn: &dyn Fn(&Resource) -> String,
+) -> Result<(), String> {
+    let mut all_errors = Vec::new();
+
+    for resource in resources.iter_mut() {
+        let schema_key = schema_key_fn(resource);
+
+        let schema = match schemas.get(&schema_key) {
+            Some(s) => s,
+            None => continue, // Unknown resource type; validate_resources will catch this
+        };
+
+        // Collect prefix attributes to process
+        let prefix_attrs: Vec<(String, String)> = resource
+            .attributes
+            .iter()
+            .filter_map(|(key, value)| {
+                if let Some(base_attr) = key.strip_suffix("_prefix")
+                    && let Value::String(prefix_value) = value
+                    && let Some(attr_schema) = schema.attributes.get(base_attr)
+                    && is_string_compatible_type(&attr_schema.attr_type)
+                {
+                    return Some((base_attr.to_string(), prefix_value.clone()));
+                }
+                None
+            })
+            .collect();
+
+        for (base_attr, prefix_value) in prefix_attrs {
+            let prefix_key = format!("{}_prefix", base_attr);
+
+            // Error if prefix is empty
+            if prefix_value.is_empty() {
+                all_errors.push(format!("{}: '{}' cannot be empty", resource.id, prefix_key));
+                continue;
+            }
+
+            // Error if both prefix and base attribute are specified
+            if resource.attributes.contains_key(&base_attr) {
+                all_errors.push(format!(
+                    "{}: cannot specify both '{}' and '{}'",
+                    resource.id, prefix_key, base_attr
+                ));
+                continue;
+            }
+
+            // Remove the _prefix attribute
+            resource.attributes.remove(&prefix_key);
+
+            // Store prefix
+            resource
+                .prefixes
+                .insert(base_attr.clone(), prefix_value.clone());
+
+            // Generate temporary name
+            let generated_name = format!("{}{}", prefix_value, generate_random_suffix());
+            resource
+                .attributes
+                .insert(base_attr, Value::String(generated_name));
+        }
+    }
+
+    if all_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(all_errors.join("\n"))
+    }
+}
+
+/// State information needed for prefix reconciliation.
+pub struct PrefixStateInfo {
+    /// Attribute prefixes stored in state (e.g., {"bucket_name": "my-app-"})
+    pub prefixes: HashMap<String, String>,
+    /// Attribute string values from state (e.g., {"bucket_name": "my-app-existing1"})
+    pub attribute_values: HashMap<String, String>,
+}
+
+/// Reconcile prefixed names with existing state.
+///
+/// For resources that have prefixes and a matching entry in state (same prefix),
+/// reuses the existing name from state instead of the temporarily generated one.
+/// If the prefix has changed or there's no state match, keeps the new generated name.
+pub fn reconcile_prefixed_names(
+    resources: &mut [Resource],
+    find_state: &dyn Fn(&str, &str) -> Option<PrefixStateInfo>,
+) {
+    for resource in resources.iter_mut() {
+        if resource.prefixes.is_empty() {
+            continue;
+        }
+
+        // Find matching resource in state
+        let state_info = find_state(&resource.id.resource_type, &resource.id.name);
+        let state_info = match state_info {
+            Some(si) => si,
+            None => continue,
+        };
+
+        for (attr_name, prefix) in &resource.prefixes {
+            // Check if state has the same prefix for this attribute
+            if let Some(state_prefix) = state_info.prefixes.get(attr_name)
+                && state_prefix == prefix
+            {
+                // Same prefix: reuse the existing name from state
+                if let Some(name_str) = state_info.attribute_values.get(attr_name) {
+                    resource
+                        .attributes
+                        .insert(attr_name.clone(), Value::String(name_str.clone()));
+                }
+            }
+            // If prefix changed or no state prefix exists, keep the newly generated name
+        }
+    }
+}
+
+/// Compute stable identifiers for anonymous resources (those with empty ResourceId.name).
+/// Uses create-only properties and provider identity attributes to generate a deterministic hash.
+///
+/// `identity_attributes_fn` takes a provider name and returns the list of identity attribute names
+/// for that provider (e.g., `["region"]`).
+pub fn compute_anonymous_identifiers(
+    resources: &mut [Resource],
+    providers: &[ProviderConfig],
+    schemas: &HashMap<String, ResourceSchema>,
+    schema_key_fn: &dyn Fn(&Resource) -> String,
+    identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
+) -> Result<(), String> {
+    use std::collections::BTreeMap;
+    use std::hash::{Hash, Hasher};
+
+    // First pass: compute identifiers and detect collisions
+    let mut computed: Vec<(usize, String)> = Vec::new();
+
+    for (idx, resource) in resources.iter().enumerate() {
+        if !resource.id.name.is_empty() {
+            continue;
+        }
+
+        // Look up schema for this resource's provider (skip if no _provider set)
+        let Some(Value::String(provider_name)) = resource.attributes.get("_provider") else {
+            continue;
+        };
+        let schema_key = schema_key_fn(resource);
+
+        let Some(schema) = schemas.get(&schema_key) else {
+            continue;
+        };
+
+        let create_only_attrs = schema.create_only_attributes();
+        if create_only_attrs.is_empty() {
+            return Err(format!(
+                "Anonymous resource '{}' has no create-only properties. Use `let` binding for identification.",
+                resource.id.display_type()
+            ));
+        }
+
+        // Collect identity attribute values (e.g., region) from provider config
+        let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
+        let identity_attrs = identity_attributes_fn(provider_name);
+        if let Some(pc) = providers.iter().find(|p| p.name == *provider_name) {
+            for attr_name in &identity_attrs {
+                if let Some(value) = pc.attributes.get(attr_name.as_str()) {
+                    identity_values.insert(attr_name.clone(), format!("{:?}", value));
+                }
+            }
+        }
+
+        // Collect create-only values in sorted order for deterministic hashing
+        let mut create_only_values: BTreeMap<&str, String> = BTreeMap::new();
+        for attr_name in &create_only_attrs {
+            if let Some(value) = resource.attributes.get(*attr_name) {
+                create_only_values.insert(attr_name, format!("{:?}", value));
+            }
+        }
+
+        if create_only_values.is_empty() {
+            return Err(format!(
+                "Anonymous resource '{}' has no create-only property values set. Use `let` binding for identification.",
+                resource.id.display_type()
+            ));
+        }
+
+        // Compute deterministic hash: identity attributes first, then create-only values
+        let mut hasher = std::hash::DefaultHasher::new();
+        for (k, v) in &identity_values {
+            k.hash(&mut hasher);
+            v.hash(&mut hasher);
+        }
+        for (k, v) in &create_only_values {
+            k.hash(&mut hasher);
+            v.hash(&mut hasher);
+        }
+        let hash = hasher.finish();
+        let hash_str = format!("{:08x}", hash & 0xFFFFFFFF); // 8 hex chars
+
+        // Build identifier: resource_type_hash (e.g., ec2_vpc_a3f2b1c8)
+        let identifier = format!(
+            "{}_{}",
+            resource.id.resource_type.replace('.', "_"),
+            hash_str
+        );
+
+        computed.push((idx, identifier));
+    }
+
+    // Detect collisions
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    for (idx, identifier) in &computed {
+        if let Some(first_idx) = seen.get(identifier) {
+            return Err(format!(
+                "Anonymous resource identifier collision: '{}' and '{}' produce the same identifier '{}'. \
+                 Use `let` bindings to give them distinct names.",
+                resources[*first_idx].id.display_type(),
+                resources[*idx].id.display_type(),
+                identifier,
+            ));
+        }
+        seen.insert(identifier.clone(), *idx);
+    }
+
+    // Second pass: apply identifiers
+    for (idx, identifier) in computed {
+        let provider = resources[idx].id.provider.clone();
+        let resource_type = resources[idx].id.resource_type.clone();
+        resources[idx].id = ResourceId::with_provider(&provider, &resource_type, identifier);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::Resource;
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    fn make_s3_bucket_schema() -> (String, ResourceSchema) {
+        let schema = ResourceSchema::new("awscc.s3.bucket")
+            .attribute(AttributeSchema::new("bucket_name", AttributeType::String));
+        ("awscc.s3.bucket".to_string(), schema)
+    }
+
+    fn schema_key_fn(resource: &Resource) -> String {
+        match resource.attributes.get("_provider") {
+            Some(Value::String(provider)) => format!("{}.{}", provider, resource.id.resource_type),
+            _ => resource.id.resource_type.clone(),
+        }
+    }
+
+    #[test]
+    fn test_generate_random_suffix_format() {
+        let suffix = generate_random_suffix();
+        assert_eq!(suffix.len(), 8);
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .attributes
+            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        resource.attributes.insert(
+            "bucket_name_prefix".to_string(),
+            Value::String("my-app-".to_string()),
+        );
+
+        let schemas: HashMap<String, ResourceSchema> =
+            vec![make_s3_bucket_schema()].into_iter().collect();
+        let mut resources = vec![resource];
+        resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn).unwrap();
+
+        // bucket_name_prefix should be removed
+        assert!(!resources[0].attributes.contains_key("bucket_name_prefix"));
+
+        // bucket_name should be generated with the prefix
+        let bucket_name = match resources[0].attributes.get("bucket_name").unwrap() {
+            Value::String(s) => s.clone(),
+            _ => panic!("expected String"),
+        };
+        assert!(bucket_name.starts_with("my-app-"));
+        assert_eq!(bucket_name.len(), "my-app-".len() + 8); // prefix + 8 hex chars
+
+        // prefixes map should have the entry
+        assert_eq!(
+            resources[0].prefixes.get("bucket_name"),
+            Some(&"my-app-".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .attributes
+            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        resource.attributes.insert(
+            "nonexistent_attr_prefix".to_string(),
+            Value::String("some-value".to_string()),
+        );
+
+        let schemas: HashMap<String, ResourceSchema> =
+            vec![make_s3_bucket_schema()].into_iter().collect();
+        let mut resources = vec![resource];
+        resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn).unwrap();
+
+        // nonexistent_attr_prefix should remain untouched
+        assert!(
+            resources[0]
+                .attributes
+                .contains_key("nonexistent_attr_prefix")
+        );
+        assert!(resources[0].prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .attributes
+            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        resource.attributes.insert(
+            "bucket_name_prefix".to_string(),
+            Value::String("my-app-".to_string()),
+        );
+        resource.attributes.insert(
+            "bucket_name".to_string(),
+            Value::String("my-actual-bucket".to_string()),
+        );
+
+        let schemas: HashMap<String, ResourceSchema> =
+            vec![make_s3_bucket_schema()].into_iter().collect();
+        let mut resources = vec![resource];
+        let result = resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cannot specify both"));
+    }
+
+    #[test]
+    fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .attributes
+            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        resource.attributes.insert(
+            "bucket_name_prefix".to_string(),
+            Value::String("".to_string()),
+        );
+
+        let schemas: HashMap<String, ResourceSchema> =
+            vec![make_s3_bucket_schema()].into_iter().collect();
+        let mut resources = vec![resource];
+        let result = resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_reconcile_prefixed_names_reuses_state_name_when_prefix_matches() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .prefixes
+            .insert("bucket_name".to_string(), "my-app-".to_string());
+        resource.attributes.insert(
+            "bucket_name".to_string(),
+            Value::String("my-app-temporary".to_string()),
+        );
+
+        let mut resources = vec![resource];
+        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| {
+            Some(PrefixStateInfo {
+                prefixes: vec![("bucket_name".to_string(), "my-app-".to_string())]
+                    .into_iter()
+                    .collect(),
+                attribute_values: vec![("bucket_name".to_string(), "my-app-existing1".to_string())]
+                    .into_iter()
+                    .collect(),
+            })
+        });
+
+        // Should reuse the state name, not the temporary one
+        assert_eq!(
+            resources[0].attributes.get("bucket_name"),
+            Some(&Value::String("my-app-existing1".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_prefixed_names_generates_new_name_when_prefix_changes() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .prefixes
+            .insert("bucket_name".to_string(), "new-prefix-".to_string());
+        resource.attributes.insert(
+            "bucket_name".to_string(),
+            Value::String("new-prefix-abcd1234".to_string()),
+        );
+
+        let mut resources = vec![resource];
+        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| {
+            Some(PrefixStateInfo {
+                prefixes: vec![("bucket_name".to_string(), "old-prefix-".to_string())]
+                    .into_iter()
+                    .collect(),
+                attribute_values: vec![(
+                    "bucket_name".to_string(),
+                    "old-prefix-existing1".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            })
+        });
+
+        // Should keep the newly generated name since prefix changed
+        assert_eq!(
+            resources[0].attributes.get("bucket_name"),
+            Some(&Value::String("new-prefix-abcd1234".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
+        resource
+            .prefixes
+            .insert("bucket_name".to_string(), "my-app-".to_string());
+        resource.attributes.insert(
+            "bucket_name".to_string(),
+            Value::String("my-app-abcd1234".to_string()),
+        );
+
+        let mut resources = vec![resource];
+        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| None);
+
+        // No state, so keep the generated name
+        assert_eq!(
+            resources[0].attributes.get("bucket_name"),
+            Some(&Value::String("my-app-abcd1234".to_string()))
+        );
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod deps;
 pub mod differ;
 pub mod effect;
 pub mod formatter;
+pub mod identifier;
 pub mod interpreter;
 pub mod module;
 pub mod module_resolver;


### PR DESCRIPTION
## Summary

- Extract `generate_random_suffix`, `resolve_attr_prefixes`, `reconcile_prefixed_names`, and `compute_anonymous_identifiers` from `carina-cli/src/main.rs` into a new `carina-core::identifier` module
- CLI retains thin wrappers that supply provider-specific dependencies (schemas, factory lookups)
- `reconcile_prefixed_names` uses a `PrefixStateInfo` struct and closure to avoid coupling carina-core to carina-state
- Moved `uuid` dependency from carina-cli to carina-core (no longer needed in CLI)
- All existing tests preserved: pure logic tests in carina-core, integration tests remain in CLI

Part of #328

## Test plan

- [x] `cargo test` — all 560+ tests pass
- [x] `cargo fmt` / `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)