### PR TITLE
fix: secret in Map false diff on plan-verify (refresh=true)

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -248,10 +248,16 @@ fn is_type_default(value: &Value, attr_type: Option<&AttributeType>) -> bool {
     }
 }
 
-/// Check if a secret's inner value matches a state hash string.
+/// Check if a secret's inner value matches a state value.
 ///
-/// Hashes the inner value the same way `value_to_json` does for `Value::Secret`,
-/// then compares the resulting hash string with the state value.
+/// Two cases are handled:
+/// 1. **Hash string** (from state file, `--refresh=false`): the state value is
+///    `"_secret:argon2:<hex>"`. We hash the inner value and compare hashes.
+/// 2. **Plain-text string** (from provider read, `--refresh=true`): the state
+///    value is the raw secret. We compare the inner value directly. This is the
+///    fix for issue #1249 where secrets nested in Maps (e.g., tags) caused false
+///    diffs because the provider returns plain-text values on read.
+///
 /// When `context` is provided, uses context-specific salt for hashing.
 fn secret_matches_state(
     inner: &Value,
@@ -261,18 +267,25 @@ fn secret_matches_state(
     let Value::String(state_str) = state_value else {
         return false;
     };
-    let Some(state_hash) = state_str.strip_prefix(SECRET_PREFIX) else {
-        return false;
-    };
-    // Compute the hash of the inner value
-    let Ok(inner_json) = value_to_json_with_context(inner, context) else {
-        return false;
-    };
-    let Ok(json_str) = serde_json::to_string(&inner_json) else {
-        return false;
-    };
-    let computed_hash = argon2id_hash(json_str.as_bytes(), context);
-    computed_hash == state_hash
+
+    // Case 1: State has a hashed value (from state file / --refresh=false)
+    if let Some(state_hash) = state_str.strip_prefix(SECRET_PREFIX) {
+        let Ok(inner_json) = value_to_json_with_context(inner, context) else {
+            return false;
+        };
+        let Ok(json_str) = serde_json::to_string(&inner_json) else {
+            return false;
+        };
+        let computed_hash = argon2id_hash(json_str.as_bytes(), context);
+        return computed_hash == state_hash;
+    }
+
+    // Case 2: State has plain-text value (from provider read / --refresh=true).
+    // Compare the inner secret value directly against the raw state string.
+    match inner {
+        Value::String(inner_str) => inner_str == state_str,
+        _ => false,
+    }
 }
 
 /// Find changed attributes between desired and current state.

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -761,3 +761,85 @@ fn secret_same_password_different_resources_produces_different_hashes() {
         "Hash from db-1 should not match db-2's context"
     );
 }
+
+/// Regression test for #1249: Secret compared against plain-text state value
+/// (as returned by provider.read in refresh=true mode) should match when
+/// the inner values are equal.
+#[test]
+fn secret_matches_plain_text_state_value() {
+    let secret = Value::Secret(Box::new(Value::String("my-password".to_string())));
+    let plain = Value::String("my-password".to_string());
+    assert!(
+        type_aware_equal(&secret, &plain, None, None),
+        "Secret should match plain-text state when inner values are equal"
+    );
+    assert!(
+        type_aware_equal(&plain, &secret, None, None),
+        "Plain-text state should match secret when inner values are equal"
+    );
+}
+
+/// Secret with different inner value should NOT match plain-text state.
+#[test]
+fn secret_does_not_match_different_plain_text() {
+    let secret = Value::Secret(Box::new(Value::String("my-password".to_string())));
+    let plain = Value::String("other-password".to_string());
+    assert!(
+        !type_aware_equal(&secret, &plain, None, None),
+        "Secret should not match different plain-text state"
+    );
+}
+
+/// Regression test for #1249: secret nested inside a Map (e.g., tags) with
+/// refresh=true. After apply, plan reads from the provider which returns
+/// the plain-text tag value. The differ must recognize that
+/// Secret("super-secret-value") matches String("super-secret-value") when
+/// the state value is the raw provider response (not a hash).
+#[test]
+fn secret_in_map_with_refresh_no_false_diff() {
+    use crate::resource::ResourceId;
+    use crate::schema::{AttributeSchema, ResourceSchema};
+
+    let resource_id = ResourceId::with_provider("awscc", "ec2.vpc", "ec2_vpc_fb75c929");
+
+    // Desired: tags map with a secret value (as written in .crn)
+    let desired_tags = Value::Map(HashMap::from([
+        ("Name".to_string(), Value::String("test".to_string())),
+        (
+            "SecretTag".to_string(),
+            Value::Secret(Box::new(Value::String("super-secret-value".to_string()))),
+        ),
+    ]));
+
+    // Current state from provider read (refresh=true): plain-text values
+    let current_tags = Value::Map(HashMap::from([
+        ("Name".to_string(), Value::String("test".to_string())),
+        (
+            "SecretTag".to_string(),
+            Value::String("super-secret-value".to_string()),
+        ),
+    ]));
+
+    // Build schema with tags as Map(String)
+    let schema = ResourceSchema::new("ec2.vpc").attribute(AttributeSchema::new(
+        "tags",
+        AttributeType::Map(Box::new(AttributeType::String)),
+    ));
+
+    let desired = HashMap::from([("tags".to_string(), desired_tags)]);
+    let current = HashMap::from([("tags".to_string(), current_tags)]);
+
+    let changed = find_changed_attributes(
+        &desired,
+        &current,
+        None,
+        None,
+        Some(&schema),
+        Some(&resource_id),
+    );
+    assert!(
+        changed.is_empty(),
+        "Secret in map should not show false diff when current has plain-text from provider (issue #1249), got changed: {:?}",
+        changed,
+    );
+}


### PR DESCRIPTION
## Summary

- Fix `secret_matches_state()` to handle plain-text state values from provider read (refresh=true), not just hash strings from state file
- Add regression tests for secret-in-Map with refresh=true and direct secret-vs-plaintext comparison

## Root Cause

After `apply`, running `plan` with refresh=true reads from the provider which returns plain-text tag values. `secret_matches_state()` only handled `_secret:argon2:...` hash strings (from the state file), so `Secret("value")` vs `String("value")` always returned false, causing a false diff.

## Test plan

- [x] Failing test written first, confirms the bug
- [x] `cargo test -p carina-core` passes (843 tests)
- [x] `cargo test -p carina-state` passes (75 tests)
- [x] `cargo clippy -p carina-core` clean
- [ ] Acceptance test: `CARINA_TEST_SECRET_VALUE="super-secret-value" aws-vault exec carina-test-000 -- ./carina-provider-awscc/acceptance-tests/secret_env/run.sh secret_tag`

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)