### PR TITLE
fix: rewrite _binding and ResourceRef in module expansion

### DIFF
--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -244,16 +244,16 @@ impl ModuleResolver {
                 Value::String(instance_prefix.to_string()),
             );
 
-            // Substitute input references and rewrite intra-module ResourceRefs
+            // Rewrite intra-module ResourceRefs BEFORE substituting inputs.
+            // This ensures that caller-provided ResourceRef values (which may
+            // coincidentally share a binding name with a module-internal binding)
+            // are not incorrectly prefixed.
             let mut substituted_attrs = HashMap::new();
             for (key, value) in &new_resource.attributes {
-                let substituted = substitute_inputs(value, &input_values);
-                let rewritten = rewrite_intra_module_refs(
-                    &substituted,
-                    instance_prefix,
-                    &intra_module_bindings,
-                );
-                substituted_attrs.insert(key.clone(), rewritten);
+                let rewritten =
+                    rewrite_intra_module_refs(value, instance_prefix, &intra_module_bindings);
+                let substituted = substitute_inputs(&rewritten, &input_values);
+                substituted_attrs.insert(key.clone(), substituted);
             }
             new_resource.attributes = substituted_attrs;
 


### PR DESCRIPTION
## Summary
- Fix multiple module instances colliding in binding maps by rewriting `_binding` attributes with instance prefix during module expansion
- Fix intra-module `ResourceRef.binding_name` references being cross-wired between instances by rewriting them with instance prefix
- Add `rewrite_intra_module_refs()` helper that rewrites only references targeting bindings defined within the module

Closes #845

## Test plan
- [x] Add `test_multiple_module_instances_no_collision` that expands the same module twice with different prefixes and asserts `_binding`, `ResourceRef.binding_name`, and `id.name` are all distinct per instance
- [x] All 412 existing carina-core tests pass
- [x] clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)