### PR TITLE
feat: add acceptance test for ec2.transit_gateway_attachment

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -1,0 +1,31 @@
+# EC2 Transit Gateway Attachment - Basic test
+#
+# Tests: subnet_ids, transit_gateway_id, vpc_id
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "Acceptance test Transit Gateway"
+}
+
+let tgw_attachment = awscc.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}


### PR DESCRIPTION
## Summary

- Add acceptance test for `ec2.transit_gateway_attachment` resource (closes #522)
- Test creates VPC, subnet, transit gateway, and transit gateway attachment connecting them
- Brings acceptance test coverage to 100% (24/24 AWSCC resources)

## Test plan

- [ ] Run `run-tests.sh full` with `ec2_transit_gateway_attachment` filter to verify create/plan-verify/destroy cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)