### PR TITLE
fix: detect destroy failures in multi-step test cleanup

### DIFF
--- a/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
@@ -99,20 +99,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step test
@@ -172,7 +187,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-aws/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-aws/acceptance-tests/in_place_update/run.sh
@@ -105,20 +105,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step test
@@ -178,7 +193,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-aws/acceptance-tests/tag_deletion/run.sh
@@ -108,20 +108,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step tag deletion test
@@ -181,7 +196,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/run.sh
@@ -100,20 +100,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step attribute removal test
@@ -173,7 +188,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
@@ -101,20 +101,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step test
@@ -174,7 +189,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/run.sh
@@ -118,20 +118,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step test
@@ -191,7 +206,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-awscc/acceptance-tests/simhash_update/run.sh
+++ b/carina-provider-awscc/acceptance-tests/simhash_update/run.sh
@@ -104,20 +104,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step test
@@ -177,11 +192,41 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""
     echo ""
+}
+
+# Single-step cleanup helper: try to destroy with one config, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
+cleanup_single() {
+    local work_dir="$1"
+    local crn_file="$2"
+    local any_success=false
+
+    set +e
+    echo "  Cleanup: destroying resources..."
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1; then
+        any_success=true
+    fi
+    set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single-step test (apply + plan-verify + destroy, no update)
@@ -209,11 +254,7 @@ run_test_single() {
 
     # Step 1: Apply
     if ! run_step "$work_dir" "step1: apply" "apply" "$crn_file" "--auto-approve"; then
-        set +e
-        echo "  Cleanup: destroying resources..."
-        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-        set -e
+        cleanup_single "$work_dir" "$crn_file"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
@@ -221,22 +262,21 @@ run_test_single() {
 
     # Step 2: Plan-verify (idempotency check)
     if ! run_plan_verify "$work_dir" "step2: plan-verify" "$crn_file"; then
-        set +e
-        echo "  Cleanup: destroying resources..."
-        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-        cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-        set -e
+        cleanup_single "$work_dir" "$crn_file"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 3: Destroy (retry to handle transient failures)
-    set +e
-    echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1
-    set -e
+    # Step 3: Destroy
+    if ! cleanup_single "$work_dir" "$crn_file"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""

--- a/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
+++ b/carina-provider-awscc/acceptance-tests/tag_deletion/run.sh
@@ -106,20 +106,35 @@ run_plan_verify() {
 }
 
 # Cleanup helper: try to destroy with both step configs, then retry
+# Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
+    local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1
-    cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+        any_success=true
+    fi
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+        any_success=true
+    fi
     set -e
+
+    if [ "$any_success" = false ]; then
+        return 1
+    fi
+    return 0
 }
 
 # Run a single multi-step tag deletion test
@@ -179,7 +194,14 @@ run_test() {
     fi
 
     # Step 4: Destroy (use cleanup to try both configs and retry)
-    cleanup "$work_dir" "$step2" "$step1"
+    if ! cleanup "$work_dir" "$step2" "$step1"; then
+        echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
+        echo "    $work_dir"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        ACTIVE_WORK_DIR=""
+        echo ""
+        return 1
+    fi
 
     rm -rf "$work_dir"
     ACTIVE_WORK_DIR=""


### PR DESCRIPTION
## Summary
- `cleanup()` now tracks whether at least one destroy attempt succeeded (via `any_success` flag)
- When ALL destroy attempts fail, the test is marked as FAIL, `TOTAL_FAILED` is incremented, and the work dir is preserved
- A WARNING message with the temp dir path is printed so state files and logs remain available for debugging
- Applied consistently to all 8 multi-step `run.sh` scripts across both `carina-provider-aws` and `carina-provider-awscc`
- The `simhash_update/run.sh` script's `run_test_single()` inline cleanup was also refactored into a `cleanup_single()` helper with the same tracking

## Test plan
- [ ] Verify `bash -n` passes on all 8 scripts (done locally, all pass)
- [ ] Confirm cleanup still retries destroys (set +e / set -e pattern preserved)
- [ ] Confirm work dir is deleted on successful cleanup (normal path unchanged)
- [ ] Confirm work dir is preserved and FAIL incremented when all destroys fail

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)