### PR TITLE
Use anonymous resource syntax in documentation examples

### DIFF
--- a/carina-provider-awscc/examples/ec2_egress_only_internet_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_egress_only_internet_gateway/main.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let eoigw = awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_eip/main.crn
+++ b/carina-provider-awscc/examples/ec2_eip/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let eip = awscc.ec2.eip {
+awscc.ec2.eip {
   domain = "vpc"
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_flow_log/main.crn
+++ b/carina-provider-awscc/examples/ec2_flow_log/main.crn
@@ -11,7 +11,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let flow_log = awscc.ec2.flow_log {
+awscc.ec2.flow_log {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/carina-provider-awscc/examples/ec2_internet_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_internet_gateway/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let igw = awscc.ec2.internet_gateway {
+awscc.ec2.internet_gateway {
   tags = {
     Environment = "example"
   }

--- a/carina-provider-awscc/examples/ec2_ipam/main.crn
+++ b/carina-provider-awscc/examples/ec2_ipam/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+awscc.ec2.ipam {
   description = "Example IPAM"
   tier        = free
 

--- a/carina-provider-awscc/examples/ec2_ipam_pool/main.crn
+++ b/carina-provider-awscc/examples/ec2_ipam_pool/main.crn
@@ -17,7 +17,7 @@ let ipam = awscc.ec2.ipam {
   ]
 }
 
-let ipam_pool = awscc.ec2.ipam_pool {
+awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"

--- a/carina-provider-awscc/examples/ec2_nat_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_nat_gateway/main.crn
@@ -23,7 +23,7 @@ let eip = awscc.ec2.eip {
   domain = "vpc"
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+awscc.ec2.nat_gateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/carina-provider-awscc/examples/ec2_route/main.crn
+++ b/carina-provider-awscc/examples/ec2_route/main.crn
@@ -25,7 +25,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw_attachment.internet_gateway_id

--- a/carina-provider-awscc/examples/ec2_route_table/main.crn
+++ b/carina-provider-awscc/examples/ec2_route_table/main.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   enable_dns_hostnames = true
 }
 
-let rt = awscc.ec2.route_table {
+awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_security_group/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group/main.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 

--- a/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group_egress/main.crn
@@ -16,7 +16,7 @@ let sg = awscc.ec2.security_group {
   group_description = "Example security group"
 }
 
-let egress = awscc.ec2.security_group_egress {
+awscc.ec2.security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound traffic"
   ip_protocol = all

--- a/carina-provider-awscc/examples/ec2_security_group_ingress/main.crn
+++ b/carina-provider-awscc/examples/ec2_security_group_ingress/main.crn
@@ -16,7 +16,7 @@ let sg = awscc.ec2.security_group {
   group_description = "Example security group"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/examples/ec2_subnet/main.crn
+++ b/carina-provider-awscc/examples/ec2_subnet/main.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"

--- a/carina-provider-awscc/examples/ec2_subnet_route_table_association/main.crn
+++ b/carina-provider-awscc/examples/ec2_subnet_route_table_association/main.crn
@@ -23,7 +23,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let rt_assoc = awscc.ec2.subnet_route_table_association {
+awscc.ec2.subnet_route_table_association {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/carina-provider-awscc/examples/ec2_transit_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_transit_gateway/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let tgw = awscc.ec2.transit_gateway {
+awscc.ec2.transit_gateway {
   description = "Example Transit Gateway"
 
   tags = {

--- a/carina-provider-awscc/examples/ec2_vpc/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/examples/ec2_vpc_endpoint/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_endpoint/main.crn
@@ -24,7 +24,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for VPC Endpoint"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"
@@ -33,7 +33,7 @@ let ingress = awscc.ec2.security_group_ingress {
   cidr_ip     = "10.0.0.0/16"
 }
 
-let vpc_endpoint = awscc.ec2.vpc_endpoint {
+awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = "Interface"

--- a/carina-provider-awscc/examples/ec2_vpc_gateway_attachment/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_gateway_attachment/main.crn
@@ -15,7 +15,7 @@ let vpc = awscc.ec2.vpc {
 let igw = awscc.ec2.internet_gateway {
 }
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/carina-provider-awscc/examples/ec2_vpc_peering_connection/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpc_peering_connection/main.crn
@@ -14,7 +14,7 @@ let vpc2 = awscc.ec2.vpc {
   cidr_block = "10.1.0.0/16"
 }
 
-let peering = awscc.ec2.vpc_peering_connection {
+awscc.ec2.vpc_peering_connection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/carina-provider-awscc/examples/ec2_vpn_gateway/main.crn
+++ b/carina-provider-awscc/examples/ec2_vpn_gateway/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpn_gw = awscc.ec2.vpn_gateway {
+awscc.ec2.vpn_gateway {
   type = "ipsec.1"
 
   tags = {

--- a/docs/src/providers/awscc/ec2_egress_only_internet_gateway.md
+++ b/docs/src/providers/awscc/ec2_egress_only_internet_gateway.md
@@ -35,7 +35,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let eoigw = awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -90,7 +90,7 @@ Shorthand formats: `vpc` or `Domain.vpc`
 ## Example
 
 ```crn
-let eip = awscc.ec2.eip {
+awscc.ec2.eip {
   domain = "vpc"
 
   tags = {

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -148,7 +148,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let flow_log = awscc.ec2.flow_log {
+awscc.ec2.flow_log {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/docs/src/providers/awscc/ec2_internet_gateway.md
+++ b/docs/src/providers/awscc/ec2_internet_gateway.md
@@ -24,7 +24,7 @@ Any tags to assign to the internet gateway.
 ## Example
 
 ```crn
-let igw = awscc.ec2.internet_gateway {
+awscc.ec2.internet_gateway {
   tags = {
     Environment = "example"
   }

--- a/docs/src/providers/awscc/ec2_ipam.md
+++ b/docs/src/providers/awscc/ec2_ipam.md
@@ -126,7 +126,7 @@ Shorthand formats: `free` or `Tier.free`
 ## Example
 
 ```crn
-let ipam = awscc.ec2.ipam {
+awscc.ec2.ipam {
   description = "Example IPAM"
   tier        = free
 

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -232,7 +232,7 @@ let ipam = awscc.ec2.ipam {
   ]
 }
 
-let ipam_pool = awscc.ec2.ipam_pool {
+awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -167,7 +167,7 @@ let eip = awscc.ec2.eip {
   domain = "vpc"
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+awscc.ec2.nat_gateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/docs/src/providers/awscc/ec2_route.md
+++ b/docs/src/providers/awscc/ec2_route.md
@@ -142,7 +142,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw_attachment.internet_gateway_id

--- a/docs/src/providers/awscc/ec2_route_table.md
+++ b/docs/src/providers/awscc/ec2_route_table.md
@@ -38,7 +38,7 @@ let vpc = awscc.ec2.vpc {
   enable_dns_hostnames = true
 }
 
-let rt = awscc.ec2.route_table {
+awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/docs/src/providers/awscc/ec2_security_group.md
+++ b/docs/src/providers/awscc/ec2_security_group.md
@@ -97,7 +97,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Example security group"
 

--- a/docs/src/providers/awscc/ec2_security_group_egress.md
+++ b/docs/src/providers/awscc/ec2_security_group_egress.md
@@ -107,7 +107,7 @@ let sg = awscc.ec2.security_group {
   group_description = "Example security group"
 }
 
-let egress = awscc.ec2.security_group_egress {
+awscc.ec2.security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound traffic"
   ip_protocol = all

--- a/docs/src/providers/awscc/ec2_security_group_ingress.md
+++ b/docs/src/providers/awscc/ec2_security_group_ingress.md
@@ -124,7 +124,7 @@ let sg = awscc.ec2.security_group {
   group_description = "Example security group"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -172,7 +172,7 @@ let vpc = awscc.ec2.vpc {
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"

--- a/docs/src/providers/awscc/ec2_subnet_route_table_association.md
+++ b/docs/src/providers/awscc/ec2_subnet_route_table_association.md
@@ -47,7 +47,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let rt_assoc = awscc.ec2.subnet_route_table_association {
+awscc.ec2.subnet_route_table_association {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/docs/src/providers/awscc/ec2_transit_gateway.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway.md
@@ -169,7 +169,7 @@ Shorthand formats: `enable` or `VpnEcmpSupport.enable`
 ## Example
 
 ```crn
-let tgw = awscc.ec2.transit_gateway {
+awscc.ec2.transit_gateway {
   description = "Example Transit Gateway"
 
   tags = {

--- a/docs/src/providers/awscc/ec2_vpc.md
+++ b/docs/src/providers/awscc/ec2_vpc.md
@@ -96,7 +96,7 @@ Shorthand formats: `default` or `InstanceTenancy.default`
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -183,7 +183,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for VPC Endpoint"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"
@@ -192,7 +192,7 @@ let ingress = awscc.ec2.security_group_ingress {
   cidr_ip     = "10.0.0.0/16"
 }
 
-let vpc_endpoint = awscc.ec2.vpc_endpoint {
+awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = "Interface"

--- a/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2_vpc_gateway_attachment.md
@@ -47,7 +47,7 @@ let vpc = awscc.ec2.vpc {
 let igw = awscc.ec2.internet_gateway {
 }
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/docs/src/providers/awscc/ec2_vpc_peering_connection.md
+++ b/docs/src/providers/awscc/ec2_vpc_peering_connection.md
@@ -65,7 +65,7 @@ let vpc2 = awscc.ec2.vpc {
   cidr_block = "10.1.0.0/16"
 }
 
-let peering = awscc.ec2.vpc_peering_connection {
+awscc.ec2.vpc_peering_connection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/docs/src/providers/awscc/ec2_vpn_gateway.md
+++ b/docs/src/providers/awscc/ec2_vpn_gateway.md
@@ -39,7 +39,7 @@ The type of VPN connection the virtual private gateway supports.
 ## Example
 
 ```crn
-let vpn_gw = awscc.ec2.vpn_gateway {
+awscc.ec2.vpn_gateway {
   type = "ipsec.1"
 
   tags = {


### PR DESCRIPTION
## Summary

- Remove unused `let` bindings from all 20 example `.crn` files under `carina-provider-awscc/examples/`
- Single-resource examples (ec2_vpc, ec2_eip, ec2_internet_gateway, ec2_ipam, ec2_vpn_gateway, ec2_transit_gateway) now use anonymous syntax entirely
- Multi-resource examples keep `let` only for variables that are cross-referenced, and use anonymous syntax for the final unreferenced resource
- Regenerated all documentation files in `docs/src/providers/awscc/`

Closes #410

## Test plan

- [x] `cargo test` passes (5 pre-existing TLS cert failures unrelated to this change)
- [x] Documentation regenerated via `generate-docs.sh`
- [x] Verified all remaining `let` bindings are actually referenced by other resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)