### PR TITLE
test: add interface VPC endpoint in-place update acceptance test

### DIFF
--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
@@ -1,0 +1,26 @@
+# EC2 VPC Endpoint (Interface) - in-place update test (step 1)
+#
+# Tests: create interface endpoint with private_dns_enabled=false
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.108.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for interface endpoint test"
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.sts"
+  vpc_endpoint_type   = Interface
+  security_group_ids  = [sg.group_id]
+  private_dns_enabled = false
+}

--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
@@ -1,0 +1,26 @@
+# EC2 VPC Endpoint (Interface) - in-place update test (step 2)
+#
+# Tests: update private_dns_enabled (false -> true)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.108.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for interface endpoint test"
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.sts"
+  vpc_endpoint_type   = Interface
+  security_group_ids  = [sg.group_id]
+  private_dns_enabled = true
+}

--- a/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
@@ -24,6 +24,7 @@
 #   ec2_transit_gateway_attachment     - Update tags
 #   ec2_route                          - Change route target (IGW -> NAT GW)
 #   ec2_ipam_pool                      - Change description
+#   ec2_vpc_endpoint_interface         - Change private_dns_enabled (false -> true)
 #
 # Filter (optional): substring to match test names (e.g. "logs_log_group", "s3_bucket")
 
@@ -314,6 +315,12 @@ run_test "ec2_ipam_pool" \
     "$SCRIPT_DIR/ec2_ipam_pool_step1.crn" \
     "$SCRIPT_DIR/ec2_ipam_pool_step2.crn" \
     "Test 19: EC2 IPAM Pool (description update)"
+
+# Test 20: EC2 VPC Endpoint (Interface) - change private_dns_enabled (false -> true)
+run_test "ec2_vpc_endpoint_interface" \
+    "$SCRIPT_DIR/ec2_vpc_endpoint_interface_step1.crn" \
+    "$SCRIPT_DIR/ec2_vpc_endpoint_interface_step2.crn" \
+    "Test 20: EC2 VPC Endpoint Interface (private_dns_enabled false -> true)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `ec2_vpc_endpoint_interface_step1.crn` and `ec2_vpc_endpoint_interface_step2.crn` for interface endpoint update testing
- Step 1 creates an interface VPC endpoint (STS service) with `private_dns_enabled=false`
- Step 2 updates `private_dns_enabled` to `true` (in-place update)
- Register as Test 20 in `run.sh`

Closes #830

## Test plan
- [ ] Run `run.sh ec2_vpc_endpoint_interface` to verify the new test passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)