### PR TITLE
feat: add semantic token highlighting for import/output/input keywords

### DIFF
--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -146,7 +146,10 @@ impl SemanticTokensProvider {
                     let as_start = import_start + 7 + as_pos + 1; // position of "as"
                     tokens.push((as_start as u32, 2, 0)); // KEYWORD: as
                     let alias_start = as_start + 3; // position after "as "
-                    let alias = line[alias_start..].trim();
+                    let rest = &line[alias_start..];
+                    let alias = rest
+                        .find(|c: char| !c.is_alphanumeric() && c != '_')
+                        .map_or(rest, |end| &rest[..end]);
                     if !alias.is_empty() {
                         tokens.push((alias_start as u32, alias.len() as u32, 2)); // VARIABLE
                     }


### PR DESCRIPTION
## Summary
- Add keyword tokenization for `import`, `output`, and `input` DSL keywords that were missing from the LSP semantic tokens provider
- Highlight `as` keyword and module alias name in `import` statements
- Exclude `import`, `output`, and `input` from nested block name detection to avoid misclassifying them as PROPERTY tokens
- Add 5 new tests covering all missing keywords

Closes #679

## Test plan
- [x] New tests for `import`, `output`, `input` keyword highlighting
- [x] New test for `as` keyword in import statements
- [x] New test for module alias name as VARIABLE in import statements
- [x] All existing tests pass (78 total)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)