### PR TITLE
Fix source_resource syntax in with_ipam.crn acceptance test

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -57,14 +57,12 @@ let vpc_pool = awscc.ec2.ipam_pool {
   locale             = "ap-northeast-1"
   source_ipam_pool_id = top_pool.ipam_pool_id
 
-  source_resource = [
-    {
-      resource_id     = vpc.vpc_id
-      resource_owner  = identity.account_id
-      resource_region = "ap-northeast-1"
-      resource_type   = "vpc"
-    }
-  ]
+  source_resource = {
+    resource_id     = vpc.vpc_id
+    resource_owner  = identity.account_id
+    resource_region = "ap-northeast-1"
+    resource_type   = "vpc"
+  }
 
   provisioned_cidrs = [
     {


### PR DESCRIPTION
## Summary

- Fix `source_resource` attribute syntax in `ec2_subnet/with_ipam.crn` acceptance test
- CloudFormation schema defines `SourceResource` as a single object (`type: "object"`), not an array
- Changed from list syntax `[{ ... }]` to map assignment syntax `{ ... }`

Closes #432

## Test plan

- [x] `cargo run -- validate` passes on the fixed file
- [x] `cargo test -p carina-provider-awscc` passes
- [ ] Run acceptance test `ec2_subnet/with_ipam.crn` to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)