### PR TITLE
feat: add default_tags support to provider block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ plan-default-values:
 plan-explicit:
 	cd $(FIXTURES)/explicit && $(CARINA) plan --refresh=false --detail explicit main.crn
 
+plan-default-tags:
+	cd $(FIXTURES)/default_tags && $(CARINA) plan --refresh=false main.crn
+
 plan-map-diff-tui:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false --tui main.crn
 
@@ -91,8 +94,11 @@ plan-fixtures:
 	@echo ""
 	@echo "=== explicit ==="
 	@$(MAKE) plan-explicit
+	@echo ""
+	@echo "=== default_tags ==="
+	@$(MAKE) plan-default-tags
 
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
-        plan-default-values plan-explicit \
+        plan-default-values plan-explicit plan-default-tags \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui plan-fixtures

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -108,6 +108,9 @@ fn build_plan_and_states_from_fixture(
     // Normalize state enum values to match DSL format
     normalize_state_with_ctx(&wiring, &mut current_states);
 
+    // Merge default_tags from provider configs into resources that support tags
+    crate::wiring::merge_default_tags(&wiring, &mut resources, &parsed.providers);
+
     // Resolve enum aliases (e.g., "all" -> "-1") in both desired and current states
     resolve_enum_aliases_with_ctx(&wiring, &mut resources);
     resolve_enum_aliases_in_states(&wiring, &mut current_states);
@@ -330,6 +333,18 @@ fn snapshot_explicit() {
     let output = strip_ansi(&format_plan(
         &plan,
         DetailLevel::Explicit,
+        &HashMap::new(),
+        Some(&schemas),
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_default_tags() {
+    let (plan, schemas) = build_plan_from_fixture("default_tags");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
         &HashMap::new(),
         Some(&schemas),
     ));

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_tags.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_tags.snap
@@ -1,0 +1,21 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.ec2.vpc vpc
+      cidr_block: "10.0.0.0/16"
+      tags: {Environment: "staging", ManagedBy: "carina", Name: "main-vpc"}
+      cidr_block_associations: (known after apply)
+      default_network_acl: (known after apply)
+      default_security_group: (known after apply)
+      ipv6_cidr_blocks: (known after apply)
+      vpc_id: (known after apply)
+        │
+        └─ + awscc.ec2.route_table ec2_route_table_d8d0c86b
+              tags: {Environment: "production", ManagedBy: "carina"}
+              vpc_id: vpc.vpc_id
+              route_table_id: (known after apply)
+
+Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -276,6 +276,7 @@ fn plan_file_serde_round_trip() {
                 "region".to_string(),
                 Value::String("aws.Region.ap_northeast_1".to_string()),
             )]),
+            default_tags: HashMap::new(),
         }],
         backend_config: Some(BackendConfig {
             backend_type: "s3".to_string(),
@@ -536,6 +537,7 @@ fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
     ProviderConfig {
         name: "awscc".to_string(),
         attributes: attrs,
+        default_tags: HashMap::new(),
     }
 }
 

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -320,6 +320,69 @@ fn resolve_value_alias(
     }
 }
 
+/// Merge default_tags from provider configs into resources that support tags.
+///
+/// For each resource whose schema includes a `tags` attribute:
+/// - If the resource has no `tags`, set it to `default_tags`
+/// - If the resource has `tags`, merge default_tags into it (resource-level tags win on conflict)
+///
+/// Resources whose schema does not include `tags` are skipped.
+pub fn merge_default_tags(
+    ctx: &WiringContext,
+    resources: &mut [Resource],
+    providers: &[ProviderConfig],
+) {
+    // Build a map of provider name -> default_tags for quick lookup
+    let provider_tags: HashMap<&str, &HashMap<String, Value>> = providers
+        .iter()
+        .filter(|p| !p.default_tags.is_empty())
+        .map(|p| (p.name.as_str(), &p.default_tags))
+        .collect();
+
+    if provider_tags.is_empty() {
+        return;
+    }
+
+    for resource in resources.iter_mut() {
+        let default_tags = match provider_tags.get(resource.id.provider.as_str()) {
+            Some(tags) => *tags,
+            None => continue,
+        };
+
+        // Check if the resource schema has a `tags` attribute
+        let schema_key = provider_mod::schema_key_for_resource(ctx.factories(), resource);
+        let has_tags = ctx
+            .schemas()
+            .get(&schema_key)
+            .is_some_and(|s| s.attributes.contains_key("tags"));
+
+        if !has_tags {
+            continue;
+        }
+
+        // Merge default_tags into the resource's tags
+        match resource.attributes.get_mut("tags") {
+            Some(Value::Map(existing_tags)) => {
+                // Resource-level tags take precedence: only insert defaults for missing keys
+                for (key, value) in default_tags {
+                    existing_tags
+                        .entry(key.clone())
+                        .or_insert_with(|| value.clone());
+                }
+            }
+            None => {
+                // No tags on the resource: use default_tags as-is
+                resource
+                    .attributes
+                    .insert("tags".to_string(), Value::Map(default_tags.clone()));
+            }
+            _ => {
+                // tags is some other value type (unexpected), skip
+            }
+        }
+    }
+}
+
 pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
     validation::check_unused_bindings(parsed)
 }
@@ -490,6 +553,10 @@ pub async fn create_plan_from_parsed(
     // Without this, raw AWS values (e.g., "ap-northeast-1a") in state would diff against
     // normalized desired values (e.g., "awscc.ec2.subnet.AvailabilityZone.ap_northeast_1a").
     provider.normalize_state(&mut current_states);
+
+    // Merge default_tags from provider configs into resources that support tags.
+    // Done after normalize_desired so enum values in tags are already resolved.
+    merge_default_tags(&ctx, &mut resources, &parsed.providers);
 
     // Resolve enum aliases (e.g., "all" -> "-1") in both desired resources
     // and current states so the differ sees canonical AWS values.
@@ -716,5 +783,155 @@ mod tests {
             resources[0].attributes.get("vpc_id"),
             Some(&Value::String("vpc-12345".to_string())),
         );
+    }
+
+    #[test]
+    fn test_merge_default_tags_resource_tags_win() {
+        let ctx = WiringContext::new();
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        resource.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        let mut resource_tags = HashMap::new();
+        resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
+        resource_tags.insert(
+            "Environment".to_string(),
+            Value::String("staging".to_string()),
+        );
+        resource
+            .attributes
+            .insert("tags".to_string(), Value::Map(resource_tags));
+
+        let mut default_tags = HashMap::new();
+        default_tags.insert(
+            "Environment".to_string(),
+            Value::String("production".to_string()),
+        );
+        default_tags.insert("Team".to_string(), Value::String("platform".to_string()));
+
+        let providers = vec![ProviderConfig {
+            name: "awscc".to_string(),
+            attributes: HashMap::new(),
+            default_tags,
+        }];
+
+        let mut resources = vec![resource];
+        merge_default_tags(&ctx, &mut resources, &providers);
+
+        if let Some(Value::Map(tags)) = resources[0].attributes.get("tags") {
+            // Resource-level "Environment" should win
+            assert_eq!(
+                tags.get("Environment"),
+                Some(&Value::String("staging".to_string()))
+            );
+            // Resource-level "Name" preserved
+            assert_eq!(tags.get("Name"), Some(&Value::String("my-vpc".to_string())));
+            // Default "Team" added
+            assert_eq!(
+                tags.get("Team"),
+                Some(&Value::String("platform".to_string()))
+            );
+        } else {
+            panic!("Expected tags to be a Map");
+        }
+    }
+
+    #[test]
+    fn test_merge_default_tags_no_explicit_tags() {
+        let ctx = WiringContext::new();
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        resource.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        // No tags attribute on the resource
+
+        let mut default_tags = HashMap::new();
+        default_tags.insert(
+            "Environment".to_string(),
+            Value::String("production".to_string()),
+        );
+
+        let providers = vec![ProviderConfig {
+            name: "awscc".to_string(),
+            attributes: HashMap::new(),
+            default_tags,
+        }];
+
+        let mut resources = vec![resource];
+        merge_default_tags(&ctx, &mut resources, &providers);
+
+        if let Some(Value::Map(tags)) = resources[0].attributes.get("tags") {
+            assert_eq!(
+                tags.get("Environment"),
+                Some(&Value::String("production".to_string()))
+            );
+        } else {
+            panic!("Expected tags to be set from default_tags");
+        }
+    }
+
+    #[test]
+    fn test_merge_default_tags_skips_no_tag_schema() {
+        let ctx = WiringContext::new();
+        // iam.role does not have a "tags" attribute in schema (it uses "tags" but let's
+        // use a resource type that definitely doesn't have tags to test skip behavior).
+        // ec2.route has no tags attribute.
+        let mut resource = Resource::with_provider("awscc", "ec2.route", "test-route");
+        resource.attributes.insert(
+            "route_table_id".to_string(),
+            Value::String("rtb-123".to_string()),
+        );
+
+        let mut default_tags = HashMap::new();
+        default_tags.insert(
+            "Environment".to_string(),
+            Value::String("production".to_string()),
+        );
+
+        let providers = vec![ProviderConfig {
+            name: "awscc".to_string(),
+            attributes: HashMap::new(),
+            default_tags,
+        }];
+
+        let mut resources = vec![resource];
+        merge_default_tags(&ctx, &mut resources, &providers);
+
+        // Should not have tags since ec2.route schema doesn't support tags
+        assert!(!resources[0].attributes.contains_key("tags"));
+    }
+
+    #[test]
+    fn test_merge_default_tags_no_default_tags() {
+        let ctx = WiringContext::new();
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        resource.attributes.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        let mut resource_tags = HashMap::new();
+        resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
+        resource
+            .attributes
+            .insert("tags".to_string(), Value::Map(resource_tags));
+
+        let providers = vec![ProviderConfig {
+            name: "awscc".to_string(),
+            attributes: HashMap::new(),
+            default_tags: HashMap::new(),
+        }];
+
+        let mut resources = vec![resource];
+        merge_default_tags(&ctx, &mut resources, &providers);
+
+        // Tags should be unchanged since there are no default_tags
+        if let Some(Value::Map(tags)) = resources[0].attributes.get("tags") {
+            assert_eq!(tags.len(), 1);
+            assert_eq!(tags.get("Name"), Some(&Value::String("my-vpc".to_string())));
+        } else {
+            panic!("Expected tags to be unchanged");
+        }
     }
 }

--- a/carina-cli/tests/fixtures/plan_display/default_tags/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/default_tags/main.crn
@@ -1,0 +1,23 @@
+# default_tags: provider-level tags merged into all taggable resources
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+  default_tags = {
+    Environment = "production"
+    ManagedBy   = "carina"
+  }
+}
+
+# Resource with explicit tags - should merge with default_tags (resource wins on conflict)
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name        = "main-vpc"
+    Environment = "staging"
+  }
+}
+
+# Resource without explicit tags - should receive default_tags
+awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -741,6 +741,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -950,6 +951,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -988,6 +990,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -1031,6 +1034,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1134,6 +1138,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -1245,6 +1250,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1434,6 +1440,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1540,6 +1547,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1613,6 +1621,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1670,6 +1679,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1769,6 +1779,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1810,6 +1821,7 @@ mod tests {
         let providers = vec![ProviderConfig {
             name: "awscc".to_string(),
             attributes: HashMap::new(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -2004,6 +2016,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
+            default_tags: HashMap::new(),
         }];
         let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -142,6 +142,10 @@ pub struct ModuleCall {
 pub struct ProviderConfig {
     pub name: String,
     pub attributes: HashMap<String, Value>,
+    /// Default tags to apply to all resources that support tags.
+    /// Extracted from `default_tags = { ... }` in the provider block.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub default_tags: HashMap<String, Value>,
 }
 
 /// Backend configuration for state storage
@@ -609,7 +613,18 @@ fn parse_provider_block(
         }
     }
 
-    Ok(ProviderConfig { name, attributes })
+    // Extract default_tags from attributes if present
+    let default_tags = if let Some(Value::Map(tags)) = attributes.remove("default_tags") {
+        tags
+    } else {
+        HashMap::new()
+    };
+
+    Ok(ProviderConfig {
+        name,
+        attributes,
+        default_tags,
+    })
 }
 
 fn parse_backend_block(
@@ -2790,5 +2805,51 @@ aws.s3.bucket {
 
         let result = parse(input).unwrap();
         assert_eq!(result.resources.len(), 1);
+    }
+
+    #[test]
+    fn parse_provider_block_with_default_tags() {
+        let input = r#"
+            provider awscc {
+                region = awscc.Region.ap_northeast_1
+                default_tags = {
+                    Environment = "production"
+                    Team        = "platform"
+                    ManagedBy   = "carina"
+                }
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(result.providers.len(), 1);
+        assert_eq!(result.providers[0].name, "awscc");
+        // default_tags should be extracted from attributes
+        assert!(!result.providers[0].attributes.contains_key("default_tags"));
+        assert_eq!(result.providers[0].default_tags.len(), 3);
+        assert_eq!(
+            result.providers[0].default_tags.get("Environment"),
+            Some(&Value::String("production".to_string()))
+        );
+        assert_eq!(
+            result.providers[0].default_tags.get("Team"),
+            Some(&Value::String("platform".to_string()))
+        );
+        assert_eq!(
+            result.providers[0].default_tags.get("ManagedBy"),
+            Some(&Value::String("carina".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_provider_block_without_default_tags() {
+        let input = r#"
+            provider awscc {
+                region = awscc.Region.ap_northeast_1
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(result.providers.len(), 1);
+        assert!(result.providers[0].default_tags.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `default_tags` map attribute to provider blocks, parsed and stored separately from other provider attributes
- Merge default_tags into resources at plan generation time (not parse time), only for resources whose schema includes a `tags` attribute
- Resource-level tags take precedence over default_tags on key conflicts; resources without explicit tags receive default_tags as their tags

Closes #1051

## Test plan

- [x] Parser tests: `default_tags` parsed correctly, extracted from attributes, empty when not specified
- [x] Unit tests: merge logic covers resource-wins, missing-tags-get-defaults, no-tag-schema-skipped, no-defaults-unchanged
- [x] Snapshot test: plan display fixture with default_tags showing merged tags
- [x] All existing tests pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)