### PR TITLE
refactor: centralize value formatting in carina-core (step 1 of #1034)

### DIFF
--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -8,6 +8,7 @@ use carina_core::effect::Effect;
 use carina_core::plan::{Plan, PlanSummary};
 use carina_core::resource::Value;
 use carina_core::schema::ResourceSchema;
+use carina_core::value::format_value;
 use ratatui::widgets::ListState;
 
 /// A node in the tree view representing one effect
@@ -1010,43 +1011,6 @@ fn format_attributes(attrs: &HashMap<String, Value>) -> Vec<(String, String)> {
         .collect();
     result.sort_by(|a, b| a.0.cmp(&b.0));
     result
-}
-
-/// Format a Value for display
-pub fn format_value(value: &Value) -> String {
-    match value {
-        Value::String(s) => {
-            if carina_core::utils::is_dsl_enum_format(s) {
-                let resolved = carina_core::utils::convert_enum_value(s);
-                format!("\"{}\"", resolved)
-            } else {
-                format!("\"{}\"", s)
-            }
-        }
-        Value::Int(n) => n.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Bool(b) => b.to_string(),
-        Value::List(items) => {
-            let inner: Vec<String> = items.iter().map(format_value).collect();
-            format!("[{}]", inner.join(", "))
-        }
-        Value::Map(map) => {
-            let mut entries: Vec<String> = map
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, format_value(v)))
-                .collect();
-            entries.sort();
-            format!("{{{}}}", entries.join(", "))
-        }
-        Value::ResourceRef {
-            binding_name,
-            attribute_name,
-        } => format!("{}.{}", binding_name, attribute_name),
-        Value::UnresolvedIdent(name, member) => match member {
-            Some(m) => format!("{}.{}", name, m),
-            None => name.clone(),
-        },
-    }
 }
 
 #[cfg(test)]

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -261,7 +261,7 @@ fn render_map_key_diff(
     old_map: &std::collections::HashMap<String, Value>,
     new_map: &std::collections::HashMap<String, Value>,
 ) {
-    use crate::app::format_value;
+    use carina_core::value::format_value;
 
     let mut all_keys: Vec<&String> = old_map.keys().chain(new_map.keys()).collect();
     all_keys.sort();


### PR DESCRIPTION
## Summary

- Remove the duplicate `format_value()` function from `carina-tui/src/app.rs` and replace all usages with `carina_core::value::format_value`
- Update `carina-tui/src/ui.rs` to import `format_value` from `carina_core::value` instead of `crate::app`
- The CLI (`carina-cli/src/display.rs`) already uses the core version — no changes needed there

This also brings two minor improvements to TUI value formatting (inherited from the core implementation):
- Float values now display with a decimal point (e.g., `1.0` instead of `1`)
- `UnresolvedIdent` values now resolve enum identifiers consistently with the CLI

## Test plan

- [x] All existing TUI tests pass (64 tests)
- [x] All workspace tests pass (no snapshot changes)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Part of #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)