### PR TITLE
fix: extend delete polling timeout for VPCGatewayAttachment

### DIFF
--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -256,8 +256,8 @@ impl AwsccProvider {
 
     /// Returns the max polling attempts for a given resource type and operation.
     ///
-    /// Some resource types (e.g., IPAM Pool) take significantly longer to delete
-    /// via the CloudControl API than the default timeout allows.
+    /// Some resource types (e.g., IPAM Pool, VPCGatewayAttachment) take significantly
+    /// longer to delete via the CloudControl API than the default timeout allows.
     pub(crate) fn max_polling_attempts(type_name: &str, operation: &str) -> u32 {
         if operation == "delete" {
             // IPAM Pool deletions can take 15-30 minutes via CloudControl API


### PR DESCRIPTION
## Summary
- Extends the CloudControl API delete polling timeout for `AWS::EC2::VPCGatewayAttachment` from 10 minutes (default) to 30 minutes
- VPCGatewayAttachment deletion can be slow when dependent resources (NAT gateways) are still being cleaned up, causing cascading failures that prevent IGW and VPC deletion
- Adds tests verifying the extended timeout for delete operations and default timeout for create operations

## Test plan
- [x] New unit test `test_max_polling_attempts_vpc_gateway_attachment_delete` verifies 30-minute timeout
- [x] New unit test `test_max_polling_attempts_vpc_gateway_attachment_create` verifies default timeout for create
- [x] All existing `max_polling_attempts` tests pass
- [ ] Run acceptance tests for `ec2_route/nat_gateway.crn` and `ec2_nat_gateway/public.crn` to verify destroy succeeds

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)