### PR TITLE
Add AWSCC attribute_removal acceptance test for non-tag optional attributes

### DIFF
--- a/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -1,0 +1,34 @@
+# EC2 VPC Endpoint - attribute removal test (step 1)
+#
+# Tests: create gateway endpoint with policy_document set
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.108.0.0/16"
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id            = vpc.vpc_id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = Gateway
+  route_table_ids   = [rt.route_table_id]
+
+  policy_document = {
+    version = "2012-10-17"
+    statement = [
+      {
+        effect    = "Allow"
+        principal = "*"
+        action    = "s3:GetObject"
+        resource  = "arn:aws:s3:::*"
+      }
+    ]
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
@@ -1,0 +1,22 @@
+# EC2 VPC Endpoint - attribute removal test (step 2)
+#
+# Tests: remove policy_document entirely (attribute removal)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.108.0.0/16"
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id            = vpc.vpc_id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = Gateway
+  route_table_ids   = [rt.route_table_id]
+}

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Multi-step acceptance tests for AWSCC attribute removal via CloudControl "remove" patch
+#
+# Usage:
+#   aws-vault exec <profile> -- ./run.sh [filter]
+#
+# Tests:
+#   ec2_vpc_endpoint - Remove policy_document from VPC endpoint
+#
+# Filter (optional): substring to match test names (e.g. "ec2_vpc_endpoint")
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FILTER="${1:-}"
+
+CARINA_BIN="$PROJECT_ROOT/target/debug/carina"
+if [ ! -f "$CARINA_BIN" ]; then
+    echo "Building carina..."
+    cargo build --quiet 2>/dev/null || cargo build
+fi
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+
+# Track active work dir for signal cleanup
+ACTIVE_WORK_DIR=""
+ACTIVE_STEP1=""
+ACTIVE_STEP2=""
+
+signal_cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        set +e
+        echo ""
+        echo "Interrupted. Cleaning up resources..."
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+    exit 1
+}
+
+trap signal_cleanup INT TERM
+
+run_step() {
+    local work_dir="$1"
+    local description="$2"
+    local command="$3"
+    local crn_file="$4"
+    local extra_args="${5:-}"
+
+    printf "  %-55s " "$description"
+
+    local output
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+        echo "OK"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+        return 0
+    else
+        echo "FAIL"
+        echo "  ERROR: $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+}
+
+run_plan_verify() {
+    local work_dir="$1"
+    local description="$2"
+    local crn_file="$3"
+
+    printf "  %-55s " "$description"
+
+    local output
+    local rc
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    rc=${rc:-0}
+
+    if [ $rc -eq 2 ]; then
+        echo "FAIL"
+        echo "  ERROR: Post-apply plan detected changes (not idempotent):"
+        echo "  $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    elif [ $rc -ne 0 ]; then
+        echo "FAIL"
+        echo "  ERROR: $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+
+    echo "OK"
+    TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    return 0
+}
+
+# Cleanup helper: try to destroy with both step configs, then retry
+cleanup() {
+    local work_dir="$1"
+    local step2="$2"
+    local step1="$3"
+
+    # Disable set -e to ensure all destroy attempts run
+    set +e
+    echo "  Cleanup: destroying resources..."
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    # Retry: resources may have dependencies that prevent deletion on first pass
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
+    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    set -e
+}
+
+# Run a single multi-step attribute removal test
+# Args: test_name step1_crn step2_crn description
+run_test() {
+    local test_name="$1"
+    local step1="$2"
+    local step2="$3"
+    local desc="$4"
+
+    # Apply filter
+    if [ -n "$FILTER" ] && [[ "$test_name" != *"$FILTER"* ]]; then
+        return 0
+    fi
+
+    local work_dir
+    work_dir=$(mktemp -d)
+
+    # Register for signal cleanup
+    ACTIVE_WORK_DIR="$work_dir"
+    ACTIVE_STEP1="$step1"
+    ACTIVE_STEP2="$step2"
+
+    echo "$desc"
+    echo ""
+
+    # Step 1: Apply initial config (with policy_document)
+    if ! run_step "$work_dir" "step1: apply initial (with attribute)" "apply" "$step1" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 1b: Plan-verify initial state
+    if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 2: Apply modified config (attribute removed)
+    if ! run_step "$work_dir" "step2: apply attribute removal" "apply" "$step2" "--auto-approve"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 3: Plan-verify after attribute removal (must be idempotent)
+    if ! run_plan_verify "$work_dir" "step3: plan-verify after attribute removal" "$step2"; then
+        cleanup "$work_dir" "$step2" "$step1"
+        rm -rf "$work_dir"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 4: Destroy (use cleanup to try both configs and retry)
+    cleanup "$work_dir" "$step2" "$step1"
+
+    rm -rf "$work_dir"
+    ACTIVE_WORK_DIR=""
+    echo ""
+}
+
+echo "attribute_removal multi-step acceptance tests (AWSCC)"
+echo "════════════════════════════════════════"
+echo ""
+
+# Test 1: EC2 VPC Endpoint - remove policy_document via CloudControl "remove" patch
+run_test "ec2_vpc_endpoint" \
+    "$SCRIPT_DIR/ec2_vpc_endpoint_step1.crn" \
+    "$SCRIPT_DIR/ec2_vpc_endpoint_step2.crn" \
+    "Test 1: EC2 VPC Endpoint (remove policy_document)"
+
+echo "════════════════════════════════════════"
+echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "════════════════════════════════════════"
+
+if [ $TOTAL_FAILED -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `attribute_removal` multi-step acceptance test that exercises the CloudControl "remove" JSON Patch operation for non-tag properties
- Step 1 creates a Gateway VPC endpoint with `policy_document` set; step 2 removes `policy_document` entirely
- Test flow: apply step1 -> plan-verify -> apply step2 (attribute removal) -> plan-verify -> destroy

Closes #814

## Test plan
- [ ] Run `aws-vault exec <profile> -- ./carina-provider-awscc/acceptance-tests/attribute_removal/run.sh` to verify the attribute removal works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)