### PR TITLE
Refactor: extract shared ResourceRef type-checking helper

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -283,124 +283,22 @@ impl DiagnosticEngine {
                                         s
                                     ))
                                 }
-                                // ResourceRef type check for Union types
+                                // ResourceRef type check for Union, StringEnum, and Custom types
                                 (
-                                    carina_core::schema::AttributeType::Union(_),
+                                    carina_core::schema::AttributeType::Union(_)
+                                    | carina_core::schema::AttributeType::StringEnum { .. }
+                                    | carina_core::schema::AttributeType::Custom { .. },
                                     Value::ResourceRef {
                                         binding_name: ref_binding,
                                         attribute_name: ref_attr,
                                         ..
                                     },
-                                ) => {
-                                    if let Some(ref_schema) =
-                                        binding_schema_map.get(ref_binding.as_str())
-                                    {
-                                        if let Some(ref_attr_schema) =
-                                            ref_schema.attributes.get(ref_attr.as_str())
-                                        {
-                                            let ref_type_name =
-                                                ref_attr_schema.attr_type.type_name();
-                                            if attr_schema
-                                                .attr_type
-                                                .accepts_type_name(&ref_type_name)
-                                                || ref_type_name == "String"
-                                            {
-                                                None
-                                            } else {
-                                                Some(format!(
-                                                    "Type mismatch: expected {}, got {} (from {}.{})",
-                                                    attr_schema.attr_type.type_name(),
-                                                    ref_type_name,
-                                                    ref_binding,
-                                                    ref_attr
-                                                ))
-                                            }
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                }
-                                // ResourceRef type check for Custom types
-                                (
-                                    carina_core::schema::AttributeType::StringEnum {
-                                        name: expected_name,
-                                        ..
-                                    },
-                                    Value::ResourceRef {
-                                        binding_name: ref_binding,
-                                        attribute_name: ref_attr,
-                                        ..
-                                    },
-                                ) => {
-                                    if let Some(ref_schema) =
-                                        binding_schema_map.get(ref_binding.as_str())
-                                    {
-                                        if let Some(ref_attr_schema) =
-                                            ref_schema.attributes.get(ref_attr.as_str())
-                                        {
-                                            let ref_type_name =
-                                                ref_attr_schema.attr_type.type_name();
-                                            if ref_type_name != *expected_name
-                                                && ref_type_name != "String"
-                                            {
-                                                Some(format!(
-                                                    "Type mismatch: expected {}, got {} (from {}.{})",
-                                                    expected_name,
-                                                    ref_type_name,
-                                                    ref_binding,
-                                                    ref_attr
-                                                ))
-                                            } else {
-                                                None
-                                            }
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                }
-                                (
-                                    carina_core::schema::AttributeType::Custom {
-                                        name: expected_name,
-                                        ..
-                                    },
-                                    Value::ResourceRef {
-                                        binding_name: ref_binding,
-                                        attribute_name: ref_attr,
-                                        ..
-                                    },
-                                ) => {
-                                    if let Some(ref_schema) =
-                                        binding_schema_map.get(ref_binding.as_str())
-                                    {
-                                        if let Some(ref_attr_schema) =
-                                            ref_schema.attributes.get(ref_attr.as_str())
-                                        {
-                                            let ref_type_name =
-                                                ref_attr_schema.attr_type.type_name();
-                                            if ref_type_name != *expected_name
-                                                && ref_type_name != "String"
-                                            {
-                                                Some(format!(
-                                                    "Type mismatch: expected {}, got {} (from {}.{})",
-                                                    expected_name,
-                                                    ref_type_name,
-                                                    ref_binding,
-                                                    ref_attr
-                                                ))
-                                            } else {
-                                                None
-                                            }
-                                        } else {
-                                            None
-                                        }
-                                    } else {
-                                        None
-                                    }
-                                }
+                                ) => check_resource_ref_type_mismatch(
+                                    &binding_schema_map,
+                                    &attr_schema.attr_type,
+                                    ref_binding,
+                                    ref_attr,
+                                ),
                                 // Custom type validation (all Custom types use their validate fn)
                                 (carina_core::schema::AttributeType::StringEnum { .. }, value) => {
                                     attr_schema
@@ -773,6 +671,32 @@ impl DiagnosticEngine {
             return Some((line_idx as u32, position::leading_whitespace_chars(line)));
         }
         None
+    }
+}
+
+/// Check whether a ResourceRef value is type-compatible with the expected attribute type.
+/// Returns `Some(message)` on mismatch, `None` when compatible or when the binding/attribute
+/// cannot be resolved (unknown bindings are not flagged here).
+fn check_resource_ref_type_mismatch(
+    binding_schema_map: &HashMap<String, ResourceSchema>,
+    expected_type: &carina_core::schema::AttributeType,
+    ref_binding: &str,
+    ref_attr: &str,
+) -> Option<String> {
+    let ref_schema = binding_schema_map.get(ref_binding)?;
+    let ref_attr_schema = ref_schema.attributes.get(ref_attr)?;
+    let ref_type_name = ref_attr_schema.attr_type.type_name();
+
+    if expected_type.accepts_type_name(&ref_type_name) || ref_type_name == "String" {
+        None
+    } else {
+        Some(format!(
+            "Type mismatch: expected {}, got {} (from {}.{})",
+            expected_type.type_name(),
+            ref_type_name,
+            ref_binding,
+            ref_attr
+        ))
     }
 }
 

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1166,6 +1166,145 @@ attributes {
 }
 
 #[test]
+fn resource_ref_type_check_helper_regression() {
+    // Regression test for refactoring: all three ResourceRef type-checking paths
+    // (Union, StringEnum, Custom) must produce consistent "Type mismatch" diagnostics.
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    fn dummy_validate(v: &carina_core::resource::Value) -> Result<(), String> {
+        match v {
+            carina_core::resource::Value::String(s) if s.starts_with("test.") => Ok(()),
+            _ => Err("invalid custom value".to_string()),
+        }
+    }
+
+    // Source resource: has a String attribute "name" and a Custom "my_id"
+    let source_schema = ResourceSchema::new("test.source")
+        .attribute(AttributeSchema::new("name", AttributeType::String))
+        .attribute(AttributeSchema::new(
+            "my_id",
+            AttributeType::Custom {
+                name: "MyId".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: dummy_validate,
+                namespace: Some("test".to_string()),
+                to_dsl: None,
+            },
+        ));
+
+    // Target resource: has Union, StringEnum, and Custom attributes
+    let target_schema = ResourceSchema::new("test.target")
+        .attribute(AttributeSchema::new(
+            "union_attr",
+            AttributeType::Union(vec![AttributeType::Int, AttributeType::Bool]),
+        ))
+        .attribute(AttributeSchema::new(
+            "enum_attr",
+            AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["active".to_string(), "inactive".to_string()],
+                namespace: None,
+                to_dsl: None,
+            },
+        ))
+        .attribute(AttributeSchema::new(
+            "custom_attr",
+            AttributeType::Custom {
+                name: "MyId".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: dummy_validate,
+                namespace: Some("test".to_string()),
+                to_dsl: None,
+            },
+        ));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.source".to_string(), source_schema);
+    schemas.insert("test.target".to_string(), target_schema);
+    let engine = custom_engine(schemas);
+
+    // Case 1: Union attr with incompatible ResourceRef (MyId != Int|Bool) -> mismatch
+    let doc = create_document(
+        r#"let src = test.source {
+name = "hello"
+}
+
+test.target {
+union_attr = src.my_id
+}"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let union_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
+    assert!(
+        union_mismatch.is_some(),
+        "Union attr should warn about type mismatch for incompatible ResourceRef. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // Case 2: StringEnum attr with incompatible ResourceRef (MyId != Status) -> mismatch
+    let doc = create_document(
+        r#"let src = test.source {
+name = "hello"
+}
+
+test.target {
+enum_attr = src.my_id
+}"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let enum_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
+    assert!(
+        enum_mismatch.is_some(),
+        "StringEnum attr should warn about type mismatch for incompatible ResourceRef. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // Case 3: Custom attr with compatible ResourceRef (MyId == MyId) -> no mismatch
+    let doc = create_document(
+        r#"let src = test.source {
+name = "hello"
+}
+
+test.target {
+custom_attr = src.my_id
+}"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let custom_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("custom_attr"));
+    assert!(
+        custom_mismatch.is_none(),
+        "Custom attr should NOT warn when ResourceRef type matches. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    // Case 4: Union attr with String ResourceRef -> no mismatch (String is always compatible)
+    let doc = create_document(
+        r#"let src = test.source {
+name = "hello"
+}
+
+test.target {
+union_attr = src.name
+}"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let string_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch") && d.message.contains("union_attr"));
+    assert!(
+        string_mismatch.is_none(),
+        "Union attr should NOT warn when ResourceRef is String type. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn attributes_block_ipv6_cidr_invalid() {
     let engine = test_engine();
     let doc = create_document(


### PR DESCRIPTION
## Summary
- Extract `check_resource_ref_type_mismatch()` helper function that consolidates the duplicated ResourceRef type-checking logic from three match arms (Union, StringEnum, Custom) in LSP diagnostics
- Reduces ~120 lines of near-identical code to a single ~20-line function using `AttributeType::accepts_type_name()` uniformly
- Add regression test covering all three code paths (Union mismatch, StringEnum mismatch, Custom compatible, String-is-always-compatible)

## Test plan
- [x] All 187 existing carina-lsp tests pass
- [x] New `resource_ref_type_check_helper_regression` test verifies behavior for Union, StringEnum, Custom, and String-compatible ResourceRef cases
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)