### PR TITLE
feat: add diagnostics validation for output blocks

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -380,6 +380,205 @@ impl DiagnosticEngine {
         bindings
     }
 
+    /// Check output blocks for type mismatches and undefined binding references.
+    pub(super) fn check_output_blocks(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        // Collect defined binding names from parsed resources
+        let mut defined_bindings: HashSet<String> = HashSet::new();
+        for resource in &parsed.resources {
+            if let Some(Value::String(binding_name)) = resource.attributes.get("_binding") {
+                defined_bindings.insert(binding_name.clone());
+            }
+        }
+
+        for output in &parsed.outputs {
+            if let Some(value) = &output.value {
+                // Check for undefined binding references
+                if let Value::ResourceRef { binding_name, .. } = value
+                    && !defined_bindings.contains(binding_name.as_str())
+                    && let Some((line, col)) = self.find_output_value_position(doc, &output.name)
+                {
+                    diagnostics.push(Diagnostic {
+                        range: Range {
+                            start: Position {
+                                line,
+                                character: col,
+                            },
+                            end: Position {
+                                line,
+                                character: col + binding_name.len() as u32,
+                            },
+                        },
+                        severity: Some(DiagnosticSeverity::ERROR),
+                        source: Some("carina".to_string()),
+                        message: format!(
+                            "Undefined resource '{}' in output '{}'. Define it with 'let {} = ...'",
+                            binding_name, output.name, binding_name
+                        ),
+                        ..Default::default()
+                    });
+                }
+
+                // Type validation
+                if let Some(type_error) =
+                    self.validate_output_type(&output.type_expr, value, &output.name)
+                    && let Some((line, col)) = self.find_output_param_position(doc, &output.name)
+                {
+                    diagnostics.push(Diagnostic {
+                        range: Range {
+                            start: Position {
+                                line,
+                                character: col,
+                            },
+                            end: Position {
+                                line,
+                                character: col + output.name.len() as u32,
+                            },
+                        },
+                        severity: Some(DiagnosticSeverity::WARNING),
+                        source: Some("carina".to_string()),
+                        message: type_error,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        diagnostics
+    }
+
+    /// Validate an output value against its declared type.
+    fn validate_output_type(
+        &self,
+        type_expr: &TypeExpr,
+        value: &Value,
+        output_name: &str,
+    ) -> Option<String> {
+        match (type_expr, value) {
+            // ResourceRef is always allowed (type is resolved at runtime)
+            (_, Value::ResourceRef { .. }) => None,
+            // String type checks
+            (TypeExpr::String, Value::Bool(b)) => Some(format!(
+                "Type mismatch in output '{}': expected string, got bool ({})",
+                output_name, b
+            )),
+            (TypeExpr::String, Value::Int(n)) => Some(format!(
+                "Type mismatch in output '{}': expected string, got int ({})",
+                output_name, n
+            )),
+            (TypeExpr::String, Value::Float(f)) => Some(format!(
+                "Type mismatch in output '{}': expected string, got float ({})",
+                output_name, f
+            )),
+            // Bool type checks
+            (TypeExpr::Bool, Value::String(s)) => Some(format!(
+                "Type mismatch in output '{}': expected bool, got string \"{}\". Use true or false.",
+                output_name, s
+            )),
+            (TypeExpr::Bool, Value::Int(n)) => Some(format!(
+                "Type mismatch in output '{}': expected bool, got int ({})",
+                output_name, n
+            )),
+            // Int type checks
+            (TypeExpr::Int, Value::String(s)) => Some(format!(
+                "Type mismatch in output '{}': expected int, got string \"{}\"",
+                output_name, s
+            )),
+            (TypeExpr::Int, Value::Bool(b)) => Some(format!(
+                "Type mismatch in output '{}': expected int, got bool ({})",
+                output_name, b
+            )),
+            // Float type checks
+            (TypeExpr::Float, Value::String(s)) => Some(format!(
+                "Type mismatch in output '{}': expected float, got string \"{}\"",
+                output_name, s
+            )),
+            (TypeExpr::Float, Value::Bool(b)) => Some(format!(
+                "Type mismatch in output '{}': expected float, got bool ({})",
+                output_name, b
+            )),
+            _ => None,
+        }
+    }
+
+    /// Find the position of an output parameter name in the document.
+    fn find_output_param_position(&self, doc: &Document, param_name: &str) -> Option<(u32, u32)> {
+        let text = doc.text();
+        let mut in_output_block = false;
+
+        for (line_idx, line) in text.lines().enumerate() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("output ") && trimmed.contains('{') || trimmed == "output {" {
+                in_output_block = true;
+                continue;
+            }
+
+            if in_output_block {
+                if trimmed == "}" {
+                    in_output_block = false;
+                    continue;
+                }
+
+                // Look for "param_name:" pattern
+                if trimmed.starts_with(param_name)
+                    && trimmed[param_name.len()..]
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c == ':')
+                {
+                    let leading_ws = line.len() - trimmed.len();
+                    return Some((line_idx as u32, leading_ws as u32));
+                }
+            }
+        }
+        None
+    }
+
+    /// Find the position of the value expression in an output parameter line.
+    fn find_output_value_position(&self, doc: &Document, param_name: &str) -> Option<(u32, u32)> {
+        let text = doc.text();
+        let mut in_output_block = false;
+
+        for (line_idx, line) in text.lines().enumerate() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("output ") && trimmed.contains('{') || trimmed == "output {" {
+                in_output_block = true;
+                continue;
+            }
+
+            if in_output_block {
+                if trimmed == "}" {
+                    in_output_block = false;
+                    continue;
+                }
+
+                // Look for "param_name: type = value" pattern
+                if trimmed.starts_with(param_name)
+                    && trimmed[param_name.len()..]
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c == ':')
+                {
+                    // Find the "=" and return position after it
+                    if let Some(eq_pos) = line.find('=') {
+                        let after_eq = &line[eq_pos + 1..];
+                        let trimmed_after = after_eq.trim_start();
+                        let value_col = eq_pos + 1 + (after_eq.len() - trimmed_after.len());
+                        return Some((line_idx as u32, value_col as u32));
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Check for undefined resource references in attribute values
     pub(super) fn check_undefined_references(
         &self,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -589,6 +589,9 @@ impl DiagnosticEngine {
                 }
             }
 
+            // Check output blocks
+            diagnostics.extend(self.check_output_blocks(doc, parsed));
+
             // Check for unused let bindings
             diagnostics.extend(self.check_unused_bindings(doc, parsed));
         }

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -467,3 +467,114 @@ mode = 42
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn output_block_undefined_binding_reference() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+output {
+    sg_id: string = nonexistent.id
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let undefined_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined") && d.message.contains("nonexistent"));
+    assert!(
+        undefined_diag.is_some(),
+        "Should warn about undefined binding in output block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn output_block_valid_binding_reference() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+let sg = awscc.ec2.security_group {
+group_description = "Test security group"
+}
+
+output {
+    sg_id: string = sg.group_id
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let undefined_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined") && d.message.contains("sg"));
+    assert!(
+        undefined_diag.is_none(),
+        "Should NOT warn about defined binding in output block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn output_block_type_mismatch_bool_to_string() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+output {
+    flag: string = true
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("string"));
+    assert!(
+        type_diag.is_some(),
+        "Should warn about type mismatch in output block (bool assigned to string). Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn output_block_valid_types_no_warning() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+let sg = awscc.ec2.security_group {
+group_description = "Test security group"
+}
+
+output {
+    sg_id: string = sg.group_id
+    name: string = "hello"
+    enabled: bool = true
+    count: int = 42
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("output"));
+    assert!(
+        type_diag.is_none(),
+        "Should NOT warn about valid types in output block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary
- Add output block validation to the LSP diagnostics engine
- Detect undefined binding references in output values (e.g., `output { sg_id: string = nonexistent.id }`)
- Detect type mismatches between declared output type and assigned value (e.g., `output { flag: string = true }`)
- Add 4 new tests covering undefined references, valid references, type mismatches, and valid type assignments

Closes #680

## Test plan
- [x] `output_block_undefined_binding_reference` - verifies error for undefined bindings in output values
- [x] `output_block_valid_binding_reference` - verifies no false positive for valid bindings
- [x] `output_block_type_mismatch_bool_to_string` - verifies type mismatch detection
- [x] `output_block_valid_types_no_warning` - verifies no false positive for valid types
- [x] All 88 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)