### PR TITLE
fix: apply format_sdk_error to cc_get_resource error message

### DIFF
--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -47,7 +47,11 @@ impl AwsccProvider {
                 if Self::is_not_found_error(&e) {
                     Ok(None)
                 } else {
-                    Err(ProviderError::new("Failed to get resource").with_cause(e))
+                    let detail = Self::format_sdk_error(&e);
+                    Err(ProviderError::new(format!(
+                        "Failed to get resource: {}",
+                        detail
+                    )))
                 }
             }
         }
@@ -840,6 +844,30 @@ mod tests {
             .message("Handler returned status FAILED")
             .build();
         let err = UpdateResourceError::GeneralServiceException(
+            GeneralServiceException::builder()
+                .message("Handler returned status FAILED")
+                .meta(meta)
+                .build(),
+        );
+        let sdk_err = SdkError::service_error(err, http::Response::new(""));
+        let formatted = AwsccProvider::format_sdk_error(&sdk_err);
+        assert_eq!(
+            formatted,
+            "GeneralServiceException: Handler returned status FAILED"
+        );
+    }
+
+    #[test]
+    fn test_format_sdk_error_get_resource_error() {
+        use aws_sdk_cloudcontrol::operation::get_resource::GetResourceError;
+        use aws_sdk_cloudcontrol::types::error::GeneralServiceException;
+        use aws_smithy_runtime_api::client::result::SdkError;
+
+        let meta = aws_smithy_types::error::ErrorMetadata::builder()
+            .code("GeneralServiceException")
+            .message("Handler returned status FAILED")
+            .build();
+        let err = GetResourceError::GeneralServiceException(
             GeneralServiceException::builder()
                 .message("Handler returned status FAILED")
                 .meta(meta)


### PR DESCRIPTION
## Summary
- Apply `format_sdk_error` helper to `cc_get_resource` error path for structured error messages (error code + message) instead of generic "service error" from `SdkError::Display`
- Matches the pattern already used in `cc_create_resource`, `cc_update_resource`, and `cc_delete_resource`
- Add test verifying `format_sdk_error` works with `GetResourceError` types

Closes #799

## Test plan
- [x] `cargo test -p carina-provider-awscc` passes (139 tests)
- [x] `cargo clippy -p carina-provider-awscc` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)