### PR TITLE
fix: use ProviderError.with_cause() to preserve error chain

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -1338,7 +1338,8 @@ fn generate_provider_code(
              \x20       identifier: &str,\n\
              \x20   ) -> ProviderResult<()> {{\n\
              \x20       self.{}.{}().{}(identifier).send().await.map_err(|e| {{\n\
-             \x20           ProviderError::new(format!(\"Failed to delete {}: {{:?}}\", e))\n\
+             \x20           ProviderError::new(\"Failed to delete {}\")\n\
+             \x20               .with_cause(e)\n\
              \x20               .for_resource(id.clone())\n\
              \x20       }})?;\n\
              \x20       Ok(())\n\
@@ -1428,9 +1429,10 @@ fn generate_provider_code(
                 client_field, sdk_method, id_setter
             ));
             code.push_str(&format!(
-                "\x20           ProviderError::new(format!(\"Failed to read {}: {{}}\", e))\n",
+                "\x20           ProviderError::new(\"Failed to read {}\")\n",
                 op_desc
             ));
+            code.push_str("\x20               .with_cause(e)\n");
             code.push_str("\x20               .for_resource(id.clone())\n");
             code.push_str("\x20       })?;\n");
 
@@ -1628,9 +1630,10 @@ fn generate_provider_code(
                 client_field, sdk_method, id_setter, struct_setter
             ));
             code.push_str(&format!(
-                "\x20               ProviderError::new(format!(\"Failed to {}: {{}}\", e))\n",
+                "\x20               ProviderError::new(\"Failed to {}\")\n",
                 op_desc
             ));
+            code.push_str("\x20                   .with_cause(e)\n");
             code.push_str("\x20                   .for_resource(id.clone())\n");
             code.push_str("\x20           })?;\n");
             code.push_str("\x20       }\n");

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -21,10 +21,14 @@ pub struct ProviderError {
 impl std::fmt::Display for ProviderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(ref id) = self.resource_id {
-            write!(f, "[{}.{}] {}", id.resource_type, id.name, self.message)
+            write!(f, "[{}.{}] {}", id.resource_type, id.name, self.message)?;
         } else {
-            write!(f, "{}", self.message)
+            write!(f, "{}", self.message)?;
         }
+        if let Some(ref cause) = self.cause {
+            write!(f, ": {}", cause)?;
+        }
+        Ok(())
     }
 }
 
@@ -505,6 +509,54 @@ mod tests {
         let state = router.create(&resource).await.unwrap();
         assert!(state.exists);
         assert_eq!(state.identifier, Some("mock-id-123".to_string()));
+    }
+
+    #[test]
+    fn provider_error_source_returns_cause() {
+        use std::error::Error;
+        let cause = std::io::Error::other("connection refused");
+        let err = ProviderError::new("Failed to create resource").with_cause(cause);
+        let source = err.source().expect("source should be Some");
+        assert_eq!(source.to_string(), "connection refused");
+    }
+
+    #[test]
+    fn provider_error_display_includes_cause() {
+        let cause = std::io::Error::other("connection refused");
+        let err = ProviderError::new("Failed to create resource").with_cause(cause);
+        let display = format!("{}", err);
+        assert!(
+            display.contains("connection refused"),
+            "Display should include cause message, got: {}",
+            display
+        );
+    }
+
+    #[test]
+    fn provider_error_display_without_cause() {
+        let err = ProviderError::new("simple error");
+        let display = format!("{}", err);
+        assert_eq!(display, "simple error");
+    }
+
+    #[test]
+    fn provider_error_display_with_resource_id_and_cause() {
+        let cause = std::io::Error::other("timeout");
+        let id = ResourceId::new("s3.bucket", "my-bucket");
+        let err = ProviderError::new("Failed to read")
+            .with_cause(cause)
+            .for_resource(id);
+        let display = format!("{}", err);
+        assert!(
+            display.contains("timeout"),
+            "Display should include cause message, got: {}",
+            display
+        );
+        assert!(
+            display.contains("s3.bucket"),
+            "Display should include resource type, got: {}",
+            display
+        );
     }
 
     #[tokio::test]

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -170,7 +170,8 @@ impl AwsProvider {
                     req = req.tags(aws_sdk_ec2::types::Tag::builder().key(key.as_str()).build());
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new(format!("Failed to delete tags: {:?}", e))
+                    ProviderError::new("Failed to delete tags")
+                        .with_cause(e)
                         .for_resource(resource_id.clone())
                 })?;
             }
@@ -185,7 +186,8 @@ impl AwsProvider {
                     req = req.tags(tag);
                 }
                 req.send().await.map_err(|e| {
-                    ProviderError::new(format!("Failed to tag resource: {:?}", e))
+                    ProviderError::new("Failed to tag resource")
+                        .with_cause(e)
                         .for_resource(resource_id.clone())
                 })?;
             }
@@ -212,7 +214,8 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to describe security group rules: {:?}", e))
+            ProviderError::new("Failed to describe security group rules")
+                .with_cause(e)
                 .for_resource(id.clone())
         })?;
         let rules: Vec<_> = result
@@ -396,7 +399,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to create ingress rule: {:?}", e))
+                    ProviderError::new("Failed to create ingress rule")
+                        .with_cause(e)
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -414,7 +418,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to create egress rule: {:?}", e))
+                    ProviderError::new("Failed to create egress rule")
+                        .with_cause(e)
                         .for_resource(resource.id.clone())
                 })?;
 
@@ -469,7 +474,8 @@ impl AwsProvider {
             req = req.security_group_rule_ids(*rule_id);
         }
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to describe security group rules: {:?}", e))
+            ProviderError::new("Failed to describe security group rules")
+                .with_cause(e)
                 .for_resource(id.clone())
         })?;
 
@@ -494,7 +500,8 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new(format!("Failed to delete ingress rules: {:?}", e))
+                ProviderError::new("Failed to delete ingress rules")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         } else {
@@ -506,7 +513,8 @@ impl AwsProvider {
                 request = request.security_group_rule_ids(*rule_id);
             }
             request.send().await.map_err(|e| {
-                ProviderError::new(format!("Failed to delete egress rules: {:?}", e))
+                ProviderError::new("Failed to delete egress rules")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         }

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -174,7 +174,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete vpc: {:?}", e))
+                ProviderError::new("Failed to delete vpc")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -192,7 +193,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete subnet: {:?}", e))
+                ProviderError::new("Failed to delete subnet")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -210,7 +212,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete route table: {:?}", e))
+                ProviderError::new("Failed to delete route table")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -228,7 +231,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete security group: {:?}", e))
+                ProviderError::new("Failed to delete security group")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -246,7 +250,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete bucket: {:?}", e))
+                ProviderError::new("Failed to delete bucket")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         Ok(())
@@ -318,11 +323,9 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!(
-                    "Failed to read s3.bucket GetBucketVersioning: {}",
-                    e
-                ))
-                .for_resource(id.clone())
+                ProviderError::new("Failed to read s3.bucket GetBucketVersioning")
+                    .with_cause(e)
+                    .for_resource(id.clone())
             })?;
         let value = output
             .status()
@@ -356,7 +359,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to put bucket versioning: {}", e))
+                    ProviderError::new("Failed to put bucket versioning")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/ec2/internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/internet_gateway.rs
@@ -30,7 +30,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe internet gateways: {:?}", e))
+                ProviderError::new("Failed to describe internet gateways")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -76,7 +77,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to create internet gateway: {:?}", e))
+                ProviderError::new("Failed to create internet gateway")
+                    .with_cause(e)
                     .for_resource(resource.id.clone())
             })?;
 
@@ -101,7 +103,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to attach internet gateway: {:?}", e))
+                    ProviderError::new("Failed to attach internet gateway")
+                        .with_cause(e)
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -125,7 +128,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe internet gateway: {:?}", e))
+                ProviderError::new("Failed to describe internet gateway")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -141,7 +145,8 @@ impl AwsProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(format!("Failed to detach internet gateway: {:?}", e))
+                        ProviderError::new("Failed to detach internet gateway")
+                            .with_cause(e)
                             .for_resource(id.clone())
                     })?;
             }
@@ -154,7 +159,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete internet gateway: {:?}", e))
+                ProviderError::new("Failed to delete internet gateway")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -29,7 +29,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe route table: {:?}", e))
+                ProviderError::new("Failed to describe route table")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -93,7 +94,8 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to create route: {:?}", e))
+            ProviderError::new("Failed to create route")
+                .with_cause(e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -143,7 +145,9 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to update route: {:?}", e)).for_resource(id.clone())
+            ProviderError::new("Failed to update route")
+                .with_cause(e)
+                .for_resource(id.clone())
         })?;
 
         // Route identifier is route_table_id|destination_cidr_block
@@ -172,7 +176,9 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to delete route: {:?}", e)).for_resource(id)
+                ProviderError::new("Failed to delete route")
+                    .with_cause(e)
+                    .for_resource(id)
             })?;
 
         Ok(())

--- a/carina-provider-aws/src/services/ec2/route_table.rs
+++ b/carina-provider-aws/src/services/ec2/route_table.rs
@@ -30,7 +30,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe route tables: {:?}", e))
+                ProviderError::new("Failed to describe route tables")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -93,7 +94,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to create route table: {:?}", e))
+                ProviderError::new("Failed to create route table")
+                    .with_cause(e)
                     .for_resource(resource.id.clone())
             })?;
 
@@ -137,7 +139,8 @@ impl AwsProvider {
                             .send()
                             .await
                             .map_err(|e| {
-                                ProviderError::new(format!("Failed to create route: {:?}", e))
+                                ProviderError::new("Failed to create route")
+                                    .with_cause(e)
                                     .for_resource(resource.id.clone())
                             })?;
                     }

--- a/carina-provider-aws/src/services/ec2/security_group.rs
+++ b/carina-provider-aws/src/services/ec2/security_group.rs
@@ -30,7 +30,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe security groups: {:?}", e))
+                ProviderError::new("Failed to describe security groups")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -91,7 +92,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to create security group: {:?}", e))
+                ProviderError::new("Failed to create security group")
+                    .with_cause(e)
                     .for_resource(resource.id.clone())
             })?;
 

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -31,7 +31,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe subnets: {:?}", e))
+                ProviderError::new("Failed to describe subnets")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -94,7 +95,8 @@ impl AwsProvider {
         }
 
         let result = req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to create subnet: {:?}", e))
+            ProviderError::new("Failed to create subnet")
+                .with_cause(e)
                 .for_resource(resource.id.clone())
         })?;
 

--- a/carina-provider-aws/src/services/ec2/vpc.rs
+++ b/carina-provider-aws/src/services/ec2/vpc.rs
@@ -28,7 +28,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to describe VPCs: {:?}", e))
+                ProviderError::new("Failed to describe VPCs")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -115,7 +116,8 @@ impl AwsProvider {
         }
 
         let result = create_vpc_builder.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to create VPC: {:?}", e))
+            ProviderError::new("Failed to create VPC")
+                .with_cause(e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -140,7 +142,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to set DNS support: {:?}", e))
+                    ProviderError::new("Failed to set DNS support")
+                        .with_cause(e)
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -158,7 +161,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to set DNS hostnames: {:?}", e))
+                    ProviderError::new("Failed to set DNS hostnames")
+                        .with_cause(e)
                         .for_resource(resource.id.clone())
                 })?;
         }
@@ -191,7 +195,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to update DNS support: {:?}", e))
+                    ProviderError::new("Failed to update DNS support")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -209,7 +214,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to update DNS hostnames: {:?}", e))
+                    ProviderError::new("Failed to update DNS hostnames")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -63,11 +63,9 @@ impl AwsProvider {
                         name
                     ))
                     .for_resource(id.clone())),
-                    HeadBucketErrorKind::Other => Err(ProviderError::new(format!(
-                        "Failed to read bucket: {:?}",
-                        err
-                    ))
-                    .for_resource(id.clone())),
+                    HeadBucketErrorKind::Other => Err(ProviderError::new("Failed to read bucket")
+                        .with_cause(err)
+                        .for_resource(id.clone())),
                 }
             }
         }
@@ -141,7 +139,8 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to create bucket: {:?}", e))
+            ProviderError::new("Failed to create bucket")
+                .with_cause(e)
                 .for_resource(resource.id.clone())
         })?;
 
@@ -187,7 +186,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to delete bucket tags: {:?}", e))
+                    ProviderError::new("Failed to delete bucket tags")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         } else {
@@ -222,11 +222,11 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "OwnershipControlsNotFoundError") {
-                    return Err(ProviderError::new(format!(
-                        "Failed to read bucket ownership controls: {}",
-                        err
-                    ))
-                    .for_resource(id.clone()));
+                    return Err(
+                        ProviderError::new("Failed to read bucket ownership controls")
+                            .with_cause(err)
+                            .for_resource(id.clone()),
+                    );
                 }
             }
         }
@@ -247,14 +247,16 @@ impl AwsProvider {
                 .object_ownership(ObjectOwnership::from(normalized))
                 .build()
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to build ownership controls rule: {}", e))
+                    ProviderError::new("Failed to build ownership controls rule")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
             let controls = OwnershipControls::builder()
                 .rules(rule)
                 .build()
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to build ownership controls: {}", e))
+                    ProviderError::new("Failed to build ownership controls")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
             self.s3_client
@@ -264,7 +266,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to put bucket ownership controls: {}", e))
+                    ProviderError::new("Failed to put bucket ownership controls")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         }
@@ -302,11 +305,11 @@ impl AwsProvider {
                         Value::Bool(false),
                     );
                 } else {
-                    return Err(ProviderError::new(format!(
-                        "Failed to read object lock configuration: {}",
-                        err
-                    ))
-                    .for_resource(id.clone()));
+                    return Err(
+                        ProviderError::new("Failed to read object lock configuration")
+                            .with_cause(err)
+                            .for_resource(id.clone()),
+                    );
                 }
             }
         }
@@ -327,7 +330,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to read bucket ACL: {}", e))
+                ProviderError::new("Failed to read bucket ACL")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 
@@ -469,7 +473,9 @@ impl AwsProvider {
         }
 
         req.send().await.map_err(|e| {
-            ProviderError::new(format!("Failed to put bucket ACL: {}", e)).for_resource(id.clone())
+            ProviderError::new("Failed to put bucket ACL")
+                .with_cause(e)
+                .for_resource(id.clone())
         })?;
 
         Ok(())
@@ -503,11 +509,9 @@ impl AwsProvider {
             }
             Err(err) => {
                 if !is_s3_not_configured_error(&err, "NoSuchTagSet") {
-                    return Err(ProviderError::new(format!(
-                        "Failed to read bucket tagging: {}",
-                        err
-                    ))
-                    .for_resource(id.clone()));
+                    return Err(ProviderError::new("Failed to read bucket tagging")
+                        .with_cause(err)
+                        .for_resource(id.clone()));
                 }
             }
         }
@@ -538,7 +542,8 @@ impl AwsProvider {
                 .set_tag_set(Some(tags))
                 .build()
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to build tagging: {:?}", e))
+                    ProviderError::new("Failed to build tagging")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
 
@@ -549,7 +554,8 @@ impl AwsProvider {
                 .send()
                 .await
                 .map_err(|e| {
-                    ProviderError::new(format!("Failed to put bucket tags: {:?}", e))
+                    ProviderError::new("Failed to put bucket tags")
+                        .with_cause(e)
                         .for_resource(id.clone())
                 })?;
         }

--- a/carina-provider-aws/src/services/sts/caller_identity.rs
+++ b/carina-provider-aws/src/services/sts/caller_identity.rs
@@ -17,7 +17,8 @@ impl AwsProvider {
             .send()
             .await
             .map_err(|e| {
-                ProviderError::new(format!("Failed to get STS caller identity: {:?}", e))
+                ProviderError::new("Failed to get STS caller identity")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
 

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -437,9 +437,10 @@ impl AwsccProvider {
                 req = req.version_id_marker(vim);
             }
 
-            let response = req.send().await.map_err(|e| {
-                ProviderError::new(format!("Failed to list object versions: {:?}", e))
-            })?;
+            let response = req
+                .send()
+                .await
+                .map_err(|e| ProviderError::new("Failed to list object versions").with_cause(e))?;
 
             let mut objects_to_delete = Vec::new();
 
@@ -451,7 +452,7 @@ impl AwsccProvider {
                         id = id.version_id(vid);
                     }
                     objects_to_delete.push(id.build().map_err(|e| {
-                        ProviderError::new(format!("Failed to build ObjectIdentifier: {:?}", e))
+                        ProviderError::new("Failed to build ObjectIdentifier").with_cause(e)
                     })?);
                 }
             }
@@ -464,7 +465,7 @@ impl AwsccProvider {
                         id = id.version_id(vid);
                     }
                     objects_to_delete.push(id.build().map_err(|e| {
-                        ProviderError::new(format!("Failed to build ObjectIdentifier: {:?}", e))
+                        ProviderError::new("Failed to build ObjectIdentifier").with_cause(e)
                     })?);
                 }
             }
@@ -476,7 +477,7 @@ impl AwsccProvider {
                     .quiet(true)
                     .build()
                     .map_err(|e| {
-                        ProviderError::new(format!("Failed to build Delete request: {:?}", e))
+                        ProviderError::new("Failed to build Delete request").with_cause(e)
                     })?;
 
                 s3.delete_objects()
@@ -484,9 +485,7 @@ impl AwsccProvider {
                     .delete(delete)
                     .send()
                     .await
-                    .map_err(|e| {
-                        ProviderError::new(format!("Failed to delete objects: {:?}", e))
-                    })?;
+                    .map_err(|e| ProviderError::new("Failed to delete objects").with_cause(e))?;
             }
 
             if response.is_truncated() == Some(true) {
@@ -533,10 +532,7 @@ impl AwsccProvider {
                 if Self::is_not_found_error(&e) {
                     Ok(None)
                 } else {
-                    Err(ProviderError::new(format!(
-                        "Failed to get resource: {:?}",
-                        e
-                    )))
+                    Err(ProviderError::new("Failed to get resource").with_cause(e))
                 }
             }
         }
@@ -607,10 +603,7 @@ impl AwsccProvider {
                         delay_secs = (delay_secs * 2).min(CREATE_RETRY_MAX_DELAY_SECS);
                         continue;
                     }
-                    return Err(ProviderError::new(format!(
-                        "Failed to create resource: {:?}",
-                        e
-                    )));
+                    return Err(ProviderError::new("Failed to create resource").with_cause(e));
                 }
             }
         }
@@ -633,7 +626,7 @@ impl AwsccProvider {
         }
 
         let patch_document = serde_json::to_string(&patch_ops)
-            .map_err(|e| ProviderError::new(format!("Failed to build patch: {}", e)))?;
+            .map_err(|e| ProviderError::new("Failed to build patch").with_cause(e))?;
 
         let result = self
             .cloudcontrol_client
@@ -643,7 +636,7 @@ impl AwsccProvider {
             .patch_document(patch_document)
             .send()
             .await
-            .map_err(|e| ProviderError::new(format!("Failed to update resource: {:?}", e)))?;
+            .map_err(|e| ProviderError::new("Failed to update resource").with_cause(e))?;
 
         if let Some(request_token) = result.progress_event().and_then(|p| p.request_token()) {
             self.wait_for_operation(request_token).await?;
@@ -720,10 +713,7 @@ impl AwsccProvider {
                         delay_secs = (delay_secs * 2).min(DELETE_RETRY_MAX_DELAY_SECS);
                         continue;
                     }
-                    return Err(ProviderError::new(format!(
-                        "Failed to delete resource: {:?}",
-                        e
-                    )));
+                    return Err(ProviderError::new("Failed to delete resource").with_cause(e));
                 }
             }
         }
@@ -871,9 +861,7 @@ impl AwsccProvider {
                 .request_token(request_token)
                 .send()
                 .await
-                .map_err(|e| {
-                    ProviderError::new(format!("Failed to get operation status: {:?}", e))
-                })?;
+                .map_err(|e| ProviderError::new("Failed to get operation status").with_cause(e))?;
 
             if let Some(progress) = status.progress_event() {
                 match progress.operation_status() {
@@ -1105,7 +1093,8 @@ impl AwsccProvider {
         // Handle force_delete for S3 buckets: empty the bucket before deletion
         if lifecycle.force_delete && id.resource_type == "s3.bucket" {
             self.empty_s3_bucket(identifier).await.map_err(|e| {
-                ProviderError::new(format!("Failed to empty S3 bucket before deletion: {}", e))
+                ProviderError::new("Failed to empty S3 bucket before deletion")
+                    .with_cause(e)
                     .for_resource(id.clone())
             })?;
         }
@@ -1190,10 +1179,10 @@ impl AwsccProvider {
                 self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
                     .await
                     .map_err(|e| {
-                        ProviderError::new(format!(
-                            "Failed to detach Internet Gateway from VPC before deletion: {}",
-                            e
-                        ))
+                        ProviderError::new(
+                            "Failed to detach Internet Gateway from VPC before deletion",
+                        )
+                        .with_cause(e)
                         .for_resource(id.clone())
                     })?;
             }
@@ -1408,7 +1397,7 @@ pub fn restore_unreturned_attrs_impl(
 /// Returns an error instead of silently returning an empty object when the JSON is malformed.
 fn parse_resource_properties(props_str: &str) -> ProviderResult<serde_json::Value> {
     serde_json::from_str(props_str)
-        .map_err(|e| ProviderError::new(format!("Failed to parse resource properties: {}", e)))
+        .map_err(|e| ProviderError::new("Failed to parse resource properties").with_cause(e))
 }
 
 /// Build JSON Patch operations for updating a resource.

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -93,7 +93,7 @@ impl Provider for MockProvider {
 
             states.insert(key, attrs);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new(format!("Failed to save state: {}", e)))?;
+                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
 
             Ok(
                 State::existing(resource.id.clone(), resource.attributes.clone())
@@ -124,7 +124,7 @@ impl Provider for MockProvider {
 
             states.insert(key, attrs);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new(format!("Failed to save state: {}", e)))?;
+                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
 
             Ok(State::existing(id, to.attributes.clone()))
         })
@@ -143,7 +143,7 @@ impl Provider for MockProvider {
 
             states.remove(&key);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new(format!("Failed to save state: {}", e)))?;
+                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
 
             Ok(())
         })


### PR DESCRIPTION
## Summary
- Update `ProviderError` Display impl to include cause message (e.g., `"Failed to create: <cause>"`)
- Migrate ~60 `ProviderError::new(format!("...: {:?}", e))` call sites to `.with_cause(e)` across all provider crates
- Update codegen (`carina-codegen-aws`) to emit `.with_cause(e)` for future generated code
- Add unit tests for `source()`, Display with/without cause, and Display with resource_id + cause

## Test plan
- [x] New unit tests verify `source()` returns the cause, Display includes cause message
- [x] Full `cargo test` passes
- [x] `cargo clippy` and `cargo fmt` clean

Closes #767