### PR TITLE
fix: isolate state per test in single-command modes

### DIFF
--- a/carina-provider-aws/acceptance-tests/run-tests.sh
+++ b/carina-provider-aws/acceptance-tests/run-tests.sh
@@ -550,9 +550,17 @@ fi
 echo "Running '$COMMAND' on ${#TESTS[@]} test file(s):"
 echo ""
 
+# Use per-test isolated state directories for commands that touch state
+# (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
+if [ "$COMMAND" != "validate" ]; then
+    WORK_DIR=$(mktemp -d)
+    trap "rm -rf $WORK_DIR; release_account_locks" EXIT
+fi
+
 PASSED=0
 FAILED=0
 ERRORS=()
+TEST_INDEX=0
 
 for TEST_FILE in "${TESTS[@]}"; do
     REL_PATH="${TEST_FILE#$SCRIPT_DIR/}"
@@ -562,11 +570,22 @@ for TEST_FILE in "${TESTS[@]}"; do
     if [ "$COMMAND" = "apply" ] || [ "$COMMAND" = "destroy" ]; then
         AUTO_APPROVE="--auto-approve"
     fi
-    if OUTPUT=$("$CARINA_BIN" "$COMMAND" $AUTO_APPROVE "$TEST_FILE" 2>&1); then
+
+    # Run from an isolated state directory for stateful commands
+    RUN_PREFIX=""
+    if [ "$COMMAND" != "validate" ]; then
+        STATE_DIR="$WORK_DIR/test_${TEST_INDEX}"
+        mkdir -p "$STATE_DIR"
+        RUN_PREFIX="cd $STATE_DIR &&"
+        TEST_INDEX=$((TEST_INDEX + 1))
+    fi
+
+    if OUTPUT=$(eval "$RUN_PREFIX \"$CARINA_BIN\" \"$COMMAND\" $AUTO_APPROVE \"$TEST_FILE\"" 2>&1); then
         if [ "$COMMAND" = "apply" ]; then
             # Post-apply plan verification (idempotency check)
-            PLAN_OUTPUT=$("$CARINA_BIN" plan --detailed-exitcode "$TEST_FILE" 2>&1)
-            PLAN_RC=$?
+            # Use || to capture non-zero exit codes without triggering set -e
+            PLAN_RC=0
+            PLAN_OUTPUT=$(eval "$RUN_PREFIX \"$CARINA_BIN\" plan --detailed-exitcode \"$TEST_FILE\"" 2>&1) || PLAN_RC=$?
             if [ $PLAN_RC -eq 2 ]; then
                 echo "FAIL (plan-verify)"
                 ERRORS+=("$REL_PATH: Post-apply plan detected changes (not idempotent): $PLAN_OUTPUT")

--- a/carina-provider-awscc/acceptance-tests/run-tests.sh
+++ b/carina-provider-awscc/acceptance-tests/run-tests.sh
@@ -582,9 +582,17 @@ fi
 echo "Running '$COMMAND' on ${#TESTS[@]} test file(s):"
 echo ""
 
+# Use per-test isolated state directories for commands that touch state
+# (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
+if [ "$COMMAND" != "validate" ]; then
+    WORK_DIR=$(mktemp -d)
+    trap "rm -rf $WORK_DIR; release_account_locks" EXIT
+fi
+
 PASSED=0
 FAILED=0
 ERRORS=()
+TEST_INDEX=0
 
 for TEST_FILE in "${TESTS[@]}"; do
     REL_PATH="${TEST_FILE#$SCRIPT_DIR/}"
@@ -594,11 +602,22 @@ for TEST_FILE in "${TESTS[@]}"; do
     if [ "$COMMAND" = "apply" ] || [ "$COMMAND" = "destroy" ]; then
         AUTO_APPROVE="--auto-approve"
     fi
-    if OUTPUT=$("$CARINA_BIN" "$COMMAND" $AUTO_APPROVE "$TEST_FILE" 2>&1); then
+
+    # Run from an isolated state directory for stateful commands
+    RUN_PREFIX=""
+    if [ "$COMMAND" != "validate" ]; then
+        STATE_DIR="$WORK_DIR/test_${TEST_INDEX}"
+        mkdir -p "$STATE_DIR"
+        RUN_PREFIX="cd $STATE_DIR &&"
+        TEST_INDEX=$((TEST_INDEX + 1))
+    fi
+
+    if OUTPUT=$(eval "$RUN_PREFIX \"$CARINA_BIN\" \"$COMMAND\" $AUTO_APPROVE \"$TEST_FILE\"" 2>&1); then
         if [ "$COMMAND" = "apply" ]; then
             # Post-apply plan verification (idempotency check)
-            PLAN_OUTPUT=$("$CARINA_BIN" plan --detailed-exitcode "$TEST_FILE" 2>&1)
-            PLAN_RC=$?
+            # Use || to capture non-zero exit codes without triggering set -e
+            PLAN_RC=0
+            PLAN_OUTPUT=$(eval "$RUN_PREFIX \"$CARINA_BIN\" plan --detailed-exitcode \"$TEST_FILE\"" 2>&1) || PLAN_RC=$?
             if [ $PLAN_RC -eq 2 ]; then
                 echo "FAIL (plan-verify)"
                 ERRORS+=("$REL_PATH: Post-apply plan detected changes (not idempotent): $PLAN_OUTPUT")


### PR DESCRIPTION
## Summary

- Use per-test isolated temp directories for `plan`/`apply`/`destroy` single-command modes, matching the existing `full` mode pattern
- Switch plan-verification in single-command `apply` mode to `|| rc=$?` guard to prevent `set -e` from killing the script on non-zero plan exit codes

Closes #839

## Test plan

- [ ] `bash -n` syntax check passes on both scripts (verified)
- [ ] Run `./run-tests.sh validate` to confirm validate mode is unaffected (no state dirs created)
- [ ] Run `./run-tests.sh plan` with two tests and verify each gets its own state directory
- [ ] Run `./run-tests.sh apply` with a test that produces a non-idempotent plan and confirm the failure is recorded (not an early exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)