### PR TITLE
fix: expand map values in Create and Delete plan output

### DIFF
--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
@@ -8,7 +8,8 @@ Execution Plan:
       cidr_block: "10.0.0.0/16"
       enable_dns_hostnames: true
       enable_dns_support: true
-      tags: {Name: "test-vpc"}
+      tags:
+        Name: "test-vpc"
       cidr_block_associations: (known after apply)
       default_network_acl: (known after apply)
       default_security_group: (known after apply)
@@ -16,14 +17,16 @@ Execution Plan:
       vpc_id: (known after apply)
         │
         ├─ + awscc.ec2.route_table ec2_route_table_d8d0c86b
-        │     tags: {Name: "test-route-table"}
+        │     tags:
+        │       Name: "test-route-table"
         │     vpc_id: vpc.vpc_id
         │     route_table_id: (known after apply)
         │
         └─ + awscc.ec2.subnet ec2_subnet_f5269366
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
-              tags: {Name: "test-subnet"}
+              tags:
+                Name: "test-subnet"
               vpc_id: vpc.vpc_id
               block_public_access_states: (known after apply)
               ipv6_cidr_blocks: (known after apply)

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_delete_orphan.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_delete_orphan.snap
@@ -8,7 +8,8 @@ Execution Plan:
       availability_zone: "ap-northeast-1a"
       cidr_block: "10.0.1.0/24"
       subnet_id: "subnet-0123456789abcdef0"
-      tags: {Name: "test-subnet"}
+      tags:
+        Name: "test-subnet"
       vpc_id: "vpc-0123456789abcdef0"
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
@@ -8,12 +8,14 @@ Destroy Plan:
       cidr_block: "10.0.0.0/16"
       enable_dns_hostnames: true
       enable_dns_support: true
-      tags: {Name: "test-vpc"}
+      tags:
+        Name: "test-vpc"
       vpc_id: "vpc-0123456789abcdef0"
         │
         └─ - awscc.ec2.subnet ec2_subnet_f5269366
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               subnet_id: "subnet-0123456789abcdef0"
-              tags: {Name: "test-subnet"}
+              tags:
+                Name: "test-subnet"
               vpc_id: "vpc-0123456789abcdef0"

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
@@ -8,12 +8,14 @@ Destroy Plan:
       cidr_block: "10.0.0.0/16"
       enable_dns_hostnames: true
       enable_dns_support: true
-      tags: {Name: "test-vpc"}
+      tags:
+        Name: "test-vpc"
       vpc_id: "vpc-0123456789abcdef0"
         │
         └─ - awscc.ec2.subnet my_subnet
               availability_zone: "ap-northeast-1a"
               cidr_block: "10.0.1.0/24"
               subnet_id: "subnet-0123456789abcdef0"
-              tags: {Name: "test-subnet"}
+              tags:
+                Name: "test-subnet"
               vpc_id: "vpc-0123456789abcdef0"

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_explicit.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_explicit.snap
@@ -10,7 +10,8 @@ Execution Plan:
         │
         ├─ + awscc.ec2.security_group ec2_security_group_712c54ef
         │     group_description: "Test security group"
-        │     tags: {Name: "test-sg"}
+        │     tags:
+        │       Name: "test-sg"
         │     vpc_id: "vpc-0123456789abcdef0"
         │
         └─ - awscc.ec2.subnet my_subnet

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -11,7 +11,8 @@ Execution Plan:
         │
         ├─ + awscc.ec2.security_group ec2_security_group_712c54ef
         │     group_description: "Test security group"
-        │     tags: {Name: "test-sg"}
+        │     tags:
+        │       Name: "test-sg"
         │     vpc_id: "vpc-0123456789abcdef0"
         │     group_id: (known after apply)
         │     id: (known after apply)

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_read_only_attrs.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_read_only_attrs.snap
@@ -6,7 +6,8 @@ Execution Plan:
 
   + awscc.ec2.vpc vpc
       cidr_block: "10.0.0.0/16"
-      tags: {Name: "read-only-test"}
+      tags:
+        Name: "read-only-test"
       cidr_block_associations: (known after apply)
       default_network_acl: (known after apply)
       default_security_group: (known after apply)

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -271,6 +271,8 @@ fn build_create_rows(
         }
         if is_list_of_maps(value) {
             rows.push(build_list_of_maps_row(key, value));
+        } else if let Value::Map(map) = value {
+            rows.push(build_expanded_map_row(key, map));
         } else {
             let ref_binding = match value {
                 Value::ResourceRef { binding_name, .. } => Some(binding_name.clone()),
@@ -307,6 +309,24 @@ fn build_create_rows(
     }
 
     rows
+}
+
+/// Build a `DetailRow::MapExpanded` for a map attribute (no annotations).
+fn build_expanded_map_row(key: &str, map: &HashMap<String, Value>) -> DetailRow {
+    let mut keys: Vec<_> = map.keys().collect();
+    keys.sort();
+    let entries = keys
+        .into_iter()
+        .map(|k| MapExpandedEntry {
+            key: k.clone(),
+            value: format_value_with_key(&map[k], Some(k)),
+            annotation: None,
+        })
+        .collect();
+    DetailRow::MapExpanded {
+        key: key.to_string(),
+        entries,
+    }
 }
 
 /// Build a `DetailRow::MapExpanded` for tags with `default_tags` annotations.
@@ -598,16 +618,20 @@ fn build_delete_rows(
         keys.sort();
         for key in keys {
             let value = &attrs[key];
-            let ref_binding = match value {
-                Value::ResourceRef { binding_name, .. } => Some(binding_name.clone()),
-                _ => None,
-            };
-            rows.push(DetailRow::Attribute {
-                key: key.to_string(),
-                value: format_value_with_key(value, Some(key)),
-                ref_binding,
-                annotation: None,
-            });
+            if let Value::Map(map) = value {
+                rows.push(build_expanded_map_row(key, map));
+            } else {
+                let ref_binding = match value {
+                    Value::ResourceRef { binding_name, .. } => Some(binding_name.clone()),
+                    _ => None,
+                };
+                rows.push(DetailRow::Attribute {
+                    key: key.to_string(),
+                    value: format_value_with_key(value, Some(key)),
+                    ref_binding,
+                    annotation: None,
+                });
+            }
         }
     }
 
@@ -1000,6 +1024,63 @@ mod tests {
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
         assert_eq!(rows.len(), 1);
         assert!(matches!(&rows[0], DetailRow::Removed { key, .. } if key == "removed_attr"));
+    }
+
+    #[test]
+    fn test_create_map_expanded() {
+        let mut tags = HashMap::new();
+        tags.insert("Name".to_string(), Value::String("test".to_string()));
+        tags.insert("Environment".to_string(), Value::String("prod".to_string()));
+        let resource =
+            Resource::new("s3.bucket", "my-bucket").with_attribute("tags", Value::Map(tags));
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+        assert_eq!(rows.len(), 1);
+        match &rows[0] {
+            DetailRow::MapExpanded { key, entries } => {
+                assert_eq!(key, "tags");
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].key, "Environment");
+                assert_eq!(entries[0].value, "\"prod\"");
+                assert!(entries[0].annotation.is_none());
+                assert_eq!(entries[1].key, "Name");
+                assert_eq!(entries[1].value, "\"test\"");
+                assert!(entries[1].annotation.is_none());
+            }
+            other => panic!("expected MapExpanded, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_delete_map_expanded() {
+        let id = ResourceId::new("s3.bucket", "old-bucket");
+        let effect = Effect::Delete {
+            id: id.clone(),
+            identifier: "old-bucket".to_string(),
+            lifecycle: crate::resource::LifecycleConfig::default(),
+            binding: None,
+            dependencies: HashSet::new(),
+        };
+        let mut tags = HashMap::new();
+        tags.insert("Name".to_string(), Value::String("test".to_string()));
+        let mut delete_attrs: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
+        delete_attrs.insert(
+            id.clone(),
+            [("tags".to_string(), Value::Map(tags))]
+                .into_iter()
+                .collect(),
+        );
+        let rows = build_detail_rows(&effect, None, DetailLevel::Full, Some(&delete_attrs));
+        assert_eq!(rows.len(), 1);
+        match &rows[0] {
+            DetailRow::MapExpanded { key, entries } => {
+                assert_eq!(key, "tags");
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].key, "Name");
+                assert_eq!(entries[0].value, "\"test\"");
+            }
+            other => panic!("expected MapExpanded, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Expand map/tag attribute values in Create and Delete plan output to show each key on its own line, using `DetailRow::MapExpanded` instead of `DetailRow::Attribute`
- Add unit tests for the new map expansion behavior in both Create and Delete effects

## Before
```
tags: {Name: "test", Environment: "prod"}
```

## After
```
tags:
  Name: "test"
  Environment: "prod"
```

## Test plan

- [x] `cargo test -p carina-core` passes (including new `test_create_map_expanded` and `test_delete_map_expanded` tests)
- [x] `cargo test -p carina-cli` passes (7 snapshots updated)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)