### PR TITLE
feat: add concurrent spinners for in-flight resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "colored",
  "env_logger",
  "futures",
+ "indicatif",
  "insta",
  "regex-lite",
  "serde",
@@ -973,6 +974,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1895,6 +1897,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2144,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -2467,7 +2488,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3298,6 +3319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 colored = "3"
+indicatif = "0.17"
 env_logger = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1,12 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{IsTerminal, Write as _};
+use std::io::IsTerminal;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use colored::Colorize;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::sort_resources_by_dependencies;
@@ -52,78 +52,53 @@ pub(crate) fn format_duration(d: Duration) -> String {
 /// Braille spinner frames for animated progress display.
 pub(crate) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-/// CLI observer that prints colored progress output.
-///
-/// When stdout is a TTY, it shows an animated spinner before each effect
-/// and overwrites it with the result. When piped, the spinner is skipped.
-struct CliObserver {
-    is_tty: bool,
-    /// Mutable state protected by a Mutex for concurrent access.
-    inner: Mutex<CliObserverInner>,
+/// Create the spinner style used by both apply and destroy.
+pub(crate) fn spinner_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {spinner:.cyan} {msg}...")
+        .unwrap()
+        .tick_strings(SPINNER_FRAMES)
 }
 
-/// Mutable state for the CLI observer, guarded by a Mutex.
-struct CliObserverInner {
-    /// Length of the last in-flight line (for overwriting with spaces).
-    last_inflight_len: usize,
-    /// Flag to signal the spinner thread to stop.
-    spinner_stop: Arc<AtomicBool>,
-    /// Handle to the spinner animation thread.
-    spinner_thread: Option<std::thread::JoinHandle<()>>,
+/// CLI observer that prints colored progress output using `indicatif`.
+///
+/// When stdout is a TTY, it shows animated spinners for each in-flight effect.
+/// When piped, spinners are hidden automatically by `indicatif`.
+struct CliObserver {
+    multi: MultiProgress,
+    /// Map from effect description to its spinner, guarded by a Mutex for
+    /// concurrent access from parallel effect execution.
+    spinners: Mutex<HashMap<String, ProgressBar>>,
 }
 
 impl CliObserver {
     fn new() -> Self {
+        let multi = MultiProgress::new();
+        if !std::io::stdout().is_terminal() {
+            multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+        }
         Self {
-            is_tty: std::io::stdout().is_terminal(),
-            inner: Mutex::new(CliObserverInner {
-                last_inflight_len: 0,
-                spinner_stop: Arc::new(AtomicBool::new(false)),
-                spinner_thread: None,
-            }),
+            multi,
+            spinners: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Start the spinner animation in a background thread.
-    fn start_spinner(&self, desc: String) {
-        if !self.is_tty {
-            return;
-        }
-        let mut inner = self.inner.lock().unwrap();
-        inner.spinner_stop.store(false, Ordering::Relaxed);
-        let stop = inner.spinner_stop.clone();
-        // Estimate line length for clearing (use first frame as reference).
-        // "  " + frame + " " + desc + "..."
-        inner.last_inflight_len = 2 + SPINNER_FRAMES[0].len() + 1 + desc.len() + 3;
-        inner.spinner_thread = Some(std::thread::spawn(move || {
-            let mut i = 0;
-            while !stop.load(Ordering::Relaxed) {
-                let frame = SPINNER_FRAMES[i % SPINNER_FRAMES.len()];
-                // Use raw ANSI escape for cyan since we're in a spawned thread.
-                print!("\r  \x1b[36m{}\x1b[0m {}...", frame, desc);
-                std::io::stdout().flush().ok();
-                std::thread::sleep(Duration::from_millis(80));
-                i += 1;
-            }
-        }));
+    /// Start a new spinner for an in-flight effect.
+    fn start_spinner(&self, key: String) {
+        let pb = self.multi.add(ProgressBar::new_spinner());
+        pb.set_style(spinner_style());
+        pb.set_message(key.clone());
+        pb.enable_steady_tick(Duration::from_millis(80));
+        self.spinners.lock().unwrap().insert(key, pb);
     }
 
-    /// Stop the spinner animation and clear the line.
-    fn stop_spinner(&self) {
-        let mut inner = self.inner.lock().unwrap();
-        inner.spinner_stop.store(true, Ordering::Relaxed);
-        if let Some(handle) = inner.spinner_thread.take() {
-            handle.join().ok();
-        }
-        Self::clear_inflight_inner(&inner, self.is_tty);
-        inner.last_inflight_len = 0;
-    }
-
-    /// Clear the in-flight spinner line and move cursor to the start.
-    fn clear_inflight_inner(inner: &CliObserverInner, is_tty: bool) {
-        if is_tty && inner.last_inflight_len > 0 {
-            // Overwrite with spaces, then return to start
-            print!("\r{}\r", " ".repeat(inner.last_inflight_len));
+    /// Finish and remove the spinner for a completed effect.
+    fn finish_spinner(&self, key: &str, final_message: String) {
+        let mut spinners = self.spinners.lock().unwrap();
+        if let Some(pb) = spinners.remove(key) {
+            pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+            pb.finish_with_message(final_message);
+        } else {
+            self.multi.println(format!("  {}", final_message)).ok();
         }
     }
 }
@@ -145,16 +120,16 @@ impl ExecutionObserver for CliObserver {
                 progress,
                 ..
             } => {
-                self.stop_spinner();
                 let timing = format!("[{}]", format_duration(*duration)).dimmed();
                 let counter = format_progress(progress).dimmed();
-                println!(
-                    "  {} {} {} {}",
+                let msg = format!(
+                    "{} {} {} {}",
                     "✓".green(),
                     format_effect(effect),
                     timing,
                     counter
                 );
+                self.finish_spinner(&format_effect(effect).to_string(), msg);
             }
             ExecutionEvent::EffectFailed {
                 effect,
@@ -162,60 +137,84 @@ impl ExecutionObserver for CliObserver {
                 duration,
                 progress,
             } => {
-                self.stop_spinner();
                 let timing = format!("[{}]", format_duration(*duration)).dimmed();
                 let counter = format_progress(progress).dimmed();
-                println!(
-                    "  {} {} {} {}",
+                let msg = format!(
+                    "{} {} {} {}\n      {} {}",
                     "✗".red(),
                     format_effect(effect),
                     timing,
-                    counter
+                    counter,
+                    "→".red(),
+                    error.red()
                 );
-                println!("      {} {}", "→".red(), error.red());
+                self.finish_spinner(&format_effect(effect).to_string(), msg);
             }
             ExecutionEvent::EffectSkipped {
                 effect,
                 reason,
                 progress,
             } => {
-                self.stop_spinner();
                 let counter = format_progress(progress).dimmed();
-                println!(
-                    "  {} {} - {} {}",
+                let msg = format!(
+                    "{} {} - {} {}",
                     "⊘".yellow(),
                     format_effect(effect),
                     reason,
                     counter
                 );
+                self.finish_spinner(&format_effect(effect).to_string(), msg);
             }
             ExecutionEvent::CascadeUpdateSucceeded { id } => {
-                self.stop_spinner();
-                println!("  {} Update {} (cascade)", "✓".green(), id);
+                self.multi
+                    .println(format!("  {} Update {} (cascade)", "✓".green(), id))
+                    .ok();
             }
             ExecutionEvent::CascadeUpdateFailed { id, error } => {
-                self.stop_spinner();
-                println!("  {} Update {} (cascade)", "✗".red(), id);
-                println!("      {} {}", "→".red(), error.red());
+                self.multi
+                    .println(format!("  {} Update {} (cascade)", "✗".red(), id))
+                    .ok();
+                self.multi
+                    .println(format!("      {} {}", "→".red(), error.red()))
+                    .ok();
             }
             ExecutionEvent::RenameSucceeded { id, from, to } => {
-                self.stop_spinner();
-                println!("  {} Rename {} \"{}\" → \"{}\"", "✓".green(), id, from, to);
+                self.multi
+                    .println(format!(
+                        "  {} Rename {} \"{}\" → \"{}\"",
+                        "✓".green(),
+                        id,
+                        from,
+                        to
+                    ))
+                    .ok();
             }
             ExecutionEvent::RenameFailed { id, error } => {
-                self.stop_spinner();
-                println!("  {} Rename {}", "✗".red(), id);
-                println!("      {} {}", "→".red(), error.red());
+                self.multi
+                    .println(format!("  {} Rename {}", "✗".red(), id))
+                    .ok();
+                self.multi
+                    .println(format!("      {} {}", "→".red(), error.red()))
+                    .ok();
             }
             ExecutionEvent::RefreshStarted => {
-                println!();
-                println!("{}", "Refreshing uncertain resource states...".cyan());
+                self.multi.println("").ok();
+                self.multi
+                    .println(format!(
+                        "{}",
+                        "Refreshing uncertain resource states...".cyan()
+                    ))
+                    .ok();
             }
             ExecutionEvent::RefreshSucceeded { id } => {
-                println!("  {} Refresh {}", "✓".green(), id);
+                self.multi
+                    .println(format!("  {} Refresh {}", "✓".green(), id))
+                    .ok();
             }
             ExecutionEvent::RefreshFailed { id, error } => {
-                println!("  {} Refresh {} - {}", "!".yellow(), id, error);
+                self.multi
+                    .println(format!("  {} Refresh {} - {}", "!".yellow(), id, error))
+                    .ok();
             }
         }
     }

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1,10 +1,12 @@
 use std::collections::{HashMap, HashSet};
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use colored::Colorize;
 use futures::stream::{FuturesUnordered, StreamExt};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
 use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::{
@@ -22,7 +24,7 @@ use carina_state::{
 
 use super::validate_and_resolve;
 use crate::DetailLevel;
-use crate::commands::apply::{apply_name_overrides, format_duration};
+use crate::commands::apply::{apply_name_overrides, format_duration, spinner_style};
 use crate::commands::state::map_lock_error;
 use crate::display::{format_destroy_plan, format_effect};
 use crate::error::AppError;
@@ -339,6 +341,14 @@ async fn run_destroy_locked(
     println!("{}", "Destroying resources...".red().bold());
     println!();
 
+    // Set up multi-progress for concurrent spinners
+    let multi = MultiProgress::new();
+    if !std::io::stdout().is_terminal() {
+        multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+    }
+    // Map from resource index to its spinner
+    let mut spinners: HashMap<usize, ProgressBar> = HashMap::new();
+
     // Build reverse dependency map: binding -> {bindings that depend on it}.
     // For destroy ordering, a resource can only be deleted after ALL its
     // dependents (resources that reference it) have been deleted first.
@@ -450,13 +460,15 @@ async fn run_destroy_locked(
             {
                 let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
                 let counter = format!("{}/{}", c, destroy_total).dimmed();
-                println!(
-                    "  {} {} - skipped (dependent {} failed) {}",
-                    "⊘".yellow(),
-                    format_effect(effect),
-                    failed_dep,
-                    counter
-                );
+                multi
+                    .println(format!(
+                        "  {} {} - skipped (dependent {} failed) {}",
+                        "⊘".yellow(),
+                        format_effect(effect),
+                        failed_dep,
+                        counter
+                    ))
+                    .ok();
                 skip_count += 1;
                 failed_bindings.insert(binding.clone());
                 completed_indices.insert(idx);
@@ -479,11 +491,13 @@ async fn run_destroy_locked(
                 if let Some((dep_id, dep_identifier)) =
                     timed_out_resources.remove(dep_binding.as_str())
                 {
-                    println!(
-                        "  {} Waiting for {} to be deleted...",
-                        "⏳".yellow(),
-                        dep_id
-                    );
+                    multi
+                        .println(format!(
+                            "  {} Waiting for {} to be deleted...",
+                            "⏳".yellow(),
+                            dep_id
+                        ))
+                        .ok();
 
                     match wait_for_deletion(
                         &provider,
@@ -495,32 +509,42 @@ async fn run_destroy_locked(
                     .await
                     {
                         WaitResult::Deleted => {
-                            println!(
-                                "  {} Delete {} (completed after extended wait)",
-                                "✓".green(),
-                                dep_id
-                            );
+                            multi
+                                .println(format!(
+                                    "  {} Delete {} (completed after extended wait)",
+                                    "✓".green(),
+                                    dep_id
+                                ))
+                                .ok();
                             destroyed_ids.push(dep_id.clone());
                             success_count += 1;
                         }
                         WaitResult::ReadError(msg) => {
-                            println!("  {} Delete {}", "✗".red(), dep_id);
-                            println!(
-                                "      {} {}",
-                                "→".red(),
-                                format!("read error during wait: {}", msg).red()
-                            );
+                            multi
+                                .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                                .ok();
+                            multi
+                                .println(format!(
+                                    "      {} {}",
+                                    "→".red(),
+                                    format!("read error during wait: {}", msg).red()
+                                ))
+                                .ok();
                             failed_bindings.insert(dep_binding.clone());
                             failure_count += 1;
                             wait_failed = true;
                         }
                         WaitResult::TimedOut => {
-                            println!("  {} Delete {}", "✗".red(), dep_id);
-                            println!(
-                                "      {} {}",
-                                "→".red(),
-                                "still exists after extended wait".red()
-                            );
+                            multi
+                                .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                                .ok();
+                            multi
+                                .println(format!(
+                                    "      {} {}",
+                                    "→".red(),
+                                    "still exists after extended wait".red()
+                                ))
+                                .ok();
                             failed_bindings.insert(dep_binding.clone());
                             failure_count += 1;
                             wait_failed = true;
@@ -532,17 +556,26 @@ async fn run_destroy_locked(
             if wait_failed {
                 let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
                 let counter = format!("{}/{}", c, destroy_total).dimmed();
-                println!(
-                    "  {} {} - skipped (dependent deletion did not complete) {}",
-                    "⊘".yellow(),
-                    format_effect(effect),
-                    counter
-                );
+                multi
+                    .println(format!(
+                        "  {} {} - skipped (dependent deletion did not complete) {}",
+                        "⊘".yellow(),
+                        format_effect(effect),
+                        counter
+                    ))
+                    .ok();
                 skip_count += 1;
                 failed_bindings.insert(binding.clone());
                 completed_indices.insert(idx);
                 continue;
             }
+
+            // Create spinner for this in-flight deletion
+            let pb = multi.add(ProgressBar::new_spinner());
+            pb.set_style(spinner_style());
+            pb.set_message(format_effect(effect).to_string());
+            pb.enable_steady_tick(Duration::from_millis(80));
+            spinners.insert(idx, pb);
 
             // Spawn the deletion as a concurrent future
             let resource_id = resource.id.clone();
@@ -586,12 +619,18 @@ async fn run_destroy_locked(
                     let (_, _, effect) = &resource_info[idx];
                     let c = completed_counter.fetch_add(1, Ordering::Relaxed) + 1;
                     let counter = format!("{}/{}", c, destroy_total).dimmed();
-                    println!(
-                        "  {} {} - retries exhausted (no progress possible) {}",
+                    let msg = format!(
+                        "{} {} - retries exhausted (no progress possible) {}",
                         "✗".red(),
                         format_effect(effect),
                         counter
                     );
+                    if let Some(pb) = spinners.remove(&idx) {
+                        pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                        pb.finish_with_message(msg);
+                    } else {
+                        multi.println(format!("  {}", msg)).ok();
+                    }
                     let binding = &resource_info[idx].0;
                     failed_bindings.insert(binding.clone());
                     dispatched.insert(idx);
@@ -622,25 +661,38 @@ async fn run_destroy_locked(
         let counter = format!("{}/{}", c, destroy_total).dimmed();
         let effect = &resource_info[finished_idx].2;
 
+        // Helper to finish the spinner for the completed effect
+        let finish_spinner =
+            |spinners: &mut HashMap<usize, ProgressBar>, idx: usize, msg: String| {
+                if let Some(pb) = spinners.remove(&idx) {
+                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                    pb.finish_with_message(msg);
+                } else {
+                    multi.println(format!("  {}", msg)).ok();
+                }
+            };
+
         match delete_result {
             Ok(()) => {
                 let timing = format!("[{}]", format_duration(started.elapsed())).dimmed();
-                println!(
-                    "  {} {} {} {}",
+                let msg = format!(
+                    "{} {} {} {}",
                     "✓".green(),
                     format_effect(effect),
                     timing,
                     counter
                 );
+                finish_spinner(&mut spinners, finished_idx, msg);
                 success_count += 1;
                 destroyed_ids.push(resource_id);
             }
             Err(e) if e.is_timeout => {
-                println!(
-                    "  {} {} - Operation timed out, waiting for completion...",
+                let msg = format!(
+                    "{} {} - Operation timed out, waiting for completion...",
                     "⏳".yellow(),
                     format_effect(effect)
                 );
+                finish_spinner(&mut spinners, finished_idx, msg);
                 timed_out_resources.insert(binding.clone(), (resource_id, identifier));
             }
             Err(e) => {
@@ -664,23 +716,26 @@ async fn run_destroy_locked(
                     // Undo the counter increment since this isn't truly completed
                     completed_counter.fetch_sub(1, Ordering::Relaxed);
                     let retry_num = retry_counts[&finished_idx];
-                    println!(
-                        "  {} {} - dependency violation, will retry ({}/{})",
+                    let msg = format!(
+                        "{} {} - dependency violation, will retry ({}/{})",
                         "↻".yellow(),
                         format_effect(effect),
                         retry_num,
                         max_retries
                     );
+                    finish_spinner(&mut spinners, finished_idx, msg);
                 } else {
                     let timing = format!("[{}]", format_duration(started.elapsed())).dimmed();
-                    println!(
-                        "  {} {} {} {}",
+                    let msg = format!(
+                        "{} {} {} {}\n      {} {}",
                         "✗".red(),
                         format_effect(effect),
                         timing,
-                        counter
+                        counter,
+                        "→".red(),
+                        e.to_string().red()
                     );
-                    println!("      {} {}", "→".red(), e.to_string().red());
+                    finish_spinner(&mut spinners, finished_idx, msg);
                     failure_count += 1;
                     failed_bindings.insert(binding.clone());
                 }
@@ -690,11 +745,13 @@ async fn run_destroy_locked(
 
     // Handle any remaining timed-out resources that no parent waited on
     for (dep_binding, (dep_id, dep_identifier)) in &timed_out_resources {
-        println!(
-            "  {} Waiting for {} to be deleted...",
-            "⏳".yellow(),
-            dep_id
-        );
+        multi
+            .println(format!(
+                "  {} Waiting for {} to be deleted...",
+                "⏳".yellow(),
+                dep_id
+            ))
+            .ok();
 
         match wait_for_deletion(
             &provider,
@@ -706,31 +763,41 @@ async fn run_destroy_locked(
         .await
         {
             WaitResult::Deleted => {
-                println!(
-                    "  {} Delete {} (completed after extended wait)",
-                    "✓".green(),
-                    dep_id
-                );
+                multi
+                    .println(format!(
+                        "  {} Delete {} (completed after extended wait)",
+                        "✓".green(),
+                        dep_id
+                    ))
+                    .ok();
                 destroyed_ids.push(dep_id.clone());
                 success_count += 1;
             }
             WaitResult::ReadError(msg) => {
-                println!("  {} Delete {}", "✗".red(), dep_id);
-                println!(
-                    "      {} {}",
-                    "→".red(),
-                    format!("read error during wait: {}", msg).red()
-                );
+                multi
+                    .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                    .ok();
+                multi
+                    .println(format!(
+                        "      {} {}",
+                        "→".red(),
+                        format!("read error during wait: {}", msg).red()
+                    ))
+                    .ok();
                 failed_bindings.insert(dep_binding.clone());
                 failure_count += 1;
             }
             WaitResult::TimedOut => {
-                println!("  {} Delete {}", "✗".red(), dep_id);
-                println!(
-                    "      {} {}",
-                    "→".red(),
-                    "still exists after extended wait".red()
-                );
+                multi
+                    .println(format!("  {} Delete {}", "✗".red(), dep_id))
+                    .ok();
+                multi
+                    .println(format!(
+                        "      {} {}",
+                        "→".red(),
+                        "still exists after extended wait".red()
+                    ))
+                    .ok();
                 failed_bindings.insert(dep_binding.clone());
                 failure_count += 1;
             }


### PR DESCRIPTION
## Summary

- Replace the single-spinner approach in `apply` and `destroy` with `indicatif` `MultiProgress` + `ProgressBar` to show individual animated spinners for each in-flight resource operation
- Each concurrent operation gets its own spinner line (`⠋ Create awscc.ec2.vpc vpc...`), which transitions to a result line (`✓`/`✗`/`⊘`) upon completion
- Non-TTY output is handled automatically by `indicatif` (spinners hidden when piped)

## Test plan

- [x] `cargo test -p carina-cli` passes
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes
- [ ] Manual test with `make plan-all-create` or real apply to verify visual spinner behavior
- [ ] Verify non-TTY behavior (pipe output to `cat`)

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)