### PR TITLE
Convert value conversion methods to free functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,29 +456,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "bytes",
  "h2 0.3.27",
  "h2 0.4.13",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
- "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.8.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
- "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
@@ -511,25 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1fcbefc7ece1d70dcce29e490f269695dfca2d2bacdeaf9e5c3f799e4e6a42"
 dependencies = [
  "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-protocol-test"
-version = "0.63.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01317a9e3c5c06f1af35001ef0c873c1e34e458c20b2ee1eee0fb431e6dbb010"
-dependencies = [
- "assert-json-diff",
- "aws-smithy-runtime-api",
- "base64-simd",
- "cbor-diag",
- "ciborium",
- "http 0.2.12",
- "pretty_assertions",
- "regex-lite",
- "roxmltree",
- "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -564,7 +529,6 @@ dependencies = [
  "pin-utils",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -683,15 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +745,6 @@ dependencies = [
  "aws-config",
  "aws-sdk-cloudcontrol",
  "aws-sdk-s3",
- "aws-smithy-runtime",
  "carina-core",
  "clap",
  "heck",
@@ -836,25 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cbor-diag"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
-dependencies = [
- "bs58",
- "chrono",
- "data-encoding",
- "half",
- "nom",
- "num-bigint",
- "num-rational",
- "num-traits",
- "separator",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,33 +819,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -1060,12 +968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,12 +1027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,12 +1044,6 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1466,17 +1356,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -1831,8 +1710,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1898,12 +1775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,15 +1830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,12 +1846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,35 +1854,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2041,17 +1868,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -2244,16 +2060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,15 +2169,6 @@ checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
 dependencies = [
  "smallvec",
  "str_indices",
-]
-
-[[package]]
-name = "roxmltree"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
-dependencies = [
- "xmlparser",
 ]
 
 [[package]]
@@ -2546,12 +2343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "separator"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,7 +2378,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2626,15 +2416,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -2797,15 +2578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "time"
 version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,21 +2616,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3020,49 +2777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -3136,12 +2850,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -3458,12 +3166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,26 +3186,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -22,5 +22,3 @@ regex = "1.0"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 
-[dev-dependencies]
-aws-smithy-runtime = { version = "1", features = ["test-util"] }

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -57,6 +57,260 @@ pub struct AwsccProvider {
     aws_config: aws_config::SdkConfig,
 }
 
+// =========================================================================
+// Value Conversion Helpers
+// =========================================================================
+
+/// Convert AWS value to DSL value
+fn aws_value_to_dsl(
+    dsl_name: &str,
+    value: &serde_json::Value,
+    attr_type: &AttributeType,
+    resource_type: &str,
+) -> Option<Value> {
+    // For Custom enum types with namespace, convert to DSL namespaced format
+    if let AttributeType::Custom {
+        name: type_name,
+        namespace: Some(ns),
+        to_dsl,
+        ..
+    } = attr_type
+        && let Some(s) = value.as_str()
+    {
+        // Canonicalize case using valid values registry
+        let canonical = if let Some(valid_values) = get_enum_valid_values(resource_type, dsl_name) {
+            canonicalize_enum_value(s, valid_values)
+        } else {
+            s.to_string()
+        };
+        // Apply to_dsl transformation if present (e.g., hyphens → underscores for AZs)
+        let dsl_val = to_dsl.map_or_else(|| canonical.clone(), |f| f(&canonical));
+        let namespaced = format!("{}.{}.{}", ns, type_name, dsl_val);
+        return Some(Value::String(namespaced));
+    }
+
+    // For List(Struct{fields}), recurse into struct fields for type-aware conversion
+    if let AttributeType::List(inner) = attr_type
+        && let AttributeType::Struct { fields, .. } = inner.as_ref()
+        && let Some(arr) = value.as_array()
+    {
+        let items: Vec<Value> = arr
+            .iter()
+            .filter_map(|item| {
+                if let Some(obj) = item.as_object() {
+                    let map: HashMap<String, Value> = fields
+                        .iter()
+                        .filter_map(|field| {
+                            let provider_key =
+                                field.provider_name.as_deref().unwrap_or(&field.name);
+                            let json_val = obj.get(provider_key)?;
+                            let dsl_val = aws_value_to_dsl(
+                                &field.name,
+                                json_val,
+                                &field.field_type,
+                                resource_type,
+                            );
+                            dsl_val.map(|v| (field.name.clone(), v))
+                        })
+                        .collect();
+                    if map.is_empty() {
+                        None
+                    } else {
+                        Some(Value::Map(map))
+                    }
+                } else {
+                    json_to_value(item)
+                }
+            })
+            .collect();
+        return Some(Value::List(items));
+    }
+
+    // For bare Struct{fields}, recurse into fields
+    if let AttributeType::Struct { fields, .. } = attr_type
+        && let Some(obj) = value.as_object()
+    {
+        let map: HashMap<String, Value> = fields
+            .iter()
+            .filter_map(|field| {
+                let provider_key = field.provider_name.as_deref().unwrap_or(&field.name);
+                let json_val = obj.get(provider_key)?;
+                let dsl_val =
+                    aws_value_to_dsl(&field.name, json_val, &field.field_type, resource_type);
+                dsl_val.map(|v| (field.name.clone(), v))
+            })
+            .collect();
+        if !map.is_empty() {
+            return Some(Value::Map(map));
+        }
+    }
+
+    json_to_value(value)
+}
+
+/// Convert JSON value to DSL Value
+fn json_to_value(value: &serde_json::Value) -> Option<Value> {
+    match value {
+        serde_json::Value::String(s) => Some(Value::String(s.clone())),
+        serde_json::Value::Bool(b) => Some(Value::Bool(*b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Some(Value::Int(i))
+            } else {
+                n.as_f64().map(Value::Float)
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            let items: Vec<Value> = arr.iter().filter_map(json_to_value).collect();
+            Some(Value::List(items))
+        }
+        serde_json::Value::Object(obj) => {
+            let map: HashMap<String, Value> = obj
+                .iter()
+                .filter_map(|(k, v)| json_to_value(v).map(|val| (k.to_snake_case(), val)))
+                .collect();
+            Some(Value::Map(map))
+        }
+        _ => None,
+    }
+}
+
+/// Convert DSL value to AWS JSON value
+fn dsl_value_to_aws(
+    value: &Value,
+    attr_type: &AttributeType,
+    resource_type: &str,
+    attr_name: &str,
+) -> Option<serde_json::Value> {
+    // For Custom (enum) types, convert enum values
+    if matches!(attr_type, AttributeType::Custom { .. }) {
+        match value {
+            Value::String(s) => {
+                let raw = convert_enum_value(s);
+                // Apply alias reverse mapping (e.g., "all" -> "-1")
+                let resolved = match get_enum_alias_reverse(resource_type, attr_name, &raw) {
+                    Some(canonical) => canonical.to_string(),
+                    None => raw,
+                };
+                Some(json!(resolved))
+            }
+            Value::UnresolvedIdent(ident, member) => {
+                let raw = if let Some(m) = member {
+                    m.clone()
+                } else {
+                    ident.clone()
+                };
+                let converted = raw.replace('_', "-");
+                // Apply alias reverse mapping (e.g., "all" -> "-1")
+                let resolved = match get_enum_alias_reverse(resource_type, attr_name, &converted) {
+                    Some(canonical) => canonical.to_string(),
+                    None => converted,
+                };
+                Some(json!(resolved))
+            }
+            _ => value_to_json(value),
+        }
+    } else if let AttributeType::List(inner) = attr_type
+        && let AttributeType::Struct { fields, .. } = inner.as_ref()
+        && let Value::List(items) = value
+    {
+        // Recurse into struct fields for type-aware conversion
+        let arr: Vec<serde_json::Value> = items
+            .iter()
+            .filter_map(|item| {
+                if let Value::Map(map) = item {
+                    let obj: serde_json::Map<String, serde_json::Value> = fields
+                        .iter()
+                        .filter_map(|field| {
+                            let dsl_val = map.get(&field.name)?;
+                            let provider_key = field
+                                .provider_name
+                                .as_deref()
+                                .unwrap_or(&field.name)
+                                .to_string();
+                            let json_val = dsl_value_to_aws(
+                                dsl_val,
+                                &field.field_type,
+                                resource_type,
+                                &field.name,
+                            );
+                            json_val.map(|v| (provider_key, v))
+                        })
+                        .collect();
+                    Some(serde_json::Value::Object(obj))
+                } else {
+                    value_to_json(item)
+                }
+            })
+            .collect();
+        Some(serde_json::Value::Array(arr))
+    } else if let AttributeType::Struct { fields, .. } = attr_type
+        && let Value::Map(map) = value
+    {
+        // Recurse into bare struct fields for type-aware conversion (map assignment syntax)
+        let obj: serde_json::Map<String, serde_json::Value> = fields
+            .iter()
+            .filter_map(|field| {
+                let dsl_val = map.get(&field.name)?;
+                let provider_key = field
+                    .provider_name
+                    .as_deref()
+                    .unwrap_or(&field.name)
+                    .to_string();
+                let json_val =
+                    dsl_value_to_aws(dsl_val, &field.field_type, resource_type, &field.name);
+                json_val.map(|v| (provider_key, v))
+            })
+            .collect();
+        Some(serde_json::Value::Object(obj))
+    } else if let AttributeType::Struct { fields, .. } = attr_type
+        && let Value::List(items) = value
+        && items.len() == 1
+        && let Value::Map(map) = &items[0]
+    {
+        // Recurse into bare struct fields for type-aware conversion (block syntax)
+        let obj: serde_json::Map<String, serde_json::Value> = fields
+            .iter()
+            .filter_map(|field| {
+                let dsl_val = map.get(&field.name)?;
+                let provider_key = field
+                    .provider_name
+                    .as_deref()
+                    .unwrap_or(&field.name)
+                    .to_string();
+                let json_val =
+                    dsl_value_to_aws(dsl_val, &field.field_type, resource_type, &field.name);
+                json_val.map(|v| (provider_key, v))
+            })
+            .collect();
+        Some(serde_json::Value::Object(obj))
+    } else {
+        value_to_json(value)
+    }
+}
+
+/// Convert DSL Value to JSON value
+fn value_to_json(value: &Value) -> Option<serde_json::Value> {
+    match value {
+        Value::String(s) => Some(json!(s)),
+        Value::Bool(b) => Some(json!(b)),
+        Value::Int(i) => Some(json!(i)),
+        Value::Float(f) => Some(json!(f)),
+        Value::List(items) => {
+            let arr: Vec<serde_json::Value> = items.iter().filter_map(value_to_json).collect();
+            Some(serde_json::Value::Array(arr))
+        }
+        Value::Map(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .filter_map(|(k, v)| value_to_json(v).map(|val| (k.to_pascal_case(), val)))
+                .collect();
+            Some(serde_json::Value::Object(obj))
+        }
+        _ => None,
+    }
+}
+
 impl AwsccProvider {
     /// Create a new AwsccProvider for the specified region
     pub async fn new(region: &str) -> Self {
@@ -65,25 +319,6 @@ impl AwsccProvider {
             .load()
             .await;
 
-        Self {
-            cloudcontrol_client: CloudControlClient::new(&config),
-            aws_config: config,
-        }
-    }
-
-    /// Create a lightweight provider for unit tests that don't make network calls.
-    /// Uses a no-op HTTP client to avoid TLS initialization, which panics
-    /// in environments without root certificates.
-    #[cfg(test)]
-    fn new_for_test(region: &str) -> Self {
-        use aws_smithy_runtime::client::http::test_util::StaticReplayClient;
-
-        let http_client = StaticReplayClient::new(vec![]);
-        let config = aws_config::SdkConfig::builder()
-            .behavior_version(aws_config::BehaviorVersion::latest())
-            .region(Region::new(region.to_string()))
-            .http_client(http_client)
-            .build();
         Self {
             cloudcontrol_client: CloudControlClient::new(&config),
             aws_config: config,
@@ -527,7 +762,7 @@ impl AwsccProvider {
                 && let Some(value) = props.get(aws_name.as_str())
             {
                 let dsl_value =
-                    self.aws_value_to_dsl(dsl_name, value, &attr_schema.attr_type, resource_type);
+                    aws_value_to_dsl(dsl_name, value, &attr_schema.attr_type, resource_type);
                 if let Some(v) = dsl_value {
                     attributes.insert(dsl_name.to_string(), v);
                 }
@@ -571,7 +806,7 @@ impl AwsccProvider {
             if let Some(aws_name) = &attr_schema.provider_name
                 && let Some(value) = resource.attributes.get(dsl_name.as_str())
             {
-                let aws_value = self.dsl_value_to_aws(
+                let aws_value = dsl_value_to_aws(
                     value,
                     &attr_schema.attr_type,
                     &resource.id.resource_type,
@@ -659,12 +894,8 @@ impl AwsccProvider {
             }
             if let Some(aws_name) = &attr_schema.provider_name
                 && let Some(value) = to.attributes.get(dsl_name.as_str())
-                && let Some(aws_value) = self.dsl_value_to_aws(
-                    value,
-                    &attr_schema.attr_type,
-                    &id.resource_type,
-                    dsl_name,
-                )
+                && let Some(aws_value) =
+                    dsl_value_to_aws(value, &attr_schema.attr_type, &id.resource_type, dsl_name)
             {
                 patch_ops.push(json!({
                     "op": "replace",
@@ -737,277 +968,6 @@ impl AwsccProvider {
         self.cc_delete_resource(config.aws_type_name, identifier)
             .await
             .map_err(|e| e.for_resource(id.clone()))
-    }
-
-    // =========================================================================
-    // Value Conversion Helpers
-    // =========================================================================
-
-    /// Convert AWS value to DSL value
-    fn aws_value_to_dsl(
-        &self,
-        dsl_name: &str,
-        value: &serde_json::Value,
-        attr_type: &AttributeType,
-        resource_type: &str,
-    ) -> Option<Value> {
-        // For Custom enum types with namespace, convert to DSL namespaced format
-        if let AttributeType::Custom {
-            name: type_name,
-            namespace: Some(ns),
-            to_dsl,
-            ..
-        } = attr_type
-            && let Some(s) = value.as_str()
-        {
-            // Canonicalize case using valid values registry
-            let canonical =
-                if let Some(valid_values) = get_enum_valid_values(resource_type, dsl_name) {
-                    canonicalize_enum_value(s, valid_values)
-                } else {
-                    s.to_string()
-                };
-            // Apply to_dsl transformation if present (e.g., hyphens → underscores for AZs)
-            let dsl_val = to_dsl.map_or_else(|| canonical.clone(), |f| f(&canonical));
-            let namespaced = format!("{}.{}.{}", ns, type_name, dsl_val);
-            return Some(Value::String(namespaced));
-        }
-
-        // For List(Struct{fields}), recurse into struct fields for type-aware conversion
-        if let AttributeType::List(inner) = attr_type
-            && let AttributeType::Struct { fields, .. } = inner.as_ref()
-            && let Some(arr) = value.as_array()
-        {
-            let items: Vec<Value> = arr
-                .iter()
-                .filter_map(|item| {
-                    if let Some(obj) = item.as_object() {
-                        let map: HashMap<String, Value> = fields
-                            .iter()
-                            .filter_map(|field| {
-                                let provider_key =
-                                    field.provider_name.as_deref().unwrap_or(&field.name);
-                                let json_val = obj.get(provider_key)?;
-                                let dsl_val = self.aws_value_to_dsl(
-                                    &field.name,
-                                    json_val,
-                                    &field.field_type,
-                                    resource_type,
-                                );
-                                dsl_val.map(|v| (field.name.clone(), v))
-                            })
-                            .collect();
-                        if map.is_empty() {
-                            None
-                        } else {
-                            Some(Value::Map(map))
-                        }
-                    } else {
-                        self.json_to_value(item)
-                    }
-                })
-                .collect();
-            return Some(Value::List(items));
-        }
-
-        // For bare Struct{fields}, recurse into fields
-        if let AttributeType::Struct { fields, .. } = attr_type
-            && let Some(obj) = value.as_object()
-        {
-            let map: HashMap<String, Value> = fields
-                .iter()
-                .filter_map(|field| {
-                    let provider_key = field.provider_name.as_deref().unwrap_or(&field.name);
-                    let json_val = obj.get(provider_key)?;
-                    let dsl_val = self.aws_value_to_dsl(
-                        &field.name,
-                        json_val,
-                        &field.field_type,
-                        resource_type,
-                    );
-                    dsl_val.map(|v| (field.name.clone(), v))
-                })
-                .collect();
-            if !map.is_empty() {
-                return Some(Value::Map(map));
-            }
-        }
-
-        self.json_to_value(value)
-    }
-
-    /// Convert JSON value to DSL Value
-    fn json_to_value(&self, value: &serde_json::Value) -> Option<Value> {
-        match value {
-            serde_json::Value::String(s) => Some(Value::String(s.clone())),
-            serde_json::Value::Bool(b) => Some(Value::Bool(*b)),
-            serde_json::Value::Number(n) => {
-                if let Some(i) = n.as_i64() {
-                    Some(Value::Int(i))
-                } else {
-                    n.as_f64().map(Value::Float)
-                }
-            }
-            serde_json::Value::Array(arr) => {
-                let items: Vec<Value> = arr.iter().filter_map(|v| self.json_to_value(v)).collect();
-                Some(Value::List(items))
-            }
-            serde_json::Value::Object(obj) => {
-                let map: HashMap<String, Value> = obj
-                    .iter()
-                    .filter_map(|(k, v)| self.json_to_value(v).map(|val| (k.to_snake_case(), val)))
-                    .collect();
-                Some(Value::Map(map))
-            }
-            _ => None,
-        }
-    }
-
-    /// Convert DSL value to AWS JSON value
-    fn dsl_value_to_aws(
-        &self,
-        value: &Value,
-        attr_type: &AttributeType,
-        resource_type: &str,
-        attr_name: &str,
-    ) -> Option<serde_json::Value> {
-        // For Custom (enum) types, convert enum values
-        if matches!(attr_type, AttributeType::Custom { .. }) {
-            match value {
-                Value::String(s) => {
-                    let raw = convert_enum_value(s);
-                    // Apply alias reverse mapping (e.g., "all" -> "-1")
-                    let resolved = match get_enum_alias_reverse(resource_type, attr_name, &raw) {
-                        Some(canonical) => canonical.to_string(),
-                        None => raw,
-                    };
-                    Some(json!(resolved))
-                }
-                Value::UnresolvedIdent(ident, member) => {
-                    let raw = if let Some(m) = member {
-                        m.clone()
-                    } else {
-                        ident.clone()
-                    };
-                    let converted = raw.replace('_', "-");
-                    // Apply alias reverse mapping (e.g., "all" -> "-1")
-                    let resolved =
-                        match get_enum_alias_reverse(resource_type, attr_name, &converted) {
-                            Some(canonical) => canonical.to_string(),
-                            None => converted,
-                        };
-                    Some(json!(resolved))
-                }
-                _ => self.value_to_json(value),
-            }
-        } else if let AttributeType::List(inner) = attr_type
-            && let AttributeType::Struct { fields, .. } = inner.as_ref()
-            && let Value::List(items) = value
-        {
-            // Recurse into struct fields for type-aware conversion
-            let arr: Vec<serde_json::Value> = items
-                .iter()
-                .filter_map(|item| {
-                    if let Value::Map(map) = item {
-                        let obj: serde_json::Map<String, serde_json::Value> = fields
-                            .iter()
-                            .filter_map(|field| {
-                                let dsl_val = map.get(&field.name)?;
-                                let provider_key = field
-                                    .provider_name
-                                    .as_deref()
-                                    .unwrap_or(&field.name)
-                                    .to_string();
-                                let json_val = self.dsl_value_to_aws(
-                                    dsl_val,
-                                    &field.field_type,
-                                    resource_type,
-                                    &field.name,
-                                );
-                                json_val.map(|v| (provider_key, v))
-                            })
-                            .collect();
-                        Some(serde_json::Value::Object(obj))
-                    } else {
-                        self.value_to_json(item)
-                    }
-                })
-                .collect();
-            Some(serde_json::Value::Array(arr))
-        } else if let AttributeType::Struct { fields, .. } = attr_type
-            && let Value::Map(map) = value
-        {
-            // Recurse into bare struct fields for type-aware conversion (map assignment syntax)
-            let obj: serde_json::Map<String, serde_json::Value> = fields
-                .iter()
-                .filter_map(|field| {
-                    let dsl_val = map.get(&field.name)?;
-                    let provider_key = field
-                        .provider_name
-                        .as_deref()
-                        .unwrap_or(&field.name)
-                        .to_string();
-                    let json_val = self.dsl_value_to_aws(
-                        dsl_val,
-                        &field.field_type,
-                        resource_type,
-                        &field.name,
-                    );
-                    json_val.map(|v| (provider_key, v))
-                })
-                .collect();
-            Some(serde_json::Value::Object(obj))
-        } else if let AttributeType::Struct { fields, .. } = attr_type
-            && let Value::List(items) = value
-            && items.len() == 1
-            && let Value::Map(map) = &items[0]
-        {
-            // Recurse into bare struct fields for type-aware conversion (block syntax)
-            let obj: serde_json::Map<String, serde_json::Value> = fields
-                .iter()
-                .filter_map(|field| {
-                    let dsl_val = map.get(&field.name)?;
-                    let provider_key = field
-                        .provider_name
-                        .as_deref()
-                        .unwrap_or(&field.name)
-                        .to_string();
-                    let json_val = self.dsl_value_to_aws(
-                        dsl_val,
-                        &field.field_type,
-                        resource_type,
-                        &field.name,
-                    );
-                    json_val.map(|v| (provider_key, v))
-                })
-                .collect();
-            Some(serde_json::Value::Object(obj))
-        } else {
-            self.value_to_json(value)
-        }
-    }
-
-    /// Convert DSL Value to JSON value
-    fn value_to_json(&self, value: &Value) -> Option<serde_json::Value> {
-        match value {
-            Value::String(s) => Some(json!(s)),
-            Value::Bool(b) => Some(json!(b)),
-            Value::Int(i) => Some(json!(i)),
-            Value::Float(f) => Some(json!(f)),
-            Value::List(items) => {
-                let arr: Vec<serde_json::Value> =
-                    items.iter().filter_map(|v| self.value_to_json(v)).collect();
-                Some(serde_json::Value::Array(arr))
-            }
-            Value::Map(map) => {
-                let obj: serde_json::Map<String, serde_json::Value> = map
-                    .iter()
-                    .filter_map(|(k, v)| self.value_to_json(v).map(|val| (k.to_pascal_case(), val)))
-                    .collect();
-                Some(serde_json::Value::Object(obj))
-            }
-            _ => None,
-        }
     }
 
     // =========================================================================
@@ -1785,7 +1745,6 @@ mod tests {
 
     #[test]
     fn test_aws_value_to_dsl_bare_struct_returns_map() {
-        let provider = AwsccProvider::new_for_test("us-east-1");
         let fields = vec![
             StructField::new("status", AttributeType::String).with_provider_name("Status"),
             StructField::new("mfa_delete", AttributeType::String).with_provider_name("MfaDelete"),
@@ -1798,7 +1757,7 @@ mod tests {
             "Status": "Enabled",
         });
 
-        let result = provider.aws_value_to_dsl(
+        let result = aws_value_to_dsl(
             "versioning_configuration",
             &json_val,
             &attr_type,
@@ -1819,7 +1778,6 @@ mod tests {
 
     #[test]
     fn test_dsl_value_to_aws_map_for_bare_struct() {
-        let provider = AwsccProvider::new_for_test("us-east-1");
         let fields = vec![
             StructField::new("status", AttributeType::String).with_provider_name("Status"),
             StructField::new("mfa_delete", AttributeType::String).with_provider_name("MfaDelete"),
@@ -1834,7 +1792,7 @@ mod tests {
         map.insert("status".to_string(), Value::String("Enabled".to_string()));
         let dsl_value = Value::Map(map);
 
-        let result = provider.dsl_value_to_aws(
+        let result = dsl_value_to_aws(
             &dsl_value,
             &attr_type,
             "AWS::S3::Bucket",
@@ -1852,7 +1810,6 @@ mod tests {
 
     #[test]
     fn test_dsl_value_to_aws_list_for_bare_struct() {
-        let provider = AwsccProvider::new_for_test("us-east-1");
         let fields = vec![
             StructField::new("status", AttributeType::String).with_provider_name("Status"),
             StructField::new("mfa_delete", AttributeType::String).with_provider_name("MfaDelete"),
@@ -1867,7 +1824,7 @@ mod tests {
         map.insert("status".to_string(), Value::String("Enabled".to_string()));
         let dsl_value = Value::List(vec![Value::Map(map)]);
 
-        let result = provider.dsl_value_to_aws(
+        let result = dsl_value_to_aws(
             &dsl_value,
             &attr_type,
             "AWS::S3::Bucket",
@@ -1885,7 +1842,6 @@ mod tests {
 
     #[test]
     fn test_bare_struct_roundtrip_no_spurious_diff() {
-        let provider = AwsccProvider::new_for_test("us-east-1");
         let fields =
             vec![StructField::new("status", AttributeType::String).with_provider_name("Status")];
         let attr_type = AttributeType::Struct {
@@ -1897,14 +1853,13 @@ mod tests {
         let aws_json = serde_json::json!({ "Status": "Enabled" });
 
         // Read path: convert AWS JSON to DSL value
-        let dsl_value = provider
-            .aws_value_to_dsl(
-                "versioning_configuration",
-                &aws_json,
-                &attr_type,
-                "AWS::S3::Bucket",
-            )
-            .expect("read should succeed");
+        let dsl_value = aws_value_to_dsl(
+            "versioning_configuration",
+            &aws_json,
+            &attr_type,
+            "AWS::S3::Bucket",
+        )
+        .expect("read should succeed");
 
         // Simulate parser output (what the user wrote in .crn with map assignment syntax)
         let mut parser_map = HashMap::new();
@@ -1918,14 +1873,13 @@ mod tests {
         );
 
         // Write path: convert DSL value back to AWS JSON
-        let written_json = provider
-            .dsl_value_to_aws(
-                &dsl_value,
-                &attr_type,
-                "AWS::S3::Bucket",
-                "versioning_configuration",
-            )
-            .expect("write should succeed");
+        let written_json = dsl_value_to_aws(
+            &dsl_value,
+            &attr_type,
+            "AWS::S3::Bucket",
+            "versioning_configuration",
+        )
+        .expect("write should succeed");
 
         assert_eq!(
             written_json, aws_json,
@@ -1966,16 +1920,14 @@ mod tests {
         );
 
         // 2. AWS read-back side: aws_value_to_dsl converts "Gateway" string
-        let provider = AwsccProvider::new_for_test("ap-northeast-1");
         let aws_json = serde_json::json!("Gateway");
-        let aws_dsl = provider
-            .aws_value_to_dsl(
-                "vpc_endpoint_type",
-                &aws_json,
-                &attr_schema.attr_type,
-                "ec2.vpc_endpoint",
-            )
-            .expect("aws_value_to_dsl should return Some");
+        let aws_dsl = aws_value_to_dsl(
+            "vpc_endpoint_type",
+            &aws_json,
+            &attr_schema.attr_type,
+            "ec2.vpc_endpoint",
+        )
+        .expect("aws_value_to_dsl should return Some");
 
         assert_eq!(
             aws_dsl,


### PR DESCRIPTION
## Summary

- Convert `aws_value_to_dsl`, `json_to_value`, `dsl_value_to_aws`, and `value_to_json` from `&self` methods on `AwsccProvider` to module-level free functions, since they never access any `self` fields
- Remove the now-unused `new_for_test` helper method
- Remove the `aws-smithy-runtime` dev-dependency which was only needed by `new_for_test`

Closes #427

## Test plan

- [x] All 77 existing `carina-provider-awscc` tests pass
- [x] Full `cargo test` passes across all crates
- [x] Clippy and formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)