### PR TITLE
feat: add LSP completion for provider blocks

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -71,6 +71,7 @@ impl CompletionProvider {
                 attr_path,
                 field_name,
             } => self.value_completions_for_struct_field(&resource_type, &attr_path, &field_name),
+            CompletionContext::InsideProviderBlock { .. } => self.provider_block_completions(),
             CompletionContext::AfterProviderRegion => self.region_completions(),
             CompletionContext::AfterRefType => self.ref_type_completions(position, &text),
             CompletionContext::AfterInputDot => self.input_parameter_completions(&text),
@@ -115,6 +116,7 @@ impl CompletionProvider {
         let mut brace_depth: i32 = 0;
         let mut resource_type = String::new();
         let mut module_name: Option<String> = None;
+        let mut provider_block_name: Option<String> = None;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
 
@@ -130,6 +132,19 @@ impl CompletionProvider {
             {
                 resource_type = rt;
                 module_name = None;
+            } else if brace_depth == 0 && trimmed.starts_with("provider ") && trimmed.ends_with('{')
+            {
+                // Detect "provider <name> {"
+                let name = trimmed
+                    .strip_prefix("provider ")
+                    .unwrap()
+                    .trim_end_matches('{')
+                    .trim();
+                if !name.is_empty() {
+                    provider_block_name = Some(name.to_string());
+                    resource_type.clear();
+                    module_name = None;
+                }
             } else if brace_depth == 0
                 && trimmed.ends_with('{')
                 && !trimmed.starts_with("let ")
@@ -170,6 +185,7 @@ impl CompletionProvider {
                     if brace_depth == 0 {
                         resource_type.clear();
                         module_name = None;
+                        provider_block_name = None;
                         nested_block_names.clear();
                     } else {
                         // Truncate to current depth
@@ -198,6 +214,19 @@ impl CompletionProvider {
             return CompletionContext::InsideStructBlock {
                 resource_type: resource_type.clone(),
                 attr_path: nested_block_names,
+            };
+        }
+
+        // Check if we're inside a provider block
+        if brace_depth > 0
+            && let Some(ref pname) = provider_block_name
+        {
+            if prefix.contains('=') {
+                // After "region = " inside provider block -> show region completions
+                return CompletionContext::AfterProviderRegion;
+            }
+            return CompletionContext::InsideProviderBlock {
+                provider_name: pname.clone(),
             };
         }
 
@@ -395,6 +424,9 @@ enum CompletionContext {
         resource_type: String,
         attr_path: Vec<String>,
         field_name: String,
+    },
+    InsideProviderBlock {
+        provider_name: String,
     },
     AfterProviderRegion,
     AfterRefType,

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -603,3 +603,75 @@ fn ref_completion_with_empty_parens() {
         panic!("Expected CompletionTextEdit::Edit");
     }
 }
+
+#[test]
+fn provider_block_completion_suggests_region() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"provider awscc {
+    r
+}"#,
+    );
+    // Cursor after "r" inside provider block (line 1, col 5)
+    let position = Position {
+        line: 1,
+        character: 5,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Should have "region" as a completion
+    let region_completion = completions.iter().find(|c| c.label == "region");
+    assert!(
+        region_completion.is_some(),
+        "Should have 'region' attribute completion inside provider block. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn provider_block_region_value_completion() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"provider awscc {
+    region =
+}"#,
+    );
+    // Cursor after "region = " (line 1, col 12)
+    let position = Position {
+        line: 1,
+        character: 12,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Should have region value completions (like awscc.Region.ap_northeast_1)
+    let has_region_value = completions
+        .iter()
+        .any(|c| c.label.contains("Region.ap_northeast_1"));
+    assert!(
+        has_region_value,
+        "Should have region value completions after 'region = '. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn context_detection_inside_provider_block() {
+    let provider = test_provider();
+    let text = r#"provider awscc {
+    r
+}"#;
+    let context = provider.get_completion_context(
+        text,
+        Position {
+            line: 1,
+            character: 5,
+        },
+    );
+    assert!(
+        matches!(context, CompletionContext::InsideProviderBlock { ref provider_name } if provider_name == "awscc"),
+        "Should detect InsideProviderBlock context, got: {:?}",
+        context
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -203,6 +203,23 @@ impl CompletionProvider {
         }
     }
 
+    pub(super) fn provider_block_completions(&self) -> Vec<CompletionItem> {
+        let trigger_suggest = Command {
+            title: "Trigger Suggest".to_string(),
+            command: "editor.action.triggerSuggest".to_string(),
+            arguments: None,
+        };
+
+        vec![CompletionItem {
+            label: "region".to_string(),
+            kind: Some(CompletionItemKind::PROPERTY),
+            detail: Some("Provider region".to_string()),
+            insert_text: Some("region = ".to_string()),
+            command: Some(trigger_suggest),
+            ..Default::default()
+        }]
+    }
+
     pub(super) fn generic_value_completions(&self) -> Vec<CompletionItem> {
         let mut completions = vec![
             CompletionItem {


### PR DESCRIPTION
## Summary
- Add `InsideProviderBlock` variant to `CompletionContext` for detecting cursor position inside `provider <name> { }` blocks
- Suggest `region` attribute when typing inside provider blocks
- Show region value completions (e.g., `awscc.Region.ap_northeast_1`) after `region =`

Closes #897

## Test plan
- [x] `context_detection_inside_provider_block` - verifies `InsideProviderBlock` context is detected
- [x] `provider_block_completion_suggests_region` - verifies `region` attribute is suggested
- [x] `provider_block_region_value_completion` - verifies region values appear after `region =`
- [x] All 121 existing unit tests + 4 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)