### PR TITLE
fix: support block_name in LSP nested path resolution and validation

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -303,7 +303,9 @@ impl CompletionProvider {
 
         // Walk down the remaining path
         for name in &attr_path[1..] {
-            let field = fields.iter().find(|f| f.name == *name)?;
+            let field = fields
+                .iter()
+                .find(|f| f.name == *name || f.block_name.as_deref() == Some(name))?;
             fields = self.extract_struct_fields(&field.field_type)?;
         }
 

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -286,3 +286,27 @@ fn map_completions_delegate_to_inner_type() {
         labels
     );
 }
+
+#[test]
+fn nested_struct_completions_via_block_name_in_path() {
+    // When a user writes `config { transition { ... } }` where "transition" is
+    // the block_name for field "transitions", the path resolution at depth > 1
+    // should find the struct fields via StructField.block_name.
+    let provider = test_provider_with_block_name_nested();
+    // Path: config -> transition (block_name for "transitions")
+    let completions = provider.struct_field_completions(
+        "test.block.resource",
+        &["config".to_string(), "transition".to_string()],
+    );
+    let field_names: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        field_names.contains(&"days"),
+        "Should resolve struct fields when nested path uses block_name 'transition'. Got: {:?}",
+        field_names
+    );
+    assert!(
+        field_names.contains(&"storage_class"),
+        "Should resolve struct fields when nested path uses block_name 'transition'. Got: {:?}",
+        field_names
+    );
+}

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -24,6 +24,38 @@ pub(super) fn test_provider() -> CompletionProvider {
     CompletionProvider::new(schemas, provider_names, region_completions)
 }
 
+pub(super) fn test_provider_with_block_name_nested() -> CompletionProvider {
+    // Nested struct where a StructField has block_name set.
+    // Schema: config -> transitions (List<Struct>, block_name="transition") -> each has "days" + "storage_class"
+    let transition_struct = AttributeType::Struct {
+        name: "Transition".to_string(),
+        fields: vec![
+            StructField::new("days", AttributeType::Int),
+            StructField::new("storage_class", AttributeType::String),
+        ],
+    };
+
+    let config_struct = AttributeType::Struct {
+        name: "Config".to_string(),
+        fields: vec![
+            StructField::new(
+                "transitions",
+                AttributeType::List(Box::new(transition_struct)),
+            )
+            .with_block_name("transition"),
+            StructField::new("enabled", AttributeType::Bool),
+        ],
+    };
+
+    let schema = ResourceSchema::new("test.block.resource")
+        .attribute(AttributeSchema::new("config", config_struct));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.block.resource".to_string(), schema);
+
+    CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![])
+}
+
 pub(super) fn test_provider_with_nested_structs() -> CompletionProvider {
     let inner_struct = AttributeType::Struct {
         name: "InnerStruct".to_string(),

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -580,6 +580,34 @@ output {
 }
 
 #[test]
+fn nested_block_name_not_flagged_as_unknown() {
+    // When a nested struct field uses block_name (e.g., "transition" for "transitions"),
+    // validate_struct_value should not flag it as an unknown field.
+    let engine = test_engine_with_block_name_nested();
+    let doc = create_document(
+        r#"let r = test.block.resource {
+config = {
+    transition {
+        days = 30
+        storage_class = "GLACIER"
+    }
+}
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let unknown = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown field 'transition'"));
+    assert!(
+        unknown.is_none(),
+        "block_name 'transition' should not be flagged as unknown in nested struct. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn find_let_binding_position_with_multibyte_leading_whitespace() {
     // Regression test for issue #724: find_let_binding_position uses byte offset
     // as character column. When multi-byte whitespace (e.g., full-width space U+3000)

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -63,6 +63,42 @@ pub(super) fn test_engine_with_nested_structs() -> DiagnosticEngine {
     )
 }
 
+pub(super) fn test_engine_with_block_name_nested() -> DiagnosticEngine {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+    let transition_struct = AttributeType::Struct {
+        name: "Transition".to_string(),
+        fields: vec![
+            StructField::new("days", AttributeType::Int),
+            StructField::new("storage_class", AttributeType::String),
+        ],
+    };
+
+    let config_struct = AttributeType::Struct {
+        name: "Config".to_string(),
+        fields: vec![
+            StructField::new(
+                "transitions",
+                AttributeType::List(Box::new(transition_struct)),
+            )
+            .with_block_name("transition"),
+            StructField::new("enabled", AttributeType::Bool),
+        ],
+    };
+
+    let schema = ResourceSchema::new("test.block.resource")
+        .attribute(AttributeSchema::new("config", config_struct));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.block.resource".to_string(), schema);
+
+    DiagnosticEngine::new(
+        Arc::new(schemas),
+        vec!["test".to_string()],
+        Arc::new(vec![]),
+    )
+}
+
 pub(super) fn custom_engine(
     schemas: HashMap<String, carina_core::schema::ResourceSchema>,
 ) -> DiagnosticEngine {

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -37,6 +37,11 @@ impl DiagnosticEngine {
         };
 
         let field_names: HashSet<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+        // Also include block_names as valid field names
+        let block_name_to_canonical: HashMap<&str, &str> = fields
+            .iter()
+            .filter_map(|f| f.block_name.as_deref().map(|bn| (bn, f.name.as_str())))
+            .collect();
         let field_map: HashMap<&str, &carina_core::schema::StructField> =
             fields.iter().map(|f| (f.name.as_str(), f)).collect();
 
@@ -45,8 +50,14 @@ impl DiagnosticEngine {
                 let all_positions = self.find_all_nested_field_positions(doc, attr_name, key);
                 if let Some(Some((line, col))) = all_positions.get(map_index) {
                     let (line, col) = (*line, *col);
+                    // Resolve block_name to canonical name
+                    let canonical_key = block_name_to_canonical
+                        .get(key.as_str())
+                        .copied()
+                        .unwrap_or(key.as_str());
+
                     // Check for unknown fields
-                    if !field_names.contains(key.as_str()) {
+                    if !field_names.contains(canonical_key) {
                         diagnostics.push(Diagnostic {
                             range: Range {
                                 start: Position {
@@ -67,7 +78,7 @@ impl DiagnosticEngine {
                     }
 
                     // Type validation for known fields
-                    if let Some(field) = field_map.get(key.as_str()) {
+                    if let Some(field) = field_map.get(canonical_key) {
                         // Skip validation for ResourceRef values (resolved at runtime)
                         let type_error = if matches!(val, Value::ResourceRef { .. }) {
                             None


### PR DESCRIPTION
## Summary
- Fix `resolve_struct_fields_for_path()` in completion provider to also match `StructField.block_name` when walking nested paths, so completions work inside block_name blocks (e.g., `transition { ... }` for field `transitions`)
- Fix `validate_struct_value()` in diagnostics to resolve block_name keys to canonical field names before checking for unknown fields, preventing false "Unknown field" warnings
- Add tests for both completion and diagnostics scenarios with nested block_name usage

Closes #760

## Test plan
- [x] New test `nested_struct_completions_via_block_name_in_path` verifies completions work when nested path uses block_name
- [x] New test `nested_block_name_not_flagged_as_unknown` verifies diagnostics don't flag block_name as unknown field
- [x] All existing 115 LSP unit tests + 4 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)