### PR TITLE
fix: nest dep-free resources under their dependents in plan tree

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -71,7 +71,8 @@ pub fn print_plan(plan: &Plan) {
     for (idx, deps) in &effect_deps {
         let has_dep_in_plan = deps.iter().any(|d| binding_to_effect.contains_key(d));
         if !has_dep_in_plan {
-            let children = dependents.get(idx).cloned().unwrap_or_default();
+            let mut children = dependents.get(idx).cloned().unwrap_or_default();
+            children.sort();
             if !children.is_empty() {
                 // Check if all dependents have at least one other dep in the plan
                 let binding_of_idx = effect_bindings.get(idx).map(|s| s.as_str());
@@ -84,7 +85,7 @@ pub fn print_plan(plan: &Plan) {
                     })
                 });
                 if all_dependents_have_other_deps {
-                    // Nest this resource under its first dependent
+                    // Nest this resource under its first dependent (by index order)
                     let first_dependent = children[0];
                     dependents.entry(first_dependent).or_default().push(*idx);
                     nested_under_dependent.insert(*idx);


### PR DESCRIPTION
## Summary
- Resources with no dependencies that are referenced by other resources were appearing as disconnected root-level items in the plan tree
- Now they are nested under their first dependent, provided all dependents have at least one other dependency in the plan (to avoid creating cycles)
- For example, an internet gateway (no deps) referenced by a route and a gateway attachment is now nested under the route, instead of appearing as a separate root alongside the VPC

## Test plan
- [x] Existing test `test_referenced_resource_without_deps_should_not_be_root` now passes
- [x] All existing tests continue to pass (`cargo test -p carina-cli`)
- [x] No clippy warnings

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)