### PR TITLE
fix: reject pipe operator with clear error instead of silently ignoring

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -477,9 +477,9 @@ fn parse_pipe_expr_with_resource_or_module(
         parse_primary_with_resource_or_module(primary, ctx, binding_name)?;
 
     // Pipe operator is parsed but not yet implemented — reject with a clear error
-    if inner.next().is_some() {
+    if let Some(func_call) = inner.next() {
         return Err(ParseError::InvalidExpression {
-            line: 0,
+            line: func_call.line_col().0,
             message: "Pipe operator is not yet supported".to_string(),
         });
     }
@@ -780,9 +780,9 @@ fn parse_pipe_expr(
     let value = parse_primary_value(primary, ctx)?;
 
     // Pipe operator is parsed but not yet implemented — reject with a clear error
-    if inner.next().is_some() {
+    if let Some(func_call) = inner.next() {
         return Err(ParseError::InvalidExpression {
-            line: 0,
+            line: func_call.line_col().0,
             message: "Pipe operator is not yet supported".to_string(),
         });
     }


### PR DESCRIPTION
## Summary
- The pipe operator (`|>`) was parsed by the pest grammar but silently discarded in the Rust parser, causing piped expressions to be ignored without any error
- Now returns `ParseError::InvalidExpression` with message "Pipe operator is not yet supported" when pipe syntax is used
- Added two tests: one for top-level pipe usage and one for pipe within resource attributes

## Test plan
- [x] `cargo test -p carina-core pipe_operator` passes (2 new tests)
- [x] `cargo test -p carina-core` passes (all existing tests unaffected)
- [x] `cargo clippy` and `cargo fmt` clean

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)