### PR TITLE
fix: detect duplicate let bindings (closes #915)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -29,8 +29,8 @@ pub enum ParseError {
     #[error("Duplicate module definition: {0}")]
     DuplicateModule(String),
 
-    #[error("Duplicate binding: {0}")]
-    DuplicateBinding(String),
+    #[error("Duplicate binding at line {line}: {name}")]
+    DuplicateBinding { name: String, line: usize },
 
     #[error("Module not found: {0}")]
     ModuleNotFound(String),
@@ -299,12 +299,13 @@ pub fn parse(input: &str) -> Result<ParsedFile, ParseError> {
                                 outputs.extend(parsed_outputs);
                             }
                             Rule::let_binding => {
+                                let (line, _) = stmt.as_span().start_pos().line_col();
                                 let (name, value, maybe_resource, maybe_module_call) =
                                     parse_let_binding_extended(stmt, &ctx)?;
                                 if ctx.variables.contains_key(&name)
                                     || ctx.resource_bindings.contains_key(&name)
                                 {
-                                    return Err(ParseError::DuplicateBinding(name));
+                                    return Err(ParseError::DuplicateBinding { name, line });
                                 }
                                 ctx.set_variable(name.clone(), value);
                                 if let Some(resource) = maybe_resource {
@@ -2576,10 +2577,21 @@ aws.s3.bucket {
             "Duplicate let binding 'rt' should produce an error, but parsing succeeded: {:?}",
             result.unwrap()
         );
-        let err = result.unwrap_err().to_string();
+        let err = result.unwrap_err();
+        match &err {
+            ParseError::DuplicateBinding { name, line } => {
+                assert_eq!(name, "rt");
+                assert_eq!(
+                    *line, 6,
+                    "Duplicate binding should report the line of the second 'let rt', got line {line}"
+                );
+            }
+            _ => panic!("Expected DuplicateBinding error, got: {err}"),
+        }
+        let err_str = err.to_string();
         assert!(
-            err.contains("Duplicate") && err.contains("rt"),
-            "Error should mention duplicate binding 'rt', got: {err}"
+            err_str.contains("Duplicate") && err_str.contains("rt"),
+            "Error should mention duplicate binding 'rt', got: {err_str}"
         );
     }
 
@@ -2597,10 +2609,21 @@ aws.s3.bucket {
             "Duplicate let binding 'region' should produce an error, but parsing succeeded: {:?}",
             result.unwrap()
         );
-        let err = result.unwrap_err().to_string();
+        let err = result.unwrap_err();
+        match &err {
+            ParseError::DuplicateBinding { name, line } => {
+                assert_eq!(name, "region");
+                assert_eq!(
+                    *line, 3,
+                    "Duplicate binding should report the line of the second 'let region', got line {line}"
+                );
+            }
+            _ => panic!("Expected DuplicateBinding error, got: {err}"),
+        }
+        let err_str = err.to_string();
         assert!(
-            err.contains("Duplicate") && err.contains("region"),
-            "Error should mention duplicate binding 'region', got: {err}"
+            err_str.contains("Duplicate") && err_str.contains("region"),
+            "Error should mention duplicate binding 'region', got: {err_str}"
         );
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -701,8 +701,17 @@ fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
             message: format!("Duplicate module definition: {}", name),
             ..Default::default()
         },
-        ParseError::DuplicateBinding(name) => Diagnostic {
-            range: Range::default(),
+        ParseError::DuplicateBinding { name, line } => Diagnostic {
+            range: Range {
+                start: Position {
+                    line: (line - 1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: (line - 1) as u32,
+                    character: 0,
+                },
+            },
             severity: Some(DiagnosticSeverity::ERROR),
             source: Some("carina".to_string()),
             message: format!("Duplicate binding: {}", name),


### PR DESCRIPTION
## Summary
- Add `DuplicateBinding(String)` variant to `ParseError` enum
- Check for existing bindings before inserting in the `Rule::let_binding` match arm of `parse()`
- Add LSP diagnostic mapping for `DuplicateBinding` following the `DuplicateModule` pattern

Closes #915

## Test plan
- [x] `duplicate_let_binding_resource_produces_error` — verifies duplicate resource bindings are rejected
- [x] `duplicate_let_binding_variable_produces_error` — verifies duplicate variable bindings are rejected
- [x] `distinct_let_bindings_are_accepted` — verifies distinct bindings still work
- [x] All existing tests pass (`cargo test -p carina-core`, `cargo test -p carina-lsp`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)