### PR TITLE
fix: remove redundant data_source field from AwsSchemaConfig

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -620,7 +620,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
          \x20       aws_type_name: \"{}\",\n\
          \x20       resource_type_name: \"{}\",\n\
          \x20       has_tags: {},\n\
-         \x20       data_source: {},\n\
          \x20       schema: ResourceSchema::new(\"{}\")\n",
         res.name,
         ns,
@@ -628,7 +627,6 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         cf_type_name(res.name),
         res.name,
         res.has_tags,
-        is_data_source,
         namespace,
     ));
 

--- a/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/internet_gateway.rs
@@ -14,7 +14,6 @@ pub fn ec2_internet_gateway_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
         resource_type_name: "ec2.internet_gateway",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.internet_gateway")
             .with_description("Describes an internet gateway.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route.rs
@@ -13,7 +13,6 @@ pub fn ec2_route_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
         resource_type_name: "ec2.route",
         has_tags: false,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.route")
         .with_description("Describes a route in a route table.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/route_table.rs
@@ -14,7 +14,6 @@ pub fn ec2_route_table_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
         resource_type_name: "ec2.route_table",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.route_table")
             .with_description("Describes a route table.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group.rs
@@ -14,7 +14,6 @@ pub fn ec2_security_group_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
         resource_type_name: "ec2.security_group",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group")
         .with_description("Describes a security group.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_egress.rs
@@ -40,7 +40,6 @@ pub fn ec2_security_group_egress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupEgress",
         resource_type_name: "ec2.security_group_egress",
         has_tags: false,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group_egress")
             .with_description("Describes a security group rule.")
             .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/security_group_ingress.rs
@@ -40,7 +40,6 @@ pub fn ec2_security_group_ingress_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
         resource_type_name: "ec2.security_group_ingress",
         has_tags: false,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.security_group_ingress")
         .with_description("Describes a security group rule.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -41,7 +41,6 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
         resource_type_name: "ec2.subnet",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.subnet")
         .with_description("Describes a subnet.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc.rs
@@ -29,7 +29,6 @@ pub fn ec2_vpc_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
         resource_type_name: "ec2.vpc",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.ec2.vpc")
         .with_description("Describes a VPC.")
         .attribute(

--- a/carina-provider-aws/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-aws/src/schemas/generated/s3/bucket.rs
@@ -29,7 +29,6 @@ pub fn s3_bucket_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::S3::Bucket",
         resource_type_name: "s3.bucket",
         has_tags: true,
-        data_source: false,
         schema: ResourceSchema::new("aws.s3.bucket")
         .attribute(
             AttributeSchema::new("acl", AttributeType::StringEnum {

--- a/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
+++ b/carina-provider-aws/src/schemas/generated/sts/caller_identity.rs
@@ -13,7 +13,6 @@ pub fn sts_caller_identity_config() -> AwsSchemaConfig {
         aws_type_name: "AWS::STS::CallerIdentity",
         resource_type_name: "sts.caller_identity",
         has_tags: false,
-        data_source: true,
         schema: ResourceSchema::new("aws.sts.caller_identity")
         .as_data_source()
         .attribute(

--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -19,8 +19,6 @@ pub struct AwsSchemaConfig {
     pub resource_type_name: &'static str,
     /// Whether this resource type uses tags
     pub has_tags: bool,
-    /// Whether this is a data source (read-only) resource type
-    pub data_source: bool,
     /// The resource schema with attribute definitions
     pub schema: ResourceSchema,
 }


### PR DESCRIPTION
## Summary

- Remove `data_source: bool` field from `AwsSchemaConfig` since `ResourceSchema` already tracks this via `.as_data_source()`
- The field was never read — only `schema.data_source` is used in validation and LSP diagnostics
- Update codegen to stop emitting the field and regenerate all schema files

Closes #556

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes — all tests pass
- [x] Verified `AwsSchemaConfig.data_source` was never accessed (only set)
- [x] `sts.caller_identity` still correctly marked as data source via `ResourceSchema.as_data_source()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)