### PR TITLE
test: add decrypt() acceptance test and fix block_on panic

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -179,38 +179,39 @@ fn register_kms_decryptor() {
         let ciphertext = ciphertext.to_string();
         let key = key.map(|k| k.to_string());
 
-        let rt = tokio::runtime::Handle::current();
-        rt.block_on(async {
-            let client = KMS_CLIENT
-                .get_or_init(|| async {
-                    let config =
-                        aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
-                    aws_sdk_kms::Client::new(&config)
-                })
-                .await;
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let client = KMS_CLIENT
+                    .get_or_init(|| async {
+                        let config =
+                            aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+                        aws_sdk_kms::Client::new(&config)
+                    })
+                    .await;
 
-            let blob = base64::engine::general_purpose::STANDARD
-                .decode(&ciphertext)
-                .map_err(|e| format!("decrypt(): invalid base64 ciphertext: {e}"))?;
+                let blob = base64::engine::general_purpose::STANDARD
+                    .decode(&ciphertext)
+                    .map_err(|e| format!("decrypt(): invalid base64 ciphertext: {e}"))?;
 
-            let mut req = client
-                .decrypt()
-                .ciphertext_blob(aws_sdk_kms::primitives::Blob::new(blob));
-            if let Some(k) = key {
-                req = req.key_id(k);
-            }
+                let mut req = client
+                    .decrypt()
+                    .ciphertext_blob(aws_sdk_kms::primitives::Blob::new(blob));
+                if let Some(k) = key {
+                    req = req.key_id(k);
+                }
 
-            let resp = req
-                .send()
-                .await
-                .map_err(|e| format!("decrypt(): KMS decrypt failed: {e}"))?;
+                let resp = req
+                    .send()
+                    .await
+                    .map_err(|e| format!("decrypt(): KMS decrypt failed: {e}"))?;
 
-            let plaintext = resp
-                .plaintext()
-                .ok_or_else(|| "decrypt(): KMS response contained no plaintext".to_string())?;
+                let plaintext = resp
+                    .plaintext()
+                    .ok_or_else(|| "decrypt(): KMS response contained no plaintext".to_string())?;
 
-            String::from_utf8(plaintext.as_ref().to_vec())
-                .map_err(|e| format!("decrypt(): decrypted value is not valid UTF-8: {e}"))
+                String::from_utf8(plaintext.as_ref().to_vec())
+                    .map_err(|e| format!("decrypt(): decrypted value is not valid UTF-8: {e}"))
+            })
         })
     }));
 }

--- a/carina-provider-awscc/acceptance-tests/secret_env/decrypt_tag.crn
+++ b/carina-provider-awscc/acceptance-tests/secret_env/decrypt_tag.crn
@@ -1,0 +1,16 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# KMS-encrypted value (encrypted with alias/carina-test key in carina-test-000 account)
+# Plaintext: "decrypt-test-value"
+let encrypted = "AQICAHiUU4BhXxV/24kFblvFgRinfx00Rva9nBXHESKU/n2W1QHeJgFItWvJdpm6QXmCH3s7AAAAajBoBgkqhkiG9w0BBwagWzBZAgEAMFQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdsKc/QPUdhV6Uy4dAgEQgCeZSRW3iwDwiszbvKUyTpsZRQZdGQzY9M94i6ZO70MQdiy8wEi+DEs="
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name         = "decrypt-test"
+    DecryptedTag = secret(decrypt(encrypted))
+  }
+}

--- a/carina-provider-awscc/acceptance-tests/secret_env/tests/decrypt_tag.sh
+++ b/carina-provider-awscc/acceptance-tests/secret_env/tests/decrypt_tag.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Test: secret(decrypt()) — KMS-encrypted value decrypted and stored as hash
+# Requires carina-test-000 account with alias/carina-test KMS key
+source "$(dirname "$0")/../../shared/_helpers.sh"
+
+echo "Test: secret(decrypt()) with KMS"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+ACTIVE_WORK_DIR="$WORK_DIR"
+cp "$SCRIPT_DIR/decrypt_tag.crn" "$WORK_DIR/main.crn"
+cd "$WORK_DIR"
+
+run_step "step1: apply" "$CARINA_BIN" apply --auto-approve .
+run_step "step2: plan-verify" "$CARINA_BIN" plan .
+
+assert_state_resource_count "assert: 1 resource created" "1" "$WORK_DIR"
+
+# Verify state does NOT contain plaintext
+printf "  %-50s" "assert: state does not contain plaintext"
+if grep -q "decrypt-test-value" "$WORK_DIR/carina.state.json"; then
+    echo "FAIL (plaintext found in state!)"
+    TEST_FAILED=$((TEST_FAILED + 1))
+else
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+fi
+
+# Verify state contains argon2 hash for the decrypted tag
+printf "  %-50s" "assert: state contains secret hash"
+SECRET_VAL=$(jq -r '.resources[0].attributes.tags.DecryptedTag' "$WORK_DIR/carina.state.json" 2>/dev/null)
+if echo "$SECRET_VAL" | grep -q "^_secret:argon2:"; then
+    echo "OK"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    echo "FAIL (expected _secret:argon2:..., got '$SECRET_VAL')"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Verify the actual AWS resource has the decrypted value
+# (plan idempotency confirms the value was sent correctly)
+run_step "step3: plan still idempotent" "$CARINA_BIN" plan .
+
+echo "  Cleanup: destroying resources..."
+"$CARINA_BIN" destroy --auto-approve . > /dev/null 2>&1 || true
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+finish_test


### PR DESCRIPTION
## Summary
- Add acceptance test for `secret(decrypt())` with KMS-encrypted values
- Fix tokio runtime nesting panic (block_on inside async runtime) by using `block_in_place`
- References #1242

## Known issue
Plan-verify shows false diff for `secret(decrypt())` — Argon2 context-specific salt produces different hashes between apply state save and plan diff comparison. Will be tracked in a separate issue.

## Test plan
- [x] decrypt() acceptance test: apply succeeds, state contains argon2 hash, no plaintext

🤖 Generated with [Claude Code](https://claude.com/claude-code)