### PR TITLE
fix: eagerly evaluate pure builtin function calls in for iterables

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -4695,6 +4695,14 @@ aws.s3.bucket {
         let result = parse(input).unwrap();
         // values() returns values sorted by key: prod, staging
         assert_eq!(result.resources.len(), 2);
+        assert_eq!(
+            result.resources[0].attributes.get("cidr_block"),
+            Some(&Value::String("10.0.0.0/16".to_string()))
+        );
+        assert_eq!(
+            result.resources[1].attributes.get("cidr_block"),
+            Some(&Value::String("10.1.0.0/16".to_string()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implement eager evaluation of pure builtin function calls in `for` expression iterables (e.g., `for x in keys(tags)`)
- When all arguments are statically known, evaluate at parse time; when arguments depend on runtime values (ResourceRef), return a clear error
- Add `is_static_value()` and `evaluate_static_value()` helper functions in the parser

Closes #1196

## Test plan

- [x] `parse_for_expression_with_keys_function_call` - `keys()` on a static map produces a list iterable
- [x] `parse_for_expression_with_values_function_call` - `values()` on a static map produces a list iterable
- [x] `parse_for_expression_with_concat_function_call` - `concat()` on static lists produces a list iterable
- [x] `parse_for_expression_with_runtime_function_call_errors` - function call with ResourceRef arg produces a clear error
- [x] All existing for expression tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)