### PR TITLE
fix: use text_edit for resource ref completions to prevent binding prefix duplication

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -67,6 +67,7 @@ impl CompletionProvider {
                 &attr_name,
                 &text,
                 current_binding.as_deref(),
+                position,
             ),
             CompletionContext::InsideStructBlock {
                 resource_type,

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -679,3 +679,61 @@ fn builtin_function_completions_cover_all_functions() {
         );
     }
 }
+
+#[test]
+fn resource_ref_completion_after_dot_uses_text_edit_to_avoid_duplication() {
+    // When the user has typed `internet_gateway_id = igw.` and triggers completion,
+    // the completion item should use a text_edit that replaces from the start of "igw"
+    // to the cursor position, so accepting the completion produces
+    // `internet_gateway_id = igw.internet_gateway_id` (not `igw.igw.internet_gateway_id`).
+    let provider = test_provider();
+    let doc = create_document(
+        r#"let igw = awscc.ec2.internet_gateway {
+}
+
+let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+    internet_gateway_id = igw.
+}"#,
+    );
+    // Cursor after "igw." on line 4 (character 30)
+    let position = Position {
+        line: 4,
+        character: 30,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    // Find the igw.internet_gateway_id completion
+    let igw_completion = completions
+        .iter()
+        .find(|c| c.label == "igw.internet_gateway_id")
+        .expect("Should suggest igw.internet_gateway_id");
+
+    // The completion must use text_edit (not just insert_text) to avoid duplication.
+    // The text_edit range should cover from the start of "igw" to the cursor position,
+    // so that "igw." gets replaced with "igw.internet_gateway_id".
+    assert!(
+        igw_completion.text_edit.is_some(),
+        "Resource reference completion should use text_edit to avoid prefix duplication. \
+         Got insert_text: {:?}",
+        igw_completion.insert_text
+    );
+
+    if let Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) = &igw_completion.text_edit {
+        assert_eq!(
+            edit.new_text, "igw.internet_gateway_id",
+            "text_edit new_text should be the full reference"
+        );
+        // The range should start at column 26 (where "igw" starts, after "    internet_gateway_id = ")
+        assert_eq!(
+            edit.range.start.character, 26,
+            "text_edit range should start at the binding name prefix"
+        );
+        assert_eq!(
+            edit.range.end.character, 30,
+            "text_edit range should end at the cursor position"
+        );
+    } else {
+        panic!("text_edit should be a TextEdit, not an InsertReplaceEdit");
+    }
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -68,8 +68,15 @@ impl CompletionProvider {
         attr_name: &str,
         text: &str,
         current_binding: Option<&str>,
+        position: Position,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
+
+        // Compute the text_edit range for resource reference completions.
+        // When the user has typed "igw." after "=", we need the range to cover
+        // from the start of "igw" to the cursor, so accepting a completion like
+        // "igw.internet_gateway_id" replaces "igw." instead of being appended.
+        let ref_edit_range = self.compute_value_prefix_range(text, position);
 
         // Type-based resource reference completions:
         // Look up the attribute's type from the schema. If it's a Custom type,
@@ -96,17 +103,20 @@ impl CompletionProvider {
                                 Self::extract_custom_type_name(&binding_attr.attr_type)
                                 && binding_type_name == target_name
                             {
+                                let full_ref = format!("{}.{}", binding_name, binding_attr.name);
                                 completions.push(CompletionItem {
-                                    label: format!("{}.{}", binding_name, binding_attr.name),
+                                    label: full_ref.clone(),
                                     kind: Some(CompletionItemKind::REFERENCE),
                                     detail: Some(format!(
                                         "Reference to {}'s {} ({})",
                                         binding_name, binding_attr.name, target_name
                                     )),
-                                    insert_text: Some(format!(
-                                        "{}.{}",
-                                        binding_name, binding_attr.name
-                                    )),
+                                    text_edit: Some(
+                                        tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                                            range: ref_edit_range,
+                                            new_text: full_ref,
+                                        }),
+                                    ),
                                     ..Default::default()
                                 });
                             }
@@ -154,6 +164,37 @@ impl CompletionProvider {
         // Fall back to generic value completions
         completions.extend(self.generic_value_completions());
         completions
+    }
+
+    /// Compute a text edit range covering the value prefix the user has already typed
+    /// after the `=` sign. This allows resource reference completions like `igw.internet_gateway_id`
+    /// to replace the already-typed prefix (e.g., `igw.`) instead of being appended after it.
+    fn compute_value_prefix_range(&self, text: &str, position: Position) -> Range {
+        let lines: Vec<&str> = text.lines().collect();
+        let line_idx = position.line as usize;
+        let col = position.character as usize;
+
+        let start_col = if line_idx < lines.len() {
+            let prefix: String = lines[line_idx].chars().take(col).collect();
+            // Find the position after "= " (the value start)
+            if let Some(eq_pos) = prefix.rfind('=') {
+                let after_eq = &prefix[eq_pos + 1..];
+                let whitespace_len = after_eq.len() - after_eq.trim_start().len();
+                (eq_pos + 1 + whitespace_len) as u32
+            } else {
+                position.character
+            }
+        } else {
+            position.character
+        };
+
+        Range {
+            start: Position {
+                line: position.line,
+                character: start_col,
+            },
+            end: position,
+        }
     }
 
     /// Extract the Custom type name from an AttributeType, if it is a Custom type.


### PR DESCRIPTION
## Summary

- Fix LSP attribute completion duplicating the binding prefix when the user has already typed part of a resource reference (e.g., `igw.` becoming `igw.igw.internet_gateway_id`)
- Switch resource reference completion items from `insert_text` to `text_edit` with a range covering the already-typed prefix after `=`, so the LSP client replaces rather than appends
- Add test verifying the text_edit range and content for the dot-completion scenario

## Test plan

- [x] New test `resource_ref_completion_after_dot_uses_text_edit_to_avoid_duplication` verifies text_edit is used with correct range
- [x] All 152 existing LSP tests pass
- [x] `cargo clippy` and `cargo fmt` clean

Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)