### PR TITLE
Support S3 bucket Object Lock

### DIFF
--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -171,6 +171,9 @@ impl AwsProvider {
                 self.read_s3_bucket_ownership_controls(name, &mut attributes)
                     .await;
 
+                // Get Object Lock status
+                self.read_s3_bucket_object_lock(name, &mut attributes).await;
+
                 // S3 bucket identifier is the bucket name
                 Ok(State::existing(id.clone(), attributes).with_identifier(name))
             }
@@ -234,6 +237,11 @@ impl AwsProvider {
                 .location_constraint(constraint)
                 .build();
             req = req.create_bucket_configuration(config);
+        }
+
+        // Set ObjectLockEnabledForBucket on create
+        if let Some(Value::Bool(val)) = resource.attributes.get("object_lock_enabled_for_bucket") {
+            req = req.object_lock_enabled_for_bucket(*val);
         }
 
         // Set ObjectOwnership on create
@@ -332,6 +340,39 @@ impl AwsProvider {
                 })?;
         }
         Ok(())
+    }
+
+    /// Read S3 bucket Object Lock status
+    async fn read_s3_bucket_object_lock(
+        &self,
+        identifier: &str,
+        attributes: &mut HashMap<String, Value>,
+    ) {
+        match self
+            .s3_client
+            .get_object_lock_configuration()
+            .bucket(identifier)
+            .send()
+            .await
+        {
+            Ok(output) => {
+                let enabled = output
+                    .object_lock_configuration()
+                    .and_then(|config| config.object_lock_enabled())
+                    .is_some();
+                attributes.insert(
+                    "object_lock_enabled_for_bucket".to_string(),
+                    Value::Bool(enabled),
+                );
+            }
+            Err(_) => {
+                // ObjectLockConfigurationNotFoundError means Object Lock is not enabled
+                attributes.insert(
+                    "object_lock_enabled_for_bucket".to_string(),
+                    Value::Bool(false),
+                );
+            }
+        }
     }
 
     // ========== EC2 VPC Operations ==========

--- a/carina-provider-aws/src/resource_defs.rs
+++ b/carina-provider-aws/src/resource_defs.rs
@@ -484,7 +484,6 @@ pub fn s3_resources() -> Vec<ResourceDef> {
                 "GrantWrite",
                 "GrantWriteACP",
                 "CreateBucketConfiguration",
-                "ObjectLockEnabledForBucket",
                 "ContentMD5",
                 "ChecksumAlgorithm",
                 "MFA",

--- a/carina-provider-aws/src/schemas/generated/s3_bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3_bucket.rs
@@ -62,64 +62,48 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
         has_tags: true,
         data_source: false,
         schema: ResourceSchema::new("aws.s3.bucket")
-            .attribute(
-                AttributeSchema::new("name", AttributeType::String)
-                    .with_description("Resource name"),
-            )
-            .attribute(
-                AttributeSchema::new("region", super::aws_region())
-                    .with_description("The AWS region (inherited from provider if not specified)"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "object_ownership",
-                    AttributeType::Custom {
-                        name: "ObjectOwnership".to_string(),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_object_ownership,
-                        namespace: Some("aws.s3.bucket".to_string()),
-                        to_dsl: None,
-                    },
-                )
+        .attribute(
+            AttributeSchema::new("name", AttributeType::String)
+                .with_description("Resource name"),
+        )
+        .attribute(
+            AttributeSchema::new("region", super::aws_region())
+                .with_description("The AWS region (inherited from provider if not specified)"),
+        )
+        .attribute(
+            AttributeSchema::new("object_lock_enabled_for_bucket", AttributeType::Bool)
+                .create_only()
+                .with_description("Specifies whether you want S3 Object Lock to be enabled for the new bucket. This functionality is not supported for directory buckets.")
+                .with_provider_name("ObjectLockEnabledForBucket"),
+        )
+        .attribute(
+            AttributeSchema::new("object_ownership", AttributeType::Custom {
+                name: "ObjectOwnership".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_object_ownership,
+                namespace: Some("aws.s3.bucket".to_string()),
+                to_dsl: None,
+            })
                 .with_provider_name("ObjectOwnership")
-                .with_completions(vec![
-                    CompletionValue::new(
-                        "aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced",
-                        "BucketOwnerEnforced",
-                    ),
-                    CompletionValue::new(
-                        "aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred",
-                        "BucketOwnerPreferred",
-                    ),
-                    CompletionValue::new(
-                        "aws.s3.bucket.ObjectOwnership.ObjectWriter",
-                        "ObjectWriter",
-                    ),
-                ]),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "versioning_status",
-                    AttributeType::Custom {
-                        name: "VersioningStatus".to_string(),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_versioning_status,
-                        namespace: Some("aws.s3.bucket".to_string()),
-                        to_dsl: None,
-                    },
-                )
+                .with_completions(vec![CompletionValue::new("aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced", "BucketOwnerEnforced"), CompletionValue::new("aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred", "BucketOwnerPreferred"), CompletionValue::new("aws.s3.bucket.ObjectOwnership.ObjectWriter", "ObjectWriter")]),
+        )
+        .attribute(
+            AttributeSchema::new("versioning_status", AttributeType::Custom {
+                name: "VersioningStatus".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_versioning_status,
+                namespace: Some("aws.s3.bucket".to_string()),
+                to_dsl: None,
+            })
                 .with_description("The versioning state of the bucket.")
                 .with_provider_name("VersioningStatus")
-                .with_completions(vec![
-                    CompletionValue::new("aws.s3.bucket.VersioningStatus.Enabled", "Enabled"),
-                    CompletionValue::new("aws.s3.bucket.VersioningStatus.Suspended", "Suspended"),
-                ]),
-            )
-            .attribute(
-                AttributeSchema::new("tags", tags_type())
-                    .with_description("The tags for the resource.")
-                    .with_provider_name("Tags"),
-            ),
+                .with_completions(vec![CompletionValue::new("aws.s3.bucket.VersioningStatus.Enabled", "Enabled"), CompletionValue::new("aws.s3.bucket.VersioningStatus.Suspended", "Suspended")]),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("The tags for the resource.")
+                .with_provider_name("Tags"),
+        )
     }
 }
 

--- a/docs/src/providers/aws/s3_bucket.md
+++ b/docs/src/providers/aws/s3_bucket.md
@@ -4,6 +4,13 @@ CloudFormation Type: `AWS::S3::Bucket`
 
 ## Argument Reference
 
+### `object_lock_enabled_for_bucket`
+
+- **Type:** Bool
+- **Required:** No
+
+Specifies whether you want S3 Object Lock to be enabled for the new bucket.            This functionality is not supported for directory buckets.
+
 ### `object_ownership`
 
 - **Type:** [Enum (ObjectOwnership)](#object_ownership-objectownership)


### PR DESCRIPTION
## Summary

- Add support for the `ObjectLockEnabledForBucket` create-only boolean attribute on S3 buckets
- Remove from `exclude_fields` and regenerate schemas/docs
- Implement manual read via `GetObjectLockConfiguration` API (returns nested struct, so not suitable for codegen `ReadOp`)
- Handle the attribute in `create_s3_bucket()` to set it on the `CreateBucket` API call

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test -p carina-provider-aws -p carina-core -p carina-lsp` passes
- [x] Schema correctly generates `object_lock_enabled_for_bucket` as `Bool` with `create_only()`
- [x] Documentation regenerated with new attribute
- [ ] Acceptance test with actual S3 bucket (create with Object Lock enabled)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)