### PR TITLE
Add create_before_destroy test with dependent resource rewiring

### DIFF
--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
@@ -1,0 +1,61 @@
+# EC2 Transit Gateway Attachment - create_before_destroy with dependent rewiring (Step 1: Initial)
+#
+# Creates a VPC, two subnets in different AZs, a transit gateway, and an
+# attachment using subnet_a. Step 2 switches to subnet_b, forcing replacement
+# of the attachment (subnet_ids is create-only) and testing that the dependent
+# resource reference is rewired during create_before_destroy.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.210.0.0/16"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet_a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.210.1.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-a"
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet_b = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.210.2.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-b"
+    Environment = "acceptance-test"
+  }
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}
+
+awscc.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet_a.subnet_id]
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -1,0 +1,66 @@
+# EC2 Transit Gateway Attachment - create_before_destroy with dependent rewiring (Step 2: Replace)
+#
+# Switches the attachment from subnet_a to subnet_b. Since subnet_ids is a
+# create-only property, this forces replacement of the attachment. The
+# create_before_destroy lifecycle means the new attachment must be created
+# (referencing the same VPC and transit gateway) before the old one is deleted,
+# testing that dependent resource references are correctly rewired.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.210.0.0/16"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet_a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.210.1.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-a"
+    Environment = "acceptance-test"
+  }
+}
+
+let subnet_b = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.210.2.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-b"
+    Environment = "acceptance-test"
+  }
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}
+
+awscc.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet_b.subnet_id]
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach"
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
@@ -5,10 +5,11 @@
 #   aws-vault exec <profile> -- ./run.sh [filter]
 #
 # Tests:
-#   iam_role - Replacement with temporary name (name_attribute + other create-only)
-#   ec2_vpc  - Replacement without temporary name (no name_attribute)
+#   iam_role                      - Replacement with temporary name (name_attribute + other create-only)
+#   ec2_vpc                       - Replacement without temporary name (no name_attribute)
+#   ec2_transit_gateway_attachment - Replacement with dependent resource rewiring (subnet_ids change)
 #
-# Filter (optional): substring to match test names (e.g. "iam_role", "ec2_vpc")
+# Filter (optional): substring to match test names (e.g. "iam_role", "ec2_vpc", "ec2_transit")
 
 set -e
 
@@ -197,6 +198,13 @@ run_test "ec2_vpc" \
     "$SCRIPT_DIR/ec2_vpc_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_step2.crn" \
     "Test 2: EC2 VPC (no name_attribute, no temporary name)"
+
+# Test 3: EC2 Transit Gateway Attachment - replacement with dependent resource rewiring
+# subnet_ids is create-only; changing it forces replacement while VPC/TGW refs must be rewired
+run_test "ec2_transit_gateway_attachment" \
+    "$SCRIPT_DIR/ec2_transit_gateway_attachment_step1.crn" \
+    "$SCRIPT_DIR/ec2_transit_gateway_attachment_step2.crn" \
+    "Test 3: EC2 Transit Gateway Attachment (dependent resource rewiring)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary

- Add TGW attachment acceptance test (`ec2_transit_gateway_attachment_step1/step2.crn`) that forces replacement by changing `subnet_ids` (create-only property) while VPC and transit gateway references must be correctly rewired during create-before-destroy
- Update `run.sh` to include the new test as Test 3

Closes #815

## Test plan

- [ ] Run `run.sh ec2_transit` to execute only the new TGW attachment test
- [ ] Run `run.sh` to execute all create_before_destroy tests including the new one
- [ ] Verify cleanup destroys all resources (VPC, subnets, TGW, attachment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)