### PR TITLE
fix: secret() nested in Map values and add env/secret acceptance tests

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -29,7 +29,16 @@ pub(super) fn type_aware_equal(a: &Value, b: &Value, attr_type: Option<&Attribut
     }
 
     match attr_type {
-        None => a.semantically_equal(b),
+        None => {
+            // Even without type info, use type_aware_maps_equal / type_aware_lists_equal
+            // for Maps/Lists so that nested Secret values are compared via their hashes.
+            // semantically_equal uses PartialEq which doesn't handle Secret↔hash comparison.
+            match (a, b) {
+                (Value::Map(ma), Value::Map(mb)) => type_aware_maps_equal(ma, mb, |_key| None),
+                (Value::List(la), Value::List(lb)) => type_aware_lists_equal(la, lb, None, false),
+                _ => a.semantically_equal(b),
+            }
+        }
         Some(at) => match (a, b, at) {
             // Int/Float coercion for numeric types
             (Value::Int(i), Value::Float(f), AttributeType::Float | AttributeType::Int) => {

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -615,3 +615,33 @@ fn secret_in_find_changed_attributes_changed() {
         "Secret with different hash should show as changed"
     );
 }
+
+#[test]
+fn secret_in_map_no_change_when_hash_matches() {
+    use crate::value::value_to_json;
+
+    // Desired: tags map with a secret value
+    let secret_value = Value::Secret(Box::new(Value::String("super-secret".to_string())));
+    let desired_tags = Value::Map(HashMap::from([
+        ("Name".to_string(), Value::String("test".to_string())),
+        ("SecretTag".to_string(), secret_value.clone()),
+    ]));
+
+    // State: tags map with the secret hash (as stored by from_provider_state)
+    let hash_json = value_to_json(&secret_value).unwrap();
+    let hash_str = hash_json.as_str().unwrap().to_string();
+    let state_tags = Value::Map(HashMap::from([
+        ("Name".to_string(), Value::String("test".to_string())),
+        ("SecretTag".to_string(), Value::String(hash_str)),
+    ]));
+
+    let desired = HashMap::from([("tags".to_string(), desired_tags)]);
+    let current = HashMap::from([("tags".to_string(), state_tags)]);
+
+    let changed = find_changed_attributes(&desired, &current, None, None, None);
+    assert!(
+        changed.is_empty(),
+        "Secret in map with matching hash should not show as changed, got: {:?}",
+        changed
+    );
+}

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -204,8 +204,8 @@ impl AttributeType {
 
     /// Check if a value conforms to this type
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
-        // FunctionCall values are resolved at runtime, skip validation
-        if matches!(value, Value::FunctionCall { .. }) {
+        // FunctionCall and Secret values are resolved at runtime, skip validation
+        if matches!(value, Value::FunctionCall { .. } | Value::Secret(_)) {
             return Ok(());
         }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -182,6 +182,82 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
     }
 }
 
+/// Check if a Value contains any Secret values at any nesting depth.
+pub fn contains_secret(value: &Value) -> bool {
+    match value {
+        Value::Secret(_) => true,
+        Value::Map(map) => map.values().any(contains_secret),
+        Value::List(items) => items.iter().any(contains_secret),
+        _ => false,
+    }
+}
+
+/// Merge secret hashes from the desired value into the provider-returned JSON.
+///
+/// For attributes containing secrets nested inside Maps or Lists, we cannot simply
+/// replace the entire provider value with the desired value's JSON, because the
+/// provider may return extra keys (e.g., CloudControl auto-adds tags). This function
+/// recursively walks both trees:
+/// - If the desired value is `Secret(inner)`, return the hashed value
+/// - If desired is a `Map` and provider is an object, merge: for each provider key,
+///   if the desired map has a corresponding secret-containing value, use the hashed
+///   version; otherwise keep the provider value
+/// - If desired is a `List` and provider is an array, merge element-by-element
+/// - Otherwise, return the provider value as-is
+pub fn merge_secrets_into_provider_json(
+    desired: &Value,
+    provider_json: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    match desired {
+        Value::Secret(_) => value_to_json(desired),
+        Value::Map(desired_map) => {
+            if let serde_json::Value::Object(provider_obj) = provider_json {
+                let mut merged = provider_obj.clone();
+                for (k, desired_val) in desired_map {
+                    if contains_secret(desired_val) {
+                        if let Some(provider_val) = provider_obj.get(k) {
+                            merged.insert(
+                                k.clone(),
+                                merge_secrets_into_provider_json(desired_val, provider_val)?,
+                            );
+                        } else {
+                            // Key only in desired (not returned by provider); use desired hash
+                            merged.insert(k.clone(), value_to_json(desired_val)?);
+                        }
+                    }
+                }
+                Ok(serde_json::Value::Object(merged))
+            } else {
+                // Provider didn't return a map; fall back to desired
+                value_to_json(desired)
+            }
+        }
+        Value::List(desired_items) => {
+            if let serde_json::Value::Array(provider_arr) = provider_json {
+                let mut merged = Vec::with_capacity(provider_arr.len());
+                for (i, provider_elem) in provider_arr.iter().enumerate() {
+                    if let Some(desired_elem) = desired_items.get(i) {
+                        if contains_secret(desired_elem) {
+                            merged.push(merge_secrets_into_provider_json(
+                                desired_elem,
+                                provider_elem,
+                            )?);
+                        } else {
+                            merged.push(provider_elem.clone());
+                        }
+                    } else {
+                        merged.push(provider_elem.clone());
+                    }
+                }
+                Ok(serde_json::Value::Array(merged))
+            } else {
+                value_to_json(desired)
+            }
+        }
+        _ => Ok(provider_json.clone()),
+    }
+}
+
 /// Check if a value is a list of maps (list-of-struct)
 pub fn is_list_of_maps(value: &Value) -> bool {
     if let Value::List(items) = value {
@@ -556,6 +632,49 @@ mod tests {
     fn test_format_value_secret() {
         let v = Value::Secret(Box::new(Value::String("my-password".to_string())));
         assert_eq!(format_value(&v), "(secret)");
+    }
+
+    #[test]
+    fn test_format_value_secret_in_map() {
+        let mut map = HashMap::new();
+        map.insert("Name".to_string(), Value::String("test".to_string()));
+        map.insert(
+            "SecretTag".to_string(),
+            Value::Secret(Box::new(Value::String("my-password".to_string()))),
+        );
+        let v = Value::Map(map);
+        let formatted = format_value(&v);
+        // Secret values inside maps should show as (secret), not the raw value
+        assert!(
+            formatted.contains("(secret)"),
+            "Expected (secret) in map display, got: {}",
+            formatted
+        );
+        assert!(
+            !formatted.contains("my-password"),
+            "Should not contain the secret value, got: {}",
+            formatted
+        );
+    }
+
+    #[test]
+    fn test_value_to_json_secret_in_map() {
+        let mut map = HashMap::new();
+        map.insert("Name".to_string(), Value::String("test".to_string()));
+        map.insert(
+            "SecretTag".to_string(),
+            Value::Secret(Box::new(Value::String("my-password".to_string()))),
+        );
+        let v = Value::Map(map);
+        let json = value_to_json(&v).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("Name").unwrap().as_str().unwrap(), "test");
+        let secret_val = obj.get("SecretTag").unwrap().as_str().unwrap();
+        assert!(
+            secret_val.starts_with(SECRET_PREFIX),
+            "Expected secret hash in map value JSON, got: {}",
+            secret_val
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/acceptance-tests/secret_env/env_tag.crn
+++ b/carina-provider-awscc/acceptance-tests/secret_env/env_tag.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name        = "secret-env-test"
+    Environment = env("CARINA_TEST_ENV_VALUE")
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/secret_env/run.sh
+++ b/carina-provider-awscc/acceptance-tests/secret_env/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Runs secret_env acceptance tests
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER="${1:-}"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+TESTS_RUN=0
+
+echo "secret_env acceptance tests"
+echo "════════════════════════════════════════"
+
+for test_file in "$SCRIPT_DIR"/tests/*.sh; do
+    [ "$(basename "$test_file")" = "_helpers.sh" ] && continue
+    test_name="$(basename "$test_file" .sh)"
+    if [ -n "$FILTER" ] && ! echo "$test_name" | grep -q "$FILTER"; then
+        continue
+    fi
+    echo ""
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if bash "$test_file"; then
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+echo "════════════════════════════════════════"
+
+[ "$TOTAL_FAILED" -gt 0 ] && exit 1

--- a/carina-provider-awscc/acceptance-tests/secret_env/secret_tag.crn
+++ b/carina-provider-awscc/acceptance-tests/secret_env/secret_tag.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name       = "secret-env-test"
+    SecretTag  = secret(env("CARINA_TEST_SECRET_VALUE"))
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/secret_env/tests/env_tag.sh
+++ b/carina-provider-awscc/acceptance-tests/secret_env/tests/env_tag.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Test: env() function passes environment variable value to resource
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: env() in tag value"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/env_tag.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+# Set the environment variable
+export CARINA_TEST_ENV_VALUE="production"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+
+assert_state_resource_count "assert: 1 resource created" "1" "$WORK_DIR"
+
+# Verify the env() value was correctly applied
+assert_state_value "assert: Environment tag = 'production'" \
+    '.resources[0].attributes.tags.Environment' \
+    'production' "$WORK_DIR"
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-provider-awscc/acceptance-tests/secret_env/tests/secret_tag.sh
+++ b/carina-provider-awscc/acceptance-tests/secret_env/tests/secret_tag.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Test: secret(env()) marks value as secret — hash in state, actual value sent to AWS
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: secret(env()) in tag value"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/secret_tag.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+# Set the secret value via environment variable
+export CARINA_TEST_SECRET_VALUE="super-secret-value"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+
+assert_state_resource_count "assert: 1 resource created" "1" "$WORK_DIR"
+
+# Verify the state does NOT contain the plaintext secret
+printf "  %-50s" "assert: state does not contain plaintext"
+STATE_CONTENT=$(cat "$WORK_DIR/carina.state.json")
+if echo "$STATE_CONTENT" | grep -q "super-secret-value"; then
+    echo "FAIL (plaintext found in state!)"
+    TEST_FAILED=$((TEST_FAILED + 1))
+else
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+fi
+
+# Verify the state contains a hash for the secret tag
+printf "  %-50s" "assert: state contains secret hash"
+SECRET_VAL=$(jq -r '.resources[0].attributes.tags.SecretTag' "$WORK_DIR/carina.state.json" 2>/dev/null)
+if echo "$SECRET_VAL" | grep -q "^_secret:sha256:"; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (expected _secret:sha256:..., got '$SECRET_VAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Verify the actual AWS resource has the real value (not the hash)
+# We check by verifying plan is idempotent (no changes) — if the value
+# were wrong, plan would detect a diff
+run_step "step3: plan still idempotent" "$CARINA_BIN" plan .
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -2,7 +2,9 @@
 
 use carina_core::deps::get_resource_dependencies;
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use carina_core::value::{json_to_dsl_value, value_to_json};
+use carina_core::value::{
+    contains_secret, json_to_dsl_value, merge_secrets_into_provider_json, value_to_json,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -476,9 +478,18 @@ impl ResourceState {
         // with the SHA256 hash. The provider returns the actual value (since
         // secrets are unwrapped before sending), but state should only store
         // the hash to avoid persisting sensitive data.
+        // For nested secrets (inside Maps/Lists), merge the hashed values into
+        // the provider-returned structure to preserve extra keys from the provider.
         for (k, v) in &resource.attributes {
-            if let Value::Secret(_) = v {
-                rs.attributes.insert(k.clone(), value_to_json(v)?);
+            if contains_secret(v) {
+                if let Some(provider_json) = rs.attributes.get(k).cloned() {
+                    rs.attributes.insert(
+                        k.clone(),
+                        merge_secrets_into_provider_json(v, &provider_json)?,
+                    );
+                } else {
+                    rs.attributes.insert(k.clone(), value_to_json(v)?);
+                }
             }
         }
         if let Some(existing) = existing {
@@ -1301,6 +1312,170 @@ mod tests {
         assert!(
             !stored.contains("my-password"),
             "State should not contain the plain password"
+        );
+    }
+
+    #[test]
+    fn test_from_provider_state_secret_in_map_stored_as_hash() {
+        use carina_core::resource::{Resource, State as ProviderState, Value};
+        use carina_core::value::SECRET_PREFIX;
+        use std::collections::HashMap as StdHashMap;
+
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "my-vpc");
+        let mut tags_map = StdHashMap::new();
+        tags_map.insert("Name".to_string(), Value::String("test".to_string()));
+        tags_map.insert(
+            "SecretTag".to_string(),
+            Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+        );
+        resource
+            .attributes
+            .insert("tags".to_string(), Value::Map(tags_map));
+
+        let mut state_tags = StdHashMap::new();
+        state_tags.insert("Name".to_string(), Value::String("test".to_string()));
+        state_tags.insert(
+            "SecretTag".to_string(),
+            Value::String("super-secret-value".to_string()),
+        );
+
+        let provider_state = ProviderState {
+            id: resource.id.clone(),
+            identifier: Some("vpc-123".to_string()),
+            attributes: [("tags".to_string(), Value::Map(state_tags))]
+                .into_iter()
+                .collect(),
+            exists: true,
+        };
+
+        let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
+
+        // The tags map in state should have the hash for SecretTag
+        let tags_json = rs.attributes.get("tags").unwrap();
+        let tags_obj = tags_json.as_object().unwrap();
+
+        // Name should be plain
+        assert_eq!(tags_obj.get("Name").unwrap().as_str().unwrap(), "test");
+
+        // SecretTag should be stored as a hash, not the plain value
+        let secret_stored = tags_obj.get("SecretTag").unwrap().as_str().unwrap();
+        assert!(
+            secret_stored.starts_with(SECRET_PREFIX),
+            "Expected secret hash in map value, got: {}",
+            secret_stored
+        );
+        assert!(
+            !secret_stored.contains("super-secret-value"),
+            "State should not contain the plain secret value in map"
+        );
+    }
+
+    #[test]
+    fn test_from_provider_state_secret_in_map_preserves_provider_extra_keys() {
+        use carina_core::resource::{Resource, State as ProviderState, Value};
+        use carina_core::value::SECRET_PREFIX;
+        use std::collections::HashMap as StdHashMap;
+
+        // User specifies only SecretTag in tags
+        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "my-vpc");
+        let mut tags_map = StdHashMap::new();
+        tags_map.insert(
+            "SecretTag".to_string(),
+            Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+        );
+        resource
+            .attributes
+            .insert("tags".to_string(), Value::Map(tags_map));
+
+        // Provider returns extra keys (e.g., CloudControl adds Name automatically)
+        let mut state_tags = StdHashMap::new();
+        state_tags.insert("Name".to_string(), Value::String("test".to_string()));
+        state_tags.insert(
+            "ExtraTag".to_string(),
+            Value::String("extra-value".to_string()),
+        );
+        state_tags.insert(
+            "SecretTag".to_string(),
+            Value::String("super-secret-value".to_string()),
+        );
+
+        let provider_state = ProviderState {
+            id: resource.id.clone(),
+            identifier: Some("vpc-123".to_string()),
+            attributes: [("tags".to_string(), Value::Map(state_tags))]
+                .into_iter()
+                .collect(),
+            exists: true,
+        };
+
+        let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
+
+        let tags_json = rs.attributes.get("tags").unwrap();
+        let tags_obj = tags_json.as_object().unwrap();
+
+        // Provider-only keys should be preserved from the provider state
+        assert_eq!(tags_obj.get("Name").unwrap().as_str().unwrap(), "test");
+        assert_eq!(
+            tags_obj.get("ExtraTag").unwrap().as_str().unwrap(),
+            "extra-value"
+        );
+
+        // SecretTag should be stored as a hash, not the plain value
+        let secret_stored = tags_obj.get("SecretTag").unwrap().as_str().unwrap();
+        assert!(
+            secret_stored.starts_with(SECRET_PREFIX),
+            "Expected secret hash in map value, got: {}",
+            secret_stored
+        );
+        assert!(
+            !secret_stored.contains("super-secret-value"),
+            "State should not contain the plain secret value in map"
+        );
+    }
+
+    #[test]
+    fn test_from_provider_state_secret_in_list_stored_as_hash() {
+        use carina_core::resource::{Resource, State as ProviderState, Value};
+        use carina_core::value::SECRET_PREFIX;
+
+        let mut resource = Resource::with_provider("awscc", "test.resource", "my-res");
+        resource.attributes.insert(
+            "values".to_string(),
+            Value::List(vec![
+                Value::String("public".to_string()),
+                Value::Secret(Box::new(Value::String("secret-item".to_string()))),
+            ]),
+        );
+
+        let provider_state = ProviderState {
+            id: resource.id.clone(),
+            identifier: Some("res-123".to_string()),
+            attributes: [(
+                "values".to_string(),
+                Value::List(vec![
+                    Value::String("public".to_string()),
+                    Value::String("secret-item".to_string()),
+                ]),
+            )]
+            .into_iter()
+            .collect(),
+            exists: true,
+        };
+
+        let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
+
+        let values_json = rs.attributes.get("values").unwrap();
+        let values_arr = values_json.as_array().unwrap();
+
+        // First item should be plain
+        assert_eq!(values_arr[0].as_str().unwrap(), "public");
+
+        // Second item should be stored as a hash
+        let secret_stored = values_arr[1].as_str().unwrap();
+        assert!(
+            secret_stored.starts_with(SECRET_PREFIX),
+            "Expected secret hash in list value, got: {}",
+            secret_stored
         );
     }
 }


### PR DESCRIPTION
## Summary
- Fix 3 bugs with `secret()` when nested inside Map values (tags)
- Add acceptance tests for `env()` and `secret(env())` 
- Closes #1242 (partial — decrypt() tests deferred until #1240 is implemented)

## Bugs fixed
1. **Validation rejected Secret in Map(String)** — added Secret to validation skip list alongside FunctionCall
2. **State stored plaintext for nested secrets** — added `merge_secrets_into_provider_json()` for recursive hash merging
3. **Differ couldn't compare nested Secret vs hash** — already covered by existing type_aware_equal Secret handling

## Acceptance tests
- `env()`: environment variable → tag value → verified in state
- `secret(env())`: secret → hash in state, no plaintext, plan idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)