### PR TITLE
fix: detect orphaned state resources for deletion in plan/apply

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -950,6 +950,16 @@ async fn run_apply_locked(
         current_states.insert(resource.id.clone(), state);
     }
 
+    // Seed current_states with orphaned resources from state file (#844).
+    // These are resources tracked in state but removed from the .crn config.
+    if let Some(sf) = state_file.as_ref() {
+        let desired_ids: HashSet<ResourceId> =
+            sorted_resources.iter().map(|r| r.id.clone()).collect();
+        for (id, state) in sf.build_orphan_states(&desired_ids) {
+            current_states.entry(id).or_insert(state);
+        }
+    }
+
     // Restore unreturned attributes from state file (CloudControl doesn't always return them)
     let saved_attrs = state_file
         .as_ref()

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1170,6 +1170,104 @@ async fn detect_drift_returns_messages_when_drift_detected() {
     assert!(!msgs.is_empty(), "Should have drift messages");
 }
 
+/// Test that resources tracked in the state file but removed from the .crn config
+/// produce a Delete effect in the plan.  This is the regression test for issue #844.
+#[test]
+fn orphaned_state_resource_produces_delete_effect() {
+    use carina_core::differ::create_plan;
+    use std::collections::HashSet;
+
+    // State file has two resources: "keep-bucket" and "removed-bucket"
+    let mut state_file = StateFile::new();
+    state_file.upsert_resource(
+        ResourceState::new("s3.bucket", "keep-bucket", "aws")
+            .with_identifier("keep-bucket")
+            .with_attribute("bucket", json!("keep-bucket")),
+    );
+    state_file.upsert_resource(
+        ResourceState::new("s3.bucket", "removed-bucket", "aws")
+            .with_identifier("removed-bucket")
+            .with_attribute("bucket", json!("removed-bucket")),
+    );
+
+    // Config only has "keep-bucket" -- "removed-bucket" was deleted from .crn
+    let desired = vec![
+        Resource::with_provider("aws", "s3.bucket", "keep-bucket")
+            .with_attribute("bucket", Value::String("keep-bucket".to_string())),
+    ];
+
+    let desired_ids: HashSet<ResourceId> = desired.iter().map(|r| r.id.clone()).collect();
+
+    // Build current_states from desired resources (simulates the provider read loop)
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+    for resource in &desired {
+        current_states.insert(
+            resource.id.clone(),
+            State::existing(
+                resource.id.clone(),
+                HashMap::from([(
+                    "bucket".to_string(),
+                    Value::String("keep-bucket".to_string()),
+                )]),
+            )
+            .with_identifier("keep-bucket"),
+        );
+    }
+
+    // Seed orphaned state entries -- this is the fix for #844
+    let orphan_states = state_file.build_orphan_states(&desired_ids);
+    for (id, state) in orphan_states {
+        current_states.entry(id).or_insert(state);
+    }
+
+    let lifecycles = state_file.build_lifecycles();
+    let saved_attrs = state_file.build_saved_attrs();
+    let prev_desired_keys = state_file.build_desired_keys();
+
+    let plan = create_plan(
+        &desired,
+        &current_states,
+        &lifecycles,
+        &HashMap::new(),
+        &saved_attrs,
+        &prev_desired_keys,
+    );
+
+    // The plan should contain a Delete effect for "removed-bucket"
+    let delete_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| matches!(e, Effect::Delete { .. }))
+        .collect();
+
+    assert_eq!(
+        delete_effects.len(),
+        1,
+        "Should have exactly one Delete effect for the orphaned resource, got: {:?}",
+        plan.effects()
+    );
+
+    match &delete_effects[0] {
+        Effect::Delete { id, identifier, .. } => {
+            assert_eq!(id.name, "removed-bucket");
+            assert_eq!(identifier, "removed-bucket");
+        }
+        _ => unreachable!(),
+    }
+
+    // The plan should NOT have any effects for "keep-bucket" (it's unchanged)
+    let non_delete_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| !matches!(e, Effect::Delete { .. }))
+        .collect();
+    assert!(
+        non_delete_effects.is_empty(),
+        "Should have no non-Delete effects for unchanged resource, got: {:?}",
+        non_delete_effects
+    );
+}
+
 /// A mock StateBackend that fails on write_state and tracks release_lock calls
 struct MockBackend {
     write_state_fails: bool,

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use colored::Colorize;
@@ -264,6 +264,16 @@ pub async fn create_plan_from_parsed(
             .await
             .map_err(AppError::Provider)?;
         current_states.insert(resource.id.clone(), state);
+    }
+
+    // Seed current_states with orphaned resources from state file (#844).
+    // These are resources tracked in state but removed from the .crn config.
+    if let Some(sf) = state_file.as_ref() {
+        let desired_ids: HashSet<ResourceId> =
+            sorted_resources.iter().map(|r| r.id.clone()).collect();
+        for (id, state) in sf.build_orphan_states(&desired_ids) {
+            current_states.entry(id).or_insert(state);
+        }
     }
 
     // Restore unreturned attributes from state file (CloudControl doesn't always return them)

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -135,6 +135,38 @@ impl StateFile {
         result
     }
 
+    /// Build state entries for resources tracked in the state file but absent from the
+    /// desired resource set.  These "orphan" entries are injected into `current_states`
+    /// so that `create_plan()` can detect them and emit Delete effects.
+    pub fn build_orphan_states(
+        &self,
+        desired_ids: &std::collections::HashSet<ResourceId>,
+    ) -> HashMap<ResourceId, State> {
+        let mut result = HashMap::new();
+        for rs in &self.resources {
+            let id = ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
+            if desired_ids.contains(&id) {
+                continue;
+            }
+            // Only include resources that actually have an identifier (i.e. exist in infra)
+            if let Some(ref identifier) = rs.identifier {
+                let attrs: HashMap<String, Value> = rs
+                    .attributes
+                    .iter()
+                    .filter_map(|(k, v)| json_to_dsl_value(v).map(|val| (k.clone(), val)))
+                    .collect();
+                let state = State {
+                    id: id.clone(),
+                    identifier: Some(identifier.clone()),
+                    attributes: attrs,
+                    exists: true,
+                };
+                result.insert(id, state);
+            }
+        }
+        result
+    }
+
     /// Build a map of ResourceId -> name overrides from this state file.
     /// Name overrides come from create_before_destroy with non-renameable attributes.
     pub fn build_name_overrides(&self) -> HashMap<ResourceId, HashMap<String, String>> {


### PR DESCRIPTION
## Summary
- Add `StateFile::build_orphan_states()` to build `State` entries for resources tracked in state but absent from the desired config
- Seed `current_states` with orphan entries in both `create_plan_from_parsed()` (wiring.rs, used by `plan`) and `run_apply_locked()` (apply.rs, used by `apply`)
- Add regression test `orphaned_state_resource_produces_delete_effect` verifying Delete effect is emitted for removed resources

## Test plan
- [x] New unit test covers the orphan detection scenario end-to-end
- [x] All existing `carina-cli` tests pass (47 tests)
- [x] All existing `carina-state` tests pass (41 tests)
- [x] `cargo clippy` and `cargo fmt` clean

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)