### PR TITLE
fix: include orphaned resources in destroy with dependency ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ plan-no-changes-enum:
 plan-destroy-full:
 	cd $(FIXTURES)/destroy_full && $(CARINA) destroy --refresh=false --lock=false main.crn
 
+plan-destroy-orphans:
+	cd $(FIXTURES)/destroy_orphans && $(CARINA) destroy --refresh=false --lock=false main.crn
+
 plan-map-diff-tui:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false --tui main.crn
 
@@ -67,7 +70,10 @@ plan-fixtures:
 	@echo ""
 	@echo "=== destroy_full ==="
 	@$(MAKE) plan-destroy-full
+	@echo ""
+	@echo "=== destroy_orphans ==="
+	@$(MAKE) plan-destroy-orphans
 
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
-        plan-map-diff plan-enum-display plan-destroy-full plan-map-diff-tui \
+        plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-map-diff-tui \
         plan-all-create-tui plan-mixed-tui plan-delete-tui plan-fixtures

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -42,13 +42,8 @@ pub async fn run_destroy(
     let base_dir = get_base_dir(path);
     validate_and_resolve(&mut parsed, base_dir, true)?;
 
-    // When refresh=true, exit early if no resources defined (orphans not supported
-    // in refresh mode). When refresh=false, skip this check because orphaned
-    // resources in the state file may still need to be shown/destroyed.
-    if refresh && parsed.resources.is_empty() {
-        println!("{}", "No resources defined in configuration.".yellow());
-        return Ok(());
-    }
+    // Don't exit early when resources are empty -- orphaned resources in the
+    // state file may still need to be destroyed.
 
     // Check for backend configuration - use local backend by default
     let backend_config = parsed.backend.as_ref();
@@ -169,6 +164,24 @@ async fn run_destroy_locked(
                 .map_err(AppError::Provider)?;
             current_states.insert(resource.id.clone(), state);
         }
+
+        // Include orphaned resources (in state but not in .crn).
+        // Refresh each orphan via provider.read() to verify it still exists.
+        if let Some(sf) = state_file.as_ref() {
+            let desired_ids: HashSet<ResourceId> =
+                destroy_order.iter().map(|r| r.id.clone()).collect();
+            for (id, state) in sf.build_orphan_states(&desired_ids) {
+                let refreshed = provider
+                    .read(&id, state.identifier.as_deref())
+                    .await
+                    .map_err(AppError::Provider)?;
+                if refreshed.exists {
+                    current_states.insert(id.clone(), refreshed);
+                    let orphan_resource = build_orphan_resource(sf, &id);
+                    destroy_order.push(orphan_resource);
+                }
+            }
+        }
     } else if let Some(sf) = state_file.as_ref() {
         // --refresh=false: build states from state file without AWS calls
         for resource in &destroy_order {
@@ -183,41 +196,18 @@ async fn run_destroy_locked(
         let desired_ids: HashSet<ResourceId> = destroy_order.iter().map(|r| r.id.clone()).collect();
         for (id, state) in sf.build_orphan_states(&desired_ids) {
             current_states.insert(id.clone(), state);
-            // Build a minimal Resource for the orphan so it appears in destroy_order
-            let rs = sf
-                .find_resource(&id.provider, &id.resource_type, &id.name)
-                .expect("orphan must exist in state file");
-            let mut attributes: HashMap<String, Value> = rs
-                .attributes
-                .iter()
-                .filter_map(|(k, v)| {
-                    carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
-                })
-                .collect();
-            if let Some(ref binding) = rs.binding {
-                attributes.insert("_binding".to_string(), Value::String(binding.clone()));
-            }
-            if !rs.dependency_bindings.is_empty() {
-                attributes.insert(
-                    "_dependency_bindings".to_string(),
-                    Value::List(
-                        rs.dependency_bindings
-                            .iter()
-                            .map(|b| Value::String(b.clone()))
-                            .collect(),
-                    ),
-                );
-            }
-            let orphan_resource = Resource {
-                id: id.clone(),
-                attributes,
-                read_only: false,
-                lifecycle: rs.lifecycle.clone(),
-                prefixes: rs.prefixes.clone(),
-            };
+            let orphan_resource = build_orphan_resource(sf, &id);
             destroy_order.push(orphan_resource);
         }
     }
+
+    // Re-sort destroy_order (including orphans) by dependencies to ensure
+    // dependents are deleted before their dependencies.
+    destroy_order = sort_resources_by_dependencies(&destroy_order)
+        .map_err(AppError::Config)?
+        .into_iter()
+        .rev()
+        .collect();
 
     // Collect resources that exist and will be destroyed
     // Skip the state bucket if it matches the backend bucket
@@ -645,6 +635,43 @@ async fn run_destroy_locked(
             "Destroy failed. {} succeeded, {} failed, {} skipped.",
             success_count, failure_count, skip_count
         )))
+    }
+}
+
+/// Build a minimal `Resource` for an orphaned resource from the state file.
+///
+/// This creates a Resource with attributes reconstructed from state data,
+/// including `_binding` and `_dependency_bindings` so that dependency ordering
+/// and tree display work correctly.
+fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceId) -> Resource {
+    let rs = sf
+        .find_resource(&id.provider, &id.resource_type, &id.name)
+        .expect("orphan must exist in state file");
+    let mut attributes: HashMap<String, Value> = rs
+        .attributes
+        .iter()
+        .filter_map(|(k, v)| carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val)))
+        .collect();
+    if let Some(ref binding) = rs.binding {
+        attributes.insert("_binding".to_string(), Value::String(binding.clone()));
+    }
+    if !rs.dependency_bindings.is_empty() {
+        attributes.insert(
+            "_dependency_bindings".to_string(),
+            Value::List(
+                rs.dependency_bindings
+                    .iter()
+                    .map(|b| Value::String(b.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    Resource {
+        id: id.clone(),
+        attributes,
+        read_only: false,
+        lifecycle: rs.lifecycle.clone(),
+        prefixes: rs.prefixes.clone(),
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -231,6 +231,19 @@ fn snapshot_destroy_full() {
     insta::assert_snapshot!(output);
 }
 
+#[test]
+fn snapshot_destroy_orphans() {
+    use carina_core::resource::Value;
+    let (plan, current_states) = build_plan_and_states_from_fixture("destroy_orphans");
+    let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = current_states
+        .into_iter()
+        .filter(|(_, state)| state.exists)
+        .map(|(id, state)| (id, state.attributes))
+        .collect();
+    let output = strip_ansi(&format_destroy_plan(&plan, false, &delete_attributes));
+    insta::assert_snapshot!(output);
+}
+
 /// Ensure no fixture .crn file has unused `let` bindings.
 ///
 /// `let` should only be used when a binding is referenced by another resource.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
@@ -1,0 +1,19 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Destroy Plan:
+
+  - awscc.ec2.vpc ec2_vpc_fb75c929
+      cidr_block: "10.0.0.0/16"
+      enable_dns_hostnames: true
+      enable_dns_support: true
+      tags: {Name: "test-vpc"}
+      vpc_id: "vpc-0123456789abcdef0"
+        │
+        └─ - awscc.ec2.subnet ec2_subnet_f5269366
+              availability_zone: "ap-northeast-1a"
+              cidr_block: "10.0.1.0/24"
+              subnet_id: "subnet-0123456789abcdef0"
+              tags: {Name: "test-subnet"}
+              vpc_id: "vpc-0123456789abcdef0"

--- a/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
@@ -1,0 +1,48 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-destroy-orphans",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.vpc",
+      "name": "ec2_vpc_fb75c929",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_support": true,
+        "enable_dns_hostnames": true,
+        "vpc_id": "vpc-0123456789abcdef0",
+        "tags": { "Name": "test-vpc" }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
+      "binding": "my_vpc",
+      "dependency_bindings": []
+    },
+    {
+      "resource_type": "ec2.subnet",
+      "name": "ec2_subnet_f5269366",
+      "provider": "awscc",
+      "identifier": "subnet-0123456789abcdef0",
+      "attributes": {
+        "vpc_id": "vpc-0123456789abcdef0",
+        "cidr_block": "10.0.1.0/24",
+        "availability_zone": "ap-northeast-1a",
+        "subnet_id": "subnet-0123456789abcdef0",
+        "tags": { "Name": "test-subnet" }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
+      "binding": "my_subnet",
+      "dependency_bindings": ["my_vpc"]
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/destroy_orphans/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/destroy_orphans/main.crn
@@ -1,0 +1,7 @@
+# Destroy orphans: .crn is empty, state has VPC + subnet (subnet depends on VPC)
+# Both resources are orphans and should be destroyed in dependency order
+# (subnet first, then VPC)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}


### PR DESCRIPTION
## Summary
- Add orphan handling to `destroy --refresh=true` path (reads orphans via `provider.read()` to verify they still exist)
- Re-sort full resource list (including orphans) by dependencies after orphan collection, ensuring dependents are deleted before dependencies in both `--refresh=true` and `--refresh=false` modes
- Extract `build_orphan_resource()` helper to eliminate code duplication between the two paths
- Remove premature early exit when `.crn` has no resources (orphans in state may still need destruction)

## Test plan
- [x] Added `destroy_orphans` fixture with VPC + subnet (subnet depends on VPC), empty `.crn` file
- [x] Snapshot test verifies correct dependency tree display for orphan-only destroy
- [x] All existing tests pass (`cargo test -p carina-cli`)
- [x] `cargo clippy` clean, `cargo fmt` applied

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)