### PR TITLE
test: add acceptance tests for iam.role attribute variations

### DIFF
--- a/carina-provider-awscc/acceptance-tests/iam_role/with_path.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/with_path.crn
@@ -1,0 +1,26 @@
+# IAM Role - path and tags test
+#
+# Tests: role_name_prefix, assume_role_policy_document, path (create_only), tags
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.role {
+  role_name_prefix = "carina-acc-test-"
+  path             = "/carina/acceptance-test/"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "acceptance-test"
+    ManagedBy   = "carina"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/iam_role/with_policy.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/with_policy.crn
@@ -1,0 +1,35 @@
+# IAM Role - inline policy test
+#
+# Tests: role_name_prefix, assume_role_policy_document, description,
+#        max_session_duration, inline policy block
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.role {
+  role_name_prefix = "carina-acc-test-"
+  description          = "Carina acceptance test role with inline policy"
+  max_session_duration = 7200
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  policy {
+    policy_name = "test-policy"
+    policy_document = {
+      version = "2012-10-17"
+      statement {
+        effect   = "Allow"
+        action   = "logs:CreateLogGroup"
+        resource = "*"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `with_policy.crn`: tests `description`, `max_session_duration`, and inline `policy` block (the `policies` attribute with `block_name("policy")`)
- Add `with_path.crn`: tests `path` (create_only attribute) and `tags`
- Both files use `role_name_prefix` and `assume_role_policy_document` (required)

Closes #502

## Test plan
- [x] Both files pass `carina validate`
- [ ] Run acceptance tests with `run-tests.sh full` filtering for `iam_role`

🤖 Generated with [Claude Code](https://claude.com/claude-code)