### PR TITLE
Implement resolve_enum_identifiers for AWS provider

### DIFF
--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -397,17 +397,11 @@ impl AwsProvider {
                 attributes.insert("id".to_string(), Value::String(vpc_id.clone()));
             }
 
-            // Instance tenancy - convert to DSL format
+            // Instance tenancy - return plain value, normalize_state_enums handles namespacing
             if let Some(tenancy) = vpc.instance_tenancy() {
-                let tenancy_str = match tenancy {
-                    aws_sdk_ec2::types::Tenancy::Default => "aws.vpc.InstanceTenancy.default",
-                    aws_sdk_ec2::types::Tenancy::Dedicated => "aws.vpc.InstanceTenancy.dedicated",
-                    aws_sdk_ec2::types::Tenancy::Host => "aws.vpc.InstanceTenancy.host",
-                    _ => "aws.vpc.InstanceTenancy.default",
-                };
                 attributes.insert(
                     "instance_tenancy".to_string(),
-                    Value::String(tenancy_str.to_string()),
+                    Value::String(tenancy.as_str().to_string()),
                 );
             }
 


### PR DESCRIPTION
## Summary

- Implement `resolve_enum_identifiers` for the AWS provider, consistent with the awscc provider approach
- Add `normalize_state_enums` to convert read-returned plain values (e.g., `"Enabled"`) to namespaced DSL format (e.g., `aws.s3.bucket.VersioningStatus.Enabled`)
- Both DSL-side and read-side values now match in namespaced format, eliminating perpetual plan diffs

Closes #411

## Test plan

- [x] Unit tests for `resolve_enum_identifiers_impl` (bare ident, TypeName.value, plain string, already-namespaced, non-aws provider skip)
- [x] Unit tests for `normalize_state_enums` (plain values, already-namespaced values, non-enum attributes)
- [x] All existing tests pass (`cargo test -p carina-provider-aws`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)