### PR TITLE
fix: return None for non-finite floats in awscc value_to_json

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -302,7 +302,8 @@ fn value_to_json(value: &Value) -> Option<serde_json::Value> {
         Value::String(s) => Some(json!(s)),
         Value::Bool(b) => Some(json!(b)),
         Value::Int(i) => Some(json!(i)),
-        Value::Float(f) => Some(json!(f)),
+        Value::Float(f) if f.is_finite() => Some(json!(f)),
+        Value::Float(_) => None,
         Value::List(items) => {
             let arr: Vec<serde_json::Value> = items.iter().filter_map(value_to_json).collect();
             Some(serde_json::Value::Array(arr))
@@ -2787,5 +2788,35 @@ mod tests {
              all should be replaced with log::warn!",
             actual_eprintln_calls
         );
+    }
+
+    // =========================================================================
+    // value_to_json tests
+    // =========================================================================
+
+    #[test]
+    fn test_value_to_json_nan_returns_none() {
+        let value = Value::Float(f64::NAN);
+        assert_eq!(value_to_json(&value), None);
+    }
+
+    #[test]
+    fn test_value_to_json_infinity_returns_none() {
+        let value = Value::Float(f64::INFINITY);
+        assert_eq!(value_to_json(&value), None);
+    }
+
+    #[test]
+    fn test_value_to_json_neg_infinity_returns_none() {
+        let value = Value::Float(f64::NEG_INFINITY);
+        assert_eq!(value_to_json(&value), None);
+    }
+
+    #[test]
+    fn test_value_to_json_finite_float() {
+        let value = Value::Float(1.5);
+        let result = value_to_json(&value);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), serde_json::json!(1.5));
     }
 }


### PR DESCRIPTION
## Summary
- Fix `value_to_json()` in `carina-provider-awscc/src/provider.rs` to return `None` for non-finite floats (NaN, infinity, negative infinity) instead of producing incorrect JSON values
- Add guard clause using `f.is_finite()` on the `Value::Float` match arm
- Add tests for NaN, infinity, negative infinity, and normal finite float cases

Closes #691

## Test plan
- [x] `test_value_to_json_nan_returns_none` - verifies NaN returns None
- [x] `test_value_to_json_infinity_returns_none` - verifies infinity returns None
- [x] `test_value_to_json_neg_infinity_returns_none` - verifies negative infinity returns None
- [x] `test_value_to_json_finite_float` - verifies normal floats still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)