### PR TITLE
feat: auto-generate block_name for nested List(Struct) fields

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -32,6 +32,8 @@ pub struct StructField {
     pub description: Option<String>,
     /// Provider-side property name (e.g., "IpProtocol")
     pub provider_name: Option<String>,
+    /// Alternative block name for repeated block syntax (e.g., "transition" for "transitions")
+    pub block_name: Option<String>,
 }
 
 impl StructField {
@@ -42,6 +44,7 @@ impl StructField {
             required: false,
             description: None,
             provider_name: None,
+            block_name: None,
         }
     }
 
@@ -57,6 +60,11 @@ impl StructField {
 
     pub fn with_provider_name(mut self, name: impl Into<String>) -> Self {
         self.provider_name = Some(name.into());
+        self
+    }
+
+    pub fn with_block_name(mut self, name: impl Into<String>) -> Self {
+        self.block_name = Some(name.into());
         self
     }
 }
@@ -739,11 +747,76 @@ impl ResourceSchema {
     }
 }
 
+/// Resolve block name aliases in a map using struct field definitions.
+///
+/// For each key in `map` that matches a `block_name` on a struct field,
+/// renames it to the canonical field name. Also recurses into nested
+/// struct values to resolve block names at all nesting levels.
+fn resolve_block_names_in_map(
+    map: &mut HashMap<String, Value>,
+    fields: &[StructField],
+    resource_id: &str,
+    errors: &mut Vec<String>,
+) {
+    // Build block_name -> canonical field name mapping
+    let bn_map: HashMap<String, String> = fields
+        .iter()
+        .filter_map(|f| f.block_name.as_ref().map(|bn| (bn.clone(), f.name.clone())))
+        .collect();
+
+    // Rename block name keys to canonical names
+    let renames: Vec<(String, String)> = map
+        .keys()
+        .filter_map(|key| bn_map.get(key).map(|canon| (key.clone(), canon.clone())))
+        .collect();
+
+    for (block_key, canon_key) in renames {
+        if map.contains_key(&canon_key) {
+            errors.push(format!(
+                "{}: cannot use both '{}' and '{}' (they refer to the same attribute)",
+                resource_id, block_key, canon_key
+            ));
+            continue;
+        }
+        let value = map.remove(&block_key).unwrap();
+        map.insert(canon_key, value);
+    }
+
+    // Recurse into nested struct values
+    for field in fields {
+        let value = match map.get_mut(&field.name) {
+            Some(v) => v,
+            None => continue,
+        };
+        match &field.field_type {
+            AttributeType::Struct { fields: inner, .. } => {
+                if let Value::Map(inner_map) = value {
+                    resolve_block_names_in_map(inner_map, inner, resource_id, errors);
+                }
+            }
+            AttributeType::List(inner) => {
+                if let AttributeType::Struct { fields: inner, .. } = inner.as_ref()
+                    && let Value::List(items) = value
+                {
+                    for item in items.iter_mut() {
+                        if let Value::Map(item_map) = item {
+                            resolve_block_names_in_map(item_map, inner, resource_id, errors);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Resolve block name aliases in resources.
 ///
 /// For each resource attribute key that matches a `block_name` in the schema,
 /// renames it to the canonical attribute name. Errors if both the block_name
 /// (singular) and the canonical attribute name (plural) are present.
+///
+/// Also recursively resolves block names in nested struct values.
 ///
 /// The `schema_key_fn` closure computes the schema lookup key for a resource.
 pub fn resolve_block_names(
@@ -761,9 +834,6 @@ pub fn resolve_block_names(
         };
 
         let bn_map = schema.block_name_map();
-        if bn_map.is_empty() {
-            continue;
-        }
 
         // Collect keys to rename: (block_name_key, canonical_attr_name)
         let renames: Vec<(String, String)> = resource
@@ -783,6 +853,43 @@ pub fn resolve_block_names(
 
             let value = resource.attributes.remove(&block_key).unwrap();
             resource.attributes.insert(canon_key, value);
+        }
+
+        // Recurse into nested struct values to resolve block names at all levels
+        for (attr_name, attr_schema) in &schema.attributes {
+            let value = match resource.attributes.get_mut(attr_name) {
+                Some(v) => v,
+                None => continue,
+            };
+            match &attr_schema.attr_type {
+                AttributeType::Struct { fields, .. } => {
+                    if let Value::Map(inner_map) = value {
+                        resolve_block_names_in_map(
+                            inner_map,
+                            fields,
+                            &resource.id.to_string(),
+                            &mut all_errors,
+                        );
+                    }
+                }
+                AttributeType::List(inner) => {
+                    if let AttributeType::Struct { fields, .. } = inner.as_ref()
+                        && let Value::List(items) = value
+                    {
+                        for item in items.iter_mut() {
+                            if let Value::Map(item_map) = item {
+                                resolve_block_names_in_map(
+                                    item_map,
+                                    fields,
+                                    &resource.id.to_string(),
+                                    &mut all_errors,
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
 
@@ -2140,5 +2247,82 @@ mod tests {
 
         // Key should remain unchanged
         assert!(resources[0].attributes.contains_key("operating_region"));
+    }
+
+    #[test]
+    fn struct_field_with_block_name() {
+        let field = StructField::new(
+            "transitions",
+            AttributeType::List(Box::new(AttributeType::Struct {
+                name: "Transition".to_string(),
+                fields: vec![],
+            })),
+        )
+        .with_block_name("transition");
+        assert_eq!(field.block_name.as_deref(), Some("transition"));
+    }
+
+    #[test]
+    fn resolve_block_names_nested_struct() {
+        // Simulate: lifecycle_configuration = { transition { ... } }
+        // where "transition" is the block name for "transitions" field
+        let mut inner_map = HashMap::new();
+        inner_map.insert(
+            "transition".to_string(),
+            Value::List(vec![Value::Map({
+                let mut m = HashMap::new();
+                m.insert(
+                    "storage_class".to_string(),
+                    Value::String("GLACIER".to_string()),
+                );
+                m
+            })]),
+        );
+
+        let mut resources = vec![{
+            let mut r = Resource::new("s3.bucket", "my-bucket");
+            r.attributes
+                .insert("lifecycle_configuration".to_string(), Value::Map(inner_map));
+            r.attributes
+                .insert("_provider".to_string(), Value::String("awscc".to_string()));
+            r
+        }];
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "s3.bucket".to_string(),
+            ResourceSchema::new("s3.bucket").attribute(AttributeSchema::new(
+                "lifecycle_configuration",
+                AttributeType::Struct {
+                    name: "LifecycleConfiguration".to_string(),
+                    fields: vec![
+                        StructField::new(
+                            "transitions",
+                            AttributeType::List(Box::new(AttributeType::Struct {
+                                name: "Transition".to_string(),
+                                fields: vec![],
+                            })),
+                        )
+                        .with_block_name("transition"),
+                    ],
+                },
+            )),
+        );
+
+        resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+
+        // The nested "transition" key should be renamed to "transitions"
+        let lifecycle = match resources[0].attributes.get("lifecycle_configuration") {
+            Some(Value::Map(m)) => m,
+            _ => panic!("expected Map"),
+        };
+        assert!(
+            lifecycle.contains_key("transitions"),
+            "expected 'transitions' key after resolve"
+        );
+        assert!(
+            !lifecycle.contains_key("transition"),
+            "expected 'transition' key to be removed"
+        );
     }
 }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2205,6 +2205,9 @@ fn generate_struct_type(
     let required_set: HashSet<&str> = required.iter().map(|s| s.as_str()).collect();
     let aliases = known_enum_aliases();
 
+    // Collect all field names (snake_case) to check block name conflicts
+    let all_field_names: HashSet<String> = properties.keys().map(|k| k.to_snake_case()).collect();
+
     let fields: Vec<String> = properties
         .iter()
         .map(|(field_name, field_prop)| {
@@ -2323,6 +2326,15 @@ fn generate_struct_type(
                 field_code.push_str(&format!(".with_description(\"{}\")", truncated));
             }
             field_code.push_str(&format!(".with_provider_name(\"{}\")", field_name));
+
+            // Add block_name for List(Struct) fields with a natural singular form
+            if field_type.starts_with("AttributeType::List(Box::new(AttributeType::Struct")
+                && let Some(singular) = compute_block_name(&snake_name)
+                && !all_field_names.contains(&singular)
+            {
+                field_code.push_str(&format!(".with_block_name(\"{}\")", singular));
+            }
+
             field_code
         })
         .collect();

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -388,7 +388,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("The time in seconds that your browser is to cache the preflight response for the specified resource.").with_provider_name("MaxAge")
                     ],
-                }))).required().with_description("A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.").with_provider_name("CorsRules")
+                }))).required().with_description("A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.").with_provider_name("CorsRules").with_block_name("cors_rule")
                     ],
                 })
                 .with_description("Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource Sharing]...")
@@ -428,7 +428,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).required().with_description("S3 Intelligent-Tiering access tier. See [Storage class for automatically optimizing frequently and infrequently accessed objects](https://docs.aws.ama...").with_provider_name("AccessTier"),
                     StructField::new("days", AttributeType::Int).required().with_description("The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of...").with_provider_name("Days")
                     ],
-                }))).required().with_description("Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one tier must be defined in the list. At most, you can s...").with_provider_name("Tierings")
+                }))).required().with_description("Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one tier must be defined in the list. At most, you can s...").with_provider_name("Tierings").with_block_name("tiering")
                     ],
                 })))
                 .with_description("Defines how Amazon S3 handles Intelligent-Tiering storage.")
@@ -610,7 +610,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }))).with_description("One or more transition rules that specify when an object transitions to a specified storage class. If you specify an expiration and transition time, y...").with_provider_name("Transitions")
                     ],
-                }))).required().with_description("A lifecycle rule for individual objects in an Amazon S3 bucket.").with_provider_name("Rules"),
+                }))).required().with_description("A lifecycle rule for individual objects in an Amazon S3 bucket.").with_provider_name("Rules").with_block_name("rule"),
                     StructField::new("transition_default_minimum_object_size", AttributeType::StringEnum {
                 name: "TransitionDefaultMinimumObjectSize".to_string(),
                 values: vec!["varies_by_storage_class".to_string(), "all_storage_classes_128K".to_string()],
@@ -795,14 +795,14 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
                     StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
                     ],
-                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine which objects invoke the AWS Lambda function. For example, you can create a filter so that only image files with a ...").with_provider_name("Filter"),
                     StructField::new("function", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified event type occurs.").with_provider_name("Function")
                     ],
-                }))).with_description("Describes the LAMlong functions to invoke and the events for which to invoke them.").with_provider_name("LambdaConfigurations"),
+                }))).with_description("Describes the LAMlong functions to invoke and the events for which to invoke them.").with_provider_name("LambdaConfigurations").with_block_name("lambda_configuration"),
                     StructField::new("queue_configurations", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "QueueConfiguration".to_string(),
                     fields: vec![
@@ -825,14 +825,14 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
                     StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
                     ],
-                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications onl...").with_provider_name("Filter"),
                     StructField::new("queue", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queue...").with_provider_name("Queue")
                     ],
-                }))).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations"),
+                }))).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations").with_block_name("queue_configuration"),
                     StructField::new("topic_configurations", AttributeType::List(Box::new(AttributeType::Struct {
                     name: "TopicConfiguration".to_string(),
                     fields: vec![
@@ -855,14 +855,14 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Over...").with_provider_name("Name"),
                     StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
                     ],
-                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules")
+                }))).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
                     ],
                 }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications...").with_provider_name("Filter"),
                     StructField::new("topic", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
                     ],
-                }))).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations")
+                }))).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations").with_block_name("topic_configuration")
                     ],
                 })
                 .with_description("Configuration that defines how Amazon S3 handles bucket notifications.")
@@ -920,7 +920,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("Specifies an object ownership rule.").with_provider_name("ObjectOwnership")
                     ],
-                }))).required().with_description("Specifies the container element for Object Ownership rules.").with_provider_name("Rules")
+                }))).required().with_description("Specifies the container element for Object Ownership rules.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 })
                 .with_description("Configuration that defines how Amazon S3 handles Object Ownership rules.")
@@ -1090,7 +1090,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_description("Specifies whether the rule is enabled.").with_provider_name("Status")
                     ],
-                }))).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules")
+                }))).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 })
                 .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration``...")
@@ -1160,7 +1160,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container for describing a condition that must be met for the specified redirect to apply. For example, 1. If request is for pages in the ``/docs`` ...").with_provider_name("RoutingRuleCondition")
                     ],
-                }))).with_description("Rules that define when a redirect is applied and the redirect behavior.").with_provider_name("RoutingRules")
+                }))).with_description("Rules that define when a redirect is applied and the redirect behavior.").with_provider_name("RoutingRules").with_block_name("routing_rule")
                     ],
                 })
                 .with_description("Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/Am...")


### PR DESCRIPTION
## Summary
- Add `block_name` field to `StructField` with `with_block_name()` builder method
- Update codegen to auto-generate `with_block_name()` for `List(Struct)` fields inside structs (nested block syntax support)
- Update `resolve_block_names()` to recursively resolve block name aliases in nested struct values
- Regenerate all schemas (S3 bucket gets 12 new nested block names)

## Test plan
- [x] New test: `struct_field_with_block_name` verifies the builder method works
- [x] New test: `resolve_block_names_nested_struct` verifies nested block name resolution
- [x] All existing tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)