### PR TITLE
Add AWSCC ec2_nat_gateway tag deletion test

### DIFF
--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -1,0 +1,44 @@
+# EC2 NAT Gateway - Tag deletion test (Step 1: Initial with two tags)
+#
+# Creates a NAT Gateway with two tags, along with all required parent
+# resources (VPC, internet gateway, subnet, EIP). Step 2 removes one
+# tag to test that CloudControl "remove" patch is used for the removed key.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.112.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {
+}
+
+awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let public_subnet = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.112.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = public_subnet.subnet_id
+
+  tags = {
+    Environment = "acceptance-test"
+    ToBeRemoved = "this-tag-will-be-deleted"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -1,0 +1,43 @@
+# EC2 NAT Gateway - Tag deletion test (Step 2: Remove one tag)
+#
+# Same NAT Gateway as step 1, but with the "ToBeRemoved" tag deleted.
+# After apply, the tag should be removed via CloudControl "remove"
+# patch and plan should show no changes (idempotent).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.112.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {
+}
+
+awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let public_subnet = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.112.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = public_subnet.subnet_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -1,0 +1,39 @@
+# EC2 NAT Gateway - Tag deletion test (Step 3: Remove entire tags block)
+#
+# Same NAT Gateway as step 1, but with the tags block completely removed.
+# Tests that the differ detects attribute removal when a key exists
+# in current state but is absent from desired state.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.112.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {
+}
+
+awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let public_subnet = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.112.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = public_subnet.subnet_id
+}

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
@@ -8,9 +8,11 @@
 #   ec2_vpc              - Remove a tag from VPC
 #   s3_bucket            - Remove a tag from S3 bucket
 #   iam_role             - Remove a tag from IAM role
+#   ec2_nat_gateway      - Remove a tag from NAT Gateway
 #   ec2_vpc_all_tags     - Remove entire tags block from VPC
 #   s3_bucket_all_tags   - Remove entire tags block from S3 bucket
 #   iam_role_all_tags    - Remove entire tags block from IAM role
+#   ec2_nat_gateway_all_tags - Remove entire tags block from NAT Gateway
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc", "s3_bucket")
 
@@ -206,23 +208,35 @@ run_test "iam_role" \
     "$SCRIPT_DIR/iam_role_step2.crn" \
     "Test 3: IAM Role (remove one tag key)"
 
-# Test 4: EC2 VPC - entire tags block removal
+# Test 4: EC2 NAT Gateway - tag removal via CloudControl "remove" patch
+run_test "ec2_nat_gateway" \
+    "$SCRIPT_DIR/ec2_nat_gateway_step1.crn" \
+    "$SCRIPT_DIR/ec2_nat_gateway_step2.crn" \
+    "Test 4: EC2 NAT Gateway (remove one tag key)"
+
+# Test 5: EC2 VPC - entire tags block removal
 run_test "ec2_vpc_all_tags" \
     "$SCRIPT_DIR/ec2_vpc_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_step3.crn" \
-    "Test 4: EC2 VPC (remove entire tags block)"
+    "Test 5: EC2 VPC (remove entire tags block)"
 
-# Test 5: S3 Bucket - entire tags block removal
+# Test 6: S3 Bucket - entire tags block removal
 run_test "s3_bucket_all_tags" \
     "$SCRIPT_DIR/s3_bucket_step1.crn" \
     "$SCRIPT_DIR/s3_bucket_step3.crn" \
-    "Test 5: S3 Bucket (remove entire tags block)"
+    "Test 6: S3 Bucket (remove entire tags block)"
 
-# Test 6: IAM Role - entire tags block removal
+# Test 7: IAM Role - entire tags block removal
 run_test "iam_role_all_tags" \
     "$SCRIPT_DIR/iam_role_step1.crn" \
     "$SCRIPT_DIR/iam_role_step3.crn" \
-    "Test 6: IAM Role (remove entire tags block)"
+    "Test 7: IAM Role (remove entire tags block)"
+
+# Test 8: EC2 NAT Gateway - entire tags block removal
+run_test "ec2_nat_gateway_all_tags" \
+    "$SCRIPT_DIR/ec2_nat_gateway_step1.crn" \
+    "$SCRIPT_DIR/ec2_nat_gateway_step3.crn" \
+    "Test 8: EC2 NAT Gateway (remove entire tags block)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `ec2_nat_gateway_step1.crn`, `ec2_nat_gateway_step2.crn`, `ec2_nat_gateway_step3.crn` for tag deletion acceptance tests
- Step 1: NAT Gateway with two tags (plus parent resources: VPC, IGW, subnet, EIP)
- Step 2: Remove one tag key ("ToBeRemoved")
- Step 3: Remove entire tags block
- Update `run.sh` with Test 4 (single-key removal) and Test 8 (full tags block removal), renumbering existing tests accordingly

## Test plan
- [ ] Run `bash -n run.sh` to verify syntax (done)
- [ ] Run `aws-vault exec <profile> -- ./run.sh ec2_nat_gateway` to verify both tag deletion scenarios

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)