### PR TITLE
test: add acceptance test for s3_bucket logging_configuration

### DIFF
--- a/carina-provider-awscc/acceptance-tests/s3_bucket/logging.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/logging.crn
@@ -1,0 +1,31 @@
+# S3 Bucket - logging_configuration test
+#
+# Tests: logging_configuration with destination_bucket_name and log_file_prefix,
+#        resource reference between two S3 buckets (let binding),
+#        plan-verify confirms logging settings are reconciled,
+#        destroy cleans up both buckets.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let log_bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-log-"
+
+  lifecycle {
+    force_delete = true
+  }
+}
+
+awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-src-"
+
+  logging_configuration = {
+    destination_bucket_name = log_bucket.bucket_name
+    log_file_prefix        = "access-logs/"
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary
- Add `s3_bucket/logging.crn` acceptance test covering `logging_configuration` with `destination_bucket_name` and `log_file_prefix`
- Tests resource references between two S3 buckets via `let` binding (log bucket referenced by source bucket)
- Covers a common compliance/audit scenario (server access logging)

Closes #746

## Test plan
- [ ] Run `run-tests.sh validate s3_bucket/logging` to confirm validation passes
- [ ] Run `run-tests.sh full s3_bucket/logging` to confirm apply+plan-verify+destroy cycle works

Generated with [Claude Code](https://claude.com/claude-code)