### PR TITLE
feat: add replace() built-in function

### DIFF
--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -6,6 +6,7 @@
 mod cidr_subnet;
 mod join;
 mod length;
+mod replace;
 mod split;
 mod trim;
 mod upper_lower;
@@ -24,6 +25,7 @@ pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
         "trim" => trim::builtin_trim(args),
         "upper" => upper_lower::builtin_upper(args),
         "lower" => upper_lower::builtin_lower(args),
+        "replace" => replace::builtin_replace(args),
         _ => Err(format!("Unknown built-in function: {name}")),
     }
 }

--- a/carina-core/src/builtins/replace.rs
+++ b/carina-core/src/builtins/replace.rs
@@ -1,0 +1,201 @@
+//! `replace(string, search, replacement)` built-in function
+
+use crate::resource::Value;
+
+use super::value_type_name;
+
+/// `replace(string, search, replacement)` - Replace all occurrences of a substring.
+///
+/// - First argument: input string (String)
+/// - Second argument: search substring (String)
+/// - Third argument: replacement substring (String)
+/// - Returns: String with all occurrences replaced
+///
+/// Examples:
+/// ```text
+/// replace("hello-world", "-", "_")  // => "hello_world"
+/// "hello-world" |> replace("-", "_") // => "hello_world" (pipe form)
+/// ```
+pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
+    if args.len() != 3 {
+        return Err(format!(
+            "replace() expects 3 arguments (string, search, replacement), got {}",
+            args.len()
+        ));
+    }
+
+    let input = match &args[0] {
+        Value::String(s) => s.clone(),
+        other => {
+            return Err(format!(
+                "replace() first argument must be a string, got {}",
+                value_type_name(other)
+            ));
+        }
+    };
+
+    let search = match &args[1] {
+        Value::String(s) => s.clone(),
+        other => {
+            return Err(format!(
+                "replace() second argument must be a string, got {}",
+                value_type_name(other)
+            ));
+        }
+    };
+
+    let replacement = match &args[2] {
+        Value::String(s) => s.clone(),
+        other => {
+            return Err(format!(
+                "replace() third argument must be a string, got {}",
+                value_type_name(other)
+            ));
+        }
+    };
+
+    Ok(Value::String(input.replace(&search, &replacement)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::builtins::evaluate_builtin;
+    use crate::resource::Value;
+
+    #[test]
+    fn replace_basic() {
+        let args = vec![
+            Value::String("hello-world".to_string()),
+            Value::String("-".to_string()),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("hello_world".to_string()));
+    }
+
+    #[test]
+    fn replace_multiple_occurrences() {
+        let args = vec![
+            Value::String("a-b-c-d".to_string()),
+            Value::String("-".to_string()),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("a_b_c_d".to_string()));
+    }
+
+    #[test]
+    fn replace_no_match() {
+        let args = vec![
+            Value::String("hello".to_string()),
+            Value::String("-".to_string()),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("hello".to_string()));
+    }
+
+    #[test]
+    fn replace_empty_search() {
+        let args = vec![
+            Value::String("abc".to_string()),
+            Value::String("".to_string()),
+            Value::String("-".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        // Rust's replace("", x) inserts x between every char and at boundaries
+        assert_eq!(result, Value::String("-a-b-c-".to_string()));
+    }
+
+    #[test]
+    fn replace_with_empty() {
+        let args = vec![
+            Value::String("hello-world".to_string()),
+            Value::String("-".to_string()),
+            Value::String("".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("helloworld".to_string()));
+    }
+
+    #[test]
+    fn replace_multi_char() {
+        let args = vec![
+            Value::String("foo::bar::baz".to_string()),
+            Value::String("::".to_string()),
+            Value::String(".".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("foo.bar.baz".to_string()));
+    }
+
+    #[test]
+    fn replace_empty_input() {
+        let args = vec![
+            Value::String("".to_string()),
+            Value::String("-".to_string()),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args).unwrap();
+        assert_eq!(result, Value::String("".to_string()));
+    }
+
+    #[test]
+    fn replace_wrong_arg_count() {
+        let args = vec![
+            Value::String("hello".to_string()),
+            Value::String("-".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expects 3 arguments"));
+    }
+
+    #[test]
+    fn replace_non_string_first_arg() {
+        let args = vec![
+            Value::Int(1),
+            Value::String("-".to_string()),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("first argument must be a string")
+        );
+    }
+
+    #[test]
+    fn replace_non_string_second_arg() {
+        let args = vec![
+            Value::String("hello".to_string()),
+            Value::Int(1),
+            Value::String("_".to_string()),
+        ];
+        let result = evaluate_builtin("replace", &args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("second argument must be a string")
+        );
+    }
+
+    #[test]
+    fn replace_non_string_third_arg() {
+        let args = vec![
+            Value::String("hello".to_string()),
+            Value::String("-".to_string()),
+            Value::Int(1),
+        ];
+        let result = evaluate_builtin("replace", &args);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("third argument must be a string")
+        );
+    }
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/replace.crn
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/replace.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let name = replace("web-test-vpc", "-", "_")
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = name
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/replace.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/replace.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Test: replace() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: replace() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/replace.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value \
+    "assert: tag Name = 'web_test_vpc'" \
+    '.resources[0].attributes.tags.Name' \
+    'web_test_vpc' \
+    "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test


### PR DESCRIPTION
## Summary

- Add `replace(string, search, replacement)` built-in function that replaces all occurrences of a substring
- Example: `replace("hello-world", "-", "_")` returns `"hello_world"`
- Includes 11 unit tests covering basic usage, multiple occurrences, no match, empty strings, multi-char patterns, and error cases
- Acceptance test verifies end-to-end with VPC tag name transformation

Closes #1141

## Test plan

- [x] `cargo test -p carina-core -- builtins::replace` (11 tests pass)
- [x] `cargo clippy -p carina-core` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] Acceptance test: apply, plan-verify (no changes), state value assertion, destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)