### PR TITLE
Extract config loading and file discovery into carina-core::config_loader

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -8,6 +8,9 @@ use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
 
+use carina_core::config_loader::{
+    find_crn_files_in_dir, find_crn_files_recursive, get_base_dir, load_configuration,
+};
 use carina_core::deps::{
     build_dependents_map, find_failed_dependency, find_failed_dependent, get_resource_dependencies,
     sort_resources_by_dependencies,
@@ -18,7 +21,7 @@ use carina_core::formatter::{self, FormatConfig};
 use carina_core::identifier::{self, PrefixStateInfo};
 use carina_core::lint::{find_list_literal_attrs, list_struct_attr_names};
 use carina_core::module_resolver;
-use carina_core::parser::{self, BackendConfig, ParsedFile, ProviderConfig};
+use carina_core::parser::{BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ResourceType,
@@ -423,101 +426,6 @@ fn validate_module_calls(parsed: &ParsedFile, base_dir: &Path) -> Result<(), Str
     }
 
     validation::validate_module_calls(&parsed.module_calls, &imported_modules)
-}
-
-/// Result of loading configuration, includes the file path containing backend block
-struct LoadedConfig {
-    parsed: ParsedFile,
-    backend_file: Option<PathBuf>,
-}
-
-/// Load configuration from a file or directory
-fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
-    if path.is_file() {
-        // Single file mode (existing behavior)
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-        let parsed =
-            parser::parse_and_resolve(&content).map_err(|e| format!("Parse error: {}", e))?;
-        let backend_file = if parsed.backend.is_some() {
-            Some(path.clone())
-        } else {
-            None
-        };
-        Ok(LoadedConfig {
-            parsed,
-            backend_file,
-        })
-    } else if path.is_dir() {
-        // Directory mode
-        let files = find_crn_files_in_dir(path)?;
-        if files.is_empty() {
-            return Err(format!("No .crn files found in {}", path.display()));
-        }
-
-        let mut merged = ParsedFile {
-            providers: vec![],
-            resources: vec![],
-            variables: HashMap::new(),
-            imports: vec![],
-            module_calls: vec![],
-            inputs: vec![],
-            outputs: vec![],
-            backend: None,
-        };
-        let mut parse_errors = Vec::new();
-        let mut backend_file: Option<PathBuf> = None;
-
-        for file in &files {
-            let content = fs::read_to_string(file)
-                .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
-            match parser::parse_and_resolve(&content) {
-                Ok(parsed) => {
-                    merged.providers.extend(parsed.providers);
-                    merged.resources.extend(parsed.resources);
-                    merged.variables.extend(parsed.variables);
-                    merged.imports.extend(parsed.imports);
-                    merged.module_calls.extend(parsed.module_calls);
-                    merged.inputs.extend(parsed.inputs);
-                    merged.outputs.extend(parsed.outputs);
-                    // Merge backend (only one allowed)
-                    if let Some(backend) = parsed.backend {
-                        if merged.backend.is_some() {
-                            parse_errors.push(format!(
-                                "{}: multiple backend blocks defined",
-                                file.display()
-                            ));
-                        } else {
-                            merged.backend = Some(backend);
-                            backend_file = Some(file.clone());
-                        }
-                    }
-                }
-                Err(e) => {
-                    parse_errors.push(format!("{}: {}", file.display(), e));
-                }
-            }
-        }
-
-        if !parse_errors.is_empty() {
-            return Err(parse_errors.join("\n"));
-        }
-        Ok(LoadedConfig {
-            parsed: merged,
-            backend_file,
-        })
-    } else {
-        Err(format!("Path not found: {}", path.display()))
-    }
-}
-
-/// Get base directory for module resolution
-fn get_base_dir(path: &Path) -> &Path {
-    if path.is_file() {
-        path.parent().unwrap_or(Path::new("."))
-    } else {
-        path
-    }
 }
 
 fn run_validate(path: &PathBuf) -> Result<(), String> {
@@ -3540,49 +3448,6 @@ fn run_fmt(path: &PathBuf, check: bool, show_diff: bool, recursive: bool) -> Res
         }
         Ok(())
     }
-}
-
-fn find_crn_files_recursive(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
-    let mut files = Vec::new();
-    collect_crn_files_recursive(dir, &mut files)?;
-    Ok(files)
-}
-
-fn collect_crn_files_recursive(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Result<(), String> {
-    let entries = fs::read_dir(dir)
-        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
-
-    for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-
-        if path.is_dir() {
-            // Skip hidden directories and common non-source directories
-            let name = path.file_name().unwrap_or_default().to_string_lossy();
-            if !name.starts_with('.') && name != "target" && name != "node_modules" {
-                collect_crn_files_recursive(&path, files)?;
-            }
-        } else if path.extension().is_some_and(|ext| ext == "crn") {
-            files.push(path);
-        }
-    }
-
-    Ok(())
-}
-
-fn find_crn_files_in_dir(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
-    let entries = fs::read_dir(dir)
-        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
-
-    let mut files = Vec::new();
-    for entry in entries {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "crn") {
-            files.push(path);
-        }
-    }
-    Ok(files)
 }
 
 fn print_diff(file: &Path, original: &str, formatted: &str) {

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -1,0 +1,147 @@
+//! Configuration loading and .crn file discovery utilities
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::parser::{self, ParsedFile};
+
+/// Result of loading configuration, includes the file path containing backend block
+pub struct LoadedConfig {
+    pub parsed: ParsedFile,
+    pub backend_file: Option<PathBuf>,
+}
+
+/// Load configuration from a file or directory
+pub fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
+    if path.is_file() {
+        // Single file mode (existing behavior)
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+        let parsed =
+            parser::parse_and_resolve(&content).map_err(|e| format!("Parse error: {}", e))?;
+        let backend_file = if parsed.backend.is_some() {
+            Some(path.clone())
+        } else {
+            None
+        };
+        Ok(LoadedConfig {
+            parsed,
+            backend_file,
+        })
+    } else if path.is_dir() {
+        // Directory mode
+        let files = find_crn_files_in_dir(path)?;
+        if files.is_empty() {
+            return Err(format!("No .crn files found in {}", path.display()));
+        }
+
+        let mut merged = ParsedFile {
+            providers: vec![],
+            resources: vec![],
+            variables: HashMap::new(),
+            imports: vec![],
+            module_calls: vec![],
+            inputs: vec![],
+            outputs: vec![],
+            backend: None,
+        };
+        let mut parse_errors = Vec::new();
+        let mut backend_file: Option<PathBuf> = None;
+
+        for file in &files {
+            let content = fs::read_to_string(file)
+                .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
+            match parser::parse_and_resolve(&content) {
+                Ok(parsed) => {
+                    merged.providers.extend(parsed.providers);
+                    merged.resources.extend(parsed.resources);
+                    merged.variables.extend(parsed.variables);
+                    merged.imports.extend(parsed.imports);
+                    merged.module_calls.extend(parsed.module_calls);
+                    merged.inputs.extend(parsed.inputs);
+                    merged.outputs.extend(parsed.outputs);
+                    // Merge backend (only one allowed)
+                    if let Some(backend) = parsed.backend {
+                        if merged.backend.is_some() {
+                            parse_errors.push(format!(
+                                "{}: multiple backend blocks defined",
+                                file.display()
+                            ));
+                        } else {
+                            merged.backend = Some(backend);
+                            backend_file = Some(file.clone());
+                        }
+                    }
+                }
+                Err(e) => {
+                    parse_errors.push(format!("{}: {}", file.display(), e));
+                }
+            }
+        }
+
+        if !parse_errors.is_empty() {
+            return Err(parse_errors.join("\n"));
+        }
+        Ok(LoadedConfig {
+            parsed: merged,
+            backend_file,
+        })
+    } else {
+        Err(format!("Path not found: {}", path.display()))
+    }
+}
+
+/// Get base directory for module resolution
+pub fn get_base_dir(path: &Path) -> &Path {
+    if path.is_file() {
+        path.parent().unwrap_or(Path::new("."))
+    } else {
+        path
+    }
+}
+
+/// Find all .crn files recursively in a directory, skipping hidden dirs, target, and node_modules
+pub fn find_crn_files_recursive(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
+    let mut files = Vec::new();
+    collect_crn_files_recursive(dir, &mut files)?;
+    Ok(files)
+}
+
+fn collect_crn_files_recursive(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Result<(), String> {
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            // Skip hidden directories and common non-source directories
+            let name = path.file_name().unwrap_or_default().to_string_lossy();
+            if !name.starts_with('.') && name != "target" && name != "node_modules" {
+                collect_crn_files_recursive(&path, files)?;
+            }
+        } else if path.extension().is_some_and(|ext| ext == "crn") {
+            files.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Find .crn files in a single directory (non-recursive)
+pub fn find_crn_files_in_dir(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
+
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "crn") {
+            files.push(path);
+        }
+    }
+    Ok(files)
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Core library for an infrastructure management tool that treats side effects as values
 
+pub mod config_loader;
 pub mod deps;
 pub mod differ;
 pub mod effect;


### PR DESCRIPTION
## Summary

- Extracts `load_configuration()`, `LoadedConfig`, `get_base_dir()`, `find_crn_files_in_dir()`, `find_crn_files_recursive()`, and `collect_crn_files_recursive()` from `carina-cli/src/main.rs` into a new `carina-core::config_loader` module
- Part of #328 (Phase 2: Extract orchestration logic)

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo test` — all 563 tests pass
- [x] No behavioral changes; purely structural refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)