### PR TITLE
test: add acceptance test for ec2_ipam resource

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
@@ -1,0 +1,22 @@
+# EC2 IPAM - Basic test
+#
+# Tests: tier, operating_regions, description, tags
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let ipam = awscc.ec2.ipam {
+  tier        = advanced
+  description = "Acceptance test IPAM"
+
+  operating_regions = [
+    {
+      region_name = "ap-northeast-1"
+    }
+  ]
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add acceptance test for `awscc.ec2.ipam` resource (previously only used as a dependency in `ec2_ipam_pool` test)
- Tests `tier`, `operating_regions`, `description`, and `tags` attributes

## Test plan
- [x] `cargo build` succeeds
- [x] `carina validate` passes on the new test file
- [ ] Run acceptance test: `run-tests.sh full ec2_ipam`

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)