### PR TITLE
Extract state conversion helpers into carina-core and carina-state

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -3033,57 +3033,23 @@ fn format_list_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix: &
 
 /// Convert parser BackendConfig to state BackendConfig
 fn convert_backend_config(config: &BackendConfig) -> StateBackendConfig {
-    StateBackendConfig {
-        backend_type: config.backend_type.clone(),
-        attributes: config.attributes.clone(),
-    }
+    StateBackendConfig::from(config)
 }
 
-/// Find the state bucket resource in the parsed file
 fn find_state_bucket_resource<'a>(
     parsed: &'a ParsedFile,
     bucket_name: &str,
     resource_type: &str,
 ) -> Option<&'a Resource> {
-    parsed.resources.iter().find(|r| {
-        r.id.resource_type == resource_type
-            && matches!(r.attributes.get("name"), Some(Value::String(name)) if name == bucket_name)
-    })
+    parsed.find_resource_by_name(resource_type, bucket_name)
 }
 
-/// Convert a Resource to ResourceState for the state file
 fn resource_to_state(
     resource: &Resource,
     state: &State,
     existing_state: Option<&ResourceState>,
 ) -> ResourceState {
-    let provider = resource.id.provider.clone();
-
-    let mut resource_state =
-        ResourceState::new(&resource.id.resource_type, &resource.id.name, provider);
-
-    // Copy identifier from state
-    resource_state.identifier = state.identifier.clone();
-
-    // Set attributes directly (not nested)
-    for (k, v) in &state.attributes {
-        resource_state
-            .attributes
-            .insert(k.clone(), value_to_json(v));
-    }
-
-    // Preserve protected flag from existing state
-    if let Some(existing) = existing_state {
-        resource_state.protected = existing.protected;
-    }
-
-    // Copy lifecycle configuration from resource
-    resource_state.lifecycle = resource.lifecycle.clone();
-
-    // Copy attribute prefixes from resource
-    resource_state.prefixes = resource.prefixes.clone();
-
-    resource_state
+    ResourceState::from_provider_state(resource, state, existing_state)
 }
 
 /// Run force-unlock command

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -170,6 +170,16 @@ pub struct ParsedFile {
     pub backend: Option<BackendConfig>,
 }
 
+impl ParsedFile {
+    /// Find a resource by resource type and name attribute value
+    pub fn find_resource_by_name(&self, resource_type: &str, name: &str) -> Option<&Resource> {
+        self.resources.iter().find(|r| {
+            r.id.resource_type == resource_type
+                && matches!(r.attributes.get("name"), Some(Value::String(n)) if n == name)
+        })
+    }
+}
+
 /// Parse context (variable scope)
 struct ParseContext {
     variables: HashMap<String, Value>,
@@ -2083,5 +2093,39 @@ mod tests {
         } else {
             panic!("Expected map for assume_role_policy_document");
         }
+    }
+
+    #[test]
+    fn test_find_resource_by_name() {
+        let input = r#"
+            aws.s3.bucket {
+                name = "my-bucket"
+            }
+            aws.s3.bucket {
+                name = "other-bucket"
+            }
+        "#;
+        let parsed = parse(input).unwrap();
+
+        assert!(
+            parsed
+                .find_resource_by_name("s3.bucket", "my-bucket")
+                .is_some()
+        );
+        assert!(
+            parsed
+                .find_resource_by_name("s3.bucket", "other-bucket")
+                .is_some()
+        );
+        assert!(
+            parsed
+                .find_resource_by_name("s3.bucket", "no-such")
+                .is_none()
+        );
+        assert!(
+            parsed
+                .find_resource_by_name("ec2.vpc", "my-bucket")
+                .is_none()
+        );
     }
 }

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -182,6 +182,15 @@ impl BackendConfig {
     }
 }
 
+impl From<&carina_core::parser::BackendConfig> for BackendConfig {
+    fn from(config: &carina_core::parser::BackendConfig) -> Self {
+        Self {
+            backend_type: config.backend_type.clone(),
+            attributes: config.attributes.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,5 +222,25 @@ mod tests {
 
         let error = BackendError::BucketNotFound("my-bucket".to_string());
         assert_eq!(error.to_string(), "Bucket not found: my-bucket");
+    }
+
+    #[test]
+    fn test_backend_config_from_parser_config() {
+        use carina_core::resource::Value;
+
+        let parser_config = carina_core::parser::BackendConfig {
+            backend_type: "s3".to_string(),
+            attributes: [
+                ("bucket".to_string(), Value::String("my-bucket".to_string())),
+                ("key".to_string(), Value::String("state.json".to_string())),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let state_config = BackendConfig::from(&parser_config);
+        assert_eq!(state_config.backend_type, "s3");
+        assert_eq!(state_config.get_string("bucket"), Some("my-bucket"));
+        assert_eq!(state_config.get_string("key"), Some("state.json"));
     }
 }

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -1,7 +1,7 @@
 //! State file structures for persisting infrastructure state
 
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, Value};
-use carina_core::value::json_to_dsl_value;
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::value::{json_to_dsl_value, value_to_json};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -200,6 +200,31 @@ impl ResourceState {
         self.protected = protected;
         self
     }
+
+    /// Build a ResourceState from a Resource and its provider-returned State.
+    ///
+    /// If `existing` is provided, the `protected` flag is preserved from it.
+    pub fn from_provider_state(
+        resource: &Resource,
+        state: &State,
+        existing: Option<&ResourceState>,
+    ) -> Self {
+        let mut rs = Self::new(
+            &resource.id.resource_type,
+            &resource.id.name,
+            resource.id.provider.clone(),
+        );
+        rs.identifier = state.identifier.clone();
+        for (k, v) in &state.attributes {
+            rs.attributes.insert(k.clone(), value_to_json(v));
+        }
+        if let Some(existing) = existing {
+            rs.protected = existing.protected;
+        }
+        rs.lifecycle = resource.lifecycle.clone();
+        rs.prefixes = resource.prefixes.clone();
+        rs
+    }
 }
 
 #[cfg(test)]
@@ -394,5 +419,60 @@ mod tests {
 
         let deserialized: ResourceState = serde_json::from_str(json).unwrap();
         assert!(deserialized.prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_from_provider_state() {
+        use carina_core::resource::{Resource, State as ProviderState, Value};
+
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "my-bucket");
+        resource.lifecycle.force_delete = true;
+        resource
+            .prefixes
+            .insert("bucket_name".to_string(), "my-app-".to_string());
+
+        let provider_state = ProviderState {
+            id: resource.id.clone(),
+            identifier: Some("my-bucket-abcd1234".to_string()),
+            attributes: [(
+                "region".to_string(),
+                Value::String("ap-northeast-1".to_string()),
+            )]
+            .into_iter()
+            .collect(),
+            exists: true,
+        };
+
+        let existing = ResourceState::new("s3.bucket", "my-bucket", "awscc").with_protected(true);
+
+        let rs = ResourceState::from_provider_state(&resource, &provider_state, Some(&existing));
+
+        assert_eq!(rs.identifier, Some("my-bucket-abcd1234".to_string()));
+        assert_eq!(
+            rs.attributes.get("region"),
+            Some(&serde_json::json!("ap-northeast-1"))
+        );
+        assert!(rs.protected);
+        assert!(rs.lifecycle.force_delete);
+        assert_eq!(rs.prefixes.get("bucket_name"), Some(&"my-app-".to_string()));
+    }
+
+    #[test]
+    fn test_from_provider_state_without_existing() {
+        use carina_core::resource::{Resource, State as ProviderState, Value};
+
+        let resource = Resource::with_provider("aws", "s3.bucket", "test");
+        let provider_state = ProviderState {
+            id: resource.id.clone(),
+            identifier: Some("test-id".to_string()),
+            attributes: [("name".to_string(), Value::String("test".to_string()))]
+                .into_iter()
+                .collect(),
+            exists: true,
+        };
+
+        let rs = ResourceState::from_provider_state(&resource, &provider_state, None);
+        assert!(!rs.protected);
+        assert_eq!(rs.identifier, Some("test-id".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Add `From<&parser::BackendConfig>` impl on `carina_state::BackendConfig` to replace `convert_backend_config()`
- Add `ParsedFile::find_resource_by_name()` in `carina-core` to replace `find_state_bucket_resource()`
- Add `ResourceState::from_provider_state()` in `carina-state` to replace `resource_to_state()`

CLI thin wrappers now delegate to these methods. Part of #328 Phase 2.

## Test plan

- [x] New unit tests for all three extracted methods
- [x] All existing tests pass (`cargo test -p carina-core -p carina-state -p carina-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)