### PR TITLE
Add example .crn files for all resource types and CI check script

### DIFF
--- a/carina-provider-awscc/examples/ec2_transit_gateway_attachment/main.crn
+++ b/carina-provider-awscc/examples/ec2_transit_gateway_attachment/main.crn
@@ -1,0 +1,31 @@
+# EC2 Transit Gateway Attachment Example
+#
+# Creates a VPC, subnet, transit gateway, and attaches the VPC to the transit gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  transit_gateway_id = tgw.transit_gateway_id
+  vpc_id             = vpc.vpc_id
+  subnet_ids         = [subnet.subnet_id]
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-awscc/examples/iam_role/main.crn
+++ b/carina-provider-awscc/examples/iam_role/main.crn
@@ -1,0 +1,24 @@
+# IAM Role Example
+#
+# Creates an IAM role that can be assumed by the Lambda service.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.role {
+  role_name = "my-example-role"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-awscc/examples/logs_log_group/main.crn
+++ b/carina-provider-awscc/examples/logs_log_group/main.crn
@@ -1,0 +1,16 @@
+# CloudWatch Logs Log Group Example
+#
+# Creates a log group with a 30-day retention period.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.logs.log_group {
+  log_group_name    = "/example/my-app"
+  retention_in_days = 30
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-awscc/examples/s3_bucket/main.crn
+++ b/carina-provider-awscc/examples/s3_bucket/main.crn
@@ -1,0 +1,19 @@
+# S3 Bucket Example
+#
+# Creates an S3 bucket with versioning enabled.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  bucket_name = "my-example-bucket"
+
+  versioning_configuration = {
+    status = Enabled
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-awscc/scripts/check-examples.sh
+++ b/carina-provider-awscc/scripts/check-examples.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Check that every resource type has a corresponding example file
+#
+# Usage (from project root):
+#   ./carina-provider-awscc/scripts/check-examples.sh
+#
+# This script uses the codegen binary to convert CloudFormation type names
+# to directory names, matching the same logic used by generate-docs.sh.
+
+set -e
+
+EXAMPLES_DIR="carina-provider-awscc/examples"
+
+# Same resource types as generate-schemas.sh / generate-docs.sh
+RESOURCE_TYPES=(
+    "AWS::EC2::VPC"
+    "AWS::EC2::Subnet"
+    "AWS::EC2::InternetGateway"
+    "AWS::EC2::RouteTable"
+    "AWS::EC2::Route"
+    "AWS::EC2::SubnetRouteTableAssociation"
+    "AWS::EC2::EIP"
+    "AWS::EC2::NatGateway"
+    "AWS::EC2::SecurityGroup"
+    "AWS::EC2::SecurityGroupIngress"
+    "AWS::EC2::SecurityGroupEgress"
+    "AWS::EC2::VPCEndpoint"
+    "AWS::EC2::VPCGatewayAttachment"
+    "AWS::EC2::FlowLog"
+    "AWS::EC2::IPAM"
+    "AWS::EC2::IPAMPool"
+    "AWS::EC2::VPNGateway"
+    "AWS::EC2::TransitGateway"
+    "AWS::EC2::VPCPeeringConnection"
+    "AWS::EC2::EgressOnlyInternetGateway"
+    "AWS::EC2::TransitGatewayAttachment"
+    "AWS::S3::Bucket"
+    "AWS::IAM::Role"
+    "AWS::Logs::LogGroup"
+)
+
+# Build codegen tool
+CODEGEN_BIN="target/debug/codegen"
+cargo build -p carina-provider-awscc --bin codegen --quiet 2>/dev/null || {
+    echo "ERROR: Could not build codegen binary"
+    exit 1
+}
+
+MISSING=()
+
+for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
+    FULL_RESOURCE=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-full-resource-name)
+    EXAMPLE_FILE="$EXAMPLES_DIR/$FULL_RESOURCE/main.crn"
+    if [ ! -f "$EXAMPLE_FILE" ]; then
+        MISSING+=("$TYPE_NAME ($EXAMPLE_FILE)")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "ERROR: Missing example files for the following resource types:"
+    for entry in "${MISSING[@]}"; do
+        echo "  - $entry"
+    done
+    echo ""
+    echo "Please create example .crn files in $EXAMPLES_DIR/<resource_type>/main.crn"
+    exit 1
+fi
+
+echo "All resource types have example files."

--- a/docs/src/providers/awscc/ec2_transit_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2_transit_gateway_attachment.md
@@ -4,6 +4,34 @@ CloudFormation Type: `AWS::EC2::TransitGatewayAttachment`
 
 Resource Type definition for AWS::EC2::TransitGatewayAttachment
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  transit_gateway_id = tgw.transit_gateway_id
+  vpc_id             = vpc.vpc_id
+  subnet_ids         = [subnet.subnet_id]
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `options`

--- a/docs/src/providers/awscc/iam_role.md
+++ b/docs/src/providers/awscc/iam_role.md
@@ -5,6 +5,27 @@ CloudFormation Type: `AWS::IAM::Role`
 Creates a new role for your AWS-account.
   For more information about roles, see [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *IAM User Guide*. For information about quotas for role names and the number of roles you can create, see [IAM and quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in the *IAM User Guide*.
 
+## Example
+
+```crn
+awscc.iam.role {
+  role_name = "my-example-role"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `assume_role_policy_document`

--- a/docs/src/providers/awscc/logs_log_group.md
+++ b/docs/src/providers/awscc/logs_log_group.md
@@ -8,6 +8,19 @@ The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines 
   +  Log group names can be between 1 and 512 characters long.
   +  Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).
 
+## Example
+
+```crn
+awscc.logs.log_group {
+  log_group_name    = "/example/my-app"
+  retention_in_days = 30
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `data_protection_policy`

--- a/docs/src/providers/awscc/s3_bucket.md
+++ b/docs/src/providers/awscc/s3_bucket.md
@@ -6,6 +6,22 @@ The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Reg
  To control how AWS CloudFormation handles the bucket when the stack is deleted, you can set a deletion policy for your bucket. You can choose to *retain* the bucket or to *delete* the bucket. For more information, see [DeletionPolicy Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html).
   You can only delete empty buckets. Deletion fails for buckets that have contents.
 
+## Example
+
+```crn
+awscc.s3.bucket {
+  bucket_name = "my-example-bucket"
+
+  versioning_configuration = {
+    status = Enabled
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `abac_status`


### PR DESCRIPTION
## Summary

- Add missing example `.crn` files for 4 resource types: `s3_bucket`, `iam_role`, `logs_log_group`, and `ec2_transit_gateway_attachment`
- Add `check-examples.sh` script that validates every resource type has a corresponding example file
- Regenerate documentation to include the new examples

Closes #583

## Test plan

- [x] Verify `check-examples.sh` passes with all examples present
- [x] Verify `check-examples.sh` fails when an example is removed
- [x] Verify regenerated docs include the new Example sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)