### PR TITLE
fix: validate ipv4_address, ipv6_cidr, ipv6_address in LSP module arg type checks

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -9,7 +9,10 @@ use crate::position;
 use carina_core::builtins;
 use carina_core::parser::{ArgumentParameter, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
-use carina_core::schema::{ResourceSchema, suggest_similar_name, validate_ipv4_cidr};
+use carina_core::schema::{
+    ResourceSchema, suggest_similar_name, validate_ipv4_address, validate_ipv4_cidr,
+    validate_ipv6_address, validate_ipv6_cidr,
+};
 
 use super::DiagnosticEngine;
 
@@ -252,23 +255,37 @@ impl DiagnosticEngine {
         value: &Value,
     ) -> Option<String> {
         match (type_expr, value) {
-            // CIDR type validation
-            (TypeExpr::Simple(name), Value::String(s)) if name == "cidr" => {
-                validate_ipv4_cidr(s).err()
-            }
-            // List of CIDR type validation
+            // Custom type validation (cidr, ipv4_address, ipv6_cidr, ipv6_address)
+            (TypeExpr::Simple(name), Value::String(s)) => match name.as_str() {
+                "cidr" => validate_ipv4_cidr(s).err(),
+                "ipv4_address" => validate_ipv4_address(s).err(),
+                "ipv6_cidr" => validate_ipv6_cidr(s).err(),
+                "ipv6_address" => validate_ipv6_address(s).err(),
+                _ => None,
+            },
+            // List of custom type validation
             (TypeExpr::List(inner), Value::List(items)) => {
                 if let TypeExpr::Simple(name) = inner.as_ref() {
-                    if name != "cidr" {
-                        return None;
-                    }
-                    for (i, item) in items.iter().enumerate() {
-                        if let Value::String(s) = item {
-                            if let Err(e) = validate_ipv4_cidr(s) {
-                                return Some(format!("Element {}: {}", i, e));
+                    type ValidateFn = fn(&str) -> Result<(), String>;
+                    let validator: Option<ValidateFn> = match name.as_str() {
+                        "cidr" => Some(validate_ipv4_cidr),
+                        "ipv4_address" => Some(validate_ipv4_address),
+                        "ipv6_cidr" => Some(validate_ipv6_cidr),
+                        "ipv6_address" => Some(validate_ipv6_address),
+                        _ => None,
+                    };
+                    if let Some(validate_fn) = validator {
+                        for (i, item) in items.iter().enumerate() {
+                            if let Value::String(s) = item {
+                                if let Err(e) = validate_fn(s) {
+                                    return Some(format!("Element {}: {}", i, e));
+                                }
+                            } else {
+                                return Some(format!(
+                                    "Element {}: expected string, got {:?}",
+                                    i, item
+                                ));
                             }
-                        } else {
-                            return Some(format!("Element {}: expected string, got {:?}", i, item));
                         }
                     }
                 }

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -927,6 +927,121 @@ let name = join("-", parts)
 }
 
 #[test]
+fn validate_module_arg_type_ipv4_address_invalid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv4_address".to_string());
+    let value = Value::String("not-an-ip".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_some(),
+        "Should return error for invalid ipv4_address"
+    );
+}
+
+#[test]
+fn validate_module_arg_type_ipv4_address_valid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv4_address".to_string());
+    let value = Value::String("192.168.1.1".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_none(),
+        "Should not return error for valid ipv4_address. Got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn validate_module_arg_type_ipv6_cidr_invalid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string());
+    let value = Value::String("not-a-cidr".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_some(),
+        "Should return error for invalid ipv6_cidr"
+    );
+}
+
+#[test]
+fn validate_module_arg_type_ipv6_cidr_valid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string());
+    let value = Value::String("2001:db8::/32".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_none(),
+        "Should not return error for valid ipv6_cidr. Got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn validate_module_arg_type_ipv6_address_invalid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_address".to_string());
+    let value = Value::String("not-an-ipv6".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_some(),
+        "Should return error for invalid ipv6_address"
+    );
+}
+
+#[test]
+fn validate_module_arg_type_ipv6_address_valid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::Simple("ipv6_address".to_string());
+    let value = Value::String("2001:db8::1".to_string());
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_none(),
+        "Should not return error for valid ipv6_address. Got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn validate_module_arg_type_list_ipv4_address_invalid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::List(Box::new(
+        carina_core::parser::TypeExpr::Simple("ipv4_address".to_string()),
+    ));
+    let value = Value::List(vec![
+        Value::String("192.168.1.1".to_string()),
+        Value::String("bad-ip".to_string()),
+    ]);
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_some(),
+        "Should return error for invalid ipv4_address in list"
+    );
+    assert!(
+        result.as_ref().unwrap().contains("Element 1"),
+        "Error should reference element index. Got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn validate_module_arg_type_list_ipv6_cidr_valid() {
+    let engine = test_engine();
+    let type_expr = carina_core::parser::TypeExpr::List(Box::new(
+        carina_core::parser::TypeExpr::Simple("ipv6_cidr".to_string()),
+    ));
+    let value = Value::List(vec![
+        Value::String("2001:db8::/32".to_string()),
+        Value::String("::/0".to_string()),
+    ]);
+    let result = engine.validate_module_arg_type(&type_expr, &value);
+    assert!(
+        result.is_none(),
+        "Should not return error for valid ipv6_cidr list. Got: {:?}",
+        result
+    );
+}
+
+#[test]
 fn pipe_preferred_pipe_form_no_diagnostic() {
     let engine = test_engine();
     let doc = create_document(


### PR DESCRIPTION
## Summary

- Extend `validate_module_arg_type` in `carina-lsp/src/diagnostics/checks.rs` to validate `ipv4_address`, `ipv6_cidr`, and `ipv6_address` custom types (previously only `cidr` was validated)
- Update the `List(inner)` case to validate all four custom types using a function pointer pattern
- Add 8 tests: invalid/valid for each of `ipv4_address`, `ipv6_cidr`, `ipv6_address`, plus list-level validation for `ipv4_address` and `ipv6_cidr`

Closes #1287

## Test plan

- [x] `cargo test -p carina-lsp validate_module_arg_type` -- all 8 new tests pass
- [x] `cargo test -p carina-lsp` -- all 179 tests pass
- [x] `cargo clippy -p carina-lsp` -- no warnings
- [x] `cargo fmt` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)