### PR TITLE
fix: show error details inline with failed resource in apply/destroy output

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -155,13 +155,13 @@ impl ExecutionObserver for CliObserver {
                 let timing = format!("[{}]", format_duration(*duration)).dimmed();
                 let counter = format_progress(progress).dimmed();
                 println!(
-                    "  {} {} - {} {} {}",
+                    "  {} {} {} {}",
                     "✗".red(),
                     format_effect(effect),
-                    error,
                     timing,
                     counter
                 );
+                println!("      {} {}", "→".red(), error.red());
             }
             ExecutionEvent::EffectSkipped {
                 effect,
@@ -184,7 +184,8 @@ impl ExecutionObserver for CliObserver {
             }
             ExecutionEvent::CascadeUpdateFailed { id, error } => {
                 self.stop_spinner();
-                println!("  {} Update {} (cascade) - {}", "✗".red(), id, error);
+                println!("  {} Update {} (cascade)", "✗".red(), id);
+                println!("      {} {}", "→".red(), error.red());
             }
             ExecutionEvent::RenameSucceeded { id, from, to } => {
                 self.stop_spinner();
@@ -192,7 +193,8 @@ impl ExecutionObserver for CliObserver {
             }
             ExecutionEvent::RenameFailed { id, error } => {
                 self.stop_spinner();
-                println!("  {} Rename {} - {}", "✗".red(), id, error);
+                println!("  {} Rename {}", "✗".red(), id);
+                println!("      {} {}", "→".red(), error.red());
             }
             ExecutionEvent::RefreshStarted => {
                 println!();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -445,21 +445,22 @@ async fn run_destroy_locked(
                         success_count += 1;
                     }
                     WaitResult::ReadError(msg) => {
+                        println!("  {} Delete {}", "✗".red(), dep_id);
                         println!(
-                            "  {} {} - read error during wait: {}",
-                            "✗".red(),
-                            dep_id,
-                            msg
+                            "      {} {}",
+                            "→".red(),
+                            format!("read error during wait: {}", msg).red()
                         );
                         failed_bindings.insert(dep_binding.clone());
                         failure_count += 1;
                         wait_failed = true;
                     }
                     WaitResult::TimedOut => {
+                        println!("  {} Delete {}", "✗".red(), dep_id);
                         println!(
-                            "  {} {} - still exists after extended wait",
-                            "✗".red(),
-                            dep_id
+                            "      {} {}",
+                            "→".red(),
+                            "still exists after extended wait".red()
                         );
                         failed_bindings.insert(dep_binding.clone());
                         failure_count += 1;
@@ -540,13 +541,13 @@ async fn run_destroy_locked(
             Err(e) => {
                 let timing = format!("[{}]", format_duration(started.elapsed())).dimmed();
                 println!(
-                    "  {} {} - {} {} {}",
+                    "  {} {} {} {}",
                     "✗".red(),
                     format_effect(&effect),
-                    e,
                     timing,
                     counter
                 );
+                println!("      {} {}", "→".red(), e.to_string().red());
                 failure_count += 1;
                 failed_bindings.insert(binding.clone());
             }
@@ -580,20 +581,21 @@ async fn run_destroy_locked(
                 success_count += 1;
             }
             WaitResult::ReadError(msg) => {
+                println!("  {} Delete {}", "✗".red(), dep_id);
                 println!(
-                    "  {} {} - read error during wait: {}",
-                    "✗".red(),
-                    dep_id,
-                    msg
+                    "      {} {}",
+                    "→".red(),
+                    format!("read error during wait: {}", msg).red()
                 );
                 failed_bindings.insert(dep_binding.clone());
                 failure_count += 1;
             }
             WaitResult::TimedOut => {
+                println!("  {} Delete {}", "✗".red(), dep_id);
                 println!(
-                    "  {} {} - still exists after extended wait",
-                    "✗".red(),
-                    dep_id
+                    "      {} {}",
+                    "→".red(),
+                    "still exists after extended wait".red()
                 );
                 failed_bindings.insert(dep_binding.clone());
                 failure_count += 1;


### PR DESCRIPTION
## Summary
- Display error messages on a separate indented line below the failed resource line in both apply and destroy commands
- Use red `→` arrow prefix for visual clarity, matching the format: `    → error message`
- Apply the same pattern to all failure events: EffectFailed, CascadeUpdateFailed, RenameFailed, and destroy wait errors

Before:
```
  ✗ Create awscc.ec2.subnet public_1a - InvalidParameterValue: CIDR block conflicts [12.3s] 3/6
```

After:
```
  ✗ Create awscc.ec2.subnet public_1a [12.3s] 3/6
      → InvalidParameterValue: CIDR block conflicts
```

Closes #991

## Test plan
- [x] `cargo test -p carina-cli` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Visual confirmation with actual AWS errors (acceptance test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)