### PR TITLE
fix: add missing block_name for all List<Struct> attributes

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1187,7 +1187,8 @@ pub fn iam_policy_document() -> AttributeType {
             StructField::new("version", iam_policy_version()).with_provider_name("Version"),
             StructField::new("id", AttributeType::String).with_provider_name("Id"),
             StructField::new("statement", AttributeType::list(iam_policy_statement()))
-                .with_provider_name("Statement"),
+                .with_provider_name("Statement")
+                .with_block_name("statement"),
         ],
     }
 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -155,7 +155,9 @@ impl DiagnosticEngine {
                             .unwrap_or(attr_name);
 
                         // Check for mixed syntax: both block_name and canonical name present
+                        // Skip when block_name == canonical name (singular names like "statement")
                         if let Some(canon) = bn_map.get(attr_name)
+                            && canon != attr_name
                             && resource.attributes.contains_key(canon)
                         {
                             if let Some((line, col)) = self.find_attribute_position(doc, attr_name)

--- a/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -22,11 +22,11 @@ awscc.ec2.vpc_endpoint {
 
   policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = "*"
       action    = "s3:GetObject"
       resource  = "arn:aws:s3:::*"
-    }]
+    }
   }
 }

--- a/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -20,13 +20,13 @@ let flow_log_role = awscc.iam.role {
   role_name                   = "acceptance-test-flow-log-role"
   assume_role_policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = {
         service = "vpc-flow-logs.amazonaws.com"
       }
       action    = "sts:AssumeRole"
-    }]
+    }
   }
 }
 

--- a/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/carina-provider-awscc/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -22,11 +22,11 @@ awscc.ec2.vpc_endpoint {
 
   policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = "*"
       action    = "s3:GetObject"
       resource  = "arn:aws:s3:::*"
-    }]
+    }
   }
 }

--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -19,13 +19,13 @@ let flow_log_role = awscc.iam.role {
   role_name                   = "carina-acc-test-update-flow-log-role"
   assume_role_policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = {
         service = "vpc-flow-logs.amazonaws.com"
       }
       action    = "sts:AssumeRole"
-    }]
+    }
   }
 }
 

--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -19,13 +19,13 @@ let flow_log_role = awscc.iam.role {
   role_name                   = "carina-acc-test-update-flow-log-role"
   assume_role_policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = {
         service = "vpc-flow-logs.amazonaws.com"
       }
       action    = "sts:AssumeRole"
-    }]
+    }
   }
 }
 

--- a/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/carina-provider-awscc/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -22,11 +22,11 @@ awscc.ec2.vpc_endpoint {
 
   policy_document = {
     version   = "2012-10-17"
-    statement = [{
+    statement {
       effect    = "Allow"
       principal = "*"
       action    = "s3:GetObject"
       resource  = "arn:aws:s3:::*"
-    }]
+    }
   }
 }

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/encryption.crn
@@ -13,11 +13,11 @@ awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   bucket_encryption = {
-    server_side_encryption_configuration = [{
+    server_side_encryption_configuration {
       server_side_encryption_by_default = {
         sse_algorithm = "AES256"
       }
-    }]
+    }
   }
 
   lifecycle {

--- a/carina-provider-awscc/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/carina-provider-awscc/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -14,13 +14,13 @@ awscc.s3.bucket {
   bucket_name_prefix = "carina-acc-test-"
 
   bucket_encryption = {
-    server_side_encryption_configuration = [{
+    server_side_encryption_configuration {
       bucket_key_enabled                = true
       server_side_encryption_by_default = {
         sse_algorithm     = "aws:kms"
         kms_master_key_id = "alias/aws/s3"
       }
-    }]
+    }
   }
 
   lifecycle {

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -3699,10 +3699,12 @@ fn json_default_to_markdown(val: &serde_json::Value) -> Option<String> {
     }
 }
 
-/// Compute singular block name from a plural snake_case attribute name.
+/// Compute block name from a snake_case attribute name.
 ///
-/// Returns `Some(singular)` if the singular differs from the original,
-/// or `None` if the name is already singular or doesn't match known patterns.
+/// For plural names, returns the singular form (e.g., "tags" -> "tag").
+/// For already-singular names (e.g., "statement", "security_group_egress"),
+/// returns the name itself so that `List<Struct>` attributes always have a
+/// `block_name` for the formatter to use.
 fn compute_block_name(name: &str) -> Option<String> {
     let singular = if let Some(stem) = name.strip_suffix("ies") {
         // policies -> policy, entries -> entry
@@ -3718,16 +3720,17 @@ fn compute_block_name(name: &str) -> Option<String> {
         format!("{}s", stem)
     } else if let Some(stem) = name.strip_suffix('s') {
         if name.ends_with("ss") || name.ends_with("us") {
-            // "access" ends in "ss", "status" ends in "us" -> skip
-            return None;
+            // "access" ends in "ss", "status" ends in "us" -> already singular
+            return Some(name.to_string());
         }
         // regions -> region, tags -> tag, sizes -> size
         stem.to_string()
     } else {
-        return None;
+        // Already singular (e.g., "statement", "server_side_encryption_configuration")
+        return Some(name.to_string());
     };
 
-    if singular == name || singular.is_empty() {
+    if singular.is_empty() {
         None
     } else {
         Some(singular)
@@ -6186,11 +6189,28 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_block_name_no_change() {
-        // Already singular or doesn't match patterns
-        assert_eq!(compute_block_name("name"), None);
-        assert_eq!(compute_block_name("status"), None);
-        assert_eq!(compute_block_name("access"), None);
+    fn test_compute_block_name_already_singular() {
+        // Already singular names return the name itself
+        assert_eq!(compute_block_name("name"), Some("name".to_string()));
+        assert_eq!(
+            compute_block_name("statement"),
+            Some("statement".to_string())
+        );
+        assert_eq!(
+            compute_block_name("server_side_encryption_configuration"),
+            Some("server_side_encryption_configuration".to_string())
+        );
+        // "ss" and "us" endings are treated as singular
+        assert_eq!(compute_block_name("status"), Some("status".to_string()));
+        assert_eq!(compute_block_name("access"), Some("access".to_string()));
+        assert_eq!(
+            compute_block_name("security_group_egress"),
+            Some("security_group_egress".to_string())
+        );
+        assert_eq!(
+            compute_block_name("security_group_ingress"),
+            Some("security_group_ingress".to_string())
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -56,4 +56,75 @@ mod tests {
         let vpc_id_attr = vpc_config.schema.attributes.get("vpc_id").unwrap();
         assert_eq!(vpc_id_attr.provider_name.as_deref(), Some("VpcId"));
     }
+
+    /// Verify that every `List<Struct>` attribute (both top-level and nested)
+    /// has a `block_name` defined. Without `block_name`, the formatter cannot
+    /// convert `= [{...}]` syntax into block syntax.
+    #[test]
+    fn all_list_struct_attributes_have_block_name() {
+        use carina_core::schema::{AttributeSchema, AttributeType, StructField};
+
+        /// Collect missing block_names from an AttributeType, recursing into Structs.
+        fn check_type(attr_type: &AttributeType, path: &str, missing: &mut Vec<String>) {
+            match attr_type {
+                AttributeType::Struct { fields, .. } => {
+                    for field in fields {
+                        check_field(field, path, missing);
+                    }
+                }
+                AttributeType::List { inner, .. } => {
+                    check_type(inner, path, missing);
+                }
+                AttributeType::Map(inner) => {
+                    check_type(inner, path, missing);
+                }
+                _ => {}
+            }
+        }
+
+        /// Check a StructField: if it is List<Struct>, it must have block_name.
+        fn check_field(field: &StructField, parent_path: &str, missing: &mut Vec<String>) {
+            let field_path = format!("{}.{}", parent_path, field.name);
+            if let AttributeType::List { inner, .. } = &field.field_type
+                && matches!(inner.as_ref(), AttributeType::Struct { .. })
+                && field.block_name.is_none()
+            {
+                missing.push(field_path.clone());
+            }
+            // Recurse into the field type regardless
+            check_type(&field.field_type, &field_path, missing);
+        }
+
+        /// Check a top-level AttributeSchema: if it is List<Struct>, it must have block_name.
+        fn check_attr(attr: &AttributeSchema, resource_type: &str, missing: &mut Vec<String>) {
+            let path = format!("{}.{}", resource_type, attr.name);
+            if let AttributeType::List { inner, .. } = &attr.attr_type
+                && matches!(inner.as_ref(), AttributeType::Struct { .. })
+                && attr.block_name.is_none()
+            {
+                missing.push(path.clone());
+            }
+            // Recurse into the attribute type regardless
+            check_type(&attr.attr_type, &path, missing);
+        }
+
+        let mut missing = Vec::new();
+        for config in configs() {
+            let resource_type = &config.schema.resource_type;
+            for attr in config.schema.attributes.values() {
+                check_attr(attr, resource_type, &mut missing);
+            }
+        }
+
+        missing.sort();
+        assert!(
+            missing.is_empty(),
+            "The following List<Struct> attributes are missing block_name:\n{}",
+            missing
+                .iter()
+                .map(|p| format!("  - {}", p))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -102,7 +102,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     ],
                 }))
                 .with_description("[VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.")
-                .with_provider_name("SecurityGroupEgress"),
+                .with_provider_name("SecurityGroupEgress")
+                .with_block_name("security_group_egress"),
         )
         .attribute(
             AttributeSchema::new("security_group_ingress", AttributeType::unordered_list(AttributeType::Struct {
@@ -138,7 +139,8 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     ],
                 }))
                 .with_description("The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.")
-                .with_provider_name("SecurityGroupIngress"),
+                .with_provider_name("SecurityGroupIngress")
+                .with_block_name("security_group_ingress"),
         )
         .attribute(
             AttributeSchema::new("tags", tags_type())

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -346,11 +346,12 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption, this default encryption will be applied.").with_provider_name("ServerSideEncryptionByDefault")
                     ],
-                })).required().with_description("Specifies the default server-side-encryption configuration.").with_provider_name("ServerSideEncryptionConfiguration")
+                })).required().with_description("Specifies the default server-side-encryption configuration.").with_provider_name("ServerSideEncryptionConfiguration").with_block_name("server_side_encryption_configuration")
                     ],
                 })
                 .with_description("Specifies default encryption for a bucket using server-side encryption with Amazon S3-managed keys (SSE-S3), AWS KMS-managed keys (SSE-KMS), or dual-layer server-side encryption with KMS-managed keys (DSSE-KMS). For information about the Amazon S3 default encryption feature, see [Amazon S3 Default Encryption for S3 Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("BucketEncryption"),
+                .with_provider_name("BucketEncryption")
+                .with_block_name("bucket_encryption"),
         )
         .attribute(
             AttributeSchema::new("bucket_name", AttributeType::String)
@@ -393,7 +394,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })
                 .with_description("Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("CorsConfiguration"),
+                .with_provider_name("CorsConfiguration")
+                .with_block_name("cors_configuration"),
         )
         .attribute(
             AttributeSchema::new("domain_name", AttributeType::String)
@@ -623,7 +625,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })
                 .with_description("Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("LifecycleConfiguration"),
+                .with_provider_name("LifecycleConfiguration")
+                .with_block_name("lifecycle_configuration"),
         )
         .attribute(
             AttributeSchema::new("logging_configuration", AttributeType::Struct {
@@ -800,9 +803,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
-                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key").with_block_name("s3_key")
                     ],
-                }).with_description("The filtering rules that determine which objects invoke the AWS Lambda function. For example, you can create a filter so that only image files with a ``.jpg`` extension invoke the function when they are added to the Amazon S3 bucket.").with_provider_name("Filter"),
+                }).with_description("The filtering rules that determine which objects invoke the AWS Lambda function. For example, you can create a filter so that only image files with a ``.jpg`` extension invoke the function when they are added to the Amazon S3 bucket.").with_provider_name("Filter").with_block_name("filter"),
                     StructField::new("function", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the LAMlong function that Amazon S3 invokes when the specified event type occurs.").with_provider_name("Function")
                     ],
                 })).with_description("Describes the LAMlong functions to invoke and the events for which to invoke them.").with_provider_name("LambdaConfigurations").with_block_name("lambda_configuration"),
@@ -830,9 +833,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
-                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key").with_block_name("s3_key")
                     ],
-                }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket. For more information, see [Configuring event notifications using object key name filtering](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/notification-how-to-filtering.html) in the *Amazon S3 User Guide*.").with_provider_name("Filter"),
+                }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket. For more information, see [Configuring event notifications using object key name filtering](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/notification-how-to-filtering.html) in the *Amazon S3 User Guide*.").with_provider_name("Filter").with_block_name("filter"),
                     StructField::new("queue", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queues are not allowed when enabling an SQS queue as the event notification destination.").with_provider_name("Queue")
                     ],
                 })).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations").with_block_name("queue_configuration"),
@@ -860,16 +863,17 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
                     ],
-                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key")
+                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key").with_block_name("s3_key")
                     ],
-                }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket.").with_provider_name("Filter"),
+                }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket.").with_provider_name("Filter").with_block_name("filter"),
                     StructField::new("topic", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
                     ],
                 })).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations").with_block_name("topic_configuration")
                     ],
                 })
                 .with_description("Configuration that defines how Amazon S3 handles bucket notifications.")
-                .with_provider_name("NotificationConfiguration"),
+                .with_provider_name("NotificationConfiguration")
+                .with_block_name("notification_configuration"),
         )
         .attribute(
             AttributeSchema::new("object_lock_configuration", AttributeType::Struct {
@@ -1099,7 +1103,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })
                 .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration`` property. Amazon S3 can store replicated objects in a single destination bucket or multiple destination buckets. The destination bucket or buckets must already exist.")
-                .with_provider_name("ReplicationConfiguration"),
+                .with_provider_name("ReplicationConfiguration")
+                .with_block_name("replication_configuration"),
         )
         .attribute(
             AttributeSchema::new("tags", tags_type())
@@ -1169,7 +1174,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })
                 .with_description("Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html).")
-                .with_provider_name("WebsiteConfiguration"),
+                .with_provider_name("WebsiteConfiguration")
+                .with_block_name("website_configuration"),
         )
         .attribute(
             AttributeSchema::new("website_url", AttributeType::Custom {

--- a/docs/src/providers/awscc/ec2/ipam.md
+++ b/docs/src/providers/awscc/ec2/ipam.md
@@ -11,9 +11,9 @@ awscc.ec2.ipam {
   description = "Example IPAM"
   tier        = free
 
-  operating_regions = [{
+  operating_region {
     region_name = "ap-northeast-1"
-  }]
+  }
 
   tags = {
     Environment = "example"

--- a/docs/src/providers/awscc/ec2/ipam_pool.md
+++ b/docs/src/providers/awscc/ec2/ipam_pool.md
@@ -11,9 +11,9 @@ let ipam = awscc.ec2.ipam {
   description = "Example IPAM"
   tier        = free
 
-  operating_regions = [{
+  operating_region {
     region_name = "ap-northeast-1"
-  }]
+  }
 }
 
 awscc.ec2.ipam_pool {
@@ -22,9 +22,9 @@ awscc.ec2.ipam_pool {
   locale         = "ap-northeast-1"
   description    = "Example IPv4 IPAM Pool"
 
-  provisioned_cidrs = [{
+  provisioned_cidr {
     cidr = "10.0.0.0/8"
-  }]
+  }
 
   tags = {
     Environment = "example"

--- a/docs/src/providers/awscc/iam/role.md
+++ b/docs/src/providers/awscc/iam/role.md
@@ -15,7 +15,9 @@ awscc.iam.role {
     version = "2012-10-17"
     statement {
       effect    = "Allow"
-      principal = { service = "lambda.amazonaws.com" }
+      principal = {
+        service = "lambda.amazonaws.com"
+      }
       action    = "sts:AssumeRole"
     }
   }


### PR DESCRIPTION
## Summary
- Update `compute_block_name` in codegen to return the name itself for already-singular names (e.g., `statement`, `security_group_egress`, `server_side_encryption_configuration`), ensuring every `List<Struct>` attribute gets a `block_name`
- Add `.with_block_name("statement")` to the hand-written `iam_policy_document()` helper in `carina-aws-types`
- Fix LSP duplicate detection to skip false positives when `block_name` equals the attribute name
- Regenerate schemas, docs, and format `.crn` files to use block syntax

## Test plan
- [x] `all_list_struct_attributes_have_block_name` test passes (previously failing)
- [x] All `compute_block_name` unit tests updated and passing
- [x] Full workspace `cargo test` passes (including LSP diagnostics tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)