### PR TITLE
fix: guard against non-finite floats and parser integer overflow

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -896,11 +896,23 @@ fn parse_primary_value(
             Ok(Value::Bool(b))
         }
         Rule::float => {
-            let f: f64 = inner.as_str().parse().unwrap();
+            let f: f64 = inner
+                .as_str()
+                .parse()
+                .map_err(|e| ParseError::InvalidExpression {
+                    line: inner.line_col().0,
+                    message: format!("invalid float literal: {e}"),
+                })?;
             Ok(Value::Float(f))
         }
         Rule::number => {
-            let n: i64 = inner.as_str().parse().unwrap();
+            let n: i64 = inner
+                .as_str()
+                .parse()
+                .map_err(|e| ParseError::InvalidExpression {
+                    line: inner.line_col().0,
+                    message: format!("integer literal out of range: {e}"),
+                })?;
             Ok(Value::Int(n))
         }
         Rule::string => {
@@ -2192,6 +2204,28 @@ mod tests {
             parsed
                 .find_resource_by_attr("ec2.vpc", "bucket", "my-bucket")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn parse_integer_overflow_returns_error() {
+        // i64::MAX is 9223372036854775807; one more should fail
+        let input = r#"
+provider aws {
+    region = aws.Region.ap_northeast_1
+}
+
+aws.s3.bucket {
+    name = "test"
+    count = 99999999999999999999
+}
+"#;
+        let result = parse(input);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("integer literal out of range"),
+            "expected 'integer literal out of range' error, got: {err}"
         );
     }
 }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -168,7 +168,10 @@ impl AttributeType {
             // ResourceRef values resolve to strings at runtime, so they're valid for String types
             (AttributeType::String, Value::String(_) | Value::ResourceRef { .. }) => Ok(()),
             (AttributeType::Int, Value::Int(_)) => Ok(()),
-            (AttributeType::Float, Value::Float(_)) => Ok(()),
+            (AttributeType::Float, Value::Float(f)) if f.is_finite() => Ok(()),
+            (AttributeType::Float, Value::Float(f)) => Err(TypeError::ValidationFailed {
+                message: format!("non-finite float value: {f}"),
+            }),
             (AttributeType::Float, Value::Int(_)) => Ok(()), // integers are valid numbers
             (AttributeType::Bool, Value::Bool(_)) => Ok(()),
 
@@ -1187,6 +1190,14 @@ mod tests {
         assert!(t.validate(&Value::Int(42)).is_ok()); // integers are valid numbers
         assert!(t.validate(&Value::String("3.14".to_string())).is_err());
         assert!(t.validate(&Value::Bool(true)).is_err());
+    }
+
+    #[test]
+    fn validate_float_rejects_non_finite() {
+        let t = AttributeType::Float;
+        assert!(t.validate(&Value::Float(f64::NAN)).is_err());
+        assert!(t.validate(&Value::Float(f64::INFINITY)).is_err());
+        assert!(t.validate(&Value::Float(f64::NEG_INFINITY)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reject `NaN`, `Infinity`, and `-Infinity` in `AttributeType::Float` validation with a proper `TypeError` instead of letting them propagate to a panic during JSON serialization
- Replace `.unwrap()` with `.map_err()` for integer and float parsing in the DSL parser to produce clear error messages on overflow instead of panicking

Closes #552

## Test plan

- [x] `validate_float_rejects_non_finite` — verifies NaN, Infinity, and -Infinity are rejected by Float validation
- [x] `parse_integer_overflow_returns_error` — verifies extremely large integer literals produce a parse error
- [x] All 301 existing carina-core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)