### PR TITLE
Improve pre-commit hook performance

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Pre-commit hook for Carina
 # Install: ./scripts/setup-hooks.sh
+#
+# Environment variables:
+#   SKIP_CLIPPY=1  - Skip clippy check (useful for WIP commits)
 
 set -e
 
@@ -37,11 +40,15 @@ else
     clippy_scope="${changed_crates[*]} --all-targets --all-features"
 fi
 
+# Ensure incremental compilation for faster checks
+export CARGO_INCREMENTAL=1
+
 # Run fmt and clippy in parallel
 fmt_log=$(mktemp)
 clippy_log=$(mktemp)
 trap 'rm -f "$fmt_log" "$clippy_log"' EXIT
 
+fmt_start=$(date +%s)
 if [ "$fmt_scope" = "--all" ]; then
     cargo fmt --all -- --check >"$fmt_log" 2>&1 &
 else
@@ -49,30 +56,49 @@ else
 fi
 fmt_pid=$!
 
-if [ "$fmt_scope" = "--all" ]; then
-    cargo clippy --all-targets --all-features -- -D warnings >"$clippy_log" 2>&1 &
+if [ "${SKIP_CLIPPY:-0}" = "1" ]; then
+    echo "Skipping clippy (SKIP_CLIPPY=1)"
+    clippy_pid=""
 else
-    cargo clippy ${clippy_scope} -- -D warnings >"$clippy_log" 2>&1 &
+    clippy_start=$(date +%s)
+    if [ "$fmt_scope" = "--all" ]; then
+        cargo clippy --all-targets --all-features --no-deps -- -D warnings >"$clippy_log" 2>&1 &
+    else
+        cargo clippy ${clippy_scope} --no-deps -- -D warnings >"$clippy_log" 2>&1 &
+    fi
+    clippy_pid=$!
 fi
-clippy_pid=$!
 
 # Wait for both and collect exit codes
 fmt_exit=0
 clippy_exit=0
 wait $fmt_pid || fmt_exit=$?
-wait $clippy_pid || clippy_exit=$?
+fmt_end=$(date +%s)
+fmt_elapsed=$((fmt_end - fmt_start))
+
+if [ -n "$clippy_pid" ]; then
+    wait $clippy_pid || clippy_exit=$?
+    clippy_end=$(date +%s)
+    clippy_elapsed=$((clippy_end - clippy_start))
+fi
 
 # Report results
 if [ $fmt_exit -ne 0 ]; then
-    echo "Formatting check FAILED:"
+    echo "Formatting check FAILED (${fmt_elapsed}s):"
     cat "$fmt_log"
     echo ""
+else
+    echo "Formatting check passed (${fmt_elapsed}s)"
 fi
 
-if [ $clippy_exit -ne 0 ]; then
-    echo "Clippy check FAILED:"
-    cat "$clippy_log"
-    echo ""
+if [ -n "$clippy_pid" ]; then
+    if [ $clippy_exit -ne 0 ]; then
+        echo "Clippy check FAILED (${clippy_elapsed}s):"
+        cat "$clippy_log"
+        echo ""
+    else
+        echo "Clippy check passed (${clippy_elapsed}s)"
+    fi
 fi
 
 if [ $fmt_exit -ne 0 ] || [ $clippy_exit -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Add `SKIP_CLIPPY=1` environment variable to optionally skip clippy for WIP commits
- Add `--no-deps` flag to clippy to only lint own code, not dependencies
- Set `CARGO_INCREMENTAL=1` explicitly for faster incremental builds
- Show elapsed time for each check to help identify bottlenecks

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)