### PR TITLE
ci: add awscc check-examples.sh to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: bash carina-provider-aws/scripts/check-examples.sh
+      - run: bash carina-provider-awscc/scripts/check-examples.sh
 
   test:
     name: Test


### PR DESCRIPTION
## Summary
- Add `bash carina-provider-awscc/scripts/check-examples.sh` to the `check-examples` CI job
- Add Rust toolchain and cargo cache steps since the awscc script builds the codegen binary

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)