### PR TITLE
feat: show hidden unchanged attribute count in plan update effects

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -656,6 +656,34 @@ fn format_plan_tree(
                             .unwrap();
                         }
                     }
+
+                    // Count unchanged attributes hidden from display
+                    let unchanged_count = from
+                        .attributes
+                        .iter()
+                        .filter(|(k, v)| {
+                            !k.starts_with('_')
+                                && to
+                                    .attributes
+                                    .get(k.as_str())
+                                    .map(|nv| nv.semantically_equal(v))
+                                    .unwrap_or(false)
+                        })
+                        .count();
+                    if unchanged_count > 0 {
+                        let noun = if unchanged_count == 1 {
+                            "attribute"
+                        } else {
+                            "attributes"
+                        };
+                        writeln!(
+                            out,
+                            "{}{}",
+                            attr_prefix,
+                            format!("# ({} unchanged {} hidden)", unchanged_count, noun).dimmed()
+                        )
+                        .unwrap();
+                    }
                 }
             }
             Effect::Replace {
@@ -779,6 +807,34 @@ fn format_plan_tree(
                                 writeln!(out, "{}", diff).unwrap();
                             }
                         }
+                    }
+
+                    // Count unchanged attributes hidden from display
+                    let unchanged_count = from
+                        .attributes
+                        .iter()
+                        .filter(|(k, v)| {
+                            !k.starts_with('_')
+                                && to
+                                    .attributes
+                                    .get(k.as_str())
+                                    .map(|nv| nv.semantically_equal(v))
+                                    .unwrap_or(false)
+                        })
+                        .count();
+                    if unchanged_count > 0 {
+                        let noun = if unchanged_count == 1 {
+                            "attribute"
+                        } else {
+                            "attributes"
+                        };
+                        writeln!(
+                            out,
+                            "{}{}",
+                            attr_prefix,
+                            format!("# ({} unchanged {} hidden)", unchanged_count, noun).dimmed()
+                        )
+                        .unwrap();
                     }
                 }
             }

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_map_key_diff.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_map_key_diff.snap
@@ -8,5 +8,6 @@ Execution Plan:
       tags:
         ~ Environment: "staging" → "production"
         - OldTag: "remove-me"
+      # (3 unchanged attributes hidden)
 
 Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -7,6 +7,7 @@ Execution Plan:
   ~ awscc.ec2.vpc vpc
       tags:
         + Environment: "staging"
+      # (3 unchanged attributes hidden)
         │
         ├─ + awscc.ec2.security_group ec2_security_group_712c54ef
         │     group_description: "Test security group"


### PR DESCRIPTION
## Summary

- For Update and Replace effects in plan output, add a dimmed summary line showing how many unchanged attributes are hidden (e.g., `# (3 unchanged attributes hidden)`)
- This matches Terraform's concise diff behavior, helping users understand the full scope of resources being modified without cluttering the output

Part of #943

## Test plan

- [x] Existing `mixed_operations` and `map_key_diff` snapshot tests updated to include the new hidden count line
- [x] Verified count is correct: VPC with `cidr_block`, `enable_dns_hostnames`, `enable_dns_support` unchanged = 3 hidden attributes
- [x] Hidden count line only appears when `unchanged_count > 0`
- [x] Singular/plural handled ("attribute" vs "attributes")
- [x] Not shown in compact mode (the `if compact` branch returns early before attribute rendering)
- [x] `cargo clippy` and `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)