### PR TITLE
fix: add signal trap and cleanup guards to multi-step test scripts

### DIFF
--- a/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
@@ -24,6 +24,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -101,12 +120,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -114,6 +140,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -121,6 +148,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -128,13 +156,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after replace" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 

--- a/carina-provider-aws/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-aws/acceptance-tests/in_place_update/run.sh
@@ -28,6 +28,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -105,12 +124,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -118,6 +144,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -125,6 +152,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -132,13 +160,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 

--- a/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
@@ -27,6 +27,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -104,12 +123,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config (resource with two tags)
     if ! run_step "$work_dir" "step1: apply initial (two tags)" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -117,6 +143,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -124,6 +151,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply tag removal" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -131,13 +159,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after tag removal" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
@@ -25,6 +25,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -102,12 +121,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -115,6 +141,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -122,6 +149,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -129,13 +157,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after replace" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 

--- a/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
@@ -42,6 +42,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -119,12 +138,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -132,6 +158,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -139,6 +166,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -146,13 +174,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 

--- a/carina-provider-awscc/acceptance-tests/simhash_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/simhash_update/run.sh
@@ -29,6 +29,25 @@ fi
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1 || true
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1 || true
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
 run_step() {
     local work_dir="$1"
     local description="$2"
@@ -106,12 +125,19 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -119,6 +145,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -126,6 +153,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply update (simhash reconcile)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -133,13 +161,20 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 4: Destroy
-    run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"
+    if ! run_step "$work_dir" "step4: destroy" "destroy" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 
@@ -158,12 +193,19 @@ run_test_single() {
     local work_dir
     work_dir=$(mktemp -d)
 
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$crn_file"
+    ACTIVE_STEP2="$crn_file"
+
     echo "$desc"
     echo ""
 
     # Step 1: Apply
     if ! run_step "$work_dir" "step1: apply" "apply" "$crn_file" "--auto-approve"; then
+        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1 || true
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
@@ -171,13 +213,20 @@ run_test_single() {
     if ! run_plan_verify "$work_dir" "step2: plan-verify" "$crn_file"; then
         cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1 || true
         rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 3: Destroy
-    run_step "$work_dir" "step3: destroy" "destroy" "$crn_file" "--auto-approve"
+    if ! run_step "$work_dir" "step3: destroy" "destroy" "$crn_file" "--auto-approve"; then
+        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1 || true
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
 
     rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
     echo ""
 }
 


### PR DESCRIPTION
## Summary

- All 6 multi-step acceptance test `run.sh` scripts had bugs that could leave orphaned AWS resources (e.g., 3 orphaned VPCs found in `carina-test-000`)
- Added `trap signal_cleanup INT TERM` handler to clean up on Ctrl-C/kill
- Wrapped step4 (final destroy) in `if ! ...` so `set -e` doesn't skip cleanup
- Added `cleanup()` call to step1 apply failure path (previously only did `rm -rf` of work_dir)

## Test plan

- [x] Verified orphaned VPCs were manually cleaned from `carina-test-000`
- [ ] Run multi-step tests and verify cleanup works on interruption (Ctrl-C)
- [ ] Run multi-step tests and verify cleanup works on step failure

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)