### PR TITLE
fix: reject unknown module arguments in expand_module_call

### DIFF
--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -1157,7 +1157,7 @@ mod tests {
             arguments: {
                 let mut args = HashMap::new();
                 args.insert("vpc_id".to_string(), Value::String("vpc-456".to_string()));
-                // Typo: vpcc_id instead of vpc_id (but vpc_id is already provided above)
+                // Unknown argument: not declared in the module
                 args.insert(
                     "unknown_arg".to_string(),
                     Value::String("should-fail".to_string()),


### PR DESCRIPTION
## Summary

- Add `UnknownArgument` variant to `ModuleError` enum
- Validate all provided arguments against declared module parameters in `expand_module_call()`, rejecting unknown arguments with a clear error message
- Add test that verifies unknown arguments are rejected

Closes #1197

## Test plan

- [x] New unit test `test_unknown_argument_rejected` verifies that passing an unknown argument to a module call returns `ModuleError::UnknownArgument`
- [x] All existing carina-core tests pass (715 tests)
- [x] Full workspace build succeeds
- [x] LSP already had unknown argument diagnostics in `check_module_calls()` — no LSP changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)