### PR TITLE
fix: replace .unwrap() with error propagation in S3 bucket emptying

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -367,7 +367,9 @@ impl AwsccProvider {
                     if let Some(vid) = version.version_id() {
                         id = id.version_id(vid);
                     }
-                    objects_to_delete.push(id.build().unwrap());
+                    objects_to_delete.push(id.build().map_err(|e| {
+                        ProviderError::new(format!("Failed to build ObjectIdentifier: {:?}", e))
+                    })?);
                 }
             }
 
@@ -378,7 +380,9 @@ impl AwsccProvider {
                     if let Some(vid) = marker.version_id() {
                         id = id.version_id(vid);
                     }
-                    objects_to_delete.push(id.build().unwrap());
+                    objects_to_delete.push(id.build().map_err(|e| {
+                        ProviderError::new(format!("Failed to build ObjectIdentifier: {:?}", e))
+                    })?);
                 }
             }
 
@@ -388,7 +392,9 @@ impl AwsccProvider {
                     .set_objects(Some(objects_to_delete))
                     .quiet(true)
                     .build()
-                    .unwrap();
+                    .map_err(|e| {
+                        ProviderError::new(format!("Failed to build Delete request: {:?}", e))
+                    })?;
 
                 s3.delete_objects()
                     .bucket(bucket_name)


### PR DESCRIPTION
## Summary

- Replace three `.unwrap()` calls in the S3 bucket emptying operation (`empty_s3_bucket`) with `.map_err()?` for proper error propagation
- Prevents potential panics during resource cleanup/deletion that could leave S3 buckets in a partially cleaned state
- Affects `ObjectIdentifier::builder().build()` (2 calls) and `Delete::builder().build()` (1 call)

Closes #681

## Test plan

- [x] `cargo test -p carina-provider-awscc` passes
- [x] `cargo clippy -p carina-provider-awscc` passes
- [x] `cargo fmt` passes
- [ ] Acceptance test with S3 bucket deletion (existing tests cover this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)