### PR TITLE
fix: add to_dsl conversion for Region type to fix idempotency

### DIFF
--- a/carina-provider-aws/src/schemas/types.rs
+++ b/carina-provider-aws/src/schemas/types.rs
@@ -52,7 +52,7 @@ pub fn aws_region() -> AttributeType {
             }
         },
         namespace: Some("aws".to_string()),
-        to_dsl: None,
+        to_dsl: Some(|s: &str| s.replace('-', "_")),
     }
 }
 

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -2135,4 +2135,30 @@ mod tests {
         let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.sg");
         assert_eq!(result, Some(Value::Int(42)));
     }
+
+    #[test]
+    fn test_aws_value_to_dsl_region_in_struct_uses_underscores() {
+        // Region values inside struct fields should use underscore format (ap_northeast_1),
+        // not hyphen format (ap-northeast-1), to match DSL conventions.
+        // This ensures idempotency for resources like ec2.ipam operating_regions.
+        use crate::schemas::awscc_types::awscc_region;
+
+        let fields = vec![
+            StructField::new("region_name", awscc_region())
+                .required()
+                .with_provider_name("RegionName"),
+        ];
+        let attr_type = AttributeType::List(Box::new(AttributeType::Struct {
+            name: "IpamOperatingRegion".to_string(),
+            fields,
+        }));
+        let json_val = json!([{"RegionName": "ap-northeast-1"}]);
+
+        let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.ipam");
+        let expected = Value::List(vec![Value::Map(HashMap::from([(
+            "region_name".to_string(),
+            Value::String("awscc.Region.ap_northeast_1".to_string()),
+        )]))]);
+        assert_eq!(result, Some(expected));
+    }
 }

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -77,7 +77,7 @@ pub fn awscc_region() -> AttributeType {
             }
         },
         namespace: Some("awscc".to_string()),
-        to_dsl: None,
+        to_dsl: Some(|s: &str| s.replace('-', "_")),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `to_dsl` function (`|s| s.replace('-', "_")`) to `awscc_region()` and `aws_region()` types, matching the existing `availability_zone()` pattern
- Without this, region values inside struct fields (e.g., `ec2.ipam` `operating_regions.region_name`) stored `awscc.Region.ap-northeast-1` (hyphens) in state, but the DSL uses `awscc.Region.ap_northeast_1` (underscores), causing false plan diffs
- Add test verifying region values in struct fields round-trip correctly

Closes #597

## Test plan

- [x] New unit test: `test_aws_value_to_dsl_region_in_struct_uses_underscores`
- [x] Existing tests pass (`cargo test -p carina-provider-awscc`, `cargo test -p carina-provider-aws`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)