### PR TITLE
feat: deduplicate validation functions in codegen

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1477,47 +1477,63 @@ fn {}(value: &Value) -> Result<(), String> {{
         ));
     }
 
-    // Generate pattern validation functions for string properties
-    for (prop_name, pattern) in &patterns {
-        let fn_name = format!("validate_{}_pattern", prop_name.to_snake_case());
-        // Convert PCRE-specific constructs to Rust regex equivalents
-        let rust_pattern = pattern.replace("\\Z", "\\z");
-        // Escape for Rust string literal (double the backslashes, escape quotes)
-        let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
-        // For the error message, also escape { and } for the inner format!() macro
-        let escaped_for_msg = escaped_for_rust.replace('{', "{{").replace('}', "}}");
-        code.push_str("fn ");
-        code.push_str(&fn_name);
-        code.push_str("(value: &Value) -> Result<(), String> {\n");
-        code.push_str("    if let Value::String(s) = value {\n");
-        code.push_str(
-            "        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {\n",
-        );
-        code.push_str(&format!(
-            "            Regex::new(\"{}\").expect(\"invalid pattern regex\")\n",
-            escaped_for_rust
-        ));
-        code.push_str("        });\n");
-        code.push_str("        if RE.is_match(s) {\n");
-        code.push_str("            Ok(())\n");
-        code.push_str("        } else {\n");
-        code.push_str(&format!(
-            "            Err(format!(\"Value '{{}}' does not match pattern {}\", s))\n",
-            escaped_for_msg
-        ));
-        code.push_str("        }\n");
-        code.push_str("    } else {\n");
-        code.push_str("        Err(\"Expected string\".to_string())\n");
-        code.push_str("    }\n");
-        code.push_str("}\n\n");
+    // Generate pattern validation functions for string properties (deduplicated)
+    // Multiple properties with the same pattern share one validation function.
+    {
+        let mut generated_patterns: HashSet<String> = HashSet::new();
+        for pattern in patterns.values() {
+            if generated_patterns.contains(pattern) {
+                continue;
+            }
+            generated_patterns.insert(pattern.clone());
+            let fn_name = pattern_fn_name(pattern);
+            // Convert PCRE-specific constructs to Rust regex equivalents
+            let rust_pattern = pattern.replace("\\Z", "\\z");
+            // Escape for Rust string literal (double the backslashes, escape quotes)
+            let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
+            // For the error message, also escape { and } for the inner format!() macro
+            let escaped_for_msg = escaped_for_rust.replace('{', "{{").replace('}', "}}");
+            code.push_str("fn ");
+            code.push_str(&fn_name);
+            code.push_str("(value: &Value) -> Result<(), String> {\n");
+            code.push_str("    if let Value::String(s) = value {\n");
+            code.push_str(
+                "        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {\n",
+            );
+            code.push_str(&format!(
+                "            Regex::new(\"{}\").expect(\"invalid pattern regex\")\n",
+                escaped_for_rust
+            ));
+            code.push_str("        });\n");
+            code.push_str("        if RE.is_match(s) {\n");
+            code.push_str("            Ok(())\n");
+            code.push_str("        } else {\n");
+            code.push_str(&format!(
+                "            Err(format!(\"Value '{{}}' does not match pattern {}\", s))\n",
+                escaped_for_msg
+            ));
+            code.push_str("        }\n");
+            code.push_str("    } else {\n");
+            code.push_str("        Err(\"Expected string\".to_string())\n");
+            code.push_str("    }\n");
+            code.push_str("}\n\n");
+        }
     }
 
-    // Generate validation functions for array item count constraints
-    for (prop_name, (min, max)) in &ranged_lists {
-        let fn_name = format!("validate_{}_items", prop_name.to_snake_case());
-        let (condition, range_display) = list_items_condition_and_display(*min, *max);
-        code.push_str(&format!(
-            r#"fn {}(value: &Value) -> Result<(), String> {{
+    // Generate validation functions for array item count constraints (deduplicated)
+    // Multiple properties with the same min/max items share one validation function.
+    {
+        let mut generated_items: HashSet<(Option<i64>, Option<i64>)> = HashSet::new();
+        for (min, max) in ranged_lists.values() {
+            let key = (*min, *max);
+            if generated_items.contains(&key) {
+                continue;
+            }
+            generated_items.insert(key);
+            let fn_name = list_items_fn_name(*min, *max);
+            let (condition, range_display) = list_items_condition_and_display(*min, *max);
+            code.push_str(&format!(
+                r#"fn {}(value: &Value) -> Result<(), String> {{
     if let Value::List(items) = value {{
         let len = items.len();
         if {} {{
@@ -1531,16 +1547,25 @@ fn {}(value: &Value) -> Result<(), String> {{
 }}
 
 "#,
-            fn_name, condition, range_display
-        ));
+                fn_name, condition, range_display
+            ));
+        }
     }
 
-    // Generate length validation functions for string properties
-    for (prop_name, (min, max)) in &ranged_strings {
-        let fn_name = format!("validate_{}_length", prop_name.to_snake_case());
-        let (condition, range_display) = string_length_condition_and_display(*min, *max);
-        code.push_str(&format!(
-            r#"fn {}(value: &Value) -> Result<(), String> {{
+    // Generate length validation functions for string properties (deduplicated)
+    // Multiple properties with the same min/max length share one validation function.
+    {
+        let mut generated_lengths: HashSet<(Option<u64>, Option<u64>)> = HashSet::new();
+        for (min, max) in ranged_strings.values() {
+            let key = (*min, *max);
+            if generated_lengths.contains(&key) {
+                continue;
+            }
+            generated_lengths.insert(key);
+            let fn_name = string_length_fn_name(*min, *max);
+            let (condition, range_display) = string_length_condition_and_display(*min, *max);
+            code.push_str(&format!(
+                r#"fn {}(value: &Value) -> Result<(), String> {{
     if let Value::String(s) = value {{
         let len = s.len();
         if {} {{
@@ -1554,8 +1579,9 @@ fn {}(value: &Value) -> Result<(), String> {{
 }}
 
 "#,
-            fn_name, condition, range_display
-        ));
+                fn_name, condition, range_display
+            ));
+        }
     }
 
     // Generate config function
@@ -2304,6 +2330,39 @@ fn string_length_display(min: Option<u64>, max: Option<u64>) -> String {
     }
 }
 
+/// Generate a constraint-based function name for string length validation.
+/// E.g., `validate_string_length_max_1024` or `validate_string_length_1_512`.
+fn string_length_fn_name(min: Option<u64>, max: Option<u64>) -> String {
+    let effective_min = min.filter(|&m| m > 0);
+    match (effective_min, max) {
+        (Some(min), Some(max)) => format!("validate_string_length_{min}_{max}"),
+        (Some(min), None) => format!("validate_string_length_min_{min}"),
+        (None, Some(max)) => format!("validate_string_length_max_{max}"),
+        (None, None) => unreachable!("at least one bound must be present"),
+    }
+}
+
+/// Generate a constraint-based function name for list items validation.
+/// E.g., `validate_list_items_1_100` or `validate_list_items_max_10`.
+fn list_items_fn_name(min: Option<i64>, max: Option<i64>) -> String {
+    match (min, max) {
+        (Some(min), Some(max)) => format!("validate_list_items_{min}_{max}"),
+        (Some(min), None) => format!("validate_list_items_min_{min}"),
+        (None, Some(max)) => format!("validate_list_items_max_{max}"),
+        (None, None) => unreachable!("at least one bound must be present"),
+    }
+}
+
+/// Generate a constraint-based function name for pattern validation.
+/// Uses a hash of the pattern to create a unique but deterministic name.
+fn pattern_fn_name(pattern: &str) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    pattern.hash(&mut hasher);
+    let hash = hasher.finish();
+    format!("validate_string_pattern_{:016x}", hash)
+}
+
 /// Generate condition string and display string for string length validation.
 /// Treats min=0 as no minimum since `usize` is always >= 0.
 fn string_length_condition_and_display(min: Option<u64>, max: Option<u64>) -> (String, String) {
@@ -2929,10 +2988,12 @@ fn cfn_type_to_carina_type_with_enum(
                 );
             }
             // Handle string-typed $ref definitions with pattern constraints
-            if def.def_type.as_deref() == Some("string") && def.pattern.is_some() {
+            if def.def_type.as_deref() == Some("string")
+                && let Some(pattern) = &def.pattern
+            {
                 // Check if name-based heuristics would override the type
                 if infer_string_type(prop_name, &schema.type_name).is_none() {
-                    let validate_fn = format!("validate_{}_pattern", prop_name.to_snake_case());
+                    let validate_fn = pattern_fn_name(pattern);
                     return (
                         format!(
                             r#"AttributeType::Custom {{
@@ -3040,8 +3101,8 @@ fn cfn_type_to_carina_type_with_enum(
             }
 
             // Check for regex pattern constraint
-            if prop.pattern.is_some() {
-                let validate_fn = format!("validate_{}_pattern", prop_name.to_snake_case());
+            if let Some(pattern) = &prop.pattern {
+                let validate_fn = pattern_fn_name(pattern);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
@@ -3061,7 +3122,7 @@ fn cfn_type_to_carina_type_with_enum(
             // Treat minLength=0 as no constraint since usize is always >= 0
             let effective_min = prop.min_length.filter(|&m| m > 0);
             if effective_min.is_some() || prop.max_length.is_some() {
-                let validate_fn = format!("validate_{}_length", prop_name.to_snake_case());
+                let validate_fn = string_length_fn_name(effective_min, prop.max_length);
                 let display = string_length_display(effective_min, prop.max_length);
                 return (
                     format!(
@@ -3251,7 +3312,7 @@ fn cfn_type_to_carina_type_with_enum(
             };
             // Wrap in Custom type if minItems/maxItems constraints exist
             if prop.min_items.is_some() || prop.max_items.is_some() {
-                let validate_fn = format!("validate_{}_items", prop_name.to_snake_case());
+                let validate_fn = list_items_fn_name(prop.min_items, prop.max_items);
                 let display = range_display_string(prop.min_items, prop.max_items);
                 (
                     format!(
@@ -6853,7 +6914,7 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("validate_log_group_name_pattern"),
+            type_str.contains("validate_string_pattern_"),
             "Should reference pattern validation function, got: {}",
             type_str
         );
@@ -6889,7 +6950,7 @@ mod tests {
         );
         // KmsKeyId should be resolved to a specific ARN type, not pattern-validated
         assert!(
-            !type_str.contains("validate_kms_key_id_pattern"),
+            !type_str.contains("validate_string_pattern_"),
             "Known type (KmsKeyId) should not get pattern validation, got: {}",
             type_str
         );
@@ -6923,7 +6984,7 @@ mod tests {
 
         let code = generate_schema_code(&schema, "AWS::Logs::LogGroup").unwrap();
         assert!(
-            code.contains("fn validate_log_group_name_pattern"),
+            code.contains("fn validate_string_pattern_"),
             "Generated code should contain pattern validation function:\n{}",
             code
         );
@@ -6976,7 +7037,7 @@ mod tests {
             "Custom type should wrap a List: {type_str}"
         );
         assert!(
-            type_str.contains("validate_private_dns_specified_domains_items"),
+            type_str.contains("validate_list_items_1_10"),
             "should reference items validation function: {type_str}"
         );
     }
@@ -7122,7 +7183,7 @@ mod tests {
 
         let generated = generate_schema_code(&schema, "AWS::EC2::VPCEndpoint").unwrap();
         assert!(
-            generated.contains("validate_private_dns_specified_domains_items"),
+            generated.contains("validate_list_items_1_10"),
             "should generate items validation function: {generated}"
         );
         assert!(
@@ -7166,7 +7227,7 @@ mod tests {
 
         // Should generate a length validation function
         assert!(
-            generated.contains("validate_log_group_name_length"),
+            generated.contains("validate_string_length_1_512"),
             "Should generate length validation function: {generated}"
         );
 
@@ -7212,7 +7273,7 @@ mod tests {
         let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
 
         assert!(
-            generated.contains("validate_resource_name_length"),
+            generated.contains("validate_string_length_min_1"),
             "Should generate length validation function for min-only: {generated}"
         );
         assert!(
@@ -7250,7 +7311,7 @@ mod tests {
         let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
 
         assert!(
-            generated.contains("validate_description_length"),
+            generated.contains("validate_string_length_max_256"),
             "Should generate length validation function for max-only: {generated}"
         );
         assert!(
@@ -7307,8 +7368,8 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("validate_expiration_date_pattern"),
-            "Should reference pattern validation function, got: {}",
+            type_str.contains("validate_string_pattern_"),
+            "Should reference hash-based pattern validation function, got: {}",
             type_str
         );
     }
@@ -7398,8 +7459,8 @@ mod tests {
 
         let generated = generate_schema_code(&schema, "AWS::S3::Bucket").unwrap();
         assert!(
-            generated.contains("validate_expiration_date_pattern"),
-            "Should generate pattern validation function for $ref definition pattern: {generated}"
+            generated.contains("fn validate_string_pattern_"),
+            "Should generate hash-based pattern validation function for $ref definition pattern: {generated}"
         );
     }
 
@@ -7442,8 +7503,212 @@ mod tests {
 
         let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
         assert!(
-            generated.contains("validate_created_date_pattern"),
-            "Should generate pattern validation function for top-level $ref pattern: {generated}"
+            generated.contains("fn validate_string_pattern_"),
+            "Should generate hash-based pattern validation function for top-level $ref pattern: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_dedup_string_length_validation_functions() {
+        // Two properties with identical maxLength constraints should share one validation function
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "Name".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("Name field".to_string()),
+                max_length: Some(1024),
+                ..Default::default()
+            },
+        );
+        properties.insert(
+            "Prefix".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("Prefix field".to_string()),
+                max_length: Some(1024),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
+
+        // Should NOT have per-property validation functions
+        assert!(
+            !generated.contains("fn validate_name_length"),
+            "Should not generate per-property length function: {generated}"
+        );
+        assert!(
+            !generated.contains("fn validate_prefix_length"),
+            "Should not generate per-property length function: {generated}"
+        );
+
+        // Should have a single shared validation function named by constraints
+        let fn_count = generated.matches("fn validate_string_length_").count();
+        assert_eq!(
+            fn_count, 1,
+            "Should generate exactly one shared length validation function, got {fn_count}: {generated}"
+        );
+
+        // Both properties should reference the same validation function
+        let ref_count = generated.matches("validate_string_length_max_1024").count();
+        assert!(
+            ref_count >= 3,
+            "Both properties should reference the shared function (1 def + 2 refs), got {ref_count}: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_dedup_pattern_validation_functions() {
+        // Two properties with identical pattern constraints should share one validation function
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "ObjectSizeGreaterThan".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                pattern: Some("[0-9]+".to_string()),
+                ..Default::default()
+            },
+        );
+        properties.insert(
+            "ObjectSizeLessThan".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                pattern: Some("[0-9]+".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
+
+        // Should NOT have per-property pattern validation functions
+        assert!(
+            !generated.contains("fn validate_object_size_greater_than_pattern"),
+            "Should not generate per-property pattern function: {generated}"
+        );
+        assert!(
+            !generated.contains("fn validate_object_size_less_than_pattern"),
+            "Should not generate per-property pattern function: {generated}"
+        );
+
+        // Should have exactly one shared pattern validation function
+        let fn_count = generated.matches("fn validate_string_pattern_").count();
+        assert_eq!(
+            fn_count, 1,
+            "Should generate exactly one shared pattern validation function, got {fn_count}: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_dedup_list_items_validation_functions() {
+        // Two array properties with identical minItems/maxItems should share one validation function
+        let mut def_props = BTreeMap::new();
+        def_props.insert(
+            "AllowedOrigins".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("array".to_string())),
+                items: Some(Box::new(CfnProperty {
+                    prop_type: Some(TypeValue::Single("string".to_string())),
+                    ..Default::default()
+                })),
+                min_items: Some(1),
+                max_items: Some(100),
+                ..Default::default()
+            },
+        );
+        def_props.insert(
+            "AllowedHeaders".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("array".to_string())),
+                items: Some(Box::new(CfnProperty {
+                    prop_type: Some(TypeValue::Single("string".to_string())),
+                    ..Default::default()
+                })),
+                min_items: Some(1),
+                max_items: Some(100),
+                ..Default::default()
+            },
+        );
+
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "CorsRule".to_string(),
+            CfnDefinition {
+                def_type: Some("object".to_string()),
+                properties: Some(def_props),
+                required: vec![],
+                one_of: vec![],
+                items: None,
+                enum_values: None,
+                pattern: None,
+            },
+        );
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "CorsRules".to_string(),
+            CfnProperty {
+                ref_path: Some("#/definitions/CorsRule".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: Some(definitions),
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
+
+        // Should NOT have per-property items validation functions
+        assert!(
+            !generated.contains("fn validate_allowed_origins_items"),
+            "Should not generate per-property items function: {generated}"
+        );
+        assert!(
+            !generated.contains("fn validate_allowed_headers_items"),
+            "Should not generate per-property items function: {generated}"
+        );
+
+        // Should have exactly one shared items validation function
+        let fn_count = generated.matches("fn validate_list_items_").count();
+        assert_eq!(
+            fn_count, 1,
+            "Should generate exactly one shared items validation function, got {fn_count}: {generated}"
         );
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -13,7 +13,7 @@ const VALID_METERED_ACCOUNT: &[&str] = &["ipam-owner", "resource-owner"];
 
 const VALID_TIER: &[&str] = &["free", "advanced"];
 
-fn validate_organizations_entity_path_length(value: &Value) -> Result<(), String> {
+fn validate_string_length_min_1(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         let len = s.len();
         if len < 1 {
@@ -26,7 +26,7 @@ fn validate_organizations_entity_path_length(value: &Value) -> Result<(), String
     }
 }
 
-fn validate_public_default_scope_id_length(value: &Value) -> Result<(), String> {
+fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         let len = s.len();
         if len > 255 {
@@ -69,7 +69,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                     StructField::new("organizations_entity_path", AttributeType::Custom {
                 name: "String(len: 1..)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_organizations_entity_path_length,
+                validate: validate_string_length_min_1,
                 namespace: None,
                 to_dsl: None,
             }).required().with_description("An AWS Organizations entity path. Build the path for the OU(s) using AWS Organizations IDs separated by a '/'. Include all child OUs by ending the pat...").with_provider_name("OrganizationsEntityPath")
@@ -123,7 +123,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
             AttributeSchema::new("public_default_scope_id", AttributeType::Custom {
                 name: "String(len: ..=255)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_public_default_scope_id_length,
+                validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -37,7 +37,7 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "Resource",
 ];
 
-fn validate_private_dns_specified_domains_items(value: &Value) -> Result<(), String> {
+fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
     if let Value::List(items) = value {
         let len = items.len();
         if !(1..=10).contains(&len) {
@@ -50,7 +50,7 @@ fn validate_private_dns_specified_domains_items(value: &Value) -> Result<(), Str
     }
 }
 
-fn validate_private_dns_specified_domains_length(value: &Value) -> Result<(), String> {
+fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         let len = s.len();
         if !(1..=255).contains(&len) {
@@ -108,11 +108,11 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 base: Box::new(AttributeType::List(Box::new(AttributeType::Custom {
                 name: "String(len: 1..=255)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_private_dns_specified_domains_length,
+                validate: validate_string_length_1_255,
                 namespace: None,
                 to_dsl: None,
             }))),
-                validate: validate_private_dns_specified_domains_items,
+                validate: validate_list_items_1_10,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Indicates which of the private domains to create private hosted zones for and associate with the specified VPC. Only supported when private DNS is ena...").with_provider_name("PrivateDnsSpecifiedDomains")

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -29,7 +29,7 @@ fn validate_retention_in_days_int_enum(value: &Value) -> Result<(), String> {
     }
 }
 
-fn validate_log_group_name_pattern(value: &Value) -> Result<(), String> {
+fn validate_string_pattern_b6dfbc56753dfe38(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^[.\\-_/#A-Za-z0-9]{1,512}\\z").expect("invalid pattern regex")
@@ -96,7 +96,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("log_group_name", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_log_group_name_pattern,
+                validate: validate_string_pattern_b6dfbc56753dfe38,
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -161,7 +161,7 @@ fn validate_max_age_range(value: &Value) -> Result<(), String> {
     }
 }
 
-fn validate_expiration_date_pattern(value: &Value) -> Result<(), String> {
+fn validate_string_pattern_cc806c69dc4cdaf7(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$").expect("invalid pattern regex")
@@ -179,7 +179,7 @@ fn validate_expiration_date_pattern(value: &Value) -> Result<(), String> {
     }
 }
 
-fn validate_object_size_greater_than_pattern(value: &Value) -> Result<(), String> {
+fn validate_string_pattern_3ee03875337c12ab(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[0-9]+").expect("invalid pattern regex"));
@@ -193,39 +193,7 @@ fn validate_object_size_greater_than_pattern(value: &Value) -> Result<(), String
     }
 }
 
-fn validate_object_size_less_than_pattern(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> =
-            std::sync::LazyLock::new(|| Regex::new("[0-9]+").expect("invalid pattern regex"));
-        if RE.is_match(s) {
-            Ok(())
-        } else {
-            Err(format!("Value '{}' does not match pattern [0-9]+", s))
-        }
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
-fn validate_transition_date_pattern(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$").expect("invalid pattern regex")
-        });
-        if RE.is_match(s) {
-            Ok(())
-        } else {
-            Err(format!(
-                "Value '{}' does not match pattern ^(\\d{{4}})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{{3}})?)Z$",
-                s
-            ))
-        }
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
-fn validate_id_length(value: &Value) -> Result<(), String> {
+fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         let len = s.len();
         if len > 255 {
@@ -238,20 +206,7 @@ fn validate_id_length(value: &Value) -> Result<(), String> {
     }
 }
 
-fn validate_name_length(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        let len = s.len();
-        if len > 1024 {
-            Err(format!("String length {} is out of range ..=1024", len))
-        } else {
-            Ok(())
-        }
-    } else {
-        Ok(())
-    }
-}
-
-fn validate_prefix_length(value: &Value) -> Result<(), String> {
+fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         let len = s.len();
         if len > 1024 {
@@ -418,7 +373,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("id", AttributeType::Custom {
                 name: "String(len: ..=255)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_id_length,
+                validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             }).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
@@ -544,7 +499,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("expiration_date", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_expiration_date_pattern,
+                validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Indicates when objects are deleted from Amazon S3 and Amazon S3 Glacier. The date value must be in ISO 8601 format. The time is always midnight UTC. I...").with_provider_name("ExpirationDate"),
@@ -553,7 +508,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("id", AttributeType::Custom {
                 name: "String(len: ..=255)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_id_length,
+                validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Unique identifier for the rule. The value can't be longer than 255 characters.").with_provider_name("Id"),
@@ -594,14 +549,14 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("object_size_greater_than", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_object_size_greater_than_pattern,
+                validate: validate_string_pattern_3ee03875337c12ab,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Specifies the minimum object size in bytes for this rule to apply to. Objects must be larger than this value in bytes. For more information about size...").with_provider_name("ObjectSizeGreaterThan"),
                     StructField::new("object_size_less_than", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_object_size_less_than_pattern,
+                validate: validate_string_pattern_3ee03875337c12ab,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than this value in bytes. For more information about siz...").with_provider_name("ObjectSizeLessThan"),
@@ -625,7 +580,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("transition_date", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_transition_date_pattern,
+                validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
@@ -644,7 +599,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("transition_date", AttributeType::Custom {
                 name: "String(pattern)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_transition_date_pattern,
+                validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
@@ -831,7 +786,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("name", AttributeType::Custom {
                 name: "String(len: ..=1024)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_name_length,
+                validate: validate_string_length_max_1024,
                 namespace: None,
                 to_dsl: None,
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
@@ -861,7 +816,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("name", AttributeType::Custom {
                 name: "String(len: ..=1024)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_name_length,
+                validate: validate_string_length_max_1024,
                 namespace: None,
                 to_dsl: None,
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
@@ -891,7 +846,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("name", AttributeType::Custom {
                 name: "String(len: ..=1024)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_name_length,
+                validate: validate_string_length_max_1024,
                 namespace: None,
                 to_dsl: None,
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
@@ -1086,14 +1041,14 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("id", AttributeType::Custom {
                 name: "String(len: ..=255)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_id_length,
+                validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             }).with_description("A unique identifier for the rule. The maximum value is 255 characters. If you don't specify a value, AWS CloudFormation generates a random ID. When us...").with_provider_name("Id"),
                     StructField::new("prefix", AttributeType::Custom {
                 name: "String(len: ..=1024)".to_string(),
                 base: Box::new(AttributeType::String),
-                validate: validate_prefix_length,
+                validate: validate_string_length_max_1024,
                 namespace: None,
                 to_dsl: None,
             }).with_description("An object key name prefix that identifies the object or objects to which the rule applies. The maximum prefix length is 1,024 characters. To include a...").with_provider_name("Prefix"),


### PR DESCRIPTION
## Summary
- Deduplicate per-property validation functions in codegen by naming them by their constraints instead of property names
- Properties with identical constraints (e.g., same `maxLength`, same `pattern`, same `minItems/maxItems`) now share a single validation function
- Applies to all three validation types: string length, pattern, and list items

## Details
Previously, the codegen generated separate validation functions for each property:
```rust
fn validate_name_length(value: &Value) -> Result<(), String> { ... max 1024 ... }
fn validate_prefix_length(value: &Value) -> Result<(), String> { ... max 1024 ... }
```

Now it generates one function per unique constraint set:
```rust
fn validate_string_length_max_1024(value: &Value) -> Result<(), String> { ... }
```

Naming scheme:
- String length: `validate_string_length_{min}_{max}`, `validate_string_length_max_{max}`, `validate_string_length_min_{min}`
- Pattern: `validate_string_pattern_{16-char hex hash}`
- List items: `validate_list_items_{min}_{max}`, `validate_list_items_max_{max}`, `validate_list_items_min_{min}`

Closes #631

## Test plan
- [x] Added `test_dedup_string_length_validation_functions` - verifies two properties with same maxLength share one function
- [x] Added `test_dedup_pattern_validation_functions` - verifies two properties with same pattern share one function
- [x] Added `test_dedup_list_items_validation_functions` - verifies two array properties with same min/max items share one function
- [x] Updated existing tests to use new constraint-based function names
- [x] All 123 codegen tests pass
- [x] Full workspace `cargo test` passes
- [x] Regenerated all schemas and verified diffs are only related to deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)