### PR TITLE
fix: stop generating synthetic (read-only) description for descriptionless attributes

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1842,8 +1842,6 @@ pub fn {}() -> AwsccSchemaConfig {{
                 "\n                .with_description(\"{}{}\")",
                 escaped, suffix
             ));
-        } else if is_read_only {
-            attr_code.push_str("\n                .with_description(\"(read-only)\")");
         }
 
         // Add provider_name mapping (AWS property name)
@@ -8485,6 +8483,82 @@ mod tests {
         assert_eq!(
             tiering.type_name, "IntelligentTieringConfigurationStatus",
             "Colliding struct field enum should be prefixed with parent struct name"
+        );
+    }
+
+    #[test]
+    fn test_read_only_attribute_preserves_original_description() {
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "FlowLogId".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("The Flow Log ID".to_string()),
+                ..Default::default()
+            },
+        );
+        properties.insert(
+            "Name".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some("The name of the resource.".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::EC2::FlowLog".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec!["/properties/FlowLogId".to_string()],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::EC2::FlowLog").unwrap();
+
+        // Read-only attribute WITH description should append " (read-only)" to the original
+        assert!(
+            generated.contains(r#".with_description("The Flow Log ID (read-only)")"#),
+            "Read-only attribute with description should have ' (read-only)' appended: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_read_only_attribute_without_description_has_no_read_only_description() {
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "ResourceId".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: None,
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::EC2::TestResource".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec!["/properties/ResourceId".to_string()],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::EC2::TestResource").unwrap();
+
+        // A read-only attribute with no description should not get a "(read-only)" description
+        assert!(
+            !generated.contains(r#".with_description("(read-only)")"#),
+            "Read-only attribute without original description should not get a '(read-only)' description: {generated}"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -143,13 +143,11 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     },
                 )
                 .read_only()
-                .with_description("(read-only)")
                 .with_provider_name("EncryptionSupportState"),
             )
             .attribute(
                 AttributeSchema::new("id", super::transit_gateway_id())
                     .read_only()
-                    .with_description("(read-only)")
                     .with_provider_name("Id"),
             )
             .attribute(
@@ -188,7 +186,6 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
             .attribute(
                 AttributeSchema::new("transit_gateway_arn", super::arn())
                     .read_only()
-                    .with_description("(read-only)")
                     .with_provider_name("TransitGatewayArn"),
             )
             .attribute(

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -19,7 +19,6 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("id", super::transit_gateway_attachment_id())
                 .read_only()
-                .with_description("(read-only)")
                 .with_provider_name("Id"),
         )
         .attribute(

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -25,7 +25,6 @@ pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("id", super::vpc_peering_connection_id())
                 .read_only()
-                .with_description("(read-only)")
                 .with_provider_name("Id"),
         )
         .attribute(

--- a/docs/src/providers/awscc/ec2/transit_gateway_attachment.md
+++ b/docs/src/providers/awscc/ec2/transit_gateway_attachment.md
@@ -22,7 +22,7 @@ let tgw = awscc.ec2.transit_gateway {
 }
 
 awscc.ec2.transit_gateway_attachment {
-  transit_gateway_id = tgw.transit_gateway_id
+  transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id
   subnet_ids         = [subnet.subnet_id]
 


### PR DESCRIPTION
## Summary

- Remove the `else if is_read_only` branch in codegen that created synthetic `"(read-only)"` descriptions for read-only attributes lacking CloudFormation descriptions
- Read-only attributes WITH descriptions still get `" (read-only)"` appended (unchanged behavior)
- Read-only attributes WITHOUT descriptions now have no description at all — the `.read_only()` flag is sufficient
- Regenerated all schemas and docs

## Test plan

- [x] Two new unit tests: one verifying description+read-only appends suffix, one verifying no-description+read-only omits description
- [x] `cargo test` — all pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean

Closes #923