### PR TITLE
test: add acceptance test for s3_bucket website_configuration

### DIFF
--- a/carina-provider-awscc/acceptance-tests/s3_bucket/website.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/website.crn
@@ -1,0 +1,22 @@
+# S3 Bucket - website_configuration test
+#
+# Tests: website_configuration with index_document and error_document,
+#        plan-verify confirms website hosting state is reconciled,
+#        destroy cleans up the bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  website_configuration = {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `s3_bucket/website.crn` acceptance test that creates an S3 bucket with `website_configuration` specifying `index_document` and `error_document`
- Verifies Struct type handling for website configuration attributes
- Follows the pattern of existing S3 bucket acceptance tests (versioning, encryption, etc.)

Closes #747

## Test plan

- [ ] Run `cargo run --bin carina -- validate` on the new `.crn` file (done, passes)
- [ ] Run acceptance test with `run-tests.sh full` against a test account

🤖 Generated with [Claude Code](https://claude.com/claude-code)