### PR TITLE
feat: show in-flight spinner during apply and destroy

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{IsTerminal, Write as _};
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use colored::Colorize;
@@ -46,14 +48,21 @@ pub(crate) fn format_duration(d: Duration) -> String {
     }
 }
 
+/// Braille spinner frames for animated progress display.
+pub(crate) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 /// CLI observer that prints colored progress output.
 ///
-/// When stdout is a TTY, it shows an in-flight spinner line before each effect
+/// When stdout is a TTY, it shows an animated spinner before each effect
 /// and overwrites it with the result. When piped, the spinner is skipped.
 struct CliObserver {
     is_tty: bool,
     /// Length of the last in-flight line (for overwriting with spaces).
     last_inflight_len: usize,
+    /// Flag to signal the spinner thread to stop.
+    spinner_stop: Arc<AtomicBool>,
+    /// Handle to the spinner animation thread.
+    spinner_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl CliObserver {
@@ -61,7 +70,42 @@ impl CliObserver {
         Self {
             is_tty: std::io::stdout().is_terminal(),
             last_inflight_len: 0,
+            spinner_stop: Arc::new(AtomicBool::new(false)),
+            spinner_thread: None,
         }
+    }
+
+    /// Start the spinner animation in a background thread.
+    fn start_spinner(&mut self, desc: String) {
+        if !self.is_tty {
+            return;
+        }
+        self.spinner_stop.store(false, Ordering::Relaxed);
+        let stop = self.spinner_stop.clone();
+        // Estimate line length for clearing (use first frame as reference).
+        // "  " + frame + " " + desc + "..."
+        self.last_inflight_len = 2 + SPINNER_FRAMES[0].len() + 1 + desc.len() + 3;
+        self.spinner_thread = Some(std::thread::spawn(move || {
+            let mut i = 0;
+            while !stop.load(Ordering::Relaxed) {
+                let frame = SPINNER_FRAMES[i % SPINNER_FRAMES.len()];
+                // Use raw ANSI escape for cyan since we're in a spawned thread.
+                print!("\r  \x1b[36m{}\x1b[0m {}...", frame, desc);
+                std::io::stdout().flush().ok();
+                std::thread::sleep(Duration::from_millis(80));
+                i += 1;
+            }
+        }));
+    }
+
+    /// Stop the spinner animation and clear the line.
+    fn stop_spinner(&mut self) {
+        self.spinner_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.spinner_thread.take() {
+            handle.join().ok();
+        }
+        self.clear_inflight();
+        self.last_inflight_len = 0;
     }
 
     /// Clear the in-flight spinner line and move cursor to the start.
@@ -82,12 +126,7 @@ impl ExecutionObserver for CliObserver {
     fn on_event(&mut self, event: &ExecutionEvent) {
         match event {
             ExecutionEvent::EffectStarted { effect } => {
-                if self.is_tty {
-                    let line = format!("  {} {}...", "⠋".cyan(), format_effect(effect));
-                    self.last_inflight_len = line.len();
-                    print!("\r{}", line);
-                    let _ = std::io::stdout().flush();
-                }
+                self.start_spinner(format_effect(effect).to_string());
             }
             ExecutionEvent::EffectSucceeded {
                 effect,
@@ -95,8 +134,7 @@ impl ExecutionObserver for CliObserver {
                 progress,
                 ..
             } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 let timing = format!("[{}]", format_duration(*duration)).dimmed();
                 let counter = format_progress(progress).dimmed();
                 println!(
@@ -113,8 +151,7 @@ impl ExecutionObserver for CliObserver {
                 duration,
                 progress,
             } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 let timing = format!("[{}]", format_duration(*duration)).dimmed();
                 let counter = format_progress(progress).dimmed();
                 println!(
@@ -131,8 +168,7 @@ impl ExecutionObserver for CliObserver {
                 reason,
                 progress,
             } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 let counter = format_progress(progress).dimmed();
                 println!(
                     "  {} {} - {} {}",
@@ -143,23 +179,19 @@ impl ExecutionObserver for CliObserver {
                 );
             }
             ExecutionEvent::CascadeUpdateSucceeded { id } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 println!("  {} Update {} (cascade)", "✓".green(), id);
             }
             ExecutionEvent::CascadeUpdateFailed { id, error } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 println!("  {} Update {} (cascade) - {}", "✗".red(), id, error);
             }
             ExecutionEvent::RenameSucceeded { id, from, to } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 println!("  {} Rename {} \"{}\" → \"{}\"", "✓".green(), id, from, to);
             }
             ExecutionEvent::RenameFailed { id, error } => {
-                self.clear_inflight();
-                self.last_inflight_len = 0;
+                self.stop_spinner();
                 println!("  {} Rename {} - {}", "✗".red(), id, error);
             }
             ExecutionEvent::RefreshStarted => {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{IsTerminal, Write as _};
 use std::path::PathBuf;
-use std::time::Instant;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
@@ -19,7 +21,7 @@ use carina_state::{
 };
 
 use super::validate_and_resolve;
-use crate::commands::apply::{apply_name_overrides, format_duration};
+use crate::commands::apply::{SPINNER_FRAMES, apply_name_overrides, format_duration};
 use crate::commands::state::map_lock_error;
 use crate::display::format_effect;
 use crate::error::AppError;
@@ -266,6 +268,8 @@ async fn run_destroy_locked(
     let destroy_total = resources_to_destroy.len();
     let mut destroy_completed: usize = 0;
     let is_tty = std::io::stdout().is_terminal();
+    let spinner_stop = Arc::new(AtomicBool::new(false));
+    let mut spinner_thread: Option<std::thread::JoinHandle<()>> = None;
     let mut last_inflight_len: usize = 0;
 
     for resource in &resources_to_destroy {
@@ -388,12 +392,22 @@ async fn run_destroy_locked(
             continue;
         }
 
-        // Show in-flight spinner
+        // Show animated spinner
         if is_tty {
-            let line = format!("  {} {}...", "⠋".cyan(), format_effect(&effect));
-            last_inflight_len = line.len();
-            print!("\r{}", line);
-            let _ = std::io::stdout().flush();
+            let desc = format_effect(&effect).to_string();
+            last_inflight_len = 2 + SPINNER_FRAMES[0].len() + 1 + desc.len() + 3;
+            spinner_stop.store(false, Ordering::Relaxed);
+            let stop = spinner_stop.clone();
+            spinner_thread = Some(std::thread::spawn(move || {
+                let mut i = 0;
+                while !stop.load(Ordering::Relaxed) {
+                    let frame = SPINNER_FRAMES[i % SPINNER_FRAMES.len()];
+                    print!("\r  \x1b[36m{}\x1b[0m {}...", frame, desc);
+                    std::io::stdout().flush().ok();
+                    std::thread::sleep(Duration::from_millis(80));
+                    i += 1;
+                }
+            }));
         }
 
         let started = Instant::now();
@@ -401,7 +415,11 @@ async fn run_destroy_locked(
             .delete(&resource.id, &identifier, &resource.lifecycle)
             .await;
 
-        // Clear in-flight spinner
+        // Stop spinner and clear line
+        spinner_stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = spinner_thread.take() {
+            handle.join().ok();
+        }
         if is_tty && last_inflight_len > 0 {
             print!("\r{}\r", " ".repeat(last_inflight_len));
             last_inflight_len = 0;


### PR DESCRIPTION
## Summary
- Show a spinning `⠋` indicator before each effect during `apply` and `destroy`, then overwrite it with the result line (checkmark/cross/skip)
- Non-TTY output (piped) skips the spinner entirely, printing only result lines
- Uses carriage return (`\r`) to update the line in place without leaving stale output

Closes #992

## Test plan
- [x] `cargo test` passes (all 115+ carina-cli tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual: run `apply` on a real .crn file and verify spinner appears before each resource
- [ ] Manual: pipe `apply` output to a file and verify no spinner artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)