### PR TITLE
feat: add local let bindings inside resource blocks

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -76,8 +76,13 @@ let_binding = {
     kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ expression
 }
 
-// Block content: attributes, trivia, nested blocks, or nested elements
-block_content = _{ trivia | nested_block | attribute }
+// Block content: local let bindings, attributes, trivia, nested blocks, or nested elements
+block_content = _{ trivia | local_binding | nested_block | attribute }
+
+// Local let binding inside a block: let name = expression
+local_binding = {
+    kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ expression
+}
 
 // Nested block: identifier { ... } (e.g., lifecycle { ... }, security_group_ingress { ... })
 nested_block = {

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -64,6 +64,7 @@ pub enum NodeKind {
     AttributesParam,
     TypeExpr,
     LetBinding,
+    LocalBinding,
     ModuleCall,
     AnonymousResource,
     ResourceExpr,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -90,6 +90,9 @@ impl<'a> CstBuilder<'a> {
             Rule::type_map => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
             Rule::type_ref => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
             Rule::let_binding => Some(CstChild::Node(self.build_node(NodeKind::LetBinding, pair))),
+            Rule::local_binding => Some(CstChild::Node(
+                self.build_node(NodeKind::LocalBinding, pair),
+            )),
             Rule::module_call => Some(CstChild::Node(self.build_node(NodeKind::ModuleCall, pair))),
             Rule::anonymous_resource => Some(CstChild::Node(
                 self.build_node(NodeKind::AnonymousResource, pair),

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -131,6 +131,7 @@ impl Formatter {
             NodeKind::ArgumentsBlock => self.format_arguments_block(node),
             NodeKind::AttributesBlock => self.format_attributes_block(node),
             NodeKind::LetBinding => self.format_let_binding(node),
+            NodeKind::LocalBinding => self.format_let_binding(node),
             NodeKind::ModuleCall => self.format_module_call(node),
             NodeKind::AnonymousResource => self.format_anonymous_resource(node),
             NodeKind::ResourceExpr => self.format_resource_expr(node),
@@ -591,7 +592,7 @@ impl Formatter {
 
     fn block_has_content(&self, node: &CstNode) -> bool {
         node.children.iter().any(|child| {
-            matches!(child, CstChild::Node(n) if n.kind == NodeKind::Attribute || n.kind == NodeKind::NestedBlock)
+            matches!(child, CstChild::Node(n) if n.kind == NodeKind::Attribute || n.kind == NodeKind::NestedBlock || n.kind == NodeKind::LocalBinding)
                 || matches!(child, CstChild::Trivia(Trivia::LineComment(_)))
         })
     }
@@ -609,7 +610,9 @@ impl Formatter {
         for child in &node.children {
             match child {
                 CstChild::Node(n)
-                    if n.kind == NodeKind::Attribute || n.kind == NodeKind::NestedBlock =>
+                    if n.kind == NodeKind::Attribute
+                        || n.kind == NodeKind::NestedBlock
+                        || n.kind == NodeKind::LocalBinding =>
                 {
                     // Write any pending standalone comments
                     for comment in pending_comments.drain(..) {
@@ -680,9 +683,11 @@ impl Formatter {
                 0
             };
 
-            // Format each attribute/nested block in this group
+            // Format each attribute/nested block/local binding in this group
             for attr in group {
-                if attr.kind == NodeKind::NestedBlock {
+                if attr.kind == NodeKind::LocalBinding {
+                    self.format_let_binding(attr);
+                } else if attr.kind == NodeKind::NestedBlock {
                     self.format_nested_block(attr);
                 } else if let Some(block_name) = self.should_convert_to_blocks(attr) {
                     self.emit_list_as_blocks(attr, &block_name);

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -60,8 +60,12 @@ provider_block = {
 // Variable/resource definition: let name = value
 let_binding = { "let" ~ identifier ~ "=" ~ expression }
 
-// Block content: either an attribute (key = value) or a nested block (key { ... })
-block_content = { attribute | nested_block }
+// Block content: a local let binding, an attribute (key = value), or a nested block (key { ... })
+block_content = { local_binding | attribute | nested_block }
+
+// Local let binding inside a block: let name = expression
+// These are block-scoped variables, NOT sent to the provider
+local_binding = { "let" ~ identifier ~ "=" ~ expression }
 
 // Attribute: key = value
 attribute = { identifier ~ "=" ~ expression }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -191,6 +191,7 @@ impl ParsedFile {
 }
 
 /// Parse context (variable scope)
+#[derive(Clone)]
 struct ParseContext {
     variables: HashMap<String, Value>,
     /// Resource bindings (binding_name -> Resource)
@@ -753,8 +754,10 @@ fn parse_anonymous_resource(
     })
 }
 
-/// Parse block contents (attributes and nested blocks)
-/// Nested blocks with the same name are collected into a list
+/// Parse block contents (attributes, nested blocks, and local let bindings)
+/// Nested blocks with the same name are collected into a list.
+/// Local let bindings are resolved within the block scope and NOT included in
+/// the returned attributes.
 fn parse_block_contents(
     pairs: pest::iterators::Pairs<Rule>,
     ctx: &ParseContext,
@@ -762,11 +765,27 @@ fn parse_block_contents(
     let mut attributes: HashMap<String, Value> = HashMap::new();
     let mut nested_blocks: HashMap<String, Vec<Value>> = HashMap::new();
 
+    // Local scope extends the parent context with block-scoped let bindings
+    let mut local_ctx = ctx.clone();
+
     for content_pair in pairs {
         match content_pair.as_rule() {
             Rule::block_content => {
                 let inner = first_inner(content_pair, "block content item", "block content")?;
                 match inner.as_rule() {
+                    Rule::local_binding => {
+                        let mut binding_inner = inner.into_inner();
+                        let name =
+                            next_pair(&mut binding_inner, "binding name", "local let binding")?
+                                .as_str()
+                                .to_string();
+                        let value = parse_expression(
+                            next_pair(&mut binding_inner, "binding value", "local let binding")?,
+                            &local_ctx,
+                        )?;
+                        // Add to local scope only, not to attributes
+                        local_ctx.set_variable(name, value);
+                    }
                     Rule::attribute => {
                         let mut attr_inner = inner.into_inner();
                         let key = next_pair(&mut attr_inner, "attribute name", "block content")?
@@ -774,7 +793,7 @@ fn parse_block_contents(
                             .to_string();
                         let value = parse_expression(
                             next_pair(&mut attr_inner, "attribute value", "block content")?,
-                            ctx,
+                            &local_ctx,
                         )?;
                         attributes.insert(key, value);
                     }
@@ -785,7 +804,7 @@ fn parse_block_contents(
                             .to_string();
 
                         // Recursively parse nested block contents (supports arbitrary depth)
-                        let block_attrs = parse_block_contents(block_inner, ctx)?;
+                        let block_attrs = parse_block_contents(block_inner, &local_ctx)?;
 
                         // Add to the list of blocks with this name
                         nested_blocks
@@ -803,7 +822,7 @@ fn parse_block_contents(
                     .to_string();
                 let value = parse_expression(
                     next_pair(&mut attr_inner, "attribute value", "block content")?,
-                    ctx,
+                    &local_ctx,
                 )?;
                 attributes.insert(key, value);
             }
@@ -3518,5 +3537,155 @@ aws.s3.bucket {
                 Value::String("prod".to_string())
             ),]))
         );
+    }
+
+    #[test]
+    fn parse_local_let_binding_in_resource_block() {
+        let input = r#"
+            let subnet = awscc.ec2.subnet {
+                let name = "my-subnet"
+                cidr_block = "10.0.1.0/24"
+                tag_name = name
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Local let binding should NOT appear in attributes
+        assert!(!subnet.attributes.contains_key("name"));
+
+        // The local binding value should be resolved in subsequent attributes
+        assert_eq!(
+            subnet.attributes.get("tag_name"),
+            Some(&Value::String("my-subnet".to_string()))
+        );
+        assert_eq!(
+            subnet.attributes.get("cidr_block"),
+            Some(&Value::String("10.0.1.0/24".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_local_let_binding_with_interpolation() {
+        let input = r#"
+            let env = "prod"
+            let subnet = awscc.ec2.subnet {
+                let name = "app-${env}"
+                cidr_block = "10.0.1.0/24"
+                tag_name = name
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Local binding should resolve outer scope variable in interpolation
+        assert_eq!(
+            subnet.attributes.get("tag_name"),
+            Some(&Value::Interpolation(vec![
+                InterpolationPart::Literal("app-".to_string()),
+                InterpolationPart::Expr(Value::String("prod".to_string())),
+            ]))
+        );
+    }
+
+    #[test]
+    fn parse_local_let_binding_chain() {
+        let input = r#"
+            let subnet = awscc.ec2.subnet {
+                let prefix = "app"
+                let name = "${prefix}-subnet"
+                cidr_block = "10.0.1.0/24"
+                tag_name = name
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Chained local bindings should resolve correctly
+        assert_eq!(
+            subnet.attributes.get("tag_name"),
+            Some(&Value::Interpolation(vec![
+                InterpolationPart::Expr(Value::String("app".to_string())),
+                InterpolationPart::Literal("-subnet".to_string()),
+            ]))
+        );
+
+        // Local bindings should NOT appear in attributes
+        assert!(!subnet.attributes.contains_key("prefix"));
+        assert!(!subnet.attributes.contains_key("name"));
+    }
+
+    #[test]
+    fn parse_local_let_binding_with_function_call() {
+        let input = r#"
+            let subnet = awscc.ec2.subnet {
+                let name = "my-subnet"
+                cidr_block = "10.0.1.0/24"
+                tag_name = upper(name)
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Local binding used inside function call
+        assert_eq!(
+            subnet.attributes.get("tag_name"),
+            Some(&Value::FunctionCall {
+                name: "upper".to_string(),
+                args: vec![Value::String("my-subnet".to_string())],
+            })
+        );
+    }
+
+    #[test]
+    fn parse_local_let_binding_in_anonymous_resource() {
+        let input = r#"
+            awscc.ec2.subnet {
+                let name = "my-subnet"
+                cidr_block = "10.0.1.0/24"
+                tag_name = name
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Local let binding should work in anonymous resources too
+        assert!(!subnet.attributes.contains_key("name"));
+        assert_eq!(
+            subnet.attributes.get("tag_name"),
+            Some(&Value::String("my-subnet".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_local_let_binding_in_nested_block() {
+        let input = r#"
+            let subnet = awscc.ec2.subnet {
+                let env = "prod"
+                cidr_block = "10.0.1.0/24"
+                tags {
+                    Name = env
+                }
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        let subnet = &result.resources[0];
+
+        // Local binding should be visible in nested blocks
+        if let Some(Value::List(tags_list)) = subnet.attributes.get("tags") {
+            if let Some(Value::Map(tags)) = tags_list.first() {
+                assert_eq!(tags.get("Name"), Some(&Value::String("prod".to_string())));
+            } else {
+                panic!("Expected Map in tags list");
+            }
+        } else {
+            panic!("Expected tags attribute as List");
+        }
     }
 }

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/local_let.crn
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/local_let.crn
@@ -1,0 +1,13 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  let env = "production"
+  let name = "local-let-${env}"
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = name
+    Env  = upper(env)
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/local_let.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/local_let.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test: local let bindings inside resource blocks
+source "$(dirname "$0")/_helpers.sh"
+
+echo "Test: local let bindings inside resource blocks"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/local_let.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+assert_state_value "assert: tag Name = 'local-let-production'" '.resources[0].attributes.tags.Name' 'local-let-production' "$WORK_DIR"
+assert_state_value "assert: tag Env = 'PRODUCTION'" '.resources[0].attributes.tags.Env' 'PRODUCTION' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test


### PR DESCRIPTION
## Summary

- Add `let` bindings inside resource blocks for block-scoped local variables
- Local bindings are resolved at parse time and NOT included in the resource's attributes (not sent to the provider)
- Local bindings can reference outer scope variables, other local bindings, use string interpolation, and built-in functions
- Update both parser grammar and formatter grammar to support the new syntax

## Example

```crn
let subnet = awscc.ec2.subnet {
  let name = "app-${env}-${az}"
  cidr_block = cidr_subnet(base_cidr, 8, idx)
  tags = {
    Name = name
    DisplayName = upper(name)
  }
}
```

`name` is only visible within the block and is not sent to AWS.

Closes #1048

## Test plan

- [x] 6 unit tests for local let bindings (basic, interpolation, chaining, function calls, anonymous resources, nested blocks)
- [x] All 669 existing carina-core tests pass
- [x] Full workspace test suite passes
- [x] Acceptance test with AWS (local_let.crn: VPC with local let + upper() function)
- [x] Clippy and fmt clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)