### PR TITLE
feat: add // as alternative line comment syntax

### DIFF
--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -134,4 +134,4 @@ char = {
 WHITESPACE = _{ " " | "\t" | NEWLINE }
 
 // Comment (auto-skip)
-COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }
+COMMENT = _{ ("//" | "#") ~ (!NEWLINE ~ ANY)* }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -2662,4 +2662,53 @@ aws.s3.bucket {
             "InternalError should format with expected and context, got: {msg}"
         );
     }
+
+    #[test]
+    fn parse_slash_slash_comment_standalone() {
+        let input = r#"
+            // This is a C-style comment
+            provider aws {
+                region = aws.Region.ap_northeast_1
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(result.providers.len(), 1);
+        assert_eq!(result.providers[0].name, "aws");
+    }
+
+    #[test]
+    fn parse_slash_slash_comment_inline() {
+        let input = r#"
+            let vpc = awscc.ec2.vpc {
+                cidr_block = "10.0.0.0/16"  // inline comment
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(result.resources.len(), 1);
+        assert_eq!(
+            result.resources[0].attributes.get("cidr_block"),
+            Some(&Value::String("10.0.0.0/16".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_mixed_comment_styles() {
+        let input = r#"
+            # shell-style comment
+            // C-style comment
+            let vpc = awscc.ec2.vpc {
+                cidr_block = "10.0.0.0/16"  // inline C-style
+                tags = { Name = "main" }    # inline shell-style
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(result.resources.len(), 1);
+        assert_eq!(
+            result.resources[0].attributes.get("cidr_block"),
+            Some(&Value::String("10.0.0.0/16".to_string()))
+        );
+    }
 }

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -79,7 +79,7 @@ impl SemanticTokensProvider {
         }
 
         // Comment
-        if trimmed.starts_with("//") {
+        if trimmed.starts_with("//") || trimmed.starts_with('#') {
             tokens.push((indent, position::char_len(line) - indent, 7)); // COMMENT
             return tokens;
         }
@@ -883,5 +883,35 @@ mod tests {
         let (start, len, _) = var_token.unwrap();
         assert_eq!(*len, 6, "Variable 'bucket' should have length 6");
         assert_eq!(*start, 7, "Variable 'bucket' should start at column 7");
+    }
+
+    #[test]
+    fn test_hash_comment_highlighted() {
+        let provider = SemanticTokensProvider::new(&[]);
+        let tokens = provider.tokenize_line("# shell-style comment", 0);
+        let comment_token = tokens.iter().find(|(_, _, typ)| *typ == 7);
+        assert!(
+            comment_token.is_some(),
+            "Should highlight # comment as COMMENT. Got: {:?}",
+            tokens
+        );
+        let (start, len, _) = comment_token.unwrap();
+        assert_eq!(*start, 0);
+        assert_eq!(*len, "# shell-style comment".chars().count() as u32);
+    }
+
+    #[test]
+    fn test_indented_hash_comment_highlighted() {
+        let provider = SemanticTokensProvider::new(&[]);
+        let tokens = provider.tokenize_line("    # indented comment", 0);
+        let comment_token = tokens.iter().find(|(_, _, typ)| *typ == 7);
+        assert!(
+            comment_token.is_some(),
+            "Should highlight indented # comment as COMMENT. Got: {:?}",
+            tokens
+        );
+        let (start, len, _) = comment_token.unwrap();
+        assert_eq!(*start, 4);
+        assert_eq!(*len, "# indented comment".chars().count() as u32);
     }
 }


### PR DESCRIPTION
## Summary

- Add `//` (C-style) as an alternative line comment syntax alongside the existing `#` (shell-style) in the grammar
- Fix LSP semantic token highlighting to also recognize `#` comments, which were previously missing from the tokenizer
- Add parser tests for standalone `//`, inline `//`, and mixed `#`/`//` comment styles
- Add LSP tests for `#` comment highlighting

Closes #1056

## Test plan

- [x] Parser tests pass for `//` standalone comments
- [x] Parser tests pass for `//` inline comments
- [x] Parser tests pass for mixed `#` and `//` comments
- [x] LSP tests pass for `#` comment highlighting
- [x] All existing tests continue to pass (`cargo test -p carina-core`, `cargo test -p carina-lsp`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)