### PR TITLE
fix: remove unnecessary let bindings in acceptance tests

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -20,7 +20,7 @@ let dest_sg = awscc.ec2.security_group {
   group_description = "Destination security group"
 }
 
-let egress = awscc.ec2.security_group_egress {
+awscc.ec2.security_group_egress {
   group_id                     = source_sg.group_id
   description                  = "Allow HTTPS to destination SG"
   ip_protocol                  = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -24,7 +24,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for VPC Endpoint"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"
@@ -33,7 +33,7 @@ let ingress = awscc.ec2.security_group_ingress {
   cidr_ip     = "10.0.0.0/16"
 }
 
-let vpc_endpoint = awscc.ec2.vpc_endpoint {
+awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
   vpc_endpoint_type   = Interface


### PR DESCRIPTION
## Summary
- Remove unused `let` bindings in acceptance test `.crn` files, converting them to anonymous resources
- `ec2_security_group_egress/dest_sg.crn`: `egress` binding was unused
- `ec2_vpc_endpoint/interface.crn`: `ingress` and `vpc_endpoint` bindings were unused

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)