### PR TITLE
fix: validate custom types in attributes block type annotations

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -536,6 +536,42 @@ impl DiagnosticEngine {
         match (type_expr, value) {
             // ResourceRef is always allowed (type is resolved at runtime)
             (_, Value::ResourceRef { .. }) => None,
+            // Custom type validation (cidr, ipv4_address, ipv6_cidr, ipv6_address)
+            (TypeExpr::Simple(name), Value::String(s)) => match name.as_str() {
+                "cidr" => validate_ipv4_cidr(s).err(),
+                "ipv4_address" => validate_ipv4_address(s).err(),
+                "ipv6_cidr" => validate_ipv6_cidr(s).err(),
+                "ipv6_address" => validate_ipv6_address(s).err(),
+                _ => None,
+            },
+            // List of custom type validation
+            (TypeExpr::List(inner), Value::List(items)) => {
+                if let TypeExpr::Simple(name) = inner.as_ref() {
+                    type ValidateFn = fn(&str) -> Result<(), String>;
+                    let validator: Option<ValidateFn> = match name.as_str() {
+                        "cidr" => Some(validate_ipv4_cidr),
+                        "ipv4_address" => Some(validate_ipv4_address),
+                        "ipv6_cidr" => Some(validate_ipv6_cidr),
+                        "ipv6_address" => Some(validate_ipv6_address),
+                        _ => None,
+                    };
+                    if let Some(validate_fn) = validator {
+                        for (i, item) in items.iter().enumerate() {
+                            if let Value::String(s) = item {
+                                if let Err(e) = validate_fn(s) {
+                                    return Some(format!("Element {}: {}", i, e));
+                                }
+                            } else {
+                                return Some(format!(
+                                    "Element {}: expected string, got {:?}",
+                                    i, item
+                                ));
+                            }
+                        }
+                    }
+                }
+                None
+            }
             // String type checks
             (TypeExpr::String, Value::Bool(b)) => Some(format!(
                 "Type mismatch in attributes '{}': expected string, got bool ({})",

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1064,3 +1064,128 @@ let name = parts |> join("-")
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn attributes_block_ipv4_address_invalid() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+attributes {
+    ip: ipv4_address = "not-an-ip"
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("ipv4_address") || d.message.contains("IPv4"));
+    assert!(
+        type_diag.is_some(),
+        "Should warn about invalid ipv4_address in attributes block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn attributes_block_ipv4_address_valid() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+attributes {
+    ip: ipv4_address = "192.168.1.1"
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("ipv4_address") || d.message.contains("IPv4"));
+    assert!(
+        type_diag.is_none(),
+        "Should NOT warn about valid ipv4_address in attributes block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn attributes_block_cidr_invalid() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+attributes {
+    network: cidr = "not-a-cidr"
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("CIDR") || d.message.contains("cidr"));
+    assert!(
+        type_diag.is_some(),
+        "Should warn about invalid cidr in attributes block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn attributes_block_ipv6_address_invalid() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+attributes {
+    addr: ipv6_address = "not-ipv6"
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("ipv6") || d.message.contains("IPv6"));
+    assert!(
+        type_diag.is_some(),
+        "Should warn about invalid ipv6_address in attributes block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn attributes_block_ipv6_cidr_invalid() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"provider awscc {
+region = awscc.Region.ap_northeast_1
+}
+
+attributes {
+    net6: ipv6_cidr = "not-a-cidr"
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let type_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("IPv6") || d.message.contains("ipv6"));
+    assert!(
+        type_diag.is_some(),
+        "Should warn about invalid ipv6_cidr in attributes block. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary
- Add `TypeExpr::Simple` custom type validation (cidr, ipv4_address, ipv6_cidr, ipv6_address) to `validate_attributes_type` in `checks.rs`
- Add `TypeExpr::List` custom type validation for list-of-custom-type in attributes blocks
- Add 5 tests covering invalid/valid ipv4_address, invalid cidr, invalid ipv6_address, and invalid ipv6_cidr in attributes blocks

## Test plan
- [x] `cargo test -p carina-lsp` passes (5 new tests + all existing)
- [x] `cargo clippy -p carina-lsp` clean
- [x] `cargo fmt` clean

Closes #1291

🤖 Generated with [Claude Code](https://claude.com/claude-code)