### PR TITLE
fix: remove unnecessary let bindings from plan display fixtures

### DIFF
--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -203,3 +203,47 @@ fn snapshot_destroy_full() {
     let output = strip_ansi(&format_destroy_plan(&plan));
     insta::assert_snapshot!(output);
 }
+
+/// Ensure no fixture .crn file has unused `let` bindings.
+///
+/// `let` should only be used when a binding is referenced by another resource.
+/// This test prevents regressions where unnecessary `let` bindings are added
+/// to fixture files.
+#[test]
+fn no_unused_let_bindings_in_fixtures() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let fixtures_dir = format!("{}/tests/fixtures/plan_display", manifest_dir);
+
+    let mut failures: Vec<(String, Vec<String>)> = Vec::new();
+
+    for entry in std::fs::read_dir(&fixtures_dir).unwrap() {
+        let entry = entry.unwrap();
+        if !entry.file_type().unwrap().is_dir() {
+            continue;
+        }
+        let fixture_name = entry.file_name().to_string_lossy().to_string();
+        let crn_path = PathBuf::from(format!("{}/{}/main.crn", fixtures_dir, fixture_name));
+        if !crn_path.exists() {
+            continue;
+        }
+
+        let loaded = load_configuration(&crn_path).unwrap();
+        let unused = crate::wiring::check_unused_bindings(&loaded.unresolved_parsed);
+        if !unused.is_empty() {
+            failures.push((fixture_name, unused));
+        }
+    }
+
+    if !failures.is_empty() {
+        let msg: Vec<String> = failures
+            .iter()
+            .map(|(name, bindings)| {
+                format!("  {}: unused let bindings: {}", name, bindings.join(", "))
+            })
+            .collect();
+        panic!(
+            "Fixture .crn files must not have unused let bindings:\n{}",
+            msg.join("\n")
+        );
+    }
+}

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
@@ -14,7 +14,7 @@ Execution Plan:
         │     tags: {Name: "test-route-table"}
         │     vpc_id: vpc.vpc_id
         │
-        └─ + awscc.ec2.subnet subnet
+        └─ + awscc.ec2.subnet ec2_subnet_f5269366
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               tags: {Name: "test-subnet"}

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_compact.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_compact.snap
@@ -1,12 +1,11 @@
 ---
 source: carina-cli/src/plan_snapshot_tests.rs
-assertion_line: 164
 expression: output
 ---
 Execution Plan:
 
   + awscc.ec2.vpc vpc
         ├─ + awscc.ec2.route_table ec2_route_table_d8d0c86b
-        └─ + awscc.ec2.subnet subnet
+        └─ + awscc.ec2.subnet (availability_zone: awscc.AvailabilityZone.ap_northeast_1a)
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
@@ -4,5 +4,5 @@ expression: output
 ---
 Destroy Plan:
 
-  - awscc.ec2.vpc vpc
-        └─ - awscc.ec2.subnet subnet
+  - awscc.ec2.vpc ec2_vpc_fb75c929
+        └─ - awscc.ec2.subnet ec2_subnet_f5269366

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_map_key_diff.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_map_key_diff.snap
@@ -1,11 +1,10 @@
 ---
 source: carina-cli/src/plan_snapshot_tests.rs
-assertion_line: 171
 expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.vpc vpc
+  ~ awscc.ec2.vpc ec2_vpc_fb75c929
       tags:
         ~ Environment: "staging" → "production"
         - OldTag: "remove-me"

--- a/carina-cli/tests/fixtures/plan_display/all_create/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/all_create/main.crn
@@ -14,7 +14,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"

--- a/carina-cli/tests/fixtures/plan_display/compact/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/compact/main.crn
@@ -14,7 +14,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.vpc",
-      "name": "vpc",
+      "name": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -21,7 +21,7 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
-      "binding": "vpc",
+      "binding": "ec2_vpc_fb75c929",
       "dependency_bindings": []
     },
     {
@@ -42,7 +42,7 @@
       "name_overrides": {},
       "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "my_subnet",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": ["ec2_vpc_fb75c929"]
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/delete_orphan/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan/main.crn
@@ -4,7 +4,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.vpc",
-      "name": "vpc",
+      "name": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -21,12 +21,12 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
-      "binding": "vpc",
+      "binding": "ec2_vpc_fb75c929",
       "dependency_bindings": []
     },
     {
       "resource_type": "ec2.subnet",
-      "name": "subnet",
+      "name": "ec2_subnet_f5269366",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {
@@ -41,8 +41,8 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
-      "binding": "subnet",
-      "dependency_bindings": ["vpc"]
+      "binding": "ec2_subnet_f5269366",
+      "dependency_bindings": ["ec2_vpc_fb75c929"]
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
@@ -6,7 +6,7 @@
   "resources": [
     {
       "resource_type": "ec2.vpc",
-      "name": "vpc",
+      "name": "ec2_vpc_fb75c929",
       "provider": "awscc",
       "identifier": "vpc-0123456789abcdef0",
       "attributes": {
@@ -21,7 +21,7 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
-      "binding": "vpc",
+      "binding": "ec2_vpc_fb75c929",
       "dependency_bindings": []
     }
   ]

--- a/carina-cli/tests/fixtures/plan_display/map_key_diff/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/map_key_diff/main.crn
@@ -4,7 +4,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+awscc.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
@@ -26,7 +26,7 @@
     },
     {
       "resource_type": "ec2.subnet",
-      "name": "my_subnet",
+      "name": "ec2_subnet_aac7c86b",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {
@@ -40,7 +40,7 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["vpc_id", "cidr_block", "tags"],
-      "binding": "my_subnet",
+      "binding": "ec2_subnet_aac7c86b",
       "dependency_bindings": ["vpc"]
     }
   ]

--- a/carina-cli/tests/fixtures/plan_display/no_changes/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/no_changes/main.crn
@@ -14,7 +14,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let my_subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
 

--- a/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
@@ -25,7 +25,7 @@
     },
     {
       "resource_type": "ec2.subnet",
-      "name": "my_subnet",
+      "name": "ec2_subnet_f5269366",
       "provider": "awscc",
       "identifier": "subnet-0123456789abcdef0",
       "attributes": {
@@ -40,7 +40,7 @@
       "prefixes": {},
       "name_overrides": {},
       "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
-      "binding": "my_subnet",
+      "binding": "ec2_subnet_f5269366",
       "dependency_bindings": ["vpc"]
     }
   ]

--- a/carina-cli/tests/fixtures/plan_display/no_changes_enum/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/no_changes_enum/main.crn
@@ -13,7 +13,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let my_subnet = awscc.ec2.subnet {
+awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = "ap-northeast-1a"


### PR DESCRIPTION
## Summary

- Remove unused `let` bindings from 7 fixture `.crn` files (`all_create`, `no_changes`, `compact`, `delete_orphan`, `map_key_diff`, `destroy_full`, `no_changes_enum`) where bindings are not referenced by other resources
- Update corresponding state files (`carina.state.json`) to use auto-generated anonymous resource names (e.g., `ec2_vpc_fb75c929`, `ec2_subnet_f5269366`)
- Update snapshot files to reflect the new anonymous resource names in plan output
- Add `no_unused_let_bindings_in_fixtures` test to prevent future fixtures from introducing unnecessary `let` bindings

## Test plan

- [x] All plan snapshot tests pass (`cargo test -p carina-cli plan_snapshot`)
- [x] TUI tests pass (`cargo test -p carina-tui`)
- [x] New prevention test catches unused bindings in fixture files
- [x] `cargo fmt` and `cargo clippy` pass

Closes #1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)