### PR TITLE
fix: validate custom types in fn args/returns and resource type params

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1792,8 +1792,7 @@ fn check_fn_arg_type(
                     || actual_type != &expected_path.resource_type
                 {
                     return Err(ParseError::UserFunctionError(format!(
-                        "function '{fn_name}': parameter '{param_name}' expects resource type '{expected_path}', \
-                                 got {actual_provider}.{actual_type}"
+                        "function '{fn_name}': parameter '{param_name}' expects resource type '{expected_path}', got {actual_provider}.{actual_type}"
                     )));
                 }
             }
@@ -7446,7 +7445,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("cidr"),
+            msg.contains("type 'cidr' validation failed"),
             "Expected cidr validation error, got: {msg}"
         );
     }
@@ -7476,7 +7475,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv4_address"),
+            msg.contains("type 'ipv4_address' validation failed"),
             "Expected ipv4_address validation error, got: {msg}"
         );
     }
@@ -7506,7 +7505,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv6"),
+            msg.contains("type 'ipv6_cidr' validation failed"),
             "Expected ipv6_cidr validation error, got: {msg}"
         );
     }
@@ -7536,7 +7535,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv6"),
+            msg.contains("type 'ipv6_address' validation failed"),
             "Expected ipv6_address validation error, got: {msg}"
         );
     }
@@ -7600,7 +7599,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("cidr"),
+            msg.contains("return type 'cidr' validation failed"),
             "Expected cidr validation error, got: {msg}"
         );
     }
@@ -7617,7 +7616,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv4_address"),
+            msg.contains("return type 'ipv4_address' validation failed"),
             "Expected ipv4_address validation error, got: {msg}"
         );
     }
@@ -7634,7 +7633,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv6"),
+            msg.contains("return type 'ipv6_cidr' validation failed"),
             "Expected ipv6_cidr validation error, got: {msg}"
         );
     }
@@ -7651,7 +7650,7 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("invalid") || msg.contains("ipv6"),
+            msg.contains("return type 'ipv6_address' validation failed"),
             "Expected ipv6_address validation error, got: {msg}"
         );
     }
@@ -7697,7 +7696,8 @@ aws.s3.bucket {
         let err = parse(input).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("ec2.vpc") || msg.contains("type mismatch"),
+            msg.contains("expects resource type 'awscc.ec2.vpc'")
+                && msg.contains("got awscc.ec2.security_group"),
             "Expected resource type mismatch error, got: {msg}"
         );
     }


### PR DESCRIPTION
## Summary

- **#1283**: Add value validation for custom type annotations (`cidr`, `ipv4_address`, `ipv6_cidr`, `ipv6_address`) against actual string values. Types like `arn` and `availability_zone` accept any string since their formats vary.
- **#1284**: Validate function return values against custom return type annotations (e.g., `fn f(): cidr { "invalid" }` now errors).
- **#1285**: Validate function call arguments against custom type params and resource type params (`TypeExpr::Ref`). For resource type params, the binding's actual resource type is checked against the declared type at call site.

## Changes

- Added `validate_custom_type()` helper that dispatches to existing validators (`validate_ipv4_cidr`, `validate_ipv4_address`, etc.)
- Updated `check_fn_arg_type()` to validate `TypeExpr::Simple` values and check `TypeExpr::Ref` against `ctx.resource_bindings`
- Updated `check_fn_return_type()` to validate `TypeExpr::Simple` return values
- Added 17 tests covering valid/invalid cases for all custom types, resource ref passthrough, and resource type mismatch

Closes #1283, closes #1284, closes #1285

## Test plan

- [x] `cargo test -p carina-core` — all 930 tests pass
- [x] `cargo clippy -p carina-core` — no warnings
- [x] `cargo fmt -p carina-core` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)