### PR TITLE
test: add in-place update acceptance test for ec2_transit_gateway_attachment

### DIFF
--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
@@ -1,0 +1,31 @@
+# EC2 Transit Gateway Attachment - in-place update test (step 1)
+#
+# Tests: create transit gateway attachment with initial tags
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "carina acceptance test - tgw attachment update"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
@@ -1,0 +1,32 @@
+# EC2 Transit Gateway Attachment - in-place update test (step 2)
+#
+# Tests: update tags (in-place update)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "carina acceptance test - tgw attachment update"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+    UpdatedBy   = "carina"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
@@ -19,6 +19,7 @@
 #   ec2_egress_only_internet_gateway   - Update tags
 #   ec2_vpc_endpoint                   - Add policy_document
 #   ec2_vpc_peering_connection         - Update tags
+#   ec2_transit_gateway_attachment      - Update tags
 #   ec2_route                          - Change route target (IGW -> NAT GW)
 #
 # Filter (optional): substring to match test names (e.g. "logs_log_group", "s3_bucket")
@@ -240,11 +241,17 @@ run_test "ec2_vpc_peering_connection" \
     "$SCRIPT_DIR/ec2_vpc_peering_connection_step2.crn" \
     "Test 14: EC2 VPC Peering Connection (tags update)"
 
-# Test 15: EC2 Route - change route target (IGW -> NAT GW)
+# Test 15: EC2 Transit Gateway Attachment - update tags
+run_test "ec2_transit_gateway_attachment" \
+    "$SCRIPT_DIR/ec2_transit_gateway_attachment_step1.crn" \
+    "$SCRIPT_DIR/ec2_transit_gateway_attachment_step2.crn" \
+    "Test 15: EC2 Transit Gateway Attachment (tags update)"
+
+# Test 16: EC2 Route - change route target (IGW -> NAT GW)
 run_test "ec2_route" \
     "$SCRIPT_DIR/ec2_route_step1.crn" \
     "$SCRIPT_DIR/ec2_route_step2.crn" \
-    "Test 15: EC2 Route (target IGW -> NAT GW)"
+    "Test 16: EC2 Route (target IGW -> NAT GW)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `ec2_transit_gateway_attachment_step1.crn` and `ec2_transit_gateway_attachment_step2.crn` to `in_place_update/` directory
- Step 1 creates VPC, subnet, transit gateway, and attachment with initial tags
- Step 2 updates tags (adds `UpdatedBy = "carina"`) to verify in-place update works
- Update `run.sh` to include the new test as Test 15 (renumbering ec2_route to Test 16)

Closes #739

## Test plan
- [x] Both .crn files pass `carina validate`
- [ ] Run `run-tests.sh full ec2_transit_gateway_attachment` to verify apply/plan-verify/destroy cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)