### PR TITLE
fix: skip block_name rename when block_name equals canonical name

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -857,6 +857,10 @@ fn resolve_block_names_in_map(
         .collect();
 
     for (block_key, canon_key) in renames {
+        // When block_name == canonical name, no rename is needed
+        if block_key == canon_key {
+            continue;
+        }
         if map.contains_key(&canon_key) {
             errors.push(format!(
                 "{}: cannot use both '{}' and '{}' (they refer to the same attribute)",
@@ -939,6 +943,10 @@ pub fn resolve_block_names(
             .collect();
 
         for (block_key, canon_key) in renames {
+            // When block_name == canonical name, no rename is needed
+            if block_key == canon_key {
+                continue;
+            }
             if resource.attributes.contains_key(&canon_key) {
                 all_errors.push(format!(
                     "{}: cannot use both '{}' and '{}' (they refer to the same attribute)",


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #913 where `block_name == canonical_name` (e.g., `statement`, `security_group_ingress`, `server_side_encryption_configuration`) caused a false "cannot use both" conflict error during block name resolution.

## Root Cause

When `compute_block_name()` returns the attribute name itself (for singular names like `statement`), the rename logic finds `block_key == canon_key`. Since the key already exists in the map (it's the same key), `map.contains_key(&canon_key)` returns `true` and triggers a spurious error.

## Fix

Skip the rename entirely when `block_key == canon_key` — no rename is needed in this case.

Both `resolve_block_names_in_map()` and `resolve_block_names()` are fixed.

## Test plan

- All 11 failing acceptance tests (iam_role, ec2_security_group, ec2_vpc_endpoint, s3_bucket, ec2_flow_log) should pass after this fix