### PR TITLE
fix: filter region completions by provider namespace

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -72,7 +72,9 @@ impl CompletionProvider {
                 field_name,
             } => self.value_completions_for_struct_field(&resource_type, &attr_path, &field_name),
             CompletionContext::InsideProviderBlock { .. } => self.provider_block_completions(),
-            CompletionContext::AfterProviderRegion => self.region_completions(),
+            CompletionContext::AfterProviderRegion { provider_name } => {
+                self.region_completions_for_provider(&provider_name)
+            }
             CompletionContext::AfterRefType => self.ref_type_completions(position, &text),
             CompletionContext::AfterInputDot => self.input_parameter_completions(&text),
             CompletionContext::None => vec![],
@@ -101,7 +103,9 @@ impl CompletionProvider {
             let dot_pattern = format!("{}.Region.", provider_name);
             let end_pattern = format!("{}.Region", provider_name);
             if prefix.contains(&dot_pattern) || prefix.ends_with(&end_pattern) {
-                return CompletionContext::AfterProviderRegion;
+                return CompletionContext::AfterProviderRegion {
+                    provider_name: provider_name.clone(),
+                };
             }
         }
 
@@ -223,7 +227,9 @@ impl CompletionProvider {
         {
             if prefix.contains('=') {
                 // After "region = " inside provider block -> show region completions
-                return CompletionContext::AfterProviderRegion;
+                return CompletionContext::AfterProviderRegion {
+                    provider_name: pname.clone(),
+                };
             }
             return CompletionContext::InsideProviderBlock {
                 provider_name: pname.clone(),
@@ -428,7 +434,9 @@ enum CompletionContext {
     InsideProviderBlock {
         provider_name: String,
     },
-    AfterProviderRegion,
+    AfterProviderRegion {
+        provider_name: String,
+    },
     AfterRefType,
     AfterInputDot,
     None,

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -675,3 +675,79 @@ fn context_detection_inside_provider_block() {
         context
     );
 }
+
+#[test]
+fn provider_block_region_completions_use_matching_namespace() {
+    let provider = test_provider();
+
+    // Inside "provider awscc { region = }", completions should only contain awscc.Region.*
+    let doc = create_document(
+        r#"provider awscc {
+    region =
+}"#,
+    );
+    let position = Position {
+        line: 1,
+        character: 12,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Should have awscc.Region completions
+    let has_awscc_region = completions
+        .iter()
+        .any(|c| c.label.starts_with("awscc.Region."));
+    assert!(
+        has_awscc_region,
+        "Inside 'provider awscc', should have awscc.Region.* completions. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+
+    // Should NOT have aws.Region completions
+    let has_aws_region = completions
+        .iter()
+        .any(|c| c.label.starts_with("aws.Region."));
+    assert!(
+        !has_aws_region,
+        "Inside 'provider awscc', should NOT have aws.Region.* completions. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn provider_block_region_completions_use_aws_namespace() {
+    let provider = test_provider();
+
+    // Inside "provider aws { region = }", completions should only contain aws.Region.*
+    let doc = create_document(
+        r#"provider aws {
+    region =
+}"#,
+    );
+    let position = Position {
+        line: 1,
+        character: 12,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Should have aws.Region completions
+    let has_aws_region = completions
+        .iter()
+        .any(|c| c.label.starts_with("aws.Region."));
+    assert!(
+        has_aws_region,
+        "Inside 'provider aws', should have aws.Region.* completions. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+
+    // Should NOT have awscc.Region completions
+    let has_awscc_region = completions
+        .iter()
+        .any(|c| c.label.starts_with("awscc.Region."));
+    assert!(
+        !has_awscc_region,
+        "Inside 'provider aws', should NOT have awscc.Region.* completions. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -253,6 +253,24 @@ impl CompletionProvider {
             .collect()
     }
 
+    pub(super) fn region_completions_for_provider(
+        &self,
+        provider_name: &str,
+    ) -> Vec<CompletionItem> {
+        let prefix = format!("{}.Region.", provider_name);
+        self.region_completions_data
+            .iter()
+            .filter(|c| c.value.starts_with(&prefix))
+            .map(|c| CompletionItem {
+                label: c.value.clone(),
+                kind: Some(CompletionItemKind::ENUM_MEMBER),
+                detail: Some(c.description.clone()),
+                insert_text: Some(c.value.clone()),
+                ..Default::default()
+            })
+            .collect()
+    }
+
     pub(super) fn cidr_completions(&self) -> Vec<CompletionItem> {
         let cidrs = vec![
             ("10.0.0.0/16", "VPC CIDR (65,536 IPs)"),


### PR DESCRIPTION
## Summary

- Inside `provider awscc { region = }`, only `awscc.Region.*` completions are shown (not `aws.Region.*`), and vice versa
- Added `provider_name` field to `CompletionContext::AfterProviderRegion` to carry the provider name from context detection to completion generation
- Added `region_completions_for_provider()` that filters `region_completions_data` by the matching provider prefix

## Test plan

- [x] `provider_block_region_completions_use_matching_namespace` -- verifies `provider awscc` block only shows `awscc.Region.*`
- [x] `provider_block_region_completions_use_aws_namespace` -- verifies `provider aws` block only shows `aws.Region.*`
- [x] All 123 existing carina-lsp tests pass

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)