### PR TITLE
Add scope field to Custom and Union types

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -79,6 +79,10 @@ pub enum AttributeType {
         /// For example, availability_zone uses `|s| s.replace('-', "_")` to convert
         /// "ap-northeast-1a" to "ap_northeast_1a" for DSL identifier form.
         to_dsl: Option<fn(&str) -> String>,
+        /// Scope indicating which resource/service this type belongs to.
+        /// Prevents name collisions across different resource contexts.
+        /// e.g., "ec2.route" for gateway_id, "ec2.vpc" for instance_tenancy
+        scope: Option<String>,
     },
     /// List
     List(Box<AttributeType>),
@@ -90,7 +94,13 @@ pub enum AttributeType {
         fields: Vec<StructField>,
     },
     /// Union of multiple types (value is valid if it matches any member)
-    Union(Vec<AttributeType>),
+    Union {
+        types: Vec<AttributeType>,
+        /// Scope indicating which resource/service this union belongs to.
+        /// Prevents name collisions when different resources use unions with the same member types.
+        /// e.g., "ec2.route" for gateway_id (InternetGatewayId | VpnGatewayId)
+        scope: Option<String>,
+    },
 }
 
 impl AttributeType {
@@ -225,7 +235,7 @@ impl AttributeType {
             }
 
             // Union type: valid if any member accepts the value
-            (AttributeType::Union(types), _) => {
+            (AttributeType::Union { types, .. }, _) => {
                 for member in types {
                     if member.validate(value).is_ok() {
                         return Ok(());
@@ -255,7 +265,7 @@ impl AttributeType {
             AttributeType::List(inner) => format!("List<{}>", inner.type_name()),
             AttributeType::Map(inner) => format!("Map<{}>", inner.type_name()),
             AttributeType::Struct { name, .. } => format!("Struct({})", name),
-            AttributeType::Union(types) => {
+            AttributeType::Union { types, .. } => {
                 let names: Vec<String> = types.iter().map(|t| t.type_name()).collect();
                 names.join(" | ")
             }
@@ -267,7 +277,7 @@ impl AttributeType {
     /// For other types, returns true if self.type_name() == name.
     pub fn accepts_type_name(&self, name: &str) -> bool {
         match self {
-            AttributeType::Union(types) => types.iter().any(|t| t.accepts_type_name(name)),
+            AttributeType::Union { types, .. } => types.iter().any(|t| t.accepts_type_name(name)),
             _ => self.type_name() == name,
         }
     }
@@ -658,6 +668,7 @@ pub mod types {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         }
     }
 
@@ -675,6 +686,7 @@ pub mod types {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         }
     }
 
@@ -692,6 +704,7 @@ pub mod types {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         }
     }
 
@@ -709,6 +722,7 @@ pub mod types {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         }
     }
 
@@ -726,6 +740,7 @@ pub mod types {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         }
     }
 }
@@ -1635,6 +1650,7 @@ mod tests {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
         let type_b = AttributeType::Custom {
             name: "TypeB".to_string(),
@@ -1652,9 +1668,13 @@ mod tests {
             },
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
 
-        let union_type = AttributeType::Union(vec![type_a, type_b]);
+        let union_type = AttributeType::Union {
+            types: vec![type_a, type_b],
+            scope: None,
+        };
 
         // Valid: matches first member
         assert!(
@@ -1693,6 +1713,7 @@ mod tests {
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
         let type_b = AttributeType::Custom {
             name: "TypeB".to_string(),
@@ -1700,9 +1721,13 @@ mod tests {
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
 
-        let union_type = AttributeType::Union(vec![type_a, type_b]);
+        let union_type = AttributeType::Union {
+            types: vec![type_a, type_b],
+            scope: None,
+        };
         assert_eq!(union_type.type_name(), "TypeA | TypeB");
     }
 
@@ -1714,6 +1739,7 @@ mod tests {
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
         let type_b = AttributeType::Custom {
             name: "TypeB".to_string(),
@@ -1721,9 +1747,13 @@ mod tests {
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
+            scope: None,
         };
 
-        let union_type = AttributeType::Union(vec![type_a, type_b]);
+        let union_type = AttributeType::Union {
+            types: vec![type_a, type_b],
+            scope: None,
+        };
         assert!(union_type.accepts_type_name("TypeA"));
         assert!(union_type.accepts_type_name("TypeB"));
         assert!(!union_type.accepts_type_name("TypeC"));
@@ -1732,6 +1762,62 @@ mod tests {
         let simple = AttributeType::String;
         assert!(simple.accepts_type_name("String"));
         assert!(!simple.accepts_type_name("Int"));
+    }
+
+    #[test]
+    fn custom_type_scope() {
+        let scoped = AttributeType::Custom {
+            name: "GatewayId".to_string(),
+            base: Box::new(AttributeType::String),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+            scope: Some("ec2.route".to_string()),
+        };
+        let unscoped = AttributeType::Custom {
+            name: "GatewayId".to_string(),
+            base: Box::new(AttributeType::String),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+            scope: None,
+        };
+
+        // Both have the same type_name (scope doesn't affect display)
+        assert_eq!(scoped.type_name(), "GatewayId");
+        assert_eq!(unscoped.type_name(), "GatewayId");
+
+        // Scope is stored and accessible
+        if let AttributeType::Custom { scope, .. } = &scoped {
+            assert_eq!(scope.as_deref(), Some("ec2.route"));
+        }
+        if let AttributeType::Custom { scope, .. } = &unscoped {
+            assert_eq!(*scope, None);
+        }
+    }
+
+    #[test]
+    fn union_type_scope() {
+        let scoped_union = AttributeType::Union {
+            types: vec![AttributeType::String, AttributeType::Int],
+            scope: Some("ec2.route".to_string()),
+        };
+        let unscoped_union = AttributeType::Union {
+            types: vec![AttributeType::String, AttributeType::Int],
+            scope: None,
+        };
+
+        // Both display the same type name
+        assert_eq!(scoped_union.type_name(), "String | Int");
+        assert_eq!(unscoped_union.type_name(), "String | Int");
+
+        // Scope is stored and accessible
+        if let AttributeType::Union { scope, .. } = &scoped_union {
+            assert_eq!(scope.as_deref(), Some("ec2.route"));
+        }
+        if let AttributeType::Union { scope, .. } = &unscoped_union {
+            assert_eq!(*scope, None);
+        }
     }
 
     #[test]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -137,7 +137,7 @@ pub fn validate_resource_ref_types(
 pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
     match attr_type {
         AttributeType::String | AttributeType::Custom { .. } | AttributeType::Enum(_) => true,
-        AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
+        AttributeType::Union { types, .. } => types.iter().all(is_string_compatible_type),
         _ => false,
     }
 }

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -655,7 +655,7 @@ impl CompletionProvider {
             } if name == "AvailabilityZone" => {
                 self.availability_zone_completions(namespace.as_deref().unwrap_or(""), name)
             }
-            AttributeType::Union(_) | AttributeType::String | AttributeType::Custom { .. } => {
+            AttributeType::Union { .. } | AttributeType::String | AttributeType::Custom { .. } => {
                 vec![CompletionItem {
                     label: "env".to_string(),
                     kind: Some(CompletionItemKind::FUNCTION),

--- a/carina-lsp/src/diagnostics.rs
+++ b/carina-lsp/src/diagnostics.rs
@@ -273,7 +273,7 @@ impl DiagnosticEngine {
                                 }
                                 // ResourceRef type check for Union types
                                 (
-                                    carina_core::schema::AttributeType::Union(_),
+                                    carina_core::schema::AttributeType::Union { .. },
                                     Value::ResourceRef {
                                         binding_name: ref_binding,
                                         attribute_name: ref_attr,

--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -709,6 +709,7 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
                  \x20               validate: {},\n\
                  \x20               namespace: Some(\"{}\".to_string()),\n\
                  \x20               to_dsl: {},\n\
+                 \x20               scope: None,\n\
                  \x20           }}",
                 ei.type_name, validate_fn, namespace, to_dsl_code
             )
@@ -957,6 +958,7 @@ fn resolve_type(
                          \x20               validate: {},\n\
                          \x20               namespace: None,\n\
                          \x20               to_dsl: None,\n\
+                         \x20               scope: None,\n\
                          \x20           }}",
                         r.min, r.max, validate_fn
                     ),
@@ -1122,6 +1124,7 @@ fn generate_struct_type(
                  \x20               validate: {},\n\
                  \x20               namespace: Some(\"{}\".to_string()),\n\
                  \x20               to_dsl: {},\n\
+                 \x20               scope: None,\n\
                  \x20           }}",
                 ei.type_name, validate_fn, namespace, to_dsl_code
             )

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_egress.rs
@@ -103,6 +103,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         validate: validate_from_port_range,
                         namespace: None,
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .create_only()
@@ -128,6 +129,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                             "-1" => "all".to_string(),
                             _ => s.replace('-', "_"),
                         }),
+                        scope: None,
                     },
                 )
                 .required()
@@ -166,6 +168,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                         validate: validate_to_port_range,
                         namespace: None,
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .create_only()

--- a/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_security_group_ingress.rs
@@ -95,6 +95,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 validate: validate_from_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP, this is the ICMP type or -1 (all ICMP types). To specify ...")
@@ -119,6 +120,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 validate: validate_ip_protocol,
                 namespace: Some("aws.ec2.security_group_ingress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
+                scope: None,
             })
                 .required()
                 .create_only()
@@ -151,6 +153,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 validate: validate_to_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP, this is the ICMP code or -1 (all ICMP codes). If the start ...")

--- a/carina-provider-aws/src/schemas/generated/ec2_subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_subnet.rs
@@ -113,6 +113,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("An IPv4 netmask length for the subnet.")
@@ -143,6 +144,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 validate: validate_ipv6_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("An IPv6 netmask length for the subnet.")
@@ -171,6 +173,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 validate: validate_hostname_type,
                 namespace: Some("aws.ec2.subnet".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             }).with_description("The type of hostname for EC2 instances. For IPv4 only subnets, an instance DNS name must be based on the instance IPv4 address. For IPv6 only subnets,...").with_provider_name("HostnameType")
                     ],
                 })

--- a/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2_vpc.rs
@@ -82,6 +82,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 validate: validate_instance_tenancy,
                 namespace: Some("aws.ec2.vpc".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The tenancy options for instances launched into the VPC. For default, instances are launched with shared tenancy by default. You can launch instances ...")
@@ -101,6 +102,7 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPA...")

--- a/carina-provider-aws/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3_bucket.rs
@@ -55,6 +55,7 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
                         validate: validate_versioning_status,
                         namespace: Some("aws.s3.bucket".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_description("The versioning state of the bucket.")

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -139,6 +139,7 @@ pub fn aws_region() -> AttributeType {
         },
         namespace: Some("aws".to_string()),
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -195,6 +196,7 @@ pub(crate) fn aws_resource_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -213,6 +215,7 @@ pub(crate) fn vpc_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -231,6 +234,7 @@ pub(crate) fn subnet_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -249,6 +253,7 @@ pub(crate) fn security_group_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -267,6 +272,7 @@ pub(crate) fn internet_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -285,6 +291,7 @@ pub(crate) fn route_table_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -303,6 +310,7 @@ pub(crate) fn nat_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -322,6 +330,7 @@ pub(crate) fn vpc_peering_connection_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -340,6 +349,7 @@ pub(crate) fn transit_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -359,6 +369,7 @@ pub(crate) fn vpn_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -381,6 +392,7 @@ pub(crate) fn egress_only_internet_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -399,6 +411,7 @@ pub(crate) fn vpc_endpoint_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -418,6 +431,7 @@ pub(crate) fn arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -450,6 +464,7 @@ pub(crate) fn iam_role_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -469,6 +484,7 @@ pub(crate) fn iam_policy_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -487,6 +503,7 @@ pub(crate) fn kms_key_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -505,6 +522,7 @@ pub(crate) fn kms_key_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -525,6 +543,7 @@ pub(crate) fn ipam_pool_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -572,6 +591,7 @@ pub(crate) fn availability_zone() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1109,6 +1109,7 @@ pub fn {}() -> AwsccSchemaConfig {{
                 validate: {},
                 namespace: Some("{}".to_string()),
                 to_dsl: {},
+                scope: None,
             }}"#,
                 enum_info.type_name, validate_fn, namespace, to_dsl_code
             )
@@ -1473,6 +1474,7 @@ fn generate_struct_type(
                 validate: {},
                 namespace: Some("{}".to_string()),
                 to_dsl: {},
+                scope: None,
             }}"#,
                         enum_info.type_name, validate_fn, namespace, to_dsl_code
                     )
@@ -1959,6 +1961,7 @@ fn cfn_type_to_carina_type_with_enum(
                 validate: {},
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }}"#,
                         min, max, validate_fn
                     ),
@@ -1986,6 +1989,7 @@ fn cfn_type_to_carina_type_with_enum(
                 validate: {},
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }}"#,
                         min, max, validate_fn
                     ),

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -1685,6 +1685,7 @@ mod tests {
                         "-1" => "all".to_string(),
                         _ => s.to_string(),
                     }),
+                    scope: None,
                 },
             )
             .with_provider_name("IpProtocol"),

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -102,6 +102,7 @@ pub(crate) fn ipam_pool_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -132,6 +133,7 @@ pub(crate) fn arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -164,6 +166,7 @@ pub(crate) fn aws_resource_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -219,6 +222,7 @@ pub(crate) fn vpc_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -237,6 +241,7 @@ pub(crate) fn subnet_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -255,6 +260,7 @@ pub(crate) fn security_group_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -273,6 +279,7 @@ pub(crate) fn internet_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -291,6 +298,7 @@ pub(crate) fn route_table_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -309,6 +317,7 @@ pub(crate) fn nat_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -328,6 +337,7 @@ pub(crate) fn vpc_peering_connection_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -346,6 +356,7 @@ pub(crate) fn transit_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -364,13 +375,17 @@ pub(crate) fn vpn_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
 /// Gateway ID type — union of InternetGatewayId and VpnGatewayId.
 /// Used for attributes like ec2_route.gateway_id that accept both igw-* and vgw-* IDs.
 pub(crate) fn gateway_id() -> AttributeType {
-    AttributeType::Union(vec![internet_gateway_id(), vpn_gateway_id()])
+    AttributeType::Union {
+        types: vec![internet_gateway_id(), vpn_gateway_id()],
+        scope: None,
+    }
 }
 
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
@@ -393,6 +408,7 @@ pub(crate) fn egress_only_internet_gateway_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -411,6 +427,7 @@ pub(crate) fn vpc_endpoint_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -464,6 +481,7 @@ pub fn awscc_region() -> AttributeType {
         },
         namespace: Some("awscc".to_string()),
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -487,6 +505,7 @@ pub(crate) fn availability_zone() -> AttributeType {
         },
         namespace: Some("awscc".to_string()),
         to_dsl: Some(|s: &str| s.replace('-', "_")),
+        scope: None,
     }
 }
 
@@ -566,6 +585,7 @@ pub(crate) fn iam_role_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -584,6 +604,7 @@ pub(crate) fn iam_policy_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -602,6 +623,7 @@ pub(crate) fn kms_key_arn() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -624,6 +646,7 @@ pub(crate) fn kms_key_id() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -671,18 +694,24 @@ fn validate_kms_key_id(value: &str) -> Result<(), String> {
 
 /// String or list of strings type — for IAM policy fields like action, resource
 fn string_or_list_of_strings() -> AttributeType {
-    AttributeType::Union(vec![
-        AttributeType::String,
-        AttributeType::List(Box::new(AttributeType::String)),
-    ])
+    AttributeType::Union {
+        types: vec![
+            AttributeType::String,
+            AttributeType::List(Box::new(AttributeType::String)),
+        ],
+        scope: None,
+    }
 }
 
 /// String or map type — for IAM policy principal fields
 fn string_or_map() -> AttributeType {
-    AttributeType::Union(vec![
-        AttributeType::String,
-        AttributeType::Map(Box::new(string_or_list_of_strings())),
-    ])
+    AttributeType::Union {
+        types: vec![
+            AttributeType::String,
+            AttributeType::Map(Box::new(string_or_list_of_strings())),
+        ],
+        scope: None,
+    }
 }
 
 /// IAM Policy Effect enum type
@@ -706,6 +735,7 @@ fn iam_policy_effect() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -730,6 +760,7 @@ fn iam_policy_version() -> AttributeType {
         },
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 
@@ -776,6 +807,7 @@ pub(crate) fn iam_policy_document() -> AttributeType {
         validate: |value| validate_iam_policy_document(value),
         namespace: None,
         to_dsl: None,
+        scope: None,
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2_eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_eip.rs
@@ -50,6 +50,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 validate: validate_domain,
                 namespace: Some("awscc.ec2.eip".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("The network (``vpc``). If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a depend...")
                 .with_provider_name("Domain")

--- a/carina-provider-awscc/src/schemas/generated/ec2_flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_flow_log.rs
@@ -129,6 +129,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 validate: validate_log_destination_type,
                 namespace: Some("awscc.ec2.flow_log".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             })
                 .create_only()
                 .with_description("Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3.")
@@ -167,6 +168,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 validate: validate_resource_type,
                 namespace: Some("awscc.ec2.flow_log".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .required()
                 .create_only()
@@ -186,6 +188,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 validate: validate_traffic_type,
                 namespace: Some("awscc.ec2.flow_log".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic.")

--- a/carina-provider-awscc/src/schemas/generated/ec2_ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_ipam.rs
@@ -101,6 +101,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 validate: validate_metered_account,
                 namespace: Some("awscc.ec2.ipam".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             })
                 .with_description("A metered account is an account that is charged for active IP addresses managed in IPAM")
                 .with_provider_name("MeteredAccount")
@@ -149,6 +150,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 validate: validate_tier,
                 namespace: Some("awscc.ec2.ipam".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("The tier of the IPAM.")
                 .with_provider_name("Tier")

--- a/carina-provider-awscc/src/schemas/generated/ec2_ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_ipam_pool.rs
@@ -128,6 +128,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_address_family,
                 namespace: Some("awscc.ec2.ipam_pool".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .required()
                 .create_only()
@@ -172,6 +173,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_aws_service,
                 namespace: Some("awscc.ec2.ipam_pool".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             })
                 .create_only()
                 .with_description("Limits which service in Amazon Web Services that the pool can be used in.")
@@ -211,6 +213,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_ipam_scope_type,
                 namespace: Some("awscc.ec2.ipam_pool".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("Determines whether this scope contains publicly routable space or space for a private network (read-only)")
                 .with_provider_name("IpamScopeType")
@@ -245,6 +248,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_public_ip_source,
                 namespace: Some("awscc.ec2.ipam_pool".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Default is `byoip`.")
@@ -283,6 +287,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 validate: validate_state,
                 namespace: Some("awscc.ec2.ipam_pool".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             })
                 .with_description("The state of this pool. This can be one of the following values: \"create-in-progress\", \"create-complete\", \"modify-in-progress\", \"modify-complet... (read-only)")
                 .with_provider_name("State")

--- a/carina-provider-awscc/src/schemas/generated/ec2_nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_nat_gateway.rs
@@ -83,6 +83,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 validate: validate_availability_mode,
                 namespace: Some("awscc.ec2.nat_gateway".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("Indicates whether this is a zonal (single-AZ) or regional (multi-AZ) NAT gateway. A zonal NAT gateway is a NAT Gateway that provides redundancy and sc...")
@@ -109,6 +110,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                 validate: validate_connectivity_type,
                 namespace: Some("awscc.ec2.nat_gateway".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity.")

--- a/carina-provider-awscc/src/schemas/generated/ec2_security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_security_group.rs
@@ -100,6 +100,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_from_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Custom {
                 name: "IpProtocol".to_string(),
@@ -107,6 +108,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_ip_protocol,
                 namespace: Some("awscc.ec2.security_group".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
+                scope: None,
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Custom {
                 name: "Int(-1..=65535)".to_string(),
@@ -114,6 +116,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_to_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }).with_provider_name("ToPort")
                     ],
                 })))
@@ -133,6 +136,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_from_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }).with_provider_name("FromPort"),
                     StructField::new("ip_protocol", AttributeType::Custom {
                 name: "IpProtocol".to_string(),
@@ -140,6 +144,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_ip_protocol,
                 namespace: Some("awscc.ec2.security_group".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
+                scope: None,
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("source_prefix_list_id", super::aws_resource_id()).with_provider_name("SourcePrefixListId"),
                     StructField::new("source_security_group_id", super::security_group_id()).with_provider_name("SourceSecurityGroupId"),
@@ -151,6 +156,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 validate: validate_to_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             }).with_provider_name("ToPort")
                     ],
                 })))

--- a/carina-provider-awscc/src/schemas/generated/ec2_security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_security_group_egress.rs
@@ -97,6 +97,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 validate: validate_from_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP type or -1 (all ICMP types).")
@@ -121,6 +122,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 validate: validate_ip_protocol,
                 namespace: Some("awscc.ec2.security_group_egress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
+                scope: None,
             })
                 .required()
                 .create_only()
@@ -135,6 +137,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 validate: validate_to_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP code or -1 (all ICMP codes). If ...")

--- a/carina-provider-awscc/src/schemas/generated/ec2_security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_security_group_ingress.rs
@@ -85,6 +85,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 validate: validate_from_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. A value of -1 indicates all ICMP/ICMPv6 types. If you specify al...")
@@ -114,6 +115,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 validate: validate_ip_protocol,
                 namespace: Some("awscc.ec2.security_group_ingress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
+                scope: None,
             })
                 .required()
                 .create_only()
@@ -152,6 +154,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 validate: validate_to_port_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type...")

--- a/carina-provider-awscc/src/schemas/generated/ec2_subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_subnet.rs
@@ -97,6 +97,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("An IPv4 netmask length for the subnet.")
@@ -131,6 +132,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 validate: validate_ipv6_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("An IPv6 netmask length for the subnet.")

--- a/carina-provider-awscc/src/schemas/generated/ec2_transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_transit_gateway.rs
@@ -202,6 +202,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_auto_accept_shared_attachments,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("AutoAcceptSharedAttachments")
@@ -225,6 +226,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_default_route_table_association,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("DefaultRouteTableAssociation")
@@ -248,6 +250,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_default_route_table_propagation,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("DefaultRouteTablePropagation")
@@ -275,6 +278,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_dns_support,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("DnsSupport")
@@ -292,6 +296,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_encryption_support,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("EncryptionSupport")
@@ -325,6 +330,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_multicast_support,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .create_only()
@@ -356,6 +362,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_security_group_referencing_support,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("SecurityGroupReferencingSupport")
@@ -392,6 +399,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                         validate: validate_vpn_ecmp_support,
                         namespace: Some("awscc.ec2.transit_gateway".to_string()),
                         to_dsl: None,
+                        scope: None,
                     },
                 )
                 .with_provider_name("VpnEcmpSupport")

--- a/carina-provider-awscc/src/schemas/generated/ec2_vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_vpc.rs
@@ -88,6 +88,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 validate: validate_instance_tenancy,
                 namespace: Some("awscc.ec2.vpc".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("The allowed tenancy of instances launched into the VPC.  + ``default``: An instance launched into the VPC runs on shared hardware by default, unless y...")
                 .with_provider_name("InstanceTenancy")
@@ -106,6 +107,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPA...")

--- a/carina-provider-awscc/src/schemas/generated/ec2_vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2_vpc_endpoint.rs
@@ -161,6 +161,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_dns_record_ip_type,
                 namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             }).with_description("The DNS records created for the endpoint.").with_provider_name("DnsRecordIpType"),
                     StructField::new("private_dns_only_for_inbound_resolver_endpoint", AttributeType::Custom {
                 name: "PrivateDnsOnlyForInboundResolverEndpoint".to_string(),
@@ -168,6 +169,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_private_dns_only_for_inbound_resolver_endpoint,
                 namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Indicates whether to enable private DNS only for inbound endpoints. This option is available only for services that support both gateway and interface...").with_provider_name("PrivateDnsOnlyForInboundResolverEndpoint"),
                     StructField::new("private_dns_preference", AttributeType::Custom {
                 name: "PrivateDnsPreference".to_string(),
@@ -175,6 +177,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_private_dns_preference,
                 namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS...").with_provider_name("PrivateDnsPreference"),
                     StructField::new("private_dns_specified_domains", AttributeType::List(Box::new(AttributeType::String))).with_description("Indicates which of the private domains to create private hosted zones for and associate with the specified VPC. Only supported when private DNS is ena...").with_provider_name("PrivateDnsSpecifiedDomains")
                     ],
@@ -194,6 +197,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_ip_address_type,
                 namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
+                scope: None,
             })
                 .with_description("The supported IP address types.")
                 .with_provider_name("IpAddressType")
@@ -265,6 +269,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 validate: validate_vpc_endpoint_type,
                 namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .create_only()
                 .with_description("The type of endpoint. Default: Gateway")

--- a/carina-provider-awscc/src/schemas/generated/iam_role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam_role.rs
@@ -57,6 +57,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
                 validate: validate_max_session_duration_range,
                 namespace: None,
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default val...")
                 .with_provider_name("MaxSessionDuration"),

--- a/carina-provider-awscc/src/schemas/generated/logs_log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs_log_group.rs
@@ -70,6 +70,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 validate: validate_log_group_class,
                 namespace: Some("awscc.logs.log_group".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("Specifies the log group class for this log group. There are two classes:  + The ``Standard`` log class supports all CWL features.  + The ``Infrequent ...")
                 .with_provider_name("LogGroupClass")

--- a/carina-provider-awscc/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3_bucket.rs
@@ -398,6 +398,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_abac_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general p...")
                 .with_provider_name("AbacStatus")
@@ -413,6 +414,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_acceleration_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies the transfer acceleration status of the bucket.").with_provider_name("AccelerationStatus")
                     ],
                 })
@@ -426,6 +428,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_access_control,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             })
                 .with_description("This is a legacy property, and it is not recommended for most use cases. A majority of modern use cases in Amazon S3 no longer require the use of ACLs...")
                 .with_provider_name("AccessControl")
@@ -454,6 +457,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_format,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
                     StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
                     ],
@@ -551,6 +555,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies the status of the configuration.").with_provider_name("Status"),
                     StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("A container for a key-value pair.").with_provider_name("TagFilters"),
                     StructField::new("tierings", AttributeType::List(Box::new(AttributeType::Struct {
@@ -562,6 +567,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_access_tier,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("S3 Intelligent-Tiering access tier. See [Storage class for automatically optimizing frequently and infrequently accessed objects](https://docs.aws.ama...").with_provider_name("AccessTier"),
                     StructField::new("days", AttributeType::Int).required().with_description("The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of...").with_provider_name("Days")
                     ],
@@ -587,6 +593,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_format,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
                     StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
                     ],
@@ -599,6 +606,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_included_object_versions,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Object versions to include in the inventory list. If set to ``All``, the list includes all the object versions, which adds the version-related fields ...").with_provider_name("IncludedObjectVersions"),
                     StructField::new("optional_fields", AttributeType::List(Box::new(AttributeType::String))).with_description("Contains the optional fields that are included in the inventory results.").with_provider_name("OptionalFields"),
                     StructField::new("prefix", AttributeType::String).with_description("Specifies the inventory filter prefix.").with_provider_name("Prefix"),
@@ -608,6 +616,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_schedule_frequency,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies the schedule for generating inventory results.").with_provider_name("ScheduleFrequency")
                     ],
                 })))
@@ -650,6 +659,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_storage_class,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days cal...").with_provider_name("TransitionInDays")
                     ],
@@ -664,6 +674,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_storage_class,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days cal...").with_provider_name("TransitionInDays")
                     ],
@@ -677,6 +688,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied.").with_provider_name("Status"),
                     StructField::new("tag_filters", AttributeType::List(Box::new(tags_type()))).with_description("Tags to use to identify a subset of objects to which the lifecycle rule applies.").with_provider_name("TagFilters"),
                     StructField::new("transition", AttributeType::Struct {
@@ -688,6 +700,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_storage_class,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::String).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
                     StructField::new("transition_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are transitioned to the specified storage class. If the specified storage class is ``INTELLIG...").with_provider_name("TransitionInDays")
@@ -702,6 +715,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_storage_class,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::String).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
                     StructField::new("transition_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are transitioned to the specified storage class. If the specified storage class is ``INTELLIG...").with_provider_name("TransitionInDays")
@@ -715,6 +729,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_transition_default_minimum_object_size,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Indicates which default minimum object size behavior is applied to the lifecycle configuration.  This parameter applies to general purpose buckets onl...").with_provider_name("TransitionDefaultMinimumObjectSize")
                     ],
                 })
@@ -747,6 +762,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_table_bucket_type,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The type of the table bucket where the metadata configuration is stored. The ``aws`` value indicates an AWS managed table bucket, and the ``customer``...").with_provider_name("TableBucketType"),
                     StructField::new("table_namespace", AttributeType::String).with_description("The namespace in the table bucket where the metadata tables for a metadata configuration are stored.").with_provider_name("TableNamespace")
                     ],
@@ -760,6 +776,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_configuration_state,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The configuration state of the inventory table, indicating whether the inventory table is enabled or disabled.").with_provider_name("ConfigurationState"),
                     StructField::new("encryption_configuration", AttributeType::Struct {
                     name: "MetadataTableEncryptionConfiguration".to_string(),
@@ -771,6 +788,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_sse_algorithm,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To...").with_provider_name("SseAlgorithm")
                     ],
                 }).with_description("The encryption configuration for the inventory table.").with_provider_name("EncryptionConfiguration"),
@@ -791,6 +809,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_sse_algorithm,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To...").with_provider_name("SseAlgorithm")
                     ],
                 }).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),
@@ -804,6 +823,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_expiration,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether journal table record expiration is enabled or disabled.").with_provider_name("Expiration")
                     ],
                 }).required().with_description("The journal table record expiration settings for the journal table.").with_provider_name("RecordExpiration"),
@@ -953,6 +973,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_mode,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("The default Object Lock retention mode you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, you must specify ...").with_provider_name("Mode"),
                     StructField::new("years", AttributeType::Int).with_description("The number of years that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify eith...").with_provider_name("Years")
                     ],
@@ -982,6 +1003,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_object_ownership,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Specifies an object ownership rule.").with_provider_name("ObjectOwnership")
                     ],
                 }))).required().with_description("Specifies the container element for Object Ownership rules.").with_provider_name("Rules")
@@ -1025,6 +1047,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Indicates whether to replicate delete markers.").with_provider_name("Status")
                     ],
                 }).with_description("Specifies whether Amazon S3 replicates delete markers. If you specify a ``Filter`` in your replication configuration, you must also include a ``Delete...").with_provider_name("DeleteMarkerReplication"),
@@ -1060,6 +1083,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
                     ],
                 }).with_description("A container specifying replication metrics-related settings enabling replication metrics and events.").with_provider_name("Metrics"),
@@ -1072,6 +1096,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
                     StructField::new("time", AttributeType::Struct {
                     name: "ReplicationTimeValue".to_string(),
@@ -1087,6 +1112,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_storage_class,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the sour...").with_provider_name("StorageClass")
                     ],
                 }).required().with_description("A container for information about the replication destination and its configurations including enabling the S3 Replication Time Control (S3 RTC).").with_provider_name("Destination"),
@@ -1119,6 +1145,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
                     ],
                 }).with_description("A filter that you can specify for selection for modifications on replicas.").with_provider_name("ReplicaModifications"),
@@ -1131,6 +1158,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
                     ],
                 }).with_description("A container for filter information for the selection of Amazon S3 objects encrypted with AWS KMS.").with_provider_name("SseKmsEncryptedObjects")
@@ -1142,6 +1170,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("Specifies whether the rule is enabled.").with_provider_name("Status")
                     ],
                 }))).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules")
@@ -1165,6 +1194,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_status,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).required().with_description("The versioning state of the bucket.").with_provider_name("Status")
                     ],
                 })
@@ -1187,6 +1217,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_protocol,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol")
                     ],
                 }).with_description("The redirect behavior for every request to this bucket's website endpoint.  If you specify this property, you can't specify any other property.").with_provider_name("RedirectAllRequestsTo"),
@@ -1204,6 +1235,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_protocol,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol"),
                     StructField::new("replace_key_prefix_with", AttributeType::Custom {
                 name: "ReplaceKeyPrefixWith".to_string(),
@@ -1211,6 +1243,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 validate: validate_replace_key_prefix_with,
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
+                scope: None,
             }).with_description("The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix ``docs/`` (objects in the ``docs/`` ...").with_provider_name("ReplaceKeyPrefixWith"),
                     StructField::new("replace_key_with", AttributeType::String).with_description("The specific object key to use in the redirect request. For example, redirect request to ``error.html``. Not required if one of the siblings is presen...").with_provider_name("ReplaceKeyWith")
                     ],


### PR DESCRIPTION
## Summary

- Adds `scope: Option<String>` field to `AttributeType::Custom` to indicate which resource/service a type belongs to (e.g., `"ec2.route"` for `gateway_id`)
- Changes `AttributeType::Union(Vec<AttributeType>)` to `Union { types, scope }` struct variant for the same purpose
- Updates both codegen tools (awscc CloudFormation and aws Smithy) to emit `scope: None`
- Regenerates all schema files
- Adds tests for scope field storage and access

This prevents name collisions when different resources use types with the same name but different semantics (e.g., "GatewayId" for EC2 Route vs a hypothetical API Gateway).

Closes #314

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all existing + 2 new tests)
- [x] Pre-commit checks (fmt + clippy) pass
- [x] Schemas regenerated from both codegen tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)