### PR TITLE
test: add AWS ec2_route NAT gateway test and in-place update

### DIFF
--- a/carina-provider-aws/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_route/nat_gateway.crn
@@ -1,0 +1,63 @@
+# EC2 Route - NAT Gateway test
+#
+# Tests: route creation with route_table_id, destination_cidr_block, nat_gateway_id
+#
+# Uses awscc provider for resources not yet available in aws provider
+# (vpc_gateway_attachment, eip, nat_gateway).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet = aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+let nat_gw = awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = subnet.subnet_id
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let route = aws.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw.nat_gateway_id
+}

--- a/carina-provider-aws/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/carina-provider-aws/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -1,0 +1,63 @@
+# EC2 Route - in-place update test (step 1)
+#
+# Tests: create route 10.1.0.0/16 via Internet Gateway
+#
+# Uses awscc provider for resources not yet available in aws provider
+# (vpc_gateway_attachment, eip, nat_gateway).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet = aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+let nat_gw = awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = subnet.subnet_id
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "10.1.0.0/16"
+  gateway_id             = igw.internet_gateway_id
+}

--- a/carina-provider-aws/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/carina-provider-aws/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -1,0 +1,63 @@
+# EC2 Route - in-place update test (step 2)
+#
+# Tests: change route target from IGW to NAT Gateway (in-place update)
+#
+# Uses awscc provider for resources not yet available in aws provider
+# (vpc_gateway_attachment, eip, nat_gateway).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let igw = aws.ec2.internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet = aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+let nat_gw = awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = subnet.subnet_id
+}
+
+let rt = aws.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "10.1.0.0/16"
+  nat_gateway_id         = nat_gw.nat_gateway_id
+}

--- a/carina-provider-aws/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-aws/acceptance-tests/in_place_update/run.sh
@@ -9,6 +9,7 @@
 #   ec2_route_table    - Update tags
 #   ec2_security_group - Update tags
 #   ec2_subnet         - Toggle map_public_ip_on_launch (false -> true)
+#   ec2_route          - Change route target (IGW -> NAT Gateway)
 #   s3_bucket          - Toggle versioning (Enabled -> Suspended)
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
@@ -211,11 +212,17 @@ run_test "ec2_subnet" \
     "$SCRIPT_DIR/ec2_subnet_step2.crn" \
     "Test 4: EC2 Subnet (map_public_ip_on_launch false -> true)"
 
-# Test 5: S3 Bucket - toggle versioning (Enabled -> Suspended)
+# Test 5: EC2 Route - change route target (IGW -> NAT Gateway)
+run_test "ec2_route" \
+    "$SCRIPT_DIR/ec2_route_step1.crn" \
+    "$SCRIPT_DIR/ec2_route_step2.crn" \
+    "Test 5: EC2 Route (gateway_id -> nat_gateway_id)"
+
+# Test 6: S3 Bucket - toggle versioning (Enabled -> Suspended)
 run_test "s3_bucket" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step2.crn" \
-    "Test 5: S3 Bucket (versioning Enabled -> Suspended)"
+    "Test 6: S3 Bucket (versioning Enabled -> Suspended)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `ec2_route/nat_gateway.crn` acceptance test for route creation via NAT gateway (`nat_gateway_id`)
- Add `in_place_update/ec2_route_step1.crn` and `ec2_route_step2.crn` for IGW-to-NAT route target change
- Update `in_place_update/run.sh` with the new ec2_route test case (Test 5)
- Uses awscc provider for EIP and NAT gateway resources not yet available in aws provider

Closes #817

## Test plan
- [ ] Run `ec2_route/nat_gateway.crn` via `run-tests.sh full`
- [ ] Run `in_place_update/run.sh ec2_route` to verify IGW-to-NAT in-place update

🤖 Generated with [Claude Code](https://claude.com/claude-code)