### PR TITLE
Remove ref() wrapper from type annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ Modules enable reusable infrastructure components with typed inputs and outputs.
 
 ```hcl
 input {
-  vpc: ref(aws.vpc)
+  vpc: aws.vpc
   cidr_blocks: list(cidr)
   enable_https: bool = true
 }
 
 output {
-  security_group: ref(aws.security_group) = web_sg.id
+  security_group: aws.security_group = web_sg.id
 }
 
 let web_sg = aws.security_group {
@@ -264,20 +264,20 @@ Module: web_tier
 
 === REQUIRES ===
 
-  vpc: ref(aws.vpc)  (required)
+  vpc: aws.vpc  (required)
   cidr_blocks: list(cidr)  (required)
   enable_https: bool = true
 
 === CREATES ===
 
-  input { vpc: ref(aws.vpc) }
+  input { vpc: aws.vpc }
     └── web_sg: aws.security_group
        ├── http: aws.security_group.ingress_rule
        └── https: aws.security_group.ingress_rule
 
 === EXPOSES ===
 
-  security_group: ref(aws.security_group)
+  security_group: aws.security_group
     <- from: web_sg
 ```
 

--- a/carina-cli/src/snapshots/carina__module_info_snapshot_tests__snapshot_module_info.snap
+++ b/carina-cli/src/snapshots/carina__module_info_snapshot_tests__snapshot_module_info.snap
@@ -6,20 +6,20 @@ Module: module_info
 
 === ARGUMENTS ===
 
-  vpc_id: ref(awscc.ec2.vpc)  (required)
+  vpc_id: awscc.ec2.vpc  (required)
   environment: string  (required)
   instance_type: string = "t3.micro"  
   enable_monitoring: bool = true  
 
 === CREATES ===
 
-  arguments { vpc_id: ref(awscc.ec2.vpc) }
+  arguments { vpc_id: awscc.ec2.vpc }
     └── web_sg: awscc.ec2.security_group
        └── web_instance: awscc.ec2.instance
 
 === ATTRIBUTES ===
 
-  security_group_id: ref(awscc.ec2.security_group)
+  security_group_id: awscc.ec2.security_group
     <- from: web_sg
-  instance_id: ref(awscc.ec2.instance)
+  instance_id: awscc.ec2.instance
     <- from: web_instance

--- a/carina-cli/tests/fixtures/module_info/main.crn
+++ b/carina-cli/tests/fixtures/module_info/main.crn
@@ -1,13 +1,13 @@
 arguments {
-    vpc_id: ref(awscc.ec2.vpc)
+    vpc_id: awscc.ec2.vpc
     environment: string
     instance_type: string = "t3.micro"
     enable_monitoring: bool = true
 }
 
 attributes {
-    security_group_id: ref(awscc.ec2.security_group) = web_sg.id
-    instance_id: ref(awscc.ec2.instance) = web_instance.id
+    security_group_id: awscc.ec2.security_group = web_sg.id
+    instance_id: awscc.ec2.instance = web_instance.id
 }
 
 let web_sg = awscc.ec2.security_group {

--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -62,7 +62,7 @@ attributes_param = {
     identifier ~ trivia* ~ colon ~ trivia* ~ type_expr ~ trivia* ~ equals ~ trivia* ~ expression
 }
 
-// Type expression: string, bool, int, cidr, list(type), map(type), ref(aws.resource)
+// Type expression: string, bool, int, cidr, list(type), map(type), aws.resource (resource ref)
 type_expr = {
     type_ref | type_list | type_map | type_primitive
 }
@@ -73,7 +73,7 @@ type_list = { kw_list ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ c
 
 type_map = { kw_map ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ close_paren }
 
-type_ref = { kw_ref ~ trivia* ~ open_paren ~ trivia* ~ namespaced_id ~ trivia* ~ close_paren }
+type_ref = { namespaced_id }
 
 // Variable/resource definition: let name = value
 let_binding = {
@@ -175,6 +175,5 @@ kw_as = { "as" }
 kw_let = { "let" }
 kw_arguments = { "arguments" }
 kw_attributes = { "attributes" }
-kw_ref = { "ref" }
 kw_list = { "list" }
 kw_map = { "map" }

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -156,7 +156,6 @@ impl<'a> CstBuilder<'a> {
             Rule::kw_attributes => {
                 Some(CstChild::Token(Token::new("attributes".to_string(), span)))
             }
-            Rule::kw_ref => Some(CstChild::Token(Token::new("ref".to_string(), span))),
             Rule::kw_list => Some(CstChild::Token(Token::new("list".to_string(), span))),
             Rule::kw_map => Some(CstChild::Token(Token::new("map".to_string(), span))),
 

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -461,7 +461,7 @@ impl Formatter {
     }
 
     fn format_type_expr(&mut self, node: &CstNode) {
-        // Type expressions: ref(aws.vpc), list(cidr), map(string), string, bool, int, cidr
+        // Type expressions: aws.vpc, list(cidr), map(string), string, bool, int, cidr
         for child in &node.children {
             match child {
                 CstChild::Token(token) => {

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -987,7 +987,7 @@ impl ModuleSignature {
     fn format_type_expr(&self, type_expr: &TypeExpr, c: &Colors) -> String {
         match type_expr {
             TypeExpr::Ref(path) => {
-                format!("{}ref({}{}{}){}", c.green, c.yellow, path, c.green, c.reset)
+                format!("{}{}{}", c.yellow, path, c.reset)
             }
             TypeExpr::List(inner) => {
                 format!(
@@ -1042,8 +1042,8 @@ impl ModuleSignature {
                 .filter_map(|r| {
                     if let TypeExpr::Ref(path) = &r.type_expr {
                         Some(format!(
-                            "{}{}{}: {}ref({}{}{}){}",
-                            c.white, r.name, c.reset, c.green, c.yellow, path, c.green, c.reset
+                            "{}{}{}: {}{}{}",
+                            c.white, r.name, c.reset, c.yellow, path, c.reset
                         ))
                     } else {
                         None
@@ -1220,12 +1220,12 @@ mod tests {
 
         let input = r#"
             arguments {
-                vpc: ref(aws.vpc)
+                vpc: aws.vpc
                 enable_https: bool = true
             }
 
             attributes {
-                security_group: ref(aws.security_group) = web_sg.id
+                security_group: aws.security_group = web_sg.id
             }
 
             let web_sg = aws.security_group {
@@ -1252,8 +1252,8 @@ mod tests {
         assert!(display.contains("=== ATTRIBUTES ==="));
 
         // Check ref types are displayed correctly
-        assert!(display.contains("ref(aws.vpc)"));
-        assert!(display.contains("ref(aws.security_group)"));
+        assert!(display.contains("aws.vpc"));
+        assert!(display.contains("aws.security_group"));
 
         // Check tree structure shows resources
         assert!(display.contains("web_sg: aws.security_group"));
@@ -1290,12 +1290,12 @@ mod tests {
         // Parse a directory-based module (no module {} wrapper)
         let input = r#"
             arguments {
-                vpc: ref(aws.vpc)
+                vpc: aws.vpc
                 enable_https: bool = true
             }
 
             attributes {
-                security_group: ref(aws.security_group) = web_sg.id
+                security_group: aws.security_group = web_sg.id
             }
 
             let web_sg = aws.security_group {
@@ -1337,10 +1337,10 @@ mod tests {
         // Directory-based module (top-level arguments/attributes)
         let input = r#"
             arguments {
-                vpc: ref(aws.vpc)
+                vpc: aws.vpc
             }
             attributes {
-                sg: ref(aws.security_group)
+                sg: aws.security_group
             }
         "#;
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -25,11 +25,11 @@ attributes_param = {
     identifier ~ ":" ~ type_expr ~ ("=" ~ expression)?
 }
 
-// Type expression: string, bool, int, float, list(type), map(type), ref(resource_type)
+// Type expression: string, bool, int, float, list(type), map(type), aws.vpc (resource ref)
 type_expr = { type_ref | type_generic | type_simple }
 type_simple = @{ "string" | "bool" | "int" | "float" | "cidr" }
 type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
-type_ref = { "ref" ~ "(" ~ resource_type_path ~ ")" }
+type_ref = { resource_type_path }
 resource_type_path = @{ identifier ~ ("." ~ identifier)+ }
 
 // Import statement: import "./path/to/module.crn" as name

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -87,7 +87,7 @@ pub enum TypeExpr {
     Cidr,
     List(Box<TypeExpr>),
     Map(Box<TypeExpr>),
-    /// Reference to a resource type (e.g., ref(aws.vpc))
+    /// Reference to a resource type (e.g., aws.vpc)
     Ref(ResourceTypePath),
 }
 
@@ -101,7 +101,7 @@ impl std::fmt::Display for TypeExpr {
             TypeExpr::Cidr => write!(f, "cidr"),
             TypeExpr::List(inner) => write!(f, "list({})", inner),
             TypeExpr::Map(inner) => write!(f, "map({})", inner),
-            TypeExpr::Ref(path) => write!(f, "ref({})", path),
+            TypeExpr::Ref(path) => write!(f, "{}", path),
         }
     }
 }
@@ -460,7 +460,7 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
             }
         }
         Rule::type_ref => {
-            // Parse ref(resource_type_path)
+            // Parse resource_type_path directly (e.g., aws.vpc)
             let mut ref_inner = inner.into_inner();
             let path_str = next_pair(&mut ref_inner, "resource type path", "type ref")?.as_str();
             let path = ResourceTypePath::parse(path_str).ok_or_else(|| {
@@ -1769,12 +1769,12 @@ mod tests {
     fn parse_ref_type_expression() {
         let input = r#"
             arguments {
-                vpc: ref(aws.vpc)
+                vpc: aws.vpc
                 enable_https: bool = true
             }
 
             attributes {
-                security_group_id: ref(aws.security_group) = web_sg.id
+                security_group_id: aws.security_group = web_sg.id
             }
 
             let web_sg = aws.security_group {
@@ -1805,8 +1805,8 @@ mod tests {
     fn parse_ref_type_with_nested_resource_type() {
         let input = r#"
             arguments {
-                sg: ref(aws.security_group)
-                rule: ref(aws.security_group.ingress_rule)
+                sg: aws.security_group
+                rule: aws.security_group.ingress_rule
             }
 
             attributes {
@@ -1865,7 +1865,7 @@ mod tests {
         );
         assert_eq!(
             TypeExpr::Ref(ResourceTypePath::new("aws", "vpc")).to_string(),
-            "ref(aws.vpc)"
+            "aws.vpc"
         );
     }
 

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -81,7 +81,7 @@ impl CompletionProvider {
             CompletionContext::AfterProviderRegion { provider_name } => {
                 self.region_completions_for_provider(&provider_name)
             }
-            CompletionContext::AfterRefType => self.ref_type_completions(position, &text),
+            CompletionContext::InTypePosition => self.ref_type_completions(position, &text),
             CompletionContext::AfterArgumentsDot => self.argument_parameter_completions(&text),
             CompletionContext::None => vec![],
         }
@@ -115,12 +115,10 @@ impl CompletionProvider {
             }
         }
 
-        // Check if we're typing after an unclosed "ref(" on this line.
-        if let Some(ref_pos) = prefix.rfind("ref(")
-            && !prefix[ref_pos..].contains(')')
-        {
-            return CompletionContext::AfterRefType;
-        }
+        // Check if we're in a type position after ":" in arguments/attributes blocks.
+        // e.g., "vpc: aws." or "vpc: " — detect by checking if the line has a colon
+        // but no equals sign, and we're inside arguments/attributes blocks.
+        // This is checked later after determining block context.
 
         // Check if we're inside a resource block or module call and find the type
         let mut brace_depth: i32 = 0;
@@ -128,6 +126,7 @@ impl CompletionProvider {
         let mut current_binding: Option<String> = None;
         let mut module_name: Option<String> = None;
         let mut provider_block_name: Option<String> = None;
+        let mut in_args_or_attrs_block = false;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
 
@@ -163,6 +162,13 @@ impl CompletionProvider {
                     resource_type.clear();
                     module_name = None;
                 }
+            } else if brace_depth == 0
+                && (trimmed.starts_with("arguments") || trimmed.starts_with("attributes"))
+                && trimmed.ends_with('{')
+            {
+                in_args_or_attrs_block = true;
+                resource_type.clear();
+                module_name = None;
             } else if brace_depth == 0
                 && trimmed.ends_with('{')
                 && !trimmed.starts_with("let ")
@@ -205,6 +211,7 @@ impl CompletionProvider {
                         current_binding = None;
                         module_name = None;
                         provider_block_name = None;
+                        in_args_or_attrs_block = false;
                         nested_block_names.clear();
                     } else {
                         // Truncate to current depth
@@ -214,6 +221,17 @@ impl CompletionProvider {
                         }
                     }
                 }
+            }
+        }
+
+        // Check if we're in a type position inside arguments/attributes block
+        // e.g., "vpc: " or "vpc: aws." — after colon, before any equals sign
+        if in_args_or_attrs_block && brace_depth > 0 && prefix.contains(':') {
+            // Check we're after the colon part, not after an equals sign
+            let after_colon = prefix.rsplit(':').next().unwrap_or("").trim();
+            let has_equals_after_colon = after_colon.contains('=');
+            if !has_equals_after_colon {
+                return CompletionContext::InTypePosition;
             }
         }
 
@@ -454,7 +472,7 @@ enum CompletionContext {
     AfterProviderRegion {
         provider_name: String,
     },
-    AfterRefType,
+    InTypePosition,
     AfterArgumentsDot,
     None,
 }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -118,7 +118,7 @@ fn module_parameter_completion_with_directory_module() {
     // Create main.crn with argument parameters
     let module_content = r#"
 arguments {
-vpc: ref(aws.ec2.vpc)
+vpc: aws.ec2.vpc
 cidr_blocks: list(cidr)
 enable_https: bool = true
 }
@@ -509,31 +509,31 @@ security_group_ingress {
 }
 
 #[test]
-fn context_detection_uses_last_ref_on_line() {
+fn context_detection_type_position_in_arguments() {
     let provider = test_provider();
-    let text = r#"value = ref(aws.ec2.vpc) other = ref("#;
+    let text = "arguments {\nvpc: aws.";
     let context = provider.get_completion_context(
         text,
         Position {
-            line: 0,
-            character: text.len() as u32,
+            line: 1,
+            character: 9, // cursor after "vpc: aws."
         },
     );
     assert!(
-        matches!(context, CompletionContext::AfterRefType),
-        "Should detect AfterRefType for the last unclosed ref(), got: {:?}",
+        matches!(context, CompletionContext::InTypePosition),
+        "Should detect InTypePosition for type annotation after colon, got: {:?}",
         context
     );
 }
 
 #[test]
-fn ref_completion_uses_text_edit_to_replace_from_ref_open_paren() {
+fn type_completion_uses_text_edit_to_replace_from_colon() {
     let provider = test_provider();
-    // User has typed "ref(aws." and wants completion for a resource type
-    let doc = create_document("ref(aws.");
+    // User has typed "vpc: aws." inside arguments block
+    let doc = create_document("arguments {\nvpc: aws.");
     let position = Position {
-        line: 0,
-        character: 8, // cursor after "ref(aws."
+        line: 1,
+        character: 9, // cursor after "vpc: aws."
     };
 
     let completions = provider.complete(&doc, position, None);
@@ -542,27 +542,27 @@ fn ref_completion_uses_text_edit_to_replace_from_ref_open_paren() {
     let s3_completion = completions
         .iter()
         .find(|c| c.label == "aws.s3.bucket")
-        .expect("Should have aws.s3.bucket ref completion");
+        .expect("Should have aws.s3.bucket type completion");
 
     // Must use text_edit (not insert_text) to avoid duplication with dotted identifiers
     assert!(
         s3_completion.text_edit.is_some(),
-        "ref() completion should use text_edit to handle dotted identifiers correctly"
+        "Type completion should use text_edit to handle dotted identifiers correctly"
     );
 
-    // The text_edit range should start right after "ref(" (column 4) and end at cursor (column 8)
+    // The text_edit range should start right after "vpc: " (column 5) and end at cursor (column 9)
     if let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &s3_completion.text_edit {
         assert_eq!(
-            edit.range.start.character, 4,
-            "Should replace from right after 'ref('"
+            edit.range.start.character, 5,
+            "Should replace from right after colon and space"
         );
         assert_eq!(
-            edit.range.end.character, 8,
+            edit.range.end.character, 9,
             "Should replace up to cursor position"
         );
         assert_eq!(
-            edit.new_text, "aws.s3.bucket)",
-            "Insert text should include closing paren"
+            edit.new_text, "aws.s3.bucket",
+            "Insert text should be the resource type"
         );
     } else {
         panic!("Expected CompletionTextEdit::Edit");
@@ -570,13 +570,13 @@ fn ref_completion_uses_text_edit_to_replace_from_ref_open_paren() {
 }
 
 #[test]
-fn ref_completion_with_empty_parens() {
+fn type_completion_with_empty_type() {
     let provider = test_provider();
-    // User has typed "ref(" with nothing after
-    let doc = create_document("ref(");
+    // User has typed "vpc: " inside arguments block
+    let doc = create_document("arguments {\nvpc: ");
     let position = Position {
-        line: 0,
-        character: 4, // cursor right after "ref("
+        line: 1,
+        character: 5, // cursor right after "vpc: "
     };
 
     let completions = provider.complete(&doc, position, None);
@@ -584,20 +584,20 @@ fn ref_completion_with_empty_parens() {
     let s3_completion = completions
         .iter()
         .find(|c| c.label == "aws.s3.bucket")
-        .expect("Should have aws.s3.bucket ref completion");
+        .expect("Should have aws.s3.bucket type completion");
 
     if let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &s3_completion.text_edit {
         assert_eq!(
-            edit.range.start.character, 4,
-            "Should replace from right after 'ref('"
+            edit.range.start.character, 5,
+            "Should replace from right after colon and space"
         );
         assert_eq!(
-            edit.range.end.character, 4,
+            edit.range.end.character, 5,
             "Should replace up to cursor position"
         );
         assert_eq!(
-            edit.new_text, "aws.s3.bucket)",
-            "Insert text should include closing paren"
+            edit.new_text, "aws.s3.bucket",
+            "Insert text should be the resource type"
         );
     } else {
         panic!("Expected CompletionTextEdit::Edit");

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -104,14 +104,6 @@ impl CompletionProvider {
                 detail: Some("Configure state backend (S3)".to_string()),
                 ..Default::default()
             },
-            CompletionItem {
-                label: "ref".to_string(),
-                kind: Some(CompletionItemKind::TYPE_PARAMETER),
-                insert_text: Some("ref(${1:aws.ec2.vpc})".to_string()),
-                insert_text_format: Some(InsertTextFormat::SNIPPET),
-                detail: Some("Typed resource reference".to_string()),
-                ..Default::default()
-            },
         ];
 
         // Generate resource type completions from schemas
@@ -312,10 +304,7 @@ impl CompletionProvider {
             parser::TypeExpr::List(inner) => format!("list({})", self.format_type_expr(inner)),
             parser::TypeExpr::Map(inner) => format!("map({})", self.format_type_expr(inner)),
             parser::TypeExpr::Ref(resource_path) => {
-                format!(
-                    "ref({}.{})",
-                    resource_path.provider, resource_path.resource_type
-                )
+                format!("{}.{}", resource_path.provider, resource_path.resource_type)
             }
         }
     }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -372,18 +372,20 @@ impl CompletionProvider {
         position: Position,
         text: &str,
     ) -> Vec<CompletionItem> {
-        // Calculate the replacement range: from right after "ref(" to the cursor position.
+        // Calculate the replacement range: from right after ":" to the cursor position.
         // This ensures dotted identifiers like "aws.ec2.vpc" are replaced correctly
         // without duplication from LSP word-boundary-based insertion.
         let lines: Vec<&str> = text.lines().collect();
         let line_idx = position.line as usize;
         let col = position.character as usize;
 
-        let ref_content_start = if line_idx < lines.len() {
+        let type_start = if line_idx < lines.len() {
             let prefix: String = lines[line_idx].chars().take(col).collect();
-            // Find the last unclosed "ref(" and position right after the "("
-            if let Some(ref_pos) = prefix.rfind("ref(") {
-                (ref_pos + 4) as u32
+            // Find the colon and position right after it (plus any whitespace)
+            if let Some(colon_pos) = prefix.rfind(':') {
+                let after_colon = &prefix[colon_pos + 1..];
+                let whitespace_len = after_colon.len() - after_colon.trim_start().len();
+                (colon_pos + 1 + whitespace_len) as u32
             } else {
                 position.character
             }
@@ -394,7 +396,7 @@ impl CompletionProvider {
         let replacement_range = Range {
             start: Position {
                 line: position.line,
-                character: ref_content_start,
+                character: type_start,
             },
             end: position,
         };
@@ -414,7 +416,7 @@ impl CompletionProvider {
                     detail: Some(format!("{} reference", description)),
                     text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                         range: replacement_range,
-                        new_text: format!("{})", resource_type),
+                        new_text: resource_type.clone(),
                     })),
                     ..Default::default()
                 }

--- a/carina-provider-awscc/acceptance-tests/module/modules/network/main.crn
+++ b/carina-provider-awscc/acceptance-tests/module/modules/network/main.crn
@@ -21,6 +21,6 @@ let subnet = awscc.ec2.subnet {
 }
 
 attributes {
-  vpc_id: ref(awscc.ec2.vpc) = vpc.vpc_id
-  subnet_id: ref(awscc.ec2.subnet) = subnet.subnet_id
+  vpc_id: awscc.ec2.vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.subnet = subnet.subnet_id
 }


### PR DESCRIPTION
## Summary

- Remove `ref()` wrapper from type annotations in the DSL grammar, parser, formatter, LSP, and all `.crn` files
- Resource type references are now written directly: `vpc: aws.vpc` instead of `vpc: ref(aws.vpc)`
- Update LSP completions to detect type position via colon-based context detection instead of `ref(` prefix

Closes #1112

## Test plan

- [x] All 483 carina-core tests pass
- [x] All 140 carina-lsp tests pass (including updated completion tests)
- [x] All 157 carina-cli tests pass (including updated snapshot)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)