### PR TITLE
fix: revert to dynamic progress display for apply/destroy

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -61,20 +61,21 @@ pub(crate) fn spinner_style() -> ProgressStyle {
 
 /// CLI observer that prints colored progress output using `indicatif`.
 ///
-/// Shows a static dependency tree with all effects visible from the start.
-/// Each line is an indicatif ProgressBar that gets updated in place as
-/// effects transition through waiting -> in-progress -> completed/failed.
+/// Uses dynamic display: resources appear only when they start executing or
+/// complete. No upfront tree is shown. Spinners are created lazily on
+/// `EffectStarted` and finished on `EffectSucceeded`/`EffectFailed`.
 struct CliObserver {
     multi: MultiProgress,
-    /// Map from effect description to its pre-created ProgressBar, guarded by
-    /// a Mutex for concurrent access from parallel effect execution.
+    /// Map from effect description to its ProgressBar, created lazily when
+    /// the effect starts executing. Guarded by a Mutex for concurrent access.
     bars: Mutex<HashMap<String, ProgressBar>>,
     /// Map from effect description to its tree prefix string.
     prefixes: HashMap<String, String>,
 }
 
 impl CliObserver {
-    /// Create a new observer with pre-built tree structure from the plan.
+    /// Create a new observer. Computes tree prefixes from the plan but does
+    /// NOT create any progress bars upfront.
     fn new(plan: &Plan) -> Self {
         let multi = MultiProgress::new();
         if !std::io::stdout().is_terminal() {
@@ -82,35 +83,20 @@ impl CliObserver {
         }
 
         let tree_entries = build_effect_tree_entries(plan);
-        let mut bars = HashMap::new();
         let mut prefixes = HashMap::new();
 
         for entry in &tree_entries {
             let effect = &plan.effects()[entry.effect_idx];
-
-            // Skip Read effects - they are no-ops completed immediately by the
-            // executor without emitting events, so a progress bar would never
-            // transition away from waiting state.
             if matches!(effect, Effect::Read { .. }) {
                 continue;
             }
-
             let key = format_effect(effect);
-            let prefix = &entry.prefix;
-
-            // Create a progress bar in waiting state
-            let pb = multi.add(ProgressBar::new_spinner());
-            pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-            let msg = format!("{} {}{}", "⏳", prefix, format_effect(effect));
-            pb.set_message(msg);
-
-            bars.insert(key.clone(), pb);
-            prefixes.insert(key, prefix.clone());
+            prefixes.insert(key, entry.prefix.clone());
         }
 
         Self {
             multi,
-            bars: Mutex::new(bars),
+            bars: Mutex::new(HashMap::new()),
             prefixes,
         }
     }
@@ -129,35 +115,19 @@ fn format_progress(progress: &ProgressInfo) -> String {
 impl ExecutionObserver for CliObserver {
     fn on_event(&self, event: &ExecutionEvent) {
         match event {
-            ExecutionEvent::Waiting {
-                effect,
-                pending_dependencies,
-            } => {
-                let key = format_effect(effect);
-                let prefix = self.prefix_for(&key);
-                let dep_list = pending_dependencies.join(", ");
-                let msg = format!(
-                    "{} {}{} {}",
-                    "⏳",
-                    prefix,
-                    format_effect(effect),
-                    format!("[waiting for: {}]", dep_list).dimmed()
-                );
-                let bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.get(&key) {
-                    pb.set_message(msg);
-                }
+            ExecutionEvent::Waiting { .. } => {
+                // Dynamic display: don't show waiting resources.
+                // They will appear when they start executing.
             }
             ExecutionEvent::EffectStarted { effect } => {
                 let key = format_effect(effect);
                 let prefix = self.prefix_for(&key);
-                let bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.get(&key) {
-                    pb.set_style(spinner_style());
-                    let msg = format!("{}{}", prefix, key);
-                    pb.set_message(msg);
-                    pb.enable_steady_tick(Duration::from_millis(80));
-                }
+                let pb = self.multi.add(ProgressBar::new_spinner());
+                pb.set_style(spinner_style());
+                let msg = format!("{}{}", prefix, key);
+                pb.set_message(msg);
+                pb.enable_steady_tick(Duration::from_millis(80));
+                self.bars.lock().unwrap().insert(key, pb);
             }
             ExecutionEvent::EffectSucceeded {
                 effect,
@@ -177,8 +147,8 @@ impl ExecutionObserver for CliObserver {
                     timing,
                     counter
                 );
-                let bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.get(&key) {
+                let mut bars = self.bars.lock().unwrap();
+                if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 }
@@ -203,8 +173,8 @@ impl ExecutionObserver for CliObserver {
                     "→".red(),
                     error.red()
                 );
-                let bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.get(&key) {
+                let mut bars = self.bars.lock().unwrap();
+                if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 }
@@ -225,10 +195,14 @@ impl ExecutionObserver for CliObserver {
                     reason,
                     counter
                 );
-                let bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.get(&key) {
+                // Skipped effects may not have a spinner (they were never started),
+                // so print directly via multi.println().
+                let mut bars = self.bars.lock().unwrap();
+                if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
+                } else {
+                    self.multi.println(format!("  {}", msg)).ok();
                 }
             }
             ExecutionEvent::CascadeUpdateSucceeded { id } => {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -347,14 +347,14 @@ async fn run_destroy_locked(
         multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
     }
 
-    // Build tree entries and prefixes from the destroy plan
+    // Build tree entries and prefixes from the destroy plan for indentation
     let tree_entries = build_effect_tree_entries(&destroy_plan);
     let mut tree_prefixes: HashMap<usize, String> = HashMap::new();
     for entry in &tree_entries {
         tree_prefixes.insert(entry.effect_idx, entry.prefix.clone());
     }
 
-    // Map from resource index to its spinner
+    // Map from resource index to its spinner (populated lazily on dispatch)
     let mut spinners: HashMap<usize, ProgressBar> = HashMap::new();
 
     // Build reverse dependency map: binding -> {bindings that depend on it}.
@@ -404,18 +404,6 @@ async fn run_destroy_locked(
             (binding, identifier, effect)
         })
         .collect();
-
-    // Pre-create all progress bars in tree order (static tree display)
-    for entry in &tree_entries {
-        let idx = entry.effect_idx;
-        let (_, _, effect) = &resource_info[idx];
-        let prefix = &entry.prefix;
-        let pb = multi.add(ProgressBar::new_spinner());
-        pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-        let msg = format!("{} {}{}", "⏳", prefix, format_effect(effect));
-        pb.set_message(msg);
-        spinners.insert(idx, pb);
-    }
 
     // Build binding -> index mapping for ready-queue scheduling
     let mut binding_to_idx: HashMap<String, usize> = HashMap::new();
@@ -467,37 +455,6 @@ async fn run_destroy_locked(
             }
         }
         newly_ready.sort();
-
-        // Update waiting indicators for effects with unmet dependencies
-        for &idx in &all_indices {
-            if dispatched.contains(&idx)
-                || retry_pending.contains(&idx)
-                || newly_ready.contains(&idx)
-            {
-                continue;
-            }
-            let deps = &deletion_deps[&idx];
-            let pending: Vec<String> = deps
-                .iter()
-                .filter(|d| !completed_indices.contains(d))
-                .map(|d| resource_info[*d].0.clone())
-                .collect();
-            if !pending.is_empty() {
-                let (_, _, effect) = &resource_info[idx];
-                let prefix = tree_prefixes.get(&idx).map(|s| s.as_str()).unwrap_or("");
-                let dep_list = pending.join(", ");
-                let msg = format!(
-                    "{} {}{} {}",
-                    "⏳",
-                    prefix,
-                    format_effect(effect),
-                    format!("[waiting for: {}]", dep_list).dimmed()
-                );
-                if let Some(pb) = spinners.get(&idx) {
-                    pb.set_message(msg);
-                }
-            }
-        }
 
         // Process newly ready resources
         for idx in newly_ready {
@@ -634,12 +591,12 @@ async fn run_destroy_locked(
                 continue;
             }
 
-            // Transition pre-created progress bar to spinner for in-flight deletion
-            if let Some(pb) = spinners.get(&idx) {
-                pb.set_style(spinner_style());
-                pb.set_message(format!("{}{}", prefix, format_effect(effect)));
-                pb.enable_steady_tick(Duration::from_millis(80));
-            }
+            // Create a spinner for the in-flight deletion
+            let pb = multi.add(ProgressBar::new_spinner());
+            pb.set_style(spinner_style());
+            pb.set_message(format!("{}{}", prefix, format_effect(effect)));
+            pb.enable_steady_tick(Duration::from_millis(80));
+            spinners.insert(idx, pb);
 
             // Spawn the deletion as a concurrent future
             let resource_id = resource.id.clone();


### PR DESCRIPTION
## Summary

- Revert from static upfront tree display to dynamic progress: resources appear only when they start executing, not all at once
- Remove pre-creation of ProgressBars for all resources in both apply and destroy
- Create spinners lazily on `EffectStarted` (apply) / dispatch (destroy), finish them on completion
- Skip showing waiting resources entirely -- they appear when execution begins
- Fix spacing issue where spinner width caused extra padding between checkmark and effect text

Fixes the two problems with the static tree approach:
1. Extra space between checkmark icons and effect text (from indicatif spinner width)
2. Resources that don't fit on screen are invisible with no way to scroll

Part of #1092

## Test plan

- [x] `cargo test -p carina-cli` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Visual confirmation with `make plan-mixed` fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)