### PR TITLE
Add ec2_security_group tag deletion acceptance tests

### DIFF
--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step1.crn
@@ -1,0 +1,27 @@
+# EC2 Security Group - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates a VPC and security group with two tags. Step 2 removes one tag
+# to test that delete_tags is called for the removed key.
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.106.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.security_group {
+  group_name  = "carina-tag-deletion-test"
+  description = "Carina acceptance test for tag deletion"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step2.crn
@@ -1,0 +1,27 @@
+# EC2 Security Group - Tag deletion test (Step 2: Remove one tag)
+#
+# Same VPC and security group as step 1, but with the "ToBeRemoved" tag
+# deleted. After apply, the tag should be removed from AWS and plan
+# should show no changes (idempotent).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.106.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.security_group {
+  group_name  = "carina-tag-deletion-test"
+  description = "Carina acceptance test for tag deletion"
+  vpc_id      = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/ec2_security_group_step3.crn
@@ -1,0 +1,24 @@
+# EC2 Security Group - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same VPC and security group as step 1, but with the tags block completely
+# removed from the security group. Tests that the differ detects attribute
+# removal when a key exists in current state but is absent from desired
+# state (issue #447).
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.106.0.0/16"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}
+
+aws.ec2.security_group {
+  group_name  = "carina-tag-deletion-test"
+  description = "Carina acceptance test for tag deletion"
+  vpc_id      = vpc.vpc_id
+}

--- a/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
@@ -5,14 +5,16 @@
 #   aws-vault exec <profile> -- ./run.sh [filter]
 #
 # Tests:
-#   ec2_vpc                  - Remove a tag from VPC (EC2 delete_tags API)
-#   s3_bucket                - Remove a tag from S3 bucket (put_bucket_tagging API)
-#   ec2_route_table          - Remove a tag from route table (EC2 delete_tags API)
-#   ec2_subnet               - Remove a tag from subnet (EC2 delete_tags API)
-#   ec2_vpc_all_tags         - Remove entire tags block from VPC (issue #447)
-#   s3_bucket_all_tags       - Remove entire tags block from S3 bucket (issue #447)
-#   ec2_route_table_all_tags - Remove entire tags block from route table (issue #447)
-#   ec2_subnet_all_tags      - Remove entire tags block from subnet (issue #447)
+#   ec2_vpc                      - Remove a tag from VPC (EC2 delete_tags API)
+#   s3_bucket                    - Remove a tag from S3 bucket (put_bucket_tagging API)
+#   ec2_route_table              - Remove a tag from route table (EC2 delete_tags API)
+#   ec2_subnet                   - Remove a tag from subnet (EC2 delete_tags API)
+#   ec2_security_group           - Remove a tag from security group (EC2 delete_tags API)
+#   ec2_vpc_all_tags             - Remove entire tags block from VPC (issue #447)
+#   s3_bucket_all_tags           - Remove entire tags block from S3 bucket (issue #447)
+#   ec2_route_table_all_tags     - Remove entire tags block from route table (issue #447)
+#   ec2_subnet_all_tags          - Remove entire tags block from subnet (issue #447)
+#   ec2_security_group_all_tags  - Remove entire tags block from security group (issue #447)
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
 
@@ -214,29 +216,41 @@ run_test "ec2_subnet" \
     "$SCRIPT_DIR/ec2_subnet_step2.crn" \
     "Test 4: EC2 Subnet (delete_tags for removed tag key)"
 
-# Test 5: EC2 VPC - entire tags block removal (issue #447)
+# Test 5: EC2 Security Group - tag removal via delete_tags API
+run_test "ec2_security_group" \
+    "$SCRIPT_DIR/ec2_security_group_step1.crn" \
+    "$SCRIPT_DIR/ec2_security_group_step2.crn" \
+    "Test 5: EC2 Security Group (delete_tags for removed tag key)"
+
+# Test 6: EC2 VPC - entire tags block removal (issue #447)
 run_test "ec2_vpc_all_tags" \
     "$SCRIPT_DIR/ec2_vpc_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_step3.crn" \
-    "Test 5: EC2 VPC (remove entire tags block)"
+    "Test 6: EC2 VPC (remove entire tags block)"
 
-# Test 6: S3 Bucket - entire tags block removal (issue #447)
+# Test 7: S3 Bucket - entire tags block removal (issue #447)
 run_test "s3_bucket_all_tags" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step3.crn" \
-    "Test 6: S3 Bucket (remove entire tags block)"
+    "Test 7: S3 Bucket (remove entire tags block)"
 
-# Test 7: EC2 Route Table - entire tags block removal (issue #447)
+# Test 8: EC2 Route Table - entire tags block removal (issue #447)
 run_test "ec2_route_table_all_tags" \
     "$SCRIPT_DIR/ec2_route_table_step1.crn" \
     "$SCRIPT_DIR/ec2_route_table_step3.crn" \
-    "Test 7: EC2 Route Table (remove entire tags block)"
+    "Test 8: EC2 Route Table (remove entire tags block)"
 
-# Test 8: EC2 Subnet - entire tags block removal (issue #447)
+# Test 9: EC2 Subnet - entire tags block removal (issue #447)
 run_test "ec2_subnet_all_tags" \
     "$SCRIPT_DIR/ec2_subnet_step1.crn" \
     "$SCRIPT_DIR/ec2_subnet_step3.crn" \
-    "Test 8: EC2 Subnet (remove entire tags block)"
+    "Test 9: EC2 Subnet (remove entire tags block)"
+
+# Test 10: EC2 Security Group - entire tags block removal (issue #447)
+run_test "ec2_security_group_all_tags" \
+    "$SCRIPT_DIR/ec2_security_group_step1.crn" \
+    "$SCRIPT_DIR/ec2_security_group_step3.crn" \
+    "Test 10: EC2 Security Group (remove entire tags block)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `ec2_security_group_step1.crn` / `step2.crn` / `step3.crn` for security group tag deletion tests (two tags -> one tag -> no tags)
- Update `run.sh` with two new test cases: single key removal (Test 5) and entire tags block removal (Test 10)
- Security group uses VPC parent, CIDR `10.106.0.0/16`

Closes #828

## Test plan
- [ ] Run `aws-vault exec <profile> -- ./run.sh ec2_security_group` to verify both test cases pass
- [ ] `bash -n run.sh` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)