### PR TITLE
fix: add force_replace schema flag for resources that reject CloudControl updates

### DIFF
--- a/carina-core/src/differ.rs
+++ b/carina-core/src/differ.rs
@@ -324,7 +324,12 @@ pub fn create_plan(
                     schemas,
                 );
 
-                if changed_create_only.is_empty() {
+                // Check if the resource type forces replacement (no update support)
+                let schema_force_replace =
+                    find_schema(&resource.id.provider, &resource.id.resource_type, schemas)
+                        .is_some_and(|s| s.force_replace);
+
+                if changed_create_only.is_empty() && !schema_force_replace {
                     plan.add(Effect::Update {
                         id,
                         from,
@@ -859,6 +864,66 @@ mod tests {
         assert!(
             matches!(plan.effects()[0], Effect::Update { .. }),
             "Expected Update, got {:?}",
+            plan.effects()[0]
+        );
+    }
+
+    #[test]
+    fn replace_when_schema_force_replace() {
+        use crate::schema::AttributeType;
+
+        // Resource has changed attributes but NO create-only attributes
+        let resources = vec![
+            Resource::new("ec2.internet_gateway", "my-igw").with_attribute(
+                "tags",
+                Value::Map(
+                    vec![("Name".to_string(), Value::String("new-name".to_string()))]
+                        .into_iter()
+                        .collect(),
+                ),
+            ),
+        ];
+
+        let mut current_states = HashMap::new();
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "tags".to_string(),
+            Value::Map(
+                vec![("Name".to_string(), Value::String("old-name".to_string()))]
+                    .into_iter()
+                    .collect(),
+            ),
+        );
+        current_states.insert(
+            ResourceId::new("ec2.internet_gateway", "my-igw"),
+            State::existing(ResourceId::new("ec2.internet_gateway", "my-igw"), attrs),
+        );
+
+        // Schema has force_replace=true (no create-only attributes)
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "ec2.internet_gateway".to_string(),
+            crate::schema::ResourceSchema::new("ec2.internet_gateway")
+                .attribute(crate::schema::AttributeSchema::new(
+                    "tags",
+                    AttributeType::String,
+                ))
+                .force_replace(),
+        );
+
+        let plan = create_plan(
+            &resources,
+            &current_states,
+            &HashMap::new(),
+            &schemas,
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+
+        assert_eq!(plan.effects().len(), 1);
+        assert!(
+            matches!(plan.effects()[0], Effect::Replace { .. }),
+            "Expected Replace for force_replace schema, got {:?}",
             plan.effects()[0]
         );
     }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -610,6 +610,11 @@ pub struct ResourceSchema {
     /// Used for automatic unique name generation during create-before-destroy replacement.
     /// (e.g., "bucket_name" for s3.bucket, "log_group_name" for logs.log_group)
     pub name_attribute: Option<String>,
+    /// If true, updates are not supported for this resource type.
+    /// The differ will always generate Replace instead of Update.
+    /// Used for resource types where the provider API rejects updates
+    /// despite the schema indicating update support.
+    pub force_replace: bool,
 }
 
 impl ResourceSchema {
@@ -621,6 +626,7 @@ impl ResourceSchema {
             validator: None,
             data_source: false,
             name_attribute: None,
+            force_replace: false,
         }
     }
 
@@ -646,6 +652,11 @@ impl ResourceSchema {
 
     pub fn with_name_attribute(mut self, attr: impl Into<String>) -> Self {
         self.name_attribute = Some(attr.into());
+        self
+    }
+
+    pub fn force_replace(mut self) -> Self {
+        self.force_replace = true;
         self
     }
 

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1487,6 +1487,13 @@ pub fn {}() -> AwsccSchemaConfig {{
         }
     }
 
+    // Resource types where CloudControl API rejects updates despite the schema
+    // having an update handler. These must be replaced instead of updated.
+    const FORCE_REPLACE_TYPES: &[&str] = &["AWS::EC2::InternetGateway", "AWS::EC2::IPAM"];
+    if FORCE_REPLACE_TYPES.contains(&type_name) {
+        code.push_str("        .force_replace()\n");
+    }
+
     // Close the schema (ResourceSchema) and the AwsccSchemaConfig struct
     code.push_str("    }\n}\n");
 

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -857,8 +857,8 @@ impl AwsccProvider {
                 .for_resource(id.clone())
         })?;
 
-        // Only VPC supports in-place updates currently
-        if id.resource_type != "ec2.vpc" {
+        // Reject updates for resource types marked as force_replace in the schema
+        if config.schema.force_replace {
             return Err(ProviderError::new(format!(
                 "Update not supported for {}, delete and recreate",
                 id.resource_type

--- a/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
@@ -26,6 +26,7 @@ pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
                 .with_description("Any tags to assign to the internet gateway.")
                 .with_provider_name("Tags"),
         )
+        .force_replace()
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -116,6 +116,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 .with_description("The tier of the IPAM.")
                 .with_provider_name("Tier"),
         )
+        .force_replace()
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `force_replace` flag to `ResourceSchema` for resource types where CloudControl API rejects updates despite the schema indicating update support
- The differ now generates `Replace` instead of `Update` for `ec2.internet_gateway` and `ec2.ipam`
- Replace hardcoded VPC-only update check in AWSCC provider with schema-driven `force_replace` check
- Add codegen support to automatically set `force_replace` for known problematic resource types

Closes #595

## Test plan

- [x] New unit test `replace_when_schema_force_replace` verifies the differ generates Replace for force_replace schemas
- [x] All existing tests pass (323 carina-core tests + full workspace)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)