### PR TITLE
fix: use chars().count() for string length validation

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1658,7 +1658,7 @@ fn {}(value: &Value) -> Result<(), String> {{
             code.push_str(&format!(
                 r#"fn {}(value: &Value) -> Result<(), String> {{
     if let Value::String(s) = value {{
-        let len = s.len();
+        let len = s.chars().count();
         if {} {{
             Err(format!("String length {{}} is out of range {}", len))
         }} else {{
@@ -1697,7 +1697,7 @@ fn {}(value: &Value) -> Result<(), String> {{
         if !RE.is_match(s) {{
             return Err(format!("Value '{{}}' does not match pattern {escaped_for_msg}", s));
         }}
-        let len = s.len();
+        let len = s.chars().count();
         if {len_condition} {{
             return Err(format!("String length {{}} is out of range {range_display}", len));
         }}
@@ -7908,6 +7908,48 @@ mod tests {
         assert!(
             ref_count >= 3,
             "Both properties should reference the shared function (1 def + 2 refs), got {ref_count}: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_string_length_validation_uses_char_count() {
+        // String length validation should use s.chars().count() (character count)
+        // instead of s.len() (byte count) to correctly handle multi-byte characters.
+        // e.g., "テスト" is 3 characters but 9 bytes in UTF-8.
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "DisplayName".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("Display name.".to_string()),
+                max_length: Some(10),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::Test::Resource").unwrap();
+
+        // Should use chars().count() for character-based length, not byte-based len()
+        assert!(
+            generated.contains("s.chars().count()"),
+            "String length validation should use s.chars().count() instead of s.len(): {generated}"
+        );
+        assert!(
+            !generated.contains("let len = s.len()"),
+            "String length validation should NOT use s.len() for string properties: {generated}"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -15,7 +15,7 @@ const VALID_TIER: &[&str] = &["free", "advanced"];
 
 fn validate_string_length_min_1(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
-        let len = s.len();
+        let len = s.chars().count();
         if len < 1 {
             Err(format!("String length {} is out of range 1..", len))
         } else {
@@ -28,7 +28,7 @@ fn validate_string_length_min_1(value: &Value) -> Result<(), String> {
 
 fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
-        let len = s.len();
+        let len = s.chars().count();
         if len > 255 {
             Err(format!("String length {} is out of range ..=255", len))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -52,7 +52,7 @@ fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
 
 fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
-        let len = s.len();
+        let len = s.chars().count();
         if !(1..=255).contains(&len) {
             Err(format!("String length {} is out of range 1..=255", len))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -40,7 +40,7 @@ fn validate_string_pattern_b6dfbc56753dfe38_len_1_512(value: &Value) -> Result<(
                 s
             ));
         }
-        let len = s.len();
+        let len = s.chars().count();
         if !(1..=512).contains(&len) {
             return Err(format!("String length {} is out of range 1..=512", len));
         }

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -181,7 +181,7 @@ fn validate_string_pattern_cc806c69dc4cdaf7(value: &Value) -> Result<(), String>
 
 fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
-        let len = s.len();
+        let len = s.chars().count();
         if len > 255 {
             Err(format!("String length {} is out of range ..=255", len))
         } else {
@@ -194,7 +194,7 @@ fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
 
 fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
-        let len = s.len();
+        let len = s.chars().count();
         if len > 1024 {
             Err(format!("String length {} is out of range ..=1024", len))
         } else {
@@ -212,7 +212,7 @@ fn validate_string_pattern_3ee03875337c12ab_len_max_20(value: &Value) -> Result<
         if !RE.is_match(s) {
             return Err(format!("Value '{}' does not match pattern [0-9]+", s));
         }
-        let len = s.len();
+        let len = s.chars().count();
         if len > 20 {
             return Err(format!("String length {} is out of range ..=20", len));
         }


### PR DESCRIPTION
## Summary
- Changed codegen to use `s.chars().count()` instead of `s.len()` for string length validation, so constraints count Unicode characters rather than UTF-8 bytes
- Regenerated all schema files to apply the fix
- Added a test to verify the generated code uses character-based counting

closes #729

## Test plan
- [x] Added `test_string_length_validation_uses_char_count` test that verifies generated code uses `s.chars().count()`
- [x] All 139 existing tests pass
- [x] Verified regenerated schemas only contain the `s.len()` -> `s.chars().count()` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)