### PR TITLE
fix: allow validate command to work on module files

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod plan;
 pub mod state;
 pub mod validate;
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use carina_core::module_resolver;
@@ -54,7 +55,9 @@ pub fn validate_and_resolve(
 
     if !skip_resource_validation {
         validate_resources_with_ctx(&ctx, &parsed.resources)?;
-        validate_resource_ref_types_with_ctx(&ctx, &parsed.resources)?;
+        let argument_names: HashSet<String> =
+            parsed.arguments.iter().map(|a| a.name.clone()).collect();
+        validate_resource_ref_types_with_ctx(&ctx, &parsed.resources, &argument_names)?;
     }
 
     // Compute anonymous identifiers

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -75,10 +75,14 @@ pub fn validate_resources_with_ctx(
 pub fn validate_resource_ref_types_with_ctx(
     ctx: &WiringContext,
     resources: &[Resource],
+    argument_names: &HashSet<String>,
 ) -> Result<(), AppError> {
-    validation::validate_resource_ref_types(resources, ctx.schemas(), &|r| {
-        provider_mod::schema_key_for_resource(ctx.factories(), r)
-    })
+    validation::validate_resource_ref_types(
+        resources,
+        ctx.schemas(),
+        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
+        argument_names,
+    )
     .map_err(AppError::Validation)
 }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1167,6 +1167,11 @@ pub fn resolve_resource_refs(parsed: &mut ParsedFile) -> Result<(), ParseError> 
         }
     }
 
+    // Register argument parameters so they're recognized as valid bindings
+    for arg in &parsed.arguments {
+        binding_map.entry(arg.name.clone()).or_default();
+    }
+
     // Resolve references in each resource
     for resource in &mut parsed.resources {
         let mut resolved_attrs: HashMap<String, Value> = HashMap::new();
@@ -2852,5 +2857,38 @@ aws.s3.bucket {
         let result = parse(input).unwrap();
         assert_eq!(result.providers.len(), 1);
         assert!(result.providers[0].default_tags.is_empty());
+    }
+
+    #[test]
+    fn resolve_resource_refs_with_argument_parameters() {
+        let input = r#"
+            arguments {
+                cidr_block: string
+                subnet_cidr: string
+                az: string
+            }
+
+            let vpc = awscc.ec2.vpc {
+                cidr_block = cidr_block
+            }
+
+            let subnet = awscc.ec2.subnet {
+                vpc_id = vpc.vpc_id
+                cidr_block = subnet_cidr
+                availability_zone = az
+            }
+
+            attributes {
+                vpc_id: awscc.ec2.vpc = vpc.vpc_id
+            }
+        "#;
+
+        // parse_and_resolve should succeed without "Undefined variable" errors
+        let result = parse_and_resolve(input);
+        assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+
+        let parsed = result.unwrap();
+        assert_eq!(parsed.resources.len(), 2);
+        assert_eq!(parsed.arguments.len(), 3);
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -56,6 +56,7 @@ pub fn validate_resource_ref_types(
     resources: &[Resource],
     schemas: &HashMap<String, ResourceSchema>,
     schema_key_fn: &dyn Fn(&Resource) -> String,
+    argument_names: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
@@ -93,6 +94,11 @@ pub fn validate_resource_ref_types(
                 continue;
             };
             let expected_type_name = attr_schema.attr_type.type_name();
+
+            // Skip type checking for argument parameter references (resolved at call site)
+            if argument_names.contains(ref_binding.as_str()) {
+                continue;
+            }
 
             // Look up the referenced binding's schema to get the type of the referenced attribute
             let Some(ref_resource) = binding_map.get(ref_binding.as_str()) else {
@@ -586,7 +592,8 @@ let route = awscc.ec2.route {
             },
         );
 
-        let result = validate_resource_ref_types(&[subnet], &schemas, &test_schema_key_fn);
+        let result =
+            validate_resource_ref_types(&[subnet], &schemas, &test_schema_key_fn, &HashSet::new());
         assert_eq!(
             result.unwrap_err(),
             "awscc.ec2.subnet.web-subnet: unknown binding 'vpc' in reference vpc.vpc_id"
@@ -619,7 +626,12 @@ let route = awscc.ec2.route {
             },
         );
 
-        let result = validate_resource_ref_types(&[vpc, subnet], &schemas, &test_schema_key_fn);
+        let result = validate_resource_ref_types(
+            &[vpc, subnet],
+            &schemas,
+            &test_schema_key_fn,
+            &HashSet::new(),
+        );
         assert_eq!(
             result.unwrap_err(),
             "awscc.ec2.subnet.web-subnet: unknown attribute 'nonexistent_attr' on 'vpc' in reference vpc.nonexistent_attr"

--- a/scripts/validate-crn-files.sh
+++ b/scripts/validate-crn-files.sh
@@ -42,7 +42,7 @@ for dir in "${DIRS[@]}"; do
             echo ""
             FAILED=$((FAILED + 1))
         fi
-    done < <(find "$dir" -name '*.crn' -not -path '*/modules/*' -print0)
+    done < <(find "$dir" -name '*.crn' -print0)
 done
 
 echo ""


### PR DESCRIPTION
## Summary

- Register argument parameter names in `binding_map` during `resolve_resource_refs()` so references to argument parameters (e.g., `cidr_block`) are recognized as valid bindings instead of producing "Undefined variable" errors
- Add `argument_names` parameter to `validate_resource_ref_types()` to skip type checking for argument parameter references, which are resolved at the module call site
- Remove `*/modules/*` exclusion from CI `validate-crn-files.sh` script so module files are validated in CI
- Add test for `parse_and_resolve` with argument parameters

## Test plan

- [x] `cargo test` passes (all 490+ tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `carina validate .../modules/network/main.crn` succeeds
- [ ] CI passes

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)