### PR TITLE
fix: report errors for unknown bindings/attributes in ResourceRef validation

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -570,12 +570,9 @@ let route = awscc.ec2.route {
         );
 
         let result = validate_resource_ref_types(&[subnet], &schemas, &test_schema_key_fn);
-        assert!(result.is_err(), "Expected error for unknown binding 'vpc'");
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("vpc"),
-            "Error should mention the unknown binding 'vpc': {}",
-            err
+        assert_eq!(
+            result.unwrap_err(),
+            "awscc.ec2.subnet.web-subnet: unknown binding 'vpc' in reference vpc.vpc_id"
         );
     }
 
@@ -606,15 +603,9 @@ let route = awscc.ec2.route {
         );
 
         let result = validate_resource_ref_types(&[vpc, subnet], &schemas, &test_schema_key_fn);
-        assert!(
-            result.is_err(),
-            "Expected error for unknown attribute 'nonexistent_attr'"
-        );
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("nonexistent_attr"),
-            "Error should mention the unknown attribute: {}",
-            err
+        assert_eq!(
+            result.unwrap_err(),
+            "awscc.ec2.subnet.web-subnet: unknown attribute 'nonexistent_attr' on 'vpc' in reference vpc.nonexistent_attr"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Unknown binding references (e.g., `nonexistent_binding.attr`) now produce a validation error instead of being silently skipped
- Unknown attribute references (e.g., `vpc.nonexistent_attr`) now produce a validation error instead of being silently skipped
- Added tests for both cases

Closes #656

## Test plan
- [x] `cargo test -p carina-core` passes (including new tests)
- [x] `cargo clippy -p carina-core` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)