### PR TITLE
fix: namespace definition-scoped enums by parent struct in codegen

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -570,9 +570,14 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
         let aliases = known_enum_aliases();
         md.push_str("## Enum Values\n\n");
         for (prop_name, enum_info) in &enums {
-            let attr_name = prop_name.to_snake_case();
+            // For composite keys "DefName.FieldName", use just "FieldName" for display
+            let field_name = prop_name
+                .split('.')
+                .next_back()
+                .unwrap_or(prop_name.as_str());
+            let attr_name = field_name.to_snake_case();
             let has_hyphens = enum_info.values.iter().any(|v| v.contains('-'));
-            let prop_aliases = aliases.get(prop_name.as_str());
+            let prop_aliases = aliases.get(field_name);
             md.push_str(&format!("### {} ({})\n\n", attr_name, enum_info.type_name));
             md.push_str("| Value | DSL Identifier |\n");
             md.push_str("|-------|----------------|\n");
@@ -874,24 +879,27 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
     }
 
     // Also scan definitions for struct field enum properties
+    // Use composite key "DefName.FieldName" to avoid conflicts when different
+    // definitions have fields with the same name but different enum values
+    // (e.g., IntelligentTieringConfiguration.Status vs VersioningConfiguration.Status)
     if let Some(definitions) = &schema.definitions {
-        // Build set of existing snake_case names to avoid duplicates
+        // Build set of existing snake_case names from top-level properties
         // (e.g., "SSEAlgorithm" and "SseAlgorithm" both become "sse_algorithm")
         let existing_snake: HashSet<String> = enums.keys().map(|k| k.to_snake_case()).collect();
-        let mut seen_snake: HashSet<String> = existing_snake;
-        for def in definitions.values() {
+        for (def_name, def) in definitions {
             if let Some(props) = &def.properties {
                 for (field_name, field_prop) in props {
                     let snake = field_name.to_snake_case();
-                    if seen_snake.contains(&snake) {
+                    // Skip if a top-level property with the same snake_case name exists
+                    if existing_snake.contains(&snake) {
                         continue;
                     }
                     let (_, field_enum_info) = cfn_type_to_carina_type_with_enum(
                         field_prop, field_name, schema, &namespace, &enums,
                     );
                     if let Some(info) = field_enum_info {
-                        seen_snake.insert(snake);
-                        enums.insert(field_name.clone(), info);
+                        let composite_key = format!("{}.{}", def_name, field_name);
+                        enums.insert(composite_key, info);
                     }
                 }
             }
@@ -952,6 +960,11 @@ use super::AwsccSchemaConfig;
     // Constants are always emitted (referenced by enum_valid_values()).
     let aliases = known_enum_aliases();
     for (prop_name, enum_info) in &enums {
+        // For composite keys like "DefName.FieldName", extract just "FieldName" for alias lookup
+        let field_name = prop_name
+            .split('.')
+            .next_back()
+            .unwrap_or(prop_name.as_str());
         let const_name = format!("VALID_{}", prop_name.to_snake_case().to_uppercase());
 
         // Generate constant (including alias values) - always emitted
@@ -960,7 +973,7 @@ use super::AwsccSchemaConfig;
             .iter()
             .map(|v| format!("\"{}\"", v))
             .collect();
-        if let Some(prop_aliases) = aliases.get(prop_name.as_str()) {
+        if let Some(prop_aliases) = aliases.get(field_name) {
             for (_, alias) in prop_aliases {
                 all_values.push(format!("\"{}\"", alias));
             }
@@ -1195,8 +1208,15 @@ pub fn {}() -> AwsccSchemaConfig {{
             let entries: Vec<String> = enums
                 .keys()
                 .map(|prop_name| {
-                    let attr_name = prop_name.to_snake_case();
-                    let const_name = format!("VALID_{}", attr_name.to_uppercase());
+                    // For composite keys "DefName.FieldName", use just "FieldName" for attribute name
+                    let field_name = prop_name
+                        .split('.')
+                        .next_back()
+                        .unwrap_or(prop_name.as_str());
+                    let attr_name = field_name.to_snake_case();
+                    // Constant name uses the full composite key for uniqueness
+                    let const_name =
+                        format!("VALID_{}", prop_name.to_snake_case().to_uppercase());
                     format!("        (\"{}\", {}),", attr_name, const_name)
                 })
                 .collect();
@@ -1211,14 +1231,23 @@ pub fn {}() -> AwsccSchemaConfig {{
     // Generate enum_alias_reverse() function that maps DSL alias -> canonical AWS value
     {
         let mut match_arms: Vec<String> = Vec::new();
+        let mut seen_arms: HashSet<String> = HashSet::new();
         for prop_name in enums.keys() {
-            if let Some(prop_aliases) = aliases.get(prop_name.as_str()) {
-                let attr_name = prop_name.to_snake_case();
+            // For composite keys "DefName.FieldName", use just "FieldName" for alias lookup
+            let field_name = prop_name
+                .split('.')
+                .next_back()
+                .unwrap_or(prop_name.as_str());
+            if let Some(prop_aliases) = aliases.get(field_name) {
+                let attr_name = field_name.to_snake_case();
                 for (canonical, alias) in prop_aliases {
-                    match_arms.push(format!(
+                    let arm = format!(
                         "        (\"{}\", \"{}\") => Some(\"{}\")",
                         attr_name, alias, canonical
-                    ));
+                    );
+                    if seen_arms.insert(arm.clone()) {
+                        match_arms.push(arm);
+                    }
                 }
             }
         }
@@ -1418,8 +1447,12 @@ fn generate_struct_type(
             let (field_type, enum_info) =
                 cfn_type_to_carina_type_with_enum(field_prop, field_name, schema, namespace, enums);
             // If enum detected in struct field and it's in the enums map, use shared string enum type.
+            // Try composite key "DefName.FieldName" first (for definition-scoped enums),
+            // then fall back to plain "FieldName" (for top-level property enums).
             let field_type = if let Some(local_enum_info) = enum_info {
-                if let Some(enum_info) = enums.get(field_name) {
+                let composite_key = format!("{}.{}", def_name, field_name);
+                if let Some(enum_info) = enums.get(&composite_key).or_else(|| enums.get(field_name))
+                {
                     let prop_aliases = aliases.get(field_name.as_str());
                     let has_hyphens = enum_info.values.iter().any(|v| v.contains('-'));
                     let to_dsl_code = if let Some(alias_list) = prop_aliases {

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -9,7 +9,9 @@ use super::tags_type;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField, types};
 
-const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+const VALID_EGRESS_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
+
+const VALID_INGRESS_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
     if let Value::Int(n) = value {
@@ -155,7 +157,13 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.security_group", &[("ip_protocol", VALID_IP_PROTOCOL)])
+    (
+        "ec2.security_group",
+        &[
+            ("ip_protocol", VALID_EGRESS_IP_PROTOCOL),
+            ("ip_protocol", VALID_INGRESS_IP_PROTOCOL),
+        ],
+    )
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
-const VALID_DNS_RECORD_IP_TYPE: &[&str] = &[
+const VALID_DNS_OPTIONS_SPECIFICATION_DNS_RECORD_IP_TYPE: &[&str] = &[
     "ipv4",
     "ipv6",
     "dualstack",
@@ -16,17 +16,17 @@ const VALID_DNS_RECORD_IP_TYPE: &[&str] = &[
     "not-specified",
 ];
 
-const VALID_IP_ADDRESS_TYPE: &[&str] = &["ipv4", "ipv6", "dualstack", "not-specified"];
-
-const VALID_PRIVATE_DNS_ONLY_FOR_INBOUND_RESOLVER_ENDPOINT: &[&str] =
+const VALID_DNS_OPTIONS_SPECIFICATION_PRIVATE_DNS_ONLY_FOR_INBOUND_RESOLVER_ENDPOINT: &[&str] =
     &["OnlyInboundResolver", "AllResolvers", "NotSpecified"];
 
-const VALID_PRIVATE_DNS_PREFERENCE: &[&str] = &[
+const VALID_DNS_OPTIONS_SPECIFICATION_PRIVATE_DNS_PREFERENCE: &[&str] = &[
     "VERIFIED_DOMAINS_ONLY",
     "ALL_DOMAINS",
     "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS",
     "SPECIFIED_DOMAINS_ONLY",
 ];
+
+const VALID_IP_ADDRESS_TYPE: &[&str] = &["ipv4", "ipv6", "dualstack", "not-specified"];
 
 const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "Interface",
@@ -185,13 +185,19 @@ pub fn enum_valid_values() -> (
     (
         "ec2.vpc_endpoint",
         &[
-            ("dns_record_ip_type", VALID_DNS_RECORD_IP_TYPE),
-            ("ip_address_type", VALID_IP_ADDRESS_TYPE),
+            (
+                "dns_record_ip_type",
+                VALID_DNS_OPTIONS_SPECIFICATION_DNS_RECORD_IP_TYPE,
+            ),
             (
                 "private_dns_only_for_inbound_resolver_endpoint",
-                VALID_PRIVATE_DNS_ONLY_FOR_INBOUND_RESOLVER_ENDPOINT,
+                VALID_DNS_OPTIONS_SPECIFICATION_PRIVATE_DNS_ONLY_FOR_INBOUND_RESOLVER_ENDPOINT,
             ),
-            ("private_dns_preference", VALID_PRIVATE_DNS_PREFERENCE),
+            (
+                "private_dns_preference",
+                VALID_DNS_OPTIONS_SPECIFICATION_PRIVATE_DNS_PREFERENCE,
+            ),
+            ("ip_address_type", VALID_IP_ADDRESS_TYPE),
             ("vpc_endpoint_type", VALID_VPC_ENDPOINT_TYPE),
         ],
     )

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -10,7 +10,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, Struct
 
 const VALID_ABAC_STATUS: &[&str] = &["Enabled", "Disabled"];
 
-const VALID_ACCELERATION_STATUS: &[&str] = &["Enabled", "Suspended"];
+const VALID_ACCELERATE_CONFIGURATION_ACCELERATION_STATUS: &[&str] = &["Enabled", "Suspended"];
 
 const VALID_ACCESS_CONTROL: &[&str] = &[
     "AuthenticatedRead",
@@ -23,37 +23,30 @@ const VALID_ACCESS_CONTROL: &[&str] = &[
     "PublicReadWrite",
 ];
 
-const VALID_ACCESS_TIER: &[&str] = &["ARCHIVE_ACCESS", "DEEP_ARCHIVE_ACCESS"];
+const VALID_DEFAULT_RETENTION_MODE: &[&str] = &["COMPLIANCE", "GOVERNANCE"];
 
-const VALID_CONFIGURATION_STATE: &[&str] = &["ENABLED", "DISABLED"];
+const VALID_DELETE_MARKER_REPLICATION_STATUS: &[&str] = &["Disabled", "Enabled"];
 
-const VALID_EXPIRATION: &[&str] = &["ENABLED", "DISABLED"];
+const VALID_DESTINATION_FORMAT: &[&str] = &["CSV", "ORC", "Parquet"];
 
-const VALID_FORMAT: &[&str] = &["CSV", "ORC", "Parquet"];
+const VALID_INTELLIGENT_TIERING_CONFIGURATION_STATUS: &[&str] = &["Disabled", "Enabled"];
 
-const VALID_INCLUDED_OBJECT_VERSIONS: &[&str] = &["All", "Current"];
+const VALID_INVENTORY_CONFIGURATION_INCLUDED_OBJECT_VERSIONS: &[&str] = &["All", "Current"];
 
-const VALID_MODE: &[&str] = &["COMPLIANCE", "GOVERNANCE"];
+const VALID_INVENTORY_CONFIGURATION_SCHEDULE_FREQUENCY: &[&str] = &["Daily", "Weekly"];
 
-const VALID_OBJECT_OWNERSHIP: &[&str] = &[
-    "ObjectWriter",
-    "BucketOwnerPreferred",
-    "BucketOwnerEnforced",
-];
+const VALID_INVENTORY_TABLE_CONFIGURATION_CONFIGURATION_STATE: &[&str] = &["ENABLED", "DISABLED"];
 
-const VALID_PARTITION_DATE_SOURCE: &[&str] = &["EventTime", "DeliveryTime"];
+const VALID_LIFECYCLE_CONFIGURATION_TRANSITION_DEFAULT_MINIMUM_OBJECT_SIZE: &[&str] =
+    &["varies_by_storage_class", "all_storage_classes_128K"];
 
-const VALID_PROTOCOL: &[&str] = &["http", "https"];
+const VALID_METADATA_DESTINATION_TABLE_BUCKET_TYPE: &[&str] = &["aws", "customer"];
 
-const VALID_REPLACE_KEY_PREFIX_WITH: &[&str] = &["docs/", "documents/", "/documents"];
+const VALID_METADATA_TABLE_ENCRYPTION_CONFIGURATION_SSE_ALGORITHM: &[&str] = &["aws:kms", "AES256"];
 
-const VALID_SCHEDULE_FREQUENCY: &[&str] = &["Daily", "Weekly"];
+const VALID_METRICS_STATUS: &[&str] = &["Disabled", "Enabled"];
 
-const VALID_SSE_ALGORITHM: &[&str] = &["aws:kms", "AES256"];
-
-const VALID_STATUS: &[&str] = &["Disabled", "Enabled"];
-
-const VALID_STORAGE_CLASS: &[&str] = &[
+const VALID_NONCURRENT_VERSION_TRANSITION_STORAGE_CLASS: &[&str] = &[
     "DEEP_ARCHIVE",
     "GLACIER",
     "Glacier",
@@ -63,10 +56,59 @@ const VALID_STORAGE_CLASS: &[&str] = &[
     "STANDARD_IA",
 ];
 
-const VALID_TABLE_BUCKET_TYPE: &[&str] = &["aws", "customer"];
+const VALID_OWNERSHIP_CONTROLS_RULE_OBJECT_OWNERSHIP: &[&str] = &[
+    "ObjectWriter",
+    "BucketOwnerPreferred",
+    "BucketOwnerEnforced",
+];
 
-const VALID_TRANSITION_DEFAULT_MINIMUM_OBJECT_SIZE: &[&str] =
-    &["varies_by_storage_class", "all_storage_classes_128K"];
+const VALID_PARTITIONED_PREFIX_PARTITION_DATE_SOURCE: &[&str] = &["EventTime", "DeliveryTime"];
+
+const VALID_RECORD_EXPIRATION_EXPIRATION: &[&str] = &["ENABLED", "DISABLED"];
+
+const VALID_REDIRECT_ALL_REQUESTS_TO_PROTOCOL: &[&str] = &["http", "https"];
+
+const VALID_REDIRECT_RULE_PROTOCOL: &[&str] = &["http", "https"];
+
+const VALID_REDIRECT_RULE_REPLACE_KEY_PREFIX_WITH: &[&str] = &["docs/", "documents/", "/documents"];
+
+const VALID_REPLICA_MODIFICATIONS_STATUS: &[&str] = &["Enabled", "Disabled"];
+
+const VALID_REPLICATION_DESTINATION_STORAGE_CLASS: &[&str] = &[
+    "DEEP_ARCHIVE",
+    "GLACIER",
+    "GLACIER_IR",
+    "INTELLIGENT_TIERING",
+    "ONEZONE_IA",
+    "REDUCED_REDUNDANCY",
+    "STANDARD",
+    "STANDARD_IA",
+];
+
+const VALID_REPLICATION_RULE_STATUS: &[&str] = &["Disabled", "Enabled"];
+
+const VALID_REPLICATION_TIME_STATUS: &[&str] = &["Disabled", "Enabled"];
+
+const VALID_RULE_STATUS: &[&str] = &["Enabled", "Disabled"];
+
+const VALID_SERVER_SIDE_ENCRYPTION_BY_DEFAULT_SSE_ALGORITHM: &[&str] =
+    &["aws:kms", "AES256", "aws:kms:dsse"];
+
+const VALID_SSE_KMS_ENCRYPTED_OBJECTS_STATUS: &[&str] = &["Disabled", "Enabled"];
+
+const VALID_TIERING_ACCESS_TIER: &[&str] = &["ARCHIVE_ACCESS", "DEEP_ARCHIVE_ACCESS"];
+
+const VALID_TRANSITION_STORAGE_CLASS: &[&str] = &[
+    "DEEP_ARCHIVE",
+    "GLACIER",
+    "Glacier",
+    "GLACIER_IR",
+    "INTELLIGENT_TIERING",
+    "ONEZONE_IA",
+    "STANDARD_IA",
+];
+
+const VALID_VERSIONING_CONFIGURATION_STATUS: &[&str] = &["Enabled", "Suspended"];
 
 /// Returns the schema config for s3_bucket (AWS::S3::Bucket)
 pub fn s3_bucket_config() -> AwsccSchemaConfig {
@@ -172,7 +214,12 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "ServerSideEncryptionByDefault".to_string(),
                     fields: vec![
                     StructField::new("kms_master_key_id", super::kms_key_id()).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *General purpose buckets* - This parameter is allowed if...").with_provider_name("KMSMasterKeyID"),
-                    StructField::new("sse_algorithm", AttributeType::Enum(vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()])).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encrypt...").with_provider_name("SSEAlgorithm")
+                    StructField::new("sse_algorithm", AttributeType::StringEnum {
+                name: "SseAlgorithm".to_string(),
+                values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
+                namespace: Some("awscc.s3.bucket".to_string()),
+                to_dsl: None,
+            }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encrypt...").with_provider_name("SSEAlgorithm")
                     ],
                 }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption...").with_provider_name("ServerSideEncryptionByDefault")
                     ],
@@ -345,7 +392,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("prefix", AttributeType::String).with_description("Object key prefix that identifies one or more objects to which this rule applies. Replacement must be made for object keys containing special characte...").with_provider_name("Prefix"),
                     StructField::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
-                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                values: vec!["Enabled".to_string(), "Disabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied.").with_provider_name("Status"),
@@ -757,7 +804,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).with_description("A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time when all objects and operations on objec...").with_provider_name("ReplicationTime"),
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "StorageClass".to_string(),
-                values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "Glacier".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
+                values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
             }).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the sour...").with_provider_name("StorageClass")
@@ -788,7 +835,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
-                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                values: vec!["Enabled".to_string(), "Disabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
@@ -831,7 +878,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
-                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                values: vec!["Enabled".to_string(), "Suspended".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The versioning state of the bucket.").with_provider_name("Status")
@@ -913,27 +960,72 @@ pub fn enum_valid_values() -> (
         "s3.bucket",
         &[
             ("abac_status", VALID_ABAC_STATUS),
-            ("acceleration_status", VALID_ACCELERATION_STATUS),
+            (
+                "acceleration_status",
+                VALID_ACCELERATE_CONFIGURATION_ACCELERATION_STATUS,
+            ),
             ("access_control", VALID_ACCESS_CONTROL),
-            ("access_tier", VALID_ACCESS_TIER),
-            ("configuration_state", VALID_CONFIGURATION_STATE),
-            ("expiration", VALID_EXPIRATION),
-            ("format", VALID_FORMAT),
-            ("included_object_versions", VALID_INCLUDED_OBJECT_VERSIONS),
-            ("mode", VALID_MODE),
-            ("object_ownership", VALID_OBJECT_OWNERSHIP),
-            ("partition_date_source", VALID_PARTITION_DATE_SOURCE),
-            ("protocol", VALID_PROTOCOL),
-            ("replace_key_prefix_with", VALID_REPLACE_KEY_PREFIX_WITH),
-            ("schedule_frequency", VALID_SCHEDULE_FREQUENCY),
-            ("sse_algorithm", VALID_SSE_ALGORITHM),
-            ("status", VALID_STATUS),
-            ("storage_class", VALID_STORAGE_CLASS),
-            ("table_bucket_type", VALID_TABLE_BUCKET_TYPE),
+            ("mode", VALID_DEFAULT_RETENTION_MODE),
+            ("status", VALID_DELETE_MARKER_REPLICATION_STATUS),
+            ("format", VALID_DESTINATION_FORMAT),
+            ("status", VALID_INTELLIGENT_TIERING_CONFIGURATION_STATUS),
+            (
+                "included_object_versions",
+                VALID_INVENTORY_CONFIGURATION_INCLUDED_OBJECT_VERSIONS,
+            ),
+            (
+                "schedule_frequency",
+                VALID_INVENTORY_CONFIGURATION_SCHEDULE_FREQUENCY,
+            ),
+            (
+                "configuration_state",
+                VALID_INVENTORY_TABLE_CONFIGURATION_CONFIGURATION_STATE,
+            ),
             (
                 "transition_default_minimum_object_size",
-                VALID_TRANSITION_DEFAULT_MINIMUM_OBJECT_SIZE,
+                VALID_LIFECYCLE_CONFIGURATION_TRANSITION_DEFAULT_MINIMUM_OBJECT_SIZE,
             ),
+            (
+                "table_bucket_type",
+                VALID_METADATA_DESTINATION_TABLE_BUCKET_TYPE,
+            ),
+            (
+                "sse_algorithm",
+                VALID_METADATA_TABLE_ENCRYPTION_CONFIGURATION_SSE_ALGORITHM,
+            ),
+            ("status", VALID_METRICS_STATUS),
+            (
+                "storage_class",
+                VALID_NONCURRENT_VERSION_TRANSITION_STORAGE_CLASS,
+            ),
+            (
+                "object_ownership",
+                VALID_OWNERSHIP_CONTROLS_RULE_OBJECT_OWNERSHIP,
+            ),
+            (
+                "partition_date_source",
+                VALID_PARTITIONED_PREFIX_PARTITION_DATE_SOURCE,
+            ),
+            ("expiration", VALID_RECORD_EXPIRATION_EXPIRATION),
+            ("protocol", VALID_REDIRECT_ALL_REQUESTS_TO_PROTOCOL),
+            ("protocol", VALID_REDIRECT_RULE_PROTOCOL),
+            (
+                "replace_key_prefix_with",
+                VALID_REDIRECT_RULE_REPLACE_KEY_PREFIX_WITH,
+            ),
+            ("status", VALID_REPLICA_MODIFICATIONS_STATUS),
+            ("storage_class", VALID_REPLICATION_DESTINATION_STORAGE_CLASS),
+            ("status", VALID_REPLICATION_RULE_STATUS),
+            ("status", VALID_REPLICATION_TIME_STATUS),
+            ("status", VALID_RULE_STATUS),
+            (
+                "sse_algorithm",
+                VALID_SERVER_SIDE_ENCRYPTION_BY_DEFAULT_SSE_ALGORITHM,
+            ),
+            ("status", VALID_SSE_KMS_ENCRYPTED_OBJECTS_STATUS),
+            ("access_tier", VALID_TIERING_ACCESS_TIER),
+            ("storage_class", VALID_TRANSITION_STORAGE_CLASS),
+            ("status", VALID_VERSIONING_CONFIGURATION_STATUS),
         ],
     )
 }


### PR DESCRIPTION
## Summary

- Fix codegen enum deduplication bug where different CloudFormation definitions with same-named fields but different enum values would shadow each other (e.g., `IntelligentTieringConfiguration.Status` with `["Disabled", "Enabled"]` shadowed `VersioningConfiguration.Status` with `["Enabled", "Suspended"]`)
- Use composite keys `DefName.FieldName` for definition-scoped enums so each struct gets its own correct enum values
- Regenerate all affected schemas (s3/bucket, ec2/security_group, ec2/vpc_endpoint)

Closes #539

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] Verified generated `VALID_VERSIONING_CONFIGURATION_STATUS` contains `["Enabled", "Suspended"]`
- [x] Verified `enum_valid_values()` uses field names (not composite keys) for attribute lookup
- [x] Verified `enum_alias_reverse()` correctly resolves aliases (e.g., `"all" -> "-1"` for `ip_protocol`)
- [ ] Run acceptance tests for S3 bucket to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)