### PR TITLE
fix: use structured error metadata for not-found detection

### DIFF
--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -1645,7 +1645,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_not_found_error_throttling_is_not_found() {
+    fn test_is_not_found_error_false_for_throttling() {
         use aws_sdk_cloudcontrol::operation::get_resource::GetResourceError;
         use aws_sdk_cloudcontrol::types::error::ThrottlingException;
         use aws_smithy_runtime_api::client::result::SdkError;
@@ -1661,7 +1661,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_not_found_error_timeout_is_not_found() {
+    fn test_is_not_found_error_false_for_timeout() {
         use aws_sdk_cloudcontrol::operation::get_resource::GetResourceError;
         use aws_smithy_runtime_api::client::result::SdkError;
 


### PR DESCRIPTION
## Summary
- Replace fragile `format!("{:?}", e).contains("NotFound")` string matching in `cc_get_resource` with AWS SDK's structured `ProvideErrorMetadata::code()` API
- Add `is_not_found_error()` helper function (follows the same pattern as existing `is_retryable_sdk_error()`)
- Check for `ResourceNotFoundException` and `HandlerNotFoundException` error codes

## Test plan
- [x] Added 4 unit tests for `is_not_found_error`:
  - `ResourceNotFoundException` correctly detected as not-found
  - `HandlerNotFoundException` (via unhandled/generic error) correctly detected
  - `ThrottlingException` is NOT detected as not-found (negative test)
  - `TimeoutError` is NOT detected as not-found (negative test)
- [x] All 138 existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)