### PR TITLE
fix: skip write-only attributes absent from current state in differ

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -232,6 +232,16 @@ pub(super) fn find_changed_attributes(
             continue;
         }
 
+        // Skip write-only attributes not present in current state.
+        // CloudControl API does not return write-only properties, so their
+        // absence from state is expected and should not trigger a diff.
+        if schema
+            .and_then(|s| s.attributes.get(key))
+            .is_some_and(|attr| attr.write_only && !current.contains_key(key))
+        {
+            continue;
+        }
+
         let attr_type = schema
             .and_then(|s| s.attributes.get(key))
             .map(|a| &a.attr_type);

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -417,3 +417,122 @@ fn type_aware_unordered_list_ignores_reorder() {
         "Unordered list should treat reorder as equal"
     );
 }
+
+// --- Tests for write-only attribute skip in find_changed_attributes ---
+
+#[test]
+fn write_only_attr_in_desired_not_in_current_no_diff() {
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let schema = ResourceSchema::new("ec2.vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("ipv4_netmask_length", AttributeType::Int).write_only());
+
+    let desired = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+    ]);
+    // CloudControl Read API does not return write-only attributes
+    let current = HashMap::from([(
+        "cidr_block".to_string(),
+        Value::String("10.0.0.0/16".to_string()),
+    )]);
+
+    let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema));
+    assert!(
+        changed.is_empty(),
+        "Write-only attribute absent from current should not trigger a diff, got: {:?}",
+        changed
+    );
+}
+
+#[test]
+fn write_only_attr_in_both_same_value_no_diff() {
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let schema = ResourceSchema::new("ec2.vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("ipv4_netmask_length", AttributeType::Int).write_only());
+
+    let desired = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+    ]);
+    let current = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+    ]);
+
+    let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema));
+    assert!(
+        changed.is_empty(),
+        "Write-only attribute with same value should not trigger a diff, got: {:?}",
+        changed
+    );
+}
+
+#[test]
+fn write_only_attr_in_both_different_value_detects_diff() {
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let schema = ResourceSchema::new("ec2.vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("ipv4_netmask_length", AttributeType::Int).write_only());
+
+    let desired = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("ipv4_netmask_length".to_string(), Value::Int(24)),
+    ]);
+    let current = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("ipv4_netmask_length".to_string(), Value::Int(16)),
+    ]);
+
+    let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema));
+    assert!(
+        changed.contains(&"ipv4_netmask_length".to_string()),
+        "Write-only attribute with different value should trigger a diff"
+    );
+}
+
+#[test]
+fn non_write_only_attr_in_desired_not_in_current_detects_diff() {
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let schema = ResourceSchema::new("ec2.vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("enable_dns", AttributeType::Bool));
+
+    let desired = HashMap::from([
+        (
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        ),
+        ("enable_dns".to_string(), Value::Bool(true)),
+    ]);
+    let current = HashMap::from([(
+        "cidr_block".to_string(),
+        Value::String("10.0.0.0/16".to_string()),
+    )]);
+
+    let changed = find_changed_attributes(&desired, &current, None, None, Some(&schema));
+    assert!(
+        changed.contains(&"enable_dns".to_string()),
+        "Non-write-only attribute absent from current should trigger a diff"
+    );
+}

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -23,6 +23,8 @@ use crate::resource::LifecycleConfig;
 #[cfg(test)]
 use crate::schema::AttributeType;
 #[cfg(test)]
+use comparison::find_changed_attributes;
+#[cfg(test)]
 use comparison::type_aware_equal;
 
 /// Result of a diff operation


### PR DESCRIPTION
## Summary

- Skip write-only attributes in `find_changed_attributes()` when they are absent from current state, preventing false diffs caused by CloudControl Read API not returning write-only properties
- Only skips when current does NOT have the key; if current has a value, comparison proceeds normally
- Adds 4 tests covering: write-only absent from current (no diff), write-only same value (no diff), write-only different value (diff detected), non-write-only absent (diff detected)

Closes #1232

## Test plan

- [x] `cargo test -p carina-core write_only_attr` -- all 4 new tests pass
- [x] `cargo test -p carina-core` -- all existing tests pass
- [x] `cargo clippy -p carina-core` -- no warnings
- [x] `cargo fmt -- --check` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)