### PR TITLE
feat: add --refresh=false option to skip provider reads during plan

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -61,6 +61,7 @@ pub async fn run_plan(
     out: Option<&PathBuf>,
     compact: bool,
     tui: bool,
+    refresh: bool,
 ) -> Result<bool, AppError> {
     let mut parsed = load_configuration(path)?.parsed;
 
@@ -166,7 +167,14 @@ pub async fn run_plan(
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 
-    let ctx = create_plan_from_parsed(&parsed, &state_file).await?;
+    if !refresh {
+        eprintln!(
+            "{}",
+            "Warning: using cached state (--refresh=false). Plan may not reflect actual infrastructure.".yellow()
+        );
+    }
+
+    let ctx = create_plan_from_parsed(&parsed, &state_file, refresh).await?;
     let has_changes = ctx.plan.mutation_count() > 0;
 
     if tui {

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -55,6 +55,10 @@ enum Commands {
         /// Display plan in interactive TUI mode
         #[arg(long)]
         tui: bool,
+
+        /// Refresh state from provider before planning (default: true)
+        #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
+        refresh: bool,
     },
     /// Apply changes to reach the desired state
     Apply {
@@ -148,9 +152,10 @@ async fn main() {
         detailed_exitcode,
         compact,
         tui,
+        refresh,
     } = cli.command
     {
-        match run_plan(&path, out.as_ref(), compact, tui).await {
+        match run_plan(&path, out.as_ref(), compact, tui, refresh).await {
             Ok(has_changes) => {
                 if detailed_exitcode && has_changes {
                     std::process::exit(2);

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2119,3 +2119,170 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
         delete_effects
     );
 }
+
+/// Issue #950: --refresh=false should use cached state from state file
+/// instead of calling provider.read().
+///
+/// This test simulates the refresh=false code path:
+/// 1. State file has "my-bucket" with known attributes
+/// 2. With refresh=false, current_states are built from state file
+/// 3. No provider.read() calls are made
+#[test]
+fn refresh_false_uses_cached_state_from_state_file() {
+    use carina_core::differ::create_plan;
+
+    let mut state_file = StateFile::new();
+    state_file.upsert_resource(
+        ResourceState::new("s3.bucket", "my-bucket", "awscc")
+            .with_identifier("my-bucket-id")
+            .with_attribute("bucket_name", json!("my-bucket"))
+            .with_attribute("region", json!("ap-northeast-1")),
+    );
+
+    let mut resource = Resource::with_provider("awscc", "s3.bucket", "my-bucket");
+    resource.attributes.insert(
+        "bucket_name".to_string(),
+        Value::String("my-bucket".to_string()),
+    );
+    resource.attributes.insert(
+        "region".to_string(),
+        Value::String("ap-northeast-1".to_string()),
+    );
+
+    let desired = vec![resource];
+
+    // Simulate refresh=false code path: build current_states from state file
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+    for res in &desired {
+        let state = state_file.build_state_for_resource(res);
+        current_states.insert(res.id.clone(), state);
+    }
+
+    // Verify state was loaded from state file
+    let id = ResourceId::with_provider("awscc", "s3.bucket", "my-bucket");
+    let cached_state = current_states.get(&id).unwrap();
+    assert!(cached_state.exists, "State should exist from state file");
+    assert_eq!(
+        cached_state.identifier,
+        Some("my-bucket-id".to_string()),
+        "Identifier should come from state file"
+    );
+    assert_eq!(
+        cached_state.attributes.get("bucket_name"),
+        Some(&Value::String("my-bucket".to_string())),
+        "Attributes should come from state file"
+    );
+
+    let lifecycles = state_file.build_lifecycles();
+    let saved_attrs = state_file.build_saved_attrs();
+    let prev_desired_keys = state_file.build_desired_keys();
+
+    let plan = create_plan(
+        &desired,
+        &current_states,
+        &lifecycles,
+        &HashMap::new(),
+        &saved_attrs,
+        &prev_desired_keys,
+    );
+
+    // No changes expected since desired matches cached state
+    assert_eq!(
+        plan.mutation_count(),
+        0,
+        "No changes expected when desired state matches cached state"
+    );
+}
+
+/// Issue #950: --refresh=false with orphaned resources should use state file data
+/// directly without calling provider.read().
+#[test]
+fn refresh_false_includes_orphaned_resources_from_state_file() {
+    use carina_core::differ::create_plan;
+
+    let mut state_file = StateFile::new();
+    state_file.upsert_resource(
+        ResourceState::new("s3.bucket", "orphaned-bucket", "awscc")
+            .with_identifier("orphaned-bucket-id")
+            .with_attribute("bucket_name", json!("orphaned-bucket")),
+    );
+
+    // No desired resources — the bucket was removed from .crn
+    let desired: Vec<Resource> = vec![];
+    let desired_ids: HashSet<ResourceId> = desired.iter().map(|r| r.id.clone()).collect();
+
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+
+    // Simulate refresh=false code path: include orphans directly from state file
+    for (id, state) in state_file.build_orphan_states(&desired_ids) {
+        current_states.entry(id).or_insert(state);
+    }
+
+    let lifecycles = state_file.build_lifecycles();
+    let saved_attrs = state_file.build_saved_attrs();
+    let prev_desired_keys = state_file.build_desired_keys();
+
+    let plan = create_plan(
+        &desired,
+        &current_states,
+        &lifecycles,
+        &HashMap::new(),
+        &saved_attrs,
+        &prev_desired_keys,
+    );
+
+    // With refresh=false, orphaned resources are assumed to still exist,
+    // so a Delete effect should be generated
+    let delete_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| matches!(e, Effect::Delete { .. }))
+        .collect();
+
+    assert_eq!(
+        delete_effects.len(),
+        1,
+        "Issue #950: orphaned resource with refresh=false should produce Delete effect"
+    );
+}
+
+/// Issue #950: --refresh=false without a state file should treat all resources as new.
+#[test]
+fn refresh_false_without_state_file_treats_resources_as_new() {
+    use carina_core::differ::create_plan;
+
+    let mut resource = Resource::with_provider("awscc", "s3.bucket", "new-bucket");
+    resource.attributes.insert(
+        "bucket_name".to_string(),
+        Value::String("new-bucket".to_string()),
+    );
+
+    let desired = vec![resource];
+
+    // Simulate refresh=false with no state file
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+    for res in &desired {
+        current_states.insert(res.id.clone(), State::not_found(res.id.clone()));
+    }
+
+    let plan = create_plan(
+        &desired,
+        &current_states,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+
+    let create_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| matches!(e, Effect::Create { .. }))
+        .collect();
+
+    assert_eq!(
+        create_effects.len(),
+        1,
+        "Without state file, all resources should be created"
+    );
+}

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -264,6 +264,7 @@ pub async fn create_providers_from_configs(configs: &[ProviderConfig]) -> Provid
 pub async fn create_plan_from_parsed(
     parsed: &ParsedFile,
     state_file: &Option<StateFile>,
+    refresh: bool,
 ) -> Result<PlanContext, AppError> {
     let ctx = WiringContext::new();
     let sorted_resources =
@@ -272,33 +273,56 @@ pub async fn create_plan_from_parsed(
     // Select appropriate Provider based on configuration
     let provider = get_provider_with_ctx(&ctx, parsed).await;
 
-    // Read states for all resources using identifier from state
-    // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
-    for resource in &sorted_resources {
-        let identifier = state_file
-            .as_ref()
-            .and_then(|sf| sf.get_identifier_for_resource(resource));
-        let state = provider
-            .read(&resource.id, identifier.as_deref())
-            .await
-            .map_err(AppError::Provider)?;
-        current_states.insert(resource.id.clone(), state);
-    }
 
-    // Seed current_states with orphaned resources from state file (#844).
-    // These are resources tracked in state but removed from the .crn config.
-    // Refresh each orphan via provider.read() to verify it still exists (#931).
-    if let Some(sf) = state_file.as_ref() {
-        let desired_ids: HashSet<ResourceId> =
-            sorted_resources.iter().map(|r| r.id.clone()).collect();
-        for (id, state) in sf.build_orphan_states(&desired_ids) {
-            let refreshed = provider
-                .read(&id, state.identifier.as_deref())
+    if refresh {
+        // Read states for all resources using identifier from state
+        // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
+        for resource in &sorted_resources {
+            let identifier = state_file
+                .as_ref()
+                .and_then(|sf| sf.get_identifier_for_resource(resource));
+            let state = provider
+                .read(&resource.id, identifier.as_deref())
                 .await
                 .map_err(AppError::Provider)?;
-            if refreshed.exists {
-                current_states.entry(id).or_insert(refreshed);
+            current_states.insert(resource.id.clone(), state);
+        }
+
+        // Seed current_states with orphaned resources from state file (#844).
+        // These are resources tracked in state but removed from the .crn config.
+        // Refresh each orphan via provider.read() to verify it still exists (#931).
+        if let Some(sf) = state_file.as_ref() {
+            let desired_ids: HashSet<ResourceId> =
+                sorted_resources.iter().map(|r| r.id.clone()).collect();
+            for (id, state) in sf.build_orphan_states(&desired_ids) {
+                let refreshed = provider
+                    .read(&id, state.identifier.as_deref())
+                    .await
+                    .map_err(AppError::Provider)?;
+                if refreshed.exists {
+                    current_states.entry(id).or_insert(refreshed);
+                }
+            }
+        }
+    } else {
+        // --refresh=false: use cached state from state file instead of calling provider.read()
+        if let Some(sf) = state_file.as_ref() {
+            for resource in &sorted_resources {
+                let state = sf.build_state_for_resource(resource);
+                current_states.insert(resource.id.clone(), state);
+            }
+
+            // Also include orphaned resources from state file
+            let desired_ids: HashSet<ResourceId> =
+                sorted_resources.iter().map(|r| r.id.clone()).collect();
+            for (id, state) in sf.build_orphan_states(&desired_ids) {
+                current_states.entry(id).or_insert(state);
+            }
+        } else {
+            // No state file: all resources are new (not found)
+            for resource in &sorted_resources {
+                current_states.insert(resource.id.clone(), State::not_found(resource.id.clone()));
             }
         }
     }

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -145,6 +145,31 @@ impl StateFile {
         result
     }
 
+    /// Build a `State` for a resource from the state file data.
+    /// Returns a non-existing state if the resource is not found in the state file.
+    pub fn build_state_for_resource(&self, resource: &Resource) -> State {
+        let rs = self.find_resource(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            &resource.id.name,
+        );
+        if let Some(identifier) = rs.and_then(|r| r.identifier.as_deref()) {
+            let attrs: HashMap<String, Value> = rs
+                .unwrap()
+                .attributes
+                .iter()
+                .filter_map(|(k, v)| json_to_dsl_value(v).map(|val| (k.clone(), val)))
+                .collect();
+            return State {
+                id: resource.id.clone(),
+                identifier: Some(identifier.to_string()),
+                attributes: attrs,
+                exists: true,
+            };
+        }
+        State::not_found(resource.id.clone())
+    }
+
     /// Build state entries for resources tracked in the state file but absent from the
     /// desired resource set.  These "orphan" entries are injected into `current_states`
     /// so that `create_plan()` can detect them and emit Delete effects.
@@ -673,5 +698,56 @@ mod tests {
             saved.get(&awscc_id).unwrap().get("region"),
             Some(&Value::String("ap-northeast-1".to_string()))
         );
+    }
+
+    #[test]
+    fn test_build_state_for_resource_existing() {
+        use carina_core::resource::{Resource, Value};
+
+        let mut state = StateFile::new();
+        state.upsert_resource(
+            ResourceState::new("s3.bucket", "my-bucket", "awscc")
+                .with_identifier("my-bucket-id")
+                .with_attribute("region".to_string(), serde_json::json!("ap-northeast-1")),
+        );
+
+        let resource = Resource::with_provider("awscc", "s3.bucket", "my-bucket");
+        let result = state.build_state_for_resource(&resource);
+
+        assert!(result.exists);
+        assert_eq!(result.identifier, Some("my-bucket-id".to_string()));
+        assert_eq!(
+            result.attributes.get("region"),
+            Some(&Value::String("ap-northeast-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_build_state_for_resource_not_found() {
+        let state = StateFile::new();
+        let resource =
+            carina_core::resource::Resource::with_provider("awscc", "s3.bucket", "missing");
+        let result = state.build_state_for_resource(&resource);
+
+        assert!(!result.exists);
+        assert!(result.identifier.is_none());
+        assert!(result.attributes.is_empty());
+    }
+
+    #[test]
+    fn test_build_state_for_resource_without_identifier() {
+        let mut state = StateFile::new();
+        // Resource in state but without identifier (not yet created)
+        state.upsert_resource(
+            ResourceState::new("s3.bucket", "pending", "awscc")
+                .with_attribute("region".to_string(), serde_json::json!("us-east-1")),
+        );
+
+        let resource =
+            carina_core::resource::Resource::with_provider("awscc", "s3.bucket", "pending");
+        let result = state.build_state_for_resource(&resource);
+
+        assert!(!result.exists);
+        assert!(result.identifier.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Add `--refresh` boolean flag to `carina plan` (default: `true`). Use `--refresh=false` to skip provider reads and use cached state from the state file.
- When `refresh=false`, `create_plan_from_parsed()` builds `current_states` from the state file instead of calling `provider.read()` for each resource. Orphaned resources are also taken directly from the state file.
- Print a yellow warning message when `--refresh=false` is used to alert that the plan may not reflect actual infrastructure.

## Test plan

- [x] `build_state_for_resource` returns existing state with identifier and attributes from state file
- [x] `build_state_for_resource` returns not-found state when resource is not in state file
- [x] `build_state_for_resource` returns not-found state when resource has no identifier
- [x] `refresh=false` code path builds current states from state file (no provider.read calls)
- [x] `refresh=false` includes orphaned resources from state file (produces Delete effects)
- [x] `refresh=false` without state file treats all resources as new (produces Create effects)
- [x] All existing tests pass

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)