### PR TITLE
feat: color attribute values by type in TUI detail panel

### DIFF
--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -224,8 +224,6 @@ fn render_detail_row_to_lines(
             let is_navigable = ref_binding.is_some();
             let value_style = if is_navigable {
                 Style::default().fg(Color::Cyan)
-            } else if kind == EffectKind::Create {
-                Style::default().fg(Color::Green)
             } else if let Some(color) = value_color(value) {
                 Style::default().fg(color)
             } else {


### PR DESCRIPTION
## Summary
- Add `value_color()` helper that infers value type from rendered strings and returns an appropriate color: green for strings, yellow for booleans, white for numbers, magenta for DSL identifiers
- Apply type-based coloring to `DetailRow::Attribute` (non-Create, non-ResourceRef), `DetailRow::Changed` (new value), and `DetailRow::Default` (value portion, with DIM modifier)
- ResourceRef values remain cyan (handled separately, already done in #1043)

Part of #942

## Test plan
- [x] Unit tests for `value_color()` covering strings, booleans, numbers, DSL identifiers, and fallback cases
- [ ] Visual confirmation with `make plan-mixed-tui` to verify colors render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)