### PR TITLE
fix: add policy_document to ec2_vpc_endpoint gateway test

### DIFF
--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -19,4 +19,16 @@ awscc.ec2.vpc_endpoint {
   service_name      = "com.amazonaws.ap-northeast-1.s3"
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
+
+  policy_document = {
+    version = "2012-10-17"
+    statement = [
+      {
+        effect    = "Allow"
+        principal = "*"
+        action    = "s3:GetObject"
+        resource  = "arn:aws:s3:::*"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Add `policy_document` attribute to the `ec2_vpc_endpoint/gateway.crn` acceptance test
- The test comment already claimed to cover `policy_document` but the resource block never set it
- Uses a simple S3 read-only policy, matching the syntax from the `in_place_update/ec2_vpc_endpoint_step2.crn` test

Closes #819

## Test plan

- [ ] Run `ec2_vpc_endpoint/gateway` acceptance test to verify the gateway endpoint is created with the policy document

🤖 Generated with [Claude Code](https://claude.com/claude-code)