### PR TITLE
fix: remove dual provider identity (_provider attribute)

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -3186,9 +3186,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -3219,9 +3216,6 @@ mod tests {
     fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
         // If base attr doesn't exist in schema, leave _prefix as-is
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "nonexistent_attr_prefix".to_string(),
             Value::String("some-value".to_string()),
@@ -3242,9 +3236,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -3263,9 +3254,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("".to_string()),
@@ -3281,9 +3269,6 @@ mod tests {
     fn test_resolve_names_handles_block_name_before_prefix() {
         // resolve_names should first resolve block names, then resolve attr prefixes
         let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "operating_region".to_string(),
             Value::List(vec![Value::Map(
@@ -3428,16 +3413,12 @@ mod tests {
     fn test_anonymous_id_different_regions_produce_different_identifiers() {
         // Two anonymous ec2_vpc resources with same cidr_block but different provider regions
         let mut r1 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
 
         let mut r2 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -3465,16 +3446,12 @@ mod tests {
     fn test_anonymous_id_same_region_same_create_only_collides() {
         // Two anonymous ec2_vpc resources with same cidr_block and same provider region → collision
         let mut r1 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
 
         let mut r2 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -3491,16 +3468,12 @@ mod tests {
     fn test_anonymous_id_different_create_only_same_region_no_collision() {
         // Two anonymous ec2_vpc resources with different cidr_block in same provider region → no collision
         let mut r1 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
 
         let mut r2 = Resource::with_provider("awscc", "ec2.vpc", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.1.0.0/16".to_string()),
@@ -3519,8 +3492,6 @@ mod tests {
     fn test_anonymous_id_named_resources_are_skipped() {
         // Named resources should not be processed by compute_anonymous_identifiers
         let mut r1 = Resource::with_provider("awscc", "ec2.vpc", "my_vpc");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -3574,8 +3545,7 @@ mod tests {
 
     #[test]
     fn validate_data_source_without_read_keyword_errors() {
-        let resource = Resource::with_provider("aws", "sts.caller_identity", "identity")
-            .with_attribute("_provider", Value::String("aws".to_string()));
+        let resource = Resource::with_provider("aws", "sts.caller_identity", "identity");
         // read_only defaults to false, simulating missing `read` keyword
         let result = validate_resources(&[resource]);
         assert!(result.is_err());
@@ -3594,9 +3564,8 @@ mod tests {
 
     #[test]
     fn validate_data_source_with_read_keyword_passes() {
-        let resource = Resource::with_provider("aws", "sts.caller_identity", "identity")
-            .with_attribute("_provider", Value::String("aws".to_string()))
-            .with_read_only(true);
+        let resource =
+            Resource::with_provider("aws", "sts.caller_identity", "identity").with_read_only(true);
         let result = validate_resources(&[resource]);
         assert!(
             result.is_ok(),
@@ -3608,7 +3577,6 @@ mod tests {
     #[test]
     fn validate_regular_resource_without_read_keyword_passes() {
         let resource = Resource::with_provider("aws", "s3.bucket", "my-bucket")
-            .with_attribute("_provider", Value::String("aws".to_string()))
             .with_attribute("bucket", Value::String("my-bucket".to_string()))
             .with_attribute("region", Value::String("ap-northeast-1".to_string()));
         let result = validate_resources(&[resource]);
@@ -3675,9 +3643,6 @@ mod tests {
         // --- First run (apply) ---
         // 1. Parse: anonymous resource with bucket_name_prefix
         let mut resource_run1 = Resource::with_provider("awscc", "s3.bucket", "");
-        resource_run1
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run1.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -3732,9 +3697,6 @@ mod tests {
         // --- Second run (plan-verify) ---
         // 1. Parse again: same anonymous resource with bucket_name_prefix
         let mut resource_run2 = Resource::with_provider("awscc", "s3.bucket", "");
-        resource_run2
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run2.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -3784,9 +3746,6 @@ mod tests {
 
         // --- First run ---
         let mut resource_run1 = Resource::with_provider("awscc", "iam.role", "");
-        resource_run1
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run1.attributes.insert(
             "role_name_prefix".to_string(),
             Value::String("carina-acc-test-".to_string()),
@@ -3841,9 +3800,6 @@ mod tests {
 
         // --- Second run ---
         let mut resource_run2 = Resource::with_provider("awscc", "iam.role", "");
-        resource_run2
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run2.attributes.insert(
             "role_name_prefix".to_string(),
             Value::String("carina-acc-test-".to_string()),
@@ -3892,9 +3848,6 @@ mod tests {
 
         // --- First run ---
         let mut resource_run1 = Resource::with_provider("awscc", "ec2.flow_log", "");
-        resource_run1
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run1.attributes.insert(
             "resource_id".to_string(),
             Value::ResourceRef {
@@ -3952,9 +3905,6 @@ mod tests {
 
         // --- Second run ---
         let mut resource_run2 = Resource::with_provider("awscc", "ec2.flow_log", "");
-        resource_run2
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource_run2.attributes.insert(
             "resource_id".to_string(),
             Value::ResourceRef {

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -249,10 +249,11 @@ pub fn compute_anonymous_identifiers(
             continue;
         }
 
-        // Look up schema for this resource's provider (skip if no _provider set)
-        let Some(Value::String(provider_name)) = resource.attributes.get("_provider") else {
+        // Look up schema for this resource's provider (skip if no provider set)
+        if resource.id.provider.is_empty() {
             continue;
-        };
+        }
+        let provider_name = &resource.id.provider;
         let schema_key = schema_key_fn(resource);
 
         let Some(schema) = schemas.get(&schema_key) else {
@@ -295,7 +296,7 @@ pub fn compute_anonymous_identifiers(
             // No create-only values available: hash all user-specified attributes
             for (key, value) in &resource.attributes {
                 if key.starts_with('_') {
-                    continue; // Skip internal attributes like _provider
+                    continue; // Skip internal attributes like _type, _binding
                 }
                 hash_values.insert(key.as_str(), deterministic_value_string(value));
             }
@@ -488,9 +489,10 @@ mod tests {
     }
 
     fn schema_key_fn(resource: &Resource) -> String {
-        match resource.attributes.get("_provider") {
-            Some(Value::String(provider)) => format!("{}.{}", provider, resource.id.resource_type),
-            _ => resource.id.resource_type.clone(),
+        if resource.id.provider.is_empty() {
+            resource.id.resource_type.clone()
+        } else {
+            format!("{}.{}", resource.id.provider, resource.id.resource_type)
         }
     }
 
@@ -504,9 +506,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -538,9 +537,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "nonexistent_attr_prefix".to_string(),
             Value::String("some-value".to_string()),
@@ -563,9 +559,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("my-app-".to_string()),
@@ -586,9 +579,6 @@ mod tests {
     #[test]
     fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
         let mut resource = Resource::with_provider("awscc", "s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "bucket_name_prefix".to_string(),
             Value::String("".to_string()),
@@ -704,8 +694,6 @@ mod tests {
 
         // Step 1: compute identifier with path="/"
         let mut r1 = Resource::with_provider("awscc", "iam.role", "");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes.insert(
             "role_name".to_string(),
             Value::String("my-role".to_string()),
@@ -725,8 +713,6 @@ mod tests {
 
         // Step 2: compute identifier with path="/carina/" (changed create-only)
         let mut r2 = Resource::with_provider("awscc", "iam.role", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes.insert(
             "role_name".to_string(),
             Value::String("my-role".to_string()),
@@ -917,8 +903,6 @@ mod tests {
 
         let mut r = Resource::with_provider("awscc", "ec2.eip", "");
         r.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
-        r.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
 
         let mut resources = vec![r];
@@ -957,8 +941,6 @@ mod tests {
 
         let make_resource = || {
             let mut r = Resource::with_provider("awscc", "ec2.eip", "");
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r.attributes
                 .insert("domain".to_string(), Value::String("vpc".to_string()));
             r
@@ -1002,13 +984,9 @@ mod tests {
 
         let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
         r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
-        r1.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
 
         let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
 
@@ -1110,8 +1088,6 @@ mod tests {
         // Step 1: compute identifier with tag_env="production"
         let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
         r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
-        r1.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
         r1.attributes
             .insert("tag_name".to_string(), Value::String("my-eip".to_string()));
@@ -1132,8 +1108,6 @@ mod tests {
 
         // Step 2: compute identifier with tag_env="staging" (one attribute changed)
         let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
-        r2.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r2.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
         r2.attributes
@@ -1224,8 +1198,6 @@ mod tests {
 
         // Compute identifier without setting the create-only property
         let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
-        r1.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         r1.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
         let mut resources = vec![r1];
@@ -1417,8 +1389,6 @@ mod tests {
         let make_resource = |env: &str, team: &str| {
             let mut r = Resource::with_provider("awscc", "ec2.eip", "");
             r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
-            r.attributes
                 .insert("domain".to_string(), Value::String("vpc".to_string()));
             r.attributes
                 .insert("tag_name".to_string(), Value::String("my-eip".to_string()));
@@ -1523,8 +1493,6 @@ mod tests {
 
         let mut r = Resource::with_provider("awscc", "ec2.eip", "");
         r.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
-        r.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
         let mut resources = vec![r];
         compute_anonymous_identifiers(
@@ -1599,8 +1567,6 @@ mod tests {
         let make_resource = |env: &str| {
             let mut r = Resource::with_provider("awscc", "ec2.internet_gateway", "");
             r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
-            r.attributes
                 .insert("tag_name".to_string(), Value::String("my-igw".to_string()));
             r.attributes
                 .insert("tag_env".to_string(), Value::String(env.to_string()));
@@ -1656,8 +1622,6 @@ mod tests {
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
         let mut vpc = Resource::with_provider("awscc", "ec2.vpc", "");
-        vpc.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         vpc.attributes.insert(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -1666,8 +1630,6 @@ mod tests {
             .insert("tag_name".to_string(), Value::String("my-vpc".to_string()));
 
         let mut eip = Resource::with_provider("awscc", "ec2.eip", "");
-        eip.attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         eip.attributes
             .insert("domain".to_string(), Value::String("vpc".to_string()));
         eip.attributes
@@ -1707,9 +1669,6 @@ mod tests {
 
         // Resource with both create-only props set
         let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
         resource.attributes.insert(
             "role_name".to_string(),
             Value::String("my-role".to_string()),
@@ -1764,8 +1723,6 @@ mod tests {
         // Simulate two runs with different random suffixes but same prefix
         let make_resource = |generated_name: &str| {
             let mut r = Resource::with_provider("awscc", "s3.bucket", "");
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r.attributes.insert(
                 "bucket_name".to_string(),
                 Value::String(generated_name.to_string()),
@@ -1806,8 +1763,6 @@ mod tests {
 
         let make_resource = |prefix: &str, generated_name: &str| {
             let mut r = Resource::with_provider("awscc", "s3.bucket", "");
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r.attributes.insert(
                 "bucket_name".to_string(),
                 Value::String(generated_name.to_string()),

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -652,9 +652,7 @@ fn parse_anonymous_resource(
     // identifier computed from create-only properties after parsing.
     let resource_name = String::new();
 
-    // Add provider information to attributes
     let mut attributes = attributes;
-    attributes.insert("_provider".to_string(), Value::String(provider.to_string()));
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
 
     // Extract lifecycle block from attributes (it's a meta-argument, not a real attribute)
@@ -783,8 +781,6 @@ fn parse_resource_expr(
     // Extract lifecycle block from attributes (it's a meta-argument, not a real attribute)
     let lifecycle = extract_lifecycle_config(&mut attributes);
 
-    // Add provider information to attributes
-    attributes.insert("_provider".to_string(), Value::String(provider.to_string()));
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
     // Save binding name (for reference)
     attributes.insert(
@@ -831,8 +827,6 @@ fn parse_read_resource_expr(
     // Extract lifecycle block from attributes (it's a meta-argument, not a real attribute)
     let lifecycle = extract_lifecycle_config(&mut attributes);
 
-    // Add provider information to attributes
-    attributes.insert("_provider".to_string(), Value::String(provider.to_string()));
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
     // Save binding name (for reference)
     attributes.insert(
@@ -1305,10 +1299,9 @@ mod tests {
         let result = parse(input).unwrap();
         assert_eq!(result.resources.len(), 1);
         assert_eq!(result.resources[0].id.resource_type, "storage.bucket");
-        assert_eq!(
-            result.resources[0].attributes.get("_provider"),
-            Some(&Value::String("gcp".to_string()))
-        );
+        assert_eq!(result.resources[0].id.provider, "gcp");
+        // _provider attribute should NOT be set (provider identity is in ResourceId)
+        assert!(!result.resources[0].attributes.contains_key("_provider"));
     }
 
     #[test]

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -316,15 +316,13 @@ pub fn schema_key_for_resource(
     factories: &[Box<dyn ProviderFactory>],
     resource: &Resource,
 ) -> String {
-    match resource.attributes.get("_provider") {
-        Some(Value::String(provider)) => {
-            if let Some(factory) = find_factory(factories, provider) {
-                factory.format_schema_key(&resource.id.resource_type)
-            } else {
-                resource.id.resource_type.clone()
-            }
-        }
-        _ => resource.id.resource_type.clone(),
+    if resource.id.provider.is_empty() {
+        return resource.id.resource_type.clone();
+    }
+    if let Some(factory) = find_factory(factories, &resource.id.provider) {
+        factory.format_schema_key(&resource.id.resource_type)
+    } else {
+        resource.id.resource_type.clone()
     }
 }
 
@@ -549,5 +547,49 @@ mod tests {
                 .message
                 .contains("Unknown provider: nonexistent")
         );
+    }
+
+    // Mock ProviderFactory for testing schema_key_for_resource
+    struct MockProviderFactory;
+
+    impl ProviderFactory for MockProviderFactory {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        fn display_name(&self) -> &str {
+            "Mock provider"
+        }
+
+        fn validate_config(&self, _attributes: &HashMap<String, Value>) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn extract_region(&self, _attributes: &HashMap<String, Value>) -> String {
+            "us-east-1".to_string()
+        }
+
+        fn create_provider(
+            &self,
+            _attributes: &HashMap<String, Value>,
+        ) -> BoxFuture<'_, Box<dyn Provider>> {
+            Box::pin(async { Box::new(MockProvider) as Box<dyn Provider> })
+        }
+
+        fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
+            vec![]
+        }
+    }
+
+    #[test]
+    fn schema_key_for_resource_uses_id_provider_not_attribute() {
+        let factories: Vec<Box<dyn ProviderFactory>> = vec![Box::new(MockProviderFactory)];
+
+        // Resource with id.provider set but NO _provider attribute
+        let resource = Resource::with_provider("mock", "s3.bucket", "my-bucket");
+        assert!(!resource.attributes.contains_key("_provider"));
+
+        let key = schema_key_for_resource(&factories, &resource);
+        assert_eq!(key, "mock.s3.bucket");
     }
 }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -2186,8 +2186,6 @@ mod tests {
                     m
                 })]),
             );
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r
         }];
 
@@ -2328,8 +2326,6 @@ mod tests {
             let mut r = Resource::new("s3.bucket", "my-bucket");
             r.attributes
                 .insert("lifecycle_configuration".to_string(), Value::Map(inner_map));
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r
         }];
 
@@ -2396,8 +2392,6 @@ mod tests {
             let mut r = Resource::new("s3.bucket", "my-bucket");
             r.attributes
                 .insert("lifecycle_configuration".to_string(), Value::Map(inner_map));
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r
         }];
 
@@ -2468,8 +2462,6 @@ mod tests {
             let mut r = Resource::new("s3.bucket", "my-bucket");
             r.attributes
                 .insert("lifecycle_configuration".to_string(), Value::Map(inner_map));
-            r.attributes
-                .insert("_provider".to_string(), Value::String("awscc".to_string()));
             r
         }];
 

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -692,11 +692,7 @@ fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
 
     for resource in resources.iter_mut() {
         // Only handle aws resources
-        let is_aws = matches!(
-            resource.attributes.get("_provider"),
-            Some(Value::String(p)) if p == "aws"
-        );
-        if !is_aws {
+        if resource.id.provider != "aws" {
             continue;
         }
 
@@ -801,10 +797,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_namespaced_value() {
-        let mut resource = Resource::new("s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "versioning_status".to_string(),
             Value::String("aws.s3.bucket.VersioningStatus.Enabled".to_string()),
@@ -821,10 +814,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::new("s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "versioning_status".to_string(),
             Value::UnresolvedIdent("Enabled".to_string(), None),
@@ -841,10 +831,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::new("s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "object_ownership".to_string(),
             Value::UnresolvedIdent(
@@ -864,10 +851,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_plain_string() {
-        let mut resource = Resource::new("s3.bucket", "test-bucket");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "versioning_status".to_string(),
             Value::String("Enabled".to_string()),
@@ -884,10 +868,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_aws() {
-        let mut resource = Resource::new("s3.bucket", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "s3.bucket", "test");
         resource.attributes.insert(
             "versioning_status".to_string(),
             Value::String("Enabled".to_string()),
@@ -904,10 +885,8 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_with_to_dsl() {
         // ip_protocol has to_dsl that maps "-1" → "all"
-        let mut resource = Resource::new("ec2.security_group_ingress", "test-rule");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource =
+            Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
         resource
             .attributes
             .insert("ip_protocol".to_string(), Value::String("-1".to_string()));
@@ -1480,10 +1459,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_vpc_instance_tenancy() {
-        let mut resource = Resource::new("ec2.vpc", "test-vpc");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "ec2.vpc", "test-vpc");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
             Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),
@@ -1500,10 +1476,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ec2_security_group_ingress_protocol() {
-        let mut resource = Resource::new("ec2.security_group_ingress", "test-rule");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource =
+            Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
         resource.attributes.insert(
             "ip_protocol".to_string(),
             Value::UnresolvedIdent("IpProtocol".to_string(), Some("tcp".to_string())),

--- a/carina-provider-awscc/src/provider.rs
+++ b/carina-provider-awscc/src/provider.rs
@@ -1236,11 +1236,7 @@ pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
 
     for resource in resources.iter_mut() {
         // Only handle awscc resources
-        let is_awscc = matches!(
-            resource.attributes.get("_provider"),
-            Some(Value::String(p)) if p == "awscc"
-        );
-        if !is_awscc {
+        if resource.id.provider != "awscc" {
             continue;
         }
 
@@ -1837,10 +1833,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::new("ec2.vpc", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
             Value::UnresolvedIdent("dedicated".to_string(), None),
@@ -1861,10 +1854,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::new("ec2.vpc", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
             Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),
@@ -1884,10 +1874,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = Resource::new("s3.bucket", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("aws".to_string()));
+        let mut resource = Resource::with_provider("aws", "s3.bucket", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
             Value::UnresolvedIdent("dedicated".to_string(), None),
@@ -1905,10 +1892,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
         // Test that flow log's log_destination_type with hyphens gets converted to underscores
-        let mut resource = Resource::new("ec2.flow_log", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.flow_log", "test");
         resource.attributes.insert(
             "log_destination_type".to_string(),
             Value::UnresolvedIdent("cloud_watch_logs".to_string(), None),
@@ -1931,10 +1915,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
         // Test that a plain string with hyphens is converted to underscores via to_dsl
-        let mut resource = Resource::new("ec2.flow_log", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.flow_log", "test");
         resource.attributes.insert(
             "log_destination_type".to_string(),
             Value::String("cloud-watch-logs".to_string()),
@@ -2069,10 +2050,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         // Test that bare "all" identifier resolves to namespaced form for IpProtocol
-        let mut resource = Resource::new("ec2.security_group_egress", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
         resource.attributes.insert(
             "ip_protocol".to_string(),
             Value::UnresolvedIdent("all".to_string(), None),
@@ -2095,10 +2073,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
         // Test that bare "tcp" identifier resolves correctly
-        let mut resource = Resource::new("ec2.security_group_egress", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
         resource.attributes.insert(
             "ip_protocol".to_string(),
             Value::UnresolvedIdent("tcp".to_string(), None),
@@ -2379,10 +2354,7 @@ mod tests {
         let attr_schema = config.schema.attributes.get("vpc_endpoint_type").unwrap();
 
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
-        let mut resource = Resource::new("ec2.vpc_endpoint", "test");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc_endpoint", "test");
         resource
             .attributes
             .insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
@@ -2446,10 +2418,7 @@ mod tests {
     fn test_resolve_enum_identifiers_impl_struct_field() {
         // Test that resolve_enum_identifiers_impl handles struct field enums
         // in ec2_security_group
-        let mut resource = Resource::new("ec2.security_group", "test-sg");
-        resource
-            .attributes
-            .insert("_provider".to_string(), Value::String("awscc".to_string()));
+        let mut resource = Resource::with_provider("awscc", "ec2.security_group", "test-sg");
         resource.attributes.insert(
             "group_description".to_string(),
             Value::String("test".to_string()),


### PR DESCRIPTION
## Summary
- Remove `attributes["_provider"]` as a redundant source of provider identity
- Use `ResourceId.provider` as the single source of truth throughout the codebase
- Update `schema_key_for_resource()`, `compute_anonymous_identifiers()`, and `resolve_enum_identifiers` in both AWS providers to read from `resource.id.provider` instead of `attributes["_provider"]`
- Remove `_provider` attribute insertion from the parser (3 locations: anonymous, let-binding, and read resources)

## Test plan
- [x] Added test `schema_key_for_resource_uses_id_provider_not_attribute` that verifies schema lookup works via `ResourceId.provider` without `_provider` attribute
- [x] Updated parser test to assert `_provider` attribute is no longer set
- [x] All existing tests pass (405 core, 85 aws, 139 awscc, 42 cli)
- [x] `cargo clippy` clean

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)