### PR TITLE
Propagate errors from generated read_ops helpers

### DIFF
--- a/carina-provider-aws/src/bin/smithy_codegen.rs
+++ b/carina-provider-aws/src/bin/smithy_codegen.rs
@@ -1419,19 +1419,24 @@ fn generate_provider_code(
             let defaults: HashMap<&str, &str> = read_op.defaults.iter().copied().collect();
 
             // Method signature
-            code.push_str(&format!(
-                "\x20   /// Read {} {} (generated)\n",
-                res.name, read_op.operation
-            ));
+            let op_desc = format!("{} {}", res.name, read_op.operation);
+            code.push_str(&format!("\x20   /// Read {} (generated)\n", op_desc));
             code.push_str(&format!("\x20   pub(crate) async fn {}(\n", method_name));
             code.push_str("\x20       &self,\n");
+            code.push_str("\x20       id: &ResourceId,\n");
             code.push_str("\x20       identifier: &str,\n");
             code.push_str("\x20       attributes: &mut HashMap<String, Value>,\n");
-            code.push_str("\x20   ) {\n");
+            code.push_str("\x20   ) -> ProviderResult<()> {\n");
             code.push_str(&format!(
-                "\x20       if let Ok(output) = self.{}.{}().{}(identifier).send().await {{\n",
+                "\x20       let output = self.{}.{}().{}(identifier).send().await.map_err(|e| {{\n",
                 client_field, sdk_method, id_setter
             ));
+            code.push_str(&format!(
+                "\x20           ProviderError::new(format!(\"Failed to read {}: {{}}\", e))\n",
+                op_desc
+            ));
+            code.push_str("\x20               .for_resource(id.clone())\n");
+            code.push_str("\x20       })?;\n");
 
             // Extract each field
             for (field_name, rename) in &read_op.fields {
@@ -1454,27 +1459,27 @@ fn generate_provider_code(
 
                 if let Some(default_value) = defaults.get(effective_name) {
                     code.push_str(&format!(
-                        "\x20           let value = output.{}().map(|v| {}).unwrap_or_else(|| \"{}\".to_string());\n",
+                        "\x20       let value = output.{}().map(|v| {}).unwrap_or_else(|| \"{}\".to_string());\n",
                         accessor, value_expr, default_value,
                     ));
                     code.push_str(&format!(
-                        "\x20           attributes.insert(\"{}\".to_string(), Value::String(value));\n",
+                        "\x20       attributes.insert(\"{}\".to_string(), Value::String(value));\n",
                         attr_snake,
                     ));
                 } else {
                     code.push_str(&format!(
-                        "\x20           if let Some(v) = output.{}() {{\n",
+                        "\x20       if let Some(v) = output.{}() {{\n",
                         accessor,
                     ));
                     code.push_str(&format!(
-                        "\x20               attributes.insert(\"{}\".to_string(), Value::String({}));\n",
+                        "\x20           attributes.insert(\"{}\".to_string(), Value::String({}));\n",
                         attr_snake, value_expr,
                     ));
-                    code.push_str("\x20           }\n");
+                    code.push_str("\x20       }\n");
                 }
             }
 
-            code.push_str("\x20       }\n");
+            code.push_str("\x20       Ok(())\n");
             code.push_str("\x20   }\n\n");
         }
     }

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -217,7 +217,8 @@ impl AwsProvider {
                 attributes.insert("region".to_string(), Value::String(region_dsl));
 
                 // Get versioning status
-                self.read_s3_bucket_versioning(name, &mut attributes).await;
+                self.read_s3_bucket_versioning(id, name, &mut attributes)
+                    .await?;
 
                 // Get object ownership
                 self.read_s3_bucket_ownership_controls(id, name, &mut attributes)

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -295,22 +295,29 @@ impl AwsProvider {
     /// Read s3.bucket GetBucketVersioning (generated)
     pub(crate) async fn read_s3_bucket_versioning(
         &self,
+        id: &ResourceId,
         identifier: &str,
         attributes: &mut HashMap<String, Value>,
-    ) {
-        if let Ok(output) = self
+    ) -> ProviderResult<()> {
+        let output = self
             .s3_client
             .get_bucket_versioning()
             .bucket(identifier)
             .send()
             .await
-        {
-            let value = output
-                .status()
-                .map(|v| v.as_str().to_string())
-                .unwrap_or_else(|| "Suspended".to_string());
-            attributes.insert("versioning_status".to_string(), Value::String(value));
-        }
+            .map_err(|e| {
+                ProviderError::new(format!(
+                    "Failed to read s3.bucket GetBucketVersioning: {}",
+                    e
+                ))
+                .for_resource(id.clone())
+            })?;
+        let value = output
+            .status()
+            .map(|v| v.as_str().to_string())
+            .unwrap_or_else(|| "Suspended".to_string());
+        attributes.insert("versioning_status".to_string(), Value::String(value));
+        Ok(())
     }
 
     /// Write s3.bucket PutBucketVersioning (generated)


### PR DESCRIPTION
## Summary

- Updated codegen (`smithy_codegen.rs`) to generate read_ops helpers that accept `&ResourceId`, return `ProviderResult<()>`, and propagate real API errors via `map_err` instead of silently swallowing them with `if let Ok(...)`
- Updated call site in `lib.rs` to pass `id` and use `?`
- Regenerated `provider_generated.rs`

Closes #442

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 41 tests pass
- [x] Verified codegen produces identical output to manual edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)