### PR TITLE
fix: re-resolve ResourceRefs in Update effects after CBD replacement

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -76,6 +76,7 @@ pub async fn execute_effects(
     provider: &dyn Provider,
     binding_map: &mut HashMap<String, HashMap<String, Value>>,
     current_states: &mut HashMap<ResourceId, State>,
+    unresolved_resources: &HashMap<ResourceId, Resource>,
 ) -> ApplyResult {
     let mut success_count = 0;
     let mut failure_count = 0;
@@ -144,9 +145,14 @@ pub async fn execute_effects(
                 }
             }
             Effect::Update { id, from, to, .. } => {
-                // Re-resolve references
+                // Re-resolve references from unresolved resource if available.
+                // The `to` in the effect may contain stale pre-resolved values when
+                // a dependency was replaced via create_before_destroy. Using the
+                // unresolved resource's attributes (which still contain ResourceRef
+                // values) ensures we resolve against the updated binding_map.
+                let resolve_source = unresolved_resources.get(id).unwrap_or(to);
                 let mut resolved_to = to.clone();
-                for (key, value) in &to.attributes {
+                for (key, value) in &resolve_source.attributes {
                     resolved_to
                         .attributes
                         .insert(key.clone(), resolve_ref_value(value, binding_map));
@@ -1056,7 +1062,20 @@ async fn run_apply_locked(
     println!("{}", "Applying changes...".cyan().bold());
     println!();
 
-    let result = execute_effects(&plan, &provider, &mut binding_map, &mut current_states).await;
+    // Build unresolved resource map for re-resolution at apply time
+    let unresolved_resources: HashMap<ResourceId, Resource> = sorted_resources
+        .iter()
+        .map(|r| (r.id.clone(), r.clone()))
+        .collect();
+
+    let result = execute_effects(
+        &plan,
+        &provider,
+        &mut binding_map,
+        &mut current_states,
+        &unresolved_resources,
+    )
+    .await;
 
     finalize_apply(
         &result,
@@ -1292,7 +1311,20 @@ async fn run_apply_from_plan_locked(
     println!("{}", "Applying changes...".cyan().bold());
     println!();
 
-    let result = execute_effects(plan, &provider, &mut binding_map, &mut current_states).await;
+    // Build unresolved resource map for re-resolution at apply time
+    let unresolved_resources: HashMap<ResourceId, Resource> = sorted_resources
+        .iter()
+        .map(|r| (r.id.clone(), r.clone()))
+        .collect();
+
+    let result = execute_effects(
+        plan,
+        &provider,
+        &mut binding_map,
+        &mut current_states,
+        &unresolved_resources,
+    )
+    .await;
 
     finalize_apply(
         &result,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -12,8 +12,8 @@ use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value}
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
 
 use crate::commands::apply::{
-    ApplyResult, ApplyStateSave, build_state_after_apply, detect_drift, finalize_apply,
-    queue_state_refresh, refresh_pending_states,
+    ApplyResult, ApplyStateSave, build_state_after_apply, detect_drift, execute_effects,
+    finalize_apply, queue_state_refresh, refresh_pending_states,
 };
 use crate::commands::plan::{CurrentStateEntry, PlanFile};
 use crate::wiring::{
@@ -1368,5 +1368,221 @@ async fn lock_released_on_write_state_failure() {
     assert!(
         lock_released.load(Ordering::SeqCst),
         "Lock should be released even when write_state fails"
+    );
+}
+
+/// Mock provider that records update calls for verification.
+/// Used to test that dependents with their own Update effects get the new
+/// (post-replacement) dependency IDs, not stale pre-replacement IDs.
+struct RecordingProvider {
+    /// Tracks the `to` resource passed to each update call, keyed by resource ID string.
+    update_calls: std::sync::Mutex<Vec<(String, Resource)>>,
+}
+
+impl RecordingProvider {
+    fn new() -> Self {
+        Self {
+            update_calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn get_update_calls(&self) -> Vec<(String, Resource)> {
+        self.update_calls.lock().unwrap().clone()
+    }
+}
+
+impl Provider for RecordingProvider {
+    fn name(&self) -> &'static str {
+        "test"
+    }
+
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: Option<&str>,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(State::not_found(id)) })
+    }
+
+    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        // Return a state with a new identifier to simulate resource creation
+        let mut attrs = resource.attributes.clone();
+        // Simulate AWS returning a new ID
+        attrs.insert("vpc_id".to_string(), Value::String("vpc-NEW".to_string()));
+        let state = State::existing(resource.id.clone(), attrs).with_identifier("vpc-NEW");
+        Box::pin(async move { Ok(state) })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _from: &State,
+        to: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        self.update_calls
+            .lock()
+            .unwrap()
+            .push((id.to_string(), to.clone()));
+        let state =
+            State::existing(id.clone(), to.attributes.clone()).with_identifier("subnet-123");
+        Box::pin(async move { Ok(state) })
+    }
+
+    fn delete(
+        &self,
+        _id: &ResourceId,
+        _identifier: &str,
+        _lifecycle: &LifecycleConfig,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+/// Regression test for #865: when a resource is replaced via create_before_destroy
+/// and a dependent resource has its own Update effect, the dependent's `to` state
+/// should reference the new (post-replacement) resource ID, not the old one.
+#[tokio::test]
+async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
+    let vpc_id = ResourceId::new("ec2.vpc", "my-vpc");
+    let subnet_id = ResourceId::new("ec2.subnet", "my-subnet");
+
+    // --- Unresolved resources (before ref resolution) ---
+    let vpc_unresolved = Resource::new("ec2.vpc", "my-vpc")
+        .with_attribute("_binding", Value::String("vpc".to_string()))
+        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+
+    let subnet_unresolved = Resource::new("ec2.subnet", "my-subnet")
+        .with_attribute("_binding", Value::String("subnet".to_string()))
+        .with_attribute(
+            "vpc_id",
+            Value::ResourceRef {
+                binding_name: "vpc".to_string(),
+                attribute_name: "vpc_id".to_string(),
+            },
+        )
+        .with_attribute("cidr_block", Value::String("10.1.2.0/24".to_string()));
+
+    // --- Resolved resources (after ref resolution with old state) ---
+    // The subnet's vpc_id has been eagerly resolved to "vpc-OLD"
+    let subnet_resolved = Resource::new("ec2.subnet", "my-subnet")
+        .with_attribute("_binding", Value::String("subnet".to_string()))
+        .with_attribute("vpc_id", Value::String("vpc-OLD".to_string()))
+        .with_attribute("cidr_block", Value::String("10.1.2.0/24".to_string()));
+
+    // --- Current states ---
+    let mut current_states = HashMap::new();
+
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.0.0.0/16".to_string()),
+    );
+    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-OLD".to_string()));
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-OLD"),
+    );
+
+    let mut subnet_attrs = HashMap::new();
+    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-OLD".to_string()));
+    subnet_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.1.1.0/24".to_string()),
+    );
+    current_states.insert(
+        subnet_id.clone(),
+        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
+    );
+
+    // --- Build plan ---
+    // VPC: Replace with create_before_destroy (no cascading updates for subnet
+    //       because subnet already has its own Update effect)
+    // Subnet: Update (cidr_block changed, vpc_id eagerly resolved to old value)
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc_unresolved
+            .clone()
+            .with_attribute("_binding", Value::String("vpc".to_string())),
+        lifecycle: LifecycleConfig {
+            force_delete: false,
+            create_before_destroy: true,
+        },
+        changed_create_only: vec!["cidr_block".to_string()],
+        cascading_updates: vec![],
+        temporary_name: None,
+    });
+    plan.add(Effect::Update {
+        id: subnet_id.clone(),
+        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
+        to: subnet_resolved.clone(), // Has stale "vpc-OLD" in vpc_id
+        changed_attributes: vec!["cidr_block".to_string()],
+    });
+
+    // --- Initial binding map (with old state) ---
+    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    binding_map.insert(
+        "vpc".to_string(),
+        HashMap::from([
+            ("vpc_id".to_string(), Value::String("vpc-OLD".to_string())),
+            (
+                "cidr_block".to_string(),
+                Value::String("10.0.0.0/16".to_string()),
+            ),
+            ("_binding".to_string(), Value::String("vpc".to_string())),
+        ]),
+    );
+    binding_map.insert(
+        "subnet".to_string(),
+        HashMap::from([
+            ("vpc_id".to_string(), Value::String("vpc-OLD".to_string())),
+            (
+                "cidr_block".to_string(),
+                Value::String("10.1.1.0/24".to_string()),
+            ),
+            ("_binding".to_string(), Value::String("subnet".to_string())),
+        ]),
+    );
+
+    // --- Unresolved resource map ---
+    let unresolved_resources: HashMap<ResourceId, Resource> = HashMap::from([
+        (vpc_id.clone(), vpc_unresolved),
+        (subnet_id.clone(), subnet_unresolved),
+    ]);
+
+    // --- Execute ---
+    let provider = RecordingProvider::new();
+    let result = execute_effects(
+        &plan,
+        &provider,
+        &mut binding_map,
+        &mut current_states,
+        &unresolved_resources,
+    )
+    .await;
+
+    assert_eq!(result.success_count, 2, "Both effects should succeed");
+    assert_eq!(result.failure_count, 0, "No effects should fail");
+
+    // --- Verify the subnet update received the NEW vpc_id ---
+    let update_calls = provider.get_update_calls();
+    let subnet_update = update_calls
+        .iter()
+        .find(|(id_str, _)| id_str.contains("subnet"))
+        .expect("Should have an update call for subnet");
+
+    let vpc_id_in_update = subnet_update
+        .1
+        .attributes
+        .get("vpc_id")
+        .expect("subnet update should have vpc_id attribute");
+
+    assert_eq!(
+        *vpc_id_in_update,
+        Value::String("vpc-NEW".to_string()),
+        "Subnet update should reference the NEW vpc_id (vpc-NEW), not the stale old one (vpc-OLD)"
     );
 }


### PR DESCRIPTION
## Summary

- Fix stale dependency IDs in Update effects when a dependency is replaced via `create_before_destroy`
- Pass unresolved resources (containing `ResourceRef` values) to `execute_effects` so the Update handler can re-resolve against the post-replacement `binding_map`
- Add regression test verifying that a subnet's `vpc_id` gets the new VPC ID after the VPC is replaced

## Problem

When a resource is replaced via `create_before_destroy` and a dependent resource has its own `Update` effect (e.g., its `cidr_block` also changed), the cascade logic correctly skips the dependent (to avoid duplicates). However, the dependent's `to` state was eagerly resolved before planning and contained the old (pre-replacement) VPC ID. At apply time, `resolve_ref_value` on these already-resolved string values was a no-op, so the update was sent with stale references.

## Fix

`execute_effects` now receives an `unresolved_resources` map (ResourceId -> Resource with original `ResourceRef` values). In the `Update` handler, if an unresolved resource exists for the effect's ID, its attributes are used as the resolution source instead of the pre-resolved `to.attributes`. This ensures `resolve_ref_value` can actually resolve `ResourceRef` values against the current (post-replacement) `binding_map`.

## Test plan

- [x] New test `update_effect_resolves_refs_against_post_replacement_binding_map` verifies the fix
- [x] All 48 `carina-cli` tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)