### PR TITLE
fix: remove redundant output block detection condition in LSP diagnostics

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -514,7 +514,7 @@ impl DiagnosticEngine {
         for (line_idx, line) in text.lines().enumerate() {
             let trimmed = line.trim();
 
-            if trimmed.starts_with("output ") && trimmed.contains('{') || trimmed == "output {" {
+            if trimmed.starts_with("output ") && trimmed.contains('{') {
                 in_output_block = true;
                 continue;
             }
@@ -548,7 +548,7 @@ impl DiagnosticEngine {
         for (line_idx, line) in text.lines().enumerate() {
             let trimmed = line.trim();
 
-            if trimmed.starts_with("output ") && trimmed.contains('{') || trimmed == "output {" {
+            if trimmed.starts_with("output ") && trimmed.contains('{') {
                 in_output_block = true;
                 continue;
             }

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -578,3 +578,32 @@ output {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn output_block_detection_with_brace_on_same_line() {
+    // Regression test: ensure output block detection works correctly
+    // after removing the redundant `|| trimmed == "output {"` condition.
+    // The simplified condition `starts_with("output ") && contains('{')` must
+    // still detect `output {` (the only valid output block syntax).
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+output {
+    flag: string = true
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("string"));
+    assert!(
+        type_diag.is_some(),
+        "Output block detection should work with simplified condition. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Removed redundant `|| trimmed == "output {"` from output block detection conditions in `find_output_param_position` and `find_output_value_position`
- The condition `"output {"` already satisfies both `starts_with("output ")` and `contains('{')`, making the `||` branch unreachable
- Added regression test to verify output block detection works correctly with the simplified condition

Closes #708

## Test plan

- [x] Existing output block tests pass (`cargo test -p carina-lsp`)
- [x] New regression test `output_block_detection_with_brace_on_same_line` verifies the fix
- [x] `cargo clippy -p carina-lsp` passes with no warnings
- [x] No unrelated schema diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)