### PR TITLE
feat: add full VPC example

### DIFF
--- a/carina-provider-awscc/examples/vpc_full/main.crn
+++ b/carina-provider-awscc/examples/vpc_full/main.crn
@@ -1,0 +1,384 @@
+# Full VPC Example
+#
+# Creates a complete VPC setup with public, private, and database subnets
+# across three availability zones (ap-northeast-1a, 1c, 1d).
+#
+# Includes:
+# - VPC with DNS support
+# - Internet Gateway
+# - NAT Gateways (one per AZ) with Elastic IPs
+# - Public subnets (10.0.0.0/24, 10.0.1.0/24, 10.0.2.0/24)
+# - Private subnets (10.0.100.0/24, 10.0.101.0/24, 10.0.102.0/24)
+# - Database subnets (10.0.200.0/24, 10.0.201.0/24, 10.0.202.0/24)
+# - Route tables and associations for each subnet tier
+# - VPC Endpoints (ecr.dkr, ecr.api, s3, logs, ssm, ssmmessages)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# --- VPC and Internet Gateway ---
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "main"
+  }
+}
+
+let igw = awscc.ec2.internet_gateway {
+  tags = {
+    Name = "main"
+  }
+}
+
+let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+# --- Public Subnets ---
+
+let public_subnet_1a = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.0.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1a"
+  }
+}
+
+let public_subnet_1c = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1c"
+  }
+}
+
+let public_subnet_1d = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1d"
+  }
+}
+
+# --- Public Route Table ---
+
+let public_rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "public"
+  }
+}
+
+awscc.ec2.route {
+  route_table_id         = public_rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw_attachment.internet_gateway_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1a.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1c.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1d.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+# --- Elastic IPs and NAT Gateways ---
+
+let eip_1a = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1a"
+  }
+}
+
+let eip_1c = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1c"
+  }
+}
+
+let eip_1d = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1d"
+  }
+}
+
+let nat_gw_1a = awscc.ec2.nat_gateway {
+  allocation_id = eip_1a.allocation_id
+  subnet_id     = public_subnet_1a.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1a"
+  }
+}
+
+let nat_gw_1c = awscc.ec2.nat_gateway {
+  allocation_id = eip_1c.allocation_id
+  subnet_id     = public_subnet_1c.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1c"
+  }
+}
+
+let nat_gw_1d = awscc.ec2.nat_gateway {
+  allocation_id = eip_1d.allocation_id
+  subnet_id     = public_subnet_1d.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1d"
+  }
+}
+
+# --- Private Subnets ---
+
+let private_subnet_1a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.100.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name = "private-ap-northeast-1a"
+  }
+}
+
+let private_subnet_1c = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.101.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "private-ap-northeast-1c"
+  }
+}
+
+let private_subnet_1d = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.102.0/24"
+  availability_zone = "ap-northeast-1d"
+
+  tags = {
+    Name = "private-ap-northeast-1d"
+  }
+}
+
+# --- Private Route Tables ---
+
+let private_rt_1a = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1a"
+  }
+}
+
+let private_rt_1c = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1c"
+  }
+}
+
+let private_rt_1d = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1d"
+  }
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1a.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1a.nat_gateway_id
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1c.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1c.nat_gateway_id
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1d.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1d.nat_gateway_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1a.subnet_id
+  route_table_id = private_rt_1a.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1c.subnet_id
+  route_table_id = private_rt_1c.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1d.subnet_id
+  route_table_id = private_rt_1d.route_table_id
+}
+
+# --- Database Subnets ---
+
+let database_subnet_1a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.200.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name = "database-ap-northeast-1a"
+  }
+}
+
+let database_subnet_1c = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.201.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "database-ap-northeast-1c"
+  }
+}
+
+let database_subnet_1d = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.202.0/24"
+  availability_zone = "ap-northeast-1d"
+
+  tags = {
+    Name = "database-ap-northeast-1d"
+  }
+}
+
+# --- Database Route Table ---
+
+let database_rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "database"
+  }
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1a.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1c.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1d.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+# --- Security Group for VPC Endpoints ---
+
+let endpoint_sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for VPC Endpoint"
+
+  tags = {
+    Name = "vpc-endpoint"
+  }
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = endpoint_sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}
+
+# --- VPC Endpoints (Interface type) ---
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+# --- VPC Endpoint (Gateway type) ---
+
+awscc.ec2.vpc_endpoint {
+  vpc_id            = vpc.vpc_id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [private_rt_1a.route_table_id, private_rt_1c.route_table_id, private_rt_1d.route_table_id]
+}


### PR DESCRIPTION
## Summary

- Add `carina-provider-awscc/examples/vpc_full/main.crn` demonstrating a complete VPC setup equivalent to [mizzy/terraform-modules/aws/vpc](https://github.com/mizzy/terraform-modules/tree/main/aws/vpc)
- Defines 44 resources across 3 AZs: VPC, Internet Gateway, public/private/database subnets, route tables with associations, EIPs, NAT Gateways, security group for endpoints, and 6 VPC endpoints (ecr.dkr, ecr.api, s3, logs, ssm, ssmmessages)
- Uses Gateway-type endpoint with `route_table_ids` for S3, Interface-type endpoints with `subnet_ids`/`security_group_ids` for the rest

Closes #930

## Test plan

- [x] `cargo run --bin carina -- validate` passes (44 resources)
- [x] `cargo run --bin carina -- fmt` confirms proper formatting
- [x] `cargo test` passes (all tests including example file validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)