### PR TITLE
test: add acceptance tests for logs.log_group attribute variations

### DIFF
--- a/carina-provider-awscc/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/carina-provider-awscc/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -1,0 +1,13 @@
+# CloudWatch Logs Log Group - infrequent access class test
+#
+# Tests: log_group_name_prefix, log_group_class, retention_in_days
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let log_group = awscc.logs.log_group {
+  log_group_name_prefix = "/carina/acc-test-"
+  log_group_class       = awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS
+  retention_in_days     = 1
+}

--- a/carina-provider-awscc/acceptance-tests/logs_log_group/retention.crn
+++ b/carina-provider-awscc/acceptance-tests/logs_log_group/retention.crn
@@ -1,0 +1,16 @@
+# CloudWatch Logs Log Group - retention and tags test
+#
+# Tests: log_group_name_prefix, retention_in_days, tags
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let log_group = awscc.logs.log_group {
+  log_group_name_prefix = "/carina/acc-test-"
+  retention_in_days     = 7
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `retention.crn` testing `retention_in_days` (7 days) and `tags` attributes
- Add `infrequent_access.crn` testing `log_group_class` with `INFREQUENT_ACCESS` enum value

Closes #503

## Test plan
- [x] `cargo build` succeeds
- [x] `carina validate` passes for both new test files
- [ ] Run acceptance tests with `run-tests.sh full` against `logs_log_group`

🤖 Generated with [Claude Code](https://claude.com/claude-code)