### PR TITLE
feat: show spinner progress during state refresh

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -59,6 +59,47 @@ pub(crate) fn spinner_style() -> ProgressStyle {
         .tick_strings(SPINNER_FRAMES)
 }
 
+/// Spinner for tracking state refresh progress per resource.
+///
+/// Shows a spinner while each resource is being read, then displays timing
+/// when done. Uses `indicatif` for animated terminal output.
+pub(crate) struct RefreshProgress {
+    pb: ProgressBar,
+    start: std::time::Instant,
+}
+
+impl RefreshProgress {
+    /// Print the "Refreshing state..." header and prepare for per-resource spinners.
+    pub fn start_header() {
+        println!("{}", "Refreshing state...".cyan());
+    }
+
+    /// Begin tracking a resource read. Shows a spinner with the resource ID.
+    pub fn begin(id: &ResourceId) -> Self {
+        let pb = ProgressBar::new_spinner();
+        if !std::io::stdout().is_terminal() {
+            pb.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+        }
+        pb.set_style(spinner_style());
+        pb.set_message(format!("{}", id));
+        pb.enable_steady_tick(Duration::from_millis(80));
+        Self {
+            pb,
+            start: std::time::Instant::now(),
+        }
+    }
+
+    /// Finish the spinner with a success checkmark and elapsed time.
+    pub fn finish(self) {
+        let elapsed = self.start.elapsed();
+        let timing = format!("[{}]", format_duration(elapsed)).dimmed();
+        let msg = format!("{} {} {}", "✓".green(), self.pb.message(), timing);
+        self.pb
+            .set_style(ProgressStyle::with_template("  {msg}").unwrap());
+        self.pb.finish_with_message(msg);
+    }
+}
+
 /// CLI observer that prints colored progress output using `indicatif`.
 ///
 /// Uses dynamic display: resources appear only when they start executing or
@@ -828,8 +869,10 @@ async fn run_apply_locked(
 
     // Read states for all resources using identifier from state
     // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
+    RefreshProgress::start_header();
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
     for resource in &sorted_resources {
+        let progress = RefreshProgress::begin(&resource.id);
         let identifier = state_file
             .as_ref()
             .and_then(|sf| sf.get_identifier_for_resource(resource));
@@ -837,6 +880,7 @@ async fn run_apply_locked(
             .read(&resource.id, identifier.as_deref())
             .await
             .map_err(AppError::Provider)?;
+        progress.finish();
         current_states.insert(resource.id.clone(), state);
     }
 

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -24,7 +24,9 @@ use carina_state::{
 
 use super::validate_and_resolve;
 use crate::DetailLevel;
-use crate::commands::apply::{apply_name_overrides, format_duration, spinner_style};
+use crate::commands::apply::{
+    RefreshProgress, apply_name_overrides, format_duration, spinner_style,
+};
 use crate::commands::state::map_lock_error;
 use crate::display::{format_destroy_plan, format_effect};
 use crate::error::AppError;
@@ -149,12 +151,15 @@ async fn run_destroy_locked(
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
 
     if refresh {
+        RefreshProgress::start_header();
+
         // Read states for managed resources using identifier from state
         // Skip data sources (read-only) -- they won't be destroyed
         for resource in &all_resources {
             if resource.read_only {
                 continue;
             }
+            let progress = RefreshProgress::begin(&resource.id);
             let identifier = state_file
                 .as_ref()
                 .and_then(|sf| sf.get_identifier_for_resource(resource));
@@ -162,6 +167,7 @@ async fn run_destroy_locked(
                 .read(&resource.id, identifier.as_deref())
                 .await
                 .map_err(AppError::Provider)?;
+            progress.finish();
             current_states.insert(resource.id.clone(), state);
         }
 
@@ -171,10 +177,12 @@ async fn run_destroy_locked(
             let desired_ids: HashSet<ResourceId> =
                 all_resources.iter().map(|r| r.id.clone()).collect();
             for (id, state) in sf.build_orphan_states(&desired_ids) {
+                let progress = RefreshProgress::begin(&id);
                 let refreshed = provider
                     .read(&id, state.identifier.as_deref())
                     .await
                     .map_err(AppError::Provider)?;
+                progress.finish();
                 if refreshed.exists {
                     current_states.insert(id.clone(), refreshed);
                     let orphan_resource = build_orphan_resource(sf, &id);

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -22,6 +22,7 @@ use carina_provider_awscc::AwsccProviderFactory;
 use carina_provider_mock::MockProvider;
 use carina_state::StateFile;
 
+use crate::commands::apply::RefreshProgress;
 use crate::error::AppError;
 
 /// Result of creating a plan, with context needed for saving
@@ -490,9 +491,12 @@ pub async fn create_plan_from_parsed(
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
 
     if refresh {
+        RefreshProgress::start_header();
+
         // Read states for all resources using identifier from state
         // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
         for resource in &sorted_resources {
+            let progress = RefreshProgress::begin(&resource.id);
             let identifier = state_file
                 .as_ref()
                 .and_then(|sf| sf.get_identifier_for_resource(resource));
@@ -500,6 +504,7 @@ pub async fn create_plan_from_parsed(
                 .read(&resource.id, identifier.as_deref())
                 .await
                 .map_err(AppError::Provider)?;
+            progress.finish();
             current_states.insert(resource.id.clone(), state);
         }
 
@@ -510,10 +515,12 @@ pub async fn create_plan_from_parsed(
             let desired_ids: HashSet<ResourceId> =
                 sorted_resources.iter().map(|r| r.id.clone()).collect();
             for (id, state) in sf.build_orphan_states(&desired_ids) {
+                let progress = RefreshProgress::begin(&id);
                 let refreshed = provider
                     .read(&id, state.identifier.as_deref())
                     .await
                     .map_err(AppError::Provider)?;
+                progress.finish();
                 if refreshed.exists {
                     current_states.entry(id).or_insert(refreshed);
                 }


### PR DESCRIPTION
## Summary

- Add `RefreshProgress` helper struct that shows an indicatif spinner per resource during state refresh, with elapsed time on completion
- Apply to all three state refresh code paths: plan (`wiring.rs`), apply (`apply.rs`), and destroy (`destroy.rs`)
- Respects `--refresh=false` (no output when skipping refresh) and non-terminal environments (hidden draw target)

Closes #1091

## Test plan

- [x] `cargo test -p carina-cli` passes (157 tests)
- [x] `cargo clippy -p carina-cli` passes with no warnings
- [x] `cargo fmt` passes
- [ ] Manual test: `cargo run -- plan example.crn` shows spinner per resource during refresh
- [ ] Manual test: `cargo run -- plan --refresh=false example.crn` shows no refresh output
- [ ] Manual test: `cargo run -- apply example.crn` shows spinner during refresh
- [ ] Manual test: `cargo run -- destroy example.crn` shows spinner during refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)