### PR TITLE
fix: resolve chained forward references to ResourceRef with field_path

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -2088,9 +2088,10 @@ fn resolve_forward_ref_in_value(
 ) -> Value {
     match value {
         Value::String(ref s) => {
-            // A dotted string like "vpc.vpc_id" may be a forward reference that
-            // was stored as a string during single-pass parsing. Resolve it to
-            // ResourceRef if the first segment is a known resource binding.
+            // A dotted string like "vpc.vpc_id" or "vpc.attr.nested" may be a
+            // forward reference that was stored as a string during single-pass
+            // parsing. Resolve it to ResourceRef if the first segment is a known
+            // resource binding. Parts after the second become field_path.
             let parts: Vec<&str> = s.splitn(3, '.').collect();
             if parts.len() >= 2 && resource_bindings.contains_key(parts[0]) {
                 let field_path = parts


### PR DESCRIPTION
## Summary

- Fix `resolve_forward_ref_in_value()` to handle dotted strings with 3+ parts (e.g., `"vpc.attr.nested"`) by splitting into `binding_name`, `attribute_name`, and `field_path`
- The previous code explicitly rejected strings with more than one dot via `!member.contains('.')`, leaving chained forward references as plain `String` values

## Test plan

- [x] Added `forward_reference_chained_three_parts` test: `"vpc.encryption_specification.status"` resolves to `ResourceRef` with `field_path: ["status"]`
- [x] Added `forward_reference_chained_four_parts` test: `"vpc.config.deep.nested"` resolves to `ResourceRef` with `field_path: ["deep", "nested"]`
- [x] All existing forward reference tests still pass (6/6)
- [x] Full `cargo test -p carina-core` passes

Closes #1259

🤖 Generated with [Claude Code](https://claude.com/claude-code)