### PR TITLE
test: add acceptance test for s3_bucket lifecycle_configuration

### DIFF
--- a/carina-provider-awscc/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/lifecycle.crn
@@ -1,0 +1,41 @@
+# S3 Bucket - lifecycle_configuration test
+#
+# Tests: lifecycle_configuration with two rules:
+#        an expiration rule (expire objects after 90 days)
+#        and a transition rule (move to GLACIER after 30 days),
+#        plan-verify confirms lifecycle settings are reconciled,
+#        destroy cleans up the bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  lifecycle_configuration = {
+    rules = [
+      {
+        id     = "expire-old-objects"
+        status = awscc.s3.bucket.RuleStatus.Enabled
+
+        expiration_in_days = 90
+      },
+      {
+        id     = "transition-to-glacier"
+        status = awscc.s3.bucket.RuleStatus.Enabled
+
+        transitions = [
+          {
+            storage_class     = awscc.s3.bucket.TransitionStorageClass.GLACIER
+            transition_in_days = 30
+          }
+        ]
+      }
+    ]
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary
- Add `s3_bucket/lifecycle.crn` acceptance test covering `lifecycle_configuration`
- Tests two lifecycle rules: expiration (expire objects after 90 days) and transition (move to GLACIER after 30 days)
- Uses namespaced enum identifiers for `RuleStatus` and `TransitionStorageClass`

Closes #743

## Test plan
- [x] `run-tests.sh validate s3_bucket/lifecycle` passes
- [ ] `run-tests.sh full s3_bucket/lifecycle` applies, verifies plan, and destroys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)