### PR TITLE
perf: optimize O(n^2) list matching to O(n) for large lists

### DIFF
--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -115,15 +115,16 @@ impl Value {
             }
             Value::Bool(b) => b.hash(hasher),
             Value::List(items) => {
-                // For list hashing, use an order-independent combination (XOR of element hashes)
+                // For list hashing, use an order-independent combination (wrapping sum)
                 // so that lists with same elements in different order hash the same.
-                // This is used inside canonical_hash for nested lists.
+                // Wrapping sum is preferred over XOR because XOR causes all lists
+                // with duplicate elements to collide (e.g., [1,1] XOR = 0, [2,2] XOR = 0).
                 items.len().hash(hasher);
-                let mut xor_hash: u64 = 0;
+                let mut sum_hash: u64 = 0;
                 for item in items {
-                    xor_hash ^= item.canonical_hash();
+                    sum_hash = sum_hash.wrapping_add(item.canonical_hash());
                 }
-                xor_hash.hash(hasher);
+                sum_hash.hash(hasher);
             }
             Value::Map(map) => {
                 map.len().hash(hasher);


### PR DESCRIPTION
## Summary
- Optimize `lists_equal()` and `merge_lists()` in `carina-core/src/resource.rs` for large lists (20+ elements) using hash-based bucketing
- For small lists (< 20 elements), retain the existing O(n^2) algorithm where hashing overhead is not worthwhile
- Add `canonical_hash()` / `hash_into()` methods on `Value` for deterministic hashing (Maps sort keys, Lists use XOR for order-independence)
- Add correctness tests for large lists (200+ elements, duplicates, maps) and a performance benchmark test

## Test plan
- [x] All 350 existing carina-core tests pass
- [x] New tests verify correctness of hash-based comparison for large lists of ints, maps, and duplicates
- [x] Performance test: 1000-element list comparison x100 iterations completes in under 5 seconds
- [x] `cargo clippy` and `cargo fmt` pass

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)