### PR TITLE
fix: validate unsupported ec2.route target/destination types

### DIFF
--- a/carina-provider-aws/src/services/ec2/route.rs
+++ b/carina-provider-aws/src/services/ec2/route.rs
@@ -5,6 +5,66 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 
 use crate::AwsProvider;
 
+/// Unsupported destination attribute names for ec2.route.
+/// The aws provider only supports destination_cidr_block (IPv4 CIDR).
+const UNSUPPORTED_DESTINATIONS: &[&str] =
+    &["destination_ipv6_cidr_block", "destination_prefix_list_id"];
+
+/// Unsupported target attribute names for ec2.route.
+/// The aws provider only supports gateway_id and nat_gateway_id.
+const UNSUPPORTED_TARGETS: &[&str] = &[
+    "carrier_gateway_id",
+    "core_network_arn",
+    "egress_only_internet_gateway_id",
+    "instance_id",
+    "local_gateway_id",
+    "network_interface_id",
+    "transit_gateway_id",
+    "vpc_endpoint_id",
+    "vpc_peering_connection_id",
+];
+
+/// Validate that a route resource only uses supported destination and target types.
+/// Returns an error if any unsupported attributes are set.
+pub(crate) fn validate_ec2_route_attributes(
+    attributes: &HashMap<String, Value>,
+    resource_id: &ResourceId,
+) -> ProviderResult<()> {
+    let unsupported_dest: Vec<&str> = UNSUPPORTED_DESTINATIONS
+        .iter()
+        .filter(|attr| attributes.contains_key(**attr))
+        .copied()
+        .collect();
+
+    if !unsupported_dest.is_empty() {
+        return Err(ProviderError::new(format!(
+            "aws.ec2.route does not support destination type: {}. \
+             Only destination_cidr_block (IPv4 CIDR) is supported. \
+             Use awscc.ec2.route for other destination types.",
+            unsupported_dest.join(", ")
+        ))
+        .for_resource(resource_id.clone()));
+    }
+
+    let unsupported_tgt: Vec<&str> = UNSUPPORTED_TARGETS
+        .iter()
+        .filter(|attr| attributes.contains_key(**attr))
+        .copied()
+        .collect();
+
+    if !unsupported_tgt.is_empty() {
+        return Err(ProviderError::new(format!(
+            "aws.ec2.route does not support target type: {}. \
+             Only gateway_id and nat_gateway_id are supported. \
+             Use awscc.ec2.route for other target types.",
+            unsupported_tgt.join(", ")
+        ))
+        .for_resource(resource_id.clone()));
+    }
+
+    Ok(())
+}
+
 impl AwsProvider {
     /// Read an EC2 Route (routes are identified by route_table_id + destination)
     pub(crate) async fn read_ec2_route(
@@ -61,6 +121,8 @@ impl AwsProvider {
 
     /// Create an EC2 Route
     pub(crate) async fn create_ec2_route(&self, resource: Resource) -> ProviderResult<State> {
+        validate_ec2_route_attributes(&resource.attributes, &resource.id)?;
+
         let route_table_id = match resource.attributes.get("route_table_id") {
             Some(Value::String(s)) => s.clone(),
             _ => {
@@ -111,6 +173,8 @@ impl AwsProvider {
         _identifier: &str,
         to: Resource,
     ) -> ProviderResult<State> {
+        validate_ec2_route_attributes(&to.attributes, &id)?;
+
         let route_table_id = match to.attributes.get("route_table_id") {
             Some(Value::String(s)) => s.clone(),
             _ => {

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -6,6 +6,345 @@ use carina_core::resource::Value;
 
 use crate::AwsProvider;
 
+// --- ec2.route unsupported attribute validation tests ---
+
+mod ec2_route_validation {
+    use std::collections::HashMap;
+
+    use carina_core::resource::{ResourceId, Value};
+
+    use crate::services::ec2::route::validate_ec2_route_attributes;
+
+    fn make_resource_id() -> ResourceId {
+        ResourceId::new("ec2.route", "test-route")
+    }
+
+    #[test]
+    fn test_supported_gateway_id_route() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("0.0.0.0/0".to_string()),
+        );
+        attrs.insert(
+            "gateway_id".to_string(),
+            Value::String("igw-123".to_string()),
+        );
+        let id = make_resource_id();
+        assert!(validate_ec2_route_attributes(&attrs, &id).is_ok());
+    }
+
+    #[test]
+    fn test_supported_nat_gateway_id_route() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("0.0.0.0/0".to_string()),
+        );
+        attrs.insert(
+            "nat_gateway_id".to_string(),
+            Value::String("nat-123".to_string()),
+        );
+        let id = make_resource_id();
+        assert!(validate_ec2_route_attributes(&attrs, &id).is_ok());
+    }
+
+    #[test]
+    fn test_unsupported_destination_ipv6() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_ipv6_cidr_block".to_string(),
+            Value::String("::/0".to_string()),
+        );
+        attrs.insert(
+            "gateway_id".to_string(),
+            Value::String("igw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("destination_ipv6_cidr_block"), "got: {msg}");
+        assert!(msg.contains("awscc.ec2.route"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_destination_prefix_list() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_prefix_list_id".to_string(),
+            Value::String("pl-123".to_string()),
+        );
+        attrs.insert(
+            "gateway_id".to_string(),
+            Value::String("igw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("destination_prefix_list_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_transit_gateway() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "transit_gateway_id".to_string(),
+            Value::String("tgw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("transit_gateway_id"), "got: {msg}");
+        assert!(msg.contains("awscc.ec2.route"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_vpc_peering() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "vpc_peering_connection_id".to_string(),
+            Value::String("pcx-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("vpc_peering_connection_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_vpc_endpoint() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "vpc_endpoint_id".to_string(),
+            Value::String("vpce-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("vpc_endpoint_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_network_interface() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "network_interface_id".to_string(),
+            Value::String("eni-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("network_interface_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_egress_only_igw() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "egress_only_internet_gateway_id".to_string(),
+            Value::String("eigw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("egress_only_internet_gateway_id"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_unsupported_target_carrier_gateway() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "carrier_gateway_id".to_string(),
+            Value::String("cagw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("carrier_gateway_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_local_gateway() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "local_gateway_id".to_string(),
+            Value::String("lgw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("local_gateway_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_core_network_arn() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "core_network_arn".to_string(),
+            Value::String("arn:aws:networkmanager::123456789012:core-network/cn-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("core_network_arn"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_target_instance_id() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "instance_id".to_string(),
+            Value::String("i-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("instance_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_multiple_unsupported_targets() {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_cidr_block".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        );
+        attrs.insert(
+            "transit_gateway_id".to_string(),
+            Value::String("tgw-123".to_string()),
+        );
+        attrs.insert(
+            "vpc_peering_connection_id".to_string(),
+            Value::String("pcx-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("transit_gateway_id"), "got: {msg}");
+        assert!(msg.contains("vpc_peering_connection_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_unsupported_destination_checked_before_target() {
+        // When both unsupported destination and target are present,
+        // the destination error should be returned first
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+        attrs.insert(
+            "destination_ipv6_cidr_block".to_string(),
+            Value::String("::/0".to_string()),
+        );
+        attrs.insert(
+            "transit_gateway_id".to_string(),
+            Value::String("tgw-123".to_string()),
+        );
+        let id = make_resource_id();
+        let err = validate_ec2_route_attributes(&attrs, &id).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("destination_ipv6_cidr_block"), "got: {msg}");
+        // Should not contain target error since destination check fails first
+        assert!(!msg.contains("transit_gateway_id"), "got: {msg}");
+    }
+}
+
 // --- extract_ec2_vpc_attributes tests ---
 
 #[test]


### PR DESCRIPTION
## Summary

- Add pre-apply validation in `create_ec2_route` and `update_ec2_route` that rejects unsupported destination types (`destination_ipv6_cidr_block`, `destination_prefix_list_id`) and target types (`carrier_gateway_id`, `core_network_arn`, `egress_only_internet_gateway_id`, `instance_id`, `local_gateway_id`, `network_interface_id`, `transit_gateway_id`, `vpc_endpoint_id`, `vpc_peering_connection_id`)
- Error messages suggest using `awscc.ec2.route` instead
- Add 15 unit tests covering all supported/unsupported attribute combinations

Closes #847

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 105 tests pass
- [x] `cargo clippy -p carina-provider-aws` — no warnings
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)