### PR TITLE
refactor: split Provider trait into ProviderRuntime and ProviderSchemaExt

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -25,7 +25,7 @@ use carina_core::lint::{find_list_literal_attrs, list_struct_attr_names};
 use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
-use carina_core::provider::{self as provider_mod, Provider};
+use carina_core::provider::{self as provider_mod, Provider, ProviderSchemaExt};
 use carina_core::resolver::{resolve_ref_value, resolve_refs_with_state};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
@@ -1393,7 +1393,7 @@ async fn run_apply_locked(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
-    provider.restore_unreturned_attrs(&mut current_states, &saved_attrs);
+    provider.hydrate_read_state(&mut current_states, &saved_attrs);
 
     // Build initial binding map for reference resolution
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -1417,7 +1417,7 @@ async fn run_apply_locked(
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
     resolve_refs_with_state(&mut resources_for_plan, &current_states);
-    provider.resolve_enum_identifiers(&mut resources_for_plan);
+    provider.normalize_desired(&mut resources_for_plan);
     let lifecycles = state_file
         .as_ref()
         .map(|sf| sf.build_lifecycles())
@@ -2582,7 +2582,7 @@ async fn run_state_refresh_locked(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
-    provider.restore_unreturned_attrs(&mut current_states, &saved_attrs);
+    provider.hydrate_read_state(&mut current_states, &saved_attrs);
 
     let mut state = state_file.take().unwrap();
 
@@ -2899,7 +2899,9 @@ fn run_lint(path: &PathBuf) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
+    use carina_core::provider::{
+        BoxFuture, ProviderError, ProviderResult, ProviderRuntime, ProviderSchemaExt,
+    };
     use serde_json::json;
 
     struct TestProvider {
@@ -2926,7 +2928,7 @@ mod tests {
         }
     }
 
-    impl Provider for TestProvider {
+    impl ProviderRuntime for TestProvider {
         fn name(&self) -> &'static str {
             "test"
         }
@@ -2968,6 +2970,8 @@ mod tests {
             Box::pin(async { Err(ProviderError::new("unexpected delete")) })
         }
     }
+
+    impl ProviderSchemaExt for TestProvider {}
 
     #[tokio::test]
     async fn refresh_pending_states_updates_saved_state_from_provider_read() {

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -9,7 +9,9 @@ use carina_core::identifier::{self, AnonymousIdStateInfo, PrefixStateInfo};
 use carina_core::module_resolver;
 use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
-use carina_core::provider::{self as provider_mod, Provider, ProviderFactory, ProviderRouter};
+use carina_core::provider::{
+    self as provider_mod, Provider, ProviderFactory, ProviderRouter, ProviderSchemaExt,
+};
 use carina_core::resolver::resolve_refs_with_state;
 use carina_core::resource::{Resource, ResourceId, State};
 use carina_core::schema::{ResourceSchema, resolve_block_names};
@@ -253,12 +255,12 @@ pub async fn create_plan_from_parsed(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
-    provider.restore_unreturned_attrs(&mut current_states, &saved_attrs);
+    provider.hydrate_read_state(&mut current_states, &saved_attrs);
 
     // Resolve ResourceRef values and enum identifiers using AWS state
     let mut resources = sorted_resources.clone();
     resolve_refs_with_state(&mut resources, &current_states);
-    provider.resolve_enum_identifiers(&mut resources);
+    provider.normalize_desired(&mut resources);
 
     // Build lifecycles map from state file for orphaned resource deletion
     let lifecycles = state_file

--- a/carina-core/src/interpreter.rs
+++ b/carina-core/src/interpreter.rs
@@ -5,7 +5,7 @@
 
 use crate::effect::Effect;
 use crate::plan::Plan;
-use crate::provider::{Provider, ProviderError, ProviderResult};
+use crate::provider::{ProviderError, ProviderResult, ProviderRuntime};
 use crate::resource::State;
 
 /// Result of executing each Effect
@@ -49,12 +49,12 @@ pub struct InterpreterConfig {
 }
 
 /// Interpreter that executes Effects using a Provider
-pub struct Interpreter<P: Provider> {
+pub struct Interpreter<P: ProviderRuntime> {
     provider: P,
     config: InterpreterConfig,
 }
 
-impl<P: Provider> Interpreter<P> {
+impl<P: ProviderRuntime> Interpreter<P> {
     pub fn new(provider: P) -> Self {
         Self {
             provider,
@@ -205,7 +205,7 @@ mod tests {
 
     struct TestProvider;
 
-    impl Provider for TestProvider {
+    impl ProviderRuntime for TestProvider {
         fn name(&self) -> &'static str {
             "test"
         }
@@ -326,7 +326,7 @@ mod tests {
         ops: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     }
 
-    impl Provider for OrderTrackingProvider {
+    impl ProviderRuntime for OrderTrackingProvider {
         fn name(&self) -> &'static str {
             "order_tracking"
         }
@@ -652,7 +652,7 @@ mod tests {
         ops: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     }
 
-    impl Provider for RenameFailProvider {
+    impl ProviderRuntime for RenameFailProvider {
         fn name(&self) -> &'static str {
             "rename_fail"
         }

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -71,11 +71,11 @@ pub type ProviderResult<T> = Result<T, ProviderError>;
 /// Return type for async operations
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Main Provider trait
+/// Runtime CRUD operations for a provider.
 ///
-/// Each infrastructure provider (AWS, GCP, etc.) implements this trait.
-/// All operations are async and involve side effects.
-pub trait Provider: Send + Sync {
+/// Each infrastructure provider (AWS, GCP, etc.) implements this trait
+/// to define how resources are read, created, updated, and deleted.
+pub trait ProviderRuntime: Send + Sync {
     /// Name of this Provider (e.g., "aws")
     fn name(&self) -> &'static str;
 
@@ -114,27 +114,42 @@ pub trait Provider: Send + Sync {
         identifier: &str,
         lifecycle: &LifecycleConfig,
     ) -> BoxFuture<'_, ProviderResult<()>>;
+}
 
-    /// Resolve enum identifiers in resources to their fully-qualified DSL format.
+/// Plan-time schema extensions for a provider.
+///
+/// Handles normalization of desired state and hydration of read state.
+/// These operations are synchronous and run before/after CRUD operations.
+pub trait ProviderSchemaExt: Send + Sync {
+    /// Normalize desired resources before diffing.
     ///
-    /// For example, resolves bare `advanced` or `Tier.advanced` into
-    /// `awscc.ec2_ipam.Tier.advanced` based on schema definitions.
+    /// For example, resolves bare enum identifiers like `advanced` or `Tier.advanced`
+    /// into fully-qualified DSL format like `awscc.ec2_ipam.Tier.advanced`.
     /// Default implementation is a no-op for providers without enum types.
-    fn resolve_enum_identifiers(&self, _resources: &mut [Resource]) {}
+    fn normalize_desired(&self, _resources: &mut [Resource]) {}
 
-    /// Restore unreturned attributes from saved state into current read states.
+    /// Hydrate read state with saved attributes that the API did not return.
     ///
     /// Some APIs (e.g., CloudControl) don't return certain properties in read responses
     /// (create-only properties, or normal properties like `description` on some resources).
     /// This method carries them forward from previously saved attribute values.
     /// Default implementation is a no-op.
-    fn restore_unreturned_attrs(
+    fn hydrate_read_state(
         &self,
         _current_states: &mut HashMap<ResourceId, State>,
         _saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     ) {
     }
 }
+
+/// Main Provider trait combining runtime operations and schema extensions.
+///
+/// This is a supertrait of `ProviderRuntime` and `ProviderSchemaExt`.
+/// Providers that implement both traits automatically implement `Provider`.
+pub trait Provider: ProviderRuntime + ProviderSchemaExt {}
+
+/// Blanket implementation: any type implementing both sub-traits is a Provider.
+impl<T: ProviderRuntime + ProviderSchemaExt> Provider for T {}
 
 /// A provider that routes operations to the correct sub-provider
 /// based on the resource's provider name (`ResourceId.provider`).
@@ -171,7 +186,7 @@ impl ProviderRouter {
     }
 }
 
-impl Provider for ProviderRouter {
+impl ProviderRuntime for ProviderRouter {
     fn name(&self) -> &'static str {
         "router"
     }
@@ -218,20 +233,22 @@ impl Provider for ProviderRouter {
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
+}
 
-    fn resolve_enum_identifiers(&self, resources: &mut [Resource]) {
+impl ProviderSchemaExt for ProviderRouter {
+    fn normalize_desired(&self, resources: &mut [Resource]) {
         for provider in self.providers.values() {
-            provider.resolve_enum_identifiers(resources);
+            provider.normalize_desired(resources);
         }
     }
 
-    fn restore_unreturned_attrs(
+    fn hydrate_read_state(
         &self,
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     ) {
         for provider in self.providers.values() {
-            provider.restore_unreturned_attrs(current_states, saved_attrs);
+            provider.hydrate_read_state(current_states, saved_attrs);
         }
     }
 }
@@ -326,9 +343,9 @@ pub fn schema_key_for_resource(
     }
 }
 
-/// Provider implementation for Box<dyn Provider>
+/// ProviderRuntime implementation for Box<dyn Provider>
 /// This enables dynamic dispatch for Providers
-impl Provider for Box<dyn Provider> {
+impl ProviderRuntime for Box<dyn Provider> {
     fn name(&self) -> &'static str {
         (**self).name()
     }
@@ -363,17 +380,19 @@ impl Provider for Box<dyn Provider> {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         (**self).delete(id, identifier, lifecycle)
     }
+}
 
-    fn resolve_enum_identifiers(&self, resources: &mut [Resource]) {
-        (**self).resolve_enum_identifiers(resources)
+impl ProviderSchemaExt for Box<dyn Provider> {
+    fn normalize_desired(&self, resources: &mut [Resource]) {
+        (**self).normalize_desired(resources)
     }
 
-    fn restore_unreturned_attrs(
+    fn hydrate_read_state(
         &self,
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     ) {
-        (**self).restore_unreturned_attrs(current_states, saved_attrs)
+        (**self).hydrate_read_state(current_states, saved_attrs)
     }
 }
 
@@ -384,7 +403,7 @@ mod tests {
     // Mock Provider for testing
     struct MockProvider;
 
-    impl Provider for MockProvider {
+    impl ProviderRuntime for MockProvider {
         fn name(&self) -> &'static str {
             "mock"
         }
@@ -425,6 +444,8 @@ mod tests {
             Box::pin(async { Ok(()) })
         }
     }
+
+    impl ProviderSchemaExt for MockProvider {}
 
     #[tokio::test]
     async fn mock_provider_read_returns_not_found() {
@@ -579,6 +600,116 @@ mod tests {
         fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
             vec![]
         }
+    }
+
+    // --- Tests for ProviderRuntime + ProviderSchemaExt trait split ---
+
+    struct SplitMockProvider;
+
+    impl ProviderRuntime for SplitMockProvider {
+        fn name(&self) -> &'static str {
+            "split_mock"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+
+        fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = resource.id.clone();
+            let attrs = resource.attributes.clone();
+            Box::pin(async move { Ok(State::existing(id, attrs).with_identifier("split-id")) })
+        }
+
+        fn update(
+            &self,
+            id: &ResourceId,
+            _identifier: &str,
+            _from: &State,
+            to: &Resource,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            let attrs = to.attributes.clone();
+            Box::pin(async move { Ok(State::existing(id, attrs)) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _lifecycle: &LifecycleConfig,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    impl ProviderSchemaExt for SplitMockProvider {
+        fn normalize_desired(&self, resources: &mut [Resource]) {
+            // Mock: uppercase all string attribute values
+            for r in resources.iter_mut() {
+                if r.id.provider != "split_mock" {
+                    continue;
+                }
+                for val in r.attributes.values_mut() {
+                    if let Value::String(s) = val {
+                        *s = s.to_uppercase();
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn split_traits_can_be_implemented_separately() {
+        let provider = SplitMockProvider;
+        // ProviderRuntime methods work
+        let id = ResourceId::new("test", "example");
+        let state = provider.read(&id, None).await.unwrap();
+        assert!(!state.exists);
+
+        let resource = Resource::new("test", "example");
+        let state = provider.create(&resource).await.unwrap();
+        assert!(state.exists);
+        assert_eq!(state.identifier, Some("split-id".to_string()));
+    }
+
+    #[test]
+    fn split_traits_normalize_desired_works() {
+        let provider = SplitMockProvider;
+        let mut resources = vec![
+            Resource::with_provider("split_mock", "test", "example")
+                .with_attribute("key", Value::String("hello".to_string())),
+        ];
+        provider.normalize_desired(&mut resources);
+        assert_eq!(
+            resources[0].attributes.get("key"),
+            Some(&Value::String("HELLO".to_string()))
+        );
+    }
+
+    #[test]
+    fn split_traits_hydrate_read_state_default_is_noop() {
+        let provider = SplitMockProvider;
+        let id = ResourceId::new("test", "example");
+        let mut states = HashMap::new();
+        states.insert(id.clone(), State::existing(id.clone(), HashMap::new()));
+        let saved = HashMap::new();
+        // Default implementation should not panic
+        provider.hydrate_read_state(&mut states, &saved);
+    }
+
+    #[test]
+    fn provider_supertrait_requires_both() {
+        // SplitMockProvider implements both ProviderRuntime and ProviderSchemaExt,
+        // so it should satisfy the Provider supertrait bound.
+        fn assert_provider<T: Provider>(_p: &T) {}
+        let provider = SplitMockProvider;
+        assert_provider(&provider);
     }
 
     #[test]

--- a/carina-provider-aws/src/lib.rs
+++ b/carina-provider-aws/src/lib.rs
@@ -12,7 +12,10 @@ use aws_config::Region;
 use aws_sdk_ec2::Client as Ec2Client;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_sts::Client as StsClient;
-use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult};
+use carina_core::provider::{
+    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderResult, ProviderRuntime,
+    ProviderSchemaExt,
+};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::utils::convert_enum_value;
 
@@ -521,7 +524,7 @@ impl AwsProvider {
     }
 }
 
-impl Provider for AwsProvider {
+impl ProviderRuntime for AwsProvider {
     fn name(&self) -> &'static str {
         "aws"
     }
@@ -645,10 +648,6 @@ impl Provider for AwsProvider {
         })
     }
 
-    fn resolve_enum_identifiers(&self, resources: &mut [Resource]) {
-        resolve_enum_identifiers_impl(resources);
-    }
-
     fn delete(
         &self,
         id: &ResourceId,
@@ -680,6 +679,12 @@ impl Provider for AwsProvider {
                 .for_resource(id.clone())),
             }
         })
+    }
+}
+
+impl ProviderSchemaExt for AwsProvider {
+    fn normalize_desired(&self, resources: &mut [Resource]) {
+        resolve_enum_identifiers_impl(resources);
     }
 }
 

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -17,7 +17,9 @@ pub use provider::AwsccProvider;
 
 use std::collections::HashMap;
 
-use carina_core::provider::{BoxFuture, Provider, ProviderFactory, ProviderResult};
+use carina_core::provider::{
+    BoxFuture, Provider, ProviderFactory, ProviderResult, ProviderRuntime, ProviderSchemaExt,
+};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 
 /// Factory for creating and configuring the AWSCC Provider
@@ -80,7 +82,7 @@ impl ProviderFactory for AwsccProviderFactory {
 // Provider Trait Implementation
 // =============================================================================
 
-impl Provider for AwsccProvider {
+impl ProviderRuntime for AwsccProvider {
     fn name(&self) -> &'static str {
         "awscc"
     }
@@ -128,12 +130,14 @@ impl Provider for AwsccProvider {
         let lifecycle = lifecycle.clone();
         Box::pin(async move { self.delete_resource(&id, &identifier, &lifecycle).await })
     }
+}
 
-    fn resolve_enum_identifiers(&self, resources: &mut [Resource]) {
+impl ProviderSchemaExt for AwsccProvider {
+    fn normalize_desired(&self, resources: &mut [Resource]) {
         crate::provider::resolve_enum_identifiers_impl(resources);
     }
 
-    fn restore_unreturned_attrs(
+    fn hydrate_read_state(
         &self,
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
+use carina_core::provider::{
+    BoxFuture, ProviderError, ProviderResult, ProviderRuntime, ProviderSchemaExt,
+};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::value::{json_to_dsl_value, value_to_json};
 
@@ -47,7 +49,7 @@ impl Default for MockProvider {
     }
 }
 
-impl Provider for MockProvider {
+impl ProviderRuntime for MockProvider {
     fn name(&self) -> &'static str {
         "mock"
     }
@@ -145,3 +147,5 @@ impl Provider for MockProvider {
         })
     }
 }
+
+impl ProviderSchemaExt for MockProvider {}


### PR DESCRIPTION
## Summary
- Split `Provider` trait into two focused traits: `ProviderRuntime` (async CRUD) and `ProviderSchemaExt` (plan-time normalization/hydration)
- `Provider` becomes a supertrait with a blanket impl so existing `dyn Provider` usage is preserved
- Renamed `resolve_enum_identifiers` to `normalize_desired` and `restore_unreturned_attrs` to `hydrate_read_state` for clearer intent

## Test plan
- [x] New tests verify that `ProviderRuntime` and `ProviderSchemaExt` can be implemented separately
- [x] New test verifies that types implementing both traits satisfy the `Provider` supertrait bound
- [x] All existing tests pass (410 in carina-core, full workspace green)
- [x] `cargo clippy` and `cargo fmt` clean

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)