### PR TITLE
fix: prevent LSP position_to_offset panic and fix byte vs char comparison

### DIFF
--- a/carina-lsp/src/document.rs
+++ b/carina-lsp/src/document.rs
@@ -50,8 +50,12 @@ impl Document {
     }
 
     fn position_to_offset(&self, pos: Position) -> usize {
-        let line_start = self.content.line_to_char(pos.line as usize);
-        line_start + pos.character as usize
+        let line_count = self.content.len_lines();
+        let line_idx = (pos.line as usize).min(line_count.saturating_sub(1));
+        let line_start = self.content.line_to_char(line_idx);
+        let line_len = self.content.line(line_idx).len_chars();
+        let col = (pos.character as usize).min(line_len);
+        line_start + col
     }
 
     pub fn text(&self) -> String {
@@ -82,11 +86,11 @@ impl Document {
         let line = self.line_at(position.line)?;
         let col = position.character as usize;
 
-        if col > line.len() {
+        let chars: Vec<char> = line.chars().collect();
+
+        if col > chars.len() {
             return None;
         }
-
-        let chars: Vec<char> = line.chars().collect();
 
         // Find word boundaries
         let mut start = col;
@@ -109,4 +113,98 @@ impl Document {
 
 fn is_word_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '.'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_position_to_offset_beyond_last_line() {
+        let mut doc = Document::new("hello\nworld".to_string());
+        // Line 10 is beyond the document - should not panic
+        let change = TextDocumentContentChangeEvent {
+            range: Some(tower_lsp::lsp_types::Range {
+                start: Position {
+                    line: 10,
+                    character: 0,
+                },
+                end: Position {
+                    line: 10,
+                    character: 0,
+                },
+            }),
+            range_length: None,
+            text: "x".to_string(),
+        };
+        // Should not panic
+        doc.apply_change(change);
+    }
+
+    #[test]
+    fn test_position_to_offset_empty_document() {
+        let mut doc = Document::new("".to_string());
+        let change = TextDocumentContentChangeEvent {
+            range: Some(tower_lsp::lsp_types::Range {
+                start: Position {
+                    line: 5,
+                    character: 3,
+                },
+                end: Position {
+                    line: 5,
+                    character: 3,
+                },
+            }),
+            range_length: None,
+            text: "x".to_string(),
+        };
+        doc.apply_change(change);
+    }
+
+    #[test]
+    fn test_word_at_with_multibyte_characters() {
+        // "hello 日本語" - ASCII word, space, then multi-byte chars
+        // byte length = 5 + 1 + 9 = 15, char count = 5 + 1 + 3 = 9
+        let doc = Document::new("hello 日本語".to_string());
+        // col=6 is char index of '日'
+        let word = doc.word_at(Position {
+            line: 0,
+            character: 6,
+        });
+        assert_eq!(word, Some("日本語".to_string()));
+
+        // col=10 is beyond the last char - should return None, not panic
+        // With the byte-length bug (line.len()=15), col=10 < 15 passes guard
+        // but chars vec has only 9 elements, so chars[10] would be out of bounds
+        let word = doc.word_at(Position {
+            line: 0,
+            character: 10,
+        });
+        assert_eq!(word, None);
+    }
+
+    #[test]
+    fn test_word_at_col_beyond_line_chars() {
+        let doc = Document::new("hi".to_string());
+        // col=10 is beyond the 2-char line
+        let word = doc.word_at(Position {
+            line: 0,
+            character: 10,
+        });
+        assert_eq!(word, None);
+    }
+
+    #[test]
+    fn test_word_at_multibyte_col_between_byte_and_char_len() {
+        // "日本" has char_len=2 but byte_len=6
+        // col=4 is beyond char_len but within byte_len
+        // The bug: line.len() returns 6 (bytes), so col=4 < 6 passes the check
+        // but chars vec has only 2 elements, causing index out of bounds
+        let doc = Document::new("日本".to_string());
+        let word = doc.word_at(Position {
+            line: 0,
+            character: 4,
+        });
+        assert_eq!(word, None);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix `position_to_offset()` in `carina-lsp/src/document.rs` to clamp out-of-bounds line/character positions instead of panicking
- Fix `word_at()` to use character-based length (`chars().count()`) instead of byte-based length (`len()`) for bounds checking, preventing incorrect behavior with multi-byte UTF-8 characters
- Add 5 tests covering: out-of-bounds line, empty document, multi-byte characters, character beyond line length, and character index between byte and char length

## Test plan
- [x] `cargo test -p carina-lsp --lib` passes all new and existing tests
- [x] `cargo clippy -p carina-lsp` passes with no warnings
- [x] `cargo fmt -p carina-lsp` produces no changes

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)