### PR TITLE
feat: add AWS provider acceptance tests for route, sg egress/ingress

### DIFF
--- a/carina-provider-aws/acceptance-tests/ec2_route/igw.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_route/igw.crn
@@ -1,0 +1,37 @@
+# EC2 Route - Internet Gateway test
+#
+# Tests: route creation with route_table_id, destination_cidr_block, gateway_id
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let route = aws.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw.internet_gateway_id
+}

--- a/carina-provider-aws/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -1,0 +1,32 @@
+# EC2 Security Group Egress - Basic test
+#
+# Tests: group_id, ip_protocol, cidr_ip, description
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let sg = aws.ec2.security_group {
+  group_name  = "carina-acc-test-aws-sg-egress"
+  description = "SG for egress rule test"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let egress = aws.ec2.security_group_egress {
+  group_id    = sg.group_id
+  description = "Allow all outbound"
+  ip_protocol = all
+  cidr_ip     = "0.0.0.0/0"
+}

--- a/carina-provider-aws/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -1,0 +1,34 @@
+# EC2 Security Group Ingress - Basic test
+#
+# Tests: group_id, ip_protocol, from_port, to_port, cidr_ip, description
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let sg = aws.ec2.security_group {
+  group_name  = "carina-acc-test-aws-sg-ingress"
+  description = "SG for ingress rule test"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let ingress = aws.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -50,7 +50,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
                 .with_provider_name("EgressOnlyInternetGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("gateway_id", super::aws_resource_id())
+            AttributeSchema::new("gateway_id", super::gateway_id())
                 .with_description("The ID of an internet gateway or virtual private gateway attached to your VPC.")
                 .with_provider_name("GatewayId"),
         )

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -321,7 +321,6 @@ pub(crate) fn transit_gateway_id() -> AttributeType {
 }
 
 /// VPN Gateway ID type (e.g., "vgw-12345678")
-#[allow(dead_code)]
 pub(crate) fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
         name: "VpnGatewayId".to_string(),
@@ -377,6 +376,12 @@ pub(crate) fn vpc_endpoint_id() -> AttributeType {
         namespace: None,
         to_dsl: None,
     }
+}
+
+/// Gateway ID type — union of InternetGatewayId and VpnGatewayId.
+/// Used for attributes like ec2_route.gateway_id that accept both igw-* and vgw-* IDs.
+pub(crate) fn gateway_id() -> AttributeType {
+    AttributeType::Union(vec![internet_gateway_id(), vpn_gateway_id()])
 }
 
 // ========== ARN validators ==========


### PR DESCRIPTION
## Summary

- Add acceptance tests for `ec2.route`, `ec2.security_group_egress`, and `ec2.security_group_ingress` resource types in the AWS provider
- Fix `gateway_id` type in route schema from generic `AwsResourceId` to `Union(InternetGatewayId, VpnGatewayId)` to allow resource reference type checking to pass (matching the AWSCC provider pattern)

Closes #499

## Test plan

- [x] All three `.crn` files pass `carina validate`
- [x] `cargo test -p carina-provider-aws` passes
- [ ] Run acceptance tests with `run-tests.sh full` against AWS accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)