### PR TITLE
Add AWSCC tag deletion acceptance tests

### DIFF
--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -1,0 +1,19 @@
+# EC2 VPC - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates a VPC with two tags. Step 2 removes one tag to test
+# that CloudControl "remove" patch is used for the removed key.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.100.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -1,0 +1,19 @@
+# EC2 VPC - Tag deletion test (Step 2: Remove one tag)
+#
+# Same VPC as step 1, but with the "ToBeRemoved" tag deleted.
+# After apply, the tag should be removed via CloudControl "remove"
+# patch and plan should show no changes (idempotent).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.100.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -1,0 +1,15 @@
+# EC2 VPC - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same VPC as step 1, but with the tags block completely removed.
+# Tests that the differ detects attribute removal when a key exists
+# in current state but is absent from desired state.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.100.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -1,0 +1,26 @@
+# IAM Role - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates an IAM role with two tags. Step 2 removes one tag to test
+# that CloudControl "remove" patch is used for the removed key.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.role {
+  role_name_prefix = "carina-acc-test-tag-del-"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -1,0 +1,26 @@
+# IAM Role - Tag deletion test (Step 2: Remove one tag)
+#
+# Same role as step 1, but with the "ToBeRemoved" tag deleted.
+# After apply, the tag should be removed via CloudControl "remove"
+# patch and plan should show no changes (idempotent).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.role {
+  role_name_prefix = "carina-acc-test-tag-del-"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -1,0 +1,22 @@
+# IAM Role - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same role as step 1, but with the tags block completely removed.
+# Tests that the differ detects attribute removal when a key exists
+# in current state but is absent from desired state.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let role = awscc.iam.role {
+  role_name_prefix = "carina-acc-test-tag-del-"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect    = "Allow"
+      principal = { service = "lambda.amazonaws.com" }
+      action    = "sts:AssumeRole"
+    }
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# Multi-step acceptance tests for AWSCC tag deletion via CloudControl "remove" patch
+#
+# Usage:
+#   aws-vault exec <profile> -- ./run.sh [filter]
+#
+# Tests:
+#   ec2_vpc              - Remove a tag from VPC
+#   s3_bucket            - Remove a tag from S3 bucket
+#   iam_role             - Remove a tag from IAM role
+#   ec2_vpc_all_tags     - Remove entire tags block from VPC
+#   s3_bucket_all_tags   - Remove entire tags block from S3 bucket
+#   iam_role_all_tags    - Remove entire tags block from IAM role
+#
+# Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FILTER="${1:-}"
+
+CARINA_BIN="$PROJECT_ROOT/target/debug/carina"
+if [ ! -f "$CARINA_BIN" ]; then
+    echo "Building carina..."
+    cargo build --quiet 2>/dev/null || cargo build
+fi
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        set +e
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
+run_step() {
+    local work_dir="$1"
+    local description="$2"
+    local command="$3"
+    local crn_file="$4"
+    local extra_args="${5:-}"
+
+    printf "  %-55s " "$description"
+
+    local output
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+        echo "OK"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+        return 0
+    else
+        echo "FAIL"
+        echo "  ERROR: $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+}
+
+run_plan_verify() {
+    local work_dir="$1"
+    local description="$2"
+    local crn_file="$3"
+
+    printf "  %-55s " "$description"
+
+    local output
+    local rc
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    rc=${rc:-0}
+
+    if [ $rc -eq 2 ]; then
+        echo "FAIL"
+        echo "  ERROR: Post-apply plan detected changes (not idempotent):"
+        echo "  $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    elif [ $rc -ne 0 ]; then
+        echo "FAIL"
+        echo "  ERROR: $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+
+    echo "OK"
+    TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    return 0
+}
+
+# Cleanup helper: try to destroy with both step configs, then retry
+cleanup() {
+    local work_dir="$1"
+    local step2="$2"
+    local step1="$3"
+
+    # Disable set -e to ensure all destroy attempts run
+    set +e
+    echo "  Cleanup: destroying resources..."
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    # Retry: resources may have dependencies that prevent deletion on first pass
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    set -e
+}
+
+# Run a single multi-step tag deletion test
+# Args: test_name step1_crn step2_crn description
+run_test() {
+    local test_name="$1"
+    local step1="$2"
+    local step2="$3"
+    local desc="$4"
+
+    # Apply filter
+    if [ -n "$FILTER" ] && [[ "$test_name" != *"$FILTER"* ]]; then
+        return 0
+    fi
+
+    local work_dir
+    work_dir=$(mktemp -d)
+
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
+    echo "$desc"
+    echo ""
+
+    # Step 1: Apply initial config (resource with two tags)
+    if ! run_step "$work_dir" "step1: apply initial (two tags)" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 1b: Plan-verify initial state
+    if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 2: Apply modified config (tag(s) removed)
+    if ! run_step "$work_dir" "step2: apply tag removal" "apply" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 3: Plan-verify after tag removal (must be idempotent)
+    if ! run_plan_verify "$work_dir" "step3: plan-verify after tag removal" "$step2"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 4: Destroy (use cleanup to try both configs and retry)
+    cleanup "$work_dir" "$step2" "$step1"
+
+    rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
+    echo ""
+}
+
+echo "tag_deletion multi-step acceptance tests (AWSCC)"
+echo "════════════════════════════════════════"
+echo ""
+
+# Test 1: EC2 VPC - tag removal via CloudControl "remove" patch
+run_test "ec2_vpc" \
+    "$SCRIPT_DIR/ec2_vpc_step1.crn" \
+    "$SCRIPT_DIR/ec2_vpc_step2.crn" \
+    "Test 1: EC2 VPC (remove one tag key)"
+
+# Test 2: S3 Bucket - tag removal via CloudControl "remove" patch
+run_test "s3_bucket" \
+    "$SCRIPT_DIR/s3_bucket_step1.crn" \
+    "$SCRIPT_DIR/s3_bucket_step2.crn" \
+    "Test 2: S3 Bucket (remove one tag key)"
+
+# Test 3: IAM Role - tag removal via CloudControl "remove" patch
+run_test "iam_role" \
+    "$SCRIPT_DIR/iam_role_step1.crn" \
+    "$SCRIPT_DIR/iam_role_step2.crn" \
+    "Test 3: IAM Role (remove one tag key)"
+
+# Test 4: EC2 VPC - entire tags block removal
+run_test "ec2_vpc_all_tags" \
+    "$SCRIPT_DIR/ec2_vpc_step1.crn" \
+    "$SCRIPT_DIR/ec2_vpc_step3.crn" \
+    "Test 4: EC2 VPC (remove entire tags block)"
+
+# Test 5: S3 Bucket - entire tags block removal
+run_test "s3_bucket_all_tags" \
+    "$SCRIPT_DIR/s3_bucket_step1.crn" \
+    "$SCRIPT_DIR/s3_bucket_step3.crn" \
+    "Test 5: S3 Bucket (remove entire tags block)"
+
+# Test 6: IAM Role - entire tags block removal
+run_test "iam_role_all_tags" \
+    "$SCRIPT_DIR/iam_role_step1.crn" \
+    "$SCRIPT_DIR/iam_role_step3.crn" \
+    "Test 6: IAM Role (remove entire tags block)"
+
+echo "════════════════════════════════════════"
+echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "════════════════════════════════════════"
+
+if [ $TOTAL_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -1,0 +1,21 @@
+# S3 Bucket - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates an S3 bucket with two tags. Step 2 removes one tag to test
+# that CloudControl "remove" patch is used for the removed key.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-tag-del-"
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -1,0 +1,21 @@
+# S3 Bucket - Tag deletion test (Step 2: Remove one tag)
+#
+# Same bucket as step 1, but with the "ToBeRemoved" tag deleted.
+# After apply, the tag should be removed via CloudControl "remove"
+# patch and plan should show no changes (idempotent).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-tag-del-"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+
+  lifecycle {
+    force_delete = true
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -1,0 +1,17 @@
+# S3 Bucket - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same bucket as step 1, but with the tags block completely removed.
+# Tests that the differ detects attribute removal when a key exists
+# in current state but is absent from desired state.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.bucket {
+  bucket_name_prefix = "carina-acc-test-tag-del-"
+
+  lifecycle {
+    force_delete = true
+  }
+}


### PR DESCRIPTION
## Summary
- Add multi-step acceptance tests for AWSCC tag deletion via CloudControl API "remove" patch
- Cover 3 resource types: EC2 VPC, S3 Bucket, IAM Role
- Each resource has 3 step files: step1 (two tags), step2 (one tag removed), step3 (entire tags block removed)
- 6 test scenarios total: 3 single-tag removal + 3 entire-tags-block removal

## Test plan
- [ ] Run `aws-vault exec <profile> -- ./carina-provider-awscc/acceptance-tests/tag_deletion/run.sh` to verify all 6 tests pass
- [ ] Verify filter works: `./run.sh ec2_vpc` runs only VPC tests
- [ ] Verify signal cleanup works on Ctrl+C

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)