### PR TITLE
fix: rewrite TGW attachment CBD test and fix assert_identifiers

### DIFF
--- a/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-aws/acceptance-tests/create_before_destroy/run.sh
@@ -78,6 +78,10 @@ get_identifiers() {
 
 # Assert that two identifier sets match the expected relationship
 # Args: description ids_after_step1 ids_after_step2 expected("equal"|"different")
+#
+# For "different" mode, uses set-based comparison (comm -3) to check if at least
+# one identifier differs between the two sets. This handles the case where most
+# resources keep the same identifiers but only the replaced resource changes.
 assert_identifiers() {
     local description="$1"
     local ids1="$2"
@@ -107,13 +111,17 @@ assert_identifiers() {
             return 1
         fi
     else
-        if [ "$ids1" != "$ids2" ]; then
+        # Use comm -3 to find lines unique to either set (symmetric difference).
+        # If there are any unique lines, at least one identifier changed.
+        local diff_lines
+        diff_lines=$(comm -3 <(echo "$ids1") <(echo "$ids2"))
+        if [ -n "$diff_lines" ]; then
             echo "OK"
             TOTAL_PASSED=$((TOTAL_PASSED + 1))
             return 0
         else
             echo "FAIL"
-            echo "  ERROR: Identifiers unchanged (expected different): $ids1"
+            echo "  ERROR: Identifiers unchanged (expected at least one to differ): $ids1"
             TOTAL_FAILED=$((TOTAL_FAILED + 1))
             return 1
         fi

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
@@ -1,9 +1,8 @@
-# EC2 Transit Gateway Attachment - create_before_destroy with dependent rewiring (Step 1: Initial)
+# EC2 Transit Gateway Attachment - create_before_destroy with transit_gateway_id change (Step 1: Initial)
 #
-# Creates a VPC, two subnets in different AZs, a transit gateway, and an
-# attachment using subnet_a. Step 2 switches to subnet_b, forcing replacement
-# of the attachment (subnet_ids is create-only) and testing that the dependent
-# resource reference is rewired during create_before_destroy.
+# Creates a VPC, subnet, two transit gateways (tgw_a and tgw_b), and an
+# attachment to tgw_a. Step 2 switches the attachment to tgw_b, forcing
+# replacement because transit_gateway_id is a create-only property.
 
 provider awscc {
   region = awscc.Region.ap_northeast_1
@@ -18,30 +17,10 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet_a = awscc.ec2.subnet {
+let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.210.1.0/24"
   availability_zone = "ap-northeast-1a"
-
-  tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-a"
-    Environment = "acceptance-test"
-  }
-}
-
-let subnet_b = awscc.ec2.subnet {
-  vpc_id            = vpc.vpc_id
-  cidr_block        = "10.210.2.0/24"
-  availability_zone = "ap-northeast-1c"
-
-  tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-b"
-    Environment = "acceptance-test"
-  }
-}
-
-let tgw = awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach"
 
   tags = {
     Name        = "carina-acc-test-cbd-tgw-attach"
@@ -49,9 +28,27 @@ let tgw = awscc.ec2.transit_gateway {
   }
 }
 
+let tgw_a = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach-a"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-a"
+    Environment = "acceptance-test"
+  }
+}
+
+let tgw_b = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach-b"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-b"
+    Environment = "acceptance-test"
+  }
+}
+
 awscc.ec2.transit_gateway_attachment {
-  subnet_ids         = [subnet_a.subnet_id]
-  transit_gateway_id = tgw.id
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw_a.id
   vpc_id             = vpc.vpc_id
 
   tags = {

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -1,10 +1,9 @@
-# EC2 Transit Gateway Attachment - create_before_destroy with dependent rewiring (Step 2: Replace)
+# EC2 Transit Gateway Attachment - create_before_destroy with transit_gateway_id change (Step 2: Replace)
 #
-# Switches the attachment from subnet_a to subnet_b. Since subnet_ids is a
+# Switches the attachment from tgw_a to tgw_b. Since transit_gateway_id is a
 # create-only property, this forces replacement of the attachment. The
-# create_before_destroy lifecycle means the new attachment must be created
-# (referencing the same VPC and transit gateway) before the old one is deleted,
-# testing that dependent resource references are correctly rewired.
+# create_before_destroy lifecycle means the new attachment (to tgw_b) must be
+# created before the old one (to tgw_a) is deleted.
 
 provider awscc {
   region = awscc.Region.ap_northeast_1
@@ -19,30 +18,10 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet_a = awscc.ec2.subnet {
+let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.210.1.0/24"
   availability_zone = "ap-northeast-1a"
-
-  tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-a"
-    Environment = "acceptance-test"
-  }
-}
-
-let subnet_b = awscc.ec2.subnet {
-  vpc_id            = vpc.vpc_id
-  cidr_block        = "10.210.2.0/24"
-  availability_zone = "ap-northeast-1c"
-
-  tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-b"
-    Environment = "acceptance-test"
-  }
-}
-
-let tgw = awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach"
 
   tags = {
     Name        = "carina-acc-test-cbd-tgw-attach"
@@ -50,9 +29,27 @@ let tgw = awscc.ec2.transit_gateway {
   }
 }
 
+let tgw_a = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach-a"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-a"
+    Environment = "acceptance-test"
+  }
+}
+
+let tgw_b = awscc.ec2.transit_gateway {
+  description = "carina-acc-test-cbd-tgw-attach-b"
+
+  tags = {
+    Name        = "carina-acc-test-cbd-tgw-attach-b"
+    Environment = "acceptance-test"
+  }
+}
+
 awscc.ec2.transit_gateway_attachment {
-  subnet_ids         = [subnet_b.subnet_id]
-  transit_gateway_id = tgw.id
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw_b.id
   vpc_id             = vpc.vpc_id
 
   lifecycle {

--- a/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
+++ b/carina-provider-awscc/acceptance-tests/create_before_destroy/run.sh
@@ -7,7 +7,7 @@
 # Tests:
 #   iam_role                      - Replacement with temporary name (name_attribute + other create-only)
 #   ec2_vpc                       - Replacement without temporary name (no name_attribute)
-#   ec2_transit_gateway_attachment - Replacement with dependent resource rewiring (subnet_ids change)
+#   ec2_transit_gateway_attachment - Replacement via transit_gateway_id change (create-only property)
 #
 # Filter (optional): substring to match test names (e.g. "iam_role", "ec2_vpc", "ec2_transit")
 
@@ -80,6 +80,10 @@ get_identifiers() {
 
 # Assert that two identifier sets match the expected relationship
 # Args: description ids_after_step1 ids_after_step2 expected("equal"|"different")
+#
+# For "different" mode, uses set-based comparison (comm -3) to check if at least
+# one identifier differs between the two sets. This handles the case where most
+# resources keep the same identifiers but only the replaced resource changes.
 assert_identifiers() {
     local description="$1"
     local ids1="$2"
@@ -109,13 +113,17 @@ assert_identifiers() {
             return 1
         fi
     else
-        if [ "$ids1" != "$ids2" ]; then
+        # Use comm -3 to find lines unique to either set (symmetric difference).
+        # If there are any unique lines, at least one identifier changed.
+        local diff_lines
+        diff_lines=$(comm -3 <(echo "$ids1") <(echo "$ids2"))
+        if [ -n "$diff_lines" ]; then
             echo "OK"
             TOTAL_PASSED=$((TOTAL_PASSED + 1))
             return 0
         else
             echo "FAIL"
-            echo "  ERROR: Identifiers unchanged (expected different): $ids1"
+            echo "  ERROR: Identifiers unchanged (expected at least one to differ): $ids1"
             TOTAL_FAILED=$((TOTAL_FAILED + 1))
             return 1
         fi
@@ -289,12 +297,12 @@ run_test "ec2_vpc" \
     "$SCRIPT_DIR/ec2_vpc_step2.crn" \
     "Test 2: EC2 VPC (no name_attribute, no temporary name)"
 
-# Test 3: EC2 Transit Gateway Attachment - replacement with dependent resource rewiring
-# subnet_ids is create-only; changing it forces replacement while VPC/TGW refs must be rewired
+# Test 3: EC2 Transit Gateway Attachment - replacement via transit_gateway_id change
+# transit_gateway_id is create-only; changing it forces replacement
 run_test "ec2_transit_gateway_attachment" \
     "$SCRIPT_DIR/ec2_transit_gateway_attachment_step1.crn" \
     "$SCRIPT_DIR/ec2_transit_gateway_attachment_step2.crn" \
-    "Test 3: EC2 Transit Gateway Attachment (dependent resource rewiring)"
+    "Test 3: EC2 Transit Gateway Attachment (transit_gateway_id change)"
 
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"


### PR DESCRIPTION
## Summary
- Rewrite the EC2 Transit Gateway Attachment test (Test 3) to actually trigger replacement by changing `transit_gateway_id` (which IS create-only) instead of `subnet_ids` (which is NOT create-only)
- Both steps now define two TGWs (tgw_a and tgw_b); step1 attaches to tgw_a, step2 attaches to tgw_b with `create_before_destroy`
- Fix `assert_identifiers` "different" mode in both providers' `create_before_destroy/run.sh` to use `comm -3` set-based comparison instead of full string equality, so it correctly detects when only the replaced resource's identifier changes

Closes #862

## Test plan
- [ ] Run awscc create_before_destroy acceptance tests (`run.sh ec2_transit`)
- [ ] Verify the TGW attachment is actually replaced (new identifier)
- [ ] Verify dependent resources (VPC, subnet, TGWs) keep their identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)