### PR TITLE
fix: add missing semantic string types for Region, Arn, Ipv4Address, AwsAccountId

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2412,6 +2412,8 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
         m.insert("ReplicaKmsKeyID", "super::kms_key_id()");
         m.insert("KmsKeyArn", "super::kms_key_arn()");
         m.insert("SecurityGroupRuleId", "super::security_group_rule_id()");
+        m.insert("Locale", "super::aws_region()");
+        m.insert("BucketAccountId", "super::aws_account_id()");
         m
     });
     &OVERRIDES
@@ -2489,6 +2491,11 @@ fn infer_string_type(prop_name: &str) -> Option<String> {
         return Some("super::availability_zone()".to_string());
     }
 
+    // Region types (e.g., PeerRegion, ServiceRegion, RegionName, ResourceRegion)
+    if prop_lower.ends_with("region") || prop_lower == "regionname" {
+        return Some("super::aws_region()".to_string());
+    }
+
     // Check ARN pattern
     if prop_lower.ends_with("arn") || prop_lower.ends_with("arns") || prop_lower.contains("_arn") {
         return Some("super::arn()".to_string());
@@ -2504,8 +2511,8 @@ fn infer_string_type(prop_name: &str) -> Option<String> {
         return Some(get_resource_id_type(singular_name).to_string());
     }
 
-    // AWS Account ID (owner IDs are 12-digit account IDs)
-    if prop_lower.ends_with("ownerid") {
+    // AWS Account ID (owner IDs and account IDs are 12-digit account IDs)
+    if prop_lower.ends_with("ownerid") || prop_lower.ends_with("accountid") {
         return Some("super::aws_account_id()".to_string());
     }
 

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -351,6 +351,8 @@ fn infer_string_type_display(prop_name: &str, resource_type: &str) -> String {
         }
     } else if prop_lower == "availabilityzone" || prop_lower == "availabilityzones" {
         "AvailabilityZone".to_string()
+    } else if prop_lower.ends_with("region") || prop_lower == "regionname" {
+        "Region".to_string()
     } else if prop_lower.ends_with("arn")
         || prop_lower.ends_with("arns")
         || prop_lower.contains("_arn")
@@ -360,7 +362,7 @@ fn infer_string_type_display(prop_name: &str, resource_type: &str) -> String {
         "IpamPoolId".to_string()
     } else if is_aws_resource_id_property(singular_name) {
         get_resource_id_display_name(singular_name).to_string()
-    } else if prop_lower.ends_with("ownerid") {
+    } else if prop_lower.ends_with("ownerid") || prop_lower.ends_with("accountid") {
         "AwsAccountId".to_string()
     } else {
         "String".to_string()
@@ -395,6 +397,10 @@ fn override_type_to_display_name(override_type: &str) -> &str {
         "super::subnet_route_table_association_id()" => "SubnetRouteTableAssociationId",
         "super::ipam_id()" => "IpamId",
         "super::iam_role_id()" => "IamRoleId",
+        "super::awscc_region()" => "Region",
+        "types::ipv4_address()" => "Ipv4Address",
+        "super::arn()" => "Arn",
+        "super::ipam_pool_id()" => "IpamPoolId",
         _ => "String",
     }
 }
@@ -1641,6 +1647,8 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
         m.insert("ReplicaKmsKeyID", "super::kms_key_id()");
         m.insert("KmsKeyArn", "super::kms_key_arn()");
         m.insert("IpamId", "super::ipam_id()");
+        m.insert("Locale", "super::awscc_region()");
+        m.insert("BucketAccountId", "super::aws_account_id()");
         m
     });
     &OVERRIDES
@@ -1687,6 +1695,22 @@ fn resource_specific_type_overrides() -> &'static HashMap<(&'static str, &'stati
                 ("AWS::EC2::SubnetRouteTableAssociation", "Id"),
                 "super::subnet_route_table_association_id()",
             );
+            // EIP Address and TransferAddress are IPv4 addresses
+            m.insert(("AWS::EC2::EIP", "Address"), "types::ipv4_address()");
+            m.insert(
+                ("AWS::EC2::EIP", "TransferAddress"),
+                "types::ipv4_address()",
+            );
+            // FlowLog LogDestination is an ARN (S3 bucket, CloudWatch log group, or Firehose)
+            m.insert(("AWS::EC2::FlowLog", "LogDestination"), "super::arn()");
+            // S3 Bucket notification ARNs
+            m.insert(("AWS::S3::Bucket", "Function"), "super::arn()");
+            m.insert(("AWS::S3::Bucket", "Queue"), "super::arn()");
+            m.insert(("AWS::S3::Bucket", "Topic"), "super::arn()");
+            // S3 Bucket replication role is an IAM Role ARN
+            m.insert(("AWS::S3::Bucket", "Role"), "super::iam_role_arn()");
+            // S3 Bucket replication destination account
+            m.insert(("AWS::S3::Bucket", "Account"), "super::aws_account_id()");
             m
         });
     &OVERRIDES
@@ -1752,6 +1776,11 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
         return Some("super::availability_zone()".to_string());
     }
 
+    // Region types (e.g., PeerRegion, ServiceRegion, RegionName, ResourceRegion)
+    if prop_lower.ends_with("region") || prop_lower == "regionname" {
+        return Some("super::awscc_region()".to_string());
+    }
+
     // Check ARN pattern
     if prop_lower.ends_with("arn") || prop_lower.ends_with("arns") || prop_lower.contains("_arn") {
         return Some("super::arn()".to_string());
@@ -1767,8 +1796,8 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
         return Some(get_resource_id_type(singular_name).to_string());
     }
 
-    // AWS Account ID (owner IDs are 12-digit account IDs)
-    if prop_lower.ends_with("ownerid") {
+    // AWS Account ID (owner IDs and account IDs are 12-digit account IDs)
+    if prop_lower.ends_with("ownerid") || prop_lower.ends_with("accountid") {
         return Some("super::aws_account_id()".to_string());
     }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
@@ -19,7 +19,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.ec2.eip")
         .with_description("Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool c...")
         .attribute(
-            AttributeSchema::new("address", AttributeType::String)
+            AttributeSchema::new("address", types::ipv4_address())
                 .create_only()
                 .with_description("")
                 .with_provider_name("Address"),
@@ -72,7 +72,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags"),
         )
         .attribute(
-            AttributeSchema::new("transfer_address", AttributeType::String)
+            AttributeSchema::new("transfer_address", types::ipv4_address())
                 .create_only()
                 .with_description("The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfe...")
                 .with_provider_name("TransferAddress"),

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -64,7 +64,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("log_destination", AttributeType::String)
+            AttributeSchema::new("log_destination", super::arn())
                 .create_only()
                 .with_description("Specifies the destination to which the flow log data is to be published. Flow log data can be published to a CloudWatch Logs log group, an Amazon S3 b...")
                 .with_provider_name("LogDestination"),

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -74,7 +74,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
             AttributeSchema::new("operating_regions", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "IpamOperatingRegion".to_string(),
                     fields: vec![
-                    StructField::new("region_name", AttributeType::String).required().with_description("The name of the region.").with_provider_name("RegionName")
+                    StructField::new("region_name", super::awscc_region()).required().with_description("The name of the region.").with_provider_name("RegionName")
                     ],
                 })))
                 .with_description("The regions IPAM is enabled for. Allows pools to be created in these regions, as well as enabling monitoring")

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
@@ -123,7 +123,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("IpamScopeType"),
         )
         .attribute(
-            AttributeSchema::new("locale", AttributeType::String)
+            AttributeSchema::new("locale", super::awscc_region())
                 .create_only()
                 .with_description("The region of this pool. If not set, this will default to \"None\" which will disable non-custom allocations. If the locale has been specified for the...")
                 .with_provider_name("Locale"),
@@ -173,7 +173,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("resource_id", AttributeType::String).required().with_provider_name("ResourceId"),
                     StructField::new("resource_owner", AttributeType::String).required().with_provider_name("ResourceOwner"),
-                    StructField::new("resource_region", AttributeType::String).required().with_provider_name("ResourceRegion"),
+                    StructField::new("resource_region", super::awscc_region()).required().with_provider_name("ResourceRegion"),
                     StructField::new("resource_type", AttributeType::String).required().with_provider_name("ResourceType")
                     ],
                 })

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -141,7 +141,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("ServiceNetworkArn"),
         )
         .attribute(
-            AttributeSchema::new("service_region", AttributeType::String)
+            AttributeSchema::new("service_region", super::awscc_region())
                 .create_only()
                 .with_description("Describes a Region.")
                 .with_provider_name("ServiceRegion"),

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -6,7 +6,7 @@
 
 use super::AwsccSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, ResourceSchema};
 
 /// Returns the schema config for ec2_vpc_peering_connection (AWS::EC2::VPCPeeringConnection)
 pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
@@ -16,6 +16,12 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
         has_tags: true,
         schema: ResourceSchema::new("awscc.ec2.vpc_peering_connection")
         .with_description("Resource Type definition for AWS::EC2::VPCPeeringConnection")
+        .attribute(
+            AttributeSchema::new("assume_role_region", super::awscc_region())
+                .create_only()
+                .with_description("The Region code to use when calling Security Token Service (STS) to assume the PeerRoleArn, if provided.")
+                .with_provider_name("AssumeRoleRegion"),
+        )
         .attribute(
             AttributeSchema::new("id", super::vpc_peering_connection_id())
                 .with_description("(read-only)")
@@ -28,7 +34,7 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
                 .with_provider_name("PeerOwnerId"),
         )
         .attribute(
-            AttributeSchema::new("peer_region", AttributeType::String)
+            AttributeSchema::new("peer_region", super::awscc_region())
                 .create_only()
                 .with_description("The Region code for the accepter VPC, if the accepter VPC is located in a Region other than the Region in which you make the request.")
                 .with_provider_name("PeerRegion"),

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -168,7 +168,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("destination", AttributeType::Struct {
                     name: "Destination".to_string(),
                     fields: vec![
-                    StructField::new("bucket_account_id", AttributeType::String).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this valu...").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this valu...").with_provider_name("BucketAccountId"),
                     StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
                     StructField::new("format", AttributeType::StringEnum {
                 name: "Format".to_string(),
@@ -303,7 +303,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("destination", AttributeType::Struct {
                     name: "Destination".to_string(),
                     fields: vec![
-                    StructField::new("bucket_account_id", AttributeType::String).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this valu...").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this valu...").with_provider_name("BucketAccountId"),
                     StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
                     StructField::new("format", AttributeType::StringEnum {
                 name: "Format".to_string(),
@@ -605,7 +605,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine which objects invoke the AWS Lambda function. For example, you can create a filter so that only image files with a ...").with_provider_name("Filter"),
-                    StructField::new("function", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified event type occurs.").with_provider_name("Function")
+                    StructField::new("function", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified event type occurs.").with_provider_name("Function")
                     ],
                 }))).with_description("Describes the LAMlong functions to invoke and the events for which to invoke them.").with_provider_name("LambdaConfigurations"),
                     StructField::new("queue_configurations", AttributeType::List(Box::new(AttributeType::Struct {
@@ -629,7 +629,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications onl...").with_provider_name("Filter"),
-                    StructField::new("queue", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queue...").with_provider_name("Queue")
+                    StructField::new("queue", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queue...").with_provider_name("Queue")
                     ],
                 }))).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations"),
                     StructField::new("topic_configurations", AttributeType::List(Box::new(AttributeType::Struct {
@@ -653,7 +653,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications...").with_provider_name("Filter"),
-                    StructField::new("topic", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
+                    StructField::new("topic", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
                     ],
                 }))).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations")
                     ],
@@ -736,7 +736,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             AttributeSchema::new("replication_configuration", AttributeType::Struct {
                     name: "ReplicationConfiguration".to_string(),
                     fields: vec![
-                    StructField::new("role", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating objects. For more information, see [How to Set Up Rep...").with_provider_name("Role"),
+                    StructField::new("role", super::iam_role_arn()).required().with_description("The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating objects. For more information, see [How to Set Up Rep...").with_provider_name("Role"),
                     StructField::new("rules", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "ReplicationRule".to_string(),
                     fields: vec![
@@ -760,7 +760,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("owner", AttributeType::String).required().with_description("Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucket...").with_provider_name("Owner")
                     ],
                 }).with_description("Specify this only in a cross-account scenario (where source and destination bucket owners are not the same), and you want to change replica ownership ...").with_provider_name("AccessControlTranslation"),
-                    StructField::new("account", AttributeType::String).with_description("Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to change replica ownership to the AWS-account that owns the...").with_provider_name("Account"),
+                    StructField::new("account", super::aws_account_id()).with_description("Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to change replica ownership to the AWS-account that owns the...").with_provider_name("Account"),
                     StructField::new("bucket", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the bucket where you want Amazon S3 to store the results.").with_provider_name("Bucket"),
                     StructField::new("encryption_configuration", AttributeType::Struct {
                     name: "EncryptionConfiguration".to_string(),

--- a/docs/src/providers/awscc/ec2_eip.md
+++ b/docs/src/providers/awscc/ec2_eip.md
@@ -22,7 +22,7 @@ awscc.ec2.eip {
 
 ### `address`
 
-- **Type:** String
+- **Type:** Ipv4Address
 - **Required:** No
 
 
@@ -71,7 +71,7 @@ Any tags assigned to the Elastic IP address. Updates to the ``Tags`` property ma
 
 ### `transfer_address`
 
-- **Type:** String
+- **Type:** Ipv4Address
 - **Required:** No
 
 The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfers, see [Transfer Elastic IP addresses](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#transfer-EIPs-intro) in the *Amazon Virtual Private Cloud User Guide*.

--- a/docs/src/providers/awscc/ec2_flow_log.md
+++ b/docs/src/providers/awscc/ec2_flow_log.md
@@ -47,7 +47,7 @@ The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a Cloud
 
 ### `log_destination`
 
-- **Type:** String
+- **Type:** Arn
 - **Required:** No
 
 Specifies the destination to which the flow log data is to be published. Flow log data can be published to a CloudWatch Logs log group, an Amazon S3 bucket, or a Kinesis Firehose stream. The value specified for this parameter depends on the value specified for LogDestinationType.

--- a/docs/src/providers/awscc/ec2_ipam.md
+++ b/docs/src/providers/awscc/ec2_ipam.md
@@ -98,7 +98,7 @@ Shorthand formats: `free` or `Tier.free`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `region_name` | String | Yes | The name of the region. |
+| `region_name` | Region | Yes | The name of the region. |
 
 ### IpamOrganizationalUnitExclusion
 

--- a/docs/src/providers/awscc/ec2_ipam_pool.md
+++ b/docs/src/providers/awscc/ec2_ipam_pool.md
@@ -101,7 +101,7 @@ The Id of the scope this pool is a part of.
 
 ### `locale`
 
-- **Type:** String
+- **Type:** Region
 - **Required:** No
 
 The region of this pool. If not set, this will default to "None" which will disable non-custom allocations. If the locale has been specified for the source pool, this value must match.
@@ -211,7 +211,7 @@ Shorthand formats: `create_in_progress` or `State.create_in_progress`
 |-------|------|----------|-------------|
 | `resource_id` | String | Yes |  |
 | `resource_owner` | String | Yes |  |
-| `resource_region` | String | Yes |  |
+| `resource_region` | Region | Yes |  |
 | `resource_type` | String | Yes |  |
 
 ## Attribute Reference

--- a/docs/src/providers/awscc/ec2_vpc_endpoint.md
+++ b/docs/src/providers/awscc/ec2_vpc_endpoint.md
@@ -113,7 +113,7 @@ The Amazon Resource Name (ARN) of the service network.
 
 ### `service_region`
 
-- **Type:** String
+- **Type:** Region
 - **Required:** No
 
 Describes a Region.

--- a/docs/src/providers/awscc/ec2_vpc_peering_connection.md
+++ b/docs/src/providers/awscc/ec2_vpc_peering_connection.md
@@ -27,6 +27,13 @@ awscc.ec2.vpc_peering_connection {
 
 ## Argument Reference
 
+### `assume_role_region`
+
+- **Type:** Region
+- **Required:** No
+
+The Region code to use when calling Security Token Service (STS) to assume the PeerRoleArn, if provided.
+
 ### `peer_owner_id`
 
 - **Type:** AwsAccountId
@@ -36,7 +43,7 @@ The AWS account ID of the owner of the accepter VPC.
 
 ### `peer_region`
 
-- **Type:** String
+- **Type:** Region
 - **Required:** No
 
 The Region code for the accepter VPC, if the accepter VPC is located in a Region other than the Region in which you make the request.

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -319,7 +319,7 @@ Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `role` | String | Yes | The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating obj... |
+| `role` | IamRoleArn | Yes | The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating obj... |
 | `rules` | [List\<ReplicationRule\>](#replicationrule) | Yes | A container for one or more replication rules. A replication configuration must have at least one ru... |
 
 ### VersioningConfiguration


### PR DESCRIPTION
## Summary

- Add Region type inference pattern (`*Region`, `RegionName`) and `Locale` override in both AWSCC and AWS codegens
- Add resource-specific overrides for EC2::EIP `Address`/`TransferAddress` → `Ipv4Address`
- Add resource-specific overrides for FlowLog `LogDestination`, S3 Bucket `Function`/`Queue`/`Topic` → `Arn`
- Add resource-specific override for S3 Bucket replication `Role` → `IamRoleArn`
- Add `*AccountId` pattern and overrides for `BucketAccountId`, S3 Bucket replication `Account` → `AwsAccountId`
- Regenerate all schemas and docs

Closes #548

## Test plan

- [x] `cargo test -p carina-provider-awscc` — 87 tests pass
- [x] `cargo test` — all workspace tests pass
- [x] Verified generated schema diffs match expected type changes
- [x] Pre-commit hooks (fmt + clippy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)