### PR TITLE
feat: change import syntax to let binding form

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ let web_sg = aws.security_group {
 **Using modules**:
 
 ```hcl
-import "./modules/web_tier" as web_tier
+let web_tier = import "./modules/web_tier"
 
 let main_vpc = aws.vpc {
   name       = "main-vpc"

--- a/carina-cli/tests/fixtures/module_list/main.crn
+++ b/carina-cli/tests/fixtures/module_list/main.crn
@@ -1,2 +1,2 @@
-import "./modules/web_tier" as web_tier
-import "./modules/network" as network
+let web_tier = import "./modules/web_tier"
+let network = import "./modules/network"

--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -11,12 +11,7 @@ ws = @{ (" " | "\t")+ }
 newline = @{ NEWLINE }
 comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
 
-statement = { import_stmt | backend_block | provider_block | arguments_block | attributes_block | let_binding | module_call | anonymous_resource }
-
-// Import statement: import "./path/to/module.crn" as name
-import_stmt = {
-    kw_import ~ trivia+ ~ string ~ trivia+ ~ kw_as ~ trivia+ ~ identifier
-}
+statement = { backend_block | provider_block | arguments_block | attributes_block | let_binding | module_call | anonymous_resource }
 
 // Backend block: backend s3 { ... }
 backend_block = {
@@ -108,9 +103,13 @@ function_call = {
     identifier ~ open_paren ~ (trivia* ~ expression ~ (trivia* ~ comma ~ trivia* ~ expression)*)? ~ trivia* ~ close_paren
 }
 
+// Import expression: import "path" (used in let binding RHS)
+import_expr = { kw_import ~ trivia+ ~ string }
+
 // Primary value
 primary = {
     resource_expr
+  | import_expr
   | list
   | map
   | namespaced_id
@@ -172,7 +171,6 @@ pipe_op = { "|>" }
 kw_provider = { "provider" }
 kw_backend = { "backend" }
 kw_import = { "import" }
-kw_as = { "as" }
 kw_let = { "let" }
 kw_arguments = { "arguments" }
 kw_attributes = { "attributes" }

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -55,7 +55,7 @@ impl Token {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeKind {
     File,
-    ImportStmt,
+    ImportExpr,
     BackendBlock,
     ProviderBlock,
     ArgumentsBlock,
@@ -94,7 +94,6 @@ pub enum NodeKind {
     Comma,
     // Keywords
     KwImport,
-    KwAs,
     KwBackend,
     KwProvider,
     KwLet,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -63,7 +63,7 @@ impl<'a> CstBuilder<'a> {
                 let inner = pair.into_inner().next()?;
                 self.build_child(inner)
             }
-            Rule::import_stmt => Some(CstChild::Node(self.build_node(NodeKind::ImportStmt, pair))),
+            Rule::import_expr => Some(CstChild::Node(self.build_node(NodeKind::ImportExpr, pair))),
             Rule::backend_block => Some(CstChild::Node(
                 self.build_node(NodeKind::BackendBlock, pair),
             )),
@@ -148,7 +148,6 @@ impl<'a> CstBuilder<'a> {
 
             // Keywords
             Rule::kw_import => Some(CstChild::Token(Token::new("import".to_string(), span))),
-            Rule::kw_as => Some(CstChild::Token(Token::new("as".to_string(), span))),
             Rule::kw_backend => Some(CstChild::Token(Token::new("backend".to_string(), span))),
             Rule::kw_provider => Some(CstChild::Token(Token::new("provider".to_string(), span))),
             Rule::kw_let => Some(CstChild::Token(Token::new("let".to_string(), span))),

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -125,7 +125,7 @@ impl Formatter {
 
     fn format_node(&mut self, node: &CstNode) {
         match node.kind {
-            NodeKind::ImportStmt => self.format_import_stmt(node),
+            NodeKind::ImportExpr => self.format_import_expr(node),
             NodeKind::BackendBlock => self.format_backend_block(node),
             NodeKind::ProviderBlock => self.format_provider_block(node),
             NodeKind::ArgumentsBlock => self.format_arguments_block(node),
@@ -149,36 +149,20 @@ impl Formatter {
         }
     }
 
-    fn format_import_stmt(&mut self, node: &CstNode) {
-        self.write_indent();
+    fn format_import_expr(&mut self, node: &CstNode) {
         self.write("import ");
-
-        let mut found_path = false;
-        let mut found_as = false;
 
         for child in &node.children {
             if let CstChild::Token(token) = child {
                 if token.text == "import" {
                     continue;
                 }
-                if token.text.starts_with('"') && !found_path {
-                    self.write(&token.text);
-                    found_path = true;
-                    continue;
-                }
-                if token.text == "as" {
-                    self.write(" as ");
-                    found_as = true;
-                    continue;
-                }
-                if found_as && self.is_identifier(&token.text) {
+                if token.text.starts_with('"') {
                     self.write(&token.text);
                     break;
                 }
             }
         }
-
-        self.write_newline();
     }
 
     fn format_backend_block(&mut self, node: &CstNode) {

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -3,7 +3,7 @@
 // Entry point
 file = { SOI ~ statement* ~ EOI }
 
-statement = { import_stmt | backend_block | provider_block | arguments_block | attributes_block | let_binding | module_call | anonymous_resource }
+statement = { backend_block | provider_block | arguments_block | attributes_block | let_binding | module_call | anonymous_resource }
 
 // Arguments block: arguments { vpc_id: string, ... }
 arguments_block = {
@@ -33,10 +33,8 @@ type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
 type_ref = { resource_type_path }
 resource_type_path = @{ identifier ~ ("." ~ identifier)+ }
 
-// Import statement: import "./path/to/module.crn" as name
-import_stmt = {
-    "import" ~ string ~ "as" ~ identifier
-}
+// Import expression: import "path" (used in let binding RHS)
+import_expr = { "import" ~ string }
 
 // Backend block: backend s3 { bucket = "...", key = "...", ... }
 backend_block = {
@@ -91,6 +89,7 @@ function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 primary = {
     read_resource_expr   // Must come before resource_expr for "read aws..." parsing
   | resource_expr
+  | import_expr          // Must come before variable_ref since "import" is an identifier
   | list
   | map
   | namespaced_id

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -270,12 +270,6 @@ pub fn parse(input: &str) -> Result<ParsedFile, ParseError> {
                 if inner.as_rule() == Rule::statement {
                     for stmt in inner.into_inner() {
                         match stmt.as_rule() {
-                            Rule::import_stmt => {
-                                let import = parse_import_stmt(stmt)?;
-                                ctx.imported_modules
-                                    .insert(import.alias.clone(), import.path.clone());
-                                imports.push(import);
-                            }
                             Rule::backend_block => {
                                 backend = Some(parse_backend_block(stmt, &ctx)?);
                             }
@@ -306,7 +300,7 @@ pub fn parse(input: &str) -> Result<ParsedFile, ParseError> {
                             }
                             Rule::let_binding => {
                                 let (line, _) = stmt.as_span().start_pos().line_col();
-                                let (name, value, maybe_resource, maybe_module_call) =
+                                let (name, value, maybe_resource, maybe_module_call, maybe_import) =
                                     parse_let_binding_extended(stmt, &ctx)?;
                                 if ctx.variables.contains_key(&name)
                                     || ctx.resource_bindings.contains_key(&name)
@@ -319,8 +313,13 @@ pub fn parse(input: &str) -> Result<ParsedFile, ParseError> {
                                     resources.push(resource);
                                 }
                                 if let Some(mut call) = maybe_module_call {
-                                    call.binding_name = Some(name);
+                                    call.binding_name = Some(name.clone());
                                     module_calls.push(call);
+                                }
+                                if let Some(import) = maybe_import {
+                                    ctx.imported_modules
+                                        .insert(import.alias.clone(), import.path.clone());
+                                    imports.push(import);
                                 }
                             }
                             Rule::module_call => {
@@ -483,15 +482,18 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
     }
 }
 
-/// Parse import statement
-fn parse_import_stmt(pair: pest::iterators::Pair<Rule>) -> Result<ImportStatement, ParseError> {
+/// Parse import expression (RHS of `let name = import "path"`)
+fn parse_import_expr(
+    pair: pest::iterators::Pair<Rule>,
+    binding_name: &str,
+) -> Result<ImportStatement, ParseError> {
     let mut inner = pair.into_inner();
-    let path = parse_string(next_pair(&mut inner, "import path", "import statement")?);
-    let alias = next_pair(&mut inner, "alias", "import statement")?
-        .as_str()
-        .to_string();
+    let path = parse_string(next_pair(&mut inner, "import path", "import expression")?);
 
-    Ok(ImportStatement { path, alias })
+    Ok(ImportStatement {
+        path,
+        alias: binding_name.to_string(),
+    })
 }
 
 /// Parse module call
@@ -526,30 +528,48 @@ fn parse_module_call(
     })
 }
 
-/// Extended parse_let_binding that also handles module calls
+/// Result of parsing the RHS of a let binding: (value, resource, module_call, import)
+type LetBindingRhs = (
+    Value,
+    Option<Resource>,
+    Option<ModuleCall>,
+    Option<ImportStatement>,
+);
+
+/// Extended parse_let_binding that also handles module calls and imports
+#[allow(clippy::type_complexity)]
 fn parse_let_binding_extended(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<(String, Value, Option<Resource>, Option<ModuleCall>), ParseError> {
+) -> Result<
+    (
+        String,
+        Value,
+        Option<Resource>,
+        Option<ModuleCall>,
+        Option<ImportStatement>,
+    ),
+    ParseError,
+> {
     let mut inner = pair.into_inner();
     let name = next_pair(&mut inner, "binding name", "let binding")?
         .as_str()
         .to_string();
     let expr_pair = next_pair(&mut inner, "expression", "let binding")?;
 
-    // Check if it's a module call or resource expression
-    let (value, maybe_resource, maybe_module_call) =
+    // Check if it's a module call, resource expression, or import expression
+    let (value, maybe_resource, maybe_module_call, maybe_import) =
         parse_expression_with_resource_or_module(expr_pair, ctx, &name)?;
 
-    Ok((name, value, maybe_resource, maybe_module_call))
+    Ok((name, value, maybe_resource, maybe_module_call, maybe_import))
 }
 
-/// Parse expression with potential resource or module call
+/// Parse expression with potential resource, module call, or import
 fn parse_expression_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
     binding_name: &str,
-) -> Result<(Value, Option<Resource>, Option<ModuleCall>), ParseError> {
+) -> Result<LetBindingRhs, ParseError> {
     let inner = first_inner(pair, "expression", "expression with resource or module")?;
     parse_pipe_expr_with_resource_or_module(inner, ctx, binding_name)
 }
@@ -558,10 +578,10 @@ fn parse_pipe_expr_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
     binding_name: &str,
-) -> Result<(Value, Option<Resource>, Option<ModuleCall>), ParseError> {
+) -> Result<LetBindingRhs, ParseError> {
     let mut inner = pair.into_inner();
     let primary = next_pair(&mut inner, "primary expression", "pipe expression")?;
-    let (value, maybe_resource, maybe_module_call) =
+    let (value, maybe_resource, maybe_module_call, maybe_import) =
         parse_primary_with_resource_or_module(primary, ctx, binding_name)?;
 
     // Pipe operator is parsed but not yet implemented — reject with a clear error
@@ -572,32 +592,37 @@ fn parse_pipe_expr_with_resource_or_module(
         });
     }
 
-    Ok((value, maybe_resource, maybe_module_call))
+    Ok((value, maybe_resource, maybe_module_call, maybe_import))
 }
 
 fn parse_primary_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
     binding_name: &str,
-) -> Result<(Value, Option<Resource>, Option<ModuleCall>), ParseError> {
+) -> Result<LetBindingRhs, ParseError> {
     let inner = first_inner(pair, "value", "primary expression")?;
 
     match inner.as_rule() {
         Rule::read_resource_expr => {
             let resource = parse_read_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, Some(resource), None))
+            Ok((ref_value, Some(resource), None, None))
         }
         Rule::resource_expr => {
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, Some(resource), None))
+            Ok((ref_value, Some(resource), None, None))
+        }
+        Rule::import_expr => {
+            let import = parse_import_expr(inner, binding_name)?;
+            let value = Value::String(format!("${{import:{}}}", import.path));
+            Ok((value, None, None, Some(import)))
         }
         _ => {
             // Check if it could be a module call (identifier followed by braces)
             // This is handled by checking if it's a simple identifier that matches a module
             let value = parse_primary_value(inner, ctx)?;
-            Ok((value, None, None))
+            Ok((value, None, None, None))
         }
     }
 }
@@ -1720,9 +1745,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_import_statement() {
+    fn parse_import_expression() {
         let input = r#"
-            import "./modules/web_tier.crn" as web_tier
+            let web_tier = import "./modules/web_tier.crn"
         "#;
 
         let result = parse(input).unwrap();

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -130,7 +130,7 @@ name = "web-sg"
     fs::write(module_dir.join("main.crn"), module_content).expect("Failed to write module file");
 
     // Create main file that imports the module
-    let main_content = r#"import "./modules/web_tier" as web_tier
+    let main_content = r#"let web_tier = import "./modules/web_tier"
 
 web_tier {
 
@@ -205,7 +205,7 @@ count: int = 1
     fs::write(module_dir.join("simple.crn"), module_content).expect("Failed to write module file");
 
     // Create main file that imports the module
-    let main_content = r#"import "./modules/simple.crn" as simple
+    let main_content = r#"let simple = import "./modules/simple.crn"
 
 simple {
 n

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -89,9 +89,9 @@ impl CompletionProvider {
                 ..Default::default()
             },
             CompletionItem {
-                label: "import".to_string(),
+                label: "let import".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("import \"${1:./modules/name/main.crn}\" as ${2:module_name}".to_string()),
+                insert_text: Some("let ${1:module_name} = import \"${2:./modules/name}\"".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Import a module".to_string()),
                 ..Default::default()
@@ -285,22 +285,26 @@ impl CompletionProvider {
         }
     }
 
-    /// Find the import path for a given module name from the import statements
+    /// Find the import path for a given module name from let import bindings
     pub(super) fn find_module_import_path(&self, module_name: &str, text: &str) -> Option<String> {
         for line in text.lines() {
             let trimmed = line.trim();
-            // Parse: import "path" as name
-            if let Some(rest) = trimmed.strip_prefix("import ")
-                && let Some(quote_start) = rest.find('"')
-                && let Some(quote_end) = rest[quote_start + 1..].find('"')
-            {
-                let path = &rest[quote_start + 1..quote_start + 1 + quote_end];
-                // Look for "as module_name"
-                let after_path = &rest[quote_start + 1 + quote_end + 1..];
-                if let Some(as_pos) = after_path.find(" as ") {
-                    let alias = after_path[as_pos + 4..].trim();
-                    if alias == module_name {
-                        return Some(path.to_string());
+            // Parse: let name = import "path"
+            if let Some(rest) = trimmed.strip_prefix("let ") {
+                let rest = rest.trim_start();
+                if let Some(eq_pos) = rest.find('=') {
+                    let alias = rest[..eq_pos].trim();
+                    let after_eq = rest[eq_pos + 1..].trim();
+                    if let Some(import_rest) = after_eq.strip_prefix("import ") {
+                        let import_rest = import_rest.trim();
+                        if let Some(path_start) = import_rest.find('"')
+                            && let Some(path_end) = import_rest[path_start + 1..].find('"')
+                        {
+                            let path = &import_rest[path_start + 1..path_start + 1 + path_end];
+                            if alias == module_name {
+                                return Some(path.to_string());
+                            }
+                        }
                     }
                 }
             }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -330,7 +330,7 @@ impl HoverProvider {
                 "## arguments\n\nDefines module argument parameters that must be provided by the caller.\n\n```carina\narguments {\n    env: String\n    region: String\n}\n```",
             ),
             "import" => Some(
-                "## import\n\nImports a module from a file or directory.\n\n```carina\nimport \"./modules/network/main.crn\" as network\n```",
+                "## import\n\nImports a module from a file or directory.\n\n```carina\nlet network = import \"./modules/network\"\n```",
             ),
             "backend" => Some(
                 "## backend\n\nConfigures the state backend for storing resource state.\n\n```carina\nbackend s3 {\n    bucket = \"my-carina-state\"\n    key    = \"prod/carina.crnstate\"\n    region = aws.Region.ap_northeast_1\n}\n```",

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -254,23 +254,10 @@ impl SemanticTokensProvider {
                     let read_start = let_start + 4 + read_pos + 2; // position of "read"
                     tokens.push((read_start as u32, 4, 0)); // KEYWORD: read
                 }
-            }
-        } else if trimmed.starts_with("import ") {
-            tokens.push((indent, 6, 0)); // KEYWORD: import
-            // Find "as" keyword and module alias name
-            if let Some(import_start) = line.find("import ") {
-                let after_import = &line[import_start + 7..];
-                if let Some(as_pos) = after_import.find(" as ") {
-                    let as_start = import_start + 7 + as_pos + 1; // position of "as"
-                    tokens.push((as_start as u32, 2, 0)); // KEYWORD: as
-                    let alias_start = as_start + 3; // position after "as "
-                    let rest = &line[alias_start..];
-                    let alias = rest
-                        .find(|c: char| !c.is_alphanumeric() && c != '_')
-                        .map_or(rest, |end| &rest[..end]);
-                    if !alias.is_empty() {
-                        tokens.push((alias_start as u32, alias.len() as u32, 2)); // VARIABLE
-                    }
+                // Check for "import" keyword after "let name = import ..."
+                if let Some(import_pos) = after_let.find("= import ") {
+                    let import_start = let_start + 4 + import_pos + 2; // position of "import"
+                    tokens.push((import_start as u32, 6, 0)); // KEYWORD: import
                 }
             }
         } else if trimmed.starts_with("attributes ") || trimmed == "attributes{" {
@@ -284,7 +271,6 @@ impl SemanticTokensProvider {
         if !trimmed.starts_with("provider ")
             && !trimmed.starts_with("backend ")
             && !trimmed.starts_with("let ")
-            && !trimmed.starts_with("import ")
             && !trimmed.starts_with("attributes ")
             && !trimmed.starts_with("attributes{")
             && !trimmed.starts_with("arguments ")
@@ -749,16 +735,14 @@ mod tests {
     #[test]
     fn test_import_keyword_highlighted() {
         let provider = SemanticTokensProvider::new(&[]);
-        let tokens = provider.tokenize_line("import \"./modules/web.crn\" as web", 0);
-        let keyword_token = tokens
-            .iter()
-            .find(|(start, _, typ)| *start == 0 && *typ == 0);
+        let tokens = provider.tokenize_line("let web = import \"./modules/web.crn\"", 0);
+        let import_token = tokens.iter().find(|(_, len, typ)| *typ == 0 && *len == 6);
         assert!(
-            keyword_token.is_some(),
+            import_token.is_some(),
             "Should highlight 'import' as KEYWORD. Got: {:?}",
             tokens
         );
-        let (_, len, _) = keyword_token.unwrap();
+        let (_, len, _) = import_token.unwrap();
         assert_eq!(*len, 6, "import keyword length should be 6");
     }
 
@@ -795,29 +779,23 @@ mod tests {
     }
 
     #[test]
-    fn test_import_as_keyword_highlighted() {
+    fn test_import_let_binding_variable_highlighted() {
         let provider = SemanticTokensProvider::new(&[]);
-        let tokens = provider.tokenize_line("import \"./modules/web.crn\" as web", 0);
-        // "as" should also be highlighted as KEYWORD
-        let as_token = tokens
+        let tokens = provider.tokenize_line("let web = import \"./modules/web.crn\"", 0);
+        // "let" should be KEYWORD
+        let let_token = tokens
             .iter()
-            .find(|(start, len, typ)| *typ == 0 && *len == 2 && *start > 0);
+            .find(|(start, len, typ)| *start == 0 && *len == 3 && *typ == 0);
         assert!(
-            as_token.is_some(),
-            "Should highlight 'as' as KEYWORD in import statement. Got: {:?}",
+            let_token.is_some(),
+            "Should highlight 'let' as KEYWORD. Got: {:?}",
             tokens
         );
-    }
-
-    #[test]
-    fn test_import_module_name_highlighted_as_variable() {
-        let provider = SemanticTokensProvider::new(&[]);
-        let tokens = provider.tokenize_line("import \"./modules/web.crn\" as web", 0);
-        // "web" should be highlighted as VARIABLE
+        // "web" should be VARIABLE
         let var_token = tokens.iter().find(|(_, _, typ)| *typ == 2);
         assert!(
             var_token.is_some(),
-            "Should highlight module alias as VARIABLE in import statement. Got: {:?}",
+            "Should highlight module alias as VARIABLE in let import. Got: {:?}",
             tokens
         );
     }

--- a/carina-provider-awscc/acceptance-tests/module/basic.crn
+++ b/carina-provider-awscc/acceptance-tests/module/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-import "./modules/network" as network
+let network = import "./modules/network"
 
 network {
   cidr_block  = "10.0.0.0/16"


### PR DESCRIPTION
## Summary

- Change import syntax from `import "path" as name` to `let name = import "path"`
- `import` is now an expression in the RHS of `let` bindings, not a standalone statement
- Update grammar, parser, formatter, LSP (completion, hover, semantic tokens, diagnostics), all `.crn` files, and README

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Parser test updated to verify new syntax
- [x] LSP semantic token tests updated for new syntax
- [x] LSP completion tests updated for new syntax

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)