### PR TITLE
feat: add --lock=false option to skip state locking

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -481,6 +481,9 @@ pub async fn execute_effects(
 }
 
 /// Save state after apply. Does NOT release the lock -- caller is responsible.
+///
+/// When `lock` is `None` (i.e. `--lock=false`), state is written without lock
+/// validation via `save_state_unlocked`.
 pub async fn finalize_apply(
     result: &ApplyResult,
     state_file: Option<StateFile>,
@@ -488,7 +491,7 @@ pub async fn finalize_apply(
     current_states: &HashMap<ResourceId, State>,
     plan: &Plan,
     backend: &dyn StateBackend,
-    lock: &LockInfo,
+    lock: Option<&LockInfo>,
 ) -> Result<(), AppError> {
     println!();
     println!("{}", "Saving state...".cyan());
@@ -504,7 +507,11 @@ pub async fn finalize_apply(
         failed_refreshes: &result.failed_refreshes,
     })?;
 
-    save_state_locked(backend, lock, &mut state).await?;
+    if let Some(lock) = lock {
+        save_state_locked(backend, lock, &mut state).await?;
+    } else {
+        save_state_unlocked(backend, &mut state).await?;
+    }
     println!("  {} State saved (serial: {})", "✓".green(), state.serial);
 
     Ok(())
@@ -526,6 +533,18 @@ pub async fn save_state_locked(
         .write_state_locked(state, &renewed)
         .await
         .map_err(AppError::Backend)
+}
+
+/// Write state without lock validation.
+///
+/// Used when `--lock=false` is specified. Increments the serial number and
+/// writes using `write_state` (no lock check).
+pub async fn save_state_unlocked(
+    backend: &dyn StateBackend,
+    state: &mut StateFile,
+) -> Result<(), AppError> {
+    state.increment_serial();
+    backend.write_state(state).await.map_err(AppError::Backend)
 }
 
 pub fn queue_state_refresh(
@@ -736,7 +755,7 @@ pub async fn detect_drift(
     }
 }
 
-pub async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), AppError> {
+pub async fn run_apply(path: &PathBuf, auto_approve: bool, lock: bool) -> Result<(), AppError> {
     let ctx = WiringContext::new();
     let loaded = load_configuration(path)?;
     let mut parsed = loaded.parsed;
@@ -758,7 +777,7 @@ pub async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), AppErro
 
     // Handle bootstrap if S3 backend is configured
     #[allow(unused_assignments)]
-    let mut lock: Option<LockInfo> = None;
+    let mut lock_info: Option<LockInfo> = None;
 
     if let Some(config) = backend_config {
         // Check if bucket exists (bootstrap detection)
@@ -921,10 +940,12 @@ pub async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), AppErro
                 backend.init().await.map_err(AppError::Backend)?;
             }
         }
+    }
 
-        // Acquire lock
+    // Acquire lock (unless --lock=false)
+    if lock {
         println!("{}", "Acquiring state lock...".cyan());
-        lock = Some(
+        lock_info = Some(
             backend
                 .acquire_lock("apply")
                 .await
@@ -932,34 +953,37 @@ pub async fn run_apply(path: &PathBuf, auto_approve: bool) -> Result<(), AppErro
         );
         println!("  {} Lock acquired", "✓".green());
     } else {
-        // Local backend: acquire lock
-        println!("{}", "Acquiring state lock...".cyan());
-        lock = Some(
-            backend
-                .acquire_lock("apply")
-                .await
-                .map_err(map_lock_error)?,
+        println!(
+            "{}",
+            "Warning: State locking is disabled. This is unsafe if others might run commands against the same state."
+                .yellow()
+                .bold()
         );
-        println!("  {} Lock acquired", "✓".green());
     }
 
     // All code after lock acquisition is wrapped so that lock release is guaranteed
-    let lock_info = lock.as_ref().expect("lock should have been acquired");
-    let op_result =
-        run_apply_locked(&ctx, &mut parsed, auto_approve, backend.as_ref(), lock_info).await;
+    let op_result = run_apply_locked(
+        &ctx,
+        &mut parsed,
+        auto_approve,
+        backend.as_ref(),
+        lock_info.as_ref(),
+    )
+    .await;
 
-    // Always release lock, regardless of whether the operation succeeded
-    let release_result = backend
-        .release_lock(lock_info)
-        .await
-        .map_err(AppError::Backend);
+    // Always release lock if it was acquired
+    if let Some(ref li) = lock_info {
+        let release_result = backend.release_lock(li).await.map_err(AppError::Backend);
 
-    if release_result.is_ok() && op_result.is_ok() {
-        println!("  {} Lock released", "✓".green());
+        if release_result.is_ok() && op_result.is_ok() {
+            println!("  {} Lock released", "✓".green());
+        }
+
+        op_result?;
+        release_result
+    } else {
+        op_result
     }
-
-    op_result?;
-    release_result
 }
 
 async fn run_apply_locked(
@@ -967,7 +991,7 @@ async fn run_apply_locked(
     parsed: &mut carina_core::parser::ParsedFile,
     auto_approve: bool,
     backend: &dyn StateBackend,
-    lock: &LockInfo,
+    lock: Option<&LockInfo>,
 ) -> Result<(), AppError> {
     // Read current state from backend
     let state_file = backend.read_state().await.map_err(AppError::Backend)?;
@@ -1146,7 +1170,11 @@ async fn run_apply_locked(
     }
 }
 
-pub async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Result<(), AppError> {
+pub async fn run_apply_from_plan(
+    plan_path: &PathBuf,
+    auto_approve: bool,
+    lock: bool,
+) -> Result<(), AppError> {
     // Read and deserialize the plan file
     let content =
         fs::read_to_string(plan_path).map_err(|e| format!("Failed to read plan file: {}", e))?;
@@ -1192,33 +1220,53 @@ pub async fn run_apply_from_plan(plan_path: &PathBuf, auto_approve: bool) -> Res
         create_local_backend()
     };
 
-    // Acquire lock
-    println!("{}", "Acquiring state lock...".cyan());
-    let lock = backend
-        .acquire_lock("apply")
-        .await
-        .map_err(map_lock_error)?;
-    println!("  {} Lock acquired", "✓".green());
+    // Acquire lock (unless --lock=false)
+    let lock_info: Option<LockInfo> = if lock {
+        println!("{}", "Acquiring state lock...".cyan());
+        let li = backend
+            .acquire_lock("apply")
+            .await
+            .map_err(map_lock_error)?;
+        println!("  {} Lock acquired", "✓".green());
+        Some(li)
+    } else {
+        println!(
+            "{}",
+            "Warning: State locking is disabled. This is unsafe if others might run commands against the same state."
+                .yellow()
+                .bold()
+        );
+        None
+    };
 
-    let op_result =
-        run_apply_from_plan_locked(plan_file, auto_approve, backend.as_ref(), &lock).await;
+    let op_result = run_apply_from_plan_locked(
+        plan_file,
+        auto_approve,
+        backend.as_ref(),
+        lock_info.as_ref(),
+    )
+    .await;
 
-    // Always release lock, regardless of whether the operation succeeded
-    let release_result = backend.release_lock(&lock).await.map_err(AppError::Backend);
+    // Always release lock if it was acquired
+    if let Some(ref li) = lock_info {
+        let release_result = backend.release_lock(li).await.map_err(AppError::Backend);
 
-    if release_result.is_ok() && op_result.is_ok() {
-        println!("  {} Lock released", "✓".green());
+        if release_result.is_ok() && op_result.is_ok() {
+            println!("  {} Lock released", "✓".green());
+        }
+
+        op_result?;
+        release_result
+    } else {
+        op_result
     }
-
-    op_result?;
-    release_result
 }
 
 async fn run_apply_from_plan_locked(
     plan_file: PlanFile,
     auto_approve: bool,
     backend: &dyn StateBackend,
-    lock: &LockInfo,
+    lock: Option<&LockInfo>,
 ) -> Result<(), AppError> {
     // Read current state and validate lineage
     let state_file = backend.read_state().await.map_err(AppError::Backend)?;

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -25,7 +25,7 @@ use crate::wiring::{
     reconcile_prefixed_names,
 };
 
-pub async fn run_destroy(path: &PathBuf, auto_approve: bool) -> Result<(), AppError> {
+pub async fn run_destroy(path: &PathBuf, auto_approve: bool, lock: bool) -> Result<(), AppError> {
     let mut parsed = load_configuration(path)?.parsed;
 
     let base_dir = get_base_dir(path);
@@ -57,32 +57,47 @@ pub async fn run_destroy(path: &PathBuf, auto_approve: bool) -> Result<(), AppEr
         });
     }
 
-    // Acquire lock
-    println!("{}", "Acquiring state lock...".cyan());
-    let lock = backend
-        .acquire_lock("destroy")
-        .await
-        .map_err(map_lock_error)?;
-    println!("  {} Lock acquired", "✓".green());
+    // Acquire lock (unless --lock=false)
+    let lock_info: Option<LockInfo> = if lock {
+        println!("{}", "Acquiring state lock...".cyan());
+        let li = backend
+            .acquire_lock("destroy")
+            .await
+            .map_err(map_lock_error)?;
+        println!("  {} Lock acquired", "✓".green());
+        Some(li)
+    } else {
+        println!(
+            "{}",
+            "Warning: State locking is disabled. This is unsafe if others might run commands against the same state."
+                .yellow()
+                .bold()
+        );
+        None
+    };
 
     let op_result = run_destroy_locked(
         &mut parsed,
         auto_approve,
         backend.as_ref(),
         protected_bucket,
-        &lock,
+        lock_info.as_ref(),
     )
     .await;
 
-    // Always release lock, regardless of whether the operation succeeded
-    let release_result = backend.release_lock(&lock).await.map_err(AppError::Backend);
+    // Always release lock if it was acquired
+    if let Some(ref li) = lock_info {
+        let release_result = backend.release_lock(li).await.map_err(AppError::Backend);
 
-    if release_result.is_ok() && op_result.is_ok() {
-        println!("  {} Lock released", "✓".green());
+        if release_result.is_ok() && op_result.is_ok() {
+            println!("  {} Lock released", "✓".green());
+        }
+
+        op_result?;
+        release_result
+    } else {
+        op_result
     }
-
-    op_result?;
-    release_result
 }
 
 async fn run_destroy_locked(
@@ -90,7 +105,7 @@ async fn run_destroy_locked(
     auto_approve: bool,
     backend: &dyn StateBackend,
     protected_bucket: Option<String>,
-    lock: &LockInfo,
+    lock: Option<&LockInfo>,
 ) -> Result<(), AppError> {
     let ctx = WiringContext::new();
 
@@ -439,8 +454,12 @@ async fn run_destroy_locked(
         state.remove_resource(&id.provider, &id.resource_type, &id.name);
     }
 
-    // Renew lock and save with lock validation
-    crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;
+    // Save state (with or without lock validation)
+    if let Some(lock) = lock {
+        crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;
+    } else {
+        crate::commands::apply::save_state_unlocked(backend, &mut state).await?;
+    }
     println!("  {} State saved (serial: {})", "✓".green(), state.serial);
 
     println!();

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -60,6 +60,10 @@ pub enum StateCommands {
         /// Path to .crn file or directory
         #[arg(default_value = ".")]
         path: PathBuf,
+
+        /// Enable/disable state locking (default: true)
+        #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
+        lock: bool,
     },
 }
 
@@ -71,7 +75,7 @@ pub async fn run_state_command(command: StateCommands) -> Result<(), AppError> {
             force,
             path,
         } => run_state_bucket_delete(&bucket_name, force, &path).await,
-        StateCommands::Refresh { path } => run_state_refresh(&path).await,
+        StateCommands::Refresh { path, lock } => run_state_refresh(&path, lock).await,
     }
 }
 
@@ -216,7 +220,7 @@ async fn run_state_bucket_delete(
 }
 
 /// Run state refresh command
-pub async fn run_state_refresh(path: &PathBuf) -> Result<(), AppError> {
+pub async fn run_state_refresh(path: &PathBuf, lock: bool) -> Result<(), AppError> {
     let loaded = load_configuration(path)?;
     let mut parsed = loaded.parsed;
 
@@ -234,27 +238,43 @@ pub async fn run_state_refresh(path: &PathBuf) -> Result<(), AppError> {
         create_local_backend()
     };
 
-    // Acquire lock
-    println!("{}", "Acquiring state lock...".cyan());
-    let lock = backend
-        .acquire_lock("refresh")
-        .await
-        .map_err(map_lock_error)?;
-    println!("  {} Lock acquired", "✓".green());
+    // Acquire lock (unless --lock=false)
+    let lock_info: Option<LockInfo> = if lock {
+        println!("{}", "Acquiring state lock...".cyan());
+        let li = backend
+            .acquire_lock("refresh")
+            .await
+            .map_err(map_lock_error)?;
+        println!("  {} Lock acquired", "✓".green());
+        Some(li)
+    } else {
+        println!(
+            "{}",
+            "Warning: State locking is disabled. This is unsafe if others might run commands against the same state."
+                .yellow()
+                .bold()
+        );
+        None
+    };
 
-    let op_result = run_state_refresh_locked(&mut parsed, backend.as_ref(), &lock).await;
+    let op_result =
+        run_state_refresh_locked(&mut parsed, backend.as_ref(), lock_info.as_ref()).await;
 
-    // Always release lock, regardless of whether the operation succeeded
-    let release_result = backend.release_lock(&lock).await.map_err(AppError::Backend);
+    // Always release lock if it was acquired
+    if let Some(ref li) = lock_info {
+        let release_result = backend.release_lock(li).await.map_err(AppError::Backend);
 
-    op_result?;
-    release_result
+        op_result?;
+        release_result
+    } else {
+        op_result
+    }
 }
 
 pub(crate) async fn run_state_refresh_locked(
     parsed: &mut carina_core::parser::ParsedFile,
     backend: &dyn StateBackend,
-    lock: &LockInfo,
+    lock: Option<&LockInfo>,
 ) -> Result<(), AppError> {
     let ctx = WiringContext::new();
 
@@ -572,8 +592,12 @@ pub(crate) async fn run_state_refresh_locked(
         }
     }
 
-    // Renew lock and save with lock validation
-    crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;
+    // Save state (with or without lock validation)
+    if let Some(lock) = lock {
+        crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;
+    } else {
+        crate::commands::apply::save_state_unlocked(backend, &mut state).await?;
+    }
 
     // Summary
     println!(

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -57,6 +57,10 @@ enum Commands {
         /// Skip confirmation prompt (auto-approve)
         #[arg(long)]
         auto_approve: bool,
+
+        /// Enable/disable state locking (default: true)
+        #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
+        lock: bool,
     },
     /// Destroy all resources defined in the configuration file
     Destroy {
@@ -67,6 +71,10 @@ enum Commands {
         /// Skip confirmation prompt (auto-approve)
         #[arg(long)]
         auto_approve: bool,
+
+        /// Enable/disable state locking (default: true)
+        #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
+        lock: bool,
     },
     /// Format .crn files
     Fmt {
@@ -149,14 +157,22 @@ async fn main() {
     let result = match cli.command {
         Commands::Validate { path } => run_validate(&path),
         Commands::Plan { .. } => unreachable!(),
-        Commands::Apply { path, auto_approve } => {
+        Commands::Apply {
+            path,
+            auto_approve,
+            lock,
+        } => {
             if path.extension().is_some_and(|ext| ext == "json") {
-                run_apply_from_plan(&path, auto_approve).await
+                run_apply_from_plan(&path, auto_approve, lock).await
             } else {
-                run_apply(&path, auto_approve).await
+                run_apply(&path, auto_approve, lock).await
             }
         }
-        Commands::Destroy { path, auto_approve } => run_destroy(&path, auto_approve).await,
+        Commands::Destroy {
+            path,
+            auto_approve,
+            lock,
+        } => run_destroy(&path, auto_approve, lock).await,
         Commands::Fmt {
             path,
             check,

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1357,7 +1357,7 @@ async fn lock_released_on_write_state_failure() {
         &HashMap::new(),
         &Plan::new(),
         &backend,
-        &lock,
+        Some(&lock),
     )
     .await;
 
@@ -1487,7 +1487,7 @@ async fn finalize_apply_uses_write_state_locked() {
         &HashMap::new(),
         &Plan::new(),
         &backend,
-        &lock,
+        Some(&lock),
     )
     .await;
 
@@ -1934,7 +1934,7 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
 
     // MockProvider returns not_found for both resources (simulates external deletion)
     let lock = LockInfo::new("state-refresh");
-    let result = run_state_refresh_locked(&mut parsed, &backend, &lock).await;
+    let result = run_state_refresh_locked(&mut parsed, &backend, Some(&lock)).await;
     assert!(result.is_ok(), "refresh should succeed: {:?}", result);
 
     // Verify the written state
@@ -1949,6 +1949,73 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
             .find_resource("", "s3.bucket", "orphan-bucket")
             .is_none(),
         "Orphaned resource should be removed from state after refresh (issue #879)"
+    );
+}
+
+/// Test that save_state_unlocked uses write_state (not write_state_locked) and
+/// does NOT call renew_lock.
+#[tokio::test]
+async fn save_state_unlocked_uses_write_state_without_lock() {
+    use crate::commands::apply::save_state_unlocked;
+
+    let backend = LockTrackingBackend::new();
+    let mut state = StateFile::new();
+
+    let result = save_state_unlocked(&backend, &mut state).await;
+    assert!(result.is_ok(), "save_state_unlocked should succeed");
+
+    assert!(
+        backend.write_state_called.load(Ordering::SeqCst),
+        "save_state_unlocked must call write_state"
+    );
+    assert!(
+        !backend.renew_lock_called.load(Ordering::SeqCst),
+        "save_state_unlocked must NOT call renew_lock"
+    );
+    assert!(
+        !backend.write_state_locked_called.load(Ordering::SeqCst),
+        "save_state_unlocked must NOT call write_state_locked"
+    );
+}
+
+/// Test that finalize_apply with lock=None uses write_state (unlocked path).
+#[tokio::test]
+async fn finalize_apply_without_lock_uses_write_state() {
+    let backend = LockTrackingBackend::new();
+
+    let result = ApplyResult {
+        success_count: 0,
+        failure_count: 0,
+        skip_count: 0,
+        applied_states: HashMap::new(),
+        permanent_name_overrides: HashMap::new(),
+        successfully_deleted: HashSet::new(),
+        failed_refreshes: HashSet::new(),
+    };
+
+    let op_result = finalize_apply(
+        &result,
+        Some(StateFile::new()),
+        &[],
+        &HashMap::new(),
+        &Plan::new(),
+        &backend,
+        None, // No lock
+    )
+    .await;
+
+    assert!(op_result.is_ok(), "finalize_apply should succeed");
+    assert!(
+        backend.write_state_called.load(Ordering::SeqCst),
+        "finalize_apply without lock must use write_state"
+    );
+    assert!(
+        !backend.write_state_locked_called.load(Ordering::SeqCst),
+        "finalize_apply without lock must NOT use write_state_locked"
+    );
+    assert!(
+        !backend.renew_lock_called.load(Ordering::SeqCst),
+        "finalize_apply without lock must NOT call renew_lock"
     );
 }
 


### PR DESCRIPTION
## Summary

- Add `--lock` flag (default: `true`) to `apply`, `destroy`, and `state refresh` commands
- When `--lock=false` is specified, skip lock acquisition/release and use `write_state` instead of `write_state_locked`
- Print a warning when locking is disabled so users are aware of the risk

## Usage

```bash
carina apply --lock=false
carina destroy --lock=false
carina state refresh --lock=false
```

## Test plan

- [x] New test: `save_state_unlocked_uses_write_state_without_lock` verifies the unlocked write path uses `write_state` and skips `renew_lock`/`write_state_locked`
- [x] New test: `finalize_apply_without_lock_uses_write_state` verifies `finalize_apply` with `lock=None` uses the unlocked path
- [x] Existing tests updated and passing (55 unit tests + 10 integration tests)

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)