### PR TITLE
refactor: split builtin_functions/run.sh into per-function test scripts

### DIFF
--- a/carina-provider-awscc/acceptance-tests/builtin_functions/run.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/run.sh
@@ -1,204 +1,48 @@
 #!/bin/bash
-# Acceptance tests for built-in functions
+# Runs all builtin function acceptance tests
 #
 # Usage:
 #   aws-vault exec <profile> -- ./run.sh [filter]
+#
+# Each test is a separate script in tests/. The optional filter argument
+# is matched against test filenames (without .sh extension).
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 FILTER="${1:-}"
-
-CARINA_BIN="$PROJECT_ROOT/target/debug/carina"
-if [ ! -f "$CARINA_BIN" ]; then
-    echo "Building carina..."
-    cargo build --quiet 2>/dev/null || cargo build
-fi
 
 TOTAL_PASSED=0
 TOTAL_FAILED=0
-
-ACTIVE_WORK_DIR=""
-cleanup() {
-    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
-        echo "  Cleanup: destroying resources..."
-        cd "$ACTIVE_WORK_DIR"
-        "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
-        "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
-        rm -f carina.state.json carina.state.lock
-    fi
-}
-trap cleanup EXIT
-
-run_step() {
-    local description="$1"
-    shift
-    printf "  %-50s" "$description"
-    if "$@" > /dev/null 2>&1; then
-        echo "OK"
-        TOTAL_PASSED=$((TOTAL_PASSED + 1))
-    else
-        echo "FAIL"
-        TOTAL_FAILED=$((TOTAL_FAILED + 1))
-    fi
-}
-
-assert_state_value() {
-    local description="$1"
-    local jq_query="$2"
-    local expected="$3"
-    local work_dir="$4"
-
-    printf "  %-50s" "$description"
-    local actual
-    actual=$(jq -r "$jq_query" "$work_dir/carina.state.json" 2>/dev/null)
-    if [ "$actual" = "$expected" ]; then
-        echo "OK"
-        TOTAL_PASSED=$((TOTAL_PASSED + 1))
-    else
-        echo "FAIL (expected '$expected', got '$actual')"
-        TOTAL_FAILED=$((TOTAL_FAILED + 1))
-    fi
-}
+TESTS_RUN=0
 
 echo "builtin_functions acceptance tests"
 echo "════════════════════════════════════════"
 
-# ─── Test: join() ───
-if [ -z "$FILTER" ] || echo "join" | grep -q "$FILTER"; then
+for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+    # Skip the helpers file
+    [ "$(basename "$test_file")" = "_helpers.sh" ] && continue
+
+    test_name="$(basename "$test_file" .sh)"
+
+    # Apply filter if provided
+    if [ -n "$FILTER" ] && ! echo "$test_name" | grep -q "$FILTER"; then
+        continue
+    fi
+
     echo ""
-    echo "Test: join() function"
-    echo ""
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/join.crn" "$WORK_DIR/main.crn"
-    cd "$WORK_DIR"
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-    assert_state_value "assert: tag Name = 'web-test-vpc'" '.resources[0].attributes.tags.Name' 'web-test-vpc' "$WORK_DIR"
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
+    TESTS_RUN=$((TESTS_RUN + 1))
 
-# ─── Test: trim() ───
-if [ -z "$FILTER" ] || echo "trim" | grep -q "$FILTER"; then
-    echo ""
-    echo "Test: trim() function"
-    echo ""
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/trim.crn" "$WORK_DIR/main.crn"
-    cd "$WORK_DIR"
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-    assert_state_value "assert: tag Name = 'trim-test-vpc'" '.resources[0].attributes.tags.Name' 'trim-test-vpc' "$WORK_DIR"
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
-
-# ─── Test: upper() and lower() ───
-if [ -z "$FILTER" ] || echo "upper_lower" | grep -q "$FILTER"; then
-    echo ""
-    echo "Test: upper() and lower() functions"
-    echo ""
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/upper_lower.crn" "$WORK_DIR/main.crn"
-    cd "$WORK_DIR"
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-    assert_state_value "assert: tag Name = 'PRODUCTION'" '.resources[0].attributes.tags.Name' 'PRODUCTION' "$WORK_DIR"
-    assert_state_value "assert: tag App = 'webapp'" '.resources[0].attributes.tags.App' 'webapp' "$WORK_DIR"
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
-
-# ─── Test: length() ───
-if [ -z "$FILTER" ] || echo "length" | grep -q "$FILTER"; then
-    echo ""
-    echo "Test: length() function"
-    echo ""
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/length.crn" "$WORK_DIR/main.crn"
-    cd "$WORK_DIR"
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-    assert_state_value "assert: tag Name = 'count-3'" '.resources[0].attributes.tags.Name' 'count-3' "$WORK_DIR"
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
-
-# ─── Test: cidr_subnet() ───
-if [ -z "$FILTER" ] || echo "cidr_subnet" | grep -q "$FILTER"; then
-    echo ""
-    echo "Test: cidr_subnet() function"
-    echo ""
-
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/cidr_subnet.crn" "$WORK_DIR/main.crn"
-
-    cd "$WORK_DIR"
-
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-
-    # Verify the cidr_subnet() result in state - subnet should have cidr_block = "10.0.1.0/24"
-    assert_state_value \
-        "assert: subnet cidr_block = '10.0.1.0/24'" \
-        '.resources[] | select(.resource_type == "ec2.subnet") | .attributes.cidr_block' \
-        '10.0.1.0/24' \
-        "$WORK_DIR"
-
-    # Cleanup
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
-
-# ─── Test: split() ───
-if [ -z "$FILTER" ] || echo "split" | grep -q "$FILTER"; then
-    echo ""
-    echo "Test: split() function"
-    echo ""
-
-    WORK_DIR=$(mktemp -d)
-    ACTIVE_WORK_DIR="$WORK_DIR"
-    cp "$SCRIPT_DIR/split.crn" "$WORK_DIR/main.crn"
-
-    cd "$WORK_DIR"
-
-    run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
-    run_step "step2: plan-verify" "$CARINA_BIN" plan .
-
-    # Verify the split() + join() round-trip result in state
-    assert_state_value \
-        "assert: tag Name = 'web-test-vpc'" \
-        '.resources[0].attributes.tags.Name' \
-        'web-test-vpc' \
-        "$WORK_DIR"
-
-    # Cleanup
-    echo "  Cleanup: destroying resources..."
-    "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
-    rm -rf "$WORK_DIR"
-    ACTIVE_WORK_DIR=""
-fi
+    if bash "$test_file"; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
 
 echo ""
 echo "════════════════════════════════════════"
-echo "Total: $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
 
 if [ "$TOTAL_FAILED" -gt 0 ]; then

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/_helpers.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/_helpers.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Common helpers for builtin function acceptance tests
+
+set -e
+
+HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$HELPERS_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+CARINA_BIN="$PROJECT_ROOT/target/debug/carina"
+if [ ! -f "$CARINA_BIN" ]; then
+    echo "Building carina..."
+    cargo build --manifest-path "$PROJECT_ROOT/Cargo.toml" --quiet 2>/dev/null \
+        || cargo build --manifest-path "$PROJECT_ROOT/Cargo.toml"
+fi
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+ACTIVE_WORK_DIR=""
+cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        echo "  Cleanup: destroying resources..."
+        cd "$ACTIVE_WORK_DIR"
+        "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
+        "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
+        rm -f carina.state.json carina.state.lock
+    fi
+}
+trap cleanup EXIT
+
+run_step() {
+    local description="$1"
+    shift
+    printf "  %-50s" "$description"
+    if "$@" > /dev/null 2>&1; then
+        echo "OK"
+        TEST_PASSED=$((TEST_PASSED + 1))
+    else
+        echo "FAIL"
+        TEST_FAILED=$((TEST_FAILED + 1))
+    fi
+}
+
+assert_state_value() {
+    local description="$1"
+    local jq_query="$2"
+    local expected="$3"
+    local work_dir="$4"
+
+    printf "  %-50s" "$description"
+    local actual
+    actual=$(jq -r "$jq_query" "$work_dir/carina.state.json" 2>/dev/null)
+    if [ "$actual" = "$expected" ]; then
+        echo "OK"
+        TEST_PASSED=$((TEST_PASSED + 1))
+    else
+        echo "FAIL (expected '$expected', got '$actual')"
+        TEST_FAILED=$((TEST_FAILED + 1))
+    fi
+}
+
+# Print test results and exit with appropriate code
+finish_test() {
+    echo ""
+    echo "  Results: $TEST_PASSED passed, $TEST_FAILED failed"
+    if [ "$TEST_FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/cidr_subnet.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/cidr_subnet.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Test: cidr_subnet() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: cidr_subnet() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/cidr_subnet.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value \
+    "assert: subnet cidr_block = '10.0.1.0/24'" \
+    '.resources[] | select(.resource_type == "ec2.subnet") | .attributes.cidr_block' \
+    '10.0.1.0/24' \
+    "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/join.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/join.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test: join() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: join() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/join.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'web-test-vpc'" '.resources[0].attributes.tags.Name' 'web-test-vpc' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/length.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/length.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test: length() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: length() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/length.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'count-3'" '.resources[0].attributes.tags.Name' 'count-3' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/split.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/split.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Test: split() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: split() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/split.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value \
+    "assert: tag Name = 'web-test-vpc'" \
+    '.resources[0].attributes.tags.Name' \
+    'web-test-vpc' \
+    "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/trim.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/trim.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test: trim() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: trim() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/trim.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'trim-test-vpc'" '.resources[0].attributes.tags.Name' 'trim-test-vpc' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/upper_lower.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/upper_lower.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test: upper() and lower() functions
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: upper() and lower() functions"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/upper_lower.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'PRODUCTION'" '.resources[0].attributes.tags.Name' 'PRODUCTION' "$WORK_DIR"
+assert_state_value "assert: tag App = 'webapp'" '.resources[0].attributes.tags.App' 'webapp' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test


### PR DESCRIPTION
## Summary

- Extract each builtin function acceptance test (join, split, trim, upper_lower, length, cidr_subnet) into its own script under `tests/`
- Create `tests/_helpers.sh` with shared helper functions (`run_step`, `assert_state_value`, `cleanup` trap, `finish_test`)
- Rewrite `run.sh` as a lightweight framework that auto-discovers and runs all `tests/*.sh` files
- New builtin function tests can now be added by creating a new file in `tests/` without modifying `run.sh`

## Test plan

- [ ] Verify `run.sh` discovers all test scripts (check output header lists each test)
- [ ] Run a single test with filter: `./run.sh join`
- [ ] Run full suite with AWS credentials to confirm end-to-end behavior is preserved

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)