### PR TITLE
feat: show resource count on root nodes in TUI

### DIFF
--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -193,6 +193,15 @@ impl App {
         self.visible_nodes().len()
     }
 
+    /// Count all descendant nodes (recursively) under the given node index.
+    pub fn descendant_count(&self, idx: usize) -> usize {
+        let mut count = 0;
+        for &child in &self.nodes[idx].children {
+            count += 1 + self.descendant_count(child);
+        }
+        count
+    }
+
     /// Returns the set of node indices whose effect_label matches the search query.
     fn matching_node_indices(&self) -> HashSet<usize> {
         let mut result = HashSet::new();
@@ -1629,5 +1638,56 @@ mod tests {
             .find(|r| matches!(r, DetailRow::Attribute { key, .. } if key == "vpc_id"))
             .expect("vpc_id detail row should exist");
         assert!(matches!(ref_row, DetailRow::Attribute { value, .. } if value == "vpc.vpc_id"));
+    }
+
+    #[test]
+    fn descendant_count_root_with_children() {
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(
+            Resource::new("ec2.vpc", "my-vpc")
+                .with_attribute("_binding", Value::String("vpc".to_string()))
+                .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.subnet", "subnet-a")
+                .with_attribute("_binding", Value::String("subnet_a".to_string()))
+                .with_attribute(
+                    "vpc_id",
+                    Value::ResourceRef {
+                        binding_name: "vpc".to_string(),
+                        attribute_name: "vpc_id".to_string(),
+                    },
+                ),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.subnet", "subnet-b")
+                .with_attribute("_binding", Value::String("subnet_b".to_string()))
+                .with_attribute(
+                    "vpc_id",
+                    Value::ResourceRef {
+                        binding_name: "vpc".to_string(),
+                        attribute_name: "vpc_id".to_string(),
+                    },
+                ),
+        ));
+
+        let app = App::new(&plan, &HashMap::new());
+
+        // Root node (vpc) has 2 descendants
+        assert_eq!(app.descendant_count(0), 2);
+        // Leaf nodes have 0 descendants
+        assert_eq!(app.descendant_count(1), 0);
+        assert_eq!(app.descendant_count(2), 0);
+    }
+
+    #[test]
+    fn descendant_count_standalone_root() {
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(Resource::new("s3.bucket", "my-bucket")));
+
+        let app = App::new(&plan, &HashMap::new());
+
+        // Standalone root has no descendants
+        assert_eq!(app.descendant_count(0), 0);
     }
 }

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_all_create.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_all_create.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.vpc vpc (2 resources)                                                                                           │
 │    ├── + ec2.route_table rt                                                                                          │
 │    └── + ec2.subnet subnet                                                                                           │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_second_node.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_second_node.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.vpc vpc (2 resources)                                                                                           │
 │    ├── + ec2.route_table rt                                                                                          │
 │    └── + ec2.subnet subnet                                                                                           │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_third_node.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_third_node.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.vpc vpc (2 resources)                                                                                           │
 │    ├── + ec2.route_table rt                                                                                          │
 │    └── + ec2.subnet subnet                                                                                           │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_route_table.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_route_table.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.vpc vpc (2 resources)                                                                                           │
 │    └── + ec2.route_table rt                                                                                          │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_subnet.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_subnet.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.vpc vpc (2 resources)                                                                                           │
 │    └── + ec2.subnet subnet                                                                                           │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_mixed_operations.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 1 to create, 1 to update, 1 to delete) ──────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
+│~ ec2.vpc vpc (1 resource)                                                                                            │
 │    └── + ec2.security_group sg                                                                                       │
 │- ec2.subnet old-subnet                                                                                               │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_update_unchanged_count.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_update_unchanged_count.snap
@@ -3,7 +3,7 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 1 to create, 1 to update, 1 to delete) ──────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
+│~ ec2.vpc vpc (1 resource)                                                                                            │
 │    └── + ec2.security_group sg                                                                                       │
 │- ec2.subnet old-subnet                                                                                               │
 │                                                                                                                      │

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -68,6 +68,17 @@ fn draw_tree(frame: &mut Frame, app: &mut App, area: Rect) {
                 Span::raw(" "),
                 Span::styled(node.name_part.clone(), effect_color),
             ];
+            // Show descendant resource count on root nodes
+            if node.parent.is_none() {
+                let count = app.descendant_count(node_idx);
+                if count > 0 {
+                    let noun = if count == 1 { "resource" } else { "resources" };
+                    spans.push(Span::styled(
+                        format!(" ({} {})", count, noun),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+            }
             if app.selected == row_idx {
                 spans = spans
                     .into_iter()


### PR DESCRIPTION
## Summary

- Display the total number of descendant resources next to root nodes in the TUI tree view (e.g., `vpc (2 resources)`)
- Only shown on root nodes (nodes with no parent) that have children
- Uses singular "resource" for count of 1, plural "resources" otherwise
- Displayed in dimmed text to avoid visual clutter

Part of #942

## Test plan

- [x] Added `descendant_count` method to `App` with unit tests for root-with-children and standalone-root cases
- [x] Updated 7 TUI snapshots to reflect new resource count display
- [x] All 74 carina-tui tests pass
- [x] clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)