### PR TITLE
Extract module loading functions into carina-core::module_resolver

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -386,10 +386,10 @@ fn run_module_command(command: ModuleCommands) -> Result<(), String> {
     }
 }
 
-fn run_module_info(path: &PathBuf) -> Result<(), String> {
+fn run_module_info(path: &Path) -> Result<(), String> {
     let parsed = if path.is_dir() {
         // Read all .crn files in the directory and merge them
-        load_module_from_directory(path)?
+        module_resolver::load_module_from_directory(path)?
     } else {
         module_resolver::get_parsed_file(path).map_err(|e| format!("Failed to load file: {}", e))?
     };
@@ -397,7 +397,7 @@ fn run_module_info(path: &PathBuf) -> Result<(), String> {
     // Derive module name from directory structure
     // For directory-based modules like modules/web_tier/, use the directory name
     // For file-based modules like modules/web_tier.crn, use the file stem
-    let module_name = derive_module_name(path);
+    let module_name = module_resolver::derive_module_name(path);
 
     // Build and display the file signature (module or root config)
     let signature =
@@ -405,81 +405,6 @@ fn run_module_info(path: &PathBuf) -> Result<(), String> {
     println!("{}", signature.display());
 
     Ok(())
-}
-
-/// Load a module from a directory by reading all .crn files
-fn load_module_from_directory(dir: &PathBuf) -> Result<ParsedFile, String> {
-    let entries = fs::read_dir(dir)
-        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
-
-    let mut merged = ParsedFile {
-        providers: vec![],
-        resources: vec![],
-        variables: std::collections::HashMap::new(),
-        imports: vec![],
-        module_calls: vec![],
-        inputs: vec![],
-        outputs: vec![],
-        backend: None,
-    };
-
-    for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-
-        if path.extension().is_some_and(|ext| ext == "crn") {
-            let content = fs::read_to_string(&path)
-                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-
-            let parsed = parser::parse(&content)
-                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
-
-            // Merge parsed content
-            merged.providers.extend(parsed.providers);
-            merged.resources.extend(parsed.resources);
-            merged.variables.extend(parsed.variables);
-            merged.imports.extend(parsed.imports);
-            merged.module_calls.extend(parsed.module_calls);
-            merged.inputs.extend(parsed.inputs);
-            merged.outputs.extend(parsed.outputs);
-        }
-    }
-
-    Ok(merged)
-}
-
-/// Derive the module name from a file or directory path
-/// Examples:
-/// - modules/web_tier/ -> web_tier (directory)
-/// - modules/web_tier/main.crn -> web_tier (directory-based)
-/// - modules/web_tier.crn -> web_tier (file-based)
-/// - web_tier.crn -> web_tier
-fn derive_module_name(path: &Path) -> String {
-    // If it's a directory, use the directory name
-    if path.is_dir() {
-        return path
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown")
-            .to_string();
-    }
-
-    let file_stem = path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("unknown");
-
-    // If file is named main.crn, use the parent directory name
-    if file_stem == "main"
-        && let Some(parent) = path.parent()
-        && let Some(parent_name) = parent.file_name()
-        && let Some(name) = parent_name.to_str()
-    {
-        return name.to_string();
-    }
-
-    // Otherwise use the file stem
-    file_stem.to_string()
 }
 
 fn validate_provider_region(parsed: &ParsedFile) -> Result<(), String> {
@@ -492,65 +417,12 @@ fn validate_module_calls(parsed: &ParsedFile, base_dir: &Path) -> Result<(), Str
     let mut imported_modules = HashMap::new();
     for import in &parsed.imports {
         let module_path = base_dir.join(&import.path);
-        if let Some(module_parsed) = load_module(&module_path) {
+        if let Some(module_parsed) = module_resolver::load_module(&module_path) {
             imported_modules.insert(import.alias.clone(), module_parsed.inputs);
         }
     }
 
     validation::validate_module_calls(&parsed.module_calls, &imported_modules)
-}
-
-/// Load a module from a file or directory
-fn load_module(path: &Path) -> Option<ParsedFile> {
-    if path.is_dir() {
-        let main_path = path.join("main.crn");
-        if main_path.exists() {
-            let content = fs::read_to_string(&main_path).ok()?;
-            parser::parse(&content).ok()
-        } else {
-            load_directory_module(path)
-        }
-    } else {
-        let content = fs::read_to_string(path).ok()?;
-        parser::parse(&content).ok()
-    }
-}
-
-/// Load all .crn files from a directory and merge them
-fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
-    let entries = fs::read_dir(dir_path).ok()?;
-    let mut merged = ParsedFile {
-        providers: vec![],
-        resources: vec![],
-        variables: HashMap::new(),
-        imports: vec![],
-        module_calls: vec![],
-        inputs: vec![],
-        outputs: vec![],
-        backend: None,
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "crn")
-            && let Ok(content) = fs::read_to_string(&path)
-            && let Ok(parsed) = parser::parse(&content)
-        {
-            merged.providers.extend(parsed.providers);
-            merged.resources.extend(parsed.resources);
-            merged.variables.extend(parsed.variables);
-            merged.imports.extend(parsed.imports);
-            merged.module_calls.extend(parsed.module_calls);
-            merged.inputs.extend(parsed.inputs);
-            merged.outputs.extend(parsed.outputs);
-        }
-    }
-
-    if merged.inputs.is_empty() && merged.outputs.is_empty() {
-        None
-    } else {
-        Some(merged)
-    }
 }
 
 /// Result of loading configuration, includes the file path containing backend block

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -290,6 +290,141 @@ pub fn get_parsed_file(path: &Path) -> Result<ParsedFile, ModuleError> {
     Ok(parsed)
 }
 
+/// Load a module from a file or directory path.
+///
+/// For directories, tries `main.crn` first, then falls back to merging all `.crn` files.
+/// Returns `None` if the path cannot be read/parsed, or if the directory contains
+/// no module definitions (no inputs or outputs).
+pub fn load_module(path: &Path) -> Option<ParsedFile> {
+    if path.is_dir() {
+        let main_path = path.join("main.crn");
+        if main_path.exists() {
+            let content = fs::read_to_string(&main_path).ok()?;
+            crate::parser::parse(&content).ok()
+        } else {
+            load_directory_module(path)
+        }
+    } else {
+        let content = fs::read_to_string(path).ok()?;
+        crate::parser::parse(&content).ok()
+    }
+}
+
+/// Load all `.crn` files from a directory and merge them into a single `ParsedFile`.
+///
+/// Returns `None` if no module definitions (inputs/outputs) are found.
+pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
+    let entries = fs::read_dir(dir_path).ok()?;
+    let mut merged = ParsedFile {
+        providers: vec![],
+        resources: vec![],
+        variables: HashMap::new(),
+        imports: vec![],
+        module_calls: vec![],
+        inputs: vec![],
+        outputs: vec![],
+        backend: None,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "crn")
+            && let Ok(content) = fs::read_to_string(&path)
+            && let Ok(parsed) = crate::parser::parse(&content)
+        {
+            merged.providers.extend(parsed.providers);
+            merged.resources.extend(parsed.resources);
+            merged.variables.extend(parsed.variables);
+            merged.imports.extend(parsed.imports);
+            merged.module_calls.extend(parsed.module_calls);
+            merged.inputs.extend(parsed.inputs);
+            merged.outputs.extend(parsed.outputs);
+        }
+    }
+
+    if merged.inputs.is_empty() && merged.outputs.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
+}
+
+/// Derive the module name from a file or directory path.
+///
+/// Examples:
+/// - `modules/web_tier/` → `web_tier` (directory)
+/// - `modules/web_tier/main.crn` → `web_tier` (directory-based)
+/// - `modules/web_tier.crn` → `web_tier` (file-based)
+/// - `web_tier.crn` → `web_tier`
+pub fn derive_module_name(path: &Path) -> String {
+    if path.is_dir() {
+        return path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+    }
+
+    let file_stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+
+    // If file is named main.crn, use the parent directory name
+    if file_stem == "main"
+        && let Some(parent) = path.parent()
+        && let Some(parent_name) = parent.file_name()
+        && let Some(name) = parent_name.to_str()
+    {
+        return name.to_string();
+    }
+
+    file_stem.to_string()
+}
+
+/// Load a module from a directory by reading all `.crn` files.
+///
+/// Unlike [`load_directory_module`], this returns a `Result` with descriptive error messages
+/// and does not check for module definitions (inputs/outputs).
+pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
+
+    let mut merged = ParsedFile {
+        providers: vec![],
+        resources: vec![],
+        variables: HashMap::new(),
+        imports: vec![],
+        module_calls: vec![],
+        inputs: vec![],
+        outputs: vec![],
+        backend: None,
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+
+        if path.extension().is_some_and(|ext| ext == "crn") {
+            let content = fs::read_to_string(&path)
+                .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+            let parsed = crate::parser::parse(&content)
+                .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+
+            merged.providers.extend(parsed.providers);
+            merged.resources.extend(parsed.resources);
+            merged.variables.extend(parsed.variables);
+            merged.imports.extend(parsed.imports);
+            merged.module_calls.extend(parsed.module_calls);
+            merged.inputs.extend(parsed.inputs);
+            merged.outputs.extend(parsed.outputs);
+        }
+    }
+
+    Ok(merged)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -892,7 +892,7 @@ impl CompletionProvider {
             && let Some(base) = base_path
         {
             let module_path = base.join(&import_path);
-            if let Some(parsed) = self.load_module(&module_path) {
+            if let Some(parsed) = carina_core::module_resolver::load_module(&module_path) {
                 // Extract input parameters from the module
                 for input in &parsed.inputs {
                     let type_str = self.format_type_expr(&input.type_expr);
@@ -921,58 +921,6 @@ impl CompletionProvider {
         }
 
         completions
-    }
-
-    /// Load module from path, handling both file and directory-based modules
-    fn load_module(&self, path: &Path) -> Option<parser::ParsedFile> {
-        if path.is_dir() {
-            // Directory-based module: load main.crn
-            let main_path = path.join("main.crn");
-            if main_path.exists() {
-                let content = std::fs::read_to_string(&main_path).ok()?;
-                parser::parse(&content).ok()
-            } else {
-                // Fallback: merge all .crn files in the directory
-                self.load_directory_module(path)
-            }
-        } else {
-            // Single file module
-            let content = std::fs::read_to_string(path).ok()?;
-            parser::parse(&content).ok()
-        }
-    }
-
-    /// Load all .crn files from a directory and merge them
-    fn load_directory_module(&self, dir_path: &Path) -> Option<parser::ParsedFile> {
-        let entries = std::fs::read_dir(dir_path).ok()?;
-        let mut merged = parser::ParsedFile {
-            providers: vec![],
-            resources: vec![],
-            variables: HashMap::new(),
-            imports: vec![],
-            module_calls: vec![],
-            inputs: vec![],
-            outputs: vec![],
-            backend: None,
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "crn")
-                && let Ok(content) = std::fs::read_to_string(&path)
-                && let Ok(parsed) = parser::parse(&content)
-            {
-                merged.providers.extend(parsed.providers);
-                merged.resources.extend(parsed.resources);
-                merged.variables.extend(parsed.variables);
-                merged.imports.extend(parsed.imports);
-                merged.module_calls.extend(parsed.module_calls);
-                merged.inputs.extend(parsed.inputs);
-                merged.outputs.extend(parsed.outputs);
-            }
-        }
-
-        Some(merged)
     }
 
     /// Provide completions for input parameters in the current file (after "input.")

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -893,7 +893,7 @@ impl DiagnosticEngine {
 
         for import in &parsed.imports {
             let module_path = base_path.join(&import.path);
-            if let Some(module_parsed) = self.load_module(&module_path) {
+            if let Some(module_parsed) = carina_core::module_resolver::load_module(&module_path) {
                 imported_modules.insert(import.alias.clone(), module_parsed.inputs);
             }
         }
@@ -1185,63 +1185,6 @@ impl DiagnosticEngine {
         }
 
         diagnostics
-    }
-
-    /// Load a module from a file or directory
-    /// Handles both single-file modules and directory-based modules
-    fn load_module(&self, path: &Path) -> Option<ParsedFile> {
-        if path.is_dir() {
-            // Directory-based module: load main.crn or merge all .crn files
-            let main_path = path.join("main.crn");
-            if main_path.exists() {
-                let content = std::fs::read_to_string(&main_path).ok()?;
-                carina_core::parser::parse(&content).ok()
-            } else {
-                // Merge all .crn files in the directory
-                self.load_directory_module(path)
-            }
-        } else {
-            // Single file module
-            let content = std::fs::read_to_string(path).ok()?;
-            carina_core::parser::parse(&content).ok()
-        }
-    }
-
-    /// Load all .crn files from a directory and merge them
-    fn load_directory_module(&self, dir_path: &Path) -> Option<ParsedFile> {
-        let entries = std::fs::read_dir(dir_path).ok()?;
-        let mut merged = ParsedFile {
-            providers: vec![],
-            resources: vec![],
-            variables: HashMap::new(),
-            imports: vec![],
-            module_calls: vec![],
-            inputs: vec![],
-            outputs: vec![],
-            backend: None,
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "crn")
-                && let Ok(content) = std::fs::read_to_string(&path)
-                && let Ok(parsed) = carina_core::parser::parse(&content)
-            {
-                merged.providers.extend(parsed.providers);
-                merged.resources.extend(parsed.resources);
-                merged.variables.extend(parsed.variables);
-                merged.imports.extend(parsed.imports);
-                merged.module_calls.extend(parsed.module_calls);
-                merged.inputs.extend(parsed.inputs);
-                merged.outputs.extend(parsed.outputs);
-            }
-        }
-
-        if merged.inputs.is_empty() && merged.outputs.is_empty() {
-            None
-        } else {
-            Some(merged)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Move `load_module()`, `load_directory_module()`, `derive_module_name()`, and `load_module_from_directory()` from `carina-cli` and `carina-lsp` into `carina-core::module_resolver` as public free functions
- Eliminate duplicate implementations that existed across three crates (cli, lsp/completion, lsp/diagnostics)
- Net reduction of ~100 lines of duplicated code

Part of #328 (Phase 1: Module loading)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all tests pass
- [x] Clippy and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)