### PR TITLE
Add logs_log_group attribute_removal acceptance test

### DIFF
--- a/carina-provider-awscc/acceptance-tests/attribute_removal/logs_log_group_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/logs_log_group_step1.crn
@@ -1,0 +1,12 @@
+# Logs Log Group - attribute removal test (step 1)
+#
+# Tests: create log group with retention_in_days set
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.logs.log_group {
+  log_group_name    = "/carina/acc-test-attr-removal"
+  retention_in_days = 7
+}

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/logs_log_group_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/logs_log_group_step2.crn
@@ -1,0 +1,11 @@
+# Logs Log Group - attribute removal test (step 2)
+#
+# Tests: remove retention_in_days entirely (revert to never-expire default)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.logs.log_group {
+  log_group_name = "/carina/acc-test-attr-removal"
+}

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
@@ -6,6 +6,7 @@
 #
 # Tests:
 #   ec2_vpc_endpoint - Remove policy_document from VPC endpoint
+#   logs_log_group   - Remove retention_in_days from log group
 #
 # Filter (optional): substring to match test names (e.g. "ec2_vpc_endpoint")
 
@@ -188,6 +189,12 @@ run_test "ec2_vpc_endpoint" \
     "$SCRIPT_DIR/ec2_vpc_endpoint_step1.crn" \
     "$SCRIPT_DIR/ec2_vpc_endpoint_step2.crn" \
     "Test 1: EC2 VPC Endpoint (remove policy_document)"
+
+# Test 2: Logs Log Group - remove retention_in_days via CloudControl "remove" patch
+run_test "logs_log_group" \
+    "$SCRIPT_DIR/logs_log_group_step1.crn" \
+    "$SCRIPT_DIR/logs_log_group_step2.crn" \
+    "Test 2: Logs Log Group (remove retention_in_days)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Add `logs_log_group_step1.crn` and `logs_log_group_step2.crn` to the `attribute_removal` acceptance test suite
- Step 1 creates a log group with `retention_in_days = 7`; step 2 removes `retention_in_days` to revert to the never-expire default
- Update `run.sh` to include the new test case as Test 2

Closes #829

## Test plan
- [ ] Run `aws-vault exec <profile> -- ./run.sh logs_log_group` to verify the new test passes
- [ ] Run `aws-vault exec <profile> -- ./run.sh` to verify all attribute_removal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)