### PR TITLE
test: add S3 bucket acceptance tests for object_ownership and ACL

### DIFF
--- a/carina-provider-aws/acceptance-tests/s3_bucket/acl_private.crn
+++ b/carina-provider-aws/acceptance-tests/s3_bucket/acl_private.crn
@@ -1,0 +1,19 @@
+# S3 Bucket - acl_private test
+#
+# Tests: ACL with private, object_ownership with BucketOwnerPreferred
+# Note: ACL requires object_ownership to be BucketOwnerPreferred or ObjectWriter
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.bucket {
+  bucket = "carina-acc-test-aws-s3-acl-private"
+
+  acl = aws.s3.bucket.ACL.private
+  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/s3_bucket/object_ownership.crn
+++ b/carina-provider-aws/acceptance-tests/s3_bucket/object_ownership.crn
@@ -1,0 +1,17 @@
+# S3 Bucket - object_ownership test
+#
+# Tests: object_ownership with BucketOwnerEnforced
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = aws.s3.bucket {
+  bucket = "carina-acc-test-aws-s3-object-ownership"
+
+  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `object_ownership.crn` acceptance test: creates S3 bucket with `ObjectOwnership.BucketOwnerEnforced` and tags
- Add `acl_private.crn` acceptance test: creates S3 bucket with `ACL.private` and `ObjectOwnership.BucketOwnerPreferred` and tags
- No Rust code changes needed; existing `run-tests.sh` auto-discovers new `.crn` files

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)