### PR TITLE
Strengthen type inference in smithy-codegen for aws provider schemas

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -845,52 +845,9 @@ fn resolve_type(
 
     match kind {
         Some(ShapeKind::String) => {
-            // Check name-based type inference
+            // Check name-based type inference (handles CIDR, IP, AZ, ARN, resource IDs, etc.)
             if let Some(inferred) = infer_string_type(field_name) {
                 return (inferred, None);
-            }
-
-            // Check for CIDR patterns
-            let lower = field_name.to_lowercase();
-            if lower.contains("cidr") {
-                if lower.contains("ipv6") {
-                    return ("types::ipv6_cidr()".to_string(), None);
-                }
-                return ("types::ipv4_cidr()".to_string(), None);
-            }
-
-            // Check for IP address patterns
-            if (lower.contains("ipaddress")
-                || lower.ends_with("ip")
-                || lower.contains("ipaddresses"))
-                && !lower.contains("cidr")
-                && !lower.contains("count")
-                && !lower.contains("type")
-            {
-                if lower.contains("ipv6") {
-                    return ("types::ipv6_address()".to_string(), None);
-                }
-                return ("types::ipv4_address()".to_string(), None);
-            }
-
-            // IPAM Pool IDs
-            if is_ipam_pool_id_property(field_name) {
-                return ("super::ipam_pool_id()".to_string(), None);
-            }
-
-            // Resource IDs
-            if is_aws_resource_id_property(field_name) {
-                return (get_resource_id_type(field_name).to_string(), None);
-            }
-
-            // ARN patterns
-            if lower.ends_with("arn") || lower.ends_with("arns") || lower.contains("_arn") {
-                return ("super::arn()".to_string(), None);
-            }
-
-            // Availability zone
-            if lower == "availabilityzone" {
-                return ("super::availability_zone()".to_string(), None);
             }
 
             ("AttributeType::String".to_string(), None)
@@ -2293,39 +2250,6 @@ fn type_display_string_md<'a>(
             if let Some(inferred) = infer_string_type(field_name) {
                 return type_code_to_display(&inferred);
             }
-            let lower = field_name.to_lowercase();
-            if lower.contains("cidr") {
-                return if lower.contains("ipv6") {
-                    "Ipv6Cidr".to_string()
-                } else {
-                    "Ipv4Cidr".to_string()
-                };
-            }
-            if (lower.contains("ipaddress")
-                || lower.ends_with("ip")
-                || lower.contains("ipaddresses"))
-                && !lower.contains("cidr")
-                && !lower.contains("count")
-                && !lower.contains("type")
-            {
-                return if lower.contains("ipv6") {
-                    "Ipv6Address".to_string()
-                } else {
-                    "Ipv4Address".to_string()
-                };
-            }
-            if is_ipam_pool_id_property(field_name) {
-                return "IpamPoolId".to_string();
-            }
-            if is_aws_resource_id_property(field_name) {
-                return resource_id_display(field_name);
-            }
-            if lower.ends_with("arn") || lower.ends_with("arns") || lower.contains("_arn") {
-                return "Arn".to_string();
-            }
-            if lower == "availabilityzone" {
-                return "AvailabilityZone".to_string();
-            }
             "String".to_string()
         }
         Some(ShapeKind::Boolean) => "Bool".to_string(),
@@ -2426,7 +2350,16 @@ fn type_code_to_display(type_code: &str) -> String {
         s if s.contains("subnet_id") => "SubnetId".to_string(),
         s if s.contains("security_group_id") => "SecurityGroupId".to_string(),
         s if s.contains("ipam_pool_id") => "IpamPoolId".to_string(),
+        s if s.contains("instance_id") => "InstanceId".to_string(),
+        s if s.contains("network_interface_id") => "NetworkInterfaceId".to_string(),
+        s if s.contains("allocation_id") => "AllocationId".to_string(),
+        s if s.contains("prefix_list_id") => "PrefixListId".to_string(),
+        s if s.contains("carrier_gateway_id") => "CarrierGatewayId".to_string(),
+        s if s.contains("local_gateway_id") => "LocalGatewayId".to_string(),
+        s if s.contains("network_acl_id") => "NetworkAclId".to_string(),
+        "super::gateway_id()" => "GatewayId".to_string(),
         s if s.contains("arn()") => "Arn".to_string(),
+        s if s.contains("aws_account_id") => "AwsAccountId".to_string(),
         s if s.contains("aws_resource_id") => "AwsResourceId".to_string(),
         s if s.contains("availability_zone") => "AvailabilityZone".to_string(),
         _ => type_code
@@ -2450,6 +2383,13 @@ fn resource_id_display(prop_name: &str) -> String {
         ResourceIdKind::TransitGatewayId => "TransitGatewayId".to_string(),
         ResourceIdKind::VpnGatewayId => "VpnGatewayId".to_string(),
         ResourceIdKind::VpcEndpointId => "VpcEndpointId".to_string(),
+        ResourceIdKind::InstanceId => "InstanceId".to_string(),
+        ResourceIdKind::NetworkInterfaceId => "NetworkInterfaceId".to_string(),
+        ResourceIdKind::AllocationId => "AllocationId".to_string(),
+        ResourceIdKind::PrefixListId => "PrefixListId".to_string(),
+        ResourceIdKind::CarrierGatewayId => "CarrierGatewayId".to_string(),
+        ResourceIdKind::LocalGatewayId => "LocalGatewayId".to_string(),
+        ResourceIdKind::NetworkAclId => "NetworkAclId".to_string(),
         ResourceIdKind::Generic => "AwsResourceId".to_string(),
     }
 }
@@ -2460,7 +2400,9 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
     static OVERRIDES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
         let mut m = HashMap::new();
         m.insert("DefaultSecurityGroup", "super::security_group_id()");
-        m.insert("DefaultNetworkAcl", "super::aws_resource_id()");
+        m.insert("DefaultNetworkAcl", "super::network_acl_id()");
+        m.insert("AccountId", "super::aws_account_id()");
+        m.insert("GatewayId", "super::gateway_id()");
         m.insert("DeliverCrossAccountRole", "super::iam_role_arn()");
         m.insert("DeliverLogsPermissionArn", "super::iam_role_arn()");
         m.insert("PeerRoleArn", "super::iam_role_arn()");
@@ -2502,15 +2444,71 @@ fn infer_string_type(prop_name: &str) -> Option<String> {
     if let Some(&override_type) = known_string_type_overrides().get(prop_name) {
         return Some(override_type.to_string());
     }
+
+    // Normalize plural forms for type inference
+    let singular_name = if prop_name.ends_with("Ids")
+        || prop_name.ends_with("ids")
+        || prop_name.ends_with("Arns")
+        || prop_name.ends_with("arns")
+    {
+        &prop_name[..prop_name.len() - 1]
+    } else {
+        prop_name
+    };
+
+    // Check overrides for singular form too (e.g., list items)
+    if let Some(&override_type) = known_string_type_overrides().get(singular_name) {
+        return Some(override_type.to_string());
+    }
+
+    let prop_lower = singular_name.to_lowercase();
+
+    // CIDR types - differentiate IPv4 vs IPv6 based on property name
+    if prop_lower.contains("cidr") {
+        if prop_lower.contains("ipv6") {
+            return Some("types::ipv6_cidr()".to_string());
+        }
+        return Some("types::ipv4_cidr()".to_string());
+    }
+
+    // IP address types (not CIDR) - e.g., PrivateIpAddress, PublicIp
+    if (prop_lower.contains("ipaddress")
+        || prop_lower.ends_with("ip")
+        || prop_lower.contains("ipaddresses"))
+        && !prop_lower.contains("count")
+        && !prop_lower.contains("type")
+    {
+        if prop_lower.contains("ipv6") {
+            return Some("types::ipv6_address()".to_string());
+        }
+        return Some("types::ipv4_address()".to_string());
+    }
+
+    // Availability zone (but not AvailabilityZoneId which uses AZ ID format like "use1-az1")
+    if prop_lower == "availabilityzone" || prop_lower == "availabilityzones" {
+        return Some("super::availability_zone()".to_string());
+    }
+
     // Check ARN pattern
-    let prop_lower = prop_name.to_lowercase();
     if prop_lower.ends_with("arn") || prop_lower.ends_with("arns") || prop_lower.contains("_arn") {
         return Some("super::arn()".to_string());
     }
-    // Check resource ID pattern
-    if is_aws_resource_id_property(prop_name) {
-        return Some(get_resource_id_type(prop_name).to_string());
+
+    // IPAM Pool IDs
+    if is_ipam_pool_id_property(singular_name) {
+        return Some("super::ipam_pool_id()".to_string());
     }
+
+    // Check resource ID pattern
+    if is_aws_resource_id_property(singular_name) {
+        return Some(get_resource_id_type(singular_name).to_string());
+    }
+
+    // AWS Account ID (owner IDs are 12-digit account IDs)
+    if prop_lower.ends_with("ownerid") {
+        return Some("super::aws_account_id()".to_string());
+    }
+
     None
 }
 
@@ -2564,6 +2562,13 @@ enum ResourceIdKind {
     TransitGatewayId,
     VpnGatewayId,
     VpcEndpointId,
+    InstanceId,
+    NetworkInterfaceId,
+    AllocationId,
+    PrefixListId,
+    CarrierGatewayId,
+    LocalGatewayId,
+    NetworkAclId,
     Generic,
 }
 
@@ -2602,6 +2607,34 @@ fn classify_resource_id(prop_name: &str) -> ResourceIdKind {
     if lower.contains("vpcendpoint") && lower.ends_with("id") {
         return ResourceIdKind::VpcEndpointId;
     }
+    // Instance IDs (e.g., InstanceId)
+    if lower.ends_with("instanceid") {
+        return ResourceIdKind::InstanceId;
+    }
+    // Network Interface IDs (e.g., NetworkInterfaceId, EniId)
+    if lower.ends_with("networkinterfaceid") || lower.ends_with("eniid") {
+        return ResourceIdKind::NetworkInterfaceId;
+    }
+    // Allocation IDs (e.g., AllocationId)
+    if lower.ends_with("allocationid") {
+        return ResourceIdKind::AllocationId;
+    }
+    // Prefix List IDs (e.g., PrefixListId, DestinationPrefixListId)
+    if lower.ends_with("prefixlistid") {
+        return ResourceIdKind::PrefixListId;
+    }
+    // Carrier Gateway IDs (e.g., CarrierGatewayId)
+    if lower.contains("carriergateway") && lower.ends_with("id") {
+        return ResourceIdKind::CarrierGatewayId;
+    }
+    // Local Gateway IDs (e.g., LocalGatewayId)
+    if lower.contains("localgateway") && lower.ends_with("id") {
+        return ResourceIdKind::LocalGatewayId;
+    }
+    // Network ACL IDs (e.g., NetworkAclId)
+    if lower.contains("networkacl") && lower.ends_with("id") {
+        return ResourceIdKind::NetworkAclId;
+    }
     ResourceIdKind::Generic
 }
 
@@ -2618,6 +2651,13 @@ fn get_resource_id_type(prop_name: &str) -> &'static str {
         ResourceIdKind::TransitGatewayId => "super::transit_gateway_id()",
         ResourceIdKind::VpnGatewayId => "super::vpn_gateway_id()",
         ResourceIdKind::VpcEndpointId => "super::vpc_endpoint_id()",
+        ResourceIdKind::InstanceId => "super::instance_id()",
+        ResourceIdKind::NetworkInterfaceId => "super::network_interface_id()",
+        ResourceIdKind::AllocationId => "super::allocation_id()",
+        ResourceIdKind::PrefixListId => "super::prefix_list_id()",
+        ResourceIdKind::CarrierGatewayId => "super::carrier_gateway_id()",
+        ResourceIdKind::LocalGatewayId => "super::local_gateway_id()",
+        ResourceIdKind::NetworkAclId => "super::network_acl_id()",
         ResourceIdKind::Generic => "super::aws_resource_id()",
     }
 }

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -17,7 +17,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
         schema: ResourceSchema::new("aws.ec2.route")
         .with_description("Describes a route in a route table.")
         .attribute(
-            AttributeSchema::new("carrier_gateway_id", super::aws_resource_id())
+            AttributeSchema::new("carrier_gateway_id", super::carrier_gateway_id())
                 .with_description("The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.")
                 .with_provider_name("CarrierGatewayId"),
         )
@@ -39,7 +39,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
                 .with_provider_name("DestinationIpv6CidrBlock"),
         )
         .attribute(
-            AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
+            AttributeSchema::new("destination_prefix_list_id", super::prefix_list_id())
                 .create_only()
                 .with_description("The ID of a prefix list used for the destination match.")
                 .with_provider_name("DestinationPrefixListId"),
@@ -55,12 +55,12 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
                 .with_provider_name("GatewayId"),
         )
         .attribute(
-            AttributeSchema::new("instance_id", super::aws_resource_id())
+            AttributeSchema::new("instance_id", super::instance_id())
                 .with_description("The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.")
                 .with_provider_name("InstanceId"),
         )
         .attribute(
-            AttributeSchema::new("local_gateway_id", super::aws_resource_id())
+            AttributeSchema::new("local_gateway_id", super::local_gateway_id())
                 .with_description("The ID of the local gateway.")
                 .with_provider_name("LocalGatewayId"),
         )
@@ -70,7 +70,7 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
                 .with_provider_name("NatGatewayId"),
         )
         .attribute(
-            AttributeSchema::new("network_interface_id", super::aws_resource_id())
+            AttributeSchema::new("network_interface_id", super::network_interface_id())
                 .with_description("The ID of a network interface.")
                 .with_provider_name("NetworkInterfaceId"),
         )

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -62,7 +62,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                     .with_provider_name("Description"),
             )
             .attribute(
-                AttributeSchema::new("destination_prefix_list_id", super::aws_resource_id())
+                AttributeSchema::new("destination_prefix_list_id", super::prefix_list_id())
                     .create_only()
                     .with_description("The ID of the destination prefix list.")
                     .with_provider_name("DestinationPrefixListId"),
@@ -120,7 +120,7 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
                     .with_provider_name("SourceSecurityGroupName"),
             )
             .attribute(
-                AttributeSchema::new("source_security_group_owner_id", AttributeType::String)
+                AttributeSchema::new("source_security_group_owner_id", super::aws_account_id())
                     .create_only()
                     .with_description("Not supported. Use IP permissions instead.")
                     .with_provider_name("SourceSecurityGroupOwnerId"),

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -98,7 +98,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("IpProtocol"),
         )
         .attribute(
-            AttributeSchema::new("source_prefix_list_id", super::aws_resource_id())
+            AttributeSchema::new("source_prefix_list_id", super::prefix_list_id())
                 .create_only()
                 .with_description("The ID of the source prefix list.")
                 .with_provider_name("SourcePrefixListId"),
@@ -110,7 +110,7 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
                 .with_provider_name("SourceSecurityGroupName"),
         )
         .attribute(
-            AttributeSchema::new("source_security_group_owner_id", AttributeType::String)
+            AttributeSchema::new("source_security_group_owner_id", super::aws_account_id())
                 .create_only()
                 .with_description("The Amazon Web Services account ID for the source security group, if the source security group is in a different account. The rule grants full ICMP, U...")
                 .with_provider_name("SourceSecurityGroupOwnerId"),

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -17,7 +17,7 @@ pub fn sts_caller_identity_config() -> AwsSchemaConfig {
         schema: ResourceSchema::new("aws.sts.caller_identity")
         .as_data_source()
         .attribute(
-            AttributeSchema::new("account_id", AttributeType::String)
+            AttributeSchema::new("account_id", super::aws_account_id())
                 .with_description("The Amazon Web Services account ID number of the account that owns or contains the calling entity. (read-only)")
                 .with_provider_name("AccountId"),
         )

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -158,6 +158,7 @@ fn validate_aws_resource_id(id: &str) -> Result<(), String> {
 }
 
 /// AWS resource ID type (e.g., "vpc-1a2b3c4d", "subnet-0123456789abcdef0")
+#[allow(dead_code)]
 pub(crate) fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
         name: "AwsResourceId".to_string(),
@@ -376,6 +377,165 @@ pub(crate) fn vpc_endpoint_id() -> AttributeType {
         namespace: None,
         to_dsl: None,
     }
+}
+
+/// Instance ID type (e.g., "i-0123456789abcdef0")
+pub(crate) fn instance_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "InstanceId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "i")
+                    .map_err(|reason| format!("Invalid Instance ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Network Interface ID type (e.g., "eni-0123456789abcdef0")
+pub(crate) fn network_interface_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "NetworkInterfaceId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "eni")
+                    .map_err(|reason| format!("Invalid Network Interface ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// EIP Allocation ID type (e.g., "eipalloc-0123456789abcdef0")
+#[allow(dead_code)]
+pub(crate) fn allocation_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "AllocationId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "eipalloc")
+                    .map_err(|reason| format!("Invalid Allocation ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Prefix List ID type (e.g., "pl-0123456789abcdef0")
+pub(crate) fn prefix_list_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "PrefixListId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "pl")
+                    .map_err(|reason| format!("Invalid Prefix List ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
+pub(crate) fn carrier_gateway_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "CarrierGatewayId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "cagw")
+                    .map_err(|reason| format!("Invalid Carrier Gateway ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
+pub(crate) fn local_gateway_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "LocalGatewayId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "lgw")
+                    .map_err(|reason| format!("Invalid Local Gateway ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Network ACL ID type (e.g., "acl-0123456789abcdef0")
+#[allow(dead_code)]
+pub(crate) fn network_acl_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "NetworkAclId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_prefixed_resource_id(s, "acl")
+                    .map_err(|reason| format!("Invalid Network ACL ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
+pub(crate) fn aws_account_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "AwsAccountId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_aws_account_id(s)
+                    .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+fn validate_aws_account_id(id: &str) -> Result<(), String> {
+    if id.len() != 12 {
+        return Err(format!(
+            "must be exactly 12 digits, got {} characters",
+            id.len()
+        ));
+    }
+    if !id.chars().all(|c| c.is_ascii_digit()) {
+        return Err("must contain only digits".to_string());
+    }
+    Ok(())
 }
 
 /// Gateway ID type — union of InternetGatewayId and VpnGatewayId.

--- a/docs/src/providers/aws/ec2_route.md
+++ b/docs/src/providers/aws/ec2_route.md
@@ -8,7 +8,7 @@ Describes a route in a route table.
 
 ### `carrier_gateway_id`
 
-- **Type:** AwsResourceId
+- **Type:** CarrierGatewayId
 - **Required:** No
 
 The ID of the carrier gateway. You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone.
@@ -36,7 +36,7 @@ The IPv6 CIDR block used for the destination match. Routing decisions are based 
 
 ### `destination_prefix_list_id`
 
-- **Type:** AwsResourceId
+- **Type:** PrefixListId
 - **Required:** No
 
 The ID of a prefix list used for the destination match.
@@ -50,21 +50,21 @@ The ID of a prefix list used for the destination match.
 
 ### `gateway_id`
 
-- **Type:** AwsResourceId
+- **Type:** GatewayId
 - **Required:** No
 
 The ID of an internet gateway or virtual private gateway attached to your VPC.
 
 ### `instance_id`
 
-- **Type:** AwsResourceId
+- **Type:** InstanceId
 - **Required:** No
 
 The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached.
 
 ### `local_gateway_id`
 
-- **Type:** AwsResourceId
+- **Type:** LocalGatewayId
 - **Required:** No
 
 The ID of the local gateway.
@@ -78,7 +78,7 @@ The ID of the local gateway.
 
 ### `network_interface_id`
 
-- **Type:** AwsResourceId
+- **Type:** NetworkInterfaceId
 - **Required:** No
 
 The ID of a network interface.

--- a/docs/src/providers/aws/ec2_security_group_egress.md
+++ b/docs/src/providers/aws/ec2_security_group_egress.md
@@ -29,7 +29,7 @@ The security group rule description.
 
 ### `destination_prefix_list_id`
 
-- **Type:** AwsResourceId
+- **Type:** PrefixListId
 - **Required:** No
 
 The ID of the destination prefix list.
@@ -64,7 +64,7 @@ Not supported. Use IP permissions instead.
 
 ### `source_security_group_owner_id`
 
-- **Type:** String
+- **Type:** AwsAccountId
 - **Required:** No
 
 Not supported. Use IP permissions instead.

--- a/docs/src/providers/aws/ec2_security_group_ingress.md
+++ b/docs/src/providers/aws/ec2_security_group_ingress.md
@@ -57,7 +57,7 @@ The IP protocol name (tcp, udp, icmp) or number (see Protocol Numbers). To speci
 
 ### `source_prefix_list_id`
 
-- **Type:** AwsResourceId
+- **Type:** PrefixListId
 - **Required:** No
 
 The ID of the source prefix list.
@@ -71,7 +71,7 @@ The ID of the source prefix list.
 
 ### `source_security_group_owner_id`
 
-- **Type:** String
+- **Type:** AwsAccountId
 - **Required:** No
 
 The Amazon Web Services account ID for the source security group, if the source security group is in a different account. The rule grants full ICMP, UDP, and TCP access. To create a rule with a specific protocol and port range, use IP permissions instead.

--- a/docs/src/providers/aws/sts_caller_identity.md
+++ b/docs/src/providers/aws/sts_caller_identity.md
@@ -6,7 +6,7 @@ CloudFormation Type: `AWS::STS::CallerIdentity`
 
 ### `account_id`
 
-- **Type:** String
+- **Type:** AwsAccountId
 
 ### `arn`
 


### PR DESCRIPTION
## Summary

- Port type inference improvements from the awscc codegen (#509) to the smithy-codegen
- Add 7 new specific resource ID types: `InstanceId`, `NetworkInterfaceId`, `AllocationId`, `PrefixListId`, `CarrierGatewayId`, `LocalGatewayId`, `NetworkAclId`
- Add `AwsAccountId` detection for `*OwnerId` properties and `AccountId`
- Consolidate scattered CIDR/IP/AZ/IPAM detection into `infer_string_type()`, removing duplicated logic from call sites
- Fix `DefaultNetworkAcl` override to use `network_acl_id()` instead of `aws_resource_id()`
- Regenerate all aws provider schemas and documentation

### Schema changes

| Resource | Attribute | Before | After |
|----------|-----------|--------|-------|
| ec2.security_group_egress | source_security_group_owner_id | String | AwsAccountId |
| ec2.security_group_ingress | source_security_group_owner_id | String | AwsAccountId |
| sts.caller_identity | account_id | String | AwsAccountId |
| ec2.route | carrier_gateway_id | AwsResourceId | CarrierGatewayId |
| ec2.route | destination_prefix_list_id | AwsResourceId | PrefixListId |
| ec2.route | instance_id | AwsResourceId | InstanceId |
| ec2.route | local_gateway_id | AwsResourceId | LocalGatewayId |
| ec2.route | network_interface_id | AwsResourceId | NetworkInterfaceId |
| ec2.security_group_egress | destination_prefix_list_id | AwsResourceId | PrefixListId |
| ec2.security_group_ingress | source_prefix_list_id | AwsResourceId | PrefixListId |

## Test plan

- [x] `cargo build -p carina-codegen-aws` passes
- [x] `cargo test -p carina-codegen-aws` passes
- [x] `cargo test -p carina-provider-aws` passes
- [x] `cargo test` (full workspace) passes
- [x] Pre-commit checks (formatting + clippy) pass
- [x] Schemas regenerated and verified
- [x] Documentation regenerated and verified

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)