### PR TITLE
Add S3 bucket ACL/object_ownership transition in_place_update test

### DIFF
--- a/carina-provider-aws/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-aws/acceptance-tests/in_place_update/run.sh
@@ -11,6 +11,7 @@
 #   ec2_subnet         - Toggle map_public_ip_on_launch (false -> true)
 #   ec2_route          - Change route target (IGW -> NAT Gateway)
 #   s3_bucket          - Toggle versioning (Enabled -> Suspended)
+#   s3_bucket_acl      - ACL/object_ownership transition
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
 
@@ -223,6 +224,12 @@ run_test "s3_bucket" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step2.crn" \
     "Test 6: S3 Bucket (versioning Enabled -> Suspended)"
+
+# Test 7: S3 Bucket ACL - ACL/object_ownership transition
+run_test "s3_bucket_acl" \
+    "$SCRIPT_DIR/s3_bucket_acl_step1.crn" \
+    "$SCRIPT_DIR/s3_bucket_acl_step2.crn" \
+    "Test 7: S3 Bucket ACL (ACL private + BucketOwnerPreferred -> BucketOwnerEnforced)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"

--- a/carina-provider-aws/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
+++ b/carina-provider-aws/acceptance-tests/in_place_update/s3_bucket_acl_step1.crn
@@ -1,0 +1,18 @@
+# S3 Bucket ACL - in-place update test (step 1)
+#
+# Tests: create bucket with ACL private and ObjectOwnership BucketOwnerPreferred
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.s3.bucket {
+  bucket = "carina-acc-test-aws-s3-acl-update"
+
+  acl = aws.s3.bucket.ACL.private
+  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerPreferred
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
+++ b/carina-provider-aws/acceptance-tests/in_place_update/s3_bucket_acl_step2.crn
@@ -1,0 +1,17 @@
+# S3 Bucket ACL - in-place update test (step 2)
+#
+# Tests: remove ACL, switch to ObjectOwnership BucketOwnerEnforced (in-place update)
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.s3.bucket {
+  bucket = "carina-acc-test-aws-s3-acl-update"
+
+  object_ownership = aws.s3.bucket.ObjectOwnership.BucketOwnerEnforced
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `s3_bucket_acl_step1.crn` with `acl = private` and `object_ownership = BucketOwnerPreferred`
- Add `s3_bucket_acl_step2.crn` without `acl`, with `object_ownership = BucketOwnerEnforced`
- Add Test 7 to `run.sh` for the ACL/object_ownership transition

Closes #827

## Test plan
- [ ] Run `s3_bucket_acl` filter in `run.sh` to verify the transition works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)