### PR TITLE
feat: add flatten() built-in function

### DIFF
--- a/carina-core/src/builtins/flatten.rs
+++ b/carina-core/src/builtins/flatten.rs
@@ -1,0 +1,183 @@
+//! `flatten(list)` built-in function
+
+use crate::resource::Value;
+
+use super::value_type_name;
+
+/// `flatten(list)` - Flatten a list of lists by one level.
+///
+/// - Single argument: a List
+/// - Returns: List with one level of nesting removed
+///
+/// Elements that are lists are expanded into the result;
+/// non-list elements are kept as-is.
+///
+/// Examples:
+/// ```text
+/// flatten([[1, 2], [3, 4]])      // => [1, 2, 3, 4]
+/// flatten([["a", "b"], ["c"]])   // => ["a", "b", "c"]
+/// flatten([[1, 2], 3, [4]])      // => [1, 2, 3, 4]
+/// ```
+pub(crate) fn builtin_flatten(args: &[Value]) -> Result<Value, String> {
+    if args.len() != 1 {
+        return Err(format!("flatten() expects 1 argument, got {}", args.len()));
+    }
+
+    let items = match &args[0] {
+        Value::List(items) => items,
+        other => {
+            return Err(format!(
+                "flatten() argument must be a List, got {}",
+                value_type_name(other)
+            ));
+        }
+    };
+
+    let mut result = Vec::new();
+    for item in items {
+        match item {
+            Value::List(inner) => result.extend(inner.iter().cloned()),
+            other => result.push(other.clone()),
+        }
+    }
+
+    Ok(Value::List(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::builtins::evaluate_builtin;
+    use crate::resource::Value;
+
+    #[test]
+    fn flatten_nested_lists() {
+        let args = vec![Value::List(vec![
+            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::List(vec![Value::Int(3), Value::Int(4)]),
+        ])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+                Value::Int(4),
+            ])
+        );
+    }
+
+    #[test]
+    fn flatten_string_lists() {
+        let args = vec![Value::List(vec![
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+            ]),
+            Value::List(vec![Value::String("c".to_string())]),
+        ])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::String("a".to_string()),
+                Value::String("b".to_string()),
+                Value::String("c".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn flatten_mixed_list_and_non_list() {
+        let args = vec![Value::List(vec![
+            Value::List(vec![Value::Int(1), Value::Int(2)]),
+            Value::Int(3),
+            Value::List(vec![Value::Int(4)]),
+        ])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+                Value::Int(4),
+            ])
+        );
+    }
+
+    #[test]
+    fn flatten_empty_list() {
+        let args = vec![Value::List(vec![])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(result, Value::List(vec![]));
+    }
+
+    #[test]
+    fn flatten_no_nested_lists() {
+        let args = vec![Value::List(vec![
+            Value::Int(1),
+            Value::Int(2),
+            Value::Int(3),
+        ])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(
+            result,
+            Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3),])
+        );
+    }
+
+    #[test]
+    fn flatten_single_level_only() {
+        // Nested [[1, [2, 3]]] should flatten to [1, [2, 3]], not [1, 2, 3]
+        let args = vec![Value::List(vec![Value::List(vec![
+            Value::Int(1),
+            Value::List(vec![Value::Int(2), Value::Int(3)]),
+        ])])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(
+            result,
+            Value::List(vec![
+                Value::Int(1),
+                Value::List(vec![Value::Int(2), Value::Int(3)]),
+            ])
+        );
+    }
+
+    #[test]
+    fn flatten_empty_inner_lists() {
+        let args = vec![Value::List(vec![
+            Value::List(vec![Value::Int(1)]),
+            Value::List(vec![]),
+            Value::List(vec![Value::Int(2)]),
+        ])];
+        let result = evaluate_builtin("flatten", &args).unwrap();
+        assert_eq!(result, Value::List(vec![Value::Int(1), Value::Int(2),]));
+    }
+
+    #[test]
+    fn flatten_wrong_arg_count_zero() {
+        let result = evaluate_builtin("flatten", &[]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expects 1 argument"));
+    }
+
+    #[test]
+    fn flatten_wrong_arg_count_two() {
+        let args = vec![
+            Value::List(vec![Value::Int(1)]),
+            Value::List(vec![Value::Int(2)]),
+        ];
+        let result = evaluate_builtin("flatten", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expects 1 argument"));
+    }
+
+    #[test]
+    fn flatten_invalid_type() {
+        let args = vec![Value::String("not a list".to_string())];
+        let result = evaluate_builtin("flatten", &args);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must be a List"));
+    }
+}

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -4,6 +4,7 @@
 //! Functions take `&[Value]` arguments and return `Result<Value, String>`.
 
 mod cidr_subnet;
+mod flatten;
 mod join;
 mod length;
 mod split;
@@ -18,6 +19,7 @@ use crate::resource::Value;
 pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
     match name {
         "cidr_subnet" => cidr_subnet::builtin_cidr_subnet(args),
+        "flatten" => flatten::builtin_flatten(args),
         "join" => join::builtin_join(args),
         "length" => length::builtin_length(args),
         "split" => split::builtin_split(args),

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/flatten.crn
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/flatten.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let parts = [["flat", "test"], ["vpc"]]
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = join("-", flatten(parts))
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/flatten.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/flatten.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test: flatten() function
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: flatten() function"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/flatten.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'flat-test-vpc'" '.resources[0].attributes.tags.Name' 'flat-test-vpc' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test


### PR DESCRIPTION
## Summary

- Add `flatten()` built-in function that flattens a list of lists by one level
- Non-list elements are kept as-is (e.g., `flatten([[1, 2], 3, [4]])` returns `[1, 2, 3, 4]`)
- Include 10 unit tests covering nested lists, mixed types, empty lists, single-level-only behavior, and error cases
- Add acceptance test using `join("-", flatten(parts))` to verify end-to-end with VPC tag

## Test plan

- [x] `cargo test -p carina-core flatten` - 10 tests pass
- [x] `cargo test -p carina-core` - all 599 tests pass
- [x] `cargo clippy` - clean
- [x] `cargo fmt` - clean
- [x] Acceptance test with `carina-test-005` - apply, plan-verify, assert tag value all pass

Closes #1148