### PR TITLE
fix: convert byte offset to char offset in find_let_binding_position

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -352,9 +352,10 @@ impl DiagnosticEngine {
                 let name = rest[..eq_pos].trim();
                 if name == binding_name {
                     // Find the column of the binding name in the original line
-                    let let_pos = line.find("let ").unwrap();
-                    let name_col = let_pos + 4; // "let " is 4 chars
-                    return Some((line_idx as u32, name_col as u32));
+                    let let_byte_pos = line.find("let ").unwrap();
+                    let let_char_pos = position::byte_offset_to_char_offset(line, let_byte_pos);
+                    let name_col = let_char_pos + 4; // "let " is 4 chars
+                    return Some((line_idx as u32, name_col));
                 }
             }
         }

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -580,6 +580,28 @@ output {
 }
 
 #[test]
+fn find_let_binding_position_with_multibyte_leading_whitespace() {
+    // Regression test for issue #724: find_let_binding_position uses byte offset
+    // as character column. When multi-byte whitespace (e.g., full-width space U+3000)
+    // appears before "let", the byte offset differs from the character offset.
+    let engine = test_engine();
+
+    // U+3000 (ideographic space) is 3 bytes in UTF-8 but 1 character.
+    // Rust's str::trim() strips it as Unicode whitespace.
+    // Line: "\u{3000}let my_var = awscc.ec2.vpc { }"
+    // "let " starts at byte 3, but character offset 1.
+    // name_col should be char 1 + 4 = 5 (correct)
+    // Bug produces byte 3 + 4 = 7 (wrong)
+    let text = "\u{3000}let my_var = awscc.ec2.vpc { }";
+    let result = engine.find_let_binding_position(text, "my_var");
+    assert_eq!(
+        result,
+        Some((0, 5)),
+        "Column should be character offset (5), not byte offset (7)"
+    );
+}
+
+#[test]
 fn output_block_detection_with_brace_on_same_line() {
     // Regression test: ensure output block detection works correctly
     // after removing the redundant `|| trimmed == "output {"` condition.


### PR DESCRIPTION
## Summary
- Fix `find_let_binding_position()` in `carina-lsp/src/diagnostics/checks.rs` to use `position::byte_offset_to_char_offset()` instead of raw byte offset from `str::find()`
- This prevents incorrect diagnostic underline positions when multi-byte characters appear before `let` keywords
- Add regression test using full-width space (U+3000) to verify character-based column calculation

Closes #724

## Test plan
- [x] New test `find_let_binding_position_with_multibyte_leading_whitespace` verifies correct character offset
- [x] All existing 106 LSP tests pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)