### PR TITLE
feat: show default attribute values in plan create effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ plan-destroy-orphans:
 plan-read-only-attrs:
 	cd $(FIXTURES)/read_only_attrs && $(CARINA) plan --refresh=false main.crn
 
+plan-default-values:
+	cd $(FIXTURES)/default_values && $(CARINA) plan --refresh=false main.crn
+
 plan-map-diff-tui:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false --tui main.crn
 
@@ -79,7 +82,11 @@ plan-fixtures:
 	@echo ""
 	@echo "=== read_only_attrs ==="
 	@$(MAKE) plan-read-only-attrs
+	@echo ""
+	@echo "=== default_values ==="
+	@$(MAKE) plan-default-values
 
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
+        plan-default-values \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui plan-fixtures

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -557,12 +557,36 @@ fn format_plan_tree(
                             .unwrap();
                         }
                     }
-                    // Show read-only attributes with (known after apply) placeholder
                     if let Some(schema_map) = schemas {
                         let schema_key = r.id.display_type();
                         if let Some(schema) = schema_map.get(&schema_key) {
                             let user_keys: HashSet<&str> =
                                 keys.iter().map(|k| k.as_str()).collect();
+
+                            // Show default-value attributes (not specified by user)
+                            let mut default_attrs: Vec<(&str, &Value)> = schema
+                                .default_value_attributes()
+                                .into_iter()
+                                .filter(|(a, _)| !user_keys.contains(a))
+                                .collect();
+                            default_attrs.sort_by_key(|(a, _)| *a);
+                            if !default_attrs.is_empty() {
+                                has_displayed_attrs = true;
+                            }
+                            for (attr, default_val) in default_attrs {
+                                let formatted = format_value_with_key(default_val, Some(attr));
+                                writeln!(
+                                    out,
+                                    "{}{}: {}  {}",
+                                    attr_prefix,
+                                    attr.dimmed(),
+                                    formatted.dimmed(),
+                                    "# default".dimmed()
+                                )
+                                .unwrap();
+                            }
+
+                            // Show read-only attributes with (known after apply) placeholder
                             let mut ro_attrs: Vec<&str> = schema
                                 .read_only_attributes()
                                 .into_iter()

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -257,6 +257,13 @@ fn snapshot_destroy_orphans() {
 }
 
 #[test]
+fn snapshot_default_values() {
+    let (plan, schemas) = build_plan_from_fixture("default_values");
+    let output = strip_ansi(&format_plan(&plan, false, &HashMap::new(), Some(&schemas)));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_read_only_attrs() {
     let (plan, schemas) = build_plan_from_fixture("read_only_attrs");
     let output = strip_ansi(&format_plan(&plan, false, &HashMap::new(), Some(&schemas)));

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_values.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_values.snap
@@ -1,0 +1,14 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.logs.log_group logs_log_group_702321fd
+      log_group_name: "my-app-logs"
+      retention_in_days: 30
+      deletion_protection_enabled: false  # default
+      log_group_class: "STANDARD"  # default
+      arn: (known after apply)
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/default_values/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/default_values/main.crn
@@ -1,0 +1,10 @@
+# Test default attribute values display with # default annotation
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.logs.log_group {
+  log_group_name = "my-app-logs"
+  retention_in_days = 30
+}

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -735,6 +735,16 @@ impl ResourceSchema {
             .collect()
     }
 
+    /// Returns attributes that have default values and are not read-only.
+    /// Each entry is (attribute_name, default_value).
+    pub fn default_value_attributes(&self) -> Vec<(&str, &Value)> {
+        self.attributes
+            .iter()
+            .filter(|(_, schema)| schema.default.is_some() && !schema.read_only)
+            .map(|(name, schema)| (name.as_str(), schema.default.as_ref().unwrap()))
+            .collect()
+    }
+
     /// Returns the names of create-only (immutable) attributes
     pub fn create_only_attributes(&self) -> Vec<&str> {
         self.attributes


### PR DESCRIPTION
## Summary

- For Create effects, show schema-defined default values for attributes not explicitly set by the user
- Default attributes appear after user-specified attributes, before read-only `(known after apply)` attributes
- Displayed in dimmed text with a `# default` annotation (e.g., `deletion_protection_enabled: false  # default`)

Part of #943

## Test plan

- [x] New fixture (`default_values`) with `logs.log_group` resource that has two defaults (`deletion_protection_enabled: false`, `log_group_class: "STANDARD"`)
- [x] Snapshot test verifies correct ordering: user attrs -> default attrs -> read-only attrs
- [x] All existing snapshot tests pass (no regressions)
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)