### PR TITLE
refactor: extract carina_diagnostic helper to reduce LSP boilerplate

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 use crate::document::Document;
 use crate::position;
@@ -11,7 +11,7 @@ use carina_core::parser::{ArgumentParameter, ParsedFile, TypeExpr};
 use carina_core::resource::Value;
 use carina_core::schema::{ResourceSchema, suggest_similar_name};
 
-use super::DiagnosticEngine;
+use super::{DiagnosticEngine, carina_diagnostic};
 
 impl DiagnosticEngine {
     /// Check that provider blocks are not defined inside modules.
@@ -37,22 +37,13 @@ impl DiagnosticEngine {
                     .find('{')
                     .map(|p| col + p as u32)
                     .unwrap_or(col + trimmed.len() as u32);
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line: line_idx as u32,
-                            character: col,
-                        },
-                        end: Position {
-                            line: line_idx as u32,
-                            character: end_col,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::ERROR),
-                    source: Some("carina".to_string()),
-                    message: "provider blocks are not allowed inside modules. Define providers at the root configuration level.".to_string(),
-                    ..Default::default()
-                });
+                diagnostics.push(carina_diagnostic(
+                    line_idx as u32,
+                    col,
+                    end_col,
+                    DiagnosticSeverity::ERROR,
+                    "provider blocks are not allowed inside modules. Define providers at the root configuration level.".to_string(),
+                ));
             }
         }
 
@@ -73,22 +64,13 @@ impl DiagnosticEngine {
                 && let Err(e) = factory.validate_config(&provider.attributes)
                 && let Some((line, col)) = self.find_provider_region_position(doc, &provider.name)
             {
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + 6, // "region"
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::WARNING),
-                    source: Some("carina".to_string()),
-                    message: format!("provider {}: {}", provider.name, e),
-                    ..Default::default()
-                });
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    col + 6, // "region"
+                    DiagnosticSeverity::WARNING,
+                    format!("provider {}: {}", provider.name, e),
+                ));
             }
         }
         diagnostics
@@ -162,25 +144,16 @@ impl DiagnosticEngine {
                                 .map(|arg| format!(". Did you mean '{}'?", arg.name))
                                 .unwrap_or_default();
 
-                            diagnostics.push(Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line,
-                                        character: col,
-                                    },
-                                    end: Position {
-                                        line,
-                                        character: col + arg_name.len() as u32,
-                                    },
-                                },
-                                severity: Some(DiagnosticSeverity::WARNING),
-                                source: Some("carina".to_string()),
-                                message: format!(
+                            diagnostics.push(carina_diagnostic(
+                                line,
+                                col,
+                                col + arg_name.len() as u32,
+                                DiagnosticSeverity::WARNING,
+                                format!(
                                     "Unknown parameter '{}' for module '{}'{}",
                                     arg_name, call.module_name, suggestion
                                 ),
-                                ..Default::default()
-                            });
+                            ));
                         }
                         continue;
                     }
@@ -192,22 +165,13 @@ impl DiagnosticEngine {
                         && let Some((line, col)) =
                             self.find_module_call_arg_position(doc, &call.module_name, arg_name)
                     {
-                        diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line,
-                                    character: col,
-                                },
-                                end: Position {
-                                    line,
-                                    character: col + arg_name.len() as u32,
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::WARNING),
-                            source: Some("carina".to_string()),
-                            message: type_error,
-                            ..Default::default()
-                        });
+                        diagnostics.push(carina_diagnostic(
+                            line,
+                            col,
+                            col + arg_name.len() as u32,
+                            DiagnosticSeverity::WARNING,
+                            type_error,
+                        ));
                     }
                 }
 
@@ -218,25 +182,16 @@ impl DiagnosticEngine {
                         && let Some((line, col)) =
                             self.find_module_call_position(doc, &call.module_name)
                     {
-                        diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line,
-                                    character: col,
-                                },
-                                end: Position {
-                                    line,
-                                    character: col + call.module_name.len() as u32,
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::ERROR),
-                            source: Some("carina".to_string()),
-                            message: format!(
+                        diagnostics.push(carina_diagnostic(
+                            line,
+                            col,
+                            col + call.module_name.len() as u32,
+                            DiagnosticSeverity::ERROR,
+                            format!(
                                 "Missing required parameter '{}' for module '{}'",
                                 arg.name, call.module_name
                             ),
-                            ..Default::default()
-                        });
+                        ));
                     }
                 }
             }
@@ -327,25 +282,16 @@ impl DiagnosticEngine {
 
         for binding_name in &unused_bindings {
             if let Some((line, col)) = self.find_let_binding_position(&text, binding_name) {
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + binding_name.len() as u32,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::WARNING),
-                    source: Some("carina".to_string()),
-                    message: format!(
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    col + binding_name.len() as u32,
+                    DiagnosticSeverity::WARNING,
+                    format!(
                         "Unused let binding '{}'. Consider using an anonymous resource instead.",
                         binding_name
                     ),
-                    ..Default::default()
-                });
+                ));
             }
         }
 
@@ -421,25 +367,16 @@ impl DiagnosticEngine {
                     && let Some((line, col)) =
                         self.find_attributes_value_position(doc, &attr_param.name)
                 {
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line,
-                                character: col,
-                            },
-                            end: Position {
-                                line,
-                                character: col + binding_name.len() as u32,
-                            },
-                        },
-                        severity: Some(DiagnosticSeverity::ERROR),
-                        source: Some("carina".to_string()),
-                        message: format!(
+                    diagnostics.push(carina_diagnostic(
+                        line,
+                        col,
+                        col + binding_name.len() as u32,
+                        DiagnosticSeverity::ERROR,
+                        format!(
                             "Undefined resource '{}' in attributes '{}'. Define it with 'let {} = ...'",
                             binding_name, attr_param.name, binding_name
                         ),
-                        ..Default::default()
-                    });
+                    ));
                 }
 
                 // Type validation (only when explicit type annotation is present)
@@ -449,22 +386,13 @@ impl DiagnosticEngine {
                     && let Some((line, col)) =
                         self.find_attributes_param_position(doc, &attr_param.name)
                 {
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line,
-                                character: col,
-                            },
-                            end: Position {
-                                line,
-                                character: col + attr_param.name.len() as u32,
-                            },
-                        },
-                        severity: Some(DiagnosticSeverity::WARNING),
-                        source: Some("carina".to_string()),
-                        message: type_error,
-                        ..Default::default()
-                    });
+                    diagnostics.push(carina_diagnostic(
+                        line,
+                        col,
+                        col + attr_param.name.len() as u32,
+                        DiagnosticSeverity::WARNING,
+                        type_error,
+                    ));
                 }
             }
         }
@@ -659,25 +587,16 @@ impl DiagnosticEngine {
                             let col = position::byte_offset_to_char_offset(line, eq_byte_pos)
                                 + 1
                                 + whitespace_chars as u32;
-                            diagnostics.push(Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line: line_idx as u32,
-                                        character: col,
-                                    },
-                                    end: Position {
-                                        line: line_idx as u32,
-                                        character: col + identifier.len() as u32,
-                                    },
-                                },
-                                severity: Some(DiagnosticSeverity::ERROR),
-                                source: Some("carina".to_string()),
-                                message: format!(
+                            diagnostics.push(carina_diagnostic(
+                                line_idx as u32,
+                                col,
+                                col + identifier.len() as u32,
+                                DiagnosticSeverity::ERROR,
+                                format!(
                                     "Undefined resource: '{}'. Define it with 'let {} = aws...'",
                                     identifier, identifier
                                 ),
-                                ..Default::default()
-                            });
+                            ));
                         }
                     }
                 }
@@ -716,22 +635,13 @@ impl DiagnosticEngine {
                 if !builtins::is_known_builtin(name)
                     && let Some((line, col)) = self.find_function_call_position(doc, name)
                 {
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line,
-                                character: col,
-                            },
-                            end: Position {
-                                line,
-                                character: col + name.len() as u32,
-                            },
-                        },
-                        severity: Some(DiagnosticSeverity::ERROR),
-                        source: Some("carina".to_string()),
-                        message: format!("Unknown function '{}'", name),
-                        ..Default::default()
-                    });
+                    diagnostics.push(carina_diagnostic(
+                        line,
+                        col,
+                        col + name.len() as u32,
+                        DiagnosticSeverity::ERROR,
+                        format!("Unknown function '{}'", name),
+                    ));
                 }
                 // Also check nested function calls in arguments
                 for arg in args {
@@ -850,25 +760,16 @@ impl DiagnosticEngine {
                 if let Some((line, col)) = self.find_ref_value_position(doc, &ref_text) {
                     // Highlight just the attribute part (after the dot)
                     let attr_col = col + binding_name.len() as u32 + 1; // +1 for the dot
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line,
-                                character: attr_col,
-                            },
-                            end: Position {
-                                line,
-                                character: attr_col + attribute_name.len() as u32,
-                            },
-                        },
-                        severity: Some(DiagnosticSeverity::WARNING),
-                        source: Some("carina".to_string()),
-                        message: format!(
+                    diagnostics.push(carina_diagnostic(
+                        line,
+                        attr_col,
+                        attr_col + attribute_name.len() as u32,
+                        DiagnosticSeverity::WARNING,
+                        format!(
                             "Unknown attribute '{}' on '{}' (type '{}'){}",
                             attribute_name, binding_name, ref_schema.resource_type, suggestion,
                         ),
-                        ..Default::default()
-                    });
+                    ));
                 }
             }
             Value::List(items) => {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -17,6 +17,47 @@ use carina_core::provider::ProviderFactory;
 use carina_core::resource::Value;
 use carina_core::schema::ResourceSchema;
 
+/// Create a `Diagnostic` on a single line with the standard "carina" source.
+pub(crate) fn carina_diagnostic(
+    line: u32,
+    start_col: u32,
+    end_col: u32,
+    severity: DiagnosticSeverity,
+    message: String,
+) -> Diagnostic {
+    Diagnostic {
+        range: Range {
+            start: Position {
+                line,
+                character: start_col,
+            },
+            end: Position {
+                line,
+                character: end_col,
+            },
+        },
+        severity: Some(severity),
+        source: Some("carina".to_string()),
+        message,
+        ..Default::default()
+    }
+}
+
+/// Create a `Diagnostic` with an arbitrary `Range` and the standard "carina" source.
+pub(crate) fn carina_diagnostic_range(
+    range: Range,
+    severity: DiagnosticSeverity,
+    message: String,
+) -> Diagnostic {
+    Diagnostic {
+        range,
+        severity: Some(severity),
+        source: Some("carina".to_string()),
+        message,
+        ..Default::default()
+    }
+}
+
 pub struct DiagnosticEngine {
     schemas: Arc<HashMap<String, ResourceSchema>>,
     provider_names: Vec<String>,
@@ -84,28 +125,20 @@ impl DiagnosticEngine {
                     if let Some((line, col)) =
                         self.find_resource_position(doc, &resource.id.resource_type)
                     {
-                        diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line,
-                                    character: col,
-                                },
-                                end: Position {
-                                    line,
-                                    character: col
-                                        + resource.id.resource_type.len() as u32
-                                        + provider.len() as u32
-                                        + 1, // "provider." prefix
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::ERROR),
-                            source: Some("carina".to_string()),
-                            message: format!(
+                        let end_col = col
+                            + resource.id.resource_type.len() as u32
+                            + provider.len() as u32
+                            + 1; // "provider." prefix
+                        diagnostics.push(carina_diagnostic(
+                            line,
+                            col,
+                            end_col,
+                            DiagnosticSeverity::ERROR,
+                            format!(
                                 "Unknown resource type: {}.{}",
                                 provider, resource.id.resource_type
                             ),
-                            ..Default::default()
-                        });
+                        ));
                     }
                 }
 
@@ -118,28 +151,20 @@ impl DiagnosticEngine {
                         && let Some((line, col)) =
                             self.find_resource_position(doc, &resource.id.resource_type)
                     {
-                        diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line,
-                                    character: col,
-                                },
-                                end: Position {
-                                    line,
-                                    character: col
-                                        + resource.id.resource_type.len() as u32
-                                        + provider.len() as u32
-                                        + 1,
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::ERROR),
-                            source: Some("carina".to_string()),
-                            message: format!(
+                        let end_col = col
+                            + resource.id.resource_type.len() as u32
+                            + provider.len() as u32
+                            + 1;
+                        diagnostics.push(carina_diagnostic(
+                            line,
+                            col,
+                            end_col,
+                            DiagnosticSeverity::ERROR,
+                            format!(
                                 "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
                                 full_resource_type, full_resource_type
                             ),
-                            ..Default::default()
-                        });
+                        ));
                     }
                 }
                 if let Some(schema) = schema {
@@ -165,25 +190,16 @@ impl DiagnosticEngine {
                         {
                             if let Some((line, col)) = self.find_attribute_position(doc, attr_name)
                             {
-                                diagnostics.push(Diagnostic {
-                                    range: Range {
-                                        start: Position {
-                                            line,
-                                            character: col,
-                                        },
-                                        end: Position {
-                                            line,
-                                            character: col + attr_name.len() as u32,
-                                        },
-                                    },
-                                    severity: Some(DiagnosticSeverity::ERROR),
-                                    source: Some("carina".to_string()),
-                                    message: format!(
+                                diagnostics.push(carina_diagnostic(
+                                    line,
+                                    col,
+                                    col + attr_name.len() as u32,
+                                    DiagnosticSeverity::ERROR,
+                                    format!(
                                         "Cannot use both '{}' and '{}' (they refer to the same attribute)",
                                         attr_name, canon
                                     ),
-                                    ..Default::default()
-                                });
+                                ));
                             }
                             continue;
                         }
@@ -201,25 +217,16 @@ impl DiagnosticEngine {
                                         String::new()
                                     };
 
-                                diagnostics.push(Diagnostic {
-                                    range: Range {
-                                        start: Position {
-                                            line,
-                                            character: col,
-                                        },
-                                        end: Position {
-                                            line,
-                                            character: col + attr_name.len() as u32,
-                                        },
-                                    },
-                                    severity: Some(DiagnosticSeverity::WARNING),
-                                    source: Some("carina".to_string()),
-                                    message: format!(
+                                diagnostics.push(carina_diagnostic(
+                                    line,
+                                    col,
+                                    col + attr_name.len() as u32,
+                                    DiagnosticSeverity::WARNING,
+                                    format!(
                                         "Unknown attribute '{}' for resource type '{}'{}",
                                         attr_name, resource.id.resource_type, suggestion
                                     ),
-                                    ..Default::default()
-                                });
+                                ));
                             }
                             continue;
                         }
@@ -239,25 +246,16 @@ impl DiagnosticEngine {
                                 let block_positions =
                                     self.find_all_block_positions(doc, search_name);
                                 for pos in &block_positions {
-                                    diagnostics.push(Diagnostic {
-                                        range: Range {
-                                            start: Position {
-                                                line: pos.0,
-                                                character: pos.1,
-                                            },
-                                            end: Position {
-                                                line: pos.0,
-                                                character: pos.1 + search_name.len() as u32,
-                                            },
-                                        },
-                                        severity: Some(DiagnosticSeverity::ERROR),
-                                        source: Some("carina".to_string()),
-                                        message: format!(
+                                    diagnostics.push(carina_diagnostic(
+                                        pos.0,
+                                        pos.1,
+                                        pos.1 + search_name.len() as u32,
+                                        DiagnosticSeverity::ERROR,
+                                        format!(
                                             "'{}' cannot use block syntax; use map assignment: {} = {{ ... }}",
                                             search_name, search_name
                                         ),
-                                        ..Default::default()
-                                    });
+                                    ));
                                 }
                             }
 
@@ -407,22 +405,13 @@ impl DiagnosticEngine {
                                 && let Some((line, col)) =
                                     self.find_attribute_position(doc, attr_name)
                             {
-                                diagnostics.push(Diagnostic {
-                                    range: Range {
-                                        start: Position {
-                                            line,
-                                            character: col,
-                                        },
-                                        end: Position {
-                                            line,
-                                            character: col + attr_name.len() as u32,
-                                        },
-                                    },
-                                    severity: Some(DiagnosticSeverity::WARNING),
-                                    source: Some("carina".to_string()),
+                                diagnostics.push(carina_diagnostic(
+                                    line,
+                                    col,
+                                    col + attr_name.len() as u32,
+                                    DiagnosticSeverity::WARNING,
                                     message,
-                                    ..Default::default()
-                                });
+                                ));
                             }
 
                             // Struct field validation
@@ -471,19 +460,17 @@ impl DiagnosticEngine {
                             if let Some((line, _col)) =
                                 self.find_resource_position(doc, &resource.id.resource_type)
                             {
-                                diagnostics.push(Diagnostic {
-                                    range: Range {
+                                diagnostics.push(carina_diagnostic_range(
+                                    Range {
                                         start: Position { line, character: 0 },
                                         end: Position {
                                             line: line + 1,
                                             character: 0,
                                         },
                                     },
-                                    severity: Some(DiagnosticSeverity::ERROR),
-                                    source: Some("carina".to_string()),
-                                    message: error.to_string(),
-                                    ..Default::default()
-                                });
+                                    DiagnosticSeverity::ERROR,
+                                    error.to_string(),
+                                ));
                             }
                         }
                     }
@@ -540,25 +527,16 @@ impl DiagnosticEngine {
                 let line_text = text.lines().nth(dup.line - 1)?;
                 let col = position::leading_whitespace_chars(line_text);
 
-                Some(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + dup.name.len() as u32,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::WARNING),
-                    source: Some("carina".to_string()),
-                    message: format!(
+                Some(carina_diagnostic(
+                    line,
+                    col,
+                    col + dup.name.len() as u32,
+                    DiagnosticSeverity::WARNING,
+                    format!(
                         "Duplicate attribute '{}' (first defined on line {}). The last value will be used.",
                         dup.name, dup.first_line
                     ),
-                    ..Default::default()
-                })
+                ))
             })
             .collect()
     }
@@ -577,25 +555,16 @@ impl DiagnosticEngine {
                 let byte_pos = line_text.find(&pattern)?;
                 let col = position::byte_offset_to_char_offset(line_text, byte_pos);
 
-                Some(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + pw.name.len() as u32,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::INFORMATION),
-                    source: Some("carina".to_string()),
-                    message: format!(
+                Some(carina_diagnostic(
+                    line,
+                    col,
+                    col + pw.name.len() as u32,
+                    DiagnosticSeverity::INFORMATION,
+                    format!(
                         "Consider using pipe form for '{}': data |> {}(...)",
                         pw.name, pw.name
                     ),
-                    ..Default::default()
-                })
+                ))
             })
             .collect()
     }
@@ -614,25 +583,16 @@ impl DiagnosticEngine {
                 let byte_pos = line_text.find(&nw.name)?;
                 let col = position::byte_offset_to_char_offset(line_text, byte_pos);
 
-                Some(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + nw.name.len() as u32,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::INFORMATION),
-                    source: Some("carina".to_string()),
-                    message: format!(
+                Some(carina_diagnostic(
+                    line,
+                    col,
+                    col + nw.name.len() as u32,
+                    DiagnosticSeverity::INFORMATION,
+                    format!(
                         "Binding '{}' is not snake_case. Use snake_case for binding names (e.g., 'my_resource').",
                         nw.name
                     ),
-                    ..Default::default()
-                })
+                ))
             })
             .collect()
     }
@@ -708,106 +668,63 @@ fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {
                 pest::error::LineColLocation::Span((line, col), _) => (line, col),
             };
 
-            Diagnostic {
-                range: Range {
-                    start: Position {
-                        line: (line.saturating_sub(1)) as u32,
-                        character: (col.saturating_sub(1)) as u32,
-                    },
-                    end: Position {
-                        line: (line.saturating_sub(1)) as u32,
-                        character: col as u32,
-                    },
-                },
-                severity: Some(DiagnosticSeverity::ERROR),
-                source: Some("carina".to_string()),
-                message: format!("{}", pest_error),
-                ..Default::default()
-            }
+            carina_diagnostic(
+                (line.saturating_sub(1)) as u32,
+                (col.saturating_sub(1)) as u32,
+                col as u32,
+                DiagnosticSeverity::ERROR,
+                format!("{}", pest_error),
+            )
         }
-        ParseError::InvalidExpression { line, message } => Diagnostic {
-            range: Range {
-                start: Position {
-                    line: (*line as u32).saturating_sub(1),
-                    character: 0,
-                },
-                end: Position {
-                    line: (*line as u32).saturating_sub(1),
-                    character: 100,
-                },
-            },
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: message.clone(),
-            ..Default::default()
-        },
-        ParseError::UndefinedVariable(name) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Undefined variable: {}", name),
-            ..Default::default()
-        },
-        ParseError::InvalidResourceType(name) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Invalid resource type: {}", name),
-            ..Default::default()
-        },
-        ParseError::DuplicateModule(name) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Duplicate module definition: {}", name),
-            ..Default::default()
-        },
-        ParseError::DuplicateBinding { name, line } => Diagnostic {
-            range: Range {
-                start: Position {
-                    line: (line - 1) as u32,
-                    character: 0,
-                },
-                end: Position {
-                    line: (line - 1) as u32,
-                    character: 0,
-                },
-            },
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Duplicate binding: {}", name),
-            ..Default::default()
-        },
-        ParseError::ModuleNotFound(name) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Module not found: {}", name),
-            ..Default::default()
-        },
-        ParseError::InternalError { expected, context } => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!(
+        ParseError::InvalidExpression { line, message } => carina_diagnostic(
+            (*line as u32).saturating_sub(1),
+            0,
+            100,
+            DiagnosticSeverity::ERROR,
+            message.clone(),
+        ),
+        ParseError::UndefinedVariable(name) => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!("Undefined variable: {}", name),
+        ),
+        ParseError::InvalidResourceType(name) => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!("Invalid resource type: {}", name),
+        ),
+        ParseError::DuplicateModule(name) => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!("Duplicate module definition: {}", name),
+        ),
+        ParseError::DuplicateBinding { name, line } => carina_diagnostic(
+            (line - 1) as u32,
+            0,
+            0,
+            DiagnosticSeverity::ERROR,
+            format!("Duplicate binding: {}", name),
+        ),
+        ParseError::ModuleNotFound(name) => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!("Module not found: {}", name),
+        ),
+        ParseError::InternalError { expected, context } => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!(
                 "Internal parser error: expected {} in {}",
                 expected, context
             ),
-            ..Default::default()
-        },
-        ParseError::RecursiveFunction(name) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: format!("Recursive function call detected: {}", name),
-            ..Default::default()
-        },
-        ParseError::UserFunctionError(msg) => Diagnostic {
-            range: Range::default(),
-            severity: Some(DiagnosticSeverity::ERROR),
-            source: Some("carina".to_string()),
-            message: msg.to_string(),
-            ..Default::default()
-        },
+        ),
+        ParseError::RecursiveFunction(name) => carina_diagnostic_range(
+            Range::default(),
+            DiagnosticSeverity::ERROR,
+            format!("Recursive function call detected: {}", name),
+        ),
+        ParseError::UserFunctionError(msg) => {
+            carina_diagnostic_range(Range::default(), DiagnosticSeverity::ERROR, msg.to_string())
+        }
     }
 }

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -558,3 +558,64 @@ let vpc = awscc.ec2.vpc {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn carina_diagnostic_helper_produces_correct_fields() {
+    use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Range};
+
+    let diag = carina_diagnostic(
+        5,
+        10,
+        20,
+        DiagnosticSeverity::ERROR,
+        "test error message".to_string(),
+    );
+
+    assert_eq!(
+        diag.range,
+        Range {
+            start: Position {
+                line: 5,
+                character: 10,
+            },
+            end: Position {
+                line: 5,
+                character: 20,
+            },
+        }
+    );
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(diag.source, Some("carina".to_string()));
+    assert_eq!(diag.message, "test error message");
+    // Verify default fields are not set
+    assert!(diag.code.is_none());
+    assert!(diag.code_description.is_none());
+    assert!(diag.tags.is_none());
+    assert!(diag.related_information.is_none());
+    assert!(diag.data.is_none());
+}
+
+#[test]
+fn carina_diagnostic_helper_with_multiline_range() {
+    use tower_lsp::lsp_types::{DiagnosticSeverity, Position, Range};
+
+    let diag = carina_diagnostic_range(
+        Range {
+            start: Position {
+                line: 3,
+                character: 0,
+            },
+            end: Position {
+                line: 4,
+                character: 0,
+            },
+        },
+        DiagnosticSeverity::ERROR,
+        "resource-level error".to_string(),
+    );
+
+    assert_eq!(diag.range.start.line, 3);
+    assert_eq!(diag.range.end.line, 4);
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(diag.source, Some("carina".to_string()));
+}

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -2,14 +2,14 @@
 
 use std::collections::{HashMap, HashSet};
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 use crate::document::Document;
 use crate::position;
 use carina_core::resource::Value;
 use carina_core::schema::ResourceSchema;
 
-use super::DiagnosticEngine;
+use super::{DiagnosticEngine, carina_diagnostic};
 
 impl DiagnosticEngine {
     pub(super) fn validate_struct_value(
@@ -58,22 +58,13 @@ impl DiagnosticEngine {
 
                     // Check for unknown fields
                     if !field_names.contains(canonical_key) {
-                        diagnostics.push(Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line,
-                                    character: col,
-                                },
-                                end: Position {
-                                    line,
-                                    character: col + key.len() as u32,
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::WARNING),
-                            source: Some("carina".to_string()),
-                            message: format!("Unknown field '{}' in '{}'", key, attr_name),
-                            ..Default::default()
-                        });
+                        diagnostics.push(carina_diagnostic(
+                            line,
+                            col,
+                            col + key.len() as u32,
+                            DiagnosticSeverity::WARNING,
+                            format!("Unknown field '{}' in '{}'", key, attr_name),
+                        ));
                         continue;
                     }
 
@@ -87,22 +78,13 @@ impl DiagnosticEngine {
                         };
 
                         if let Some(message) = type_error {
-                            diagnostics.push(Diagnostic {
-                                range: Range {
-                                    start: Position {
-                                        line,
-                                        character: col,
-                                    },
-                                    end: Position {
-                                        line,
-                                        character: col + key.len() as u32,
-                                    },
-                                },
-                                severity: Some(DiagnosticSeverity::WARNING),
-                                source: Some("carina".to_string()),
+                            diagnostics.push(carina_diagnostic(
+                                line,
+                                col,
+                                col + key.len() as u32,
+                                DiagnosticSeverity::WARNING,
                                 message,
-                                ..Default::default()
-                            });
+                            ));
                         }
 
                         // Recurse into nested Struct / List<Struct> fields
@@ -213,25 +195,16 @@ impl DiagnosticEngine {
             }
 
             if let Some((line, col)) = self.find_list_literal_position(doc, attr_name) {
-                diagnostics.push(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line,
-                            character: col,
-                        },
-                        end: Position {
-                            line,
-                            character: col + attr_name.len() as u32,
-                        },
-                    },
-                    severity: Some(DiagnosticSeverity::HINT),
-                    source: Some("carina".to_string()),
-                    message: format!(
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    col + attr_name.len() as u32,
+                    DiagnosticSeverity::HINT,
+                    format!(
                         "Prefer block syntax for '{}'. Use `{} {{ ... }}` instead of `{} = [{{ ... }}]`.",
                         attr_name, attr_name, attr_name
                     ),
-                    ..Default::default()
-                });
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

- Extract `carina_diagnostic()` and `carina_diagnostic_range()` helper functions to eliminate repetitive `Diagnostic { range: Range { start: Position { ... }, end: Position { ... } }, severity: Some(...), source: Some("carina".to_string()), ... }` boilerplate
- Replace all 34 occurrences across `mod.rs`, `checks.rs`, and `validation.rs` with calls to the helpers
- Net reduction of ~148 lines

## Test plan

- [x] Added `carina_diagnostic_helper_produces_correct_fields` test verifying all fields of the single-line helper
- [x] Added `carina_diagnostic_helper_with_multiline_range` test verifying the range-based helper
- [x] All 194 existing carina-lsp tests pass unchanged (behavior-preserving refactor)

closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)