### PR TITLE
feat: add example .crn files for aws provider resource types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/check-provider-boundaries.sh
 
+  check-examples:
+    name: Check Example Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash carina-provider-aws/scripts/check-examples.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/carina-provider-aws/examples/ec2_internet_gateway/main.crn
+++ b/carina-provider-aws/examples/ec2_internet_gateway/main.crn
@@ -1,0 +1,23 @@
+# EC2 Internet Gateway
+#
+# Creates an internet gateway attached to a VPC.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/ec2_route/main.crn
+++ b/carina-provider-aws/examples/ec2_route/main.crn
@@ -1,0 +1,37 @@
+# EC2 Route
+#
+# Creates a route in a route table pointing to an internet gateway.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let route = aws.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw.internet_gateway_id
+}

--- a/carina-provider-aws/examples/ec2_route_table/main.crn
+++ b/carina-provider-aws/examples/ec2_route_table/main.crn
@@ -1,0 +1,23 @@
+# EC2 Route Table
+#
+# Creates a route table within a VPC.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/ec2_security_group/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group/main.crn
@@ -1,0 +1,25 @@
+# EC2 Security Group
+#
+# Creates a security group within a VPC.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let sg = aws.ec2.security_group {
+  group_name  = "carina-example-sg"
+  description = "Example security group"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/ec2_security_group_egress/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group_egress/main.crn
@@ -1,0 +1,34 @@
+# EC2 Security Group Egress
+#
+# Creates an outbound rule allowing HTTPS traffic.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let sg = aws.ec2.security_group {
+  group_name  = "carina-example-sg-egress"
+  description = "SG for egress rule example"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let egress = aws.ec2.security_group_egress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS outbound"
+  ip_protocol = tcp
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "0.0.0.0/0"
+}

--- a/carina-provider-aws/examples/ec2_security_group_ingress/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group_ingress/main.crn
@@ -1,0 +1,34 @@
+# EC2 Security Group Ingress
+#
+# Creates an inbound rule allowing HTTPS traffic from within the VPC.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let sg = aws.ec2.security_group {
+  group_name  = "carina-example-sg-ingress"
+  description = "SG for ingress rule example"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let ingress = aws.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = tcp
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}

--- a/carina-provider-aws/examples/ec2_subnet/main.crn
+++ b/carina-provider-aws/examples/ec2_subnet/main.crn
@@ -1,0 +1,25 @@
+# EC2 Subnet
+#
+# Creates a subnet within a VPC.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "example"
+  }
+}
+
+let subnet = aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/ec2_vpc/main.crn
+++ b/carina-provider-aws/examples/ec2_vpc/main.crn
@@ -1,0 +1,18 @@
+# EC2 VPC
+#
+# Creates a VPC with DNS support and default tenancy.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/s3_bucket/main.crn
+++ b/carina-provider-aws/examples/s3_bucket/main.crn
@@ -1,0 +1,17 @@
+# S3 Bucket
+#
+# Creates an S3 bucket with versioning enabled.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.bucket {
+  bucket = "carina-example-s3-bucket"
+
+  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/carina-provider-aws/examples/sts_caller_identity/main.crn
+++ b/carina-provider-aws/examples/sts_caller_identity/main.crn
@@ -1,0 +1,10 @@
+# STS Caller Identity
+#
+# Retrieves the caller identity (data source, read-only).
+# Returns account_id, arn, and user_id of the calling entity.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let caller = read aws.sts.caller_identity {}

--- a/carina-provider-aws/scripts/check-examples.sh
+++ b/carina-provider-aws/scripts/check-examples.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Check that every resource type has a corresponding example file
+#
+# Usage (from project root):
+#   ./carina-provider-aws/scripts/check-examples.sh
+
+set -e
+
+EXAMPLES_DIR="carina-provider-aws/examples"
+
+# All resource types supported by the aws provider
+# (from carina-provider-aws/src/schemas/generated/mod.rs)
+RESOURCE_TYPES=(
+    "ec2_internet_gateway"
+    "ec2_route"
+    "ec2_route_table"
+    "ec2_security_group"
+    "ec2_security_group_egress"
+    "ec2_security_group_ingress"
+    "ec2_subnet"
+    "ec2_vpc"
+    "s3_bucket"
+    "sts_caller_identity"
+)
+
+MISSING=()
+
+for RESOURCE in "${RESOURCE_TYPES[@]}"; do
+    EXAMPLE_FILE="$EXAMPLES_DIR/$RESOURCE/main.crn"
+    if [ ! -f "$EXAMPLE_FILE" ]; then
+        MISSING+=("$RESOURCE ($EXAMPLE_FILE)")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "ERROR: Missing example files for the following resource types:"
+    for entry in "${MISSING[@]}"; do
+        echo "  - $entry"
+    done
+    echo ""
+    echo "Please create example .crn files in $EXAMPLES_DIR/<resource_type>/main.crn"
+    exit 1
+fi
+
+echo "All resource types have example files."


### PR DESCRIPTION
## Summary
- Add example `.crn` files for all 10 resource types supported by `carina-provider-aws`: `ec2_vpc`, `ec2_subnet`, `ec2_internet_gateway`, `ec2_route_table`, `ec2_route`, `ec2_security_group`, `ec2_security_group_ingress`, `ec2_security_group_egress`, `s3_bucket`, and `sts_caller_identity`
- Add `check-examples.sh` script to verify all resource types have example files
- Add CI job to run the check script on every PR

Closes #593

## Test plan
- [x] All example files pass `cargo run --bin carina -- validate`
- [x] `check-examples.sh` script passes
- [ ] CI job runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)