### PR TITLE
fix: restrict depth-based pre-sorting to destroy ordering only

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -10,7 +10,7 @@ use colored::Colorize;
 use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::{
     build_dependents_map, find_failed_dependent, get_resource_dependencies,
-    sort_resources_by_dependencies,
+    sort_resources_for_destroy,
 };
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
@@ -200,17 +200,11 @@ async fn run_destroy_locked(
         }
     }
 
-    // Sort all resources (managed + orphans) by dependencies once,
-    // then reverse for destroy order (dependents deleted before dependencies).
-    //
-    // Previously this was done with a double sort-reverse pattern
-    // (sort → reverse → add orphans → sort → reverse) which could produce
-    // incorrect destroy ordering for independent resource branches (#1067).
-    let destroy_order: Vec<Resource> = sort_resources_by_dependencies(&all_resources)
-        .map_err(AppError::Config)?
-        .into_iter()
-        .rev()
-        .collect();
+    // Sort all resources (managed + orphans) for destroy ordering.
+    // Uses depth-based pre-sorting to ensure stable ordering for independent
+    // branches, then reverses for destroy order (dependents before dependencies).
+    let destroy_order: Vec<Resource> =
+        sort_resources_for_destroy(&all_resources).map_err(AppError::Config)?;
 
     // Collect resources that exist and will be destroyed
     // Skip the state bucket if it matches the backend bucket

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -53,17 +53,36 @@ fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
 /// Sort resources topologically based on dependencies.
 ///
 /// Resources are ordered so that dependencies come before dependents (creation order).
-/// When reversed, this gives a valid destroy order (dependents before dependencies).
-///
-/// To ensure stable destroy ordering for independent branches, resources are
-/// pre-sorted by dependency depth (distance from root) before DFS traversal.
-/// Shallower resources (closer to root, like an internet gateway at depth 1)
-/// are visited first and emitted early in creation order, placing them late
-/// in destroy order -- after deeper chains have been deleted.
+/// The DFS traversal respects the input order for resources at the same level,
+/// preserving the declaration order from the .crn file.
 ///
 /// Returns an error if a circular dependency is detected, with a message
 /// showing the cycle path (e.g., "Circular dependency detected: a -> b -> c -> a").
 pub fn sort_resources_by_dependencies(resources: &[Resource]) -> Result<Vec<Resource>, String> {
+    topological_sort(resources, false)
+}
+
+/// Sort resources for destroy ordering.
+///
+/// Like `sort_resources_by_dependencies`, but pre-sorts resources by dependency
+/// depth (ascending) before DFS traversal, then reverses the result. This ensures
+/// that shallower independent resources (like an internet gateway at depth 1)
+/// appear late in destroy order -- after deeper chains have been deleted.
+///
+/// The depth-based pre-sorting is only needed for destroy ordering. For apply
+/// (creation) ordering, the plain topological sort preserves the declaration
+/// order from the .crn file, which is the expected behavior (#1071).
+pub fn sort_resources_for_destroy(resources: &[Resource]) -> Result<Vec<Resource>, String> {
+    let sorted = topological_sort(resources, true)?;
+    Ok(sorted.into_iter().rev().collect())
+}
+
+/// Internal topological sort with optional depth-based pre-sorting.
+///
+/// When `depth_presort` is true, resources are pre-sorted by dependency depth
+/// (ascending) before DFS traversal. This makes the sort input-order-independent,
+/// ensuring stable results for independent branches.
+fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<Resource>, String> {
     // Build binding name to resource mapping
     let mut binding_to_resource: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
@@ -72,84 +91,85 @@ pub fn sort_resources_by_dependencies(resources: &[Resource]) -> Result<Vec<Reso
         }
     }
 
-    // Compute the dependency depth for each resource: the length of the longest
-    // chain from a root (resource with no dependencies) to this resource.
-    // Used to pre-sort the DFS input so that shallower resources (closer to root)
-    // are visited first.
-    let mut depth_cache: HashMap<String, usize> = HashMap::new();
-    fn compute_depth(
-        binding: &str,
-        binding_to_resource: &HashMap<String, &Resource>,
-        cache: &mut HashMap<String, usize>,
-        visiting: &mut HashSet<String>,
-    ) -> usize {
-        if let Some(&cached) = cache.get(binding) {
-            return cached;
-        }
-        // Guard against circular dependencies
-        if visiting.contains(binding) {
-            return 0;
-        }
-        visiting.insert(binding.to_string());
-        let depth = if let Some(resource) = binding_to_resource.get(binding) {
-            let deps = get_resource_dependencies(resource);
-            deps.iter()
-                .map(|d| 1 + compute_depth(d, binding_to_resource, cache, visiting))
-                .max()
-                .unwrap_or(0)
-        } else {
-            0
-        };
-        visiting.remove(binding);
-        cache.insert(binding.to_string(), depth);
-        depth
-    }
-
-    let mut depth_visiting: HashSet<String> = HashSet::new();
-    for resource in resources {
-        let binding = resource
-            .attributes
-            .get("_binding")
-            .and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
-        compute_depth(
-            &binding,
-            &binding_to_resource,
-            &mut depth_cache,
-            &mut depth_visiting,
-        );
-    }
-
-    // Pre-sort resources by dependency depth (ascending) so DFS visits
-    // shallower resources first. This ensures that "leaf" resources like
-    // an internet gateway (depth 1, no dependents) are emitted early in
-    // creation order, placing them late in destroy order -- after deeper
-    // chains (like nat_gw → route) have been destroyed.
     let mut presorted: Vec<&Resource> = resources.iter().collect();
-    presorted.sort_by(|a, b| {
-        let a_binding = a
-            .attributes
-            .get("_binding")
-            .and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| format!("{}:{}", a.id.resource_type, a.id.name));
-        let b_binding = b
-            .attributes
-            .get("_binding")
-            .and_then(|v| match v {
-                Value::String(s) => Some(s.clone()),
-                _ => None,
-            })
-            .unwrap_or_else(|| format!("{}:{}", b.id.resource_type, b.id.name));
-        let a_depth = depth_cache.get(&a_binding).copied().unwrap_or(0);
-        let b_depth = depth_cache.get(&b_binding).copied().unwrap_or(0);
-        a_depth.cmp(&b_depth) // Ascending: shallower first
-    });
+
+    if depth_presort {
+        // Compute the dependency depth for each resource: the length of the longest
+        // chain from a root (resource with no dependencies) to this resource.
+        let mut depth_cache: HashMap<String, usize> = HashMap::new();
+        fn compute_depth(
+            binding: &str,
+            binding_to_resource: &HashMap<String, &Resource>,
+            cache: &mut HashMap<String, usize>,
+            visiting: &mut HashSet<String>,
+        ) -> usize {
+            if let Some(&cached) = cache.get(binding) {
+                return cached;
+            }
+            // Guard against circular dependencies
+            if visiting.contains(binding) {
+                return 0;
+            }
+            visiting.insert(binding.to_string());
+            let depth = if let Some(resource) = binding_to_resource.get(binding) {
+                let deps = get_resource_dependencies(resource);
+                deps.iter()
+                    .map(|d| 1 + compute_depth(d, binding_to_resource, cache, visiting))
+                    .max()
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+            visiting.remove(binding);
+            cache.insert(binding.to_string(), depth);
+            depth
+        }
+
+        let mut depth_visiting: HashSet<String> = HashSet::new();
+        for resource in resources {
+            let binding = resource
+                .attributes
+                .get("_binding")
+                .and_then(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            compute_depth(
+                &binding,
+                &binding_to_resource,
+                &mut depth_cache,
+                &mut depth_visiting,
+            );
+        }
+
+        // Pre-sort resources by dependency depth (ascending) so DFS visits
+        // shallower resources first. This ensures that "leaf" resources like
+        // an internet gateway (depth 1, no dependents) are emitted early in
+        // creation order, placing them late in destroy order -- after deeper
+        // chains (like nat_gw -> route) have been destroyed.
+        presorted.sort_by(|a, b| {
+            let a_binding = a
+                .attributes
+                .get("_binding")
+                .and_then(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| format!("{}:{}", a.id.resource_type, a.id.name));
+            let b_binding = b
+                .attributes
+                .get("_binding")
+                .and_then(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_else(|| format!("{}:{}", b.id.resource_type, b.id.name));
+            let a_depth = depth_cache.get(&a_binding).copied().unwrap_or(0);
+            let b_depth = depth_cache.get(&b_binding).copied().unwrap_or(0);
+            a_depth.cmp(&b_depth) // Ascending: shallower first
+        });
+    }
 
     // Build dependency graph
     let mut sorted = Vec::new();
@@ -529,10 +549,9 @@ mod tests {
         ];
 
         for (i, input) in orderings.iter().enumerate() {
-            let sorted = sort_resources_by_dependencies(input).unwrap();
-            let destroy_order: Vec<&str> = sorted
+            let destroy_order_resources = sort_resources_for_destroy(input).unwrap();
+            let destroy_order: Vec<&str> = destroy_order_resources
                 .iter()
-                .rev()
                 .filter_map(|r| match r.attributes.get("_binding") {
                     Some(Value::String(s)) => Some(s.as_str()),
                     _ => None,
@@ -582,10 +601,9 @@ mod tests {
         // Append orphan after initial resources (simulating orphan discovery)
         let all = vec![vpc, igw, subnet, eip, nat_gw, rt, route, orphan];
 
-        let sorted = sort_resources_by_dependencies(&all).unwrap();
-        let destroy_order: Vec<&str> = sorted
+        let destroy_order_resources = sort_resources_for_destroy(&all).unwrap();
+        let destroy_order: Vec<&str> = destroy_order_resources
             .iter()
-            .rev()
             .filter_map(|r| match r.attributes.get("_binding") {
                 Some(Value::String(s)) => Some(s.as_str()),
                 _ => None,
@@ -611,6 +629,169 @@ mod tests {
             igw_pos < vpc_pos,
             "IGW must be destroyed before vpc. Destroy order: {:?}",
             destroy_order
+        );
+    }
+
+    /// Regression test for #1071: depth-based pre-sorting must not change
+    /// creation (apply) order for resources with explicit dependencies.
+    ///
+    /// Models igw.crn (parsed from DSL, including anonymous resource):
+    ///   vpc (no deps)
+    ///   igw (no deps)
+    ///   igw_attachment -> vpc, igw
+    ///   rt -> vpc
+    ///   route (anonymous) -> rt, igw_attachment
+    ///
+    /// The route must always come AFTER igw_attachment in creation order.
+    #[test]
+    fn test_apply_order_route_after_gateway_attachment() {
+        use crate::parser::parse;
+
+        let input = r#"
+            provider awscc {
+              region = awscc.Region.ap_northeast_1
+            }
+
+            let vpc = awscc.ec2.vpc {
+              cidr_block = "10.0.0.0/16"
+            }
+
+            let igw = awscc.ec2.internet_gateway {}
+
+            let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+              vpc_id              = vpc.vpc_id
+              internet_gateway_id = igw.internet_gateway_id
+            }
+
+            let rt = awscc.ec2.route_table {
+              vpc_id = vpc.vpc_id
+            }
+
+            awscc.ec2.route {
+              route_table_id         = rt.route_table_id
+              destination_cidr_block = "0.0.0.0/0"
+              gateway_id             = igw_attachment.internet_gateway_id
+            }
+        "#;
+
+        let parsed = parse(input).unwrap();
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let creation_order: Vec<String> = sorted
+            .iter()
+            .map(|r| {
+                r.attributes
+                    .get("_binding")
+                    .and_then(|v| match v {
+                        Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name))
+            })
+            .collect();
+
+        let route_pos = creation_order
+            .iter()
+            .position(|b| b.contains("route") && !b.contains("route_table"))
+            .unwrap();
+        let attachment_pos = creation_order
+            .iter()
+            .position(|b| b == "igw_attachment")
+            .unwrap();
+        let rt_pos = creation_order.iter().position(|b| b == "rt").unwrap();
+
+        assert!(
+            route_pos > attachment_pos,
+            "route (pos {}) must come AFTER igw_attachment (pos {}) in creation order. Order: {:?}",
+            route_pos,
+            attachment_pos,
+            creation_order
+        );
+        assert!(
+            route_pos > rt_pos,
+            "route (pos {}) must come AFTER rt (pos {}) in creation order. Order: {:?}",
+            route_pos,
+            rt_pos,
+            creation_order
+        );
+    }
+
+    /// Regression test for #1071: models transit_gateway.crn
+    ///   vpc (no deps)
+    ///   subnet -> vpc
+    ///   tgw (no deps)
+    ///   tgw_attach -> tgw, vpc, subnet
+    ///   rt -> vpc
+    ///   route (anonymous) -> rt, tgw_attach
+    #[test]
+    fn test_apply_order_route_after_tgw_attachment() {
+        use crate::parser::parse;
+
+        let input = r#"
+            provider awscc {
+              region = awscc.Region.ap_northeast_1
+            }
+
+            let vpc = awscc.ec2.vpc {
+              cidr_block = "10.0.0.0/16"
+            }
+
+            let subnet = awscc.ec2.subnet {
+              vpc_id            = vpc.vpc_id
+              cidr_block        = "10.0.1.0/24"
+              availability_zone = "ap-northeast-1a"
+            }
+
+            let tgw = awscc.ec2.transit_gateway {
+              description = "Transit Gateway for route test"
+            }
+
+            let tgw_attach = awscc.ec2.transit_gateway_attachment {
+              transit_gateway_id = tgw.id
+              vpc_id             = vpc.vpc_id
+              subnet_ids         = [subnet.subnet_id]
+            }
+
+            let rt = awscc.ec2.route_table {
+              vpc_id = vpc.vpc_id
+            }
+
+            awscc.ec2.route {
+              route_table_id         = rt.route_table_id
+              destination_cidr_block = "10.1.0.0/16"
+              transit_gateway_id     = tgw_attach.transit_gateway_id
+            }
+        "#;
+
+        let parsed = parse(input).unwrap();
+        let sorted = sort_resources_by_dependencies(&parsed.resources).unwrap();
+        let creation_order: Vec<String> = sorted
+            .iter()
+            .map(|r| {
+                r.attributes
+                    .get("_binding")
+                    .and_then(|v| match v {
+                        Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name))
+            })
+            .collect();
+
+        let route_pos = creation_order
+            .iter()
+            .position(|b| b.contains("route") && !b.contains("route_table"))
+            .unwrap();
+        let attach_pos = creation_order
+            .iter()
+            .position(|b| b == "tgw_attach")
+            .unwrap();
+
+        assert!(
+            route_pos > attach_pos,
+            "route (pos {}) must come AFTER tgw_attach (pos {}) in creation order. Order: {:?}",
+            route_pos,
+            attach_pos,
+            creation_order
         );
     }
 


### PR DESCRIPTION
## Summary

- Separate depth-based pre-sorting (introduced in #1069) from the general topological sort, applying it only to destroy ordering
- Add `sort_resources_for_destroy()` function that combines depth pre-sorting + reverse for the destroy command
- Keep `sort_resources_by_dependencies()` as a plain topological sort that preserves .crn declaration order for apply
- Add regression tests parsing actual DSL for both IGW route and TGW route scenarios from the acceptance tests

Closes #1071

## Test plan

- [x] Existing destroy ordering tests (`test_destroy_order_igw_after_nat_gateway`, `test_destroy_order_with_orphans_appended`) updated to use `sort_resources_for_destroy` and pass
- [x] New apply ordering tests (`test_apply_order_route_after_gateway_attachment`, `test_apply_order_route_after_tgw_attachment`) verify route comes after gateway attachment in creation order
- [x] All existing tests pass (`cargo test` full workspace)
- [ ] Acceptance tests: `ec2_route/igw.crn` and `ec2_route/transit_gateway.crn` should pass apply phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)