### PR TITLE
refactor: split Provider trait into runtime CRUD and ProviderSchemaExt

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -25,7 +25,7 @@ use carina_core::lint::{find_list_literal_attrs, list_struct_attr_names};
 use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
-use carina_core::provider::{self as provider_mod, Provider, ProviderSchemaExt};
+use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
 use carina_core::resolver::{resolve_ref_value, resolve_refs_with_state};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -10,7 +10,7 @@ use carina_core::module_resolver;
 use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{
-    self as provider_mod, Provider, ProviderFactory, ProviderRouter, ProviderSchemaExt,
+    self as provider_mod, Provider, ProviderFactory, ProviderNormalizer, ProviderRouter,
 };
 use carina_core::resolver::resolve_refs_with_state;
 use carina_core::resource::{Resource, ResourceId, State};
@@ -191,8 +191,8 @@ pub async fn get_provider(parsed: &ParsedFile) -> ProviderRouter {
             );
             let provider = factory.create_provider(&provider_config.attributes).await;
             router.add_provider(provider_config.name.clone(), provider);
-            if let Some(ext) = factory.create_schema_ext(&provider_config.attributes).await {
-                router.add_schema_ext(ext);
+            if let Some(ext) = factory.create_normalizer(&provider_config.attributes).await {
+                router.add_normalizer(ext);
             }
         }
     }
@@ -220,8 +220,8 @@ pub async fn create_providers_from_configs(configs: &[ProviderConfig]) -> Provid
             );
             let provider = factory.create_provider(&config.attributes).await;
             router.add_provider(config.name.clone(), provider);
-            if let Some(ext) = factory.create_schema_ext(&config.attributes).await {
-                router.add_schema_ext(ext);
+            if let Some(ext) = factory.create_normalizer(&config.attributes).await {
+                router.add_normalizer(ext);
             }
         }
     }

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -73,7 +73,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Saved attribute values keyed by resource ID.
 ///
-/// Used by `ProviderSchemaExt::hydrate_read_state` to carry forward
+/// Used by `ProviderNormalizer::hydrate_read_state` to carry forward
 /// attributes that APIs don't return in read responses.
 pub type SavedAttrs = HashMap<ResourceId, HashMap<String, Value>>;
 
@@ -122,13 +122,13 @@ pub trait Provider: Send + Sync {
     ) -> BoxFuture<'_, ProviderResult<()>>;
 }
 
-/// Plan-time schema extensions for a provider.
+/// Plan-time normalizer for a provider.
 ///
-/// Handles normalization of desired state and hydration of read state
-/// based on provider-specific schema knowledge. Separated from `Provider`
+/// Normalizes desired state and read state so that diffs produce correct
+/// plans. Uses provider-specific schema knowledge. Separated from `Provider`
 /// because these operations are synchronous, plan-time concerns rather
 /// than runtime CRUD.
-pub trait ProviderSchemaExt: Send + Sync {
+pub trait ProviderNormalizer: Send + Sync {
     /// Normalize desired resource state before diffing.
     ///
     /// For example, resolves bare enum identifiers like `advanced` or
@@ -156,7 +156,7 @@ pub trait ProviderSchemaExt: Send + Sync {
 /// based on the resource's provider name (`ResourceId.provider`).
 pub struct ProviderRouter {
     providers: HashMap<String, Box<dyn Provider>>,
-    schema_exts: Vec<Box<dyn ProviderSchemaExt>>,
+    normalizers: Vec<Box<dyn ProviderNormalizer>>,
 }
 
 impl Default for ProviderRouter {
@@ -169,7 +169,7 @@ impl ProviderRouter {
     pub fn new() -> Self {
         Self {
             providers: HashMap::new(),
-            schema_exts: Vec::new(),
+            normalizers: Vec::new(),
         }
     }
 
@@ -177,8 +177,8 @@ impl ProviderRouter {
         self.providers.insert(name, provider);
     }
 
-    pub fn add_schema_ext(&mut self, ext: Box<dyn ProviderSchemaExt>) {
-        self.schema_exts.push(ext);
+    pub fn add_normalizer(&mut self, ext: Box<dyn ProviderNormalizer>) {
+        self.normalizers.push(ext);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -242,9 +242,9 @@ impl Provider for ProviderRouter {
     }
 }
 
-impl ProviderSchemaExt for ProviderRouter {
+impl ProviderNormalizer for ProviderRouter {
     fn normalize_desired(&self, resources: &mut [Resource]) {
-        for ext in &self.schema_exts {
+        for ext in &self.normalizers {
             ext.normalize_desired(resources);
         }
     }
@@ -254,7 +254,7 @@ impl ProviderSchemaExt for ProviderRouter {
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &SavedAttrs,
     ) {
-        for ext in &self.schema_exts {
+        for ext in &self.normalizers {
             ext.hydrate_read_state(current_states, saved_attrs);
         }
     }
@@ -291,10 +291,10 @@ pub trait ProviderFactory: Send + Sync {
     /// Returns `None` if this provider has no schema extensions (the default).
     /// Providers that need plan-time normalization or state hydration should
     /// override this method.
-    fn create_schema_ext(
+    fn create_normalizer(
         &self,
         _attributes: &HashMap<String, Value>,
-    ) -> BoxFuture<'_, Option<Box<dyn ProviderSchemaExt>>> {
+    ) -> BoxFuture<'_, Option<Box<dyn ProviderNormalizer>>> {
         Box::pin(async { None })
     }
 
@@ -606,13 +606,13 @@ mod tests {
     }
 
     #[test]
-    fn provider_schema_ext_separate_from_runtime() {
-        // Verify that ProviderSchemaExt can be implemented independently from Provider.
+    fn provider_normalizer_separate_from_runtime() {
+        // Verify that ProviderNormalizer can be implemented independently from Provider.
         // A provider implementing both traits should have its schema extension
         // methods callable without going through the Provider trait.
         struct SchemaOnlyProvider;
 
-        impl ProviderSchemaExt for SchemaOnlyProvider {
+        impl ProviderNormalizer for SchemaOnlyProvider {
             fn normalize_desired(&self, resources: &mut [Resource]) {
                 // Prefix all string attribute values with "normalized:"
                 for resource in resources.iter_mut() {
@@ -671,8 +671,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_router_delegates_schema_ext() {
-        // Test that ProviderRouter delegates ProviderSchemaExt methods to sub-providers
+    fn provider_router_delegates_normalizer() {
+        // Test that ProviderRouter delegates ProviderNormalizer methods to sub-providers
         struct NormalizingProvider;
 
         impl Provider for NormalizingProvider {
@@ -716,8 +716,8 @@ mod tests {
         }
 
         // Separate schema ext struct for the router
-        struct NormalizingExt;
-        impl ProviderSchemaExt for NormalizingExt {
+        struct TestNormalizer;
+        impl ProviderNormalizer for TestNormalizer {
             fn normalize_desired(&self, resources: &mut [Resource]) {
                 for resource in resources.iter_mut() {
                     if resource.id.provider == "normalizing" {
@@ -733,7 +733,7 @@ mod tests {
 
         let mut router = ProviderRouter::new();
         router.add_provider("normalizing".to_string(), Box::new(NormalizingProvider));
-        router.add_schema_ext(Box::new(NormalizingExt));
+        router.add_normalizer(Box::new(TestNormalizer));
 
         let mut resources = vec![
             Resource::with_provider("normalizing", "test", "example")

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -13,7 +13,7 @@ use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sts::Client as StsClient;
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ProviderSchemaExt,
+    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
 };
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
@@ -58,11 +58,11 @@ impl ProviderFactory for AwsProviderFactory {
         Box::pin(async move { Box::new(AwsProvider::new(&region).await) as Box<dyn Provider> })
     }
 
-    fn create_schema_ext(
+    fn create_normalizer(
         &self,
         _attributes: &HashMap<String, Value>,
-    ) -> BoxFuture<'_, Option<Box<dyn ProviderSchemaExt>>> {
-        Box::pin(async { Some(Box::new(AwsSchemaExt) as Box<dyn ProviderSchemaExt>) })
+    ) -> BoxFuture<'_, Option<Box<dyn ProviderNormalizer>>> {
+        Box::pin(async { Some(Box::new(AwsNormalizer) as Box<dyn ProviderNormalizer>) })
     }
 
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
@@ -81,9 +81,9 @@ impl ProviderFactory for AwsProviderFactory {
 /// Schema extension for the AWS provider.
 ///
 /// Handles plan-time normalization of enum identifiers.
-pub struct AwsSchemaExt;
+pub struct AwsNormalizer;
 
-impl ProviderSchemaExt for AwsSchemaExt {
+impl ProviderNormalizer for AwsNormalizer {
     fn normalize_desired(&self, resources: &mut [Resource]) {
         resolve_enum_identifiers_impl(resources);
     }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -18,7 +18,7 @@ pub use provider::AwsccProvider;
 use std::collections::HashMap;
 
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderFactory, ProviderResult, ProviderSchemaExt, SavedAttrs,
+    BoxFuture, Provider, ProviderFactory, ProviderNormalizer, ProviderResult, SavedAttrs,
 };
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 
@@ -26,9 +26,9 @@ use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value}
 ///
 /// Handles plan-time normalization of enum identifiers and hydration of
 /// unreturned attributes from saved state.
-pub struct AwsccSchemaExt;
+pub struct AwsccNormalizer;
 
-impl ProviderSchemaExt for AwsccSchemaExt {
+impl ProviderNormalizer for AwsccNormalizer {
     fn normalize_desired(&self, resources: &mut [Resource]) {
         crate::provider::resolve_enum_identifiers_impl(resources);
     }
@@ -85,11 +85,11 @@ impl ProviderFactory for AwsccProviderFactory {
         Box::pin(async move { Box::new(AwsccProvider::new(&region).await) as Box<dyn Provider> })
     }
 
-    fn create_schema_ext(
+    fn create_normalizer(
         &self,
         _attributes: &HashMap<String, Value>,
-    ) -> BoxFuture<'_, Option<Box<dyn ProviderSchemaExt>>> {
-        Box::pin(async { Some(Box::new(AwsccSchemaExt) as Box<dyn ProviderSchemaExt>) })
+    ) -> BoxFuture<'_, Option<Box<dyn ProviderNormalizer>>> {
+        Box::pin(async { Some(Box::new(AwsccNormalizer) as Box<dyn ProviderNormalizer>) })
     }
 
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {


### PR DESCRIPTION
## Summary

- Split the `Provider` trait into two separate traits: `Provider` (runtime CRUD operations) and `ProviderSchemaExt` (plan-time schema normalization/hydration)
- Renamed `resolve_enum_identifiers` to `normalize_desired` and `restore_unreturned_attrs` to `hydrate_read_state` for clearer intent
- Added `SavedAttrs` type alias and `ProviderFactory::create_schema_ext` method
- `ProviderRouter` now stores schema extensions separately via `add_schema_ext`

Closes #774

## Test plan

- [x] New test `provider_schema_ext_separate_from_runtime` verifies `ProviderSchemaExt` can be implemented independently
- [x] New test `provider_router_delegates_schema_ext` verifies router delegates to registered schema extensions
- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy` and `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)