### PR TITLE
Extract schema and factory utility functions into carina-core::provider

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -24,7 +24,8 @@ use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ResourceType,
+    self as provider_mod, BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult,
+    ResourceType,
 };
 use carina_core::resolver::{resolve_ref_value, resolve_refs_with_state};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
@@ -272,45 +273,15 @@ fn provider_factories() -> Vec<Box<dyn ProviderFactory>> {
     vec![Box::new(AwsProviderFactory), Box::new(AwsccProviderFactory)]
 }
 
-fn find_factory<'a>(
-    factories: &'a [Box<dyn ProviderFactory>],
-    name: &str,
-) -> Option<&'a dyn ProviderFactory> {
-    factories
-        .iter()
-        .find(|f| f.name() == name)
-        .map(|f| f.as_ref())
-}
-
-fn schema_key_for_resource(factories: &[Box<dyn ProviderFactory>], resource: &Resource) -> String {
-    match resource.attributes.get("_provider") {
-        Some(Value::String(provider)) => {
-            if let Some(factory) = find_factory(factories, provider) {
-                factory.format_schema_key(&resource.id.resource_type)
-            } else {
-                resource.id.resource_type.clone()
-            }
-        }
-        _ => resource.id.resource_type.clone(),
-    }
-}
-
 fn get_schemas() -> HashMap<String, ResourceSchema> {
-    let factories = provider_factories();
-    let mut all_schemas = HashMap::new();
-    for factory in &factories {
-        for schema in factory.schemas() {
-            all_schemas.insert(schema.resource_type.clone(), schema);
-        }
-    }
-    all_schemas
+    provider_mod::collect_schemas(&provider_factories())
 }
 
 fn validate_resources(resources: &[Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
     validation::validate_resources(resources, &schemas, &|r| {
-        schema_key_for_resource(&factories, r)
+        provider_mod::schema_key_for_resource(&factories, r)
     })
 }
 
@@ -318,7 +289,7 @@ fn validate_resource_ref_types(resources: &[Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
     validation::validate_resource_ref_types(resources, &schemas, &|r| {
-        schema_key_for_resource(&factories, r)
+        provider_mod::schema_key_for_resource(&factories, r)
     })
 }
 
@@ -327,7 +298,7 @@ fn resolve_names(resources: &mut [Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
     resolve_block_names(resources, &schemas, |r| {
-        schema_key_for_resource(&factories, r)
+        provider_mod::schema_key_for_resource(&factories, r)
     })?;
     resolve_attr_prefixes(resources)
 }
@@ -336,7 +307,7 @@ fn resolve_attr_prefixes(resources: &mut [Resource]) -> Result<(), String> {
     let factories = provider_factories();
     let schemas = get_schemas();
     identifier::resolve_attr_prefixes(resources, &schemas, &|r| {
-        schema_key_for_resource(&factories, r)
+        provider_mod::schema_key_for_resource(&factories, r)
     })
 }
 
@@ -369,9 +340,9 @@ fn compute_anonymous_identifiers(
         resources,
         providers,
         &schemas,
-        &|r| schema_key_for_resource(&factories, r),
+        &|r| provider_mod::schema_key_for_resource(&factories, r),
         &|name| {
-            find_factory(&factories, name)
+            provider_mod::find_factory(&factories, name)
                 .map(|f| {
                     f.identity_attributes()
                         .into_iter()
@@ -721,9 +692,10 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                     .provider_name()
                     .ok_or("Backend does not specify a provider name")?;
                 let factories = provider_factories();
-                let factory = find_factory(&factories, backend_provider_name).ok_or_else(|| {
-                    format!("No provider factory found for '{}'", backend_provider_name)
-                })?;
+                let factory = provider_mod::find_factory(&factories, backend_provider_name)
+                    .ok_or_else(|| {
+                        format!("No provider factory found for '{}'", backend_provider_name)
+                    })?;
                 let provider_config_attrs = parsed
                     .providers
                     .iter()
@@ -764,8 +736,8 @@ async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
                         .provider_name()
                         .ok_or("Backend does not specify a provider name")?;
                     let factories = provider_factories();
-                    let factory =
-                        find_factory(&factories, backend_provider_name).ok_or_else(|| {
+                    let factory = provider_mod::find_factory(&factories, backend_provider_name)
+                        .ok_or_else(|| {
                             format!("No provider factory found for '{}'", backend_provider_name)
                         })?;
                     let region = factory.extract_region(&config.attributes);
@@ -1875,7 +1847,7 @@ async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<
 /// Create a provider from a saved ProviderConfig
 async fn create_provider_from_config(config: &ProviderConfig) -> Box<dyn Provider> {
     let factories = provider_factories();
-    if let Some(factory) = find_factory(&factories, &config.name) {
+    if let Some(factory) = provider_mod::find_factory(&factories, &config.name) {
         let region = factory.extract_region(&config.attributes);
         println!(
             "{}",
@@ -2364,7 +2336,7 @@ async fn run_destroy(path: &PathBuf, auto_approve: bool) -> Result<(), String> {
 async fn get_provider(parsed: &ParsedFile) -> Box<dyn Provider> {
     let factories = provider_factories();
     for provider_config in &parsed.providers {
-        if let Some(factory) = find_factory(&factories, &provider_config.name) {
+        if let Some(factory) = provider_mod::find_factory(&factories, &provider_config.name) {
             let region = factory.extract_region(&provider_config.attributes);
             println!(
                 "{}",
@@ -3164,7 +3136,7 @@ async fn run_state_bucket_delete(
         .resource_type()
         .ok_or("Backend does not specify a resource type")?;
     let factories = provider_factories();
-    let factory = find_factory(&factories, backend_provider_name)
+    let factory = provider_mod::find_factory(&factories, backend_provider_name)
         .ok_or_else(|| format!("No provider factory found for '{}'", backend_provider_name))?;
 
     // Create provider to delete the bucket
@@ -3472,7 +3444,7 @@ fn run_lint(path: &PathBuf) -> Result<(), String> {
     let mut all_list_struct_attrs: HashSet<String> = HashSet::new();
     let mut block_name_suggestions: HashMap<String, String> = HashMap::new();
     for resource in &parsed.resources {
-        let schema_key = schema_key_for_resource(&factories, resource);
+        let schema_key = provider_mod::schema_key_for_resource(&factories, resource);
         if let Some(schema) = schemas.get(&schema_key) {
             all_list_struct_attrs.extend(list_struct_attr_names(schema));
             for (attr_name, attr_schema) in &schema.attributes {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -207,6 +207,47 @@ pub trait ProviderFactory: Send + Sync {
     }
 }
 
+/// Find a factory by provider name.
+pub fn find_factory<'a>(
+    factories: &'a [Box<dyn ProviderFactory>],
+    name: &str,
+) -> Option<&'a dyn ProviderFactory> {
+    factories
+        .iter()
+        .find(|f| f.name() == name)
+        .map(|f| f.as_ref())
+}
+
+/// Collect all resource schemas from the given factories into a single map.
+pub fn collect_schemas(
+    factories: &[Box<dyn ProviderFactory>],
+) -> HashMap<String, crate::schema::ResourceSchema> {
+    let mut all_schemas = HashMap::new();
+    for factory in factories {
+        for schema in factory.schemas() {
+            all_schemas.insert(schema.resource_type.clone(), schema);
+        }
+    }
+    all_schemas
+}
+
+/// Determine the schema lookup key for a resource based on its provider.
+pub fn schema_key_for_resource(
+    factories: &[Box<dyn ProviderFactory>],
+    resource: &Resource,
+) -> String {
+    match resource.attributes.get("_provider") {
+        Some(Value::String(provider)) => {
+            if let Some(factory) = find_factory(factories, provider) {
+                factory.format_schema_key(&resource.id.resource_type)
+            } else {
+                resource.id.resource_type.clone()
+            }
+        }
+        _ => resource.id.resource_type.clone(),
+    }
+}
+
 /// Provider implementation for Box<dyn Provider>
 /// This enables dynamic dispatch for Providers
 impl Provider for Box<dyn Provider> {

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use carina_core::formatter::{self, FormatConfig};
-use carina_core::provider::ProviderFactory;
+use carina_core::provider::{self as provider_mod, ProviderFactory};
 use carina_core::schema::CompletionValue;
 use dashmap::DashMap;
 use tower_lsp::jsonrpc::Result;
@@ -27,13 +26,7 @@ pub struct Backend {
 impl Backend {
     pub fn new(client: Client, factories: Vec<Box<dyn ProviderFactory>>) -> Self {
         // Build shared schema map from all factories
-        let mut schemas = HashMap::new();
-        for factory in &factories {
-            for schema in factory.schemas() {
-                schemas.insert(schema.resource_type.clone(), schema);
-            }
-        }
-        let schemas = Arc::new(schemas);
+        let schemas = Arc::new(provider_mod::collect_schemas(&factories));
 
         // Collect provider names
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -1079,7 +1079,7 @@ enum CompletionContext {
 mod tests {
     use super::*;
     use crate::document::Document;
-    use carina_core::provider::ProviderFactory;
+    use carina_core::provider::{self as provider_mod, ProviderFactory};
 
     fn create_document(content: &str) -> Document {
         Document::new(content.to_string())
@@ -1090,13 +1090,7 @@ mod tests {
             Box::new(carina_provider_aws::AwsProviderFactory),
             Box::new(carina_provider_awscc::AwsccProviderFactory),
         ];
-        let mut schemas = HashMap::new();
-        for factory in &factories {
-            for schema in factory.schemas() {
-                schemas.insert(schema.resource_type.clone(), schema);
-            }
-        }
-        let schemas = Arc::new(schemas);
+        let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
         let region_completions: Vec<CompletionValue> = factories
             .iter()

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -1271,7 +1271,7 @@ fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
 mod tests {
     use super::*;
     use crate::document::Document;
-    use carina_core::provider::ProviderFactory;
+    use carina_core::provider::{self as provider_mod, ProviderFactory};
 
     fn create_document(content: &str) -> Document {
         Document::new(content.to_string())
@@ -1282,13 +1282,7 @@ mod tests {
             Box::new(carina_provider_aws::AwsProviderFactory),
             Box::new(carina_provider_awscc::AwsccProviderFactory),
         ];
-        let mut schemas = HashMap::new();
-        for factory in &factories {
-            for schema in factory.schemas() {
-                schemas.insert(schema.resource_type.clone(), schema);
-            }
-        }
-        let schemas = Arc::new(schemas);
+        let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
         let factories = Arc::new(factories);
         DiagnosticEngine::new(schemas, provider_names, factories)
@@ -1718,13 +1712,7 @@ let bucket = aws.s3.bucket {
             Box::new(carina_provider_awscc::AwsccProviderFactory),
             Box::new(carina_provider_aws::AwsProviderFactory),
         ];
-        let mut schemas = HashMap::new();
-        for factory in &factories {
-            for schema in factory.schemas() {
-                schemas.insert(schema.resource_type.clone(), schema);
-            }
-        }
-        let schemas = Arc::new(schemas);
+        let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
         let factories = Arc::new(factories);
         DiagnosticEngine::new(schemas, provider_names, factories)


### PR DESCRIPTION
## Summary

- Extract `find_factory`, `collect_schemas`, and `schema_key_for_resource` from `carina-cli/src/main.rs` into `carina-core::provider` as public functions
- Update `carina-lsp` (backend, completion, diagnostics) to use `collect_schemas` instead of duplicated inline loops
- Remove unused `HashMap` import from `carina-lsp/src/backend.rs`

Part of #328 (Phase 2: schema/factory utilities)

## Test plan

- [x] All `carina-core` tests pass (260 tests)
- [x] All `carina-cli` tests pass (21 tests)
- [x] All `carina-lsp` tests pass (41 unit + 4 integration)
- [x] Pre-commit formatting and clippy checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)