### PR TITLE
fix: moved block with attribute changes produces Update effect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ plan-default-tags:
 plan-secret-values:
 	cd $(FIXTURES)/secret_values && $(CARINA) plan --refresh=false main.crn
 
+plan-moved-with-changes:
+	cd $(FIXTURES)/moved_with_changes && $(CARINA) plan --refresh=false main.crn
+
 plan-map-diff-tui:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false --tui main.crn
 
@@ -109,9 +112,12 @@ plan-fixtures:
 	@echo ""
 	@echo "=== secret_values ==="
 	@$(MAKE) plan-secret-values
+	@echo ""
+	@echo "=== moved_with_changes ==="
+	@$(MAKE) plan-moved-with-changes
 
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
-        plan-state-blocks plan-secret-values \
+        plan-state-blocks plan-secret-values plan-moved-with-changes \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui plan-fixtures

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1091,6 +1091,14 @@ async fn run_apply_locked(
     crate::wiring::resolve_enum_aliases_with_ctx(ctx, &mut resources_for_plan);
     crate::wiring::resolve_enum_aliases_in_states(ctx, &mut current_states);
 
+    // Pre-process moved blocks: transfer state from old name to new name
+    // so the differ sees attribute changes and produces Update/Replace effects.
+    let moved_pairs = crate::wiring::materialize_moved_states(
+        &mut current_states,
+        &parsed.state_blocks,
+        &state_file,
+    );
+
     let lifecycles = state_file
         .as_ref()
         .map(|sf| sf.build_lifecycles())
@@ -1115,7 +1123,12 @@ async fn run_apply_locked(
     cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, schemas);
 
     // Add state block effects (import/removed/moved) to the plan
-    crate::wiring::add_state_block_effects(&mut plan, &parsed.state_blocks, &state_file);
+    crate::wiring::add_state_block_effects(
+        &mut plan,
+        &parsed.state_blocks,
+        &state_file,
+        &moved_pairs,
+    );
 
     if plan.is_empty() {
         println!("{}", "No changes needed.".green());

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -161,6 +161,13 @@ fn build_plan_and_states_from_fixture(
         HashMap::new()
     };
 
+    // Pre-process moved blocks: transfer state from old name to new name
+    let moved_pairs = crate::wiring::materialize_moved_states(
+        &mut current_states,
+        &parsed.state_blocks,
+        &state_file,
+    );
+
     let mut plan = create_plan(
         &resources,
         &current_states,
@@ -179,7 +186,12 @@ fn build_plan_and_states_from_fixture(
     );
 
     // Add state block effects (import/removed/moved)
-    crate::wiring::add_state_block_effects(&mut plan, &parsed.state_blocks, &state_file);
+    crate::wiring::add_state_block_effects(
+        &mut plan,
+        &parsed.state_blocks,
+        &state_file,
+        &moved_pairs,
+    );
 
     (plan, current_states, wiring.schemas().clone())
 }
@@ -409,6 +421,18 @@ fn snapshot_secret_values() {
         &plan,
         DetailLevel::Full,
         &delete_attributes,
+        Some(&schemas),
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_moved_with_changes() {
+    let (plan, schemas) = build_plan_from_fixture("moved_with_changes");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
         Some(&schemas),
     ));
     insta::assert_snapshot!(output);

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_with_changes.snap
@@ -1,0 +1,20 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  -> awscc.ec2.vpc new_vpc (from: awscc.ec2.vpc.old_vpc)
+  ~ awscc.ec2.vpc new_vpc
+      tags: (none) → {Name: "updated"}
+      # (1 unchanged attribute hidden)
+        │
+        └─ + awscc.ec2.subnet ec2_subnet_739e36ff
+              cidr_block: "10.0.1.0/24"
+              vpc_id: new_vpc.vpc_id
+              block_public_access_states: (known after apply)
+              ipv6_cidr_blocks: (known after apply)
+              network_acl_association_id: (known after apply)
+              subnet_id: (known after apply)
+
+Plan: 1 to add, 1 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -550,6 +550,11 @@ pub async fn create_plan_from_parsed(
     resolve_enum_aliases_with_ctx(&ctx, &mut resources);
     resolve_enum_aliases_in_states(&ctx, &mut current_states);
 
+    // Pre-process moved blocks: transfer state from old name to new name
+    // so the differ sees attribute changes and produces Update/Replace effects.
+    let moved_pairs =
+        materialize_moved_states(&mut current_states, &parsed.state_blocks, state_file);
+
     // Build lifecycles map from state file for orphaned resource deletion
     let lifecycles = state_file
         .as_ref()
@@ -576,13 +581,49 @@ pub async fn create_plan_from_parsed(
     cascade_dependent_updates(&mut plan, &sorted_resources, &current_states, ctx.schemas());
 
     // Add state block effects (import/removed/moved) to the plan
-    add_state_block_effects(&mut plan, &parsed.state_blocks, state_file);
+    add_state_block_effects(&mut plan, &parsed.state_blocks, state_file, &moved_pairs);
 
     Ok(PlanContext {
         plan,
         sorted_resources,
         current_states,
     })
+}
+
+/// Pre-process moved blocks by transferring state from the old name to the new name.
+///
+/// This must be called BEFORE `create_plan()` so the differ sees the moved
+/// resource's state under its new name and can produce Update/Replace effects
+/// if attributes differ between state and desired.
+///
+/// Returns a list of active Move pairs (from, to) where the `from` resource
+/// existed in state. Callers use this to add Move effects to the plan.
+pub fn materialize_moved_states(
+    current_states: &mut HashMap<ResourceId, State>,
+    state_blocks: &[StateBlock],
+    state_file: &Option<StateFile>,
+) -> Vec<(ResourceId, ResourceId)> {
+    let mut moved_pairs = Vec::new();
+
+    for block in state_blocks {
+        if let StateBlock::Moved { from, to } = block {
+            let old_in_state = state_file.as_ref().is_some_and(|sf| {
+                sf.find_resource(&from.provider, &from.resource_type, &from.name)
+                    .is_some()
+            });
+            if old_in_state {
+                // Transfer state from the old name to the new name so the
+                // differ compares desired(to) against actual(from).
+                if let Some(mut state) = current_states.remove(from) {
+                    state.id = to.clone();
+                    current_states.insert(to.clone(), state);
+                }
+                moved_pairs.push((from.clone(), to.clone()));
+            }
+        }
+    }
+
+    moved_pairs
 }
 
 /// Add state block effects (import/removed/moved) to the plan.
@@ -592,16 +633,21 @@ pub async fn create_plan_from_parsed(
 /// - Removed: the resource does not exist in state
 /// - Moved: the old resource does not exist in state (already moved)
 ///
+/// For `moved` blocks, `materialize_moved_states()` must be called before
+/// `create_plan()` to transfer state entries. The pre-computed `moved_pairs`
+/// are passed here to add Move effects without re-checking state.
+///
 /// This function also removes Delete effects for resources covered by
-/// `removed` or `moved` blocks, since those operations manage state
-/// without destroying infrastructure.
+/// `removed` blocks, since those operations manage state without
+/// destroying infrastructure.
 pub fn add_state_block_effects(
     plan: &mut Plan,
     state_blocks: &[StateBlock],
     state_file: &Option<StateFile>,
+    moved_pairs: &[(ResourceId, ResourceId)],
 ) {
-    // Collect resource IDs that are covered by removed/moved blocks
-    // to suppress orphan Delete effects and moved-to Create effects
+    // Collect resource IDs that are covered by removed blocks
+    // to suppress orphan Delete effects
     let mut suppress_delete: std::collections::HashSet<ResourceId> =
         std::collections::HashSet::new();
     let mut suppress_create: std::collections::HashSet<ResourceId> =
@@ -636,26 +682,25 @@ pub fn add_state_block_effects(
                     new_effects.push(Effect::Remove { id: from.clone() });
                 }
             }
-            StateBlock::Moved { from, to } => {
-                // Skip if old resource is not in state (already moved)
-                let old_in_state = state_file.as_ref().is_some_and(|sf| {
-                    sf.find_resource(&from.provider, &from.resource_type, &from.name)
-                        .is_some()
-                });
-                if old_in_state {
-                    suppress_delete.insert(from.clone());
-                    suppress_create.insert(to.clone());
-                    new_effects.push(Effect::Move {
-                        from: from.clone(),
-                        to: to.clone(),
-                    });
-                }
+            StateBlock::Moved { .. } => {
+                // Moved blocks are handled by materialize_moved_states() + moved_pairs below
             }
         }
     }
 
-    // Remove Delete effects for resources covered by removed/moved blocks,
-    // and Create effects for moved-to resources (they inherit state from the old name)
+    // Add Move effects from pre-computed moved pairs.
+    // Also suppress orphan Delete for `to` when there is no desired resource
+    // for the target (the moved state entry would otherwise appear as an orphan).
+    for (from, to) in moved_pairs {
+        suppress_delete.insert(to.clone());
+        new_effects.push(Effect::Move {
+            from: from.clone(),
+            to: to.clone(),
+        });
+    }
+
+    // Remove Delete effects for resources covered by removed blocks,
+    // and Create effects for import targets (they will be imported, not created)
     if !suppress_delete.is_empty() || !suppress_create.is_empty() {
         plan.retain(|effect| match effect {
             Effect::Delete { id, .. } => !suppress_delete.contains(id),

--- a/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
@@ -1,0 +1,25 @@
+{
+  "version": 4,
+  "serial": 1,
+  "lineage": "test-moved-with-changes",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.vpc",
+      "name": "old_vpc",
+      "provider": "awscc",
+      "identifier": "vpc-old123",
+      "attributes": {
+        "vpc_id": "vpc-old123",
+        "cidr_block": "10.0.0.0/16"
+      },
+      "protected": false,
+      "lifecycle": { "force_delete": false, "create_before_destroy": false },
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block"],
+      "binding": "old_vpc",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/moved_with_changes/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/moved_with_changes/main.crn
@@ -1,0 +1,24 @@
+# Moved block with attribute changes: Move + Update
+# State has "old_vpc" with cidr_block=10.0.0.0/16, no tags.
+# After move to "new_vpc", tags are added -> expect Update effect.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+moved {
+  from = awscc.ec2.vpc "old_vpc"
+  to   = awscc.ec2.vpc "new_vpc"
+}
+
+let new_vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "updated"
+  }
+}
+
+awscc.ec2.subnet {
+  vpc_id     = new_vpc.vpc_id
+  cidr_block = "10.0.1.0/24"
+}


### PR DESCRIPTION
## Summary

- Fix `moved` block not producing Update/Replace effects when the target resource has different attributes than the source state
- Add `materialize_moved_states()` to transfer state entries from old name to new name **before** `create_plan()`, so the differ naturally detects attribute differences
- Update `add_state_block_effects()` to accept pre-computed moved pairs instead of re-processing moved blocks

## Changes

The core issue was that moved blocks were processed **after** diffing: `add_state_block_effects()` would suppress Delete(from) and Create(to), then add a Move effect. But the differ never compared the target's desired attributes against the source's actual state, so attribute changes were silently lost.

The fix moves state manipulation **before** `create_plan()`:
1. `materialize_moved_states()` transfers state entries from `from` to `to` in `current_states`
2. The differ now sees the old state under the new name and produces Update/Replace effects if attributes differ
3. `add_state_block_effects()` adds Move effects from pre-computed pairs and suppresses orphan Deletes for moved targets

Updated in three code paths: `create_plan_from_parsed` (wiring.rs), apply-from-plan (apply.rs), and snapshot test helper (plan_snapshot_tests.rs).

## Test plan

- [x] New fixture `moved_with_changes/`: state has old_vpc with cidr_block only, .crn has new_vpc with cidr_block + tags -> snapshot shows Move + Update
- [x] Existing `state_blocks` snapshot unchanged (move-only without attribute changes still works)
- [x] All 175 carina-cli tests pass
- [x] `cargo clippy` and `cargo fmt` clean

Closes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)