### PR TITLE
fix: remove unused let bindings in remaining acceptance tests

### DIFF
--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.200.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.201.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let role = awscc.iam.role {
+awscc.iam.role {
   role_name = "carina-acc-test-cbd-role"
   path      = "/"
 

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -11,7 +11,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let role = awscc.iam.role {
+awscc.iam.role {
   role_name = "carina-acc-test-cbd-role"
   path      = "/carina/"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let eoigw = awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_eip/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_eip/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let eip = awscc.ec2.eip {
+awscc.ec2.eip {
   domain = "vpc"
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -30,7 +30,7 @@ let flow_log_role = awscc.iam.role {
   }
 }
 
-let flow_log = awscc.ec2.flow_log {
+awscc.ec2.flow_log {
   resource_id                 = vpc.vpc_id
   resource_type               = VPC
   traffic_type                = ALL

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/s3.crn
@@ -17,7 +17,7 @@ let bucket = awscc.s3.bucket {
   }
 }
 
-let flow_log = awscc.ec2.flow_log {
+awscc.ec2.flow_log {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/carina-provider-awscc/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let igw = awscc.ec2.internet_gateway {
+awscc.ec2.internet_gateway {
   tags = {
     Environment = "acceptance-test"
   }

--- a/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_ipam/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+awscc.ec2.ipam {
   tier        = advanced
   description = "Acceptance test IPAM"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -17,7 +17,7 @@ let ipam = awscc.ec2.ipam {
   ]
 }
 
-let ipam_pool = awscc.ec2.ipam_pool {
+awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = "IPv4"
   locale         = "ap-northeast-1"

--- a/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/private.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/private.crn
@@ -16,7 +16,7 @@ let private_subnet = awscc.ec2.subnet {
   availability_zone = "ap-northeast-1a"
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+awscc.ec2.nat_gateway {
   subnet_id          = private_subnet.subnet_id
   connectivity_type  = private
   private_ip_address = "10.0.1.100"

--- a/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_nat_gateway/public.crn
@@ -15,7 +15,7 @@ let vpc = awscc.ec2.vpc {
 let igw = awscc.ec2.internet_gateway {
 }
 
-let igw_attach = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
@@ -31,7 +31,7 @@ let eip = awscc.ec2.eip {
   domain = "vpc"
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+awscc.ec2.nat_gateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/carina-provider-awscc/acceptance-tests/ec2_route/igw.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/igw.crn
@@ -22,7 +22,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw_attachment.internet_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/ipv6.crn
@@ -19,7 +19,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id                  = rt.route_table_id
   destination_ipv6_cidr_block     = "::/0"
   egress_only_internet_gateway_id = eoigw.id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/nat_gateway.crn
@@ -15,7 +15,7 @@ let vpc = awscc.ec2.vpc {
 let igw = awscc.ec2.internet_gateway {
 }
 
-let igw_attach = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
@@ -40,7 +40,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/transit_gateway.crn
@@ -31,7 +31,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "10.1.0.0/16"
   transit_gateway_id     = tgw_attach.transit_gateway_id

--- a/carina-provider-awscc/acceptance-tests/ec2_route/vpc_peering.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route/vpc_peering.crn
@@ -24,7 +24,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc1.vpc_id
 }
 
-let route = awscc.ec2.route {
+awscc.ec2.route {
   route_table_id             = rt.route_table_id
   destination_cidr_block     = "10.1.0.0/16"
   vpc_peering_connection_id  = peering.id

--- a/carina-provider-awscc/acceptance-tests/ec2_route_table/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_route_table/basic.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let rt = awscc.ec2.route_table {
+awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - IPv6 rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/prefix.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/prefix.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id             = vpc.vpc_id
   group_description  = "Acceptance test - group_name_prefix"
   group_name_prefix  = "carina-acc-test-"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_egress.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - egress rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let sg = awscc.ec2.security_group {
+awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
   group_description = "Acceptance test - ingress rules"
 

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -15,7 +15,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for egress rule test"
 }
 
-let egress = awscc.ec2.security_group_egress {
+awscc.ec2.security_group_egress {
   group_id    = sg.group_id
   description = "Allow all outbound"
   ip_protocol = all

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -15,7 +15,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for IPv6 egress rule test"
 }
 
-let egress = awscc.ec2.security_group_egress {
+awscc.ec2.security_group_egress {
   group_id    = sg.group_id
   description = "Allow all IPv6 outbound"
   ip_protocol = all

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -15,7 +15,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for ingress rule test"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -15,7 +15,7 @@ let sg = awscc.ec2.security_group {
   group_description = "SG for IPv6 ingress rule test"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from IPv6"
   ip_protocol = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -20,7 +20,7 @@ let dest_sg = awscc.ec2.security_group {
   group_description = "Destination security group"
 }
 
-let ingress = awscc.ec2.security_group_ingress {
+awscc.ec2.security_group_ingress {
   group_id                 = dest_sg.group_id
   description              = "Allow HTTPS from source SG"
   ip_protocol              = "tcp"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/basic.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = "10.0.1.0/24"
   availability_zone       = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/ipv6.crn
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = "10.0.0.0/16"
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id                          = vpc.vpc_id
   cidr_block                      = "10.0.1.0/24"
   availability_zone               = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -71,7 +71,7 @@ let vpc_pool = awscc.ec2.ipam_pool {
   ]
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id              = vpc.vpc_id
   ipv4_ipam_pool_id   = vpc_pool.ipam_pool_id
   ipv4_netmask_length = 24

--- a/carina-provider-awscc/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -20,7 +20,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let rt_assoc = awscc.ec2.subnet_route_table_association {
+awscc.ec2.subnet_route_table_association {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let tgw = awscc.ec2.transit_gateway {
+awscc.ec2.transit_gateway {
   description = "Acceptance test Transit Gateway"
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -20,7 +20,7 @@ let tgw = awscc.ec2.transit_gateway {
   description = "Acceptance test Transit Gateway"
 }
 
-let tgw_attachment = awscc.ec2.transit_gateway_attachment {
+awscc.ec2.transit_gateway_attachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -14,7 +14,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 }
 
-let vpc_endpoint = awscc.ec2.vpc_endpoint {
+awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = Gateway

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
@@ -13,7 +13,7 @@ let vpc = awscc.ec2.vpc {
 let igw = awscc.ec2.internet_gateway {
 }
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -15,7 +15,7 @@ let vpn_gw = awscc.ec2.vpn_gateway {
   type = "ipsec.1"
 }
 
-let vpn_attachment = awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.vpc_gateway_attachment {
   vpc_id         = vpc.vpc_id
   vpn_gateway_id = vpn_gw.vpn_gateway_id
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -14,7 +14,7 @@ let vpc2 = awscc.ec2.vpc {
   cidr_block = "10.1.0.0/16"
 }
 
-let peering = awscc.ec2.vpc_peering_connection {
+awscc.ec2.vpc_peering_connection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/carina-provider-awscc/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpn_gw = awscc.ec2.vpn_gateway {
+awscc.ec2.vpn_gateway {
   type = "ipsec.1"
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/iam_role/prefix.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let role = awscc.iam.role {
+awscc.iam.role {
   role_name_prefix = "carina-acc-test-"
 
   assume_role_policy_document = {

--- a/carina-provider-awscc/acceptance-tests/iam_role/with_path.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/with_path.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let role = awscc.iam.role {
+awscc.iam.role {
   role_name_prefix = "carina-acc-test-"
   path             = "/carina/acceptance-test/"
 

--- a/carina-provider-awscc/acceptance-tests/iam_role/with_policy.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/with_policy.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let role = awscc.iam.role {
+awscc.iam.role {
   role_name_prefix = "carina-acc-test-"
   description          = "Carina acceptance test role with inline policy"
   max_session_duration = 7200

--- a/carina-provider-awscc/acceptance-tests/in_place_update/logs_log_group_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/logs_log_group_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_group = awscc.logs.log_group {
+awscc.logs.log_group {
   log_group_name_prefix = "/carina/acc-test-update-"
   retention_in_days     = 7
 

--- a/carina-provider-awscc/acceptance-tests/in_place_update/logs_log_group_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/logs_log_group_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_group = awscc.logs.log_group {
+awscc.logs.log_group {
   log_group_name_prefix = "/carina/acc-test-update-"
   retention_in_days     = 14
 

--- a/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-update-"
 
   versioning_configuration = {

--- a/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-update-"
 
   versioning_configuration = {

--- a/carina-provider-awscc/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/carina-provider-awscc/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_group = awscc.logs.log_group {
+awscc.logs.log_group {
   log_group_name_prefix = "/carina/acc-test-"
   log_group_class       = awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS
   retention_in_days     = 1

--- a/carina-provider-awscc/acceptance-tests/logs_log_group/prefix.crn
+++ b/carina-provider-awscc/acceptance-tests/logs_log_group/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_group = awscc.logs.log_group {
+awscc.logs.log_group {
   log_group_name_prefix = "/carina/acc-test-"
   retention_in_days     = 1
 }

--- a/carina-provider-awscc/acceptance-tests/logs_log_group/retention.crn
+++ b/carina-provider-awscc/acceptance-tests/logs_log_group/retention.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_group = awscc.logs.log_group {
+awscc.logs.log_group {
   log_group_name_prefix = "/carina/acc-test-"
   retention_in_days     = 7
 

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
@@ -9,7 +9,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   bucket_encryption = {

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/prefix.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   lifecycle {

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/public_access_block.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   public_access_block_configuration = {

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let bucket = awscc.s3.bucket {
+awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   versioning_configuration = {


### PR DESCRIPTION
## Summary
- Remove unused `let` bindings in 55 acceptance test `.crn` files, converting them to anonymous resources
- Covers all files identified in #532 that were not addressed by #531

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)