### PR TITLE
fix: recursively collect nested struct definitions in markdown codegen

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -856,13 +856,20 @@ fn collect_struct_defs(
         if let Some(props) = &def.properties
             && !props.is_empty()
         {
-            struct_defs
-                .entry(def_name.to_string())
-                .or_insert_with(|| StructDefInfo {
-                    def_name: def_name.to_string(),
-                    properties: props.clone(),
-                    required: def.required.clone(),
-                });
+            if !struct_defs.contains_key(def_name) {
+                struct_defs.insert(
+                    def_name.to_string(),
+                    StructDefInfo {
+                        def_name: def_name.to_string(),
+                        properties: props.clone(),
+                        required: def.required.clone(),
+                    },
+                );
+                // Recursively collect nested struct defs
+                for (field_name, field_prop) in props {
+                    collect_struct_defs(field_prop, field_name, schema, struct_defs);
+                }
+            }
         } else if !def.one_of.is_empty() {
             // Merge oneOf variant properties into a single struct
             let mut merged_props = BTreeMap::new();
@@ -873,18 +880,19 @@ fn collect_struct_defs(
                     }
                 }
             }
-            if !merged_props.is_empty() {
+            if !merged_props.is_empty() && !struct_defs.contains_key(def_name) {
+                struct_defs.insert(
+                    def_name.to_string(),
+                    StructDefInfo {
+                        def_name: def_name.to_string(),
+                        properties: merged_props.clone(),
+                        required: vec![], // oneOf variants are mutually exclusive
+                    },
+                );
                 // Recursively collect struct defs from merged properties
                 for (field_name, field_prop) in &merged_props {
                     collect_struct_defs(field_prop, field_name, schema, struct_defs);
                 }
-                struct_defs
-                    .entry(def_name.to_string())
-                    .or_insert_with(|| StructDefInfo {
-                        def_name: def_name.to_string(),
-                        properties: merged_props,
-                        required: vec![], // oneOf variants are mutually exclusive
-                    });
             }
         }
     }
@@ -896,28 +904,40 @@ fn collect_struct_defs(
         && let Some(def) = resolve_ref(schema, ref_path)
         && let Some(props) = &def.properties
         && !props.is_empty()
+        && !struct_defs.contains_key(def_name)
     {
-        struct_defs
-            .entry(def_name.to_string())
-            .or_insert_with(|| StructDefInfo {
+        struct_defs.insert(
+            def_name.to_string(),
+            StructDefInfo {
                 def_name: def_name.to_string(),
                 properties: props.clone(),
                 required: def.required.clone(),
-            });
+            },
+        );
+        // Recursively collect nested struct defs
+        for (field_name, field_prop) in props {
+            collect_struct_defs(field_prop, field_name, schema, struct_defs);
+        }
     }
     // Handle inline object with properties
     if let Some(type_val) = &prop.prop_type
         && type_val.as_str() == Some("object")
         && let Some(props) = &prop.properties
         && !props.is_empty()
+        && !struct_defs.contains_key(prop_name)
     {
-        struct_defs
-            .entry(prop_name.to_string())
-            .or_insert_with(|| StructDefInfo {
+        struct_defs.insert(
+            prop_name.to_string(),
+            StructDefInfo {
                 def_name: prop_name.to_string(),
                 properties: props.clone(),
                 required: prop.required.clone(),
-            });
+            },
+        );
+        // Recursively collect nested struct defs
+        for (field_name, field_prop) in props {
+            collect_struct_defs(field_prop, field_name, schema, struct_defs);
+        }
     }
 }
 

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -204,6 +204,71 @@ Shorthand formats: `Enabled` or `AccelerationStatus.Enabled`
 
 Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
 
+### owner (Owner)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Destination` | `awscc.s3.bucket.Owner.Destination` |
+
+Shorthand formats: `Destination` or `Owner.Destination`
+
+### encryption_type (EncryptionType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `NONE` | `awscc.s3.bucket.EncryptionType.NONE` |
+| `SSE-C` | `awscc.s3.bucket.EncryptionType.SSE_C` |
+
+Shorthand formats: `NONE` or `EncryptionType.NONE`
+
+### allowed_methods (AllowedMethods)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `GET` | `awscc.s3.bucket.AllowedMethods.GET` |
+| `PUT` | `awscc.s3.bucket.AllowedMethods.PUT` |
+| `HEAD` | `awscc.s3.bucket.AllowedMethods.HEAD` |
+| `POST` | `awscc.s3.bucket.AllowedMethods.POST` |
+| `DELETE` | `awscc.s3.bucket.AllowedMethods.DELETE` |
+
+Shorthand formats: `GET` or `AllowedMethods.GET`
+
+### output_schema_version (OutputSchemaVersion)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `V_1` | `awscc.s3.bucket.OutputSchemaVersion.V_1` |
+
+Shorthand formats: `V_1` or `OutputSchemaVersion.V_1`
+
+### mode (Mode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `COMPLIANCE` | `awscc.s3.bucket.Mode.COMPLIANCE` |
+| `GOVERNANCE` | `awscc.s3.bucket.Mode.GOVERNANCE` |
+
+Shorthand formats: `COMPLIANCE` or `Mode.COMPLIANCE`
+
+### status (DeleteMarkerReplicationStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Disabled` | `awscc.s3.bucket.DeleteMarkerReplicationStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.DeleteMarkerReplicationStatus.Enabled` |
+
+Shorthand formats: `Disabled` or `DeleteMarkerReplicationStatus.Disabled`
+
+### format (Format)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CSV` | `awscc.s3.bucket.Format.CSV` |
+| `ORC` | `awscc.s3.bucket.Format.ORC` |
+| `Parquet` | `awscc.s3.bucket.Format.Parquet` |
+
+Shorthand formats: `CSV` or `Format.CSV`
+
 ### status (IntelligentTieringConfigurationStatus)
 
 | Value | DSL Identifier |
@@ -254,6 +319,15 @@ Shorthand formats: `Size` or `OptionalFields.Size`
 
 Shorthand formats: `Daily` or `ScheduleFrequency.Daily`
 
+### configuration_state (ConfigurationState)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ENABLED` | `awscc.s3.bucket.ConfigurationState.ENABLED` |
+| `DISABLED` | `awscc.s3.bucket.ConfigurationState.DISABLED` |
+
+Shorthand formats: `ENABLED` or `ConfigurationState.ENABLED`
+
 ### transition_default_minimum_object_size (TransitionDefaultMinimumObjectSize)
 
 | Value | DSL Identifier |
@@ -263,6 +337,46 @@ Shorthand formats: `Daily` or `ScheduleFrequency.Daily`
 
 Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectSize.varies_by_storage_class`
 
+### table_bucket_type (TableBucketType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `aws` | `awscc.s3.bucket.TableBucketType.aws` |
+| `customer` | `awscc.s3.bucket.TableBucketType.customer` |
+
+Shorthand formats: `aws` or `TableBucketType.aws`
+
+### sse_algorithm (MetadataTableEncryptionConfigurationSseAlgorithm)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `aws:kms` | `awscc.s3.bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms` |
+| `AES256` | `awscc.s3.bucket.MetadataTableEncryptionConfigurationSseAlgorithm.AES256` |
+
+Shorthand formats: `aws:kms` or `MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms`
+
+### status (MetricsStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Disabled` | `awscc.s3.bucket.MetricsStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.MetricsStatus.Enabled` |
+
+Shorthand formats: `Disabled` or `MetricsStatus.Disabled`
+
+### storage_class (NoncurrentVersionTransitionStorageClass)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `DEEP_ARCHIVE` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.ONEZONE_IA` |
+| `STANDARD_IA` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.STANDARD_IA` |
+
+Shorthand formats: `DEEP_ARCHIVE` or `NoncurrentVersionTransitionStorageClass.DEEP_ARCHIVE`
+
 ### object_lock_enabled (ObjectLockEnabled)
 
 | Value | DSL Identifier |
@@ -270,6 +384,135 @@ Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectS
 | `Enabled` | `awscc.s3.bucket.ObjectLockEnabled.Enabled` |
 
 Shorthand formats: `Enabled` or `ObjectLockEnabled.Enabled`
+
+### object_ownership (ObjectOwnership)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ObjectWriter` | `awscc.s3.bucket.ObjectOwnership.ObjectWriter` |
+| `BucketOwnerPreferred` | `awscc.s3.bucket.ObjectOwnership.BucketOwnerPreferred` |
+| `BucketOwnerEnforced` | `awscc.s3.bucket.ObjectOwnership.BucketOwnerEnforced` |
+
+Shorthand formats: `ObjectWriter` or `ObjectOwnership.ObjectWriter`
+
+### partition_date_source (PartitionDateSource)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `EventTime` | `awscc.s3.bucket.PartitionDateSource.EventTime` |
+| `DeliveryTime` | `awscc.s3.bucket.PartitionDateSource.DeliveryTime` |
+
+Shorthand formats: `EventTime` or `PartitionDateSource.EventTime`
+
+### expiration (Expiration)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ENABLED` | `awscc.s3.bucket.Expiration.ENABLED` |
+| `DISABLED` | `awscc.s3.bucket.Expiration.DISABLED` |
+
+Shorthand formats: `ENABLED` or `Expiration.ENABLED`
+
+### protocol (Protocol)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `http` | `awscc.s3.bucket.Protocol.http` |
+| `https` | `awscc.s3.bucket.Protocol.https` |
+
+Shorthand formats: `http` or `Protocol.http`
+
+### status (ReplicaModificationsStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Enabled` | `awscc.s3.bucket.ReplicaModificationsStatus.Enabled` |
+| `Disabled` | `awscc.s3.bucket.ReplicaModificationsStatus.Disabled` |
+
+Shorthand formats: `Enabled` or `ReplicaModificationsStatus.Enabled`
+
+### storage_class (ReplicationDestinationStorageClass)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `DEEP_ARCHIVE` | `awscc.s3.bucket.ReplicationDestinationStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.bucket.ReplicationDestinationStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.bucket.ReplicationDestinationStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.bucket.ReplicationDestinationStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.bucket.ReplicationDestinationStorageClass.ONEZONE_IA` |
+| `REDUCED_REDUNDANCY` | `awscc.s3.bucket.ReplicationDestinationStorageClass.REDUCED_REDUNDANCY` |
+| `STANDARD` | `awscc.s3.bucket.ReplicationDestinationStorageClass.STANDARD` |
+| `STANDARD_IA` | `awscc.s3.bucket.ReplicationDestinationStorageClass.STANDARD_IA` |
+
+Shorthand formats: `DEEP_ARCHIVE` or `ReplicationDestinationStorageClass.DEEP_ARCHIVE`
+
+### status (ReplicationRuleStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Disabled` | `awscc.s3.bucket.ReplicationRuleStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.ReplicationRuleStatus.Enabled` |
+
+Shorthand formats: `Disabled` or `ReplicationRuleStatus.Disabled`
+
+### status (ReplicationTimeStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Disabled` | `awscc.s3.bucket.ReplicationTimeStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.ReplicationTimeStatus.Enabled` |
+
+Shorthand formats: `Disabled` or `ReplicationTimeStatus.Disabled`
+
+### status (RuleStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Enabled` | `awscc.s3.bucket.RuleStatus.Enabled` |
+| `Disabled` | `awscc.s3.bucket.RuleStatus.Disabled` |
+
+Shorthand formats: `Enabled` or `RuleStatus.Enabled`
+
+### sse_algorithm (ServerSideEncryptionByDefaultSseAlgorithm)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `aws:kms` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms` |
+| `AES256` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256` |
+| `aws:kms:dsse` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms:dsse` |
+
+Shorthand formats: `aws:kms` or `ServerSideEncryptionByDefaultSseAlgorithm.aws:kms`
+
+### status (SseKmsEncryptedObjectsStatus)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `Disabled` | `awscc.s3.bucket.SseKmsEncryptedObjectsStatus.Disabled` |
+| `Enabled` | `awscc.s3.bucket.SseKmsEncryptedObjectsStatus.Enabled` |
+
+Shorthand formats: `Disabled` or `SseKmsEncryptedObjectsStatus.Disabled`
+
+### access_tier (AccessTier)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ARCHIVE_ACCESS` | `awscc.s3.bucket.AccessTier.ARCHIVE_ACCESS` |
+| `DEEP_ARCHIVE_ACCESS` | `awscc.s3.bucket.AccessTier.DEEP_ARCHIVE_ACCESS` |
+
+Shorthand formats: `ARCHIVE_ACCESS` or `AccessTier.ARCHIVE_ACCESS`
+
+### storage_class (TransitionStorageClass)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `DEEP_ARCHIVE` | `awscc.s3.bucket.TransitionStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.bucket.TransitionStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.bucket.TransitionStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.bucket.TransitionStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.bucket.TransitionStorageClass.ONEZONE_IA` |
+| `STANDARD_IA` | `awscc.s3.bucket.TransitionStorageClass.STANDARD_IA` |
+
+Shorthand formats: `DEEP_ARCHIVE` or `TransitionStorageClass.DEEP_ARCHIVE`
 
 ### status (VersioningConfigurationStatus)
 
@@ -282,11 +525,23 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 
 ## Struct Definitions
 
+### AbortIncompleteMultipartUpload
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `days_after_initiation` | Int(0..) | Yes | Specifies the number of days after which Amazon S3 stops an incomplete multipart upload. |
+
 ### AccelerateConfiguration
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `acceleration_status` | Enum | Yes | Specifies the transfer acceleration status of the bucket. |
+
+### AccessControlTranslation
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `owner` | [Enum (Owner)](#owner-owner) | Yes | Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://... |
 
 ### AnalyticsConfiguration
 
@@ -296,6 +551,12 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `prefix` | String | No | The prefix that an object must have to be included in the analytics results. |
 | `storage_class_analysis` | [Struct(StorageClassAnalysis)](#storageclassanalysis) | Yes | Contains data related to access patterns to be collected and made available to analyze the tradeoffs... |
 | `tag_filters` | `List<Map>` | No | The tags to use when evaluating an analytics filter. The analytics only includes objects that meet t... |
+
+### BlockedEncryptionTypes
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `encryption_type` | [Enum (EncryptionType)](#encryption_type-encryptiontype) | No | The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket... |
 
 ### BucketEncryption
 
@@ -308,6 +569,66 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `cors_rules` | [List\<CorsRule\>](#corsrule) | Yes | A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rul... |
+
+### CorsRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `allowed_headers` | `List<String>` | No | Headers that are specified in the ``Access-Control-Request-Headers`` header. These headers are allow... |
+| `allowed_methods` | List\<[Enum (AllowedMethods)](#allowed_methods-allowedmethods)\> | Yes | An HTTP method that you allow the origin to run. *Allowed values*: ``GET`` | ``PUT`` | ``HEAD`` | ``... |
+| `allowed_origins` | `List<String>` | Yes | One or more origins you want customers to be able to access the bucket from. |
+| `exposed_headers` | `List<String>` | No | One or more headers in the response that you want customers to be able to access from their applicat... |
+| `id` | String | No | A unique identifier for this rule. The value must be no more than 255 characters. |
+| `max_age` | Int(0..) | No | The time in seconds that your browser is to cache the preflight response for the specified resource. |
+
+### DataExport
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `destination` | [Struct(Destination)](#destination) | Yes | The place to store the data for an analysis. |
+| `output_schema_version` | [Enum (OutputSchemaVersion)](#output_schema_version-outputschemaversion) | Yes | The version of the output schema to use when exporting data. Must be ``V_1``. |
+
+### DefaultRetention
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `days` | Int | No | The number of days that you want to specify for the default retention period. If Object Lock is turn... |
+| `mode` | Enum | No | The default Object Lock retention mode you want to apply to new objects placed in the specified buck... |
+| `years` | Int | No | The number of years that you want to specify for the default retention period. If Object Lock is tur... |
+
+### DeleteMarkerReplication
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | Enum | No | Indicates whether to replicate delete markers. |
+
+### Destination
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `bucket_account_id` | AwsAccountId | No | The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not v... |
+| `bucket_arn` | Arn | Yes | The Amazon Resource Name (ARN) of the bucket to which data is exported. |
+| `format` | Enum | Yes | Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC``... |
+| `prefix` | String | No | The prefix to use when exporting data. The prefix is prepended to all results. |
+
+### EncryptionConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `replica_kms_key_id` | KmsKeyId | Yes | Specifies the ID (Key ARN or Alias ARN) of the customer managed AWS KMS key stored in AWS Key Manage... |
+
+### EventBridgeConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event_bridge_enabled` | Bool | Yes | Enables delivery of events to Amazon EventBridge. |
+
+### FilterRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes | The object key name prefix or suffix identifying one or more objects to which the filtering rule app... |
+| `value` | String | Yes | The value that the filter searches for in object key names. |
 
 ### IntelligentTieringConfiguration
 
@@ -330,6 +651,32 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `optional_fields` | List\<[Enum (OptionalFields)](#optional_fields-optionalfields)\> | No | Contains the optional fields that are included in the inventory results. |
 | `prefix` | String | No | Specifies the inventory filter prefix. |
 | `schedule_frequency` | Enum | Yes | Specifies the schedule for generating inventory results. |
+
+### InventoryTableConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `configuration_state` | Enum | Yes | The configuration state of the inventory table, indicating whether the inventory table is enabled or... |
+| `encryption_configuration` | [Struct(MetadataTableEncryptionConfiguration)](#metadatatableencryptionconfiguration) | No | The encryption configuration for the inventory table. |
+| `table_arn` | Arn | No | The Amazon Resource Name (ARN) for the inventory table. |
+| `table_name` | String | No | The name of the inventory table. |
+
+### JournalTableConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `encryption_configuration` | [Struct(MetadataTableEncryptionConfiguration)](#metadatatableencryptionconfiguration) | No | The encryption configuration for the journal table. |
+| `record_expiration` | [Struct(RecordExpiration)](#recordexpiration) | Yes | The journal table record expiration settings for the journal table. |
+| `table_arn` | Arn | No | The Amazon Resource Name (ARN) for the journal table. |
+| `table_name` | String | No | The name of the journal table. |
+
+### LambdaConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event` | String | Yes | The Amazon S3 bucket event for which to invoke the LAMlong function. For more information, see [Supp... |
+| `filter` | [Struct(NotificationFilter)](#notificationfilter) | No | The filtering rules that determine which objects invoke the AWS Lambda function. For example, you ca... |
+| `function` | Arn | Yes | The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified eve... |
 
 ### LifecycleConfiguration
 
@@ -354,11 +701,33 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `inventory_table_configuration` | [Struct(InventoryTableConfiguration)](#inventorytableconfiguration) | No | The inventory table configuration for a metadata configuration. |
 | `journal_table_configuration` | [Struct(JournalTableConfiguration)](#journaltableconfiguration) | Yes | The journal table configuration for a metadata configuration. |
 
+### MetadataDestination
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `table_bucket_arn` | Arn | No | The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored. |
+| `table_bucket_type` | Enum | Yes | The type of the table bucket where the metadata configuration is stored. The ``aws`` value indicates... |
+| `table_namespace` | String | No | The namespace in the table bucket where the metadata tables for a metadata configuration are stored. |
+
 ### MetadataTableConfiguration
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `s3_tables_destination` | [Struct(S3TablesDestination)](#s3tablesdestination) | Yes | The destination information for the metadata table configuration. The destination table bucket must ... |
+
+### MetadataTableEncryptionConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kms_key_arn` | KmsKeyArn | No | If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the ... |
+| `sse_algorithm` | Enum | Yes | The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (... |
+
+### Metrics
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event_threshold` | [Struct(ReplicationTimeValue)](#replicationtimevalue) | No | A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold... |
+| `status` | Enum | Yes | Specifies whether the replication metrics are enabled. |
 
 ### MetricsConfiguration
 
@@ -369,6 +738,21 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `prefix` | String | No | The prefix that an object must have to be included in the metrics results. |
 | `tag_filters` | `List<Map>` | No | Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration ... |
 
+### NoncurrentVersionExpiration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `newer_noncurrent_versions` | Int | No | Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent... |
+| `noncurrent_days` | Int | Yes | Specifies the number of days an object is noncurrent before S3 can perform the associated action. Fo... |
+
+### NoncurrentVersionTransition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `newer_noncurrent_versions` | Int | No | Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent... |
+| `storage_class` | Enum | Yes | The class of storage used to store the object. |
+| `transition_in_days` | Int | Yes | Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated act... |
+
 ### NotificationConfiguration
 
 | Field | Type | Required | Description |
@@ -378,6 +762,12 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `queue_configurations` | [List\<QueueConfiguration\>](#queueconfiguration) | No | The Amazon Simple Queue Service queues to publish messages to and the events for which to publish me... |
 | `topic_configurations` | [List\<TopicConfiguration\>](#topicconfiguration) | No | The topic to which notifications are sent and the events for which notifications are generated. |
 
+### NotificationFilter
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `s3_key` | [Struct(S3KeyFilter)](#s3keyfilter) | Yes | A container for object key name prefix and suffix filtering rules. |
+
 ### ObjectLockConfiguration
 
 | Field | Type | Required | Description |
@@ -385,11 +775,29 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `object_lock_enabled` | [Enum (ObjectLockEnabled)](#object_lock_enabled-objectlockenabled) | No | Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled``... |
 | `rule` | [Struct(ObjectLockRule)](#objectlockrule) | No | Specifies the Object Lock rule for the specified object. Enable this rule when you apply ``ObjectLoc... |
 
+### ObjectLockRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `default_retention` | [Struct(DefaultRetention)](#defaultretention) | No | The default Object Lock retention mode and period that you want to apply to new objects placed in th... |
+
 ### OwnershipControls
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `rules` | [List\<OwnershipControlsRule\>](#ownershipcontrolsrule) | Yes | Specifies the container element for Object Ownership rules. |
+
+### OwnershipControlsRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `object_ownership` | Enum | No | Specifies an object ownership rule. |
+
+### PartitionedPrefix
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `partition_date_source` | Enum | No | Specifies the partition date source for the partitioned prefix. ``PartitionDateSource`` can be ``Eve... |
 
 ### PublicAccessBlockConfiguration
 
@@ -400,12 +808,217 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `ignore_public_acls` | Bool | No | Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this bucket. Se... |
 | `restrict_public_buckets` | Bool | No | Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this ele... |
 
+### QueueConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event` | String | Yes | The Amazon S3 bucket event about which you want to publish messages to Amazon SQS. For more informat... |
+| `filter` | [Struct(NotificationFilter)](#notificationfilter) | No | The filtering rules that determine which objects trigger notifications. For example, you can create ... |
+| `queue` | Arn | Yes | The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when i... |
+
+### RecordExpiration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `days` | Int | No | If you enable journal table record expiration, you can set the number of days to retain your journal... |
+| `expiration` | Enum | Yes | Specifies whether journal table record expiration is enabled or disabled. |
+
+### RedirectAllRequestsTo
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host_name` | String | Yes | Name of the host where requests are redirected. |
+| `protocol` | Enum | No | Protocol to use when redirecting requests. The default is the protocol that is used in the original ... |
+
+### RedirectRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host_name` | String | No | The host name to use in the redirect request. |
+| `http_redirect_code` | String | No | The HTTP redirect code to use on the response. Not required if one of the siblings is present. |
+| `protocol` | Enum | No | Protocol to use when redirecting requests. The default is the protocol that is used in the original ... |
+| `replace_key_prefix_with` | String | No | The object key prefix to use in the redirect request. For example, to redirect requests for all page... |
+| `replace_key_with` | String | No | The specific object key to use in the redirect request. For example, redirect request to ``error.htm... |
+
+### ReplicaModifications
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | Enum | Yes | Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``... |
+
 ### ReplicationConfiguration
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `role` | IamRoleArn | Yes | The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating obj... |
 | `rules` | [List\<ReplicationRule\>](#replicationrule) | Yes | A container for one or more replication rules. A replication configuration must have at least one ru... |
+
+### ReplicationDestination
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `access_control_translation` | [Struct(AccessControlTranslation)](#accesscontroltranslation) | No | Specify this only in a cross-account scenario (where source and destination bucket owners are not th... |
+| `account` | AwsAccountId | No | Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to change ... |
+| `bucket` | String | Yes | The Amazon Resource Name (ARN) of the bucket where you want Amazon S3 to store the results. |
+| `encryption_configuration` | [Struct(EncryptionConfiguration)](#encryptionconfiguration) | No | Specifies encryption-related information. |
+| `metrics` | [Struct(Metrics)](#metrics) | No | A container specifying replication metrics-related settings enabling replication metrics and events. |
+| `replication_time` | [Struct(ReplicationTime)](#replicationtime) | No | A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and... |
+| `storage_class` | Enum | No | The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By def... |
+
+### ReplicationRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `delete_marker_replication` | [Struct(DeleteMarkerReplication)](#deletemarkerreplication) | No | Specifies whether Amazon S3 replicates delete markers. If you specify a ``Filter`` in your replicati... |
+| `destination` | [Struct(ReplicationDestination)](#replicationdestination) | Yes | A container for information about the replication destination and its configurations including enabl... |
+| `filter` | [Struct(ReplicationRuleFilter)](#replicationrulefilter) | No | A filter that identifies the subset of objects to which the replication rule applies. A ``Filter`` m... |
+| `id` | String | No | A unique identifier for the rule. The maximum value is 255 characters. If you don't specify a value,... |
+| `prefix` | String | No | An object key name prefix that identifies the object or objects to which the rule applies. The maxim... |
+| `priority` | Int | No | The priority indicates which rule has precedence whenever two or more replication rules conflict. Am... |
+| `source_selection_criteria` | [Struct(SourceSelectionCriteria)](#sourceselectioncriteria) | No | A container that describes additional filters for identifying the source objects that you want to re... |
+| `status` | Enum | Yes | Specifies whether the rule is enabled. |
+
+### ReplicationRuleAndOperator
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. |
+| `tag_filters` | `List<Map>` | No | An array of tags containing key and value pairs. |
+
+### ReplicationRuleFilter
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `and` | [Struct(ReplicationRuleAndOperator)](#replicationruleandoperator) | No | A container for specifying rule filters. The filters determine the subset of objects to which the ru... |
+| `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. Replaceme... |
+| `tag_filter` | Map | No | A container for specifying a tag key and value. The rule applies only to objects that have the tag i... |
+
+### ReplicationTime
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | Enum | Yes | Specifies whether the replication time is enabled. |
+| `time` | [Struct(ReplicationTimeValue)](#replicationtimevalue) | Yes | A container specifying the time by which replication should be complete for all objects and operatio... |
+
+### ReplicationTimeValue
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `minutes` | Int | Yes | Contains an integer specifying time in minutes. Valid value: 15 |
+
+### RoutingRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `redirect_rule` | [Struct(RedirectRule)](#redirectrule) | Yes | Container for redirect information. You can redirect requests to another host, to another page, or w... |
+| `routing_rule_condition` | [Struct(RoutingRuleCondition)](#routingrulecondition) | No | A container for describing a condition that must be met for the specified redirect to apply. For exa... |
+
+### RoutingRuleCondition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `http_error_code_returned_equals` | String | No | The HTTP error code when the redirect is applied. In the event of an error, if the error code equals... |
+| `key_prefix_equals` | String | No | The object key name prefix when the redirect is applied. For example, to redirect requests for ``Exa... |
+
+### Rule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `abort_incomplete_multipart_upload` | [Struct(AbortIncompleteMultipartUpload)](#abortincompletemultipartupload) | No | Specifies a lifecycle rule that stops incomplete multipart uploads to an Amazon S3 bucket. |
+| `expiration_date` | String | No | Indicates when objects are deleted from Amazon S3 and Amazon S3 Glacier. The date value must be in I... |
+| `expiration_in_days` | Int | No | Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon S3 Gl... |
+| `expired_object_delete_marker` | Bool | No | Indicates whether Amazon S3 will remove a delete marker without any noncurrent versions. If set to t... |
+| `id` | String | No | Unique identifier for the rule. The value can't be longer than 255 characters. |
+| `noncurrent_version_expiration` | [Struct(NoncurrentVersionExpiration)](#noncurrentversionexpiration) | No | Specifies when noncurrent object versions expire. Upon expiration, S3 permanently deletes the noncur... |
+| `noncurrent_version_expiration_in_days` | Int | No | (Deprecated.) For buckets with versioning enabled (or suspended), specifies the time, in days, betwe... |
+| `noncurrent_version_transition` | [Struct(NoncurrentVersionTransition)](#noncurrentversiontransition) | No | (Deprecated.) For buckets with versioning enabled (or suspended), specifies when non-current objects... |
+| `noncurrent_version_transitions` | [List\<NoncurrentVersionTransition\>](#noncurrentversiontransition) | No | For buckets with versioning enabled (or suspended), one or more transition rules that specify when n... |
+| `object_size_greater_than` | String | No | Specifies the minimum object size in bytes for this rule to apply to. Objects must be larger than th... |
+| `object_size_less_than` | String | No | Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than t... |
+| `prefix` | String | No | Object key prefix that identifies one or more objects to which this rule applies. Replacement must b... |
+| `status` | Enum | Yes | If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently bein... |
+| `tag_filters` | `List<Map>` | No | Tags to use to identify a subset of objects to which the lifecycle rule applies. |
+| `transition` | [Struct(Transition)](#transition) | No | (Deprecated.) Specifies when an object transitions to a specified storage class. If you specify an e... |
+| `transitions` | [List\<Transition\>](#transition) | No | One or more transition rules that specify when an object transitions to a specified storage class. I... |
+
+### S3KeyFilter
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rules` | [List\<FilterRule\>](#filterrule) | Yes | A list of containers for the key-value pair that defines the criteria for the filter rule. |
+
+### S3TablesDestination
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `table_arn` | Arn | No | The Amazon Resource Name (ARN) for the metadata table in the metadata table configuration. The speci... |
+| `table_bucket_arn` | Arn | Yes | The Amazon Resource Name (ARN) for the table bucket that's specified as the destination in the metad... |
+| `table_name` | String | Yes | The name for the metadata table in your metadata table configuration. The specified metadata table n... |
+| `table_namespace` | String | No | The table bucket namespace for the metadata table in your metadata table configuration. This value i... |
+
+### ServerSideEncryptionByDefault
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kms_master_key_id` | KmsKeyId | No | AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *Gener... |
+| `sse_algorithm` | Enum | Yes | Server-side encryption algorithm to use for the default encryption. For directory buckets, there are... |
+
+### ServerSideEncryptionRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `blocked_encryption_types` | [Struct(BlockedEncryptionTypes)](#blockedencryptiontypes) | No | A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objec... |
+| `bucket_key_enabled` | Bool | No | Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-K... |
+| `server_side_encryption_by_default` | [Struct(ServerSideEncryptionByDefault)](#serversideencryptionbydefault) | No | Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object ... |
+
+### SourceSelectionCriteria
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `replica_modifications` | [Struct(ReplicaModifications)](#replicamodifications) | No | A filter that you can specify for selection for modifications on replicas. |
+| `sse_kms_encrypted_objects` | [Struct(SseKmsEncryptedObjects)](#ssekmsencryptedobjects) | No | A container for filter information for the selection of Amazon S3 objects encrypted with AWS KMS. |
+
+### SseKmsEncryptedObjects
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | Enum | Yes | Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS ... |
+
+### StorageClassAnalysis
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `data_export` | [Struct(DataExport)](#dataexport) | No | Specifies how data related to the storage class analysis for an Amazon S3 bucket should be exported. |
+
+### TargetObjectKeyFormat
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `partitioned_prefix` | [Struct(PartitionedPrefix)](#partitionedprefix) | No |  |
+| `simple_prefix` | Map | No | This format defaults the prefix to the given log file prefix for delivering server access log file. |
+
+### Tiering
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `access_tier` | Enum | Yes | S3 Intelligent-Tiering access tier. See [Storage class for automatically optimizing frequently and i... |
+| `days` | Int | Yes | The number of consecutive days of no access after which an object will be eligible to be transitione... |
+
+### TopicConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event` | String | Yes | The Amazon S3 bucket event about which to send notifications. For more information, see [Supported E... |
+| `filter` | [Struct(NotificationFilter)](#notificationfilter) | No | The filtering rules that determine for which objects to send notifications. For example, you can cre... |
+| `topic` | Arn | Yes | The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when i... |
+
+### Transition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `storage_class` | Enum | Yes | The storage class to which you want the object to transition. |
+| `transition_date` | String | No | Indicates when objects are transitioned to the specified storage class. The date value must be in IS... |
+| `transition_in_days` | Int | No | Indicates the number of days after creation when objects are transitioned to the specified storage c... |
 
 ### VersioningConfiguration
 


### PR DESCRIPTION
## Summary

- Fix `collect_struct_defs` to recursively traverse properties of collected structs, finding nested inline struct definitions (e.g., `Tiering` inside `IntelligentTieringConfiguration`)
- Previously only the `oneOf` branch recursed; now all three branches ($ref, array items with $ref, inline objects) recurse into their fields
- Uses `contains_key` guard before insertion to prevent infinite recursion on circular references
- Regenerated all docs — only `s3_bucket.md` changed, gaining 613 lines of previously missing struct definitions

Closes #582

## Test plan

- [x] `cargo test -p carina-provider-awscc` passes (104 tests)
- [x] Verified `### Tiering` heading now appears in generated `s3_bucket.md`
- [x] Verified `#tiering` anchor link target exists in output
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)