### PR TITLE
feat: show attribute diffs for cascading updates in plan output

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -639,12 +639,13 @@ pub fn print_plan(plan: &Plan, compact: bool) {
                         );
                         for cascade in cascading_updates {
                             println!(
-                                "{}  ~ {} {}",
+                                "{}    ~ {} {}",
                                 attr_prefix,
                                 cascade.id.display_type().cyan(),
                                 cascade.id.name.magenta()
                             );
-                            let diff = format_cascading_update_diff(cascade, &attr_prefix);
+                            let cascade_prefix = format!("{}    ", attr_prefix);
+                            let diff = format_cascading_update_diff(cascade, &cascade_prefix);
                             if !diff.is_empty() {
                                 println!("{}", diff);
                             }


### PR DESCRIPTION
## Summary
- Cascading updates in plan output now show which attributes will change, not just the resource name
- Uses the same `key: old → new` format as regular Update effects (red for old, green for new)
- Added `format_cascading_update_diff()` function that diffs `CascadingUpdate.from` and `CascadingUpdate.to` attributes

## Test plan
- [x] `test_cascading_update_shows_attribute_diffs` - verifies print_plan doesn't panic with cascading updates containing attribute diffs
- [x] `test_format_cascading_update_attr_diff` - verifies the diff function shows changed attributes (vpc_id) and hides unchanged ones (cidr_block)
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)