### PR TITLE
fix: refresh orphaned resources during state refresh

### DIFF
--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
-use carina_core::resource::{LifecycleConfig, ResourceId, State, Value};
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, ResourceState, StateBackend, create_backend,
@@ -250,7 +250,7 @@ pub async fn run_state_refresh(path: &PathBuf) -> Result<(), AppError> {
     release_result
 }
 
-async fn run_state_refresh_locked(
+pub(crate) async fn run_state_refresh_locked(
     parsed: &mut carina_core::parser::ParsedFile,
     backend: &dyn StateBackend,
 ) -> Result<(), AppError> {
@@ -296,6 +296,32 @@ async fn run_state_refresh_locked(
             .await
             .map_err(AppError::Provider)?;
         current_states.insert(resource.id.clone(), fresh_state);
+    }
+
+    // Also read states for orphaned resources (in state but removed from config)
+    let desired_ids: HashSet<ResourceId> = sorted_resources.iter().map(|r| r.id.clone()).collect();
+    let orphan_ids: Vec<(ResourceId, String)> = state_file
+        .as_ref()
+        .map(|sf| {
+            sf.resources
+                .iter()
+                .filter_map(|rs| {
+                    let id = ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
+                    if desired_ids.contains(&id) {
+                        return None;
+                    }
+                    rs.identifier.as_ref().map(|ident| (id, ident.clone()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for (id, identifier) in &orphan_ids {
+        let fresh_state = provider
+            .read(id, Some(identifier.as_str()))
+            .await
+            .map_err(AppError::Provider)?;
+        current_states.insert(id.clone(), fresh_state);
     }
 
     // Restore unreturned attributes from state file (CloudControl doesn't always return them)
@@ -421,6 +447,121 @@ async fn run_state_refresh_locked(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 &resource.id.name,
+            );
+        }
+    }
+
+    // Process orphaned resources (in state but removed from config)
+    for (orphan_id, _) in &orphan_ids {
+        let fresh_state = match current_states.get(orphan_id) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let existing = state.find_resource(
+            &orphan_id.provider,
+            &orphan_id.resource_type,
+            &orphan_id.name,
+        );
+
+        let mut has_changes = false;
+        let mut changes: Vec<String> = Vec::new();
+
+        if let Some(existing_rs) = existing {
+            let old_attrs: HashMap<String, Value> = existing_rs
+                .attributes
+                .iter()
+                .filter_map(|(k, v)| json_to_dsl_value(v).map(|val| (k.clone(), val)))
+                .collect();
+
+            if !fresh_state.exists {
+                has_changes = true;
+                changes.push(format!("    {} resource no longer exists", "-".red()));
+            } else {
+                let mut all_keys: HashSet<&String> = old_attrs.keys().collect();
+                all_keys.extend(fresh_state.attributes.keys());
+
+                let mut sorted_keys: Vec<&&String> = all_keys.iter().collect();
+                sorted_keys.sort();
+
+                for key in sorted_keys {
+                    let old_val = old_attrs.get(*key);
+                    let new_val = fresh_state.attributes.get(*key);
+
+                    match (old_val, new_val) {
+                        (Some(old), Some(new)) if old != new => {
+                            has_changes = true;
+                            changes.push(format!(
+                                "    {} {}: {} {} {}",
+                                "~".yellow(),
+                                key,
+                                format_value(old).red(),
+                                "→".dimmed(),
+                                format_value(new).green(),
+                            ));
+                        }
+                        (Some(old), None) => {
+                            has_changes = true;
+                            changes.push(format!(
+                                "    {} {}: {}",
+                                "-".red(),
+                                key,
+                                format_value(old).red(),
+                            ));
+                        }
+                        (None, Some(new)) => {
+                            has_changes = true;
+                            changes.push(format!(
+                                "    {} {}: {}",
+                                "+".green(),
+                                key,
+                                format_value(new).green(),
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        } else {
+            continue;
+        }
+
+        if has_changes {
+            updated_count += 1;
+            println!(
+                "  {} \"{}\" (orphan):",
+                orphan_id.display_type().cyan(),
+                orphan_id.name
+            );
+            for change in &changes {
+                println!("{}", change);
+            }
+            println!();
+        } else {
+            unchanged_count += 1;
+        }
+
+        // Update state with refreshed data
+        if fresh_state.exists {
+            // Construct a minimal Resource from the orphan's state data for from_provider_state
+            let orphan_resource = Resource::with_provider(
+                &orphan_id.provider,
+                &orphan_id.resource_type,
+                &orphan_id.name,
+            );
+            let existing_rs = state.find_resource(
+                &orphan_id.provider,
+                &orphan_id.resource_type,
+                &orphan_id.name,
+            );
+            let resource_state =
+                ResourceState::from_provider_state(&orphan_resource, fresh_state, existing_rs)?;
+            state.upsert_resource(resource_state);
+        } else {
+            state.remove_resource(
+                &orphan_id.provider,
+                &orphan_id.resource_type,
+                &orphan_id.name,
             );
         }
     }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -16,12 +16,14 @@ use crate::commands::apply::{
     finalize_apply, queue_state_refresh, refresh_pending_states,
 };
 use crate::commands::plan::{CurrentStateEntry, PlanFile};
+use crate::commands::state::run_state_refresh_locked;
 use crate::wiring::{
     compute_anonymous_identifiers, reconcile_prefixed_names, resolve_attr_prefixes, resolve_names,
     validate_resources,
 };
 use carina_core::parser::BackendConfig;
 use carina_core::provider::Provider;
+use std::sync::Mutex;
 
 struct TestProvider {
     read_results: HashMap<(String, String), Result<State, String>>,
@@ -1584,5 +1586,125 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         *vpc_id_in_update,
         Value::String("vpc-NEW".to_string()),
         "Subnet update should reference the NEW vpc_id (vpc-NEW), not the stale old one (vpc-OLD)"
+    );
+}
+
+/// A mock StateBackend that returns a pre-configured state and captures writes.
+struct RefreshTestBackend {
+    initial_state: Option<StateFile>,
+    written_state: Mutex<Option<StateFile>>,
+}
+
+impl RefreshTestBackend {
+    fn new(state: StateFile) -> Self {
+        Self {
+            initial_state: Some(state),
+            written_state: Mutex::new(None),
+        }
+    }
+
+    fn get_written_state(&self) -> Option<StateFile> {
+        self.written_state.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl StateBackend for RefreshTestBackend {
+    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
+        Ok(self.initial_state.clone())
+    }
+    async fn write_state(&self, state: &StateFile) -> carina_state::BackendResult<()> {
+        *self.written_state.lock().unwrap() = Some(state.clone());
+        Ok(())
+    }
+    async fn acquire_lock(&self, operation: &str) -> carina_state::BackendResult<LockInfo> {
+        Ok(LockInfo::new(operation))
+    }
+    async fn release_lock(&self, _lock: &LockInfo) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn renew_lock(&self, lock: &LockInfo) -> carina_state::BackendResult<LockInfo> {
+        Ok(lock.renewed())
+    }
+    async fn write_state_locked(
+        &self,
+        state: &carina_state::StateFile,
+        _lock: &LockInfo,
+    ) -> carina_state::BackendResult<()> {
+        self.write_state(state).await
+    }
+    async fn force_unlock(&self, _lock_id: &str) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn init(&self) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn bucket_exists(&self) -> carina_state::BackendResult<bool> {
+        Ok(true)
+    }
+    async fn create_bucket(&self) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    fn resource_type(&self) -> Option<&str> {
+        None
+    }
+    fn provider_name(&self) -> Option<&str> {
+        None
+    }
+    fn resource_definition(&self, _bucket_name: &str) -> Option<String> {
+        None
+    }
+}
+
+/// Regression test for #879: state refresh should handle orphaned resources
+/// (resources in state but removed from config).
+#[tokio::test]
+async fn state_refresh_removes_orphaned_resource_deleted_externally() {
+    // State has two resources: "keep-bucket" (in config) and "orphan-bucket" (not in config)
+    let mut state = StateFile::new();
+    state.upsert_resource(
+        ResourceState::new("s3.bucket", "keep-bucket", "")
+            .with_identifier("keep-bucket")
+            .with_attribute("bucket", json!("keep-bucket")),
+    );
+    state.upsert_resource(
+        ResourceState::new("s3.bucket", "orphan-bucket", "")
+            .with_identifier("orphan-bucket")
+            .with_attribute("bucket", json!("orphan-bucket")),
+    );
+
+    let backend = RefreshTestBackend::new(state);
+
+    // Config only has "keep-bucket" -- "orphan-bucket" was removed from .crn
+    let mut parsed = ParsedFile {
+        providers: vec![],
+        backend: None,
+        resources: vec![
+            Resource::new("s3.bucket", "keep-bucket")
+                .with_attribute("bucket", Value::String("keep-bucket".to_string())),
+        ],
+        variables: HashMap::new(),
+        imports: vec![],
+        module_calls: vec![],
+        inputs: vec![],
+        outputs: vec![],
+    };
+
+    // MockProvider returns not_found for both resources (simulates external deletion)
+    let result = run_state_refresh_locked(&mut parsed, &backend).await;
+    assert!(result.is_ok(), "refresh should succeed: {:?}", result);
+
+    // Verify the written state
+    let written = backend
+        .get_written_state()
+        .expect("state should be written");
+
+    // "orphan-bucket" should have been removed from state since it was deleted externally
+    // and the refresh should have visited it
+    assert!(
+        written
+            .find_resource("", "s3.bucket", "orphan-bucket")
+            .is_none(),
+        "Orphaned resource should be removed from state after refresh (issue #879)"
     );
 }


### PR DESCRIPTION
## Summary

- Fix `carina state refresh` to also iterate over orphaned resources (tracked in state but removed from config)
- Orphaned resources are now read from the provider and removed from state if they no longer exist, or updated if their attributes changed

Closes #879

## Test plan

- [x] Added `state_refresh_removes_orphaned_resource_deleted_externally` test that verifies orphaned resources are removed from state after refresh
- [x] All existing tests pass (`cargo test -p carina-cli`)
- [x] `cargo fmt` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)