### PR TITLE
fix: use set-based comparison for create_before_destroy identifier assertion

### DIFF
--- a/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
@@ -107,13 +107,21 @@ assert_identifiers() {
             return 1
         fi
     else
-        if [ "$ids1" != "$ids2" ]; then
+        # For "different" mode, check that at least one identifier changed.
+        # This handles create_before_destroy with dependent resources: only the
+        # replaced resource's identifier changes while others stay the same.
+        # Use comm to find identifiers unique to either set (not shared).
+        local unique
+        unique=$(comm -3 <(echo "$ids1") <(echo "$ids2"))
+        if [ -n "$unique" ]; then
             echo "OK"
             TOTAL_PASSED=$((TOTAL_PASSED + 1))
             return 0
         else
             echo "FAIL"
-            echo "  ERROR: Identifiers unchanged (expected different): $ids1"
+            echo "  ERROR: No identifier changed (expected at least one to differ):"
+            echo "    before: $ids1"
+            echo "    after:  $ids2"
             TOTAL_FAILED=$((TOTAL_FAILED + 1))
             return 1
         fi

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
@@ -109,13 +109,21 @@ assert_identifiers() {
             return 1
         fi
     else
-        if [ "$ids1" != "$ids2" ]; then
+        # For "different" mode, check that at least one identifier changed.
+        # This handles create_before_destroy with dependent resources: only the
+        # replaced resource's identifier changes while others stay the same.
+        # Use comm to find identifiers unique to either set (not shared).
+        local unique
+        unique=$(comm -3 <(echo "$ids1") <(echo "$ids2"))
+        if [ -n "$unique" ]; then
             echo "OK"
             TOTAL_PASSED=$((TOTAL_PASSED + 1))
             return 0
         else
             echo "FAIL"
-            echo "  ERROR: Identifiers unchanged (expected different): $ids1"
+            echo "  ERROR: No identifier changed (expected at least one to differ):"
+            echo "    before: $ids1"
+            echo "    after:  $ids2"
             TOTAL_FAILED=$((TOTAL_FAILED + 1))
             return 1
         fi


### PR DESCRIPTION
## Summary

- Fix `assert_identifiers` "different" mode in both AWS and AWSCC `create_before_destroy/run.sh` to use `comm -3` for set-based comparison instead of simple string inequality
- The new logic checks that at least one identifier is unique to either set (i.e., at least one resource was replaced), rather than requiring the full sorted identifier string to differ
- Improved error message to show before/after identifiers for easier debugging

## Context

The `create_before_destroy` Test 3 (EC2 Transit Gateway Attachment) has dependent resources (VPC, subnets, TGW) whose identifiers don't change during replacement. The previous assertion compared the full sorted set of ALL identifiers as a string, which could fail when only the replaced resource's identifier changes among many unchanged dependent resources.

Closes #862

## Test plan

- [x] `bash -n` passes for both modified scripts
- [ ] Run `create_before_destroy` acceptance tests to confirm the assertion passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)