### PR TITLE
refactor: split builtins.rs into module directory for parallel development

### DIFF
--- a/carina-core/src/builtins/join.rs
+++ b/carina-core/src/builtins/join.rs
@@ -1,19 +1,8 @@
-//! Built-in functions for the Carina DSL
-//!
-//! Provides a registry of built-in functions that can be called from DSL expressions.
-//! Functions take `&[Value]` arguments and return `Result<Value, String>`.
+//! `join(separator, list)` built-in function
 
 use crate::resource::Value;
 
-/// Evaluate a built-in function by name with the given arguments.
-///
-/// Returns `Err` if the function is unknown or if the arguments are invalid.
-pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
-    match name {
-        "join" => builtin_join(args),
-        _ => Err(format!("Unknown built-in function: {name}")),
-    }
-}
+use super::value_type_name;
 
 /// `join(separator, list)` - Join list elements into a string with a separator.
 ///
@@ -26,7 +15,7 @@ pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
 /// join("-", ["a", "b", "c"])  // => "a-b-c"
 /// ["a", "b"] |> join("-")     // => "a-b" (pipe form)
 /// ```
-fn builtin_join(args: &[Value]) -> Result<Value, String> {
+pub(crate) fn builtin_join(args: &[Value]) -> Result<Value, String> {
     if args.len() != 2 {
         return Err(format!(
             "join() expects 2 arguments (separator, list), got {}",
@@ -69,25 +58,10 @@ fn builtin_join(args: &[Value]) -> Result<Value, String> {
     Ok(Value::String(joined))
 }
 
-/// Return a human-readable type name for a Value
-fn value_type_name(value: &Value) -> &'static str {
-    match value {
-        Value::String(_) => "String",
-        Value::Int(_) => "Int",
-        Value::Float(_) => "Float",
-        Value::Bool(_) => "Bool",
-        Value::List(_) => "List",
-        Value::Map(_) => "Map",
-        Value::ResourceRef { .. } => "ResourceRef",
-        Value::UnresolvedIdent(_, _) => "UnresolvedIdent",
-        Value::Interpolation(_) => "Interpolation",
-        Value::FunctionCall { .. } => "FunctionCall",
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::builtins::evaluate_builtin;
+    use crate::resource::Value;
 
     #[test]
     fn join_basic() {

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -1,0 +1,34 @@
+//! Built-in functions for the Carina DSL
+//!
+//! Provides a registry of built-in functions that can be called from DSL expressions.
+//! Functions take `&[Value]` arguments and return `Result<Value, String>`.
+
+mod join;
+
+use crate::resource::Value;
+
+/// Evaluate a built-in function by name with the given arguments.
+///
+/// Returns `Err` if the function is unknown or if the arguments are invalid.
+pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
+    match name {
+        "join" => join::builtin_join(args),
+        _ => Err(format!("Unknown built-in function: {name}")),
+    }
+}
+
+/// Return a human-readable type name for a Value
+fn value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::String(_) => "String",
+        Value::Int(_) => "Int",
+        Value::Float(_) => "Float",
+        Value::Bool(_) => "Bool",
+        Value::List(_) => "List",
+        Value::Map(_) => "Map",
+        Value::ResourceRef { .. } => "ResourceRef",
+        Value::UnresolvedIdent(_, _) => "UnresolvedIdent",
+        Value::Interpolation(_) => "Interpolation",
+        Value::FunctionCall { .. } => "FunctionCall",
+    }
+}


### PR DESCRIPTION
## Summary

- Convert `carina-core/src/builtins.rs` from a single file into a module directory (`builtins/mod.rs` + `builtins/join.rs`)
- Each built-in function now lives in its own file, enabling parallel development without merge conflicts
- `mod.rs` contains the `evaluate_builtin()` dispatcher and shared utilities (`value_type_name`)
- Pure refactoring with no behavior changes; all existing tests pass unchanged

Part of #1049

## Test plan

- [x] `cargo test -p carina-core` — all 529 tests pass
- [x] `cargo clippy -p carina-core` — no warnings
- [x] `cargo fmt -p carina-core -- --check` — properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)