### PR TITLE
fix: generate remove patch ops for attributes removed from DSL

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -113,13 +113,14 @@ impl Provider for AwsccProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        _from: &State,
+        from: &State,
         to: &Resource,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         let identifier = identifier.to_string();
+        let from = from.clone();
         let to = to.clone();
-        Box::pin(async move { self.update_resource(id, &identifier, to).await })
+        Box::pin(async move { self.update_resource(id, &identifier, &from, to).await })
     }
 
     fn delete(

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -1046,6 +1046,7 @@ impl AwsccProvider {
         &self,
         id: ResourceId,
         identifier: &str,
+        from: &State,
         to: Resource,
     ) -> ProviderResult<State> {
         let config = get_schema_config(&id.resource_type).ok_or_else(|| {
@@ -1062,41 +1063,7 @@ impl AwsccProvider {
             .for_resource(id));
         }
 
-        let mut patch_ops = Vec::new();
-
-        // Build patch operations for changed attributes using provider_name
-        for (dsl_name, attr_schema) in &config.schema.attributes {
-            // Skip tags - handled separately below
-            if dsl_name == "tags" {
-                continue;
-            }
-            if let Some(aws_name) = &attr_schema.provider_name
-                && let Some(value) = to.attributes.get(dsl_name.as_str())
-                && let Some(aws_value) =
-                    dsl_value_to_aws(value, &attr_schema.attr_type, &id.resource_type, dsl_name)
-            {
-                patch_ops.push(json!({
-                    "op": "replace",
-                    "path": format!("/{}", aws_name),
-                    "value": aws_value
-                }));
-            }
-        }
-
-        // Handle tags update
-        if config.has_tags
-            && let Some(Value::Map(user_tags)) = to.attributes.get("tags")
-        {
-            let mut tags = Vec::new();
-            for (key, value) in user_tags {
-                if let Value::String(v) = value {
-                    tags.push(json!({"Key": key, "Value": v}));
-                }
-            }
-            if !tags.is_empty() {
-                patch_ops.push(json!({"op": "replace", "path": "/Tags", "value": tags}));
-            }
-        }
+        let patch_ops = build_update_patches(&config, from, &to);
 
         self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
             .await
@@ -1442,6 +1409,83 @@ pub fn restore_unreturned_attrs_impl(
 fn parse_resource_properties(props_str: &str) -> ProviderResult<serde_json::Value> {
     serde_json::from_str(props_str)
         .map_err(|e| ProviderError::new(format!("Failed to parse resource properties: {}", e)))
+}
+
+/// Build JSON Patch operations for updating a resource.
+///
+/// Compares `from` (current state) and `to` (desired state) to generate:
+/// - `"replace"` operations for attributes present in `to`
+/// - `"remove"` operations for attributes present in `from` but absent in `to`
+///   (only for non-required, non-create-only attributes with a provider_name)
+fn build_update_patches(
+    config: &AwsccSchemaConfig,
+    from: &State,
+    to: &Resource,
+) -> Vec<serde_json::Value> {
+    let mut patch_ops = Vec::new();
+    let resource_type = &to.id.resource_type;
+
+    // Build replace operations for attributes present in `to`
+    for (dsl_name, attr_schema) in &config.schema.attributes {
+        // Skip tags - handled separately below
+        if dsl_name == "tags" {
+            continue;
+        }
+        if let Some(aws_name) = &attr_schema.provider_name
+            && let Some(value) = to.attributes.get(dsl_name.as_str())
+            && let Some(aws_value) =
+                dsl_value_to_aws(value, &attr_schema.attr_type, resource_type, dsl_name)
+        {
+            patch_ops.push(json!({
+                "op": "replace",
+                "path": format!("/{}", aws_name),
+                "value": aws_value
+            }));
+        }
+    }
+
+    // Build remove operations for attributes present in `from` but absent in `to`
+    for (dsl_name, attr_schema) in &config.schema.attributes {
+        if dsl_name == "tags" {
+            continue;
+        }
+        // Only generate remove for attributes that:
+        // 1. Have a provider_name (so we know the AWS path)
+        // 2. Are not required (required attributes cannot be removed)
+        // 3. Are not create-only (create-only attributes cannot be changed after creation)
+        // 4. Exist in from but not in to
+        if let Some(aws_name) = &attr_schema.provider_name
+            && !attr_schema.required
+            && !attr_schema.create_only
+            && from.attributes.contains_key(dsl_name)
+            && !to.attributes.contains_key(dsl_name)
+        {
+            patch_ops.push(json!({
+                "op": "remove",
+                "path": format!("/{}", aws_name)
+            }));
+        }
+    }
+
+    // Handle tags
+    if config.has_tags {
+        if let Some(Value::Map(user_tags)) = to.attributes.get("tags") {
+            let mut tags = Vec::new();
+            for (key, value) in user_tags {
+                if let Value::String(v) = value {
+                    tags.push(json!({"Key": key, "Value": v}));
+                }
+            }
+            if !tags.is_empty() {
+                patch_ops.push(json!({"op": "replace", "path": "/Tags", "value": tags}));
+            }
+        } else if from.attributes.contains_key("tags") {
+            // Tags existed in from but removed in to: generate remove operation
+            patch_ops.push(json!({"op": "remove", "path": "/Tags"}));
+        }
+    }
+
+    patch_ops
 }
 
 #[cfg(test)]
@@ -3174,5 +3218,158 @@ mod tests {
     fn test_parse_resource_properties_empty_string_returns_error() {
         let result = parse_resource_properties("");
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // build_update_patches tests
+    // =========================================================================
+
+    /// Helper to get an AwsccSchemaConfig for ec2.vpc (a real resource type with tags)
+    fn get_vpc_config() -> AwsccSchemaConfig {
+        get_schema_config("ec2.vpc").expect("ec2.vpc schema should exist")
+    }
+
+    #[test]
+    fn test_build_update_patches_remove_attribute_absent_in_to() {
+        let config = get_vpc_config();
+        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+
+        // from state has instance_tenancy
+        let mut from_attrs = HashMap::new();
+        from_attrs.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        from_attrs.insert(
+            "instance_tenancy".to_string(),
+            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+        );
+        let from = State::existing(id.clone(), from_attrs);
+
+        // to resource only has cidr_block, instance_tenancy removed
+        let mut to = Resource::new("ec2.vpc", "test");
+        to.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+
+        let patches = build_update_patches(&config, &from, &to);
+
+        // Should have a replace for cidr_block and a remove for instance_tenancy
+        let has_remove_instance_tenancy = patches.iter().any(|p| {
+            p.get("op").and_then(|v| v.as_str()) == Some("remove")
+                && p.get("path").and_then(|v| v.as_str()) == Some("/InstanceTenancy")
+        });
+        assert!(
+            has_remove_instance_tenancy,
+            "Expected remove patch for /InstanceTenancy, got: {:?}",
+            patches
+        );
+    }
+
+    #[test]
+    fn test_build_update_patches_remove_tags_absent_in_to() {
+        let config = get_vpc_config();
+        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+
+        // from state has tags
+        let mut from_attrs = HashMap::new();
+        from_attrs.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        let mut tags = HashMap::new();
+        tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
+        from_attrs.insert("tags".to_string(), Value::Map(tags));
+        let from = State::existing(id.clone(), from_attrs);
+
+        // to resource has no tags
+        let mut to = Resource::new("ec2.vpc", "test");
+        to.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+
+        let patches = build_update_patches(&config, &from, &to);
+
+        let has_remove_tags = patches.iter().any(|p| {
+            p.get("op").and_then(|v| v.as_str()) == Some("remove")
+                && p.get("path").and_then(|v| v.as_str()) == Some("/Tags")
+        });
+        assert!(
+            has_remove_tags,
+            "Expected remove patch for /Tags, got: {:?}",
+            patches
+        );
+    }
+
+    #[test]
+    fn test_build_update_patches_no_remove_for_required_attribute() {
+        let config = get_vpc_config();
+        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+
+        // from state has cidr_block (which is required)
+        let mut from_attrs = HashMap::new();
+        from_attrs.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        let from = State::existing(id.clone(), from_attrs);
+
+        // to resource has no cidr_block (shouldn't happen in practice, but test the guard)
+        let to = Resource::new("ec2.vpc", "test");
+
+        let patches = build_update_patches(&config, &from, &to);
+
+        // Should NOT have a remove for cidr_block since it's required
+        let has_remove_cidr = patches.iter().any(|p| {
+            p.get("op").and_then(|v| v.as_str()) == Some("remove")
+                && p.get("path").and_then(|v| v.as_str()) == Some("/CidrBlock")
+        });
+        assert!(
+            !has_remove_cidr,
+            "Should not remove required attribute CidrBlock, got: {:?}",
+            patches
+        );
+    }
+
+    #[test]
+    fn test_build_update_patches_replace_only_when_both_present() {
+        let config = get_vpc_config();
+        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+
+        // Both from and to have the same attributes
+        let mut from_attrs = HashMap::new();
+        from_attrs.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        from_attrs.insert(
+            "instance_tenancy".to_string(),
+            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+        );
+        let from = State::existing(id.clone(), from_attrs);
+
+        let mut to = Resource::new("ec2.vpc", "test");
+        to.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        to.attributes.insert(
+            "instance_tenancy".to_string(),
+            Value::String("awscc.ec2.vpc.InstanceTenancy.dedicated".to_string()),
+        );
+
+        let patches = build_update_patches(&config, &from, &to);
+
+        // Should only have replace operations, no remove
+        let has_remove = patches
+            .iter()
+            .any(|p| p.get("op").and_then(|v| v.as_str()) == Some("remove"));
+        assert!(
+            !has_remove,
+            "Should not have remove operations when attribute is present in both from and to, got: {:?}",
+            patches
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `update_resource()` to compare `from` (current state) with `to` (desired state) and generate JSON Patch `"remove"` operations for attributes/tags that were present on the resource but removed from the DSL
- Extract patch-building logic into a testable `build_update_patches()` function
- Pass `from: &State` through `Provider::update()` to `update_resource()` (previously ignored as `_from`)

## Test plan

- [x] `test_build_update_patches_remove_attribute_absent_in_to` - verifies remove op for non-required attributes present in from but absent in to
- [x] `test_build_update_patches_remove_tags_absent_in_to` - verifies remove op for tags present in from but absent in to
- [x] `test_build_update_patches_no_remove_for_required_attribute` - verifies required attributes are never removed
- [x] `test_build_update_patches_replace_only_when_both_present` - verifies no remove ops when attributes exist in both from and to
- [x] All 139 existing tests pass

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)