### PR TITLE
fix: disambiguate same-named enum types from different structs

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -615,6 +615,8 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
         }
     }
 
+    disambiguate_enum_type_names(&mut enums);
+
     // Title
     md.push_str(&format!("# awscc.{}\n\n", dsl_resource));
     md.push_str(&format!("CloudFormation Type: `{}`\n\n", type_name));
@@ -1067,6 +1069,8 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
             }
         }
     }
+
+    disambiguate_enum_type_names(&mut enums);
 
     let has_enums = !enums.is_empty();
     let has_ranged_ints = !ranged_ints.is_empty();
@@ -1617,6 +1621,40 @@ fn extract_enum_from_description(description: &str) -> Option<Vec<String>> {
     }
 
     None
+}
+
+/// Disambiguate enum type_names that collide (same type_name, different values).
+/// For struct field enums with composite keys "DefName.FieldName", prefixes the
+/// type_name with the parent struct name (e.g., "Status" -> "VersioningConfigurationStatus").
+/// Enums with the same type_name and identical values are left unchanged (they deduplicate later).
+fn disambiguate_enum_type_names(enums: &mut BTreeMap<String, EnumInfo>) {
+    let mut type_name_groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (key, info) in enums.iter() {
+        type_name_groups
+            .entry(info.type_name.clone())
+            .or_default()
+            .push(key.clone());
+    }
+    for keys in type_name_groups.values() {
+        let unique_value_sets: HashSet<Vec<String>> = keys
+            .iter()
+            .filter_map(|k| enums.get(k))
+            .map(|info| info.values.clone())
+            .collect();
+        if unique_value_sets.len() <= 1 {
+            continue; // No collision - all have identical values
+        }
+        // There's a collision: disambiguate by prefixing parent struct name
+        for key in keys {
+            if let Some(dot_pos) = key.find('.') {
+                let parent_struct = &key[..dot_pos];
+                if let Some(info) = enums.get_mut(key) {
+                    info.type_name = format!("{}{}", parent_struct, info.type_name);
+                }
+            }
+            // Top-level properties (no dot) keep their original type_name
+        }
+    }
 }
 
 /// Deduplicate enum values while preserving order.
@@ -5506,16 +5544,39 @@ mod tests {
         };
 
         let md = generate_markdown(&schema, "AWS::Test::Resource").unwrap();
-        let status_count = md.matches("### status (Status)").count();
-        assert_eq!(
-            status_count,
-            2,
-            "Expected 2 Status enum sections (different values), found {}.\nEnum Values section:\n{}",
-            status_count,
+
+        // With disambiguation, the two Status enums should have different type names
+        assert!(
+            md.contains("### status (ConfigAStatus)"),
+            "Expected ConfigAStatus heading.\nEnum Values section:\n{}",
             md.lines()
                 .filter(|l| l.contains("Status") || l.contains("status"))
                 .collect::<Vec<_>>()
                 .join("\n")
+        );
+        assert!(
+            md.contains("### status (ConfigBStatus)"),
+            "Expected ConfigBStatus heading.\nEnum Values section:\n{}",
+            md.lines()
+                .filter(|l| l.contains("Status") || l.contains("status"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+
+        // DSL identifiers should also be disambiguated
+        assert!(
+            md.contains("awscc.test.resource.ConfigAStatus.Disabled"),
+            "Expected disambiguated DSL identifier for ConfigA"
+        );
+        assert!(
+            md.contains("awscc.test.resource.ConfigBStatus.Suspended"),
+            "Expected disambiguated DSL identifier for ConfigB"
+        );
+
+        // Old ambiguous format should NOT appear
+        assert!(
+            !md.contains("### status (Status)"),
+            "Should not have ambiguous '### status (Status)' heading"
         );
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -275,7 +275,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("kms_master_key_id", super::kms_key_id()).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *General purpose buckets* - This parameter is allowed if...").with_provider_name("KMSMasterKeyID"),
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "SseAlgorithm".to_string(),
+                name: "ServerSideEncryptionByDefaultSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -343,7 +343,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the S3 Intelligent-Tiering configuration.").with_provider_name("Id"),
                     StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.").with_provider_name("Prefix"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "IntelligentTieringConfigurationStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -448,7 +448,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For...").with_provider_name("NewerNoncurrentVersions"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "StorageClass".to_string(),
+                name: "NoncurrentVersionTransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -461,7 +461,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For...").with_provider_name("NewerNoncurrentVersions"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "StorageClass".to_string(),
+                name: "NoncurrentVersionTransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -473,7 +473,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("object_size_less_than", AttributeType::String).with_description("Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than this value in bytes. For more information about siz...").with_provider_name("ObjectSizeLessThan"),
                     StructField::new("prefix", AttributeType::String).with_description("Object key prefix that identifies one or more objects to which this rule applies. Replacement must be made for object keys containing special characte...").with_provider_name("Prefix"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "RuleStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -483,7 +483,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "Transition".to_string(),
                     fields: vec![
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "StorageClass".to_string(),
+                name: "TransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -496,7 +496,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "Transition".to_string(),
                     fields: vec![
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "StorageClass".to_string(),
+                name: "TransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -580,7 +580,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must speci...").with_provider_name("KmsKeyArn"),
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "SseAlgorithm".to_string(),
+                name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -599,7 +599,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must speci...").with_provider_name("KmsKeyArn"),
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "SseAlgorithm".to_string(),
+                name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -834,7 +834,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "DeleteMarkerReplication".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "DeleteMarkerReplicationStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -873,7 +873,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold`` event.").with_provider_name("EventThreshold"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "MetricsStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -884,7 +884,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "ReplicationTime".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "ReplicationTimeStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -898,7 +898,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time when all objects and operations on objec...").with_provider_name("ReplicationTime"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "StorageClass".to_string(),
+                name: "ReplicationDestinationStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -929,7 +929,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "ReplicaModifications".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "ReplicaModificationsStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -940,7 +940,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "SseKmsEncryptedObjects".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "SseKmsEncryptedObjectsStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -950,7 +950,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container that describes additional filters for identifying the source objects that you want to replicate. You can choose to enable or disable the r...").with_provider_name("SourceSelectionCriteria"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "ReplicationRuleStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,
@@ -972,7 +972,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "VersioningConfiguration".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "Status".to_string(),
+                name: "VersioningConfigurationStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
                 namespace: Some("awscc.s3.bucket".to_string()),
                 to_dsl: None,

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -204,14 +204,14 @@ Shorthand formats: `Enabled` or `AccelerationStatus.Enabled`
 
 Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
 
-### status (Status)
+### status (IntelligentTieringConfigurationStatus)
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.Status.Disabled` |
-| `Enabled` | `awscc.s3.bucket.Status.Enabled` |
+| `Disabled` | `awscc.s3.bucket.IntelligentTieringConfigurationStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.IntelligentTieringConfigurationStatus.Enabled` |
 
-Shorthand formats: `Disabled` or `Status.Disabled`
+Shorthand formats: `Disabled` or `IntelligentTieringConfigurationStatus.Disabled`
 
 ### included_object_versions (IncludedObjectVersions)
 
@@ -271,14 +271,14 @@ Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectS
 
 Shorthand formats: `Enabled` or `ObjectLockEnabled.Enabled`
 
-### status (Status)
+### status (VersioningConfigurationStatus)
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.Status.Enabled` |
-| `Suspended` | `awscc.s3.bucket.Status.Suspended` |
+| `Enabled` | `awscc.s3.bucket.VersioningConfigurationStatus.Enabled` |
+| `Suspended` | `awscc.s3.bucket.VersioningConfigurationStatus.Suspended` |
 
-Shorthand formats: `Enabled` or `Status.Enabled`
+Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 
 ## Struct Definitions
 


### PR DESCRIPTION
## Summary

- When multiple struct definitions have fields with the same enum type name but different values (e.g., `IntelligentTieringConfiguration.Status` vs `VersioningConfiguration.Status` in S3 Bucket), the markdown docs and Rust schemas now prefix the type name with the parent struct name to disambiguate
- Extracts `disambiguate_enum_type_names()` helper used by both markdown and Rust codegen
- Regenerated all schemas and documentation

**Before:**
```
### status (Status)
| Disabled | awscc.s3.bucket.Status.Disabled |
| Enabled  | awscc.s3.bucket.Status.Enabled  |

### status (Status)
| Enabled   | awscc.s3.bucket.Status.Enabled   |
| Suspended | awscc.s3.bucket.Status.Suspended |
```

**After:**
```
### status (IntelligentTieringConfigurationStatus)
| Disabled | awscc.s3.bucket.IntelligentTieringConfigurationStatus.Disabled |
| Enabled  | awscc.s3.bucket.IntelligentTieringConfigurationStatus.Enabled  |

### status (VersioningConfigurationStatus)
| Enabled   | awscc.s3.bucket.VersioningConfigurationStatus.Enabled   |
| Suspended | awscc.s3.bucket.VersioningConfigurationStatus.Suspended |
```

Closes #580

## Test plan

- [x] Updated existing test `test_same_type_name_different_values_not_deduplicated` to verify disambiguated type names
- [x] Verified `test_shared_enum_type_across_structs_is_deduplicated_in_markdown` still passes (same values = no disambiguation needed)
- [x] All 100 codegen tests pass
- [x] Full workspace build and test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)