### PR TITLE
fix: stop suggesting Region/boolean values for _id attribute completions

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -61,7 +61,7 @@ impl CompletionProvider {
             CompletionContext::AfterEquals {
                 resource_type,
                 attr_name,
-            } => self.value_completions_for_attr(&resource_type, &attr_name, &text),
+            } => self.value_completions_for_attr(&resource_type, &attr_name, &text, base_path),
             CompletionContext::InsideStructBlock {
                 resource_type,
                 attr_path,

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -346,3 +346,178 @@ fn nested_struct_completions_via_block_name_in_path() {
         field_names
     );
 }
+
+#[test]
+fn route_table_id_completions_should_not_include_region_values() {
+    // Issue #906: When typing a value for `route_table_id` in an `awscc.ec2.route` block,
+    // the LSP should suggest resource reference bindings (e.g., `rt.id`) but NOT
+    // Region values (e.g., `aws.Region.ap_northeast_1`).
+    let provider = test_provider();
+
+    let text = r#"let rt = awscc.ec2.route_table {
+  vpc_id = vpc.id
+}
+
+awscc.ec2.route {
+  route_table_id =
+}
+"#;
+
+    let completions =
+        provider.value_completions_for_attr("awscc.ec2.route", "route_table_id", text, None);
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    // Should include resource reference binding completion
+    assert!(
+        labels.contains(&"rt.id"),
+        "Should suggest 'rt.id' as a completion for route_table_id. Got: {:?}",
+        labels
+    );
+
+    // Should NOT include Region values
+    let has_region = labels.iter().any(|l| l.contains("Region"));
+    assert!(
+        !has_region,
+        "Should NOT suggest Region values for route_table_id. Got: {:?}",
+        labels
+    );
+
+    // Should NOT include generic boolean values
+    assert!(
+        !labels.contains(&"true"),
+        "Should NOT suggest 'true' for route_table_id. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"false"),
+        "Should NOT suggest 'false' for route_table_id. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn vpc_id_completions_should_not_include_region_values() {
+    let provider = test_provider();
+
+    let text = r#"let main_vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.route_table {
+  vpc_id =
+}
+"#;
+
+    let completions =
+        provider.value_completions_for_attr("awscc.ec2.route_table", "vpc_id", text, None);
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"main_vpc.id"),
+        "Should suggest 'main_vpc.id' for vpc_id. Got: {:?}",
+        labels
+    );
+
+    let has_region = labels.iter().any(|l| l.contains("Region"));
+    assert!(
+        !has_region,
+        "Should NOT suggest Region values for vpc_id. Got: {:?}",
+        labels
+    );
+
+    assert!(
+        !labels.contains(&"true") && !labels.contains(&"false"),
+        "Should NOT suggest boolean values for vpc_id. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn subnet_id_completions_should_not_include_region_values() {
+    let provider = test_provider();
+
+    let text = r#"let web_subnet = awscc.ec2.subnet {
+  vpc_id = vpc.id
+  cidr_block = "10.0.1.0/24"
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id =
+}
+"#;
+
+    let completions = provider.value_completions_for_attr(
+        "awscc.ec2.subnet_route_table_association",
+        "subnet_id",
+        text,
+        None,
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"web_subnet.id"),
+        "Should suggest 'web_subnet.id' for subnet_id. Got: {:?}",
+        labels
+    );
+
+    let has_region = labels.iter().any(|l| l.contains("Region"));
+    assert!(
+        !has_region,
+        "Should NOT suggest Region values for subnet_id. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn sibling_crn_files_provide_bindings_for_id_completions() {
+    use std::io::Write;
+
+    let provider = test_provider();
+
+    // Create a temp directory with two .crn files
+    let dir = tempfile::tempdir().unwrap();
+
+    let vpc_file = dir.path().join("vpc.crn");
+    let mut f = std::fs::File::create(&vpc_file).unwrap();
+    writeln!(
+        f,
+        "let main_vpc = awscc.ec2.vpc {{\n  cidr_block = \"10.0.0.0/16\"\n}}"
+    )
+    .unwrap();
+
+    let route_file = dir.path().join("route.crn");
+    let mut f = std::fs::File::create(&route_file).unwrap();
+    writeln!(
+        f,
+        "let rt = awscc.ec2.route_table {{\n  vpc_id = main_vpc.id\n}}\n\nawscc.ec2.route {{\n  route_table_id =\n}}"
+    )
+    .unwrap();
+
+    // The current file is route.crn; main_vpc binding is in vpc.crn (sibling)
+    let route_text = std::fs::read_to_string(&route_file).unwrap();
+    let completions = provider.value_completions_for_attr(
+        "awscc.ec2.route",
+        "route_table_id",
+        &route_text,
+        Some(&route_file),
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    // Should include binding from the current file
+    assert!(
+        labels.contains(&"rt.id"),
+        "Should suggest 'rt.id' from current file. Got: {:?}",
+        labels
+    );
+
+    // Should include binding from the sibling file
+    assert!(
+        labels.contains(&"main_vpc.id"),
+        "Should suggest 'main_vpc.id' from sibling vpc.crn. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1,5 +1,7 @@
 //! Attribute, value, and type-specific completions.
 
+use std::path::Path;
+
 use tower_lsp::lsp_types::{
     Command, CompletionItem, CompletionItemKind, InsertTextFormat, Position, Range, TextEdit,
 };
@@ -66,12 +68,34 @@ impl CompletionProvider {
         resource_type: &str,
         attr_name: &str,
         text: &str,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
 
         // For attributes ending with _id (like vpc_id, route_table_id), suggest resource bindings
         if attr_name.ends_with("_id") {
-            let bindings = self.extract_resource_bindings(text);
+            let mut bindings = self.extract_resource_bindings(text);
+
+            // Also scan sibling .crn files in the same directory
+            if let Some(base) = base_path
+                && let Some(dir) = base.parent()
+                && let Ok(entries) = std::fs::read_dir(dir)
+            {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|ext| ext == "crn")
+                        && path != base
+                        && let Ok(sibling_text) = std::fs::read_to_string(&path)
+                    {
+                        for b in self.extract_resource_bindings(&sibling_text) {
+                            if !bindings.contains(&b) {
+                                bindings.push(b);
+                            }
+                        }
+                    }
+                }
+            }
+
             for binding_name in bindings {
                 // Add completion with .id suffix (e.g., main_vpc.id)
                 completions.push(CompletionItem {
@@ -199,7 +223,7 @@ impl CompletionProvider {
                 }
                 completions
             }
-            _ => self.generic_value_completions(),
+            _ => vec![],
         }
     }
 


### PR DESCRIPTION
## Summary
- Stop returning generic completions (Region values + true/false) for unrecognized `Custom` attribute types like `RouteTableId`, `VpcId`, `SubnetId` in the LSP completion provider
- Extend `_id` attribute completions to scan sibling `.crn` files in the same directory for `let` bindings, enabling cross-file resource reference suggestions

## Test plan
- [x] Existing test `route_table_id_completions_should_not_include_region_values` now passes
- [x] New test `vpc_id_completions_should_not_include_region_values` verifies vpc_id fix
- [x] New test `subnet_id_completions_should_not_include_region_values` verifies subnet_id fix
- [x] New test `sibling_crn_files_provide_bindings_for_id_completions` verifies cross-file binding resolution
- [x] All 134 LSP tests pass

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)