### PR TITLE
fix: reduce refresh concurrency and add throttle retry

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -35,7 +35,7 @@ use crate::commands::state::map_lock_error;
 use crate::display::{format_effect, print_plan};
 use crate::error::AppError;
 use crate::wiring::{
-    WiringContext, create_providers_from_configs, get_provider_with_ctx,
+    WiringContext, create_providers_from_configs, get_provider_with_ctx, read_with_retry,
     reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names, resolve_names_with_ctx,
 };
 
@@ -377,7 +377,7 @@ pub async fn refresh_pending_states(
     let mut failed_refreshes = HashSet::new();
 
     for (id, identifier) in refreshes {
-        match provider.read(id, Some(identifier)).await {
+        match read_with_retry(provider, id, Some(identifier)).await {
             Ok(state) => {
                 println!("  {} Refresh {}", "✓".green(), id);
                 current_states.insert(id.clone(), state);
@@ -891,15 +891,14 @@ async fn run_apply_locked(
                     .as_ref()
                     .and_then(|sf| sf.get_identifier_for_resource(resource));
                 async move {
-                    let state = provider_ref
-                        .read(&resource.id, identifier.as_deref())
+                    let state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                         .await
                         .map_err(AppError::Provider)?;
                     progress.finish();
                     Ok((resource.id.clone(), state))
                 }
             })
-            .buffer_unordered(10)
+            .buffer_unordered(5)
             .collect()
             .await;
         let mut states = HashMap::new();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -31,8 +31,8 @@ use crate::commands::state::map_lock_error;
 use crate::display::{format_destroy_plan, format_effect};
 use crate::error::AppError;
 use crate::wiring::{
-    WiringContext, get_provider_with_ctx, reconcile_anonymous_identifiers_with_ctx,
-    reconcile_prefixed_names,
+    WiringContext, get_provider_with_ctx, read_with_retry,
+    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
 };
 
 pub async fn run_destroy(
@@ -166,15 +166,14 @@ async fn run_destroy_locked(
                     .as_ref()
                     .and_then(|sf| sf.get_identifier_for_resource(resource));
                 async move {
-                    let state = provider_ref
-                        .read(&resource.id, identifier.as_deref())
+                    let state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                         .await
                         .map_err(AppError::Provider)?;
                     progress.finish();
                     Ok((resource.id.clone(), state))
                 }
             })
-            .buffer_unordered(10)
+            .buffer_unordered(5)
             .collect()
             .await;
         for result in results {
@@ -194,15 +193,15 @@ async fn run_destroy_locked(
                     .map(|(id, state)| {
                         let progress = RefreshProgress::begin_multi(&multi, &id);
                         async move {
-                            let refreshed = provider_ref
-                                .read(&id, state.identifier.as_deref())
-                                .await
-                                .map_err(AppError::Provider)?;
+                            let refreshed =
+                                read_with_retry(provider_ref, &id, state.identifier.as_deref())
+                                    .await
+                                    .map_err(AppError::Provider)?;
                             progress.finish();
                             Ok((id, refreshed))
                         }
                     })
-                    .buffer_unordered(10)
+                    .buffer_unordered(5)
                     .collect()
                     .await;
             for result in orphan_results {

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::time::Duration;
 
 use colored::Colorize;
 use futures::stream::{self, StreamExt};
@@ -11,7 +12,8 @@ use carina_core::module_resolver;
 use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{
-    self as provider_mod, Provider, ProviderFactory, ProviderNormalizer, ProviderRouter,
+    self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
+    ProviderRouter,
 };
 use carina_core::resolver::resolve_refs_with_state;
 use carina_core::resource::{Resource, ResourceId, State, Value};
@@ -505,15 +507,14 @@ pub async fn create_plan_from_parsed(
                     .as_ref()
                     .and_then(|sf| sf.get_identifier_for_resource(resource));
                 async move {
-                    let state = provider_ref
-                        .read(&resource.id, identifier.as_deref())
+                    let state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                         .await
                         .map_err(AppError::Provider)?;
                     progress.finish();
                     Ok((resource.id.clone(), state))
                 }
             })
-            .buffer_unordered(10)
+            .buffer_unordered(5)
             .collect()
             .await;
         for result in results {
@@ -534,15 +535,15 @@ pub async fn create_plan_from_parsed(
                     .map(|(id, state)| {
                         let progress = RefreshProgress::begin_multi(&multi, &id);
                         async move {
-                            let refreshed = provider_ref
-                                .read(&id, state.identifier.as_deref())
-                                .await
-                                .map_err(AppError::Provider)?;
+                            let refreshed =
+                                read_with_retry(provider_ref, &id, state.identifier.as_deref())
+                                    .await
+                                    .map_err(AppError::Provider)?;
                             progress.finish();
                             Ok((id, refreshed))
                         }
                     })
-                    .buffer_unordered(10)
+                    .buffer_unordered(5)
                     .collect()
                     .await;
             for result in orphan_results {
@@ -639,6 +640,40 @@ pub async fn create_plan_from_parsed(
         sorted_resources,
         current_states,
     })
+}
+
+/// Check whether a `ProviderError` is an AWS throttling error that should be retried.
+fn is_throttling_error(err: &ProviderError) -> bool {
+    let msg = err.to_string();
+    msg.contains("ThrottlingException") || msg.contains("Rate exceeded")
+}
+
+/// Read a resource via the provider with retry and exponential backoff for throttling errors.
+///
+/// Retries up to 3 times with delays of 1s, 2s, 4s when the error looks like an
+/// AWS throttling / rate-limit response.
+pub async fn read_with_retry(
+    provider: &dyn Provider,
+    id: &ResourceId,
+    identifier: Option<&str>,
+) -> Result<State, ProviderError> {
+    let max_retries = 3;
+    for attempt in 0..=max_retries {
+        match provider.read(id, identifier).await {
+            Ok(state) => return Ok(state),
+            Err(e) if attempt < max_retries && is_throttling_error(&e) => {
+                let delay = Duration::from_secs(1 << attempt); // 1s, 2s, 4s
+                eprintln!(
+                    "  Throttled reading {}, retrying in {}s...",
+                    id,
+                    delay.as_secs()
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
 }
 
 /// Convenience wrappers for tests. Each creates a fresh `WiringContext` internally,


### PR DESCRIPTION
## Summary

- Reduce `buffer_unordered(10)` to `buffer_unordered(5)` in all concurrent state refresh paths (wiring.rs, apply.rs, destroy.rs) to lower AWS API call rate
- Add `read_with_retry()` helper that retries `provider.read()` with exponential backoff (1s, 2s, 4s) up to 3 times when `ThrottlingException` or `Rate exceeded` errors are detected

Part of #1100

## Test plan

- [x] `cargo test -p carina-cli` passes (157 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual verification with real AWS resources that throttling is retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)