### PR TITLE
fix: deduplicate enum sections for shared struct field types in markdown docs

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -655,10 +655,12 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
     if !enums.is_empty() {
         let aliases = known_enum_aliases();
         md.push_str("## Enum Values\n\n");
-        let mut rendered_enum_types: HashSet<String> = HashSet::new();
+        let mut rendered_enums: HashSet<(String, Vec<String>)> = HashSet::new();
         for (prop_name, enum_info) in &enums {
-            // Skip duplicate enum types (e.g., Ingress.IpProtocol and Egress.IpProtocol)
-            if !rendered_enum_types.insert(enum_info.type_name.clone()) {
+            // Skip duplicate enum types with identical values
+            // (e.g., Ingress.IpProtocol and Egress.IpProtocol share the same type and values)
+            let key = (enum_info.type_name.clone(), enum_info.values.clone());
+            if !rendered_enums.insert(key) {
                 continue;
             }
             // For composite keys "DefName.FieldName", use just "FieldName" for display
@@ -5417,6 +5419,101 @@ mod tests {
             ip_protocol_count,
             md.lines()
                 .filter(|l| l.contains("IpProtocol"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    #[test]
+    fn test_same_type_name_different_values_not_deduplicated() {
+        // Two structs with a "Status" field but different enum values
+        // should produce two separate enum sections
+        let mut config_a_props = BTreeMap::new();
+        config_a_props.insert(
+            "Status".to_string(),
+            CfnProperty {
+                enum_values: Some(vec![
+                    EnumValue::Str("Disabled".to_string()),
+                    EnumValue::Str("Enabled".to_string()),
+                ]),
+                ..Default::default()
+            },
+        );
+
+        let mut config_b_props = BTreeMap::new();
+        config_b_props.insert(
+            "Status".to_string(),
+            CfnProperty {
+                enum_values: Some(vec![
+                    EnumValue::Str("Enabled".to_string()),
+                    EnumValue::Str("Suspended".to_string()),
+                ]),
+                ..Default::default()
+            },
+        );
+
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "ConfigA".to_string(),
+            CfnDefinition {
+                def_type: Some("object".to_string()),
+                properties: Some(config_a_props),
+                required: vec![],
+                enum_values: None,
+                items: None,
+                one_of: vec![],
+            },
+        );
+        definitions.insert(
+            "ConfigB".to_string(),
+            CfnDefinition {
+                def_type: Some("object".to_string()),
+                properties: Some(config_b_props),
+                required: vec![],
+                enum_values: None,
+                items: None,
+                one_of: vec![],
+            },
+        );
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "ConfigA".to_string(),
+            CfnProperty {
+                ref_path: Some("#/definitions/ConfigA".to_string()),
+                ..Default::default()
+            },
+        );
+        properties.insert(
+            "ConfigB".to_string(),
+            CfnProperty {
+                ref_path: Some("#/definitions/ConfigB".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: Some(definitions),
+            tagging: None,
+        };
+
+        let md = generate_markdown(&schema, "AWS::Test::Resource").unwrap();
+        let status_count = md.matches("### status (Status)").count();
+        assert_eq!(
+            status_count,
+            2,
+            "Expected 2 Status enum sections (different values), found {}.\nEnum Values section:\n{}",
+            status_count,
+            md.lines()
+                .filter(|l| l.contains("Status") || l.contains("status"))
                 .collect::<Vec<_>>()
                 .join("\n")
         );

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -271,6 +271,15 @@ Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectS
 
 Shorthand formats: `Enabled` or `ObjectLockEnabled.Enabled`
 
+### status (Status)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Enabled` | `awscc.s3.bucket.Status.Enabled` |
+| `Suspended` | `awscc.s3.bucket.Status.Suspended` |
+
+Shorthand formats: `Enabled` or `Status.Enabled`
+
 ## Struct Definitions
 
 ### AccelerateConfiguration


### PR DESCRIPTION
## Summary
- Deduplicate enum sections in markdown docs when multiple struct definitions share the same enum type (e.g., `Ingress.IpProtocol` and `Egress.IpProtocol`)
- Track rendered enum `type_name`s with a `HashSet` and skip duplicates during rendering
- Regenerated all documentation files to apply the fix

Closes #578

## Test plan
- [x] Added test `test_shared_enum_type_across_structs_is_deduplicated_in_markdown` verifying only one enum section is generated
- [x] All 99 codegen tests pass
- [x] Verified `ec2_security_group.md` now has single `ip_protocol (IpProtocol)` section (was duplicated)
- [x] Verified `s3_bucket.md` also had a duplicate removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)