### PR TITLE
fix: add cleanup trap for temp files in generate-docs.sh

### DIFF
--- a/carina-provider-awscc/scripts/generate-docs.sh
+++ b/carina-provider-awscc/scripts/generate-docs.sh
@@ -15,6 +15,17 @@
 
 set -e
 
+# Temp file variables (initialized for trap safety)
+EXAMPLE_TMPFILE=""
+MERGED_TMPFILE=""
+
+# Cleanup temp files on exit (normal or error)
+cleanup() {
+    [ -n "$EXAMPLE_TMPFILE" ] && rm -f "$EXAMPLE_TMPFILE"
+    [ -n "$MERGED_TMPFILE" ] && rm -f "$MERGED_TMPFILE"
+}
+trap cleanup EXIT
+
 # Parse flags
 REFRESH_CACHE=false
 for arg in "$@"; do


### PR DESCRIPTION
## Summary
- Add an `EXIT` trap to `generate-docs.sh` that removes temporary files on both normal and error exits
- Initialize temp file variables to empty strings before the trap so undefined variable references don't cause errors
- Fixes the issue where `set -e` early exits would leak `mktemp` files

Closes #712

## Test plan
- [x] Verified script syntax with `bash -n`
- [x] Verified no unrelated schema diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)