### PR TITLE
test: add S3 bucket acceptance tests for attribute variations

### DIFF
--- a/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
@@ -1,0 +1,28 @@
+# S3 Bucket - bucket_encryption test (AES256)
+#
+# Tests: bucket_encryption with server_side_encryption_configuration
+#        using AES256 as the default SSE algorithm,
+#        plan-verify confirms encryption settings are reconciled,
+#        destroy cleans up the encrypted bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [
+      {
+        server_side_encryption_by_default = {
+          sse_algorithm = "AES256"
+        }
+      }
+    ]
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/public_access_block.crn
@@ -1,0 +1,24 @@
+# S3 Bucket - public_access_block_configuration test
+#
+# Tests: public_access_block_configuration with all four settings enabled,
+#        plan-verify confirms public access block state is reconciled,
+#        destroy cleans up the bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  public_access_block_configuration = {
+    block_public_acls       = true
+    block_public_policy     = true
+    ignore_public_acls      = true
+    restrict_public_buckets = true
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
@@ -1,0 +1,21 @@
+# S3 Bucket - versioning_configuration test
+#
+# Tests: versioning_configuration with status = Enabled,
+#        plan-verify confirms versioning state is reconciled,
+#        destroy cleans up the versioned bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  versioning_configuration = {
+    status = awscc.s3.bucket.Status.Enabled
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `versioning.crn` testing `versioning_configuration` with `Status.Enabled`
- Add `encryption.crn` testing `bucket_encryption` with AES256 server-side encryption
- Add `public_access_block.crn` testing `public_access_block_configuration` with all four boolean settings enabled

Closes #501

## Test plan

- [ ] Run `run-tests.sh full s3_bucket` to execute all S3 bucket acceptance tests (apply, plan-verify, destroy)
- [ ] Verify each test creates the bucket with the expected configuration
- [ ] Verify plan-verify shows no drift after apply
- [ ] Verify destroy cleans up all resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)