### PR TITLE
test: add KMS encryption acceptance test for s3_bucket

### DIFF
--- a/carina-provider-awscc/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -1,0 +1,31 @@
+# S3 Bucket - bucket_encryption test (aws:kms)
+#
+# Tests: bucket_encryption with server_side_encryption_configuration
+#        using aws:kms as the default SSE algorithm with the
+#        AWS managed S3 KMS key (alias/aws/s3),
+#        plan-verify confirms KMS encryption settings are reconciled,
+#        destroy cleans up the KMS-encrypted bucket.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-"
+
+  bucket_encryption = {
+    server_side_encryption_configuration = [
+      {
+        bucket_key_enabled = true
+        server_side_encryption_by_default = {
+          sse_algorithm = "aws:kms"
+          kms_master_key_id = "alias/aws/s3"
+        }
+      }
+    ]
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary
- Add `kms_encryption.crn` acceptance test for S3 bucket with `aws:kms` server-side encryption
- Uses the AWS managed S3 KMS key (`alias/aws/s3`) with `bucket_key_enabled = true`
- Complements the existing `encryption.crn` test which only covers AES256 (SSE-S3)

Closes #744

## Test plan
- [ ] Run `run-tests.sh full` with the new `kms_encryption.crn` test to verify create/plan-verify/destroy cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)