### PR TITLE
fix: use text_edit for ref() completion to prevent malformed insertion

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -72,7 +72,7 @@ impl CompletionProvider {
                 field_name,
             } => self.value_completions_for_struct_field(&resource_type, &attr_path, &field_name),
             CompletionContext::AfterProviderRegion => self.region_completions(),
-            CompletionContext::AfterRefType => self.ref_type_completions(),
+            CompletionContext::AfterRefType => self.ref_type_completions(position, &text),
             CompletionContext::AfterInputDot => self.input_parameter_completions(&text),
             CompletionContext::None => vec![],
         }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -525,3 +525,81 @@ fn context_detection_uses_last_ref_on_line() {
         context
     );
 }
+
+#[test]
+fn ref_completion_uses_text_edit_to_replace_from_ref_open_paren() {
+    let provider = test_provider();
+    // User has typed "ref(aws." and wants completion for a resource type
+    let doc = create_document("ref(aws.");
+    let position = Position {
+        line: 0,
+        character: 8, // cursor after "ref(aws."
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Find any ref type completion (e.g., aws.s3.bucket)
+    let s3_completion = completions
+        .iter()
+        .find(|c| c.label == "aws.s3.bucket")
+        .expect("Should have aws.s3.bucket ref completion");
+
+    // Must use text_edit (not insert_text) to avoid duplication with dotted identifiers
+    assert!(
+        s3_completion.text_edit.is_some(),
+        "ref() completion should use text_edit to handle dotted identifiers correctly"
+    );
+
+    // The text_edit range should start right after "ref(" (column 4) and end at cursor (column 8)
+    if let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &s3_completion.text_edit {
+        assert_eq!(
+            edit.range.start.character, 4,
+            "Should replace from right after 'ref('"
+        );
+        assert_eq!(
+            edit.range.end.character, 8,
+            "Should replace up to cursor position"
+        );
+        assert_eq!(
+            edit.new_text, "aws.s3.bucket)",
+            "Insert text should include closing paren"
+        );
+    } else {
+        panic!("Expected CompletionTextEdit::Edit");
+    }
+}
+
+#[test]
+fn ref_completion_with_empty_parens() {
+    let provider = test_provider();
+    // User has typed "ref(" with nothing after
+    let doc = create_document("ref(");
+    let position = Position {
+        line: 0,
+        character: 4, // cursor right after "ref("
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    let s3_completion = completions
+        .iter()
+        .find(|c| c.label == "aws.s3.bucket")
+        .expect("Should have aws.s3.bucket ref completion");
+
+    if let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &s3_completion.text_edit {
+        assert_eq!(
+            edit.range.start.character, 4,
+            "Should replace from right after 'ref('"
+        );
+        assert_eq!(
+            edit.range.end.character, 4,
+            "Should replace up to cursor position"
+        );
+        assert_eq!(
+            edit.new_text, "aws.s3.bucket)",
+            "Insert text should include closing paren"
+        );
+    } else {
+        panic!("Expected CompletionTextEdit::Edit");
+    }
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1,6 +1,8 @@
 //! Attribute, value, and type-specific completions.
 
-use tower_lsp::lsp_types::{Command, CompletionItem, CompletionItemKind, InsertTextFormat};
+use tower_lsp::lsp_types::{
+    Command, CompletionItem, CompletionItemKind, InsertTextFormat, Position, Range, TextEdit,
+};
 
 use carina_core::schema::AttributeType;
 
@@ -339,7 +341,38 @@ impl CompletionProvider {
         }]
     }
 
-    pub(super) fn ref_type_completions(&self) -> Vec<CompletionItem> {
+    pub(super) fn ref_type_completions(
+        &self,
+        position: Position,
+        text: &str,
+    ) -> Vec<CompletionItem> {
+        // Calculate the replacement range: from right after "ref(" to the cursor position.
+        // This ensures dotted identifiers like "aws.ec2.vpc" are replaced correctly
+        // without duplication from LSP word-boundary-based insertion.
+        let lines: Vec<&str> = text.lines().collect();
+        let line_idx = position.line as usize;
+        let col = position.character as usize;
+
+        let ref_content_start = if line_idx < lines.len() {
+            let prefix: String = lines[line_idx].chars().take(col).collect();
+            // Find the last unclosed "ref(" and position right after the "("
+            if let Some(ref_pos) = prefix.rfind("ref(") {
+                (ref_pos + 4) as u32
+            } else {
+                position.character
+            }
+        } else {
+            position.character
+        };
+
+        let replacement_range = Range {
+            start: Position {
+                line: position.line,
+                character: ref_content_start,
+            },
+            end: position,
+        };
+
         self.schemas
             .keys()
             .map(|resource_type| {
@@ -353,7 +386,10 @@ impl CompletionProvider {
                     label: resource_type.clone(),
                     kind: Some(CompletionItemKind::TYPE_PARAMETER),
                     detail: Some(format!("{} reference", description)),
-                    insert_text: Some(format!("{})", resource_type)),
+                    text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                        range: replacement_range,
+                        new_text: format!("{})", resource_type),
+                    })),
                     ..Default::default()
                 }
             })


### PR DESCRIPTION
## Summary
- Fixed `ref()` completion inserting malformed text when user has partially typed a dotted resource type (e.g., `ref(aws.ec2.`)
- Switched from `insert_text` to `text_edit` with an explicit replacement range from after `ref(` to the cursor position
- This matches the approach used by top-level resource type completions for handling dotted identifiers

## Test plan
- [x] Added test `ref_completion_uses_text_edit_to_replace_from_ref_open_paren` verifying text_edit range when partial type is typed
- [x] Added test `ref_completion_with_empty_parens` verifying text_edit range when cursor is right after `ref(`
- [x] All existing carina-lsp tests pass (75 unit tests + 4 integration tests)

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)