### PR TITLE
feat: add availability_zone_id type and stricter arn() validation

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -733,6 +733,7 @@ pub fn aws_account_id() -> AttributeType {
 // ========== ARN validators ==========
 
 /// Validate basic ARN format (starts with "arn:", has 6+ colon-separated parts).
+/// Enforces that partition and service are non-empty.
 pub fn validate_arn(arn: &str) -> Result<(), String> {
     if !arn.starts_with("arn:") {
         return Err("must start with 'arn:'".to_string());
@@ -742,6 +743,16 @@ pub fn validate_arn(arn: &str) -> Result<(), String> {
         return Err(
             "must have at least 6 colon-separated parts (arn:partition:service:region:account:resource)".to_string()
         );
+    }
+    // Partition must be non-empty (e.g., "aws", "aws-cn", "aws-us-gov")
+    if parts[1].is_empty() {
+        return Err(
+            "partition must not be empty (e.g., 'aws', 'aws-cn', 'aws-us-gov')".to_string(),
+        );
+    }
+    // Service must be non-empty (e.g., "s3", "iam", "ec2")
+    if parts[2].is_empty() {
+        return Err("service must not be empty (e.g., 's3', 'iam', 'ec2')".to_string());
     }
     Ok(())
 }
@@ -999,6 +1010,61 @@ pub fn validate_availability_zone(az: &str) -> Result<(), String> {
     Ok(())
 }
 
+// ========== Availability Zone ID ==========
+
+/// Validate availability zone ID format.
+/// AZ IDs use a compact format like "use1-az1", "usw2-az2", "apne1-az4", "euc1-az1".
+/// Format: region-abbreviation + number + "-az" + digit(s)
+pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
+    // Must contain "-az" separator
+    let Some(az_pos) = az_id.find("-az") else {
+        return Err("must contain '-az' (e.g., 'use1-az1')".to_string());
+    };
+
+    let prefix = &az_id[..az_pos];
+    let suffix = &az_id[az_pos + 3..]; // after "-az"
+
+    // Prefix must be non-empty and contain only lowercase letters and digits,
+    // ending with a digit (the region number)
+    if prefix.is_empty() {
+        return Err("region prefix must not be empty".to_string());
+    }
+    if !prefix
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        return Err("region prefix must contain only lowercase letters and digits".to_string());
+    }
+    if !prefix.chars().last().is_some_and(|c| c.is_ascii_digit()) {
+        return Err("region prefix must end with a digit (e.g., 'use1', 'apne1')".to_string());
+    }
+
+    // Suffix (after "-az") must be one or more digits
+    if suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_digit()) {
+        return Err("AZ number after '-az' must be one or more digits".to_string());
+    }
+
+    Ok(())
+}
+
+/// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
+pub fn availability_zone_id() -> AttributeType {
+    AttributeType::Custom {
+        name: "AvailabilityZoneId".to_string(),
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_availability_zone_id(s)
+                    .map_err(|reason| format!("Invalid availability zone ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
 // ========== IAM Policy Document ==========
 
 /// String or list of strings type — for IAM policy fields like action, resource
@@ -1151,6 +1217,19 @@ mod tests {
     }
 
     #[test]
+    fn validate_arn_rejects_empty_partition() {
+        // "arn::::::" has empty partition and service — should be rejected
+        assert!(validate_arn("arn::s3:::my-bucket").is_err());
+        assert!(validate_arn("arn:::::").is_err());
+    }
+
+    #[test]
+    fn validate_arn_rejects_empty_service() {
+        assert!(validate_arn("arn:aws::::").is_err());
+        assert!(validate_arn("arn:aws:::123456789012:resource").is_err());
+    }
+
+    #[test]
     fn validate_arn_type_with_value() {
         let t = arn();
         assert!(
@@ -1296,6 +1375,52 @@ mod tests {
         assert!(validate_availability_zone("a").is_err()); // too short
         assert!(validate_availability_zone("invalid").is_err()); // no numeric part
         assert!(validate_availability_zone("us-east").is_err()); // no numeric part
+    }
+
+    // Availability zone ID tests
+
+    #[test]
+    fn validate_availability_zone_id_valid() {
+        assert!(validate_availability_zone_id("use1-az1").is_ok());
+        assert!(validate_availability_zone_id("use1-az2").is_ok());
+        assert!(validate_availability_zone_id("usw2-az1").is_ok());
+        assert!(validate_availability_zone_id("usw2-az4").is_ok());
+        assert!(validate_availability_zone_id("apne1-az1").is_ok());
+        assert!(validate_availability_zone_id("apne1-az4").is_ok());
+        assert!(validate_availability_zone_id("euc1-az1").is_ok());
+        assert!(validate_availability_zone_id("aps1-az1").is_ok());
+        assert!(validate_availability_zone_id("mes1-az1").is_ok());
+        assert!(validate_availability_zone_id("afs1-az1").is_ok());
+    }
+
+    #[test]
+    fn validate_availability_zone_id_invalid() {
+        assert!(validate_availability_zone_id("us-east-1a").is_err()); // AZ name, not ID
+        assert!(validate_availability_zone_id("use1").is_err()); // missing -az suffix
+        assert!(validate_availability_zone_id("az1").is_err()); // missing region prefix
+        assert!(validate_availability_zone_id("").is_err()); // empty
+        assert!(validate_availability_zone_id("USE1-AZ1").is_err()); // uppercase
+        assert!(validate_availability_zone_id("use-az1").is_err()); // prefix doesn't end with digit
+        assert!(validate_availability_zone_id("use1-az").is_err()); // missing AZ number
+        assert!(validate_availability_zone_id("use1-azX").is_err()); // non-digit after -az
+    }
+
+    #[test]
+    fn validate_availability_zone_id_type_with_value() {
+        let t = availability_zone_id();
+        assert!(t.validate(&Value::String("use1-az1".to_string())).is_ok());
+        assert!(
+            t.validate(&Value::String("us-east-1a".to_string()))
+                .is_err()
+        );
+        assert!(t.validate(&Value::Int(42)).is_err());
+        assert!(
+            t.validate(&Value::ResourceRef {
+                binding_name: "subnet".to_string(),
+                attribute_name: "availability_zone_id".to_string(),
+            })
+            .is_ok()
+        );
     }
 
     // Enum helpers

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2384,6 +2384,7 @@ fn type_code_to_display(type_code: &str) -> String {
         s if s.contains("arn()") => "Arn".to_string(),
         s if s.contains("aws_account_id") => "AwsAccountId".to_string(),
         s if s.contains("aws_resource_id") => "AwsResourceId".to_string(),
+        s if s.contains("availability_zone_id") => "AvailabilityZoneId".to_string(),
         s if s.contains("availability_zone") => "AvailabilityZone".to_string(),
         _ => type_code
             .trim_start_matches("super::")
@@ -2547,6 +2548,11 @@ fn infer_string_type(prop_name: &str) -> Option<String> {
     // Availability zone (but not AvailabilityZoneId which uses AZ ID format like "use1-az1")
     if prop_lower == "availabilityzone" || prop_lower == "availabilityzones" {
         return Some("super::availability_zone()".to_string());
+    }
+
+    // Availability zone ID (e.g., "use1-az1", "usw2-az2")
+    if prop_lower == "availabilityzoneid" || prop_lower == "availabilityzoneids" {
+        return Some("super::availability_zone_id()".to_string());
     }
 
     // Region types (e.g., PeerRegion, ServiceRegion, RegionName, ResourceRegion)

--- a/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/subnet.rs
@@ -55,7 +55,7 @@ pub fn ec2_subnet_config() -> AwsSchemaConfig {
                 .with_provider_name("AvailabilityZone"),
         )
         .attribute(
-            AttributeSchema::new("availability_zone_id", AttributeType::String)
+            AttributeSchema::new("availability_zone_id", super::availability_zone_id())
                 .create_only()
                 .with_description("The AZ ID or the Local Zone ID of the subnet.")
                 .with_provider_name("AvailabilityZoneId"),

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -377,6 +377,8 @@ fn infer_string_type_display(prop_name: &str, resource_type: &str) -> String {
         }
     } else if prop_lower == "availabilityzone" || prop_lower == "availabilityzones" {
         "AvailabilityZone".to_string()
+    } else if prop_lower == "availabilityzoneid" || prop_lower == "availabilityzoneids" {
+        "AvailabilityZoneId".to_string()
     } else if prop_lower.ends_with("region") || prop_lower == "regionname" {
         "Region".to_string()
     } else if prop_lower.ends_with("arn")
@@ -2260,6 +2262,11 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
         return Some("super::availability_zone()".to_string());
     }
 
+    // Availability zone ID (e.g., "use1-az1", "usw2-az2")
+    if prop_lower == "availabilityzoneid" || prop_lower == "availabilityzoneids" {
+        return Some("super::availability_zone_id()".to_string());
+    }
+
     // Region types (e.g., PeerRegion, ServiceRegion, RegionName, ResourceRegion)
     if prop_lower.ends_with("region") || prop_lower == "regionname" {
         return Some("super::awscc_region()".to_string());
@@ -3446,7 +3453,7 @@ mod tests {
         );
         assert_eq!(type_str, "super::availability_zone()");
 
-        // AvailabilityZoneId should stay String
+        // AvailabilityZoneId should use super::availability_zone_id()
         let (type_str, _) = cfn_type_to_carina_type_with_enum(
             &prop,
             "AvailabilityZoneId",
@@ -3454,7 +3461,7 @@ mod tests {
             "",
             &BTreeMap::new(),
         );
-        assert_eq!(type_str, "AttributeType::String");
+        assert_eq!(type_str, "super::availability_zone_id()");
     }
 
     #[test]
@@ -5012,8 +5019,11 @@ mod tests {
             infer_string_type("AvailabilityZone", ""),
             Some("super::availability_zone()".to_string())
         );
-        // AvailabilityZoneId should NOT match (uses AZ ID format like "use1-az1")
-        assert_eq!(infer_string_type("AvailabilityZoneId", ""), None);
+        // AvailabilityZoneId should use availability_zone_id()
+        assert_eq!(
+            infer_string_type("AvailabilityZoneId", ""),
+            Some("super::availability_zone_id()".to_string())
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -66,7 +66,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("allocation_ids", AttributeType::List(Box::new(super::allocation_id()))).required().with_description("The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic in this specific Availability Zone.").with_provider_name("AllocationIds"),
                     StructField::new("availability_zone", super::availability_zone()).with_description("For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NAT gateway ...").with_provider_name("AvailabilityZone"),
-                    StructField::new("availability_zone_id", AttributeType::String).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
+                    StructField::new("availability_zone_id", super::availability_zone_id()).with_description("For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway configuration will be active. Each AZ in a regional NA...").with_provider_name("AvailabilityZoneId")
                     ],
                 })))
                 .with_description("For regional NAT gateways only: Specifies which Availability Zones you want the NAT gateway to support and the Elastic IP addresses (EIPs) to use in e...")

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -53,7 +53,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                 .with_provider_name("AvailabilityZone"),
         )
         .attribute(
-            AttributeSchema::new("availability_zone_id", AttributeType::String)
+            AttributeSchema::new("availability_zone_id", super::availability_zone_id())
                 .create_only()
                 .with_description("The AZ ID of the subnet.")
                 .with_provider_name("AvailabilityZoneId"),

--- a/docs/src/providers/aws/ec2_subnet.md
+++ b/docs/src/providers/aws/ec2_subnet.md
@@ -22,7 +22,7 @@ The Availability Zone or Local Zone for the subnet. Default: Amazon Web Services
 
 ### `availability_zone_id`
 
-- **Type:** String
+- **Type:** AvailabilityZoneId
 - **Required:** No
 
 The AZ ID or the Local Zone ID of the subnet.

--- a/docs/src/providers/awscc/ec2_nat_gateway.md
+++ b/docs/src/providers/awscc/ec2_nat_gateway.md
@@ -151,7 +151,7 @@ Shorthand formats: `public` or `ConnectivityType.public`
 |-------|------|----------|-------------|
 | `allocation_ids` | `List<AllocationId>` | Yes | The allocation IDs of the Elastic IP addresses (EIPs) to be used for handling outbound NAT traffic i... |
 | `availability_zone` | AvailabilityZone | No | For regional NAT gateways only: The Availability Zone where this specific NAT gateway configuration ... |
-| `availability_zone_id` | String | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
+| `availability_zone_id` | AvailabilityZoneId | No | For regional NAT gateways only: The ID of the Availability Zone where this specific NAT gateway conf... |
 
 ## Attribute Reference
 

--- a/docs/src/providers/awscc/ec2_subnet.md
+++ b/docs/src/providers/awscc/ec2_subnet.md
@@ -45,7 +45,7 @@ The Availability Zone of the subnet. If you update this property, you must also 
 
 ### `availability_zone_id`
 
-- **Type:** String
+- **Type:** AvailabilityZoneId
 - **Required:** No
 
 The AZ ID of the subnet.


### PR DESCRIPTION
## Summary
- Add `AvailabilityZoneId` type with validator for AZ ID format (`use1-az1`, `usw2-az2`, `apne1-az4`, etc.) in `carina-aws-types`
- Make `arn()` validation stricter: reject ARNs with empty partition or service (e.g., `arn:::::` now fails)
- Update both codegens (awscc, aws) to infer `availability_zone_id()` type for `AvailabilityZoneId` properties
- Update generated schemas and documentation to use the new type

Closes #602

## Test plan
- [x] Unit tests for `validate_availability_zone_id()` with valid and invalid inputs
- [x] Unit tests for stricter `validate_arn()` rejecting empty partition/service
- [x] Unit tests for `availability_zone_id()` type wrapper
- [x] Updated codegen tests to verify `AvailabilityZoneId` infers correct type
- [x] All existing tests pass (`cargo test -p carina-aws-types -p carina-provider-awscc -p carina-provider-aws -p carina-codegen-aws`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)