### PR TITLE
Support S3 bucket Object Ownership

### DIFF
--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -166,6 +166,10 @@ impl AwsProvider {
                 // Get versioning status
                 self.read_s3_bucket_versioning(name, &mut attributes).await;
 
+                // Get object ownership
+                self.read_s3_bucket_ownership_controls(name, &mut attributes)
+                    .await;
+
                 // S3 bucket identifier is the bucket name
                 Ok(State::existing(id.clone(), attributes).with_identifier(name))
             }
@@ -231,6 +235,13 @@ impl AwsProvider {
             req = req.create_bucket_configuration(config);
         }
 
+        // Set ObjectOwnership on create
+        if let Some(Value::String(val)) = resource.attributes.get("object_ownership") {
+            use aws_sdk_s3::types::ObjectOwnership;
+            let normalized = extract_enum_value(val);
+            req = req.object_ownership(ObjectOwnership::from(normalized));
+        }
+
         req.send().await.map_err(|e| {
             ProviderError::new(format!("Failed to create bucket: {:?}", e))
                 .for_resource(resource.id.clone())
@@ -257,7 +268,69 @@ impl AwsProvider {
         self.write_s3_bucket_versioning(&id, &bucket_name, &to.attributes)
             .await?;
 
+        // Update object ownership
+        self.write_s3_bucket_ownership_controls(&id, &bucket_name, &to.attributes)
+            .await?;
+
         self.read_s3_bucket(&id, Some(&bucket_name)).await
+    }
+
+    /// Read S3 bucket ownership controls
+    async fn read_s3_bucket_ownership_controls(
+        &self,
+        identifier: &str,
+        attributes: &mut HashMap<String, Value>,
+    ) {
+        if let Ok(output) = self
+            .s3_client
+            .get_bucket_ownership_controls()
+            .bucket(identifier)
+            .send()
+            .await
+            && let Some(controls) = output.ownership_controls()
+            && let Some(rule) = controls.rules().first()
+        {
+            let value = rule.object_ownership().as_str().to_string();
+            attributes.insert("object_ownership".to_string(), Value::String(value));
+        }
+    }
+
+    /// Write S3 bucket ownership controls
+    async fn write_s3_bucket_ownership_controls(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        attributes: &HashMap<String, Value>,
+    ) -> ProviderResult<()> {
+        if let Some(Value::String(val)) = attributes.get("object_ownership") {
+            use aws_sdk_s3::types::{ObjectOwnership, OwnershipControls, OwnershipControlsRule};
+            let normalized = extract_enum_value(val);
+            let rule = OwnershipControlsRule::builder()
+                .object_ownership(ObjectOwnership::from(normalized))
+                .build()
+                .map_err(|e| {
+                    ProviderError::new(format!("Failed to build ownership controls rule: {}", e))
+                        .for_resource(id.clone())
+                })?;
+            let controls = OwnershipControls::builder()
+                .rules(rule)
+                .build()
+                .map_err(|e| {
+                    ProviderError::new(format!("Failed to build ownership controls: {}", e))
+                        .for_resource(id.clone())
+                })?;
+            self.s3_client
+                .put_bucket_ownership_controls()
+                .bucket(identifier)
+                .ownership_controls(controls)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new(format!("Failed to put bucket ownership controls: {}", e))
+                        .for_resource(id.clone())
+                })?;
+        }
+        Ok(())
     }
 
     // ========== EC2 VPC Operations ==========

--- a/carina-provider-aws/src/resource_defs.rs
+++ b/carina-provider-aws/src/resource_defs.rs
@@ -460,13 +460,19 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 defaults: vec![("VersioningStatus", "Suspended")],
             }],
             delete_op: "DeleteBucket",
-            update_ops: vec![UpdateOp {
-                operation: "PutBucketVersioning",
-                fields: FieldLayout::InsideStruct {
-                    name: "VersioningConfiguration",
-                    fields: vec!["VersioningStatus"],
+            update_ops: vec![
+                UpdateOp {
+                    operation: "PutBucketVersioning",
+                    fields: FieldLayout::InsideStruct {
+                        name: "VersioningConfiguration",
+                        fields: vec!["VersioningStatus"],
+                    },
                 },
-            }],
+                UpdateOp {
+                    operation: "PutBucketOwnershipControls",
+                    fields: FieldLayout::Flat(vec!["ObjectOwnership"]),
+                },
+            ],
             identifier: "Bucket",
             has_tags: true,
             type_overrides: vec![],
@@ -479,7 +485,6 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 "GrantWriteACP",
                 "CreateBucketConfiguration",
                 "ObjectLockEnabledForBucket",
-                "ObjectOwnership",
                 "ContentMD5",
                 "ChecksumAlgorithm",
                 "MFA",

--- a/carina-provider-aws/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3_bucket.rs
@@ -11,6 +11,30 @@ use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema};
 
 #[allow(dead_code)]
+const VALID_OBJECT_OWNERSHIP: &[&str] = &[
+    "BucketOwnerEnforced",
+    "BucketOwnerPreferred",
+    "ObjectWriter",
+];
+
+#[allow(dead_code)]
+fn validate_object_ownership(value: &Value) -> Result<(), String> {
+    validate_namespaced_enum(
+        value,
+        "ObjectOwnership",
+        "aws.s3.bucket",
+        VALID_OBJECT_OWNERSHIP,
+    )
+    .map_err(|reason| {
+        if let Value::String(s) = value {
+            format!("Invalid ObjectOwnership '{}': {}", s, reason)
+        } else {
+            reason
+        }
+    })
+}
+
+#[allow(dead_code)]
 const VALID_VERSIONING_STATUS: &[&str] = &["Enabled", "Suspended"];
 
 #[allow(dead_code)]
@@ -48,6 +72,33 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
             )
             .attribute(
                 AttributeSchema::new(
+                    "object_ownership",
+                    AttributeType::Custom {
+                        name: "ObjectOwnership".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_object_ownership,
+                        namespace: Some("aws.s3.bucket".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_provider_name("ObjectOwnership")
+                .with_completions(vec![
+                    CompletionValue::new(
+                        "aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced",
+                        "BucketOwnerEnforced",
+                    ),
+                    CompletionValue::new(
+                        "aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred",
+                        "BucketOwnerPreferred",
+                    ),
+                    CompletionValue::new(
+                        "aws.s3.bucket.ObjectOwnership.ObjectWriter",
+                        "ObjectWriter",
+                    ),
+                ]),
+            )
+            .attribute(
+                AttributeSchema::new(
                     "versioning_status",
                     AttributeType::Custom {
                         name: "VersioningStatus".to_string(),
@@ -79,7 +130,10 @@ pub fn enum_valid_values() -> (
 ) {
     (
         "s3.bucket",
-        &[("versioning_status", VALID_VERSIONING_STATUS)],
+        &[
+            ("object_ownership", VALID_OBJECT_OWNERSHIP),
+            ("versioning_status", VALID_VERSIONING_STATUS),
+        ],
     )
 }
 

--- a/docs/src/providers/aws/s3_bucket.md
+++ b/docs/src/providers/aws/s3_bucket.md
@@ -4,6 +4,11 @@ CloudFormation Type: `AWS::S3::Bucket`
 
 ## Argument Reference
 
+### `object_ownership`
+
+- **Type:** [Enum (ObjectOwnership)](#object_ownership-objectownership)
+- **Required:** No
+
 ### `versioning_status`
 
 - **Type:** [Enum (VersioningStatus)](#versioning_status-versioningstatus)
@@ -19,6 +24,16 @@ The versioning state of the bucket.
 The tags for the resource.
 
 ## Enum Values
+
+### object_ownership (ObjectOwnership)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `BucketOwnerEnforced` | `aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced` |
+| `BucketOwnerPreferred` | `aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred` |
+| `ObjectWriter` | `aws.s3.bucket.ObjectOwnership.ObjectWriter` |
+
+Shorthand formats: `BucketOwnerEnforced` or `ObjectOwnership.BucketOwnerEnforced`
 
 ### versioning_status (VersioningStatus)
 


### PR DESCRIPTION
## Summary

- Add provider implementation for S3 Object Ownership (`ObjectOwnership` attribute)
- Read current state via `GetBucketOwnershipControls` API
- Write/update via `PutBucketOwnershipControls` API
- Set on bucket creation via `CreateBucket` `ObjectOwnership` parameter
- Remove `ObjectOwnership` from `exclude_fields` and regenerate schemas/docs

Closes #296

## Test plan

- [x] `cargo build` passes
- [x] `cargo test -p carina-provider-aws -p carina-core -p carina-lsp` passes
- [x] Clippy passes
- [ ] Acceptance test: create bucket with `object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred`, verify plan is clean, update to `BucketOwnerEnforced`, destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)