### PR TITLE
feat: register AWS type validators via ProviderContext in CLI and LSP

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -216,7 +216,7 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
                 })
             })
         })),
-        validators: std::collections::HashMap::new(),
+        validators: carina_provider_awscc::schemas::awscc_types::awscc_validators(),
     }
 }
 

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use carina_core::formatter::{self, FormatConfig};
+use carina_core::parser::ProviderContext;
 use carina_core::provider::{self as provider_mod, ProviderFactory};
 use carina_core::schema::CompletionValue;
 use dashmap::DashMap;
@@ -35,10 +36,15 @@ pub struct Backend {
     completion_provider: CompletionProvider,
     hover_provider: HoverProvider,
     semantic_tokens_provider: SemanticTokensProvider,
+    provider_context: Arc<ProviderContext>,
 }
 
 impl Backend {
-    pub fn new(client: Client, factories: Vec<Box<dyn ProviderFactory>>) -> Self {
+    pub fn new(
+        client: Client,
+        factories: Vec<Box<dyn ProviderFactory>>,
+        provider_context: ProviderContext,
+    ) -> Self {
         // Build shared schema map from all factories
         let schemas = Arc::new(provider_mod::collect_schemas(&factories));
 
@@ -53,6 +59,8 @@ impl Backend {
 
         // Wrap factories in Arc for sharing
         let factories: Arc<Vec<Box<dyn ProviderFactory>>> = Arc::new(factories);
+
+        let provider_context = Arc::new(provider_context);
 
         Self {
             client,
@@ -69,6 +77,7 @@ impl Backend {
             ),
             semantic_tokens_provider: SemanticTokensProvider::new(&region_completions),
             hover_provider: HoverProvider::new(Arc::clone(&schemas), region_completions),
+            provider_context,
         }
     }
 
@@ -134,7 +143,10 @@ impl LanguageServer for Backend {
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let uri = params.text_document.uri.clone();
-        let doc = Document::new(params.text_document.text);
+        let doc = Document::new(
+            params.text_document.text,
+            Arc::clone(&self.provider_context),
+        );
         self.documents.insert(uri.clone(), doc);
         self.update_diagnostics(uri).await;
     }

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::document::Document;
+use carina_core::parser::ProviderContext;
 use carina_core::provider::{self as provider_mod, ProviderFactory};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
@@ -7,7 +10,7 @@ mod basic;
 mod extended;
 
 pub(super) fn create_document(content: &str) -> Document {
-    Document::new(content.to_string())
+    Document::new(content.to_string(), Arc::new(ProviderContext::default()))
 }
 
 pub(super) fn test_provider() -> CompletionProvider {

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -1,12 +1,15 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::document::Document;
+use carina_core::parser::ProviderContext;
 use carina_core::provider::{self as provider_mod, ProviderFactory};
 
 mod basic;
 mod extended;
 
 pub(super) fn create_document(content: &str) -> Document {
-    Document::new(content.to_string())
+    Document::new(content.to_string(), Arc::new(ProviderContext::default()))
 }
 
 pub(super) fn test_engine() -> DiagnosticEngine {

--- a/carina-lsp/src/document.rs
+++ b/carina-lsp/src/document.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ropey::Rope;
 use tower_lsp::lsp_types::{Position, TextDocumentContentChangeEvent};
 
@@ -7,14 +9,16 @@ pub struct Document {
     content: Rope,
     parsed: Option<ParsedFile>,
     parse_error: Option<ParseError>,
+    provider_context: Arc<ProviderContext>,
 }
 
 impl Document {
-    pub fn new(content: String) -> Self {
+    pub fn new(content: String, provider_context: Arc<ProviderContext>) -> Self {
         let mut doc = Self {
             content: Rope::from_str(&content),
             parsed: None,
             parse_error: None,
+            provider_context,
         };
         doc.reparse();
         doc
@@ -37,7 +41,7 @@ impl Document {
 
     fn reparse(&mut self) {
         let text = self.content.to_string();
-        match parse(&text, &ProviderContext::default()) {
+        match parse(&text, &self.provider_context) {
             Ok(parsed) => {
                 self.parsed = Some(parsed);
                 self.parse_error = None;
@@ -121,7 +125,10 @@ mod tests {
 
     #[test]
     fn test_position_to_offset_beyond_last_line() {
-        let mut doc = Document::new("hello\nworld".to_string());
+        let mut doc = Document::new(
+            "hello\nworld".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
         // Line 10 is beyond the document - should not panic
         let change = TextDocumentContentChangeEvent {
             range: Some(tower_lsp::lsp_types::Range {
@@ -143,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_position_to_offset_empty_document() {
-        let mut doc = Document::new("".to_string());
+        let mut doc = Document::new("".to_string(), Arc::new(ProviderContext::default()));
         let change = TextDocumentContentChangeEvent {
             range: Some(tower_lsp::lsp_types::Range {
                 start: Position {
@@ -165,7 +172,10 @@ mod tests {
     fn test_word_at_with_multibyte_characters() {
         // "hello 日本語" - ASCII word, space, then multi-byte chars
         // byte length = 5 + 1 + 9 = 15, char count = 5 + 1 + 3 = 9
-        let doc = Document::new("hello 日本語".to_string());
+        let doc = Document::new(
+            "hello 日本語".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
         // col=6 is char index of '日'
         let word = doc.word_at(Position {
             line: 0,
@@ -185,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_word_at_col_beyond_line_chars() {
-        let doc = Document::new("hi".to_string());
+        let doc = Document::new("hi".to_string(), Arc::new(ProviderContext::default()));
         // col=10 is beyond the 2-char line
         let word = doc.word_at(Position {
             line: 0,
@@ -200,7 +210,7 @@ mod tests {
         // col=4 is beyond char_len but within byte_len
         // The bug: line.len() returns 6 (bytes), so col=4 < 6 passes the check
         // but chars vec has only 2 elements, causing index out of bounds
-        let doc = Document::new("日本".to_string());
+        let doc = Document::new("日本".to_string(), Arc::new(ProviderContext::default()));
         let word = doc.word_at(Position {
             line: 0,
             character: 4,

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -560,6 +560,7 @@ impl HoverProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carina_core::parser::ProviderContext;
     use carina_core::schema::{AttributeSchema, AttributeType};
 
     fn create_hover_provider_with_description(
@@ -646,7 +647,10 @@ mod tests {
             desc,
         );
 
-        let doc = Document::new("secondary_allocation_ids".to_string());
+        let doc = Document::new(
+            "secondary_allocation_ids".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
         let hover = provider
             .hover(&doc, Position::new(0, 5))
             .expect("Should find hover for attribute");
@@ -762,6 +766,7 @@ awscc.ec2.vpc_gateway_attachment {
 }
 "#
             .to_string(),
+            Arc::new(ProviderContext::default()),
         );
 
         // Hover over "internet_gateway_id" on line 5 (0-indexed), column 10
@@ -792,7 +797,7 @@ awscc.ec2.vpc_gateway_attachment {
     #[test]
     fn test_builtin_function_hover_join() {
         let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
-        let doc = Document::new("join".to_string());
+        let doc = Document::new("join".to_string(), Arc::new(ProviderContext::default()));
         let hover = provider
             .hover(&doc, Position::new(0, 1))
             .expect("Should find hover for 'join'");
@@ -821,7 +826,10 @@ awscc.ec2.vpc_gateway_attachment {
     #[test]
     fn test_builtin_function_hover_cidr_subnet() {
         let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
-        let doc = Document::new("cidr_subnet".to_string());
+        let doc = Document::new(
+            "cidr_subnet".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
         let hover = provider
             .hover(&doc, Position::new(0, 3))
             .expect("Should find hover for 'cidr_subnet'");
@@ -841,7 +849,10 @@ awscc.ec2.vpc_gateway_attachment {
     #[test]
     fn test_builtin_function_hover_unknown_returns_none() {
         let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
-        let doc = Document::new("not_a_function".to_string());
+        let doc = Document::new(
+            "not_a_function".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
         let hover = provider.hover(&doc, Position::new(0, 3));
         assert!(hover.is_none(), "Unknown function should not show hover");
     }
@@ -871,7 +882,7 @@ awscc.ec2.vpc_gateway_attachment {
             "values",
         ];
         for name in &names {
-            let doc = Document::new(name.to_string());
+            let doc = Document::new(name.to_string(), Arc::new(ProviderContext::default()));
             let hover = provider.hover(&doc, Position::new(0, 1));
             assert!(
                 hover.is_some(),

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -1,6 +1,8 @@
+use carina_core::parser::ProviderContext;
 use carina_core::provider::ProviderFactory;
 use carina_provider_aws::AwsProviderFactory;
 use carina_provider_awscc::AwsccProviderFactory;
+use carina_provider_awscc::schemas::awscc_types::awscc_validators;
 use tower_lsp::{LspService, Server};
 
 use carina_lsp::Backend;
@@ -15,7 +17,11 @@ async fn main() {
     let (service, socket) = LspService::new(|client| {
         let factories: Vec<Box<dyn ProviderFactory>> =
             vec![Box::new(AwsProviderFactory), Box::new(AwsccProviderFactory)];
-        Backend::new(client, factories)
+        let provider_context = ProviderContext {
+            decryptor: None,
+            validators: awscc_validators(),
+        };
+        Backend::new(client, factories, provider_context)
     });
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -3,10 +3,12 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tower_lsp::{LspService, Server};
 
+use carina_core::parser::ProviderContext;
 use carina_core::provider::ProviderFactory;
 use carina_lsp::Backend;
 use carina_provider_aws::AwsProviderFactory;
 use carina_provider_awscc::AwsccProviderFactory;
+use carina_provider_awscc::schemas::awscc_types::awscc_validators;
 
 struct TestClient {
     writer: tokio::io::DuplexStream,
@@ -23,7 +25,11 @@ impl TestClient {
         let (service, socket) = LspService::new(|client| {
             let factories: Vec<Box<dyn ProviderFactory>> =
                 vec![Box::new(AwsProviderFactory), Box::new(AwsccProviderFactory)];
-            Backend::new(client, factories)
+            let provider_context = ProviderContext {
+                decryptor: None,
+                validators: awscc_validators(),
+            };
+            Backend::new(client, factories, provider_context)
         });
 
         tokio::spawn(async move {

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -6,6 +6,9 @@
 
 pub use carina_aws_types::*;
 
+use std::collections::HashMap;
+
+use carina_core::parser::ValidatorFn;
 use carina_core::resource::Value;
 use carina_core::schema::{AttributeType, ResourceSchema};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
@@ -23,6 +26,163 @@ pub struct AwsccSchemaConfig {
     pub has_tags: bool,
     /// The resource schema with attribute definitions
     pub schema: ResourceSchema,
+}
+
+/// Return all AWSCC type validators for registration in ProviderContext.
+///
+/// These validators are keyed by type name (matching the names used in fn/module
+/// type annotations) and wrap the validation functions from `carina-aws-types`.
+pub fn awscc_validators() -> HashMap<String, ValidatorFn> {
+    let mut m: HashMap<String, ValidatorFn> = HashMap::new();
+
+    // Single-arg validators
+    m.insert("arn".to_string(), Box::new(|s: &str| validate_arn(s)));
+    m.insert(
+        "availability_zone".to_string(),
+        Box::new(|s: &str| validate_availability_zone(s)),
+    );
+    m.insert(
+        "aws_resource_id".to_string(),
+        Box::new(|s: &str| validate_aws_resource_id(s)),
+    );
+    m.insert(
+        "iam_role_id".to_string(),
+        Box::new(|s: &str| validate_iam_role_id(s)),
+    );
+    m.insert(
+        "aws_account_id".to_string(),
+        Box::new(|s: &str| validate_aws_account_id(s)),
+    );
+    m.insert(
+        "kms_key_id".to_string(),
+        Box::new(|s: &str| validate_kms_key_id(s)),
+    );
+    m.insert(
+        "ipam_pool_id".to_string(),
+        Box::new(|s: &str| validate_ipam_pool_id(s)),
+    );
+    m.insert(
+        "availability_zone_id".to_string(),
+        Box::new(|s: &str| validate_availability_zone_id(s)),
+    );
+
+    // Prefixed resource IDs
+    m.insert(
+        "vpc_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "vpc")),
+    );
+    m.insert(
+        "subnet_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "subnet")),
+    );
+    m.insert(
+        "security_group_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "sg")),
+    );
+    m.insert(
+        "internet_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "igw")),
+    );
+    m.insert(
+        "route_table_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "rtb")),
+    );
+    m.insert(
+        "nat_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "nat")),
+    );
+    m.insert(
+        "transit_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "tgw")),
+    );
+    m.insert(
+        "vpn_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "vgw")),
+    );
+    m.insert(
+        "network_interface_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "eni")),
+    );
+    m.insert(
+        "allocation_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "eipalloc")),
+    );
+    m.insert(
+        "vpc_endpoint_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "vpce")),
+    );
+    m.insert(
+        "vpc_peering_connection_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "pcx")),
+    );
+    m.insert(
+        "instance_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "i")),
+    );
+    m.insert(
+        "prefix_list_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "pl")),
+    );
+    m.insert(
+        "carrier_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "cagw")),
+    );
+    m.insert(
+        "local_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "lgw")),
+    );
+    m.insert(
+        "network_acl_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "acl")),
+    );
+    m.insert(
+        "transit_gateway_attachment_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "tgw-attach")),
+    );
+    m.insert(
+        "flow_log_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "fl")),
+    );
+    m.insert(
+        "ipam_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "ipam")),
+    );
+    m.insert(
+        "subnet_route_table_association_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "rtbassoc")),
+    );
+    m.insert(
+        "security_group_rule_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "sgr")),
+    );
+    m.insert(
+        "vpc_cidr_block_association_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "vpc-cidr-assoc")),
+    );
+    m.insert(
+        "tgw_route_table_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "tgw-rtb")),
+    );
+    m.insert(
+        "egress_only_internet_gateway_id".to_string(),
+        Box::new(|s: &str| validate_prefixed_resource_id(s, "eigw")),
+    );
+
+    // Service ARNs
+    m.insert(
+        "iam_role_arn".to_string(),
+        Box::new(|s: &str| validate_service_arn(s, "iam", Some("role/"))),
+    );
+    m.insert(
+        "iam_policy_arn".to_string(),
+        Box::new(|s: &str| validate_service_arn(s, "iam", Some("policy/"))),
+    );
+    m.insert(
+        "kms_key_arn".to_string(),
+        Box::new(|s: &str| validate_kms_key_id(s)),
+    );
+
+    m
 }
 
 /// Validate a namespaced enum value.


### PR DESCRIPTION
## Summary
- Add `awscc_validators()` function to `carina-provider-awscc/src/schemas/awscc_types.rs` returning all AWS type validators (arn, availability_zone, aws_resource_id, prefixed resource IDs, service ARNs)
- Wire validators through `ProviderContext` in both CLI (`main.rs`) and LSP (`main.rs` -> `Backend` -> `Document`)
- LSP `document.rs` now uses injected `ProviderContext` in `reparse()` instead of `ProviderContext::default()`, enabling type validation in the editor

## Test plan
- [x] `cargo test` -- all 174 LSP tests + 5 integration tests pass
- [x] `cargo clippy -p carina-lsp` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] `bash scripts/check-provider-boundaries.sh` -- all checks pass
- [x] No provider imports in `document.rs` (only `carina_core::parser::ProviderContext`)
- [x] Full workspace `cargo test` passes

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)