### PR TITLE
fix: exclude modules/ from test discovery and fix length test assertion

### DIFF
--- a/carina-provider-awscc/acceptance-tests/builtin_functions/tests/length.sh
+++ b/carina-provider-awscc/acceptance-tests/builtin_functions/tests/length.sh
@@ -12,7 +12,7 @@ cd "$WORK_DIR"
 
 run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
 run_step "step2: plan-verify" "$CARINA_BIN" plan .
-assert_state_value "assert: tag Name = 'count-3'" '.resources[0].attributes.tags.Name' 'count-3' "$WORK_DIR"
+assert_state_value "assert: tag ItemCount = 'count-3'" '.resources[0].attributes.tags.ItemCount' 'count-3' "$WORK_DIR"
 
 echo "  Cleanup: destroying resources..."
 "$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true

--- a/carina-provider-awscc/acceptance-tests/run-tests.sh
+++ b/carina-provider-awscc/acceptance-tests/run-tests.sh
@@ -241,6 +241,10 @@ while IFS= read -r -d '' file; do
     if [ -f "$DIR_OF_FILE/run.sh" ]; then
         continue
     fi
+    # Skip .crn files inside modules/ directories (they are imported by other tests, not standalone)
+    if echo "$REL_PATH" | grep -q '/modules/'; then
+        continue
+    fi
     # Skip slow tests unless --include-slow is set or a filter is provided
     if is_slow_test "$file" && [ $INCLUDE_SLOW -eq 0 ] && [ ${#FILTERS[@]} -eq 0 ]; then
         SKIPPED_SLOW+=("$REL_PATH")


### PR DESCRIPTION
## Summary
- run-tests.sh now skips .crn files inside `modules/` directories (they are imported by other tests, not standalone)
- Fix length.sh test: assert `ItemCount` tag (not `Name` tag) for `length()` function verification

## Test plan
- [x] `run-tests.sh full` passes with 57→54 discovered tests (3 module files excluded)
- [x] `builtin_functions/run.sh` passes all 13 tests including length

🤖 Generated with [Claude Code](https://claude.com/claude-code)