### PR TITLE
fix: use format_destroy_plan in destroy snapshot test

### DIFF
--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -15,7 +15,7 @@ use carina_core::resource::{ResourceId, State};
 use carina_state::StateFile;
 
 use crate::commands::validate_and_resolve;
-use crate::display::format_plan;
+use crate::display::{format_destroy_plan, format_plan};
 use crate::wiring::{
     WiringContext, reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
 };
@@ -181,6 +181,6 @@ fn snapshot_enum_display() {
 #[test]
 fn snapshot_destroy_full() {
     let plan = build_plan_from_fixture("destroy_full");
-    let output = strip_ansi(&format_plan(&plan, false));
+    let output = strip_ansi(&format_destroy_plan(&plan));
     insta::assert_snapshot!(output);
 }

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
@@ -2,9 +2,7 @@
 source: carina-cli/src/plan_snapshot_tests.rs
 expression: output
 ---
-Execution Plan:
+Destroy Plan:
 
   - awscc.ec2.vpc vpc
         └─ - awscc.ec2.subnet subnet
-
-Plan: 0 to add, 0 to change, 2 to destroy.


### PR DESCRIPTION
## Summary
- Change `snapshot_destroy_full` test to use `format_destroy_plan()` instead of `format_plan()`, so the snapshot matches the actual `carina destroy` output
- Update the snapshot to reflect the correct "Destroy Plan:" header and destroy-specific summary format

Closes #1001

## Test plan
- [x] `cargo test -p carina-cli plan_snapshot` passes (all 8 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)