### PR TITLE
fix: preserve dependency info through ref resolution for plan tree nesting

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -2484,4 +2484,88 @@ mod tests {
             roots
         );
     }
+
+    /// Issue #972: When ResourceRef values are resolved to literal strings
+    /// (as happens with --refresh=false), the tree algorithm loses dependency
+    /// information and places the resource as a top-level root instead of
+    /// nesting it under its parent.
+    ///
+    /// Scenario (mixed_operations fixture):
+    ///   - VPC: Update effect (existing, tags changed)
+    ///   - SG: Create effect with vpc_id = "vpc-0123456789abcdef0"
+    ///     (resolved from vpc.vpc_id by resolve_refs_with_state)
+    ///
+    /// The SG should be nested under VPC because in the DSL it has
+    /// `vpc_id = vpc.vpc_id`, but after resolve_refs_with_state() the
+    /// ResourceRef is replaced with a plain string, so
+    /// get_resource_dependencies() finds no dependencies.
+    #[test]
+    fn test_resolved_ref_loses_dependency_for_tree_nesting() {
+        // VPC: Update effect (tags changed)
+        let vpc_to = make_resource("ec2.vpc", "vpc", "vpc", &[]);
+        let vpc_from = State::existing(
+            ResourceId::new("ec2.vpc", "vpc"),
+            HashMap::from([(
+                "cidr_block".to_string(),
+                Value::String("10.0.0.0/16".to_string()),
+            )]),
+        );
+
+        // SG: Create effect with RESOLVED ref (string instead of ResourceRef).
+        // This is what happens after resolve_refs_with_state() runs:
+        // vpc_id = vpc.vpc_id becomes vpc_id = "vpc-0123456789abcdef0"
+        let mut sg = Resource::new("ec2.security_group", "sg");
+        sg.attributes
+            .insert("_binding".to_string(), Value::String("sg".to_string()));
+        // This is the resolved value — a plain string, NOT a ResourceRef
+        sg.attributes.insert(
+            "vpc_id".to_string(),
+            Value::String("vpc-0123456789abcdef0".to_string()),
+        );
+        sg.attributes.insert(
+            "group_description".to_string(),
+            Value::String("Test security group".to_string()),
+        );
+        // _dependency_bindings is saved by resolve_refs_with_state() before
+        // ResourceRef values are resolved to strings.
+        sg.attributes.insert(
+            "_dependency_bindings".to_string(),
+            Value::List(vec![Value::String("vpc".to_string())]),
+        );
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Update {
+            id: ResourceId::new("ec2.vpc", "vpc"),
+            from: Box::new(vpc_from),
+            to: vpc_to,
+            changed_attributes: vec!["tags".to_string()],
+        });
+        plan.add(Effect::Create(sg));
+
+        let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
+
+        // VPC (idx 0) should be the only root.
+        // SG has _dependency_bindings metadata that preserves the dependency
+        // on "vpc", so get_resource_dependencies() recovers it.
+        assert_eq!(
+            roots,
+            vec![0],
+            "VPC should be the only root. SG should be nested under VPC \
+             because it references vpc.vpc_id in the DSL. Got roots: {:?} \
+             (bindings: {:?})",
+            roots,
+            roots
+                .iter()
+                .filter_map(|i| effect_bindings.get(i))
+                .collect::<Vec<_>>()
+        );
+
+        // SG (idx 1) should be a child of VPC (idx 0)
+        let vpc_children: Vec<usize> = dependents.get(&0).cloned().unwrap_or_default();
+        assert!(
+            vpc_children.contains(&1),
+            "SG (idx 1) should be a child of VPC. VPC children: {:?}",
+            vpc_children
+        );
+    }
 }

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -1,17 +1,16 @@
 ---
 source: carina-cli/src/plan_snapshot_tests.rs
-assertion_line: 150
 expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.security_group ec2_security_group_712c54ef
-      group_description: "Test security group"
-      tags: {Name: "test-sg"}
-      vpc_id: "vpc-0123456789abcdef0"
   ~ awscc.ec2.vpc vpc
       tags:
         + Environment: "staging"
+        ├─ + awscc.ec2.security_group ec2_security_group_712c54ef
+        │     group_description: "Test security group"
+        │     tags: {Name: "test-sg"}
+        │     vpc_id: "vpc-0123456789abcdef0"
         └─ - awscc.ec2.subnet my_subnet
 
 Plan: 1 to add, 1 to change, 1 to destroy.

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -5,11 +5,27 @@ use std::collections::{HashMap, HashSet};
 use crate::effect::Effect;
 use crate::resource::{Resource, Value};
 
-/// Extract binding names that a resource depends on
+/// Extract binding names that a resource depends on.
+///
+/// First checks for `ResourceRef` values in attributes. If none are found,
+/// falls back to `_dependency_bindings` metadata (saved by `resolve_refs_with_state`
+/// before ResourceRef values were resolved to plain strings).
 pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
     let mut deps = HashSet::new();
     for value in resource.attributes.values() {
         collect_dependencies(value, &mut deps);
+    }
+    // Fall back to pre-computed dependency bindings if no ResourceRef deps found.
+    // This handles the case where resolve_refs_with_state() has already replaced
+    // ResourceRef values with plain strings.
+    if deps.is_empty()
+        && let Some(Value::List(bindings)) = resource.attributes.get("_dependency_bindings")
+    {
+        for b in bindings {
+            if let Value::String(name) = b {
+                deps.insert(name.clone());
+            }
+        }
     }
     deps
 }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -5,16 +5,34 @@
 
 use std::collections::HashMap;
 
+use crate::deps::get_resource_dependencies;
 use crate::resource::{Resource, ResourceId, State, Value};
 
 /// Resolve all ResourceRef values in resources using current state.
 ///
 /// Builds a binding map from resource attributes and state, then resolves
 /// all ResourceRef values across all resources.
+///
+/// Before resolving, saves dependency binding names as `_dependency_bindings`
+/// metadata on each resource. This preserves dependency information that would
+/// otherwise be lost when ResourceRef values are replaced with plain strings.
 pub fn resolve_refs_with_state(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
 ) {
+    // Save dependency bindings before resolution destroys ResourceRef values.
+    // This metadata is used by plan tree building to recover parent-child
+    // relationships (see build_plan_tree in display.rs and app.rs).
+    for resource in resources.iter_mut() {
+        let deps = get_resource_dependencies(resource);
+        if !deps.is_empty() {
+            let dep_list: Vec<Value> = deps.into_iter().map(Value::String).collect();
+            resource
+                .attributes
+                .insert("_dependency_bindings".to_string(), Value::List(dep_list));
+        }
+    }
+
     // Build a map of binding_name -> attributes (merged from DSL and AWS state)
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
 


### PR DESCRIPTION
## Summary
- `resolve_refs_with_state()` now saves `_dependency_bindings` metadata on each resource before replacing `ResourceRef` values with plain strings
- `get_resource_dependencies()` falls back to `_dependency_bindings` when no `ResourceRef` values are found
- Security groups (and other dependent resources) are now correctly nested under their parent VPC in the plan tree, even after ref resolution

## Test plan
- [x] Existing test `test_resolved_ref_loses_dependency_for_tree_nesting` now passes
- [x] Snapshot test `snapshot_mixed_operations` updated to reflect correct nesting
- [x] `make plan-mixed` shows SG nested under VPC
- [x] All `cargo test -p carina-cli` and `cargo test -p carina-tui` pass
- [x] `cargo clippy` and `cargo fmt` clean

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)