### PR TITLE
refactor: remove UnresolvedIdent variant from Value enum

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -2882,10 +2882,7 @@ mod tests {
                 )
                 .with_attribute(
                     "availability_zone",
-                    Value::UnresolvedIdent(
-                        "awscc.AvailabilityZone.ap_northeast_1a".to_string(),
-                        None,
-                    ),
+                    Value::String("awscc.AvailabilityZone.ap_northeast_1a".to_string()),
                 )
                 .with_attribute("cidr_block", Value::String("10.0.1.0/24".to_string())),
         };

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -991,15 +991,14 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run1.attributes.insert(
         "resource_type".to_string(),
-        Value::UnresolvedIdent("VPC".to_string(), None),
+        Value::String("VPC".to_string()),
     );
-    resource_run1.attributes.insert(
-        "traffic_type".to_string(),
-        Value::UnresolvedIdent("ALL".to_string(), None),
-    );
+    resource_run1
+        .attributes
+        .insert("traffic_type".to_string(), Value::String("ALL".to_string()));
     resource_run1.attributes.insert(
         "log_destination_type".to_string(),
-        Value::UnresolvedIdent("s3".to_string(), None),
+        Value::String("s3".to_string()),
     );
     resource_run1.attributes.insert(
         "log_destination".to_string(),
@@ -1050,15 +1049,14 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
     );
     resource_run2.attributes.insert(
         "resource_type".to_string(),
-        Value::UnresolvedIdent("VPC".to_string(), None),
+        Value::String("VPC".to_string()),
     );
-    resource_run2.attributes.insert(
-        "traffic_type".to_string(),
-        Value::UnresolvedIdent("ALL".to_string(), None),
-    );
+    resource_run2
+        .attributes
+        .insert("traffic_type".to_string(), Value::String("ALL".to_string()));
     resource_run2.attributes.insert(
         "log_destination_type".to_string(),
-        Value::UnresolvedIdent("s3".to_string(), None),
+        Value::String("s3".to_string()),
     );
     resource_run2.attributes.insert(
         "log_destination".to_string(),

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -196,7 +196,7 @@ pub fn compute_anonymous_identifiers_with_ctx(
 ///
 /// Creates normalizers from all registered provider factories and applies
 /// `normalize_desired()` to the resources. This resolves enum identifiers
-/// (e.g., `UnresolvedIdent` -> namespaced enum strings) without requiring
+/// (e.g., bare enum identifiers -> namespaced enum strings) without requiring
 /// actual provider instances or network access.
 #[cfg(test)]
 pub fn normalize_desired_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) {

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -142,7 +142,6 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::List(_) => "List",
         Value::Map(_) => "Map",
         Value::ResourceRef { .. } => "ResourceRef",
-        Value::UnresolvedIdent(_, _) => "UnresolvedIdent",
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
     }

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -187,9 +187,6 @@ fn deterministic_value_string(value: &Value) -> String {
                 )
             }
         }
-        Value::UnresolvedIdent(name, member) => {
-            format!("UnresolvedIdent({}, {:?})", name, member)
-        }
         Value::Interpolation(parts) => {
             use crate::resource::InterpolationPart;
             let strs: Vec<String> = parts

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -163,10 +163,6 @@ fn format_value(value: &Value) -> String {
                 format!("{}.{}", binding_name, attribute_name)
             }
         }
-        Value::UnresolvedIdent(name, member) => match member {
-            Some(m) => format!("{}.{}", name, m),
-            None => name.clone(),
-        },
         Value::Interpolation(parts) => {
             use crate::resource::InterpolationPart;
             let inner: String = parts

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -414,8 +414,8 @@ pub fn parse(input: &str) -> Result<ParsedFile, ParseError> {
 
     // Second pass: resolve forward references.
     // During parsing, unknown 2-part identifiers (e.g., vpc.vpc_id where vpc is
-    // declared later) become UnresolvedIdent. Now that we have the full binding set,
-    // convert them to ResourceRef.
+    // declared later) become String values like "vpc.vpc_id". Now that we have the
+    // full binding set, convert matching ones to ResourceRef.
     resolve_forward_references(
         &ctx.resource_bindings,
         &mut resources,
@@ -883,7 +883,7 @@ fn is_static_value(value: &Value) -> bool {
         Value::List(items) => items.iter().all(is_static_value),
         Value::Map(map) => map.values().all(is_static_value),
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
-        Value::ResourceRef { .. } | Value::Interpolation(_) | Value::UnresolvedIdent(_, _) => false,
+        Value::ResourceRef { .. } | Value::Interpolation(_) => false,
     }
 }
 
@@ -1758,10 +1758,7 @@ fn parse_primary_value(
                 } else {
                     // Unknown 2-part identifier: could be TypeName.value enum shorthand
                     // Will be resolved during schema validation
-                    Ok(Value::UnresolvedIdent(
-                        parts[0].to_string(),
-                        Some(parts[1].to_string()),
-                    ))
+                    Ok(Value::String(format!("{}.{}", parts[0], parts[1])))
                 }
             } else if ctx.is_resource_binding(parts[0]) {
                 // 3+ part identifier where first part is a resource binding:
@@ -1827,7 +1824,7 @@ fn parse_primary_value(
                 // Simple variable reference (no access chain)
                 match ctx.get_variable(first_ident) {
                     Some(val) => Ok(val.clone()),
-                    None => Ok(Value::UnresolvedIdent(first_ident.to_string(), None)),
+                    None => Ok(Value::String(first_ident.to_string())),
                 }
             } else {
                 // Build binding_name, attribute_name, and field_path from access steps.
@@ -2001,9 +1998,9 @@ fn unescape_string(s: &str) -> String {
 /// Resolve forward references after the full binding set is known.
 ///
 /// During single-pass parsing, `identifier.member` forms where `identifier` is
-/// not yet a known binding are stored as `UnresolvedIdent(identifier, Some(member))`.
+/// not yet a known binding are stored as `String("identifier.member")`.
 /// This function walks all resource attributes, module call arguments, and attribute
-/// parameter values, converting matching `UnresolvedIdent` to `ResourceRef`.
+/// parameter values, converting matching strings to `ResourceRef`.
 fn resolve_forward_references(
     resource_bindings: &HashMap<String, Resource>,
     resources: &mut [Resource],
@@ -2036,19 +2033,30 @@ fn resolve_forward_references(
 }
 
 /// Recursively resolve forward references in a single Value.
+///
+/// Strings in `"name.member"` format where `name` is a known resource binding
+/// are resolved to `ResourceRef`. This handles forward references that were
+/// stored as strings during single-pass parsing.
 fn resolve_forward_ref_in_value(
     value: Value,
     resource_bindings: &HashMap<String, Resource>,
 ) -> Value {
     match value {
-        Value::UnresolvedIdent(ref name, Some(ref member))
-            if resource_bindings.contains_key(name) =>
-        {
-            Value::ResourceRef {
-                binding_name: name.clone(),
-                attribute_name: member.clone(),
-                field_path: vec![],
+        Value::String(ref s) => {
+            // A dotted string like "vpc.vpc_id" may be a forward reference that
+            // was stored as a string during single-pass parsing. Resolve it to
+            // ResourceRef if the first segment is a known resource binding.
+            if let Some((name, member)) = s.split_once('.')
+                && !member.contains('.')
+                && resource_bindings.contains_key(name)
+            {
+                return Value::ResourceRef {
+                    binding_name: name.to_string(),
+                    attribute_name: member.to_string(),
+                    field_path: vec![],
+                };
             }
+            value
         }
         Value::List(items) => Value::List(
             items
@@ -2177,8 +2185,6 @@ fn resolve_value(
             }
             Ok(Value::Map(resolved))
         }
-        // UnresolvedIdent is kept as-is for later resolution during schema validation
-        Value::UnresolvedIdent(_, _) => Ok(value.clone()),
         Value::Interpolation(parts) => {
             use crate::resource::InterpolationPart;
             let resolved: Result<Vec<InterpolationPart>, ParseError> = parts
@@ -2482,9 +2488,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_undefined_resource_reference_becomes_unresolved() {
+    fn parse_undefined_two_part_identifier_becomes_string() {
         // When a 2-part identifier references an unknown binding,
-        // it becomes an UnresolvedIdent to be resolved during schema validation
+        // it becomes a String (e.g., "nonexistent.name") for later schema validation
         let input = r#"
             let policy = aws.s3_bucket_policy {
                 name = "my-policy"
@@ -2492,16 +2498,30 @@ mod tests {
             }
         "#;
 
-        // Parsing succeeds - unknown identifiers become UnresolvedIdent
+        // Parsing succeeds - unknown identifiers become String
         let result = parse_and_resolve(input);
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert_eq!(
             parsed.resources[0].attributes.get("bucket"),
-            Some(&Value::UnresolvedIdent(
-                "nonexistent".to_string(),
-                Some("name".to_string())
-            ))
+            Some(&Value::String("nonexistent.name".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_bare_identifier_becomes_string() {
+        // When a bare identifier is not a known variable or binding,
+        // it becomes a String for later schema validation (enum resolution)
+        let input = r#"
+            let vpc = awscc.ec2.vpc {
+                instance_tenancy = dedicated
+            }
+        "#;
+
+        let result = parse(input).unwrap();
+        assert_eq!(
+            result.resources[0].attributes.get("instance_tenancy"),
+            Some(&Value::String("dedicated".to_string()))
         );
     }
 
@@ -3646,7 +3666,7 @@ aws.s3.bucket {
     #[test]
     fn forward_reference_parsed_as_resource_ref() {
         // Issue #866: Forward references should be resolved as ResourceRef,
-        // not silently downgraded to UnresolvedIdent.
+        // not silently left as a plain string.
         let input = r#"
             let subnet = awscc.ec2.subnet {
                 vpc_id     = vpc.vpc_id
@@ -3662,7 +3682,7 @@ aws.s3.bucket {
         assert_eq!(result.resources.len(), 2);
 
         let subnet = &result.resources[0];
-        // Forward reference vpc.vpc_id should be a ResourceRef, not UnresolvedIdent
+        // Forward reference vpc.vpc_id should be a ResourceRef, not a plain String
         assert_eq!(
             subnet.attributes.get("vpc_id"),
             Some(&Value::ResourceRef {

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -76,13 +76,6 @@ pub enum Value {
         #[serde(default)]
         field_path: Vec<String>,
     },
-    /// Unresolved identifier that will be resolved during schema validation
-    /// This allows shorthand enum values like `dedicated` to be resolved to
-    /// `aws.vpc.InstanceTenancy.dedicated` based on schema context.
-    /// The tuple contains (identifier, optional_member) for forms like:
-    /// - `dedicated` -> ("dedicated", None)
-    /// - `InstanceTenancy.dedicated` -> ("InstanceTenancy", Some("dedicated"))
-    UnresolvedIdent(String, Option<String>),
     /// String interpolation: `"prefix-${expr}-suffix"`
     /// Parts are evaluated and concatenated into a final String.
     Interpolation(Vec<InterpolationPart>),
@@ -167,10 +160,6 @@ impl Value {
                 binding_name.hash(hasher);
                 attribute_name.hash(hasher);
                 field_path.hash(hasher);
-            }
-            Value::UnresolvedIdent(name, member) => {
-                name.hash(hasher);
-                member.hash(hasher);
             }
             Value::Interpolation(parts) => {
                 parts.len().hash(hasher);
@@ -584,8 +573,8 @@ mod tests {
                 attribute_name: "arn".to_string(),
                 field_path: vec![],
             },
-            Value::UnresolvedIdent("dedicated".to_string(), None),
-            Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),
+            Value::String("dedicated".to_string()),
+            Value::String("InstanceTenancy.dedicated".to_string()),
             Value::Interpolation(vec![
                 InterpolationPart::Literal("prefix-".to_string()),
                 InterpolationPart::Expr(Value::ResourceRef {

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -147,15 +147,26 @@ impl AttributeType {
         }
 
         match value {
-            Value::UnresolvedIdent(ident, member) => {
-                let expanded = match (namespace, member) {
-                    (Some(ns), Some(m)) if ident == name => format!("{}.{}.{}", ns, ident, m),
-                    (Some(_), Some(m)) => format!("{}.{}", ident, m),
-                    (Some(ns), None) => format!("{}.{}.{}", ns, name, ident),
-                    (None, Some(m)) => format!("{}.{}", ident, m),
-                    (None, None) => ident.clone(),
+            Value::String(s) if !s.contains('.') => {
+                // Bare identifier like "dedicated"
+                let expanded = match namespace {
+                    Some(ns) => format!("{}.{}.{}", ns, name, s),
+                    None => s.clone(),
                 };
                 Ok(Value::String(expanded))
+            }
+            Value::String(s) if s.split('.').count() == 2 => {
+                // Two-part identifier like "InstanceTenancy.dedicated"
+                if let Some((ident, member)) = s.split_once('.') {
+                    let expanded = match namespace {
+                        Some(ns) if ident == name => format!("{}.{}.{}", ns, ident, member),
+                        Some(_) => s.clone(),
+                        None => s.clone(),
+                    };
+                    Ok(Value::String(expanded))
+                } else {
+                    Ok(value.clone())
+                }
             }
             other => Ok(other.clone()),
         }
@@ -499,10 +510,6 @@ impl Value {
                     )
                 }
             }
-            Value::UnresolvedIdent(name, member) => match member {
-                Some(m) => format!("UnresolvedIdent({}.{})", name, m),
-                None => format!("UnresolvedIdent({})", name),
-            },
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
         }
@@ -1413,10 +1420,7 @@ mod tests {
             ))
             .is_ok()
         );
-        assert!(
-            t.validate(&Value::UnresolvedIdent("IPv6".to_string(), None))
-                .is_ok()
-        );
+        assert!(t.validate(&Value::String("IPv6".to_string())).is_ok());
         assert!(t.validate(&Value::String("ipv4".to_string())).is_ok());
         assert!(t.validate(&Value::String("IPv5".to_string())).is_err());
     }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -42,10 +42,6 @@ pub fn value_to_json(value: &Value) -> Result<serde_json::Value, String> {
             }
             Ok(serde_json::Value::String(format!("${{{}}}", path)))
         }
-        Value::UnresolvedIdent(name, member) => match member {
-            Some(m) => Ok(serde_json::Value::String(format!("{}.{}", name, m))),
-            None => Ok(serde_json::Value::String(name.clone())),
-        },
         Value::Interpolation(parts) => {
             let s = parts
                 .iter()
@@ -148,14 +144,6 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             }
             path
         }
-        Value::UnresolvedIdent(name, member) => match member {
-            Some(m) => {
-                let full = format!("{}.{}", name, m);
-                let resolved = convert_enum_value(&full);
-                format!("\"{}\"", resolved)
-            }
-            None => format!("\"{}\"", name),
-        },
         Value::Interpolation(parts) => {
             let inner: String = parts
                 .iter()
@@ -398,15 +386,16 @@ mod tests {
     }
 
     #[test]
-    fn test_format_value_unresolved_ident_with_member() {
-        let v =
-            Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string()));
+    fn test_format_value_two_part_enum_string() {
+        // Two-part enum strings like "InstanceTenancy.dedicated" are formatted
+        // through convert_enum_value which extracts the value part
+        let v = Value::String("InstanceTenancy.dedicated".to_string());
         assert_eq!(format_value(&v), "\"dedicated\"");
     }
 
     #[test]
-    fn test_format_value_unresolved_ident_bare() {
-        let v = Value::UnresolvedIdent("dedicated".to_string(), None);
+    fn test_format_value_bare_enum_string() {
+        let v = Value::String("dedicated".to_string());
         assert_eq!(format_value(&v), "\"dedicated\"");
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -418,27 +418,31 @@ impl DiagnosticEngine {
                                     },
                                     value,
                                 ) => {
-                                    // Handle UnresolvedIdent by expanding to full namespace format
+                                    // Handle bare/shorthand enum identifiers by expanding to full namespace format.
+                                    // These are String values like "dedicated" or "InstanceTenancy.dedicated".
                                     let resolved_value = match value {
-                                        Value::UnresolvedIdent(ident, member) => {
-                                            let expanded = match (namespace, member) {
-                                                // TypeName.value -> namespace.TypeName.value
-                                                (Some(ns), Some(m)) if ident == name => {
-                                                    format!("{}.{}.{}", ns, ident, m)
-                                                }
-                                                // SomeOther.value with namespace
-                                                (Some(_ns), Some(m)) => {
-                                                    format!("{}.{}", ident, m)
-                                                }
-                                                // value -> namespace.TypeName.value
-                                                (Some(ns), None) => {
-                                                    format!("{}.{}.{}", ns, name, ident)
-                                                }
-                                                // No namespace, keep as-is
-                                                (None, Some(m)) => format!("{}.{}", ident, m),
-                                                (None, None) => ident.clone(),
+                                        Value::String(s) if !s.contains('.') => {
+                                            // Bare identifier: "dedicated" -> namespace.TypeName.dedicated
+                                            let expanded = match namespace {
+                                                Some(ns) => format!("{}.{}.{}", ns, name, s),
+                                                None => s.clone(),
                                             };
                                             Value::String(expanded)
+                                        }
+                                        Value::String(s) if s.split('.').count() == 2 => {
+                                            // Two-part: "InstanceTenancy.dedicated" -> namespace.InstanceTenancy.dedicated
+                                            if let Some((ident, member)) = s.split_once('.') {
+                                                let expanded = match namespace {
+                                                    Some(ns) if ident == name => {
+                                                        format!("{}.{}.{}", ns, ident, member)
+                                                    }
+                                                    Some(_ns) => s.clone(),
+                                                    None => s.clone(),
+                                                };
+                                                Value::String(expanded)
+                                            } else {
+                                                value.clone()
+                                            }
                                         }
                                         _ => value.clone(),
                                     };

--- a/carina-provider-aws/src/normalizer.rs
+++ b/carina-provider-aws/src/normalizer.rs
@@ -107,19 +107,19 @@ pub(crate) fn resolve_enum_identifiers(resources: &mut [Resource]) {
                 && let Some((type_name, ns, to_dsl)) = attr_schema.attr_type.namespaced_enum_parts()
             {
                 let resolved = match value {
-                    Value::UnresolvedIdent(ident, None) => {
-                        // bare identifier: Enabled → aws.s3.bucket.VersioningStatus.Enabled
-                        let dsl_val = to_dsl.map_or_else(|| ident.clone(), |f| f(ident));
-                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                    }
-                    Value::UnresolvedIdent(ident, Some(member)) if ident == type_name => {
-                        // TypeName.value: VersioningStatus.Enabled → aws.s3.bucket.VersioningStatus.Enabled
-                        let dsl_val = to_dsl.map_or_else(|| member.clone(), |f| f(member));
-                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                    }
                     Value::String(s) if !s.contains('.') => {
-                        // plain string without dots: "Enabled" → aws.s3.bucket.VersioningStatus.Enabled
+                        // bare identifier or plain string: "Enabled" → aws.s3.bucket.VersioningStatus.Enabled
                         let dsl_val = to_dsl.map_or_else(|| s.clone(), |f| f(s));
+                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
+                    }
+                    Value::String(s)
+                        if s.split_once('.').is_some_and(|(ident, member)| {
+                            ident == type_name && !member.contains('.')
+                        }) =>
+                    {
+                        // TypeName.value: "VersioningStatus.Enabled" → aws.s3.bucket.VersioningStatus.Enabled
+                        let member = s.split_once('.').unwrap().1;
+                        let dsl_val = to_dsl.map_or_else(|| member.to_string(), |f| f(member));
                         Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
                     }
                     _ => value.clone(),
@@ -218,7 +218,7 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "versioning_status".to_string(),
-            Value::UnresolvedIdent("Enabled".to_string(), None),
+            Value::String("Enabled".to_string()),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
@@ -235,10 +235,7 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.bucket", "test-bucket");
         resource.attributes.insert(
             "object_ownership".to_string(),
-            Value::UnresolvedIdent(
-                "ObjectOwnership".to_string(),
-                Some("BucketOwnerEnforced".to_string()),
-            ),
+            Value::String("ObjectOwnership.BucketOwnerEnforced".to_string()),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
@@ -369,7 +366,7 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "ec2.vpc", "test-vpc");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
-            Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),
+            Value::String("InstanceTenancy.dedicated".to_string()),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);
@@ -387,7 +384,7 @@ mod tests {
             Resource::with_provider("aws", "ec2.security_group_ingress", "test-rule");
         resource.attributes.insert(
             "ip_protocol".to_string(),
-            Value::UnresolvedIdent("IpProtocol".to_string(), Some("tcp".to_string())),
+            Value::String("IpProtocol.tcp".to_string()),
         );
         let mut resources = vec![resource];
         resolve_enum_identifiers(&mut resources);

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -194,26 +194,6 @@ pub(crate) fn dsl_value_to_aws(
                 };
                 Some(json!(resolved))
             }
-            Value::UnresolvedIdent(ident, member) => {
-                let raw = if let Some(m) = member {
-                    m.clone()
-                } else {
-                    ident.clone()
-                };
-                // Use valid values when available for correct resolution
-                let converted = if let Some((_, values, _, _)) = attr_type.string_enum_parts() {
-                    let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                    canonicalize_enum_value(&raw, &valid)
-                } else {
-                    raw.replace('_', "-")
-                };
-                // Apply alias reverse mapping (e.g., "all" -> "-1")
-                let resolved = match get_enum_alias_reverse(resource_type, attr_name, &converted) {
-                    Some(canonical) => canonical.to_string(),
-                    None => converted,
-                };
-                Some(json!(resolved))
-            }
             _ => value_to_json(value),
         }
     } else if let AttributeType::List { inner, .. } = attr_type
@@ -515,7 +495,7 @@ mod tests {
             .insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
         resource.attributes.insert(
             "vpc_endpoint_type".to_string(),
-            Value::UnresolvedIdent("Gateway".to_string(), None),
+            Value::String("Gateway".to_string()),
         );
 
         let mut resources = vec![resource];

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -42,19 +42,19 @@ pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
                 && let Some((type_name, ns, to_dsl)) = attr_schema.attr_type.namespaced_enum_parts()
             {
                 let resolved = match value {
-                    Value::UnresolvedIdent(ident, None) => {
-                        // bare identifier: advanced -> awscc.ec2.ipam.Tier.advanced
-                        let dsl_val = to_dsl.map_or_else(|| ident.clone(), |f| f(ident));
-                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                    }
-                    Value::UnresolvedIdent(ident, Some(member)) if ident == type_name => {
-                        // TypeName.value: Tier.advanced -> awscc.ec2.ipam.Tier.advanced
-                        let dsl_val = to_dsl.map_or_else(|| member.clone(), |f| f(member));
-                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                    }
                     Value::String(s) if !s.contains('.') => {
-                        // plain string: "ap-northeast-1a" -> awscc.AvailabilityZone.ap_northeast_1a
+                        // bare identifier or plain string: "advanced" -> awscc.ec2.ipam.Tier.advanced
                         let dsl_val = to_dsl.map_or_else(|| s.clone(), |f| f(s));
+                        Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
+                    }
+                    Value::String(s)
+                        if s.split_once('.').is_some_and(|(ident, member)| {
+                            ident == type_name && !member.contains('.')
+                        }) =>
+                    {
+                        // TypeName.value: "Tier.advanced" -> awscc.ec2.ipam.Tier.advanced
+                        let member = s.split_once('.').unwrap().1;
+                        let dsl_val = to_dsl.map_or_else(|| member.to_string(), |f| f(member));
                         Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
                     }
                     _ => value.clone(),
@@ -91,7 +91,7 @@ pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
 }
 
 /// Resolve enum identifiers within struct field values.
-/// Recurses into List and Map values, resolving UnresolvedIdent values
+/// Recurses into List and Map values, resolving bare/shorthand enum values
 /// for struct fields that have StringEnum type with namespace.
 fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
     match value {
@@ -109,16 +109,17 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
                     && let Some((type_name, ns, to_dsl)) = field.field_type.namespaced_enum_parts()
                 {
                     let resolved = match field_value {
-                        Value::UnresolvedIdent(ident, None) => {
-                            let dsl_val = to_dsl.map_or_else(|| ident.clone(), |f| f(ident));
-                            Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                        }
-                        Value::UnresolvedIdent(ident, Some(member)) if ident == type_name => {
-                            let dsl_val = to_dsl.map_or_else(|| member.clone(), |f| f(member));
-                            Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
-                        }
                         Value::String(s) if !s.contains('.') => {
                             let dsl_val = to_dsl.map_or_else(|| s.clone(), |f| f(s));
+                            Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
+                        }
+                        Value::String(s)
+                            if s.split_once('.').is_some_and(|(ident, member)| {
+                                ident == type_name && !member.contains('.')
+                            }) =>
+                        {
+                            let member = s.split_once('.').unwrap().1;
+                            let dsl_val = to_dsl.map_or_else(|| member.to_string(), |f| f(member));
                             Value::String(format!("{}.{}.{}", ns, type_name, dsl_val))
                         }
                         _ => field_value.clone(),
@@ -245,7 +246,7 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
-            Value::UnresolvedIdent("dedicated".to_string(), None),
+            Value::String("dedicated".to_string()),
         );
 
         let mut resources = vec![resource];
@@ -265,7 +266,7 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
-            Value::UnresolvedIdent("InstanceTenancy".to_string(), Some("dedicated".to_string())),
+            Value::String("InstanceTenancy.dedicated".to_string()),
         );
 
         let mut resources = vec![resource];
@@ -285,14 +286,14 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.bucket", "test");
         resource.attributes.insert(
             "instance_tenancy".to_string(),
-            Value::UnresolvedIdent("dedicated".to_string(), None),
+            Value::String("dedicated".to_string()),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         assert!(matches!(
             &resources[0].attributes["instance_tenancy"],
-            Value::UnresolvedIdent(_, _)
+            Value::String(_)
         ));
     }
 
@@ -301,7 +302,7 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.flow_log", "test");
         resource.attributes.insert(
             "log_destination_type".to_string(),
-            Value::UnresolvedIdent("cloud_watch_logs".to_string(), None),
+            Value::String("cloud_watch_logs".to_string()),
         );
 
         let mut resources = vec![resource];
@@ -446,10 +447,9 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
-        resource.attributes.insert(
-            "ip_protocol".to_string(),
-            Value::UnresolvedIdent("all".to_string(), None),
-        );
+        resource
+            .attributes
+            .insert("ip_protocol".to_string(), Value::String("all".to_string()));
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
@@ -468,10 +468,9 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
         let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
-        resource.attributes.insert(
-            "ip_protocol".to_string(),
-            Value::UnresolvedIdent("tcp".to_string(), None),
-        );
+        resource
+            .attributes
+            .insert("ip_protocol".to_string(), Value::String("tcp".to_string()));
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
@@ -513,10 +512,7 @@ mod tests {
     fn test_resolve_struct_enum_values_bare_ident() {
         let fields = test_ip_protocol_fields();
         let mut map = HashMap::new();
-        map.insert(
-            "ip_protocol".to_string(),
-            Value::UnresolvedIdent("all".to_string(), None),
-        );
+        map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
         map.insert("from_port".to_string(), Value::Int(443));
         let value = Value::List(vec![Value::Map(map)]);
 
@@ -544,7 +540,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "ip_protocol".to_string(),
-            Value::UnresolvedIdent("IpProtocol".to_string(), Some("tcp".to_string())),
+            Value::String("IpProtocol.tcp".to_string()),
         );
         let value = Value::List(vec![Value::Map(map)]);
 
@@ -600,10 +596,7 @@ mod tests {
             Value::String("test".to_string()),
         );
         let mut egress_map = HashMap::new();
-        egress_map.insert(
-            "ip_protocol".to_string(),
-            Value::UnresolvedIdent("all".to_string(), None),
-        );
+        egress_map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
         egress_map.insert(
             "cidr_ip".to_string(),
             Value::String("0.0.0.0/0".to_string()),


### PR DESCRIPTION
## Summary

- Remove `Value::UnresolvedIdent` variant from the `Value` enum, eliminating one "impossible state" that downstream code had to handle
- Parser now emits `Value::String` for bare identifiers (`dedicated`) and two-part enum shorthands (`InstanceTenancy.dedicated`)
- Forward reference resolution updated to resolve dotted strings (e.g., `"vpc.vpc_id"`) to `ResourceRef` when the first segment is a known binding

## Details

This is Phase 1 of the Value type separation plan (Decision #2 in `docs/superpowers/specs/2026-03-27-language-design-review.md`).

**Parser changes**: `UnresolvedIdent(name, None)` → `String(name)`, `UnresolvedIdent(name, Some(member))` → `String("name.member")`. Forward reference resolution in the second pass detects single-dot strings where the first segment matches a resource binding and converts them to `ResourceRef`.

**Normalizer changes**: AWS and AWSCC normalizers now pattern-match on `Value::String` with the same logic (bare string without dots, or `TypeName.value` two-part format) instead of `Value::UnresolvedIdent`.

**14 files changed** across carina-core, carina-cli, carina-lsp, carina-provider-aws, carina-provider-awscc. Net reduction of 37 lines.

## Test plan

- [x] All 751 carina-core tests pass
- [x] Full workspace tests pass (all crates)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] New tests: `parse_undefined_two_part_identifier_becomes_string`, `parse_bare_identifier_becomes_string`

Closes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)