### PR TITLE
test: add acceptance test for iam_role with managed_policy_arns

### DIFF
--- a/carina-provider-awscc/acceptance-tests/iam_role/managed_policy.crn
+++ b/carina-provider-awscc/acceptance-tests/iam_role/managed_policy.crn
@@ -1,0 +1,29 @@
+# IAM Role - managed policy ARNs test
+#
+# Tests: role_name_prefix, assume_role_policy_document, managed_policy_arns
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.role {
+  role_name_prefix = "carina-acc-test-"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  ]
+
+  tags = {
+    Environment = "acceptance-test"
+    ManagedBy   = "carina"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `managed_policy.crn` acceptance test for IAM role with `managed_policy_arns` attribute
- Creates an IAM role with `AmazonS3ReadOnlyAccess` AWS managed policy attached
- Follows the pattern of existing `iam_role/` acceptance tests (with_path.crn, with_policy.crn)

Closes #745

## Test plan

- [ ] Run `cargo run --bin carina -- validate carina-provider-awscc/acceptance-tests/iam_role/managed_policy.crn` (done, passes)
- [ ] Run acceptance test with `run-tests.sh full` against a test account

🤖 Generated with [Claude Code](https://claude.com/claude-code)