### PR TITLE
Auto-generate read attribute extraction from Smithy models

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1360,23 +1360,42 @@ fn generate_provider_code(
         ));
     }
 
-    // No-op update methods
+    // No-op update methods (with optional tag handling)
     for res in all_resources.iter().filter(|r| r.noop_update) {
         let method_name = format!("update_{}", res.name.replace('.', "_"));
         let read_method = format!("read_{}", res.name.replace('.', "_"));
 
-        code.push_str(&format!(
-            "\x20   /// Update {} (no-op, just read back current state) (generated)\n\
-             \x20   pub(crate) async fn {}(\n\
-             \x20       &self,\n\
-             \x20       id: ResourceId,\n\
-             \x20       identifier: &str,\n\
-             \x20       _to: Resource,\n\
-             \x20   ) -> ProviderResult<State> {{\n\
-             \x20       self.{}(&id, Some(identifier)).await\n\
-             \x20   }}\n\n",
-            res.name, method_name, read_method,
-        ));
+        if res.has_tags {
+            // Tag-enabled noop update: apply tags then read back
+            code.push_str(&format!(
+                "\x20   /// Update {}: apply tag changes and read back (generated)\n\
+                 \x20   pub(crate) async fn {}(\n\
+                 \x20       &self,\n\
+                 \x20       id: ResourceId,\n\
+                 \x20       identifier: &str,\n\
+                 \x20       from: &State,\n\
+                 \x20       to: Resource,\n\
+                 \x20   ) -> ProviderResult<State> {{\n\
+                 \x20       self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))\n\
+                 \x20           .await?;\n\
+                 \x20       self.{}(&id, Some(identifier)).await\n\
+                 \x20   }}\n\n",
+                res.name, method_name, read_method,
+            ));
+        } else {
+            code.push_str(&format!(
+                "\x20   /// Update {} (no-op, just read back current state) (generated)\n\
+                 \x20   pub(crate) async fn {}(\n\
+                 \x20       &self,\n\
+                 \x20       id: ResourceId,\n\
+                 \x20       identifier: &str,\n\
+                 \x20       _to: Resource,\n\
+                 \x20   ) -> ProviderResult<State> {{\n\
+                 \x20       self.{}(&id, Some(identifier)).await\n\
+                 \x20   }}\n\n",
+                res.name, method_name, read_method,
+            ));
+        }
     }
 
     // Read helpers for read_ops (non-data-source resources only)
@@ -1631,6 +1650,167 @@ fn generate_provider_code(
             code.push_str("\x20       Ok(())\n");
             code.push_str("\x20   }\n\n");
         }
+    }
+
+    // Read attribute extraction methods for resources with read_structure
+    for res in all_resources.iter().filter(|r| r.read_structure.is_some()) {
+        let model = match models.get(res.service_namespace) {
+            Some(m) => m,
+            None => continue,
+        };
+        let ns = res.service_namespace;
+        let read_struct_name = res.read_structure.unwrap();
+        let read_struct_id = format!("{}#{}", ns, read_struct_name);
+        let read_struct = match model.get_structure(&read_struct_id) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let resource_name = res.name.replace('.', "_");
+        let sdk_crate = sdk_crate_name(ns);
+
+        // Build exclude set
+        let exclude: HashSet<&str> = res.exclude_fields.iter().copied().collect();
+
+        // Get create input members
+        let create_input = if !res.create_op.is_empty() {
+            let create_op_id = format!("{}#{}", ns, res.create_op);
+            model.operation_input(&create_op_id)
+        } else {
+            None
+        };
+
+        // Compute updatable field names
+        let updatable_fields: HashSet<&str> = res
+            .update_ops
+            .iter()
+            .flat_map(|op| op.fields.field_names().iter())
+            .copied()
+            .collect();
+
+        let extra_read_only: HashSet<&str> = res.extra_read_only.iter().copied().collect();
+
+        // Collect fields to extract: (attr_snake_name, accessor_snake_name, member_ref)
+        let mut fields_to_extract: Vec<(String, String, &carina_smithy::ShapeRef)> = Vec::new();
+
+        for (member_name, member_ref) in &read_struct.members {
+            if exclude.contains(member_name.as_str()) || member_name == "Tags" {
+                continue;
+            }
+
+            let is_schema_attr = member_name == res.identifier
+                || extra_read_only.contains(member_name.as_str())
+                || updatable_fields.contains(member_name.as_str())
+                || create_input.is_some_and(|ci| ci.members.contains_key(member_name));
+
+            if !is_schema_attr {
+                continue;
+            }
+
+            let snake_name = member_name.to_snake_case();
+            fields_to_extract.push((snake_name.clone(), snake_name, member_ref));
+        }
+
+        // Add extra_writable fields with read_source (different attr name vs accessor)
+        for extra in &res.extra_writable {
+            if let Some(read_source) = extra.read_source
+                && let Some(member_ref) = read_struct.members.get(read_source)
+            {
+                let attr_name = extra.name.to_snake_case();
+                let accessor_name = read_source.to_snake_case();
+                // Avoid duplicates (if already extracted under the same accessor)
+                if !fields_to_extract.iter().any(|(a, _, _)| a == &attr_name) {
+                    fields_to_extract.push((attr_name, accessor_name, member_ref));
+                }
+            }
+        }
+
+        // Sort fields for deterministic output
+        fields_to_extract.sort_by(|a, b| a.0.cmp(&b.0));
+
+        // Generate method
+        code.push_str(&format!(
+            "\x20   /// Extract {} attributes from SDK response type (generated)\n",
+            res.name
+        ));
+        code.push_str(&format!(
+            "\x20   pub(crate) fn extract_{}_attributes(\n",
+            resource_name
+        ));
+        code.push_str(&format!(
+            "\x20       obj: &{}::types::{},\n",
+            sdk_crate, read_struct_name
+        ));
+        code.push_str("\x20       attributes: &mut HashMap<String, Value>,\n");
+        code.push_str("\x20   ) -> Option<String> {\n");
+
+        for (attr_name, accessor_name, member_ref) in &fields_to_extract {
+            let kind = model.shape_kind(&member_ref.target);
+
+            match kind {
+                Some(ShapeKind::Enum) => {
+                    code.push_str(&format!(
+                        "\x20       if let Some(v) = obj.{}() {{\n",
+                        accessor_name
+                    ));
+                    code.push_str(&format!(
+                        "\x20           attributes.insert(\"{}\".to_string(), Value::String(v.as_str().to_string()));\n",
+                        attr_name
+                    ));
+                    code.push_str("\x20       }\n");
+                }
+                Some(ShapeKind::Boolean) => {
+                    code.push_str(&format!(
+                        "\x20       if let Some(v) = obj.{}() {{\n",
+                        accessor_name
+                    ));
+                    code.push_str(&format!(
+                        "\x20           attributes.insert(\"{}\".to_string(), Value::Bool(v));\n",
+                        attr_name
+                    ));
+                    code.push_str("\x20       }\n");
+                }
+                Some(ShapeKind::Integer) | Some(ShapeKind::Long) => {
+                    code.push_str(&format!(
+                        "\x20       if let Some(v) = obj.{}() {{\n",
+                        accessor_name
+                    ));
+                    code.push_str(&format!(
+                        "\x20           attributes.insert(\"{}\".to_string(), Value::Int(v as i64));\n",
+                        attr_name
+                    ));
+                    code.push_str("\x20       }\n");
+                }
+                Some(ShapeKind::String) => {
+                    code.push_str(&format!(
+                        "\x20       if let Some(v) = obj.{}() {{\n",
+                        accessor_name
+                    ));
+                    code.push_str(&format!(
+                        "\x20           attributes.insert(\"{}\".to_string(), Value::String(v.to_string()));\n",
+                        attr_name
+                    ));
+                    code.push_str("\x20       }\n");
+                }
+                _ => {
+                    // Skip complex types (structures, lists, maps) that need
+                    // custom handling in hand-written code
+                }
+            }
+        }
+
+        // Return identifier value (only if identifier exists in read_structure)
+        if !res.identifier.is_empty() && read_struct.members.contains_key(res.identifier) {
+            let id_snake = res.identifier.to_snake_case();
+            code.push_str(&format!(
+                "\x20       obj.{}().map(String::from)\n",
+                id_snake
+            ));
+        } else {
+            code.push_str("\x20       None\n");
+        }
+
+        code.push_str("\x20   }\n\n");
     }
 
     code.push_str("}\n");

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -800,30 +800,15 @@ impl AwsProvider {
         if let Some(vpc) = result.vpcs().first() {
             let mut attributes = HashMap::new();
 
-            if let Some(cidr) = vpc.cidr_block() {
-                attributes.insert("cidr_block".to_string(), Value::String(cidr.to_string()));
-            }
-
-            // Store VPC ID
-            let vpc_id_str = vpc.vpc_id().map(String::from);
-            if let Some(ref vpc_id) = vpc_id_str {
-                attributes.insert("vpc_id".to_string(), Value::String(vpc_id.clone()));
-            }
-
-            // Instance tenancy - return plain value, normalize_state_enums handles namespacing
-            if let Some(tenancy) = vpc.instance_tenancy() {
-                attributes.insert(
-                    "instance_tenancy".to_string(),
-                    Value::String(tenancy.as_str().to_string()),
-                );
-            }
+            // Auto-generated attribute extraction
+            let identifier_value = Self::extract_ec2_vpc_attributes(vpc, &mut attributes);
 
             // Extract user-defined tags (excluding Name)
             if let Some(tags_value) = Self::ec2_tags_to_value(vpc.tags()) {
                 attributes.insert("tags".to_string(), tags_value);
             }
 
-            // Get VPC attributes for DNS settings
+            // Get VPC attributes for DNS settings (not in Vpc struct)
             if let Some(vpc_id) = vpc.vpc_id() {
                 if let Ok(dns_support) = self
                     .ec2_client
@@ -857,8 +842,8 @@ impl AwsProvider {
             }
 
             let state = State::existing(id.clone(), attributes);
-            Ok(if let Some(vpc_id) = vpc_id_str {
-                state.with_identifier(vpc_id)
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
             } else {
                 state
             })
@@ -1034,25 +1019,13 @@ impl AwsProvider {
         if let Some(subnet) = result.subnets().first() {
             let mut attributes = HashMap::new();
 
-            if let Some(cidr) = subnet.cidr_block() {
-                attributes.insert("cidr_block".to_string(), Value::String(cidr.to_string()));
-            }
+            // Auto-generated attribute extraction
+            let identifier_value = Self::extract_ec2_subnet_attributes(subnet, &mut attributes);
 
+            // Override availability_zone with DSL format
             if let Some(az) = subnet.availability_zone() {
-                // Return availability_zone in DSL format
                 let az_dsl = format!("aws.AvailabilityZone.{}", az.replace('-', "_"));
                 attributes.insert("availability_zone".to_string(), Value::String(az_dsl));
-            }
-
-            // Store subnet ID
-            let subnet_id_str = subnet.subnet_id().map(String::from);
-            if let Some(ref subnet_id) = subnet_id_str {
-                attributes.insert("subnet_id".to_string(), Value::String(subnet_id.clone()));
-            }
-
-            // Store VPC ID
-            if let Some(vpc_id) = subnet.vpc_id() {
-                attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
             }
 
             // Extract user-defined tags
@@ -1061,8 +1034,8 @@ impl AwsProvider {
             }
 
             let state = State::existing(id.clone(), attributes);
-            Ok(if let Some(subnet_id) = subnet_id_str {
-                state.with_identifier(subnet_id)
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
             } else {
                 state
             })
@@ -1152,16 +1125,11 @@ impl AwsProvider {
         if let Some(igw) = result.internet_gateways().first() {
             let mut attributes = HashMap::new();
 
-            // Store IGW ID
-            let igw_id_str = igw.internet_gateway_id().map(String::from);
-            if let Some(ref igw_id) = igw_id_str {
-                attributes.insert(
-                    "internet_gateway_id".to_string(),
-                    Value::String(igw_id.clone()),
-                );
-            }
+            // Auto-generated attribute extraction
+            let identifier_value =
+                Self::extract_ec2_internet_gateway_attributes(igw, &mut attributes);
 
-            // Store attached VPC ID
+            // Store attached VPC ID (from Attachments, not a direct member)
             if let Some(attachment) = igw.attachments().first()
                 && let Some(vpc_id) = attachment.vpc_id()
             {
@@ -1174,8 +1142,8 @@ impl AwsProvider {
             }
 
             let state = State::existing(id.clone(), attributes);
-            Ok(if let Some(igw_id) = igw_id_str {
-                state.with_identifier(igw_id)
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
             } else {
                 state
             })
@@ -1311,18 +1279,10 @@ impl AwsProvider {
         if let Some(rt) = result.route_tables().first() {
             let mut attributes = HashMap::new();
 
-            // Store route table ID
-            let rt_id_str = rt.route_table_id().map(String::from);
-            if let Some(ref rt_id) = rt_id_str {
-                attributes.insert("route_table_id".to_string(), Value::String(rt_id.clone()));
-            }
+            // Auto-generated attribute extraction
+            let identifier_value = Self::extract_ec2_route_table_attributes(rt, &mut attributes);
 
-            // Store VPC ID
-            if let Some(vpc_id) = rt.vpc_id() {
-                attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
-            }
-
-            // Convert routes to list
+            // Convert routes to list (complex nested structure)
             let mut routes_list = Vec::new();
             for route in rt.routes() {
                 let mut route_map = HashMap::new();
@@ -1346,8 +1306,8 @@ impl AwsProvider {
             }
 
             let state = State::existing(id.clone(), attributes);
-            Ok(if let Some(rt_id) = rt_id_str {
-                state.with_identifier(rt_id)
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
             } else {
                 state
             })
@@ -1470,25 +1430,15 @@ impl AwsProvider {
             for route in rt.routes() {
                 if route.destination_cidr_block() == Some(destination_cidr_block) {
                     let mut attributes = HashMap::new();
+
+                    // Auto-generated attribute extraction
+                    Self::extract_ec2_route_attributes(route, &mut attributes);
+
+                    // route_table_id is not in the Route struct, add from parameter
                     attributes.insert(
                         "route_table_id".to_string(),
                         Value::String(route_table_id.to_string()),
                     );
-                    attributes.insert(
-                        "destination_cidr_block".to_string(),
-                        Value::String(destination_cidr_block.to_string()),
-                    );
-
-                    if let Some(gw_id) = route.gateway_id() {
-                        attributes
-                            .insert("gateway_id".to_string(), Value::String(gw_id.to_string()));
-                    }
-                    if let Some(nat_gw_id) = route.nat_gateway_id() {
-                        attributes.insert(
-                            "nat_gateway_id".to_string(),
-                            Value::String(nat_gw_id.to_string()),
-                        );
-                    }
 
                     // Route identifier is route_table_id|destination_cidr_block
                     let identifier = format!("{}|{}", route_table_id, destination_cidr_block);
@@ -1626,27 +1576,8 @@ impl AwsProvider {
         if let Some(sg) = result.security_groups().first() {
             let mut attributes = HashMap::new();
 
-            if let Some(group_name) = sg.group_name() {
-                attributes.insert(
-                    "group_name".to_string(),
-                    Value::String(group_name.to_string()),
-                );
-            }
-
-            if let Some(desc) = sg.description() {
-                attributes.insert("description".to_string(), Value::String(desc.to_string()));
-            }
-
-            // Store security group ID
-            let sg_id_str = sg.group_id().map(String::from);
-            if let Some(ref sg_id) = sg_id_str {
-                attributes.insert("group_id".to_string(), Value::String(sg_id.clone()));
-            }
-
-            // Store VPC ID
-            if let Some(vpc_id) = sg.vpc_id() {
-                attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
-            }
+            // Auto-generated attribute extraction
+            let identifier_value = Self::extract_ec2_security_group_attributes(sg, &mut attributes);
 
             // Extract user-defined tags
             if let Some(tags_value) = Self::ec2_tags_to_value(sg.tags()) {
@@ -1654,8 +1585,8 @@ impl AwsProvider {
             }
 
             let state = State::existing(id.clone(), attributes);
-            Ok(if let Some(sg_id) = sg_id_str {
-                state.with_identifier(sg_id)
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
             } else {
                 state
             })
@@ -1783,7 +1714,14 @@ impl AwsProvider {
         let first_rule = &rules[0];
         let mut attributes = HashMap::new();
 
-        // Store rule IDs (comma-separated if multiple)
+        // Auto-generated attribute extraction (common fields)
+        if is_ingress {
+            Self::extract_ec2_security_group_ingress_attributes(first_rule, &mut attributes);
+        } else {
+            Self::extract_ec2_security_group_egress_attributes(first_rule, &mut attributes);
+        }
+
+        // Override rule IDs with comma-separated values (multi-rule support)
         let rule_ids: Vec<String> = rules
             .iter()
             .filter_map(|r| r.security_group_rule_id().map(String::from))
@@ -1798,62 +1736,12 @@ impl AwsProvider {
             None
         };
 
-        // Store security group ID
-        if let Some(sg_id) = first_rule.group_id() {
-            attributes.insert("group_id".to_string(), Value::String(sg_id.to_string()));
-        }
-
-        if let Some(protocol) = first_rule.ip_protocol() {
-            // Keep protocol as raw string for comparison (tcp, udp, icmp, -1)
-            attributes.insert(
-                "ip_protocol".to_string(),
-                Value::String(protocol.to_string()),
-            );
-        }
-
-        if let Some(from_port) = first_rule.from_port() {
-            attributes.insert("from_port".to_string(), Value::Int(from_port as i64));
-        }
-
-        if let Some(to_port) = first_rule.to_port() {
-            attributes.insert("to_port".to_string(), Value::Int(to_port as i64));
-        }
-
-        // IPv4 CIDR
+        // IPv4 CIDR (CidrIp in schema maps to CidrIpv4 in SDK)
         if let Some(cidr_ip) = first_rule.cidr_ipv4() {
             attributes.insert("cidr_ip".to_string(), Value::String(cidr_ip.to_string()));
         }
 
-        // IPv6 CIDR
-        if let Some(cidr_ipv6) = first_rule.cidr_ipv6() {
-            attributes.insert(
-                "cidr_ipv6".to_string(),
-                Value::String(cidr_ipv6.to_string()),
-            );
-        }
-
-        // Description
-        if let Some(description) = first_rule.description() {
-            attributes.insert(
-                "description".to_string(),
-                Value::String(description.to_string()),
-            );
-        }
-
-        // Prefix list ID (source for ingress, destination for egress)
-        if let Some(prefix_list_id) = first_rule.prefix_list_id() {
-            let attr_name = if is_ingress {
-                "source_prefix_list_id"
-            } else {
-                "destination_prefix_list_id"
-            };
-            attributes.insert(
-                attr_name.to_string(),
-                Value::String(prefix_list_id.to_string()),
-            );
-        }
-
-        // Referenced security group ID (source for ingress, destination for egress)
+        // Referenced security group ID (nested struct, not auto-extracted)
         if let Some(ref_group) = first_rule.referenced_group_info()
             && let Some(group_id) = ref_group.group_id()
         {

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -362,4 +362,272 @@ impl AwsProvider {
         }
         Ok(())
     }
+
+    /// Extract ec2.vpc attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_vpc_attributes(
+        obj: &aws_sdk_ec2::types::Vpc,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.cidr_block() {
+            attributes.insert("cidr_block".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.instance_tenancy() {
+            attributes.insert(
+                "instance_tenancy".to_string(),
+                Value::String(v.as_str().to_string()),
+            );
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        obj.vpc_id().map(String::from)
+    }
+
+    /// Extract ec2.subnet attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_subnet_attributes(
+        obj: &aws_sdk_ec2::types::Subnet,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.assign_ipv6_address_on_creation() {
+            attributes.insert(
+                "assign_ipv6_address_on_creation".to_string(),
+                Value::Bool(v),
+            );
+        }
+        if let Some(v) = obj.availability_zone() {
+            attributes.insert(
+                "availability_zone".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.availability_zone_id() {
+            attributes.insert(
+                "availability_zone_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.cidr_block() {
+            attributes.insert("cidr_block".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.enable_dns64() {
+            attributes.insert("enable_dns64".to_string(), Value::Bool(v));
+        }
+        if let Some(v) = obj.enable_lni_at_device_index() {
+            attributes.insert(
+                "enable_lni_at_device_index".to_string(),
+                Value::Int(v as i64),
+            );
+        }
+        if let Some(v) = obj.ipv6_native() {
+            attributes.insert("ipv6_native".to_string(), Value::Bool(v));
+        }
+        if let Some(v) = obj.map_public_ip_on_launch() {
+            attributes.insert("map_public_ip_on_launch".to_string(), Value::Bool(v));
+        }
+        if let Some(v) = obj.outpost_arn() {
+            attributes.insert("outpost_arn".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.subnet_id() {
+            attributes.insert("subnet_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        obj.subnet_id().map(String::from)
+    }
+
+    /// Extract ec2.internet_gateway attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_internet_gateway_attributes(
+        obj: &aws_sdk_ec2::types::InternetGateway,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.internet_gateway_id() {
+            attributes.insert(
+                "internet_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        obj.internet_gateway_id().map(String::from)
+    }
+
+    /// Extract ec2.route_table attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_route_table_attributes(
+        obj: &aws_sdk_ec2::types::RouteTable,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.route_table_id() {
+            attributes.insert("route_table_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        obj.route_table_id().map(String::from)
+    }
+
+    /// Extract ec2.route attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_route_attributes(
+        obj: &aws_sdk_ec2::types::Route,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.carrier_gateway_id() {
+            attributes.insert(
+                "carrier_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.core_network_arn() {
+            attributes.insert("core_network_arn".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.destination_cidr_block() {
+            attributes.insert(
+                "destination_cidr_block".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.destination_ipv6_cidr_block() {
+            attributes.insert(
+                "destination_ipv6_cidr_block".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.destination_prefix_list_id() {
+            attributes.insert(
+                "destination_prefix_list_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.egress_only_internet_gateway_id() {
+            attributes.insert(
+                "egress_only_internet_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.gateway_id() {
+            attributes.insert("gateway_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.instance_id() {
+            attributes.insert("instance_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.local_gateway_id() {
+            attributes.insert("local_gateway_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.nat_gateway_id() {
+            attributes.insert("nat_gateway_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.network_interface_id() {
+            attributes.insert(
+                "network_interface_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.transit_gateway_id() {
+            attributes.insert(
+                "transit_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.vpc_peering_connection_id() {
+            attributes.insert(
+                "vpc_peering_connection_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        None
+    }
+
+    /// Extract ec2.security_group attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_security_group_attributes(
+        obj: &aws_sdk_ec2::types::SecurityGroup,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.description() {
+            attributes.insert("description".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.group_id() {
+            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.group_name() {
+            attributes.insert("group_name".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        obj.group_id().map(String::from)
+    }
+
+    /// Extract ec2.security_group_ingress attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_security_group_ingress_attributes(
+        obj: &aws_sdk_ec2::types::SecurityGroupRule,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.cidr_ipv6() {
+            attributes.insert("cidr_ipv6".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.description() {
+            attributes.insert("description".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.from_port() {
+            attributes.insert("from_port".to_string(), Value::Int(v as i64));
+        }
+        if let Some(v) = obj.group_id() {
+            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.ip_protocol() {
+            attributes.insert("ip_protocol".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.security_group_rule_id() {
+            attributes.insert(
+                "security_group_rule_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.prefix_list_id() {
+            attributes.insert(
+                "source_prefix_list_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.to_port() {
+            attributes.insert("to_port".to_string(), Value::Int(v as i64));
+        }
+        obj.security_group_rule_id().map(String::from)
+    }
+
+    /// Extract ec2.security_group_egress attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_security_group_egress_attributes(
+        obj: &aws_sdk_ec2::types::SecurityGroupRule,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.cidr_ipv6() {
+            attributes.insert("cidr_ipv6".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.description() {
+            attributes.insert("description".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.prefix_list_id() {
+            attributes.insert(
+                "destination_prefix_list_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.from_port() {
+            attributes.insert("from_port".to_string(), Value::Int(v as i64));
+        }
+        if let Some(v) = obj.group_id() {
+            attributes.insert("group_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.ip_protocol() {
+            attributes.insert("ip_protocol".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(v) = obj.security_group_rule_id() {
+            attributes.insert(
+                "security_group_rule_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.to_port() {
+            attributes.insert("to_port".to_string(), Value::Int(v as i64));
+        }
+        obj.security_group_rule_id().map(String::from)
+    }
 }


### PR DESCRIPTION
## Summary

- Add `extract_*_attributes` methods to the codegen's `provider` format output, auto-generating attribute extraction from AWS SDK response types based on Smithy read_structure definitions
- Update hand-written read functions (VPC, Subnet, Internet Gateway, Route Table, Security Group, Route, Security Group Rules) to use the generated extract methods, replacing manual attribute mapping
- Fix noop_update codegen to properly handle tag application for resources with `has_tags: true`

## Details

The codegen now generates `extract_{resource}_attributes()` methods for each resource with a `read_structure`. These methods:
- Take a reference to the SDK response type (e.g., `&aws_sdk_ec2::types::Vpc`)
- Extract all schema attributes that exist as members in the read_structure
- Handle String, Enum (`.as_str()`), Bool, and Int types; skip complex types (Struct/List)
- Map `extra_writable` fields with `read_source` to their correct accessor names
- Return `Option<String>` with the identifier value

Hand-written read functions now call these extract methods and only add custom logic for:
- Tags (via `ec2_tags_to_value`)
- Availability zone format conversion (DSL format)
- Internet Gateway VPC attachment lookup
- Route Table nested routes list
- Security Group Rule multi-rule ID handling and `cidr_ipv4→cidr_ip` mapping

## Test plan

- [x] All 580+ unit tests pass
- [ ] Acceptance tests verify no behavior change in plan/apply cycles

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)