### PR TITLE
test: add ec2_route_table and ec2_subnet tag_deletion acceptance tests

### DIFF
--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step1.crn
@@ -1,0 +1,25 @@
+# EC2 Route Table - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates a VPC and route table with two tags. Step 2 removes one tag
+# to test that delete_tags is called for the removed key.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.104.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step2.crn
@@ -1,0 +1,25 @@
+# EC2 Route Table - Tag deletion test (Step 2: Remove one tag)
+#
+# Same VPC and route table as step 1, but with the "ToBeRemoved" tag
+# deleted. After apply, the tag should be removed from AWS and plan
+# should show no changes (idempotent).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.104.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_route_table_step3.crn
@@ -1,0 +1,22 @@
+# EC2 Route Table - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same VPC and route table as step 1, but with the tags block completely
+# removed from the route table. Tests that the differ detects attribute
+# removal when a key exists in current state but is absent from desired
+# state (issue #447).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.104.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step1.crn
@@ -1,0 +1,27 @@
+# EC2 Subnet - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates a VPC and subnet with two tags. Step 2 removes one tag
+# to test that delete_tags is called for the removed key.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.105.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.105.1.0/24"
+  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step2.crn
@@ -1,0 +1,27 @@
+# EC2 Subnet - Tag deletion test (Step 2: Remove one tag)
+#
+# Same VPC and subnet as step 1, but with the "ToBeRemoved" tag
+# deleted. After apply, the tag should be removed from AWS and plan
+# should show no changes (idempotent).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.105.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.105.1.0/24"
+  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_subnet_step3.crn
@@ -1,0 +1,24 @@
+# EC2 Subnet - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same VPC and subnet as step 1, but with the tags block completely
+# removed from the subnet. Tests that the differ detects attribute
+# removal when a key exists in current state but is absent from desired
+# state (issue #447).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.105.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.105.1.0/24"
+  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
@@ -5,10 +5,14 @@
 #   aws-vault exec <profile> -- ./run.sh [filter]
 #
 # Tests:
-#   ec2_vpc              - Remove a tag from VPC (EC2 delete_tags API)
-#   s3_bucket            - Remove a tag from S3 bucket (put_bucket_tagging API)
-#   ec2_vpc_all_tags     - Remove entire tags block from VPC (issue #447)
-#   s3_bucket_all_tags   - Remove entire tags block from S3 bucket (issue #447)
+#   ec2_vpc                  - Remove a tag from VPC (EC2 delete_tags API)
+#   s3_bucket                - Remove a tag from S3 bucket (put_bucket_tagging API)
+#   ec2_route_table          - Remove a tag from route table (EC2 delete_tags API)
+#   ec2_subnet               - Remove a tag from subnet (EC2 delete_tags API)
+#   ec2_vpc_all_tags         - Remove entire tags block from VPC (issue #447)
+#   s3_bucket_all_tags       - Remove entire tags block from S3 bucket (issue #447)
+#   ec2_route_table_all_tags - Remove entire tags block from route table (issue #447)
+#   ec2_subnet_all_tags      - Remove entire tags block from subnet (issue #447)
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
 
@@ -198,17 +202,41 @@ run_test "s3_bucket" \
     "$SCRIPT_DIR/s3_bucket_step2.crn" \
     "Test 2: S3 Bucket (put_bucket_tagging replaces tag set)"
 
-# Test 3: EC2 VPC - entire tags block removal (issue #447)
+# Test 3: EC2 Route Table - tag removal via delete_tags API
+run_test "ec2_route_table" \
+    "$SCRIPT_DIR/ec2_route_table_step1.crn" \
+    "$SCRIPT_DIR/ec2_route_table_step2.crn" \
+    "Test 3: EC2 Route Table (delete_tags for removed tag key)"
+
+# Test 4: EC2 Subnet - tag removal via delete_tags API
+run_test "ec2_subnet" \
+    "$SCRIPT_DIR/ec2_subnet_step1.crn" \
+    "$SCRIPT_DIR/ec2_subnet_step2.crn" \
+    "Test 4: EC2 Subnet (delete_tags for removed tag key)"
+
+# Test 5: EC2 VPC - entire tags block removal (issue #447)
 run_test "ec2_vpc_all_tags" \
     "$SCRIPT_DIR/ec2_vpc_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_step3.crn" \
-    "Test 3: EC2 VPC (remove entire tags block)"
+    "Test 5: EC2 VPC (remove entire tags block)"
 
-# Test 4: S3 Bucket - entire tags block removal (issue #447)
+# Test 6: S3 Bucket - entire tags block removal (issue #447)
 run_test "s3_bucket_all_tags" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step3.crn" \
-    "Test 4: S3 Bucket (remove entire tags block)"
+    "Test 6: S3 Bucket (remove entire tags block)"
+
+# Test 7: EC2 Route Table - entire tags block removal (issue #447)
+run_test "ec2_route_table_all_tags" \
+    "$SCRIPT_DIR/ec2_route_table_step1.crn" \
+    "$SCRIPT_DIR/ec2_route_table_step3.crn" \
+    "Test 7: EC2 Route Table (remove entire tags block)"
+
+# Test 8: EC2 Subnet - entire tags block removal (issue #447)
+run_test "ec2_subnet_all_tags" \
+    "$SCRIPT_DIR/ec2_subnet_step1.crn" \
+    "$SCRIPT_DIR/ec2_subnet_step3.crn" \
+    "Test 8: EC2 Subnet (remove entire tags block)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add multi-step tag deletion acceptance tests for EC2 route table and EC2 subnet resources
- Each resource type has 3 step files: step1 (two tags), step2 (one tag removed), step3 (tags block removed)
- Updated `run.sh` to include 4 new test cases (single tag removal + entire tags block removal for each resource type), bringing total from 4 to 8

## Test plan
- [ ] Run `aws-vault exec <profile> -- ./run.sh ec2_route_table` to verify route table tag deletion
- [ ] Run `aws-vault exec <profile> -- ./run.sh ec2_subnet` to verify subnet tag deletion
- [ ] Run full suite `aws-vault exec <profile> -- ./run.sh` to verify all 8 tests pass

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)