### PR TITLE
fix: display orphan resources by binding name

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -782,7 +782,8 @@ fn format_plan_tree(
                     }
                 }
             }
-            Effect::Delete { id, .. } => {
+            Effect::Delete { id, binding, .. } => {
+                let display_name = binding.as_deref().unwrap_or(&id.name);
                 writeln!(
                     out,
                     "{}{}{} {} {}",
@@ -790,7 +791,7 @@ fn format_plan_tree(
                     connector,
                     colored_symbol,
                     id.display_type().cyan().bold(),
-                    id.name.red().bold().strikethrough()
+                    display_name.red().bold().strikethrough()
                 )
                 .unwrap();
                 if !compact && let Some(attrs) = delete_attributes.and_then(|da| da.get(id)) {

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
@@ -4,14 +4,14 @@ expression: output
 ---
 Destroy Plan:
 
-  - awscc.ec2.vpc ec2_vpc_fb75c929
+  - awscc.ec2.vpc my_vpc
       cidr_block: "10.0.0.0/16"
       enable_dns_hostnames: true
       enable_dns_support: true
       tags: {Name: "test-vpc"}
       vpc_id: "vpc-0123456789abcdef0"
         │
-        └─ - awscc.ec2.subnet ec2_subnet_f5269366
+        └─ - awscc.ec2.subnet my_subnet
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               subnet_id: "subnet-0123456789abcdef0"


### PR DESCRIPTION
## Summary
- When orphaned resources (in state but not in .crn) are displayed in destroy/plan output, use the binding name (`my_vpc`) instead of the auto-generated hash name (`ec2_vpc_fb75c929`)
- The `Effect::Delete` already stores the `binding` field; the display code now uses it when available

## Test plan
- [x] Updated snapshot for `destroy_orphans` fixture confirms binding names are displayed
- [x] All existing snapshot tests pass (no unintended changes)
- [x] `cargo clippy` and `cargo fmt` pass

Closes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)