### PR TITLE
fix: emit StringEnum instead of Enum for nested struct field enums

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1490,14 +1490,45 @@ fn generate_struct_type(
                         enum_info.type_name, values_str, namespace, to_dsl_code
                     )
                 } else {
-                    // Fallback: use Enum variant directly
+                    // Fallback: emit StringEnum with namespace even when not in the
+                    // pre-scanned enums map (e.g., nested struct fields that were
+                    // skipped during scanning due to snake_case name conflicts).
+                    let prop_aliases = aliases.get(field_name.as_str());
+                    let has_hyphens = local_enum_info.values.iter().any(|v| v.contains('-'));
+                    let to_dsl_code = if let Some(alias_list) = prop_aliases {
+                        let mut match_arms: Vec<String> = alias_list
+                            .iter()
+                            .map(|(canonical, alias)| {
+                                format!("\"{}\" => \"{}\".to_string()", canonical, alias)
+                            })
+                            .collect();
+                        let fallback = if has_hyphens {
+                            "_ => s.replace('-', \"_\")"
+                        } else {
+                            "_ => s.to_string()"
+                        };
+                        match_arms.push(fallback.to_string());
+                        format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
+                    } else if has_hyphens {
+                        "Some(|s: &str| s.replace('-', \"_\"))".to_string()
+                    } else {
+                        "None".to_string()
+                    };
                     let values_str = local_enum_info
                         .values
                         .iter()
                         .map(|v| format!("\"{}\".to_string()", v))
                         .collect::<Vec<_>>()
                         .join(", ");
-                    format!("AttributeType::Enum(vec![{}])", values_str)
+                    format!(
+                        r#"AttributeType::StringEnum {{
+                name: "{}".to_string(),
+                values: vec![{}],
+                namespace: Some("{}".to_string()),
+                to_dsl: {},
+            }}"#,
+                        local_enum_info.type_name, values_str, namespace, to_dsl_code
+                    )
                 }
             } else {
                 field_type
@@ -4127,6 +4158,97 @@ mod tests {
         assert!(
             !generated.contains(".with_completions("),
             "enum completions should come from schema type metadata: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_struct_field_enum_emits_string_enum_not_enum() {
+        // Simulate a resource with a struct property whose field has an enum.
+        // The struct comes from a $ref definition. If the definition's enum field
+        // was not picked up during pre-scanning (e.g., due to snake_case conflict),
+        // the fallback should still emit StringEnum, not Enum.
+        let mut def_props = BTreeMap::new();
+        def_props.insert(
+            "Mode".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("The mode setting".to_string()),
+                enum_values: Some(vec![
+                    EnumValue::Str("off".to_string()),
+                    EnumValue::Str("block-bidirectional".to_string()),
+                    EnumValue::Str("block-ingress".to_string()),
+                ]),
+                items: None,
+                ref_path: None,
+                insertion_order: None,
+                properties: None,
+                required: vec![],
+                minimum: None,
+                maximum: None,
+            },
+        );
+
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "BlockSettings".to_string(),
+            CfnDefinition {
+                def_type: None,
+                properties: Some(def_props),
+                required: vec![],
+                one_of: vec![],
+            },
+        );
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "BlockSettings".to_string(),
+            CfnProperty {
+                prop_type: None,
+                description: Some("Block settings".to_string()),
+                enum_values: None,
+                items: None,
+                ref_path: Some("#/definitions/BlockSettings".to_string()),
+                insertion_order: None,
+                properties: None,
+                required: vec![],
+                minimum: None,
+                maximum: None,
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::EC2::TestResource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: Some(definitions),
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::EC2::TestResource").unwrap();
+
+        // The struct field's enum should be StringEnum, not Enum
+        assert!(
+            !generated.contains("AttributeType::Enum("),
+            "struct field enums must use StringEnum, not Enum: {generated}"
+        );
+        assert!(
+            generated.contains("AttributeType::StringEnum {"),
+            "struct field enums should be emitted as StringEnum: {generated}"
+        );
+        // Should have namespace
+        assert!(
+            generated.contains("namespace: Some("),
+            "StringEnum should include namespace: {generated}"
+        );
+        // Should handle hyphens in values with to_dsl
+        assert!(
+            generated.contains("s.replace('-', \"_\")"),
+            "hyphenated enum values should generate to_dsl: {generated}"
         );
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -45,7 +45,12 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             AttributeSchema::new("destination_options", AttributeType::Struct {
                     name: "DestinationOptions".to_string(),
                     fields: vec![
-                    StructField::new("file_format", AttributeType::Enum(vec!["plain-text".to_string(), "parquet".to_string()])).required().with_provider_name("FileFormat"),
+                    StructField::new("file_format", AttributeType::StringEnum {
+                name: "FileFormat".to_string(),
+                values: vec!["plain-text".to_string(), "parquet".to_string()],
+                namespace: Some("awscc.ec2.flow_log".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            }).required().with_provider_name("FileFormat"),
                     StructField::new("hive_compatible_partitions", AttributeType::Bool).required().with_provider_name("HiveCompatiblePartitions"),
                     StructField::new("per_hour_partition", AttributeType::Bool).required().with_provider_name("PerHourPartition")
                     ],

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -62,7 +62,12 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
             AttributeSchema::new("block_public_access_states", AttributeType::Struct {
                     name: "BlockPublicAccessStates".to_string(),
                     fields: vec![
-                    StructField::new("internet_gateway_block_mode", AttributeType::Enum(vec!["off".to_string(), "block-bidirectional".to_string(), "block-ingress".to_string()])).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
+                    StructField::new("internet_gateway_block_mode", AttributeType::StringEnum {
+                name: "InternetGatewayBlockMode".to_string(),
+                values: vec!["off".to_string(), "block-bidirectional".to_string(), "block-ingress".to_string()],
+                namespace: Some("awscc.ec2.subnet".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            }).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
                     ],
                 })
                 .with_description(" (read-only)")
@@ -158,7 +163,12 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("enable_resource_name_dns_aaaa_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsAAAARecord"),
                     StructField::new("enable_resource_name_dns_a_record", AttributeType::Bool).with_provider_name("EnableResourceNameDnsARecord"),
-                    StructField::new("hostname_type", AttributeType::Enum(vec!["ip-name".to_string(), "resource-name".to_string()])).with_provider_name("HostnameType")
+                    StructField::new("hostname_type", AttributeType::StringEnum {
+                name: "HostnameType".to_string(),
+                values: vec!["ip-name".to_string(), "resource-name".to_string()],
+                namespace: Some("awscc.ec2.subnet".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            }).with_provider_name("HostnameType")
                     ],
                 })
                 .with_description("The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more infor...")

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -25,10 +25,30 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
             AttributeSchema::new("options", AttributeType::Struct {
                     name: "Options".to_string(),
                     fields: vec![
-                    StructField::new("appliance_mode_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("ApplianceModeSupport"),
-                    StructField::new("dns_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable DNS Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("DnsSupport"),
-                    StructField::new("ipv6_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("Ipv6Support"),
-                    StructField::new("security_group_referencing_support", AttributeType::Enum(vec!["enable".to_string(), "disable".to_string()])).with_description("Indicates whether to enable Security Group referencing support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("SecurityGroupReferencingSupport")
+                    StructField::new("appliance_mode_support", AttributeType::StringEnum {
+                name: "ApplianceModeSupport".to_string(),
+                values: vec!["enable".to_string(), "disable".to_string()],
+                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                to_dsl: None,
+            }).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("ApplianceModeSupport"),
+                    StructField::new("dns_support", AttributeType::StringEnum {
+                name: "DnsSupport".to_string(),
+                values: vec!["enable".to_string(), "disable".to_string()],
+                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                to_dsl: None,
+            }).with_description("Indicates whether to enable DNS Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("DnsSupport"),
+                    StructField::new("ipv6_support", AttributeType::StringEnum {
+                name: "Ipv6Support".to_string(),
+                values: vec!["enable".to_string(), "disable".to_string()],
+                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                to_dsl: None,
+            }).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("Ipv6Support"),
+                    StructField::new("security_group_referencing_support", AttributeType::StringEnum {
+                name: "SecurityGroupReferencingSupport".to_string(),
+                values: vec!["enable".to_string(), "disable".to_string()],
+                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                to_dsl: None,
+            }).with_description("Indicates whether to enable Security Group referencing support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("SecurityGroupReferencingSupport")
                     ],
                 })
                 .with_description("The options for the transit gateway vpc attachment.")


### PR DESCRIPTION
## Summary

- Fix codegen fallback in `generate_struct_type` to emit `AttributeType::StringEnum` with proper namespace and `to_dsl` handling instead of `AttributeType::Enum` when struct field enums are not found in the pre-scanned enums map
- Regenerate affected schemas: `ec2.subnet`, `ec2.transit_gateway_attachment`, `ec2.flow_log`, `s3.bucket`
- Add test verifying struct field enums always emit `StringEnum`

Closes #551

## Test plan

- [x] All 87 codegen tests pass including new `test_struct_field_enum_emits_string_enum_not_enum`
- [x] Full workspace `cargo test` passes
- [x] Verified affected fields (`internet_gateway_block_mode`, `hostname_type`, `appliance_mode_support`, `dns_support`, `ipv6_support`, `security_group_referencing_support`, `file_format`, `sse_algorithm`) now use `StringEnum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)