### PR TITLE
fix: add blank line separator between attribute diffs and child resources

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -375,9 +375,9 @@ pub fn format_plan(plan: &Plan, compact: bool) -> String {
         prefix: &str,
         compact: bool,
         parent_binding: Option<&str>,
-    ) {
+    ) -> bool {
         if printed.contains(&idx) {
-            return;
+            return false;
         }
         printed.insert(idx);
 
@@ -799,7 +799,7 @@ pub fn format_plan(plan: &Plan, compact: bool) -> String {
 
         for (i, child_idx) in unprinted_children.iter().enumerate() {
             let child_is_last = i == unprinted_children.len() - 1;
-            format_effect_tree(
+            let child_had_attrs = format_effect_tree(
                 out,
                 *child_idx,
                 plan,
@@ -811,7 +811,26 @@ pub fn format_plan(plan: &Plan, compact: bool) -> String {
                 compact,
                 current_binding.as_deref(),
             );
+            // Add separator line between siblings when previous sibling displayed attributes
+            if child_had_attrs && !child_is_last {
+                let separator_continuation = if is_last {
+                    format!("{}   ", prefix)
+                } else {
+                    format!("{}│  ", prefix)
+                };
+                let separator_prefix = if indent == 0 {
+                    format!("{}  ", attr_base)
+                } else {
+                    format!("{}   ", separator_continuation)
+                };
+                writeln!(out, "{}{}│", base_indent, separator_prefix).unwrap();
+            }
+            if child_had_attrs {
+                has_displayed_attrs = true;
+            }
         }
+
+        has_displayed_attrs
     }
 
     // Print from roots

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
@@ -13,6 +13,7 @@ Execution Plan:
         ├─ + awscc.ec2.route_table ec2_route_table_d8d0c86b
         │     tags: {Name: "test-route-table"}
         │     vpc_id: vpc.vpc_id
+        │
         └─ + awscc.ec2.subnet subnet
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -12,6 +12,7 @@ Execution Plan:
         │     group_description: "Test security group"
         │     tags: {Name: "test-sg"}
         │     vpc_id: "vpc-0123456789abcdef0"
+        │
         └─ - awscc.ec2.subnet my_subnet
 
 Plan: 1 to add, 1 to change, 1 to destroy.


### PR DESCRIPTION
## Summary
- Insert a blank line between the attribute block and the child resource tree in plan output
- Improves visual distinction when a resource has both attribute changes and child resources
- Applies to Create, Update, and Replace effects (only when both attributes and children are displayed)

## Test plan
- [x] `cargo test -p carina-cli` passes with updated snapshots
- [x] `make plan-mixed` shows the separator between attribute diffs and child resources
- [x] `make plan-all-create` shows the separator for Create effects with children
- [x] `cargo clippy` and `cargo fmt` pass

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)