### PR TITLE
fix: increase lock TTL to 60min, add lock renewal and conditional write

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1293,6 +1293,16 @@ impl StateBackend for MockBackend {
         self.lock_released.store(true, Ordering::SeqCst);
         Ok(())
     }
+    async fn renew_lock(&self, lock: &LockInfo) -> carina_state::BackendResult<LockInfo> {
+        Ok(lock.renewed())
+    }
+    async fn write_state_locked(
+        &self,
+        state: &carina_state::StateFile,
+        _lock: &LockInfo,
+    ) -> carina_state::BackendResult<()> {
+        self.write_state(state).await
+    }
     async fn force_unlock(&self, _lock_id: &str) -> carina_state::BackendResult<()> {
         Ok(())
     }

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -25,6 +25,10 @@ pub enum BackendError {
     #[error("Lock ID mismatch: expected {expected}, got {actual}")]
     LockMismatch { expected: String, actual: String },
 
+    /// The caller's lock is no longer held (expired or stolen)
+    #[error("Lock no longer held: {0}")]
+    LockNotHeld(String),
+
     /// The backend type is not supported
     #[error("Unsupported backend type: {0}")]
     UnsupportedBackend(String),
@@ -112,6 +116,19 @@ pub trait StateBackend: Send + Sync {
     ///
     /// This should verify that the lock being released matches the provided lock info
     async fn release_lock(&self, lock: &LockInfo) -> BackendResult<()>;
+
+    /// Renew a lock by refreshing its expiration timestamp.
+    ///
+    /// Returns an updated `LockInfo` with a fresh TTL.  The caller must verify
+    /// that the on-disk lock still belongs to it; if the lock was stolen the
+    /// method returns `LockNotHeld`.
+    async fn renew_lock(&self, lock: &LockInfo) -> BackendResult<LockInfo>;
+
+    /// Write state after verifying the caller still holds the lock.
+    ///
+    /// This prevents silent state corruption when a lock has expired and been
+    /// acquired by another process.
+    async fn write_state_locked(&self, state: &StateFile, lock: &LockInfo) -> BackendResult<()>;
 
     /// Force release a lock by its ID
     ///

--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -373,6 +373,74 @@ impl StateBackend for LocalBackend {
         }
     }
 
+    async fn renew_lock(&self, lock: &LockInfo) -> BackendResult<LockInfo> {
+        // Read the current lock file and verify it still belongs to us
+        let content = std::fs::read_to_string(&self.lock_path)
+            .map_err(|e| BackendError::Io(format!("Failed to read lock file: {}", e)))?;
+
+        let existing_lock: LockInfo = serde_json::from_str(&content)
+            .map_err(|e| BackendError::InvalidState(format!("Failed to parse lock file: {}", e)))?;
+
+        if existing_lock.id != lock.id {
+            return Err(BackendError::LockNotHeld(format!(
+                "lock {} was replaced by {}",
+                lock.id, existing_lock.id
+            )));
+        }
+
+        // Write a renewed lock atomically (write to temp, then rename)
+        let renewed = lock.renewed();
+        let new_content = serde_json::to_string_pretty(&renewed)
+            .map_err(|e| BackendError::Serialization(format!("Failed to serialize lock: {}", e)))?;
+
+        let tmp_path = self.lock_path.with_extension("lock.renew.tmp");
+        let mut file = std::fs::File::create(&tmp_path)
+            .map_err(|e| BackendError::Io(format!("Failed to create temp lock file: {}", e)))?;
+        file.write_all(new_content.as_bytes()).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            BackendError::Io(format!("Failed to write temp lock file: {}", e))
+        })?;
+        file.sync_all().map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            BackendError::Io(format!("Failed to sync temp lock file: {}", e))
+        })?;
+
+        std::fs::rename(&tmp_path, &self.lock_path)
+            .map_err(|e| BackendError::Io(format!("Failed to rename temp lock file: {}", e)))?;
+
+        Ok(renewed)
+    }
+
+    async fn write_state_locked(&self, state: &StateFile, lock: &LockInfo) -> BackendResult<()> {
+        // Verify the lock is still held by us before writing state
+        let content = match std::fs::read_to_string(&self.lock_path) {
+            Ok(c) => c,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(BackendError::LockNotHeld(
+                    "lock file no longer exists".to_string(),
+                ));
+            }
+            Err(err) => {
+                return Err(BackendError::Io(format!(
+                    "Failed to read lock file: {}",
+                    err
+                )));
+            }
+        };
+
+        let existing_lock: LockInfo = serde_json::from_str(&content)
+            .map_err(|e| BackendError::InvalidState(format!("Failed to parse lock file: {}", e)))?;
+
+        if existing_lock.id != lock.id {
+            return Err(BackendError::LockNotHeld(format!(
+                "lock {} was replaced by {}",
+                lock.id, existing_lock.id
+            )));
+        }
+
+        self.write_state(state).await
+    }
+
     async fn release_lock(&self, lock: &LockInfo) -> BackendResult<()> {
         if !self.lock_path.exists() {
             return Err(BackendError::LockNotFound(lock.id.clone()));
@@ -667,6 +735,96 @@ mod tests {
         // Verify no temp file is left behind
         let tmp_path = state_path.with_extension("json.tmp");
         assert!(!tmp_path.exists(), "temp file should be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn test_renew_lock_refreshes_expiration() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path);
+
+        let lock = backend.acquire_lock("apply").await.unwrap();
+        let renewed = backend.renew_lock(&lock).await.unwrap();
+
+        assert_eq!(renewed.id, lock.id);
+        assert_eq!(renewed.operation, lock.operation);
+        assert!(renewed.expires > lock.created);
+        assert!(!renewed.is_expired());
+
+        backend.release_lock(&renewed).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_renew_lock_fails_when_lock_stolen() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        let lock = backend.acquire_lock("apply").await.unwrap();
+
+        // Simulate another process stealing the lock by overwriting the lock file
+        let thief_lock = LockInfo::new("destroy");
+        let thief_content = serde_json::to_string_pretty(&thief_lock).unwrap();
+        std::fs::write(state_path.with_extension("lock"), thief_content).unwrap();
+
+        let result = backend.renew_lock(&lock).await;
+        assert!(matches!(result, Err(BackendError::LockNotHeld(_))));
+    }
+
+    #[tokio::test]
+    async fn test_write_state_locked_succeeds_when_lock_held() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        let lock = backend.acquire_lock("apply").await.unwrap();
+
+        let mut state_file = StateFile::new();
+        state_file.increment_serial();
+        backend
+            .write_state_locked(&state_file, &lock)
+            .await
+            .unwrap();
+
+        let read_state = backend.read_state().await.unwrap().unwrap();
+        assert_eq!(read_state.serial, 1);
+
+        backend.release_lock(&lock).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_write_state_locked_fails_when_lock_stolen() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        let lock = backend.acquire_lock("apply").await.unwrap();
+
+        // Simulate another process stealing the lock
+        let thief_lock = LockInfo::new("destroy");
+        let thief_content = serde_json::to_string_pretty(&thief_lock).unwrap();
+        std::fs::write(state_path.with_extension("lock"), thief_content).unwrap();
+
+        let mut state_file = StateFile::new();
+        state_file.increment_serial();
+        let result = backend.write_state_locked(&state_file, &lock).await;
+        assert!(matches!(result, Err(BackendError::LockNotHeld(_))));
+    }
+
+    #[tokio::test]
+    async fn test_write_state_locked_fails_when_lock_file_deleted() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path.clone());
+
+        let lock = backend.acquire_lock("apply").await.unwrap();
+
+        // Remove the lock file to simulate expiration + deletion
+        std::fs::remove_file(state_path.with_extension("lock")).unwrap();
+
+        let state_file = StateFile::new();
+        let result = backend.write_state_locked(&state_file, &lock).await;
+        assert!(matches!(result, Err(BackendError::LockNotHeld(_))));
     }
 
     #[test]

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -267,6 +267,50 @@ impl StateBackend for S3Backend {
         }
     }
 
+    async fn renew_lock(&self, lock: &LockInfo) -> BackendResult<LockInfo> {
+        // Read the current lock and its ETag
+        let Some((existing_lock, etag)) = self.read_lock_with_etag().await? else {
+            return Err(BackendError::LockNotHeld(
+                "lock file no longer exists".to_string(),
+            ));
+        };
+
+        if existing_lock.id != lock.id {
+            return Err(BackendError::LockNotHeld(format!(
+                "lock {} was replaced by {}",
+                lock.id, existing_lock.id
+            )));
+        }
+
+        // Write a renewed lock, conditioned on the current ETag
+        let renewed = lock.renewed();
+        if !self.replace_lock_if_match(&renewed, &etag).await? {
+            return Err(BackendError::LockNotHeld(
+                "lock was modified concurrently during renewal".to_string(),
+            ));
+        }
+
+        Ok(renewed)
+    }
+
+    async fn write_state_locked(&self, state: &StateFile, lock: &LockInfo) -> BackendResult<()> {
+        // Verify the lock is still held by us before writing state
+        let Some(existing_lock) = self.read_lock().await? else {
+            return Err(BackendError::LockNotHeld(
+                "lock file no longer exists".to_string(),
+            ));
+        };
+
+        if existing_lock.id != lock.id {
+            return Err(BackendError::LockNotHeld(format!(
+                "lock {} was replaced by {}",
+                lock.id, existing_lock.id
+            )));
+        }
+
+        self.write_state(state).await
+    }
+
     async fn release_lock(&self, lock: &LockInfo) -> BackendResult<()> {
         // Verify the lock exists and matches
         if let Some(existing_lock) = self.read_lock().await? {

--- a/carina-state/src/lock.rs
+++ b/carina-state/src/lock.rs
@@ -3,8 +3,12 @@
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Default lock timeout in seconds (15 minutes)
-pub const DEFAULT_LOCK_TIMEOUT_SECS: i64 = 900;
+/// Default lock timeout in seconds (60 minutes)
+///
+/// Long-running operations such as `destroy` can legitimately wait 30+ minutes
+/// for timed-out CloudControl deletes, so the TTL must be generous enough to
+/// cover those cases without expiring mid-operation.
+pub const DEFAULT_LOCK_TIMEOUT_SECS: i64 = 3600;
 
 /// Information about a state lock
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +63,21 @@ impl LockInfo {
     pub fn time_remaining(&self) -> Duration {
         self.expires - Utc::now()
     }
+
+    /// Create a renewed copy of this lock with a fresh expiration timestamp.
+    ///
+    /// The lock ID, operation, and owner remain the same; only the `created`
+    /// and `expires` fields are refreshed.
+    pub fn renewed(&self) -> Self {
+        let now = Utc::now();
+        Self {
+            id: self.id.clone(),
+            operation: self.operation.clone(),
+            who: self.who.clone(),
+            created: now,
+            expires: now + Duration::seconds(DEFAULT_LOCK_TIMEOUT_SECS),
+        }
+    }
 }
 
 /// Get the lock owner string (username@hostname)
@@ -107,6 +126,24 @@ mod tests {
     fn test_lock_owner_format() {
         let who = get_lock_owner();
         assert!(who.contains('@'));
+    }
+
+    #[test]
+    fn test_lock_info_renewed() {
+        let lock = LockInfo::with_timeout("apply", 10);
+        let renewed = lock.renewed();
+
+        // Same identity
+        assert_eq!(renewed.id, lock.id);
+        assert_eq!(renewed.operation, lock.operation);
+        assert_eq!(renewed.who, lock.who);
+
+        // Fresh expiration (should be close to DEFAULT_LOCK_TIMEOUT_SECS)
+        let remaining = renewed.time_remaining();
+        assert!(
+            remaining.num_seconds() > DEFAULT_LOCK_TIMEOUT_SECS - 5,
+            "renewed lock should have a fresh TTL"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Increase `DEFAULT_LOCK_TIMEOUT_SECS` from 900s (15min) to 3600s (60min) to cover long-running destroy operations
- Add `LockInfo::renewed()` method that creates a copy with fresh expiration while preserving identity
- Add `renew_lock()` to `StateBackend` trait, implemented for both `LocalBackend` and `S3Backend`, to refresh lock TTL during long operations
- Add `write_state_locked()` to `StateBackend` trait that verifies lock ownership before writing state, preventing silent overwrites when a lock has been stolen
- Add `LockNotHeld` error variant to `BackendError` for detecting stolen/expired locks

## Test plan

- [x] New tests: `test_renew_lock_refreshes_expiration`, `test_renew_lock_fails_when_lock_stolen`
- [x] New tests: `test_write_state_locked_succeeds_when_lock_held`, `test_write_state_locked_fails_when_lock_stolen`, `test_write_state_locked_fails_when_lock_file_deleted`
- [x] New test: `test_lock_info_renewed`
- [x] All 50 carina-state tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)