### PR TITLE
fix: scope state identity by provider to prevent multi-provider corruption

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -560,7 +560,11 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
     let mut state = state_file.unwrap_or_default();
 
     for resource in sorted_resources {
-        let existing = state.find_resource(&resource.id.resource_type, &resource.id.name);
+        let existing = state.find_resource(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            &resource.id.name,
+        );
         if let Some(applied_state) = applied_states.get(&resource.id) {
             let mut resource_state =
                 ResourceState::from_provider_state(resource, applied_state, existing)?;
@@ -576,7 +580,11 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
                     ResourceState::from_provider_state(resource, current_state, existing)?;
                 state.upsert_resource(resource_state);
             } else {
-                state.remove_resource(&resource.id.resource_type, &resource.id.name);
+                state.remove_resource(
+                    &resource.id.provider,
+                    &resource.id.resource_type,
+                    &resource.id.name,
+                );
             }
         }
     }
@@ -585,7 +593,7 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
         if let Effect::Delete { id, .. } = effect
             && successfully_deleted.contains(id)
         {
-            state.remove_resource(&id.resource_type, &id.name);
+            state.remove_resource(&id.provider, &id.resource_type, &id.name);
         }
     }
 

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -426,7 +426,7 @@ async fn run_destroy_locked(
 
     // Remove destroyed resources from state
     for id in &destroyed_ids {
-        state.remove_resource(&id.resource_type, &id.name);
+        state.remove_resource(&id.provider, &id.resource_type, &id.name);
     }
 
     // Increment serial and save

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -319,7 +319,11 @@ async fn run_state_refresh_locked(
         };
 
         // Compare old state attributes with new
-        let existing = state.find_resource(&resource.id.resource_type, &resource.id.name);
+        let existing = state.find_resource(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            &resource.id.name,
+        );
 
         let mut has_changes = false;
         let mut changes: Vec<String> = Vec::new();
@@ -404,12 +408,20 @@ async fn run_state_refresh_locked(
 
         // Update state with refreshed data
         if fresh_state.exists {
-            let existing_rs = state.find_resource(&resource.id.resource_type, &resource.id.name);
+            let existing_rs = state.find_resource(
+                &resource.id.provider,
+                &resource.id.resource_type,
+                &resource.id.name,
+            );
             let resource_state =
                 ResourceState::from_provider_state(resource, fresh_state, existing_rs)?;
             state.upsert_resource(resource_state);
         } else {
-            state.remove_resource(&resource.id.resource_type, &resource.id.name);
+            state.remove_resource(
+                &resource.id.provider,
+                &resource.id.resource_type,
+                &resource.id.name,
+            );
         }
     }
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -134,7 +134,7 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
     })
     .unwrap();
 
-    let saved_resource = saved.find_resource("s3.bucket", "bucket").unwrap();
+    let saved_resource = saved.find_resource("aws", "s3.bucket", "bucket").unwrap();
     assert_eq!(
         saved_resource.attributes.get("status"),
         Some(&json!("after"))
@@ -181,7 +181,7 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
     })
     .unwrap();
 
-    assert!(saved.find_resource("s3.bucket", "bucket").is_none());
+    assert!(saved.find_resource("aws", "s3.bucket", "bucket").is_none());
 }
 
 #[tokio::test]
@@ -227,7 +227,7 @@ async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refr
     })
     .unwrap();
 
-    let saved_resource = saved.find_resource("s3.bucket", "bucket").unwrap();
+    let saved_resource = saved.find_resource("aws", "s3.bucket", "bucket").unwrap();
     assert_eq!(
         saved_resource.attributes.get("status"),
         Some(&json!("saved"))

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -82,8 +82,8 @@ pub fn reconcile_prefixed_names(resources: &mut [Resource], state_file: &Option<
         None => return,
     };
 
-    identifier::reconcile_prefixed_names(resources, &|resource_type, name| {
-        let sr = state_file.find_resource(resource_type, name)?;
+    identifier::reconcile_prefixed_names(resources, &|provider, resource_type, name| {
+        let sr = state_file.find_resource(provider, resource_type, name)?;
         Some(PrefixStateInfo {
             prefixes: sr.prefixes.clone(),
             attribute_values: sr

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -113,7 +113,7 @@ pub struct PrefixStateInfo {
 /// If the prefix has changed or there's no state match, keeps the new generated name.
 pub fn reconcile_prefixed_names(
     resources: &mut [Resource],
-    find_state: &dyn Fn(&str, &str) -> Option<PrefixStateInfo>,
+    find_state: &dyn Fn(&str, &str, &str) -> Option<PrefixStateInfo>,
 ) {
     for resource in resources.iter_mut() {
         if resource.prefixes.is_empty() {
@@ -121,7 +121,11 @@ pub fn reconcile_prefixed_names(
         }
 
         // Find matching resource in state
-        let state_info = find_state(&resource.id.resource_type, &resource.id.name);
+        let state_info = find_state(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            &resource.id.name,
+        );
         let state_info = match state_info {
             Some(si) => si,
             None => continue,
@@ -612,7 +616,7 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| {
+        reconcile_prefixed_names(&mut resources, &|_provider, _resource_type, _name| {
             Some(PrefixStateInfo {
                 prefixes: vec![("bucket_name".to_string(), "my-app-".to_string())]
                     .into_iter()
@@ -642,7 +646,7 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| {
+        reconcile_prefixed_names(&mut resources, &|_provider, _resource_type, _name| {
             Some(PrefixStateInfo {
                 prefixes: vec![("bucket_name".to_string(), "old-prefix-".to_string())]
                     .into_iter()
@@ -675,7 +679,7 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        reconcile_prefixed_names(&mut resources, &|_resource_type, _name| None);
+        reconcile_prefixed_names(&mut resources, &|_provider, _resource_type, _name| None);
 
         // No state, so keep the generated name
         assert_eq!(

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -53,11 +53,16 @@ impl StateFile {
         self.carina_version = env!("CARGO_PKG_VERSION").to_string();
     }
 
-    /// Find a resource by type and name
-    pub fn find_resource(&self, resource_type: &str, name: &str) -> Option<&ResourceState> {
+    /// Find a resource by provider, type, and name
+    pub fn find_resource(
+        &self,
+        provider: &str,
+        resource_type: &str,
+        name: &str,
+    ) -> Option<&ResourceState> {
         self.resources
             .iter()
-            .find(|r| r.resource_type == resource_type && r.name == name)
+            .find(|r| r.provider == provider && r.resource_type == resource_type && r.name == name)
     }
 
     /// Find all resources matching a provider and resource type
@@ -68,20 +73,23 @@ impl StateFile {
             .collect()
     }
 
-    /// Find a resource mutably by type and name
+    /// Find a resource mutably by provider, type, and name
     pub fn find_resource_mut(
         &mut self,
+        provider: &str,
         resource_type: &str,
         name: &str,
     ) -> Option<&mut ResourceState> {
         self.resources
             .iter_mut()
-            .find(|r| r.resource_type == resource_type && r.name == name)
+            .find(|r| r.provider == provider && r.resource_type == resource_type && r.name == name)
     }
 
     /// Add or update a resource in the state
     pub fn upsert_resource(&mut self, resource: ResourceState) {
-        if let Some(existing) = self.find_resource_mut(&resource.resource_type, &resource.name) {
+        if let Some(existing) =
+            self.find_resource_mut(&resource.provider, &resource.resource_type, &resource.name)
+        {
             *existing = resource;
         } else {
             self.resources.push(resource);
@@ -90,9 +98,11 @@ impl StateFile {
 
     /// Get the identifier for a resource from state.
     pub fn get_identifier_for_resource(&self, resource: &Resource) -> Option<String> {
-        if let Some(resource_state) =
-            self.find_resource(&resource.id.resource_type, &resource.id.name)
-        {
+        if let Some(resource_state) = self.find_resource(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            &resource.id.name,
+        ) {
             return resource_state.identifier.clone();
         }
         None
@@ -149,12 +159,15 @@ impl StateFile {
     }
 
     /// Remove a resource from the state
-    pub fn remove_resource(&mut self, resource_type: &str, name: &str) -> Option<ResourceState> {
-        if let Some(pos) = self
-            .resources
-            .iter()
-            .position(|r| r.resource_type == resource_type && r.name == name)
-        {
+    pub fn remove_resource(
+        &mut self,
+        provider: &str,
+        resource_type: &str,
+        name: &str,
+    ) -> Option<ResourceState> {
+        if let Some(pos) = self.resources.iter().position(|r| {
+            r.provider == provider && r.resource_type == resource_type && r.name == name
+        }) {
             Some(self.resources.remove(pos))
         } else {
             None
@@ -333,12 +346,12 @@ mod tests {
         state.upsert_resource(resource);
         assert_eq!(state.resources.len(), 1);
 
-        let removed = state.remove_resource("s3.bucket", "my-bucket");
+        let removed = state.remove_resource("aws", "s3.bucket", "my-bucket");
         assert!(removed.is_some());
         assert_eq!(state.resources.len(), 0);
 
         // Removing non-existent resource returns None
-        let removed = state.remove_resource("s3.bucket", "other-bucket");
+        let removed = state.remove_resource("aws", "s3.bucket", "other-bucket");
         assert!(removed.is_none());
     }
 
@@ -511,5 +524,122 @@ mod tests {
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
         assert!(!rs.protected);
         assert_eq!(rs.identifier, Some("test-id".to_string()));
+    }
+
+    #[test]
+    fn test_multi_provider_resources_do_not_collide() {
+        use carina_core::resource::Resource;
+
+        let mut state = StateFile::new();
+
+        // Store two resources with the same resource_type and name but different providers
+        let aws_resource =
+            ResourceState::new("s3.bucket", "main", "aws").with_identifier("aws-bucket-id");
+        let awscc_resource =
+            ResourceState::new("s3.bucket", "main", "awscc").with_identifier("awscc-bucket-id");
+
+        state.upsert_resource(aws_resource);
+        state.upsert_resource(awscc_resource);
+
+        // Both should be stored independently
+        assert_eq!(state.resources.len(), 2);
+
+        // find_resource should return the correct one for each provider
+        let found_aws = state.find_resource("aws", "s3.bucket", "main").unwrap();
+        assert_eq!(found_aws.identifier, Some("aws-bucket-id".to_string()));
+
+        let found_awscc = state.find_resource("awscc", "s3.bucket", "main").unwrap();
+        assert_eq!(found_awscc.identifier, Some("awscc-bucket-id".to_string()));
+
+        // get_identifier_for_resource should return provider-scoped identifiers
+        let aws_res = Resource::with_provider("aws", "s3.bucket", "main");
+        assert_eq!(
+            state.get_identifier_for_resource(&aws_res),
+            Some("aws-bucket-id".to_string())
+        );
+
+        let awscc_res = Resource::with_provider("awscc", "s3.bucket", "main");
+        assert_eq!(
+            state.get_identifier_for_resource(&awscc_res),
+            Some("awscc-bucket-id".to_string())
+        );
+
+        // Upsert should only update the matching provider's entry
+        let updated_aws =
+            ResourceState::new("s3.bucket", "main", "aws").with_identifier("aws-bucket-id-v2");
+        state.upsert_resource(updated_aws);
+        assert_eq!(state.resources.len(), 2);
+        assert_eq!(
+            state
+                .find_resource("aws", "s3.bucket", "main")
+                .unwrap()
+                .identifier,
+            Some("aws-bucket-id-v2".to_string())
+        );
+        assert_eq!(
+            state
+                .find_resource("awscc", "s3.bucket", "main")
+                .unwrap()
+                .identifier,
+            Some("awscc-bucket-id".to_string())
+        );
+
+        // remove_resource should only remove the matching provider's entry
+        let removed = state.remove_resource("aws", "s3.bucket", "main");
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().provider, "aws");
+        assert_eq!(state.resources.len(), 1);
+
+        // The awscc entry should still exist
+        assert!(state.find_resource("awscc", "s3.bucket", "main").is_some());
+        assert!(state.find_resource("aws", "s3.bucket", "main").is_none());
+    }
+
+    #[test]
+    fn test_build_lifecycles_provider_scoped() {
+        use carina_core::resource::ResourceId;
+
+        let mut state = StateFile::new();
+        let mut aws_rs = ResourceState::new("s3.bucket", "main", "aws");
+        aws_rs.lifecycle.force_delete = true;
+        let mut awscc_rs = ResourceState::new("s3.bucket", "main", "awscc");
+        awscc_rs.lifecycle.force_delete = false;
+
+        state.upsert_resource(aws_rs);
+        state.upsert_resource(awscc_rs);
+
+        let lifecycles = state.build_lifecycles();
+        let aws_id = ResourceId::with_provider("aws", "s3.bucket", "main");
+        let awscc_id = ResourceId::with_provider("awscc", "s3.bucket", "main");
+
+        assert!(lifecycles.get(&aws_id).unwrap().force_delete);
+        assert!(!lifecycles.get(&awscc_id).unwrap().force_delete);
+    }
+
+    #[test]
+    fn test_build_saved_attrs_provider_scoped() {
+        use carina_core::resource::{ResourceId, Value};
+
+        let mut state = StateFile::new();
+        let aws_rs = ResourceState::new("s3.bucket", "main", "aws")
+            .with_attribute("region".to_string(), serde_json::json!("us-east-1"));
+        let awscc_rs = ResourceState::new("s3.bucket", "main", "awscc")
+            .with_attribute("region".to_string(), serde_json::json!("ap-northeast-1"));
+
+        state.upsert_resource(aws_rs);
+        state.upsert_resource(awscc_rs);
+
+        let saved = state.build_saved_attrs();
+        let aws_id = ResourceId::with_provider("aws", "s3.bucket", "main");
+        let awscc_id = ResourceId::with_provider("awscc", "s3.bucket", "main");
+
+        assert_eq!(
+            saved.get(&aws_id).unwrap().get("region"),
+            Some(&Value::String("us-east-1".to_string()))
+        );
+        assert_eq!(
+            saved.get(&awscc_id).unwrap().get("region"),
+            Some(&Value::String("ap-northeast-1".to_string()))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- State lookup/update/remove APIs (`find_resource`, `find_resource_mut`, `remove_resource`) keyed by only `(resource_type, name)`, ignoring the provider prefix. This meant resources like `aws.s3.bucket.main` and `awscc.s3.bucket.main` could overwrite each other's state entries.
- Added `provider` as the first parameter to all state accessor methods and updated all callers across `apply`, `destroy`, `state refresh`, and `wiring` modules.
- Updated `reconcile_prefixed_names` closure signature in `carina-core` to pass provider through.

## Test plan
- [x] Added `test_multi_provider_resources_do_not_collide` test verifying upsert, find, and remove are provider-scoped
- [x] Added `test_build_lifecycles_provider_scoped` and `test_build_saved_attrs_provider_scoped` tests
- [x] All existing tests pass (`cargo test` full workspace)
- [x] `cargo clippy` and `cargo fmt` clean

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)