### PR TITLE
feat: lint warning for direct calls to pipe-preferred functions

### DIFF
--- a/carina-cli/src/commands/lint.rs
+++ b/carina-cli/src/commands/lint.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 use colored::Colorize;
 
 use carina_core::config_loader::{find_crn_files_in_dir, get_base_dir, load_configuration};
-use carina_core::lint::{find_duplicate_attrs, find_list_literal_attrs, list_struct_attr_names};
+use carina_core::lint::{
+    find_duplicate_attrs, find_list_literal_attrs, find_pipe_preferred_direct_calls,
+    list_struct_attr_names,
+};
 use carina_core::module_resolver;
 use carina_core::provider::{self as provider_mod};
 
@@ -99,6 +102,19 @@ pub fn run_lint(path: &PathBuf) -> Result<(), AppError> {
                 message: format!(
                     "Duplicate attribute '{}' (first defined on line {}). The last value will be used.",
                     dup.name, dup.first_line
+                ),
+            });
+        }
+
+        // Check for direct calls to pipe-preferred functions
+        let pipe_warnings = find_pipe_preferred_direct_calls(source);
+        for pw in pipe_warnings {
+            warnings.push(LintWarning {
+                file: file_path.clone(),
+                line: pw.line,
+                message: format!(
+                    "Consider using pipe form for '{}': data |> {}(...)",
+                    pw.name, pw.name
                 ),
             });
         }

--- a/carina-core/src/lint.rs
+++ b/carina-core/src/lint.rs
@@ -52,6 +52,83 @@ pub fn list_struct_attr_names(schema: &ResourceSchema) -> HashSet<String> {
         .collect()
 }
 
+/// Functions that follow data-last convention for pipe compatibility.
+/// Direct calls with 2+ args work but have unintuitive argument order;
+/// pipe form is preferred.
+const PIPE_PREFERRED_FUNCTIONS: &[&str] = &["join", "split", "map", "concat", "replace"];
+
+/// A warning for direct calls to pipe-preferred functions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PipePreferredWarning {
+    /// The function name
+    pub name: String,
+    /// 1-indexed line number
+    pub line: usize,
+}
+
+/// Find direct calls to pipe-preferred transformation functions.
+///
+/// Detects patterns like `join("-", parts)` where the pipe form
+/// `parts |> join("-")` is recommended. Only warns when the function
+/// call is NOT preceded by `|>` on the same line.
+pub fn find_pipe_preferred_direct_calls(source: &str) -> Vec<PipePreferredWarning> {
+    let mut warnings = Vec::new();
+
+    for (line_idx, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        for &func_name in PIPE_PREFERRED_FUNCTIONS {
+            let pattern = format!("{}(", func_name);
+            // Search for all occurrences of the pattern on this line
+            let mut search_from = 0;
+            while let Some(rel_pos) = trimmed[search_from..].find(&pattern) {
+                let pos = search_from + rel_pos;
+                search_from = pos + pattern.len();
+
+                // Check that this is not part of a longer identifier
+                // (e.g., "my_join(" should not match "join(")
+                if pos > 0 {
+                    let prev_char = trimmed.as_bytes()[pos - 1];
+                    if prev_char.is_ascii_alphanumeric() || prev_char == b'_' {
+                        continue;
+                    }
+                }
+
+                // Check if this is a pipe call (|> before the function on this line)
+                let before = &trimmed[..pos];
+                if before.contains("|>") {
+                    continue;
+                }
+
+                // Rough check: skip if inside a string literal
+                if is_inside_string(trimmed, pos) {
+                    continue;
+                }
+
+                warnings.push(PipePreferredWarning {
+                    name: func_name.to_string(),
+                    line: line_idx + 1,
+                });
+            }
+        }
+    }
+
+    warnings
+}
+
+/// Rough heuristic to check if a byte position is inside a string literal.
+fn is_inside_string(line: &str, pos: usize) -> bool {
+    let mut in_string = false;
+    for (i, ch) in line.char_indices() {
+        if i >= pos {
+            break;
+        }
+        if ch == '"' {
+            in_string = !in_string;
+        }
+    }
+    in_string
+}
+
 /// A duplicate attribute warning with attribute name, 1-indexed line number, and first occurrence line.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DuplicateAttr {
@@ -346,6 +423,77 @@ provider awscc {
         assert!(
             !names.contains("group_description"),
             "String should not be included"
+        );
+    }
+
+    #[test]
+    fn test_pipe_preferred_direct_call_warns() {
+        let source = r#"let name = join("-", parts)"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "join");
+        assert_eq!(results[0].line, 1);
+    }
+
+    #[test]
+    fn test_pipe_preferred_pipe_form_no_warning() {
+        let source = r#"let name = parts |> join("-")"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(results.is_empty(), "Pipe form should not warn");
+    }
+
+    #[test]
+    fn test_pipe_preferred_single_arg_no_warning() {
+        // flatten is not in PIPE_PREFERRED_FUNCTIONS
+        let source = r#"let flat = flatten(list)"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(results.is_empty(), "Single-arg functions should not warn");
+    }
+
+    #[test]
+    fn test_pipe_preferred_computation_no_warning() {
+        // cidr_subnet is not in PIPE_PREFERRED_FUNCTIONS
+        let source = r#"let subnet = cidr_subnet("10.0.0.0/16", 8, 1)"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(results.is_empty(), "Computation functions should not warn");
+    }
+
+    #[test]
+    fn test_pipe_preferred_all_functions() {
+        let source = r#"
+let a = join("-", parts)
+let b = split(",", str)
+let c = map(".id", list)
+let d = concat(extra, base)
+let e = replace("old", "new", str)
+"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert_eq!(results.len(), 5);
+        assert_eq!(results[0].name, "join");
+        assert_eq!(results[1].name, "split");
+        assert_eq!(results[2].name, "map");
+        assert_eq!(results[3].name, "concat");
+        assert_eq!(results[4].name, "replace");
+    }
+
+    #[test]
+    fn test_pipe_preferred_inside_string_no_warning() {
+        let source = r#"let x = "join(a, b)""#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(
+            results.is_empty(),
+            "Function name inside string literal should not warn"
+        );
+    }
+
+    #[test]
+    fn test_pipe_preferred_no_false_positive_on_similar_name() {
+        // "my_join(" should not match "join("
+        let source = r#"let x = my_join("-", parts)"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(
+            results.is_empty(),
+            "Should not match when function name is part of a longer identifier"
         );
     }
 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -619,6 +619,9 @@ impl DiagnosticEngine {
         // Check for duplicate attribute keys (text-based, works without parsed file)
         diagnostics.extend(self.check_duplicate_attrs(doc));
 
+        // Check for direct calls to pipe-preferred functions
+        diagnostics.extend(self.check_pipe_preferred_direct_calls(doc));
+
         diagnostics
     }
 
@@ -652,6 +655,43 @@ impl DiagnosticEngine {
                     message: format!(
                         "Duplicate attribute '{}' (first defined on line {}). The last value will be used.",
                         dup.name, dup.first_line
+                    ),
+                    ..Default::default()
+                })
+            })
+            .collect()
+    }
+
+    /// Check for direct calls to pipe-preferred functions (info-level).
+    fn check_pipe_preferred_direct_calls(&self, doc: &Document) -> Vec<Diagnostic> {
+        let text = doc.text();
+        let warnings = carina_core::lint::find_pipe_preferred_direct_calls(&text);
+
+        warnings
+            .into_iter()
+            .filter_map(|pw| {
+                let line = (pw.line - 1) as u32;
+                let line_text = text.lines().nth(pw.line - 1)?;
+                let pattern = format!("{}(", pw.name);
+                let byte_pos = line_text.find(&pattern)?;
+                let col = position::byte_offset_to_char_offset(line_text, byte_pos);
+
+                Some(Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line,
+                            character: col,
+                        },
+                        end: Position {
+                            line,
+                            character: col + pw.name.len() as u32,
+                        },
+                    },
+                    severity: Some(DiagnosticSeverity::INFORMATION),
+                    source: Some("carina".to_string()),
+                    message: format!(
+                        "Consider using pipe form for '{}': data |> {}(...)",
+                        pw.name, pw.name
                     ),
                     ..Default::default()
                 })

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -895,3 +895,57 @@ awscc.ec2.vpc_gateway_attachment {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn pipe_preferred_direct_call_produces_info_diagnostic() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+let name = join("-", parts)
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let pipe_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Consider using pipe form for 'join'"));
+    assert!(
+        pipe_diag.is_some(),
+        "Direct call to pipe-preferred function should produce diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let diag = pipe_diag.unwrap();
+    assert_eq!(
+        diag.severity,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION),
+        "Pipe-preferred diagnostic should be info-level, not warning"
+    );
+}
+
+#[test]
+fn pipe_preferred_pipe_form_no_diagnostic() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+let name = parts |> join("-")
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let pipe_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Consider using pipe form for 'join'"));
+    assert!(
+        pipe_diag.is_none(),
+        "Pipe form should not produce pipe-preferred diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Add lint rule to warn when pipe-preferred transformation functions (`join`, `split`, `map`, `concat`, `replace`) are called directly with multiple arguments instead of the recommended pipe form
- `carina lint` command: displays as warning
- LSP diagnostics: info-level (not warning), so it appears as a hint in the editor
- Text-based detection with guards against false positives (longer identifiers like `my_join`, string literals)

## Test plan

- [x] Unit tests in `carina-core` for all pipe-preferred functions, pipe form, single-arg functions, computation functions, string literals, and longer identifiers
- [x] LSP integration tests verifying info-level severity for direct calls and no diagnostic for pipe form
- [x] `cargo clippy` and `cargo fmt` clean

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)