### PR TITLE
refactor: extract diff helpers to carina-core (step 3 of #1034)

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use carina_core::deps::get_resource_dependencies;
+use carina_core::diff_helpers::{compute_map_diff, compute_unchanged_count};
 use carina_core::effect::{CascadingUpdate, Effect};
 use carina_core::plan::Plan;
 use carina_core::resource::{ResourceId, Value};
@@ -715,18 +716,8 @@ fn format_plan_tree(
                     }
                     // In Full mode, show count of unchanged attributes hidden
                     if detail == DetailLevel::Full {
-                        let unchanged_count = from
-                            .attributes
-                            .iter()
-                            .filter(|(k, v)| {
-                                !k.starts_with('_')
-                                    && to
-                                        .attributes
-                                        .get(k.as_str())
-                                        .map(|nv| nv.semantically_equal(v))
-                                        .unwrap_or(false)
-                            })
-                            .count();
+                        let unchanged_count =
+                            compute_unchanged_count(&from.attributes, &to.attributes, None);
                         if unchanged_count > 0 {
                             let noun = if unchanged_count == 1 {
                                 "attribute"
@@ -834,19 +825,11 @@ fn format_plan_tree(
                     if detail == DetailLevel::Full {
                         let changed_set: HashSet<&str> =
                             changed_create_only.iter().map(|s| s.as_str()).collect();
-                        let unchanged_count = from
-                            .attributes
-                            .iter()
-                            .filter(|(k, v)| {
-                                !k.starts_with('_')
-                                    && !changed_set.contains(k.as_str())
-                                    && to
-                                        .attributes
-                                        .get(k.as_str())
-                                        .map(|nv| nv.semantically_equal(v))
-                                        .unwrap_or(false)
-                            })
-                            .count();
+                        let unchanged_count = compute_unchanged_count(
+                            &from.attributes,
+                            &to.attributes,
+                            Some(&changed_set),
+                        );
                         if unchanged_count > 0 {
                             let noun = if unchanged_count == 1 {
                                 "attribute"
@@ -1187,68 +1170,60 @@ pub fn format_map_diff(old_value: Option<&Value>, new_value: &Value, attr_prefix
         Some(Value::Map(m)) => m,
         _ => {
             // No old map; treat all new keys as added
-            let mut keys: Vec<_> = new_map.keys().collect();
-            keys.sort();
+            let empty = HashMap::new();
+            let diff = compute_map_diff(&empty, new_map);
             let mut lines = Vec::new();
-            for key in keys {
+            for entry in &diff.added {
                 lines.push(format!(
                     "{}  {} {}: {}",
                     attr_prefix,
                     "+".green(),
-                    key,
-                    format_value_with_key(&new_map[key], Some(key)).green()
+                    entry.key,
+                    format_value_with_key(&entry.value, Some(&entry.key)).green()
                 ));
             }
             return lines.join("\n");
         }
     };
 
+    let diff = compute_map_diff(old_map, new_map);
     let mut lines = Vec::new();
 
-    // Collect all keys from both maps
-    let mut all_keys: Vec<&String> = old_map.keys().chain(new_map.keys()).collect();
-    all_keys.sort();
-    all_keys.dedup();
-
-    for key in all_keys {
-        let old_val = old_map.get(key);
-        let new_val = new_map.get(key);
-        match (old_val, new_val) {
-            (Some(ov), Some(nv)) => {
-                if !ov.semantically_equal(nv) {
-                    // Changed
-                    lines.push(format!(
-                        "{}  {} {}: {} → {}",
-                        attr_prefix,
-                        "~".yellow(),
-                        key,
-                        format_value_with_key(ov, Some(key)).red().strikethrough(),
-                        format_value_with_key(nv, Some(key)).green()
-                    ));
-                }
-                // Unchanged: skip
+    // Merge all entries into a single list sorted by key (preserving original ordering)
+    for entry in diff.iter_by_key() {
+        match entry {
+            carina_core::diff_helpers::MapDiffItem::Changed(e) => {
+                lines.push(format!(
+                    "{}  {} {}: {} → {}",
+                    attr_prefix,
+                    "~".yellow(),
+                    e.key,
+                    format_value_with_key(&e.old_value, Some(&e.key))
+                        .red()
+                        .strikethrough(),
+                    format_value_with_key(&e.new_value, Some(&e.key)).green()
+                ));
             }
-            (None, Some(nv)) => {
-                // Added
+            carina_core::diff_helpers::MapDiffItem::Added(e) => {
                 lines.push(format!(
                     "{}  {} {}: {}",
                     attr_prefix,
                     "+".green(),
-                    key,
-                    format_value_with_key(nv, Some(key)).green()
+                    e.key,
+                    format_value_with_key(&e.value, Some(&e.key)).green()
                 ));
             }
-            (Some(ov), None) => {
-                // Removed
+            carina_core::diff_helpers::MapDiffItem::Removed(e) => {
                 lines.push(format!(
                     "{}  {} {}: {}",
                     attr_prefix,
                     "-".red().strikethrough(),
-                    key,
-                    format_value_with_key(ov, Some(key)).red().strikethrough()
+                    e.key,
+                    format_value_with_key(&e.value, Some(&e.key))
+                        .red()
+                        .strikethrough()
                 ));
             }
-            (None, None) => {}
         }
     }
 

--- a/carina-core/src/diff_helpers.rs
+++ b/carina-core/src/diff_helpers.rs
@@ -1,0 +1,290 @@
+//! Shared diff computation helpers for plan display.
+//!
+//! These helpers extract the pure computation logic (no formatting/coloring)
+//! that is shared between CLI and TUI frontends.
+
+use std::collections::HashMap;
+
+use crate::resource::Value;
+
+/// Count non-internal attributes that are semantically equal in both `from` and `to`.
+///
+/// Internal attributes (prefixed with `_`) are excluded from the count.
+/// An optional `exclude` set can be provided to skip additional attribute names
+/// (e.g., `changed_create_only` attributes in Replace effects).
+pub fn compute_unchanged_count(
+    from_attrs: &HashMap<String, Value>,
+    to_attrs: &HashMap<String, Value>,
+    exclude: Option<&std::collections::HashSet<&str>>,
+) -> usize {
+    from_attrs
+        .iter()
+        .filter(|(k, v)| {
+            !k.starts_with('_')
+                && exclude.is_none_or(|set| !set.contains(k.as_str()))
+                && to_attrs
+                    .get(k.as_str())
+                    .map(|nv| nv.semantically_equal(v))
+                    .unwrap_or(false)
+        })
+        .count()
+}
+
+/// Result of computing a map diff between two maps.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapDiff {
+    /// Keys added in the new map (sorted).
+    pub added: Vec<MapDiffEntry>,
+    /// Keys removed from the old map (sorted).
+    pub removed: Vec<MapDiffEntry>,
+    /// Keys present in both but with different values (sorted).
+    pub changed: Vec<MapDiffChanged>,
+}
+
+/// A single added or removed map entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapDiffEntry {
+    pub key: String,
+    pub value: Value,
+}
+
+/// A changed map entry with old and new values.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MapDiffChanged {
+    pub key: String,
+    pub old_value: Value,
+    pub new_value: Value,
+}
+
+/// A reference to a single diff entry, used when iterating in key order.
+#[derive(Debug)]
+pub enum MapDiffItem<'a> {
+    Added(&'a MapDiffEntry),
+    Removed(&'a MapDiffEntry),
+    Changed(&'a MapDiffChanged),
+}
+
+impl MapDiff {
+    /// Iterate over all diff entries in sorted key order.
+    ///
+    /// This merges added, removed, and changed entries and yields them
+    /// sorted by key, matching the original interleaved output order.
+    pub fn iter_by_key(&self) -> Vec<MapDiffItem<'_>> {
+        let mut items: Vec<(String, MapDiffItem<'_>)> = Vec::new();
+        for e in &self.added {
+            items.push((e.key.clone(), MapDiffItem::Added(e)));
+        }
+        for e in &self.removed {
+            items.push((e.key.clone(), MapDiffItem::Removed(e)));
+        }
+        for e in &self.changed {
+            items.push((e.key.clone(), MapDiffItem::Changed(e)));
+        }
+        items.sort_by(|(a, _), (b, _)| a.cmp(b));
+        items.into_iter().map(|(_, item)| item).collect()
+    }
+}
+
+/// Compute the diff between two maps, returning added, removed, and changed entries.
+///
+/// All result vectors are sorted by key for deterministic output.
+pub fn compute_map_diff(
+    old_map: &HashMap<String, Value>,
+    new_map: &HashMap<String, Value>,
+) -> MapDiff {
+    let mut all_keys: Vec<&String> = old_map.keys().chain(new_map.keys()).collect();
+    all_keys.sort();
+    all_keys.dedup();
+
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut changed = Vec::new();
+
+    for key in all_keys {
+        let old_val = old_map.get(key);
+        let new_val = new_map.get(key);
+        match (old_val, new_val) {
+            (Some(ov), Some(nv)) => {
+                if !ov.semantically_equal(nv) {
+                    changed.push(MapDiffChanged {
+                        key: key.clone(),
+                        old_value: ov.clone(),
+                        new_value: nv.clone(),
+                    });
+                }
+            }
+            (None, Some(nv)) => {
+                added.push(MapDiffEntry {
+                    key: key.clone(),
+                    value: nv.clone(),
+                });
+            }
+            (Some(ov), None) => {
+                removed.push(MapDiffEntry {
+                    key: key.clone(),
+                    value: ov.clone(),
+                });
+            }
+            (None, None) => {}
+        }
+    }
+
+    MapDiff {
+        added,
+        removed,
+        changed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_unchanged_count_basic() {
+        let from: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("region".to_string(), Value::String("us-east-1".to_string())),
+            ("size".to_string(), Value::Int(10)),
+        ]
+        .into_iter()
+        .collect();
+
+        let to: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("region".to_string(), Value::String("us-west-2".to_string())),
+            ("size".to_string(), Value::Int(10)),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(compute_unchanged_count(&from, &to, None), 2);
+    }
+
+    #[test]
+    fn test_compute_unchanged_count_excludes_internal() {
+        let from: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("_internal".to_string(), Value::String("hidden".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let to: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("_internal".to_string(), Value::String("hidden".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(compute_unchanged_count(&from, &to, None), 1);
+    }
+
+    #[test]
+    fn test_compute_unchanged_count_with_exclude_set() {
+        let from: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("region".to_string(), Value::String("us-east-1".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let to: HashMap<String, Value> = [
+            ("name".to_string(), Value::String("test".to_string())),
+            ("region".to_string(), Value::String("us-east-1".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let exclude: std::collections::HashSet<&str> = ["region"].into_iter().collect();
+        assert_eq!(compute_unchanged_count(&from, &to, Some(&exclude)), 1);
+    }
+
+    #[test]
+    fn test_compute_map_diff_added_only() {
+        let old: HashMap<String, Value> = HashMap::new();
+        let new: HashMap<String, Value> = [
+            ("key1".to_string(), Value::String("val1".to_string())),
+            ("key2".to_string(), Value::String("val2".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let diff = compute_map_diff(&old, &new);
+        assert_eq!(diff.added.len(), 2);
+        assert_eq!(diff.removed.len(), 0);
+        assert_eq!(diff.changed.len(), 0);
+        assert_eq!(diff.added[0].key, "key1");
+        assert_eq!(diff.added[1].key, "key2");
+    }
+
+    #[test]
+    fn test_compute_map_diff_removed_only() {
+        let old: HashMap<String, Value> = [("key1".to_string(), Value::String("val1".to_string()))]
+            .into_iter()
+            .collect();
+        let new: HashMap<String, Value> = HashMap::new();
+
+        let diff = compute_map_diff(&old, &new);
+        assert_eq!(diff.added.len(), 0);
+        assert_eq!(diff.removed.len(), 1);
+        assert_eq!(diff.changed.len(), 0);
+        assert_eq!(diff.removed[0].key, "key1");
+    }
+
+    #[test]
+    fn test_compute_map_diff_changed() {
+        let old: HashMap<String, Value> = [
+            ("key1".to_string(), Value::String("old_val".to_string())),
+            ("key2".to_string(), Value::String("same".to_string())),
+        ]
+        .into_iter()
+        .collect();
+        let new: HashMap<String, Value> = [
+            ("key1".to_string(), Value::String("new_val".to_string())),
+            ("key2".to_string(), Value::String("same".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let diff = compute_map_diff(&old, &new);
+        assert_eq!(diff.added.len(), 0);
+        assert_eq!(diff.removed.len(), 0);
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].key, "key1");
+        assert_eq!(
+            diff.changed[0].old_value,
+            Value::String("old_val".to_string())
+        );
+        assert_eq!(
+            diff.changed[0].new_value,
+            Value::String("new_val".to_string())
+        );
+    }
+
+    #[test]
+    fn test_compute_map_diff_mixed() {
+        let old: HashMap<String, Value> = [
+            ("keep".to_string(), Value::String("same".to_string())),
+            ("change".to_string(), Value::String("old".to_string())),
+            ("remove".to_string(), Value::String("gone".to_string())),
+        ]
+        .into_iter()
+        .collect();
+        let new: HashMap<String, Value> = [
+            ("keep".to_string(), Value::String("same".to_string())),
+            ("change".to_string(), Value::String("new".to_string())),
+            ("add".to_string(), Value::String("fresh".to_string())),
+        ]
+        .into_iter()
+        .collect();
+
+        let diff = compute_map_diff(&old, &new);
+        assert_eq!(diff.added.len(), 1);
+        assert_eq!(diff.added[0].key, "add");
+        assert_eq!(diff.removed.len(), 1);
+        assert_eq!(diff.removed[0].key, "remove");
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].key, "change");
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config_loader;
 pub mod deps;
+pub mod diff_helpers;
 pub mod differ;
 pub mod effect;
 pub mod executor;

--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use carina_core::deps::get_resource_dependencies;
+use carina_core::diff_helpers::compute_unchanged_count;
 use carina_core::effect::Effect;
 use carina_core::plan::{Plan, PlanSummary};
 use carina_core::resource::Value;
@@ -818,19 +819,8 @@ fn populate_schema_attributes(
                 }
             }
             Effect::Update { from, to, .. } => {
-                let unchanged_count = from
-                    .attributes
-                    .iter()
-                    .filter(|(k, v)| {
-                        !k.starts_with('_')
-                            && to
-                                .attributes
-                                .get(k.as_str())
-                                .map(|nv| nv.semantically_equal(v))
-                                .unwrap_or(false)
-                    })
-                    .count();
-                nodes[idx].unchanged_count = unchanged_count;
+                nodes[idx].unchanged_count =
+                    compute_unchanged_count(&from.attributes, &to.attributes, None);
             }
             Effect::Replace {
                 from,
@@ -840,20 +830,8 @@ fn populate_schema_attributes(
             } => {
                 let changed_set: HashSet<&str> =
                     changed_create_only.iter().map(|s| s.as_str()).collect();
-                let unchanged_count = from
-                    .attributes
-                    .iter()
-                    .filter(|(k, v)| {
-                        !k.starts_with('_')
-                            && !changed_set.contains(k.as_str())
-                            && to
-                                .attributes
-                                .get(k.as_str())
-                                .map(|nv| nv.semantically_equal(v))
-                                .unwrap_or(false)
-                    })
-                    .count();
-                nodes[idx].unchanged_count = unchanged_count;
+                nodes[idx].unchanged_count =
+                    compute_unchanged_count(&from.attributes, &to.attributes, Some(&changed_set));
             }
             _ => {}
         }

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -261,42 +261,39 @@ fn render_map_key_diff(
     old_map: &std::collections::HashMap<String, Value>,
     new_map: &std::collections::HashMap<String, Value>,
 ) {
+    use carina_core::diff_helpers::{MapDiffItem, compute_map_diff};
     use carina_core::value::format_value;
 
-    let mut all_keys: Vec<&String> = old_map.keys().chain(new_map.keys()).collect();
-    all_keys.sort();
-    all_keys.dedup();
-
-    for key in all_keys {
-        let old_val = old_map.get(key);
-        let new_val = new_map.get(key);
-        match (old_val, new_val) {
-            (Some(ov), Some(nv)) => {
-                if !ov.semantically_equal(nv) {
-                    lines.push(Line::from(vec![
-                        Span::raw("    "),
-                        Span::styled("~ ", Style::default().fg(Color::Yellow)),
-                        Span::raw(format!("{}: ", key)),
-                        Span::styled(
-                            format_value(ov),
-                            Style::default()
-                                .fg(Color::Red)
-                                .add_modifier(Modifier::CROSSED_OUT),
-                        ),
-                        Span::raw(" -> "),
-                        Span::styled(format_value(nv), Style::default().fg(Color::Green)),
-                    ]));
-                }
+    let diff = compute_map_diff(old_map, new_map);
+    for item in diff.iter_by_key() {
+        match item {
+            MapDiffItem::Changed(e) => {
+                lines.push(Line::from(vec![
+                    Span::raw("    "),
+                    Span::styled("~ ", Style::default().fg(Color::Yellow)),
+                    Span::raw(format!("{}: ", e.key)),
+                    Span::styled(
+                        format_value(&e.old_value),
+                        Style::default()
+                            .fg(Color::Red)
+                            .add_modifier(Modifier::CROSSED_OUT),
+                    ),
+                    Span::raw(" -> "),
+                    Span::styled(
+                        format_value(&e.new_value),
+                        Style::default().fg(Color::Green),
+                    ),
+                ]));
             }
-            (None, Some(nv)) => {
+            MapDiffItem::Added(e) => {
                 lines.push(Line::from(vec![
                     Span::raw("    "),
                     Span::styled("+ ", Style::default().fg(Color::Green)),
-                    Span::raw(format!("{}: ", key)),
-                    Span::styled(format_value(nv), Style::default().fg(Color::Green)),
+                    Span::raw(format!("{}: ", e.key)),
+                    Span::styled(format_value(&e.value), Style::default().fg(Color::Green)),
                 ]));
             }
-            (Some(ov), None) => {
+            MapDiffItem::Removed(e) => {
                 lines.push(Line::from(vec![
                     Span::raw("    "),
                     Span::styled(
@@ -306,20 +303,19 @@ fn render_map_key_diff(
                             .add_modifier(Modifier::CROSSED_OUT),
                     ),
                     Span::styled(
-                        format!("{}: ", key),
+                        format!("{}: ", e.key),
                         Style::default()
                             .fg(Color::Red)
                             .add_modifier(Modifier::CROSSED_OUT),
                     ),
                     Span::styled(
-                        format_value(ov),
+                        format_value(&e.value),
                         Style::default()
                             .fg(Color::Red)
                             .add_modifier(Modifier::CROSSED_OUT),
                     ),
                 ]));
             }
-            (None, None) => {}
         }
     }
 }


### PR DESCRIPTION
## Summary

- Extract duplicated diff computation logic from CLI (`display.rs`) and TUI (`app.rs`, `ui.rs`) into shared helpers in `carina-core::diff_helpers`
- Add `compute_unchanged_count()` to count non-internal attributes that are semantically equal between from/to, with optional exclude set for Replace effects
- Add `compute_map_diff()` / `MapDiff` struct to compute added, removed, and changed entries between two maps, with `iter_by_key()` for deterministic sorted output
- All existing snapshot tests pass unchanged — pure refactoring

Part of #1034

## Test plan

- [x] All existing snapshot tests pass (no behavior change)
- [x] New unit tests for `compute_unchanged_count` (basic, internal exclusion, exclude set)
- [x] New unit tests for `compute_map_diff` (added-only, removed-only, changed, mixed)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)