### PR TITLE
feat: support all schema types in type annotations

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -73,12 +73,12 @@ attributes_param = {
   | identifier ~ trivia* ~ equals ~ trivia* ~ expression
 }
 
-// Type expression: string, bool, int, cidr, list(type), map(type), aws.resource (resource ref)
+// Type expression: string, bool, int, cidr, arn, etc., list(type), map(type), aws.resource (resource ref)
 type_expr = {
     type_ref | type_list | type_map | type_primitive
 }
 
-type_primitive = @{ "string" | "bool" | "int" | "float" | "cidr" }
+type_primitive = @{ identifier }
 
 type_list = { kw_list ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ close_paren }
 

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -2776,4 +2776,32 @@ mod tests {
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn format_custom_schema_type_annotations() {
+        let config = FormatConfig::default();
+
+        // Custom type in arguments block
+        let input = "arguments {\nvpc_cidr: cidr\nserver_ip: ipv4_address\n}\n";
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("vpc_cidr") && result.contains("cidr"),
+            "Expected 'vpc_cidr' and 'cidr' in:\n{}",
+            result
+        );
+        assert!(
+            result.contains("server_ip") && result.contains("ipv4_address"),
+            "Expected 'server_ip' and 'ipv4_address' in:\n{}",
+            result
+        );
+
+        // Custom type in fn param
+        let input = "fn f(addr: arn) {\n  addr\n}\n";
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("addr: arn"),
+            "Expected 'addr: arn' in:\n{}",
+            result
+        );
+    }
 }

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -43,9 +43,9 @@ attributes_param = {
   | identifier ~ "=" ~ expression
 }
 
-// Type expression: string, bool, int, float, list(type), map(type), aws.vpc (resource ref)
+// Type expression: string, bool, int, float, cidr, arn, etc., list(type), map(type), aws.vpc (resource ref)
 type_expr = { type_ref | type_generic | type_simple }
-type_simple = @{ "string" | "bool" | "int" | "float" | "cidr" }
+type_simple = @{ identifier }
 type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
 type_ref = { resource_type_path }
 resource_type_path = @{ identifier ~ ("." ~ identifier)+ }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -89,8 +89,8 @@ pub enum TypeExpr {
     Bool,
     Int,
     Float,
-    /// CIDR block (e.g., "10.0.0.0/16")
-    Cidr,
+    /// Schema type identified by name (e.g., "cidr", "ipv4_address", "arn")
+    Simple(std::string::String),
     List(Box<TypeExpr>),
     Map(Box<TypeExpr>),
     /// Reference to a resource type (e.g., aws.vpc)
@@ -104,7 +104,7 @@ impl std::fmt::Display for TypeExpr {
             TypeExpr::Bool => write!(f, "bool"),
             TypeExpr::Int => write!(f, "int"),
             TypeExpr::Float => write!(f, "float"),
-            TypeExpr::Cidr => write!(f, "cidr"),
+            TypeExpr::Simple(name) => write!(f, "{}", name),
             TypeExpr::List(inner) => write!(f, "list({})", inner),
             TypeExpr::Map(inner) => write!(f, "map({})", inner),
             TypeExpr::Ref(path) => write!(f, "{}", path),
@@ -667,8 +667,7 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
             "bool" => Ok(TypeExpr::Bool),
             "int" => Ok(TypeExpr::Int),
             "float" => Ok(TypeExpr::Float),
-            "cidr" => Ok(TypeExpr::Cidr),
-            _ => Ok(TypeExpr::String), // Default fallback
+            other => Ok(TypeExpr::Simple(other.to_string())),
         },
         Rule::type_generic => {
             // Get the full string representation to determine if it's list or map
@@ -1736,8 +1735,8 @@ fn check_fn_arg_type(
         TypeExpr::Bool => matches!(value, Value::Bool(_)),
         TypeExpr::List(_) => matches!(value, Value::List(_)),
         TypeExpr::Map(_) => matches!(value, Value::Map(_)),
-        // Cidr is a string subtype
-        TypeExpr::Cidr => matches!(
+        // Simple types (cidr, ipv4_address, arn, etc.) are string subtypes at runtime
+        TypeExpr::Simple(_) => matches!(
             value,
             Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
         ),
@@ -1769,7 +1768,8 @@ fn check_fn_return_type(
         TypeExpr::Bool => matches!(value, Value::Bool(_)),
         TypeExpr::List(_) => matches!(value, Value::List(_)),
         TypeExpr::Map(_) => matches!(value, Value::Map(_)),
-        TypeExpr::Cidr => matches!(
+        // Simple types (cidr, ipv4_address, arn, etc.) are string subtypes at runtime
+        TypeExpr::Simple(_) => matches!(
             value,
             Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
         ),
@@ -7225,5 +7225,128 @@ aws.s3.bucket {
             msg.contains("return type"),
             "Expected return type error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn parse_custom_schema_type_in_fn_param() {
+        // Custom schema types like cidr, ipv4_address, arn should be accepted as type annotations
+        let input = r#"
+            fn subnet(vpc: awscc.ec2.vpc, cidr_block: cidr) {
+                awscc.ec2.subnet {
+                    name     = "test"
+                    vpc_id   = vpc.vpc_id
+                    cidr_block = cidr_block
+                }
+            }
+        "#;
+        let result = parse(input).unwrap();
+        let func = result.user_functions.get("subnet").unwrap();
+        assert_eq!(func.params[1].name, "cidr_block");
+        assert_eq!(
+            func.params[1].param_type,
+            Some(TypeExpr::Simple("cidr".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_ipv4_address_type_in_fn_param() {
+        let input = r#"
+            fn f(addr: ipv4_address) {
+                addr
+            }
+        "#;
+        let result = parse(input).unwrap();
+        let func = result.user_functions.get("f").unwrap();
+        assert_eq!(
+            func.params[0].param_type,
+            Some(TypeExpr::Simple("ipv4_address".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_arn_type_in_fn_param() {
+        let input = r#"
+            fn f(role: arn) {
+                role
+            }
+        "#;
+        let result = parse(input).unwrap();
+        let func = result.user_functions.get("f").unwrap();
+        assert_eq!(
+            func.params[0].param_type,
+            Some(TypeExpr::Simple("arn".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_custom_type_in_list_generic() {
+        let input = r#"
+            fn f(cidrs: list(cidr)) {
+                cidrs
+            }
+        "#;
+        let result = parse(input).unwrap();
+        let func = result.user_functions.get("f").unwrap();
+        assert_eq!(
+            func.params[0].param_type,
+            Some(TypeExpr::List(Box::new(TypeExpr::Simple(
+                "cidr".to_string()
+            ))))
+        );
+    }
+
+    #[test]
+    fn parse_custom_type_in_module_arguments() {
+        let input = r#"
+            arguments {
+                vpc_cidr: cidr
+                server_ip: ipv4_address
+            }
+
+            awscc.ec2.vpc {
+                name       = "test"
+                cidr_block = vpc_cidr
+            }
+        "#;
+        let result = parse(input).unwrap();
+        assert_eq!(result.arguments[0].name, "vpc_cidr");
+        assert_eq!(
+            result.arguments[0].type_expr,
+            TypeExpr::Simple("cidr".to_string())
+        );
+        assert_eq!(result.arguments[1].name, "server_ip");
+        assert_eq!(
+            result.arguments[1].type_expr,
+            TypeExpr::Simple("ipv4_address".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_custom_type_in_attributes() {
+        let input = r#"
+            attributes {
+                block: cidr = vpc.cidr_block
+            }
+
+            let vpc = awscc.ec2.vpc {
+                name       = "test"
+                cidr_block = "10.0.0.0/16"
+            }
+        "#;
+        let result = parse(input).unwrap();
+        assert_eq!(
+            result.attribute_params[0].type_expr,
+            Some(TypeExpr::Simple("cidr".to_string()))
+        );
+    }
+
+    #[test]
+    fn type_expr_display_simple() {
+        assert_eq!(TypeExpr::Simple("cidr".to_string()).to_string(), "cidr");
+        assert_eq!(
+            TypeExpr::Simple("ipv4_address".to_string()).to_string(),
+            "ipv4_address"
+        );
+        assert_eq!(TypeExpr::Simple("arn".to_string()).to_string(), "arn");
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -296,9 +296,12 @@ fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
 /// Validate a module argument value against its expected type.
 pub fn validate_module_arg_type(type_expr: &TypeExpr, value: &Value) -> Option<String> {
     match (type_expr, value) {
-        (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
+        (TypeExpr::Simple(name), Value::String(s)) if name == "cidr" => validate_ipv4_cidr(s).err(),
         (TypeExpr::List(inner), Value::List(items)) => {
-            if let TypeExpr::Cidr = inner.as_ref() {
+            if let TypeExpr::Simple(name) = inner.as_ref() {
+                if name != "cidr" {
+                    return None;
+                }
                 for (i, item) in items.iter().enumerate() {
                     if let Value::String(s) = item {
                         if let Err(e) = validate_ipv4_cidr(s) {

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -308,7 +308,7 @@ impl CompletionProvider {
             parser::TypeExpr::Bool => "bool".to_string(),
             parser::TypeExpr::Int => "int".to_string(),
             parser::TypeExpr::Float => "float".to_string(),
-            parser::TypeExpr::Cidr => "cidr".to_string(),
+            parser::TypeExpr::Simple(name) => name.clone(),
             parser::TypeExpr::List(inner) => format!("list({})", self.format_type_expr(inner)),
             parser::TypeExpr::Map(inner) => format!("map({})", self.format_type_expr(inner)),
             parser::TypeExpr::Ref(resource_path) => {

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -253,10 +253,15 @@ impl DiagnosticEngine {
     ) -> Option<String> {
         match (type_expr, value) {
             // CIDR type validation
-            (TypeExpr::Cidr, Value::String(s)) => validate_ipv4_cidr(s).err(),
+            (TypeExpr::Simple(name), Value::String(s)) if name == "cidr" => {
+                validate_ipv4_cidr(s).err()
+            }
             // List of CIDR type validation
             (TypeExpr::List(inner), Value::List(items)) => {
-                if let TypeExpr::Cidr = inner.as_ref() {
+                if let TypeExpr::Simple(name) = inner.as_ref() {
+                    if name != "cidr" {
+                        return None;
+                    }
                     for (i, item) in items.iter().enumerate() {
                         if let Value::String(s) = item {
                             if let Err(e) = validate_ipv4_cidr(s) {


### PR DESCRIPTION
## Summary

- Replace `TypeExpr::Cidr` with `TypeExpr::Simple(String)` to accept any identifier as a type name in fn parameters, module arguments, and attributes
- Update grammar (`type_simple`) in both parser and formatter to accept any `identifier` instead of hardcoded keyword list
- Update type checking to treat all `Simple` types as string subtypes at runtime
- Update LSP completion and diagnostics to handle the new variant

Closes #1279

## Test plan

- [x] New parser tests: `cidr`, `ipv4_address`, `arn` as fn param types
- [x] New parser test: custom type in `list()` generic
- [x] New parser tests: custom types in `arguments` and `attributes` blocks
- [x] New display test: `TypeExpr::Simple` renders correctly
- [x] New formatter test: custom type annotations format correctly
- [x] All 913 existing carina-core tests pass
- [x] All 19 CLI snapshot tests pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)