### PR TITLE
feat: add trim() built-in function

### DIFF
--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -4,6 +4,7 @@
 //! Functions take `&[Value]` arguments and return `Result<Value, String>`.
 
 mod join;
+mod trim;
 
 use crate::resource::Value;
 
@@ -13,6 +14,7 @@ use crate::resource::Value;
 pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
     match name {
         "join" => join::builtin_join(args),
+        "trim" => trim::builtin_trim(args),
         _ => Err(format!("Unknown built-in function: {name}")),
     }
 }

--- a/carina-core/src/builtins/trim.rs
+++ b/carina-core/src/builtins/trim.rs
@@ -1,0 +1,125 @@
+//! `trim(string)` built-in function
+
+use crate::resource::Value;
+
+use super::value_type_name;
+
+/// `trim(string)` - Remove leading and trailing whitespace from a string.
+///
+/// - First argument: string to trim
+/// - Returns: String with whitespace removed from both ends
+///
+/// Examples:
+/// ```text
+/// trim("  hello  ")  // => "hello"
+/// trim("\n hello \t") // => "hello"
+/// ```
+pub(crate) fn builtin_trim(args: &[Value]) -> Result<Value, String> {
+    if args.len() != 1 {
+        return Err(format!(
+            "trim() expects 1 argument (string), got {}",
+            args.len()
+        ));
+    }
+
+    let s = match &args[0] {
+        Value::String(s) => s,
+        other => {
+            return Err(format!(
+                "trim() argument must be a string, got {}",
+                value_type_name(other)
+            ));
+        }
+    };
+
+    Ok(Value::String(s.trim().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::builtins::evaluate_builtin;
+    use crate::resource::Value;
+
+    #[test]
+    fn trim_both_sides() {
+        let args = vec![Value::String("  hello  ".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn trim_leading_only() {
+        let args = vec![Value::String("  hello".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn trim_trailing_only() {
+        let args = vec![Value::String("hello  ".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn trim_no_whitespace() {
+        let args = vec![Value::String("hello".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn trim_empty_string() {
+        let args = vec![Value::String("".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("".to_string()));
+    }
+
+    #[test]
+    fn trim_whitespace_only() {
+        let args = vec![Value::String("   ".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("".to_string()));
+    }
+
+    #[test]
+    fn trim_tabs_and_newlines() {
+        let args = vec![Value::String("\n\t hello \t\n".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn trim_preserves_inner_whitespace() {
+        let args = vec![Value::String("  hello world  ".to_string())];
+        let result = evaluate_builtin("trim", &args).unwrap();
+        assert_eq!(result, Value::String("hello world".to_string()));
+    }
+
+    #[test]
+    fn trim_wrong_arg_count() {
+        let args = vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ];
+        let result = evaluate_builtin("trim", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expects 1 argument"));
+    }
+
+    #[test]
+    fn trim_no_args() {
+        let args = vec![];
+        let result = evaluate_builtin("trim", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expects 1 argument"));
+    }
+
+    #[test]
+    fn trim_non_string_arg() {
+        let args = vec![Value::Int(42)];
+        let result = evaluate_builtin("trim", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("argument must be a string"));
+    }
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/run.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/run.sh
@@ -94,6 +94,35 @@ if [ -z "$FILTER" ] || echo "join" | grep -q "$FILTER"; then
     ACTIVE_WORK_DIR=""
 fi
 
+# ─── Test: trim() ───
+if [ -z "$FILTER" ] || echo "trim" | grep -q "$FILTER"; then
+    echo ""
+    echo "Test: trim() function"
+    echo ""
+
+    WORK_DIR=$(mktemp -d)
+    ACTIVE_WORK_DIR="$WORK_DIR"
+    cp "$SCRIPT_DIR/trim.crn" "$WORK_DIR/main.crn"
+
+    cd "$WORK_DIR"
+
+    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+    run_step "step2: plan-verify" "$CARINA_BIN" plan .
+
+    # Verify the trim() result in state
+    assert_state_value \
+        "assert: tag Name = 'trim-test-vpc'" \
+        '.resources[0].attributes.tags.Name' \
+        'trim-test-vpc' \
+        "$WORK_DIR"
+
+    # Cleanup
+    echo "  Cleanup: destroying resources..."
+    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+    rm -rf "$WORK_DIR"
+    ACTIVE_WORK_DIR=""
+fi
+
 echo ""
 echo "════════════════════════════════════════"
 echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/trim.crn
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/trim.crn
@@ -1,0 +1,10 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = trim("  trim-test-vpc  ")
+  }
+}


### PR DESCRIPTION
## Summary

- Add `trim()` built-in function that removes leading and trailing whitespace from a string
- Add unit tests covering various whitespace patterns (spaces, tabs, newlines, inner whitespace preservation)
- Add acceptance test using `trim()` in a VPC tag value

Closes #1142

## Test plan

- [x] Unit tests pass (`cargo test -p carina-core -- builtins`)
- [x] `cargo clippy` and `cargo fmt` pass
- [ ] Acceptance test: `aws-vault exec carina-test-003 -- ./run.sh trim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)