### PR TITLE
Skip temporary name generation when name_attribute itself changes

### DIFF
--- a/carina-core/src/differ.rs
+++ b/carina-core/src/differ.rs
@@ -137,8 +137,9 @@ fn find_schema<'a>(
 /// `create_before_destroy`, we need a temporary name for the new resource to
 /// avoid conflicts with the old resource that still exists.
 ///
-/// Returns `None` if no temporary name is needed (no name_attribute, or
-/// the resource already uses name_prefix for that attribute).
+/// Returns `None` if no temporary name is needed (no name_attribute,
+/// the resource already uses name_prefix for that attribute, or
+/// the name_attribute value changed between `from` and `to`).
 fn generate_temporary_name(
     resource: &Resource,
     from: &State,


### PR DESCRIPTION
## Summary

- When `create_before_destroy` replacement is triggered by changing the `name_attribute` itself (e.g., renaming `bucket_name` from `old-bucket` to `new-bucket`), skip temporary name generation since old and new names are already different
- Fixes infinite replacement loop: temp name created → next plan sees temp vs desired → triggers another replacement

## Changes

- Added `from: &State` parameter to `generate_temporary_name()` in `carina-core/src/differ.rs`
- Compare `from` and `to` name attribute values; skip temp name when they differ
- Added test `no_temporary_name_when_name_attribute_changes`

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)