### PR TITLE
test: add plan display snapshot test for secret() values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ plan-explicit:
 plan-default-tags:
 	cd $(FIXTURES)/default_tags && $(CARINA) plan --refresh=false main.crn
 
+plan-secret-values:
+	cd $(FIXTURES)/secret_values && $(CARINA) plan --refresh=false main.crn
+
 plan-map-diff-tui:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false --tui main.crn
 
@@ -103,9 +106,12 @@ plan-fixtures:
 	@echo ""
 	@echo "=== state_blocks ==="
 	@$(MAKE) plan-state-blocks
+	@echo ""
+	@echo "=== secret_values ==="
+	@$(MAKE) plan-secret-values
 
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
-        plan-state-blocks \
+        plan-state-blocks plan-secret-values \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui plan-fixtures

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -387,6 +387,32 @@ fn snapshot_state_blocks() {
     insta::assert_snapshot!(output);
 }
 
+#[test]
+fn snapshot_secret_values() {
+    use carina_core::resource::Value;
+    let (plan, current_states, schemas) = build_plan_and_states_from_fixture("secret_values");
+    let delete_attributes: HashMap<ResourceId, HashMap<String, Value>> = plan
+        .effects()
+        .iter()
+        .filter_map(|e| {
+            if let carina_core::effect::Effect::Delete { id, .. } = e {
+                current_states
+                    .get(id)
+                    .map(|s| (id.clone(), s.attributes.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &delete_attributes,
+        Some(&schemas),
+    ));
+    insta::assert_snapshot!(output);
+}
+
 /// Ensure no fixture .crn file has unused `let` bindings.
 ///
 /// `let` should only be used when a binding is referenced by another resource.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_secret_values.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_secret_values.snap
@@ -1,0 +1,19 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  - awscc.ec2.subnet orphan_subnet
+      cidr_block: "10.0.1.0/24"
+      subnet_id: "subnet-0123456789abcdef0"
+      tags:
+        ApiKey: (secret)
+        Name: "orphan-subnet"
+      vpc_id: "vpc-0123456789abcdef0"
+  ~ awscc.ec2.vpc ec2_vpc_fb75c929
+      tags:
+        ~ Password: (secret) → (secret)
+      # (1 unchanged attribute hidden)
+
+Plan: 0 to add, 1 to change, 1 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
@@ -1,0 +1,51 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-secret",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.vpc",
+      "name": "ec2_vpc_fb75c929",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0123456789abcdef0",
+        "tags": {
+          "Name": "secret-test",
+          "Password": "_secret:argon2:0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block", "tags"],
+      "binding": null,
+      "dependency_bindings": []
+    },
+    {
+      "resource_type": "ec2.subnet",
+      "name": "orphan_subnet",
+      "provider": "awscc",
+      "identifier": "subnet-0123456789abcdef0",
+      "attributes": {
+        "vpc_id": "vpc-0123456789abcdef0",
+        "cidr_block": "10.0.1.0/24",
+        "subnet_id": "subnet-0123456789abcdef0",
+        "tags": {
+          "Name": "orphan-subnet",
+          "ApiKey": "_secret:argon2:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["vpc_id", "cidr_block", "tags"],
+      "binding": null,
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/secret_values/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/secret_values/main.crn
@@ -1,0 +1,13 @@
+# Secret values: VPC with secret tag (update scenario - state has different hash)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name     = "secret-test"
+    Password = secret("my-secret-password")
+  }
+}


### PR DESCRIPTION
## Summary

- Add `secret_values` fixture with `.crn` and state file covering secret masking in plan output
- Add `snapshot_secret_values` test that captures update and delete effects for secret attributes
- Add `plan-secret-values` Makefile target for visual confirmation

Covers:
- **Update effect**: changed secret displays `(secret) -> (secret)` (both old and new values masked)
- **Delete effect**: orphaned resource with secret tag displays `(secret)`

Closes #1252

## Test plan

- [x] `cargo test -p carina-cli plan_snapshot` passes (17 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `no_unused_let_bindings_in_fixtures` passes (no `let` used since no cross-resource references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)