### PR TITLE
fix: remove unused AttributeType::Enum variant

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -72,8 +72,6 @@ pub enum AttributeType {
     Float,
     /// Boolean
     Bool,
-    /// Enum (list of allowed values)
-    Enum(Vec<String>),
     /// String enum with optional namespace-aware DSL syntax support
     StringEnum {
         name: String,
@@ -174,18 +172,6 @@ impl AttributeType {
             }),
             (AttributeType::Float, Value::Int(_)) => Ok(()), // integers are valid numbers
             (AttributeType::Bool, Value::Bool(_)) => Ok(()),
-
-            (AttributeType::Enum(variants), Value::String(s)) => {
-                let variant = extract_enum_value(s);
-                if variants.iter().any(|v| v == variant || s == v) {
-                    Ok(())
-                } else {
-                    Err(TypeError::InvalidEnumVariant {
-                        value: s.clone(),
-                        expected: variants.clone(),
-                    })
-                }
-            }
 
             (
                 AttributeType::StringEnum {
@@ -352,7 +338,6 @@ impl AttributeType {
             AttributeType::Int => "Int".to_string(),
             AttributeType::Float => "Float".to_string(),
             AttributeType::Bool => "Bool".to_string(),
-            AttributeType::Enum(variants) => format!("Enum({})", variants.join(" | ")),
             AttributeType::StringEnum { name, .. } => name.clone(),
             AttributeType::Custom { name, .. } => name.clone(),
             AttributeType::List(inner) => format!("List<{}>", inner.type_name()),
@@ -1100,21 +1085,6 @@ mod tests {
         let t = AttributeType::String;
         assert!(t.validate(&Value::String("hello".to_string())).is_ok());
         assert!(t.validate(&Value::Int(42)).is_err());
-    }
-
-    #[test]
-    fn validate_enum_type() {
-        let t = AttributeType::Enum(vec!["a".to_string(), "b".to_string()]);
-        assert!(t.validate(&Value::String("a".to_string())).is_ok());
-        assert!(t.validate(&Value::String("Type.a".to_string())).is_ok());
-        assert!(t.validate(&Value::String("c".to_string())).is_err());
-    }
-
-    #[test]
-    fn validate_enum_type_remains_case_sensitive() {
-        let t = AttributeType::Enum(vec!["Enabled".to_string()]);
-        assert!(t.validate(&Value::String("Enabled".to_string())).is_ok());
-        assert!(t.validate(&Value::String("enabled".to_string())).is_err());
     }
 
     #[test]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -136,10 +136,9 @@ pub fn validate_resource_ref_types(
 /// Check if an AttributeType is string-compatible (can accept a string value).
 pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
     match attr_type {
-        AttributeType::String
-        | AttributeType::Custom { .. }
-        | AttributeType::Enum(_)
-        | AttributeType::StringEnum { .. } => true,
+        AttributeType::String | AttributeType::Custom { .. } | AttributeType::StringEnum { .. } => {
+            true
+        }
         AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
         _ => false,
     }

--- a/carina-lsp/src/completion.rs
+++ b/carina-lsp/src/completion.rs
@@ -620,25 +620,6 @@ impl CompletionProvider {
                     },
                 ]
             }
-            AttributeType::Enum(variants) => {
-                // Check if this is a region enum (has region-like names but no zone suffix)
-                if variants
-                    .iter()
-                    .any(|v| v.contains("northeast") || v.contains("east_1"))
-                {
-                    return self.region_completions();
-                }
-                // Generic enum completions - wrap in quotes since they're string values
-                variants
-                    .iter()
-                    .map(|v| CompletionItem {
-                        label: format!("\"{}\"", v),
-                        kind: Some(CompletionItemKind::ENUM_MEMBER),
-                        insert_text: Some(format!("\"{}\"", v)),
-                        ..Default::default()
-                    })
-                    .collect()
-            }
             AttributeType::StringEnum {
                 name,
                 values,

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -4231,11 +4231,6 @@ mod tests {
 
         let generated = generate_schema_code(&schema, "AWS::EC2::TestResource").unwrap();
 
-        // The struct field's enum should be StringEnum, not Enum
-        assert!(
-            !generated.contains("AttributeType::Enum("),
-            "struct field enums must use StringEnum, not Enum: {generated}"
-        );
         assert!(
             generated.contains("AttributeType::StringEnum {"),
             "struct field enums should be emitted as StringEnum: {generated}"


### PR DESCRIPTION
## Summary

- Remove `AttributeType::Enum(Vec<String>)` variant from `carina-core`, as all providers now use `StringEnum` exclusively
- Remove associated match arms in `schema.rs` (validate, type_name), `validation.rs` (is_string_compatible_type), and `completion.rs`
- Remove two tests that exercised the `Enum` variant
- Remove redundant codegen assertion that `Enum(` is not generated

closes #564

## Test plan

- [x] `cargo check` — full workspace compiles cleanly
- [x] `cargo test -p carina-core -p carina-lsp` — all tests pass
- [x] Codegen test `test_struct_field_enum_emits_string_enum_not_enum` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)