### PR TITLE
Disable doctests for crates without them to reduce test time

### DIFF
--- a/carina-codegen-aws/Cargo.toml
+++ b/carina-codegen-aws/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[lib]
+doctest = false
+
 [[bin]]
 name = "smithy-codegen"
 path = "src/main.rs"

--- a/carina-lsp/Cargo.toml
+++ b/carina-lsp/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 [lib]
 name = "carina_lsp"
 path = "src/lib.rs"
+doctest = false
 
 [[bin]]
 name = "carina-lsp"

--- a/carina-provider-aws/Cargo.toml
+++ b/carina-provider-aws/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[lib]
+doctest = false
+
 [dependencies]
 carina-core = { path = "../carina-core" }
 aws-config = "1"

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[lib]
+doctest = false
+
 [[bin]]
 name = "codegen"
 path = "src/bin/codegen.rs"

--- a/carina-provider-mock/Cargo.toml
+++ b/carina-provider-mock/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[lib]
+doctest = false
+
 [dependencies]
 carina-core = { path = "../carina-core" }
 serde_json = "1"

--- a/carina-smithy/Cargo.toml
+++ b/carina-smithy/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 license = "MIT"
 description = "Smithy 2.0 JSON AST parser for Carina"
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/carina-state/Cargo.toml
+++ b/carina-state/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 license = "MIT"
 description = "State management for Carina infrastructure tool"
 
+[lib]
+doctest = false
+
 [dependencies]
 carina-core = { path = "../carina-core" }
 aws-config = "1"


### PR DESCRIPTION
## Summary

- Adds `doctest = false` to 7 crates that have zero doctests (carina-lsp, carina-provider-aws, carina-provider-awscc, carina-provider-mock, carina-state, carina-smithy, carina-codegen-aws)
- Only carina-core retains doctest compilation (it has 6 actual doctests)
- This eliminates unnecessary doctest binary compilation that was adding significant overhead to every `cargo test` run

## Test plan

- [x] `cargo test` passes — all 635+ tests pass including carina-core's 6 doctests
- [ ] Verify reduced test time in CI

closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)