### PR TITLE
fix: use disambiguated VersioningConfigurationStatus enum name in tests

### DIFF
--- a/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -10,7 +10,7 @@ awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-update-"
 
   versioning_configuration = {
-    status = awscc.s3.bucket.Status.Enabled
+    status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled
   }
 
   lifecycle {

--- a/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -1,6 +1,6 @@
 # S3 Bucket - in-place update test (step 2)
 #
-# Tests: update versioning from Enabled to Disabled (in-place update)
+# Tests: update versioning from Enabled to Suspended (in-place update)
 
 provider awscc {
   region = awscc.Region.ap_northeast_1
@@ -10,7 +10,7 @@ awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-update-"
 
   versioning_configuration = {
-    status = awscc.s3.bucket.Status.Disabled
+    status = awscc.s3.bucket.VersioningConfigurationStatus.Suspended
   }
 
   lifecycle {

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/versioning.crn
@@ -12,7 +12,7 @@ awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   versioning_configuration = {
-    status = awscc.s3.bucket.Status.Enabled
+    status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled
   }
 
   lifecycle {

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -8377,6 +8377,44 @@ mod tests {
     }
 
     #[test]
+    fn test_disambiguate_prefixes_colliding_struct_field_enums() {
+        // When multiple struct field enums share the same type_name but have different
+        // values, they should be disambiguated by prefixing the parent struct name.
+        // This ensures that e.g. VersioningConfiguration.Status (Enabled/Suspended) and
+        // IntelligentTieringConfiguration.Status (Enabled/Disabled) get distinct type names.
+        // See: https://github.com/carina-rs/carina/issues/640
+        let mut enums = BTreeMap::new();
+
+        enums.insert(
+            "VersioningConfiguration.Status".to_string(),
+            EnumInfo {
+                type_name: "Status".to_string(),
+                values: vec!["Enabled".to_string(), "Suspended".to_string()],
+            },
+        );
+        enums.insert(
+            "IntelligentTieringConfiguration.Status".to_string(),
+            EnumInfo {
+                type_name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+            },
+        );
+
+        disambiguate_enum_type_names(&mut enums);
+
+        let versioning = enums.get("VersioningConfiguration.Status").unwrap();
+        assert_eq!(
+            versioning.type_name, "VersioningConfigurationStatus",
+            "Colliding struct field enum should be prefixed with parent struct name"
+        );
+        let tiering = enums.get("IntelligentTieringConfiguration.Status").unwrap();
+        assert_eq!(
+            tiering.type_name, "IntelligentTieringConfigurationStatus",
+            "Colliding struct field enum should be prefixed with parent struct name"
+        );
+    }
+
+    #[test]
     fn test_format_field_parsed_from_schema() {
         // Verify that the format field is correctly parsed from JSON
         let json = r#"{


### PR DESCRIPTION
## Summary

- Fix acceptance test `.crn` files to use the correct disambiguated enum name `VersioningConfigurationStatus` instead of the abbreviated `Status`
- Fix `s3_bucket_step2.crn` to use `Suspended` instead of `Disabled` (only valid values for `VersioningConfigurationStatus` are `Enabled` and `Suspended`)
- Add test verifying that `disambiguate_enum_type_names` correctly prefixes colliding struct field enums

## Test plan

- [x] New test `test_disambiguate_prefixes_colliding_struct_field_enums` passes
- [x] All existing codegen tests pass (138 total)
- [x] Full workspace test suite passes
- [ ] Acceptance test `s3_bucket/versioning.crn` should pass with correct enum name

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)