### PR TITLE
refactor: reduce awscc_validators() boilerplate with macro

### DIFF
--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -33,7 +33,7 @@ pub struct AwsccSchemaConfig {
 /// Generates a `HashMap<String, ValidatorFn>` from three categories:
 /// - `simple`: single-arg validators (`name => function`)
 /// - `prefixed`: prefixed resource ID validators (`name => prefix`)
-/// - `service_arn`: service ARN validators (`name => (service, resource_prefix)`)
+/// - `service_arn`: arbitrary closure validators (`name => closure_expr`)
 macro_rules! register_validators {
     (
         simple { $( $s_name:ident => $s_fn:expr ),* $(,)? }


### PR DESCRIPTION
## Summary
- Replace ~150 lines of repetitive `.insert()` calls in `awscc_validators()` with a declarative `register_validators!` macro
- The macro supports three validator categories: `simple` (single-arg), `prefixed` (resource ID with prefix), and `service_arn` (ARN validators)
- Add tests verifying all validators remain registered and produce correct results after the refactor

closes #1317

## Test plan
- [x] New `awscc_validators_all_registered` test verifies all 36 validators are present
- [x] New `awscc_validators_produce_correct_results` test checks representative validators from each category
- [x] All 159 existing tests in `carina-provider-awscc` continue to pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)