### PR TITLE
fix: remove stale dead_code annotation from egress_only_internet_gateway_id

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -375,7 +375,6 @@ pub(crate) fn gateway_id() -> AttributeType {
 }
 
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
-#[allow(dead_code)] // TODO: codegen should use this instead of internet_gateway_id() for eigw attributes
 pub(crate) fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
         name: "EgressOnlyInternetGatewayId".to_string(),


### PR DESCRIPTION
## Summary
- Remove stale `#[allow(dead_code)]` and TODO comment from `egress_only_internet_gateway_id()` in `awscc_types.rs`
- The codegen already correctly maps `EgressOnlyInternetGatewayId` properties to this function (used by `ec2/route.rs`)

## Test plan
- [x] `cargo build -p carina-provider-awscc` passes
- [x] `cargo test -p carina-provider-awscc` passes (79 tests)

closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)