### PR TITLE
fix: convert IAM policy document fields between snake_case and PascalCase

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1075,11 +1075,25 @@ fn string_or_list_of_strings() -> AttributeType {
     ])
 }
 
-/// String or map type — for IAM policy principal fields
-fn string_or_map() -> AttributeType {
+/// String or principal struct type — for IAM policy principal fields
+/// Principal can be either a string (e.g., "*") or a struct with known fields
+/// (Service, AWS, Federated) whose values are string or list of strings.
+fn string_or_principal_struct() -> AttributeType {
+    // Struct must come before String because Union tries members in order,
+    // and dsl_value_to_aws's fallthrough to value_to_json would match
+    // Value::Map against String incorrectly.
     AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "IamPolicyPrincipal".to_string(),
+            fields: vec![
+                StructField::new("service", string_or_list_of_strings())
+                    .with_provider_name("Service"),
+                StructField::new("aws", string_or_list_of_strings()).with_provider_name("AWS"),
+                StructField::new("federated", string_or_list_of_strings())
+                    .with_provider_name("Federated"),
+            ],
+        },
         AttributeType::String,
-        AttributeType::Map(Box::new(string_or_list_of_strings())),
     ])
 }
 
@@ -1145,8 +1159,10 @@ fn iam_policy_statement() -> AttributeType {
                 .with_provider_name("Resource"),
             StructField::new("not_resource", string_or_list_of_strings())
                 .with_provider_name("NotResource"),
-            StructField::new("principal", string_or_map()).with_provider_name("Principal"),
-            StructField::new("not_principal", string_or_map()).with_provider_name("NotPrincipal"),
+            StructField::new("principal", string_or_principal_struct())
+                .with_provider_name("Principal"),
+            StructField::new("not_principal", string_or_principal_struct())
+                .with_provider_name("NotPrincipal"),
             StructField::new(
                 "condition",
                 AttributeType::Map(Box::new(AttributeType::Map(Box::new(
@@ -1161,25 +1177,11 @@ fn iam_policy_statement() -> AttributeType {
 /// IAM Policy Document type
 /// Validates the structure of IAM policy documents (trust policies, inline policies, etc.)
 ///
-/// Uses `Custom` wrapping (not bare `Struct`) because the DSL uses map assignment
-/// syntax (`assume_role_policy_document = { ... }`), which produces `Value::Map`.
-/// Bare `Struct` in `aws_value_to_dsl` wraps results in `Value::List`, causing
-/// a mismatch with the parser output and false updates on every plan.
-/// The `Custom` type falls through to `json_to_value`/`value_to_json` generic paths,
-/// which correctly produce `Value::Map` for both read and write.
+/// Uses `Struct` type so that `dsl_value_to_aws` and `aws_value_to_dsl` properly
+/// convert between snake_case DSL field names and PascalCase IAM field names
+/// (e.g., `version` <-> `Version`, `statement` <-> `Statement`).
 pub fn iam_policy_document() -> AttributeType {
-    AttributeType::Custom {
-        name: "IamPolicyDocument".to_string(),
-        base: Box::new(AttributeType::Map(Box::new(AttributeType::String))),
-        validate: |value| validate_iam_policy_document(value),
-        namespace: None,
-        to_dsl: None,
-    }
-}
-
-/// Validate IAM policy document structure
-pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
-    let struct_type = AttributeType::Struct {
+    AttributeType::Struct {
         name: "IamPolicyDocument".to_string(),
         fields: vec![
             StructField::new("version", iam_policy_version()).with_provider_name("Version"),
@@ -1190,8 +1192,14 @@ pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
             )
             .with_provider_name("Statement"),
         ],
-    };
-    struct_type.validate(value).map_err(|e| e.to_string())
+    }
+}
+
+/// Validate IAM policy document structure
+pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
+    iam_policy_document()
+        .validate(value)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -2249,6 +2249,155 @@ mod tests {
     }
 
     #[test]
+    fn test_dsl_value_to_aws_iam_policy_document_uses_pascal_case() {
+        // IAM policy documents must use PascalCase keys (Version, Statement, Effect, etc.)
+        // when sent to AWS. The DSL uses snake_case (version, statement, effect, etc.).
+        use carina_aws_types::iam_policy_document;
+
+        let attr_type = iam_policy_document();
+        let value = Value::Map(
+            vec![
+                (
+                    "version".to_string(),
+                    Value::String("2012-10-17".to_string()),
+                ),
+                (
+                    "statement".to_string(),
+                    Value::List(vec![Value::Map(
+                        vec![
+                            ("effect".to_string(), Value::String("Allow".to_string())),
+                            (
+                                "action".to_string(),
+                                Value::String("sts:AssumeRole".to_string()),
+                            ),
+                            (
+                                "principal".to_string(),
+                                Value::Map(
+                                    vec![(
+                                        "service".to_string(),
+                                        Value::String("lambda.amazonaws.com".to_string()),
+                                    )]
+                                    .into_iter()
+                                    .collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let result = dsl_value_to_aws(
+            &value,
+            &attr_type,
+            "iam.role",
+            "assume_role_policy_document",
+        );
+        let result = result.expect("Should return Some");
+
+        // Top-level keys must be PascalCase
+        let obj = result.as_object().expect("Expected JSON Object");
+        assert_eq!(obj.get("Version"), Some(&json!("2012-10-17")));
+        assert!(
+            obj.get("version").is_none(),
+            "snake_case 'version' should not exist"
+        );
+
+        // Statement array
+        let statements = obj.get("Statement").expect("Should have Statement");
+        assert!(
+            obj.get("statement").is_none(),
+            "snake_case 'statement' should not exist"
+        );
+        let stmt = statements.as_array().unwrap().first().unwrap();
+        let stmt_obj = stmt.as_object().unwrap();
+
+        // Statement fields must be PascalCase
+        assert_eq!(stmt_obj.get("Effect"), Some(&json!("Allow")));
+        assert!(stmt_obj.get("effect").is_none());
+        assert_eq!(stmt_obj.get("Action"), Some(&json!("sts:AssumeRole")));
+        assert!(stmt_obj.get("action").is_none());
+
+        // Principal nested map must have PascalCase keys
+        let principal = stmt_obj.get("Principal").expect("Should have Principal");
+        assert!(stmt_obj.get("principal").is_none());
+        let principal_obj = principal.as_object().unwrap();
+        assert_eq!(
+            principal_obj.get("Service"),
+            Some(&json!("lambda.amazonaws.com"))
+        );
+        assert!(principal_obj.get("service").is_none());
+    }
+
+    #[test]
+    fn test_aws_value_to_dsl_iam_policy_document_uses_snake_case() {
+        // Reading IAM policy documents from AWS should convert PascalCase to snake_case
+        use carina_aws_types::iam_policy_document;
+
+        let attr_type = iam_policy_document();
+        let aws_json = json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {
+                    "Service": "lambda.amazonaws.com"
+                }
+            }]
+        });
+
+        let result = aws_value_to_dsl(
+            "assume_role_policy_document",
+            &aws_json,
+            &attr_type,
+            "iam.role",
+        );
+        let result = result.expect("Should return Some");
+
+        if let Value::Map(map) = &result {
+            assert_eq!(
+                map.get("version"),
+                Some(&Value::String("2012-10-17".to_string()))
+            );
+            assert!(
+                map.get("Version").is_none(),
+                "PascalCase 'Version' should not exist"
+            );
+
+            if let Some(Value::List(stmts)) = map.get("statement") {
+                if let Some(Value::Map(stmt)) = stmts.first() {
+                    assert_eq!(
+                        stmt.get("effect"),
+                        Some(&Value::String("Allow".to_string()))
+                    );
+                    assert_eq!(
+                        stmt.get("action"),
+                        Some(&Value::String("sts:AssumeRole".to_string()))
+                    );
+                    if let Some(Value::Map(principal)) = stmt.get("principal") {
+                        assert_eq!(
+                            principal.get("service"),
+                            Some(&Value::String("lambda.amazonaws.com".to_string()))
+                        );
+                    } else {
+                        panic!("Expected principal to be a Map");
+                    }
+                } else {
+                    panic!("Expected statement to contain a Map");
+                }
+            } else {
+                panic!("Expected statement to be a List");
+            }
+        } else {
+            panic!("Expected Value::Map, got: {:?}", result);
+        }
+    }
+
+    #[test]
     fn test_aws_value_to_dsl_region_in_struct_uses_underscores() {
         // Region values inside struct fields should use underscore format (ap_northeast_1),
         // not hyphen format (ap-northeast-1), to match DSL conventions.


### PR DESCRIPTION
## Summary
- Change `iam_policy_document()` from `Custom` to `Struct` type so that `dsl_value_to_aws` and `aws_value_to_dsl` properly convert between snake_case DSL field names and PascalCase IAM field names (e.g., `version` <-> `Version`, `statement` <-> `Statement`)
- Change IAM Principal type from `Map(string_or_list)` to a `Struct` with known fields (`Service`, `AWS`, `Federated`) with `provider_name` mappings for proper key conversion
- Add tests for both write path (DSL -> AWS PascalCase) and read path (AWS PascalCase -> DSL snake_case)

Closes #637

## Test plan
- [x] New test `test_dsl_value_to_aws_iam_policy_document_uses_pascal_case` verifies snake_case -> PascalCase conversion for all nested levels
- [x] New test `test_aws_value_to_dsl_iam_policy_document_uses_snake_case` verifies PascalCase -> snake_case read-back
- [x] All existing tests pass (`cargo test`)
- [ ] Run acceptance tests for IAM role resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)