### PR TITLE
fix: preserve dotted string values in enum serialization

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use carina_core::schema::{AttributeType, StructField};
 
 use crate::schemas::generated::{
-    AwsccSchemaConfig, canonicalize_enum_value, get_enum_alias_reverse,
+    AwsccSchemaConfig, canonicalize_enum_value, find_matching_enum_value, get_enum_alias_reverse,
 };
 use carina_core::utils::{convert_enum_value, extract_enum_value};
 
@@ -182,13 +182,20 @@ fn dsl_value_to_aws(
     if attr_type.namespaced_enum_parts().is_some() {
         match value {
             Value::String(s) => {
-                // Extract the raw enum value (last part of namespace), then resolve
-                // against known valid values if available. This avoids incorrect
-                // underscore-to-hyphen conversion for values like INFREQUENT_ACCESS.
-                let raw_extracted = extract_enum_value(s);
+                // First, check if the string is a plain value (not a DSL namespaced
+                // identifier) that directly matches a valid enum value. This handles
+                // cases like "ipsec.1" where the dot is part of the value itself,
+                // not a namespace separator.
                 let raw = if let Some((_, values, _, _)) = attr_type.string_enum_parts() {
                     let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                    canonicalize_enum_value(raw_extracted, &valid)
+                    if let Some(matched) = find_matching_enum_value(s, &valid) {
+                        matched.to_string()
+                    } else {
+                        // Not a direct match — extract the last part of the namespace
+                        // and resolve against valid values.
+                        let raw_extracted = extract_enum_value(s);
+                        canonicalize_enum_value(raw_extracted, &valid)
+                    }
                 } else {
                     convert_enum_value(s)
                 };
@@ -2272,5 +2279,22 @@ mod tests {
             Value::String("awscc.Region.ap_northeast_1".to_string()),
         )]))]);
         assert_eq!(result, Some(expected));
+    }
+
+    #[test]
+    fn test_dsl_value_to_aws_string_enum_with_dot_in_value() {
+        // "ipsec.1" is a valid enum value for ec2.vpn_gateway's type attribute.
+        // It contains a dot but is NOT a namespaced identifier — it's a literal string.
+        // extract_enum_value must not strip the "ipsec." prefix.
+        let attr_type = AttributeType::StringEnum {
+            name: "Type".to_string(),
+            values: vec!["ipsec.1".to_string()],
+            namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+            to_dsl: None,
+        };
+
+        let value = Value::String("ipsec.1".to_string());
+        let result = dsl_value_to_aws(&value, &attr_type, "ec2.vpn_gateway", "type");
+        assert_eq!(result, Some(json!("ipsec.1")));
     }
 }


### PR DESCRIPTION
## Summary
- Fix VPN Gateway type `"ipsec.1"` being incorrectly sent as numeric value `1` to CloudControl API
- When a StringEnum value contains a dot (like `"ipsec.1"`), check if it directly matches a valid enum value before extracting the last dot-separated part
- Add test case for dotted string enum values

## Test plan
- [x] New unit test `test_dsl_value_to_aws_string_enum_with_dot_in_value` verifies `"ipsec.1"` is preserved as-is
- [x] All existing tests pass (57 lib tests + 137 codegen tests)
- [ ] Run acceptance tests for `ec2_vpn_gateway/basic.crn` and `ec2_vpc_gateway_attachment/vpn.crn`

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)