### PR TITLE
refactor: reduce parameter sprawl with context structs

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -448,40 +448,45 @@ fn execute_state_only_effects(plan: &Plan, result: &mut ApplyResult) {
     }
 }
 
+/// Input parameters for `finalize_apply`.
+///
+/// Groups the execution result, resource data, and backend configuration
+/// needed to save state after an apply operation.
+pub struct FinalizeApplyInput<'a> {
+    pub result: &'a ApplyResult,
+    pub state_file: Option<StateFile>,
+    pub sorted_resources: &'a [Resource],
+    pub current_states: &'a HashMap<ResourceId, State>,
+    pub plan: &'a Plan,
+    pub backend: &'a dyn StateBackend,
+    pub lock: Option<&'a LockInfo>,
+    pub schemas: &'a HashMap<String, ResourceSchema>,
+}
+
 /// Save state after apply. Does NOT release the lock -- caller is responsible.
 ///
 /// When `lock` is `None` (i.e. `--lock=false`), state is written without lock
 /// validation via `save_state_unlocked`.
-#[allow(clippy::too_many_arguments)]
-pub async fn finalize_apply(
-    result: &ApplyResult,
-    state_file: Option<StateFile>,
-    sorted_resources: &[Resource],
-    current_states: &HashMap<ResourceId, State>,
-    plan: &Plan,
-    backend: &dyn StateBackend,
-    lock: Option<&LockInfo>,
-    schemas: &HashMap<String, ResourceSchema>,
-) -> Result<(), AppError> {
+pub async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), AppError> {
     println!();
     println!("{}", "Saving state...".cyan());
 
     let mut state = build_state_after_apply(ApplyStateSave {
-        state_file,
-        sorted_resources,
-        current_states,
-        applied_states: &result.applied_states,
-        permanent_name_overrides: &result.permanent_name_overrides,
-        plan,
-        successfully_deleted: &result.successfully_deleted,
-        failed_refreshes: &result.failed_refreshes,
-        schemas,
+        state_file: input.state_file,
+        sorted_resources: input.sorted_resources,
+        current_states: input.current_states,
+        applied_states: &input.result.applied_states,
+        permanent_name_overrides: &input.result.permanent_name_overrides,
+        plan: input.plan,
+        successfully_deleted: &input.result.successfully_deleted,
+        failed_refreshes: &input.result.failed_refreshes,
+        schemas: input.schemas,
     })?;
 
-    if let Some(lock) = lock {
-        save_state_locked(backend, lock, &mut state).await?;
+    if let Some(lock) = input.lock {
+        save_state_locked(input.backend, lock, &mut state).await?;
     } else {
-        save_state_unlocked(backend, &mut state).await?;
+        save_state_unlocked(input.backend, &mut state).await?;
     }
     println!("  {} State saved (serial: {})", "✓".green(), state.serial);
 
@@ -1228,16 +1233,16 @@ async fn run_apply_locked(
     // Execute remove and move effects (state-only, logged for user feedback)
     execute_state_only_effects(&plan, &mut result);
 
-    finalize_apply(
-        &result,
+    finalize_apply(FinalizeApplyInput {
+        result: &result,
         state_file,
-        &sorted_resources,
-        &current_states,
-        &plan,
+        sorted_resources: &sorted_resources,
+        current_states: &current_states,
+        plan: &plan,
         backend,
         lock,
         schemas,
-    )
+    })
     .await?;
 
     println!();
@@ -1535,16 +1540,16 @@ async fn run_apply_from_plan_locked(
     // Build schemas for write-only attribute persistence
     let ctx = WiringContext::new();
 
-    finalize_apply(
-        &result,
+    finalize_apply(FinalizeApplyInput {
+        result: &result,
         state_file,
         sorted_resources,
-        &current_states,
+        current_states: &current_states,
         plan,
         backend,
         lock,
-        ctx.schemas(),
-    )
+        schemas: ctx.schemas(),
+    })
     .await?;
 
     println!();

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -13,8 +13,9 @@ use carina_core::schema::ResourceSchema;
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
 
 use crate::commands::apply::{
-    ApplyResult, ApplyStateSave, build_state_after_apply, detect_drift, execute_effects,
-    finalize_apply, queue_state_refresh, refresh_pending_states, save_state_locked,
+    ApplyResult, ApplyStateSave, FinalizeApplyInput, build_state_after_apply, detect_drift,
+    execute_effects, finalize_apply, queue_state_refresh, refresh_pending_states,
+    save_state_locked,
 };
 use crate::commands::plan::{CurrentStateEntry, PlanFile};
 use crate::commands::state::run_state_refresh_locked;
@@ -1364,16 +1365,16 @@ async fn lock_released_on_write_state_failure() {
 
     // This mirrors the pattern used in run_apply_locked / run_apply_from_plan_locked:
     // call finalize_apply (which may fail), then always release lock in the caller.
-    let op_result = finalize_apply(
-        &result,
-        Some(StateFile::new()),
-        &[],
-        &HashMap::new(),
-        &Plan::new(),
-        &backend,
-        Some(&lock),
-        &HashMap::new(),
-    )
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(StateFile::new()),
+        sorted_resources: &[],
+        current_states: &HashMap::new(),
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: Some(&lock),
+        schemas: &HashMap::new(),
+    })
     .await;
 
     // Caller always releases the lock
@@ -1496,16 +1497,16 @@ async fn finalize_apply_uses_write_state_locked() {
         failed_refreshes: HashSet::new(),
     };
 
-    let op_result = finalize_apply(
-        &result,
-        Some(StateFile::new()),
-        &[],
-        &HashMap::new(),
-        &Plan::new(),
-        &backend,
-        Some(&lock),
-        &HashMap::new(),
-    )
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(StateFile::new()),
+        sorted_resources: &[],
+        current_states: &HashMap::new(),
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: Some(&lock),
+        schemas: &HashMap::new(),
+    })
     .await;
 
     assert!(op_result.is_ok(), "finalize_apply should succeed");
@@ -2012,16 +2013,16 @@ async fn finalize_apply_without_lock_uses_write_state() {
         failed_refreshes: HashSet::new(),
     };
 
-    let op_result = finalize_apply(
-        &result,
-        Some(StateFile::new()),
-        &[],
-        &HashMap::new(),
-        &Plan::new(),
-        &backend,
-        None, // No lock
-        &HashMap::new(),
-    )
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(StateFile::new()),
+        sorted_resources: &[],
+        current_states: &HashMap::new(),
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: None, // No lock
+        schemas: &HashMap::new(),
+    })
     .await;
 
     assert!(op_result.is_ok(), "finalize_apply should succeed");

--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -433,15 +433,17 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         };
 
         let (type_code, enum_info) = resolve_type(
-            model,
+            &mut TypeResolutionContext {
+                model,
+                namespace: &namespace,
+                type_overrides: &type_overrides,
+                enum_alias_map: &enum_alias_map,
+                to_dsl_overrides: &to_dsl_overrides,
+                all_enums: &mut all_enums,
+                all_ranged_ints: &mut all_ranged_ints,
+            },
             &member_ref.target,
             name,
-            &namespace,
-            &type_overrides,
-            &enum_alias_map,
-            &to_dsl_overrides,
-            &mut all_enums,
-            &mut all_ranged_ints,
         );
 
         attrs.push(AttrInfo {
@@ -487,15 +489,17 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
         let description = SmithyModel::documentation(&member_ref.traits).map(|s| s.to_string());
 
         let (type_code, enum_info) = resolve_type(
-            model,
+            &mut TypeResolutionContext {
+                model,
+                namespace: &namespace,
+                type_overrides: &type_overrides,
+                enum_alias_map: &enum_alias_map,
+                to_dsl_overrides: &to_dsl_overrides,
+                all_enums: &mut all_enums,
+                all_ranged_ints: &mut all_ranged_ints,
+            },
             &member_ref.target,
             name,
-            &namespace,
-            &type_overrides,
-            &enum_alias_map,
-            &to_dsl_overrides,
-            &mut all_enums,
-            &mut all_ranged_ints,
         );
 
         attrs.push(AttrInfo {
@@ -824,23 +828,30 @@ fn generate_resource(res: &ResourceDef, model: &SmithyModel) -> Result<String> {
     Ok(code)
 }
 
+/// Shared context for Smithy-to-Carina type resolution.
+///
+/// Groups the Smithy model, configuration overrides, and mutable collectors
+/// that are passed to both `resolve_type` and `generate_struct_type`.
+struct TypeResolutionContext<'a> {
+    model: &'a SmithyModel,
+    namespace: &'a str,
+    type_overrides: &'a HashMap<&'a str, &'a str>,
+    enum_alias_map: &'a HashMap<&'a str, Vec<(&'a str, &'a str)>>,
+    to_dsl_overrides: &'a HashMap<&'a str, &'a str>,
+    all_enums: &'a mut BTreeMap<String, EnumInfo>,
+    all_ranged_ints: &'a mut BTreeMap<String, IntRange>,
+}
+
 /// Resolve a Smithy type to a Carina type code string.
 /// Returns (type_code, Option<EnumInfo>).
 /// Also populates collectors for enums and ranged ints discovered during resolution.
-#[allow(clippy::too_many_arguments)]
 fn resolve_type(
-    model: &SmithyModel,
+    ctx: &mut TypeResolutionContext<'_>,
     target: &str,
     field_name: &str,
-    namespace: &str,
-    type_overrides: &HashMap<&str, &str>,
-    enum_alias_map: &HashMap<&str, Vec<(&str, &str)>>,
-    to_dsl_overrides: &HashMap<&str, &str>,
-    all_enums: &mut BTreeMap<String, EnumInfo>,
-    all_ranged_ints: &mut BTreeMap<String, IntRange>,
 ) -> (String, Option<EnumInfo>) {
     // Check type overrides first
-    if let Some(&override_type) = type_overrides.get(field_name) {
+    if let Some(&override_type) = ctx.type_overrides.get(field_name) {
         return (override_type.to_string(), None);
     }
 
@@ -851,13 +862,13 @@ fn resolve_type(
             type_name,
             values: values.iter().map(|s| s.to_string()).collect(),
         };
-        all_enums
+        ctx.all_enums
             .entry(field_name.to_string())
             .or_insert_with(|| enum_info.clone());
         return ("/* enum */".to_string(), Some(enum_info));
     }
 
-    let kind = model.shape_kind(target);
+    let kind = ctx.model.shape_kind(target);
 
     match kind {
         Some(ShapeKind::String) => {
@@ -871,9 +882,11 @@ fn resolve_type(
         Some(ShapeKind::Boolean) => ("AttributeType::Bool".to_string(), None),
         Some(ShapeKind::Integer) | Some(ShapeKind::Long) => {
             // Check for range traits on the target shape
-            let range = get_int_range(model, target, field_name);
+            let range = get_int_range(ctx.model, target, field_name);
             if let Some(r) = range {
-                all_ranged_ints.entry(field_name.to_string()).or_insert(r);
+                ctx.all_ranged_ints
+                    .entry(field_name.to_string())
+                    .or_insert(r);
                 let validate_fn = format!("validate_{}_range", field_name.to_snake_case());
                 let display = range_display_string(r.min, r.max);
                 (
@@ -898,7 +911,7 @@ fn resolve_type(
         }
         Some(ShapeKind::Enum) => {
             // Get enum values from Smithy model
-            if let Some(values) = model.enum_values(target) {
+            if let Some(values) = ctx.model.enum_values(target) {
                 // Use the field name as type_name for consistency with CF codegen
                 // (e.g., "InstanceTenancy" not "Tenancy")
                 let type_name = field_name.to_string();
@@ -907,7 +920,7 @@ fn resolve_type(
                     type_name,
                     values: string_values,
                 };
-                all_enums
+                ctx.all_enums
                     .entry(field_name.to_string())
                     .or_insert_with(|| enum_info.clone());
                 return ("/* enum */".to_string(), Some(enum_info));
@@ -917,18 +930,8 @@ fn resolve_type(
         Some(ShapeKind::IntEnum) => ("AttributeType::Int".to_string(), None),
         Some(ShapeKind::List) => {
             // Get list member type
-            if let Some(carina_smithy::Shape::List(list_shape)) = model.get_shape(target) {
-                let (item_type, _) = resolve_type(
-                    model,
-                    &list_shape.member.target,
-                    field_name,
-                    namespace,
-                    type_overrides,
-                    enum_alias_map,
-                    to_dsl_overrides,
-                    all_enums,
-                    all_ranged_ints,
-                );
+            if let Some(carina_smithy::Shape::List(list_shape)) = ctx.model.get_shape(target) {
+                let (item_type, _) = resolve_type(ctx, &list_shape.member.target, field_name);
                 (format!("AttributeType::list({})", item_type), None)
             } else {
                 (
@@ -954,18 +957,8 @@ fn resolve_type(
             }
 
             // Generate struct type for nested structures
-            if let Some(structure) = model.get_structure(target) {
-                let struct_code = generate_struct_type(
-                    model,
-                    shape_name,
-                    structure,
-                    namespace,
-                    type_overrides,
-                    enum_alias_map,
-                    to_dsl_overrides,
-                    all_enums,
-                    all_ranged_ints,
-                );
+            if let Some(structure) = ctx.model.get_structure(target) {
+                let struct_code = generate_struct_type(ctx, shape_name, structure);
                 return (struct_code, None);
             }
             ("AttributeType::String".to_string(), None)
@@ -982,62 +975,45 @@ fn resolve_type(
 }
 
 /// Generate Rust code for an AttributeType::Struct.
-#[allow(clippy::too_many_arguments)]
 fn generate_struct_type(
-    model: &SmithyModel,
+    ctx: &mut TypeResolutionContext<'_>,
     struct_name: &str,
     structure: &carina_smithy::StructureShape,
-    namespace: &str,
-    type_overrides: &HashMap<&str, &str>,
-    enum_alias_map: &HashMap<&str, Vec<(&str, &str)>>,
-    to_dsl_overrides: &HashMap<&str, &str>,
-    all_enums: &mut BTreeMap<String, EnumInfo>,
-    all_ranged_ints: &mut BTreeMap<String, IntRange>,
 ) -> String {
     let mut fields: Vec<String> = Vec::new();
     for (field_name, member_ref) in &structure.members {
         let snake_name = field_name.to_snake_case();
         let is_required = SmithyModel::is_required(member_ref);
 
-        let (field_type, enum_info) = resolve_type(
-            model,
-            &member_ref.target,
-            field_name,
-            namespace,
-            type_overrides,
-            enum_alias_map,
-            to_dsl_overrides,
-            all_enums,
-            all_ranged_ints,
-        );
+        let (field_type, enum_info) = resolve_type(ctx, &member_ref.target, field_name);
 
         // If enum detected, use shared schema enum type.
         let field_type = if let Some(ei) = enum_info {
-            let to_dsl_code = if let Some(override_code) = to_dsl_overrides.get(snake_name.as_str())
-            {
-                override_code.to_string()
-            } else {
-                let has_hyphens = ei.values.iter().any(|v| v.contains('-'));
-                if let Some(aliases) = enum_alias_map.get(snake_name.as_str()) {
-                    let mut match_arms: Vec<String> = aliases
-                        .iter()
-                        .map(|(canonical, alias)| {
-                            format!("\"{}\" => \"{}\".to_string()", canonical, alias)
-                        })
-                        .collect();
-                    let fallback = if has_hyphens {
-                        "_ => s.replace('-', \"_\")"
-                    } else {
-                        "_ => s.to_string()"
-                    };
-                    match_arms.push(fallback.to_string());
-                    format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
-                } else if has_hyphens {
-                    "Some(|s: &str| s.replace('-', \"_\"))".to_string()
+            let to_dsl_code =
+                if let Some(override_code) = ctx.to_dsl_overrides.get(snake_name.as_str()) {
+                    override_code.to_string()
                 } else {
-                    "None".to_string()
-                }
-            };
+                    let has_hyphens = ei.values.iter().any(|v| v.contains('-'));
+                    if let Some(aliases) = ctx.enum_alias_map.get(snake_name.as_str()) {
+                        let mut match_arms: Vec<String> = aliases
+                            .iter()
+                            .map(|(canonical, alias)| {
+                                format!("\"{}\" => \"{}\".to_string()", canonical, alias)
+                            })
+                            .collect();
+                        let fallback = if has_hyphens {
+                            "_ => s.replace('-', \"_\")"
+                        } else {
+                            "_ => s.to_string()"
+                        };
+                        match_arms.push(fallback.to_string());
+                        format!("Some(|s: &str| match s {{ {} }})", match_arms.join(", "))
+                    } else if has_hyphens {
+                        "Some(|s: &str| s.replace('-', \"_\"))".to_string()
+                    } else {
+                        "None".to_string()
+                    }
+                };
             let values_str = ei
                 .values
                 .iter()
@@ -1051,7 +1027,7 @@ fn generate_struct_type(
                  \x20               namespace: Some(\"{}\".to_string()),\n\
                  \x20               to_dsl: {},\n\
                  \x20           }}",
-                ei.type_name, values_str, namespace, to_dsl_code
+                ei.type_name, values_str, ctx.namespace, to_dsl_code
             )
         } else {
             field_type

--- a/carina-core/src/executor.rs
+++ b/carina-core/src/executor.rs
@@ -349,50 +349,54 @@ fn update_binding_map(
     }
 }
 
+/// Mutable execution state shared across effect processing.
+///
+/// Groups the counters, result maps, and binding state that are threaded
+/// through every call to `process_basic_result`, reducing parameter count.
+struct ExecutionState<'a> {
+    success_count: &'a mut usize,
+    failure_count: &'a mut usize,
+    applied_states: &'a mut HashMap<ResourceId, State>,
+    failed_bindings: &'a mut HashSet<String>,
+    successfully_deleted: &'a mut HashSet<ResourceId>,
+    pending_refreshes: &'a mut HashMap<ResourceId, String>,
+    binding_map: &'a mut HashMap<String, HashMap<String, Value>>,
+}
+
 /// Process a `BasicEffectResult` by updating shared execution state.
 ///
 /// This helper is used by both sequential and phased execution paths to avoid
 /// duplicating the result-processing logic for Create/Update/Delete effects.
-#[allow(clippy::too_many_arguments)]
-fn process_basic_result(
-    result: BasicEffectResult,
-    success_count: &mut usize,
-    failure_count: &mut usize,
-    applied_states: &mut HashMap<ResourceId, State>,
-    failed_bindings: &mut HashSet<String>,
-    successfully_deleted: &mut HashSet<ResourceId>,
-    pending_refreshes: &mut HashMap<ResourceId, String>,
-    binding_map: &mut HashMap<String, HashMap<String, Value>>,
-) {
+fn process_basic_result(result: BasicEffectResult, exec: &mut ExecutionState<'_>) {
     match result {
         BasicEffectResult::Success {
-            state,
+            state: effect_state,
             resource_id,
             resolved_attrs,
             binding,
         } => {
-            *success_count += 1;
-            if let Some(state) = state {
+            *exec.success_count += 1;
+            if let Some(s) = effect_state {
                 if let Some(attrs) = &resolved_attrs {
-                    update_binding_map(binding_map, attrs, binding.as_deref(), &state);
+                    update_binding_map(exec.binding_map, attrs, binding.as_deref(), &s);
                 }
-                applied_states.insert(resource_id, state);
+                exec.applied_states.insert(resource_id, s);
             }
         }
         BasicEffectResult::Failure {
             binding, refresh, ..
         } => {
-            *failure_count += 1;
+            *exec.failure_count += 1;
             if let Some(binding) = binding {
-                failed_bindings.insert(binding);
+                exec.failed_bindings.insert(binding);
             }
             if let Some((id, identifier)) = &refresh {
-                queue_state_refresh(pending_refreshes, id, Some(identifier.as_str()));
+                queue_state_refresh(exec.pending_refreshes, id, Some(identifier.as_str()));
             }
         }
         BasicEffectResult::Deleted { resource_id, .. } => {
-            *success_count += 1;
-            successfully_deleted.insert(resource_id);
+            *exec.success_count += 1;
+            exec.successfully_deleted.insert(resource_id);
         }
     }
 }
@@ -872,17 +876,19 @@ async fn execute_effects_sequential(
 
                         execute_replace_parallel(
                             provider,
-                            effect,
-                            id,
-                            from,
-                            to,
-                            lifecycle,
-                            cascading_updates,
-                            temporary_name.as_ref(),
-                            &binding_snapshot,
-                            unresolved,
-                            started,
-                            progress,
+                            &ReplaceContext {
+                                effect,
+                                id,
+                                from,
+                                to,
+                                lifecycle,
+                                cascading_updates,
+                                temporary_name: temporary_name.as_ref(),
+                                binding_map: &binding_snapshot,
+                                unresolved,
+                                started,
+                                progress,
+                            },
                             observer,
                         )
                         .await
@@ -926,13 +932,15 @@ async fn execute_effects_sequential(
             SingleEffectResult::Basic(basic) => {
                 process_basic_result(
                     basic,
-                    &mut success_count,
-                    &mut failure_count,
-                    &mut applied_states,
-                    &mut failed_bindings,
-                    &mut successfully_deleted,
-                    &mut pending_refreshes,
-                    &mut input.binding_map,
+                    &mut ExecutionState {
+                        success_count: &mut success_count,
+                        failure_count: &mut failure_count,
+                        applied_states: &mut applied_states,
+                        failed_bindings: &mut failed_bindings,
+                        successfully_deleted: &mut successfully_deleted,
+                        pending_refreshes: &mut pending_refreshes,
+                        binding_map: &mut input.binding_map,
+                    },
                 );
             }
             SingleEffectResult::Replace {
@@ -1000,90 +1008,58 @@ async fn execute_effects_sequential(
 // Replace execution for parallel path
 // ---------------------------------------------------------------------------
 
+/// Context for executing a Replace effect in the parallel path.
+///
+/// Groups the resource data, lifecycle configuration, and execution metadata
+/// that are passed to both CBD and DBD replace functions.
+struct ReplaceContext<'a> {
+    effect: &'a Effect,
+    id: &'a ResourceId,
+    from: &'a State,
+    to: &'a Resource,
+    lifecycle: &'a crate::resource::LifecycleConfig,
+    cascading_updates: &'a [crate::effect::CascadingUpdate],
+    temporary_name: Option<&'a crate::effect::TemporaryName>,
+    binding_map: &'a HashMap<String, HashMap<String, Value>>,
+    unresolved: &'a HashMap<ResourceId, Resource>,
+    started: Instant,
+    progress: ProgressInfo,
+}
+
 /// Execute a Replace effect, returning a `SingleEffectResult`.
 ///
 /// This handles both CBD and DBD replace within the parallel execution path.
 /// It does not mutate shared state directly; instead returns all data needed
 /// for the caller to update shared state after the level completes.
-#[allow(clippy::too_many_arguments)]
 async fn execute_replace_parallel(
     provider: &dyn Provider,
-    effect: &Effect,
-    id: &ResourceId,
-    from: &State,
-    to: &Resource,
-    lifecycle: &crate::resource::LifecycleConfig,
-    cascading_updates: &[crate::effect::CascadingUpdate],
-    temporary_name: Option<&crate::effect::TemporaryName>,
-    binding_map: &HashMap<String, HashMap<String, Value>>,
-    unresolved: &HashMap<ResourceId, Resource>,
-    started: Instant,
-    progress: ProgressInfo,
+    ctx: &ReplaceContext<'_>,
     observer: &dyn ExecutionObserver,
 ) -> SingleEffectResult {
-    if lifecycle.create_before_destroy {
-        execute_cbd_replace_parallel(
-            provider,
-            effect,
-            id,
-            from,
-            to,
-            lifecycle,
-            cascading_updates,
-            temporary_name,
-            binding_map,
-            unresolved,
-            started,
-            progress,
-            observer,
-        )
-        .await
+    if ctx.lifecycle.create_before_destroy {
+        execute_cbd_replace_parallel(provider, ctx, observer).await
     } else {
-        execute_dbd_replace_parallel(
-            provider,
-            effect,
-            id,
-            from,
-            to,
-            lifecycle,
-            binding_map,
-            unresolved,
-            started,
-            progress,
-            observer,
-        )
-        .await
+        execute_dbd_replace_parallel(provider, ctx, observer).await
     }
 }
 
 /// CBD Replace for the parallel execution path.
-#[allow(clippy::too_many_arguments)]
 async fn execute_cbd_replace_parallel(
     provider: &dyn Provider,
-    effect: &Effect,
-    id: &ResourceId,
-    from: &State,
-    to: &Resource,
-    lifecycle: &crate::resource::LifecycleConfig,
-    cascading_updates: &[crate::effect::CascadingUpdate],
-    temporary_name: Option<&crate::effect::TemporaryName>,
-    binding_map: &HashMap<String, HashMap<String, Value>>,
-    _unresolved: &HashMap<ResourceId, Resource>,
-    started: Instant,
-    progress: ProgressInfo,
+    ctx: &ReplaceContext<'_>,
     observer: &dyn ExecutionObserver,
 ) -> SingleEffectResult {
-    let resolved = match resolve_resource(to, binding_map) {
+    let resolved = match resolve_resource(ctx.to, ctx.binding_map) {
         Ok(r) => r,
         Err(e) => {
             observer.on_event(&ExecutionEvent::EffectFailed {
-                effect,
+                effect: ctx.effect,
                 error: &e,
-                duration: started.elapsed(),
-                progress,
+                duration: ctx.started.elapsed(),
+                progress: ctx.progress,
             });
             return SingleEffectResult::Basic(BasicEffectResult::Failure {
-                binding: effect.binding_name(),
+                binding: ctx.effect.binding_name(),
                 refresh: None,
             });
         }
@@ -1093,17 +1069,17 @@ async fn execute_cbd_replace_parallel(
     match provider.create(&resolved).await {
         Ok(state) => {
             // Build a local binding map update for cascade resolution
-            let mut local_binding_map = binding_map.clone();
+            let mut local_binding_map = ctx.binding_map.clone();
             update_binding_map(
                 &mut local_binding_map,
                 &resolved.attributes,
-                to.binding.as_deref(),
+                ctx.to.binding.as_deref(),
                 &state,
             );
 
             // Execute cascading updates
             let mut cascade_failed = false;
-            for cascade in cascading_updates {
+            for cascade in ctx.cascading_updates {
                 let resolved_to = match resolve_resource(&cascade.to, &local_binding_map) {
                     Ok(r) => r,
                     Err(e) => {
@@ -1146,43 +1122,46 @@ async fn execute_cbd_replace_parallel(
             }
 
             if cascade_failed {
-                refreshes.push((to.id.clone(), state.identifier.clone().unwrap_or_default()));
+                refreshes.push((
+                    ctx.to.id.clone(),
+                    state.identifier.clone().unwrap_or_default(),
+                ));
                 return SingleEffectResult::Replace {
                     success: false,
                     state: None,
-                    resource_id: to.id.clone(),
+                    resource_id: ctx.to.id.clone(),
                     resolved_attrs: None,
-                    binding: effect.binding_name(),
+                    binding: ctx.effect.binding_name(),
                     refreshes,
                     permanent_overrides: None,
                 };
             }
 
             // Delete the old resource
-            let identifier = from.identifier.as_deref().unwrap_or("");
-            match provider.delete(id, identifier, lifecycle).await {
+            let identifier = ctx.from.identifier.as_deref().unwrap_or("");
+            match provider.delete(ctx.id, identifier, ctx.lifecycle).await {
                 Ok(()) => {
                     // Handle rename
                     let mut permanent_overrides = None;
                     let mut final_state = state.clone();
                     let mut rename_failed = false;
 
-                    if let Some(temp) = temporary_name
+                    if let Some(temp) = ctx.temporary_name
                         && temp.can_rename
                     {
                         let new_identifier = state.identifier.as_deref().unwrap_or("");
-                        let mut rename_to = to.clone();
+                        let mut rename_to = ctx.to.clone();
                         rename_to.attributes.insert(
                             temp.attribute.clone(),
                             Value::String(temp.original_value.clone()),
                         );
                         match provider
-                            .update(id, new_identifier, &state, &rename_to)
+                            .update(ctx.id, new_identifier, &state, &rename_to)
                             .await
                         {
                             Ok(renamed_state) => {
                                 observer.on_event(&ExecutionEvent::RenameSucceeded {
-                                    id,
+                                    id: ctx.id,
                                     from: &temp.temporary_value,
                                     to: &temp.original_value,
                                 });
@@ -1191,50 +1170,50 @@ async fn execute_cbd_replace_parallel(
                             Err(e) => {
                                 let error_str = e.to_string();
                                 observer.on_event(&ExecutionEvent::RenameFailed {
-                                    id,
+                                    id: ctx.id,
                                     error: &error_str,
                                 });
                                 rename_failed = true;
                             }
                         }
-                    } else if let Some(temp) = temporary_name
+                    } else if let Some(temp) = ctx.temporary_name
                         && !temp.can_rename
                     {
                         let mut overrides = HashMap::new();
                         overrides.insert(temp.attribute.clone(), temp.temporary_value.clone());
-                        permanent_overrides = Some((to.id.clone(), overrides));
+                        permanent_overrides = Some((ctx.to.id.clone(), overrides));
                     }
 
                     if rename_failed {
                         observer.on_event(&ExecutionEvent::EffectFailed {
-                            effect,
+                            effect: ctx.effect,
                             error: "rename failed",
-                            duration: started.elapsed(),
-                            progress,
+                            duration: ctx.started.elapsed(),
+                            progress: ctx.progress,
                         });
                         SingleEffectResult::Replace {
                             success: false,
                             state: Some(final_state),
-                            resource_id: to.id.clone(),
+                            resource_id: ctx.to.id.clone(),
                             resolved_attrs: Some(resolved.attributes),
-                            binding: effect.binding_name(),
+                            binding: ctx.effect.binding_name(),
                             refreshes,
 
                             permanent_overrides,
                         }
                     } else {
                         observer.on_event(&ExecutionEvent::EffectSucceeded {
-                            effect,
+                            effect: ctx.effect,
                             state: None,
-                            duration: started.elapsed(),
-                            progress,
+                            duration: ctx.started.elapsed(),
+                            progress: ctx.progress,
                         });
                         SingleEffectResult::Replace {
                             success: true,
                             state: Some(final_state),
-                            resource_id: to.id.clone(),
+                            resource_id: ctx.to.id.clone(),
                             resolved_attrs: Some(resolved.attributes),
-                            binding: to.binding.clone(),
+                            binding: ctx.to.binding.clone(),
                             refreshes,
 
                             permanent_overrides,
@@ -1244,18 +1223,21 @@ async fn execute_cbd_replace_parallel(
                 Err(e) => {
                     let error_str = e.to_string();
                     observer.on_event(&ExecutionEvent::EffectFailed {
-                        effect,
+                        effect: ctx.effect,
                         error: &error_str,
-                        duration: started.elapsed(),
-                        progress,
+                        duration: ctx.started.elapsed(),
+                        progress: ctx.progress,
                     });
-                    refreshes.push((to.id.clone(), state.identifier.clone().unwrap_or_default()));
+                    refreshes.push((
+                        ctx.to.id.clone(),
+                        state.identifier.clone().unwrap_or_default(),
+                    ));
                     SingleEffectResult::Replace {
                         success: false,
                         state: None,
-                        resource_id: to.id.clone(),
+                        resource_id: ctx.to.id.clone(),
                         resolved_attrs: None,
-                        binding: effect.binding_name(),
+                        binding: ctx.effect.binding_name(),
                         refreshes,
 
                         permanent_overrides: None,
@@ -1266,17 +1248,17 @@ async fn execute_cbd_replace_parallel(
         Err(e) => {
             let error_str = e.to_string();
             observer.on_event(&ExecutionEvent::EffectFailed {
-                effect,
+                effect: ctx.effect,
                 error: &error_str,
-                duration: started.elapsed(),
-                progress,
+                duration: ctx.started.elapsed(),
+                progress: ctx.progress,
             });
             SingleEffectResult::Replace {
                 success: false,
                 state: None,
-                resource_id: to.id.clone(),
+                resource_id: ctx.to.id.clone(),
                 resolved_attrs: None,
-                binding: effect.binding_name(),
+                binding: ctx.effect.binding_name(),
                 refreshes,
 
                 permanent_overrides: None,
@@ -1286,61 +1268,53 @@ async fn execute_cbd_replace_parallel(
 }
 
 /// DBD Replace for the parallel execution path.
-#[allow(clippy::too_many_arguments)]
 async fn execute_dbd_replace_parallel(
     provider: &dyn Provider,
-    effect: &Effect,
-    id: &ResourceId,
-    from: &State,
-    to: &Resource,
-    lifecycle: &crate::resource::LifecycleConfig,
-    binding_map: &HashMap<String, HashMap<String, Value>>,
-    unresolved: &HashMap<ResourceId, Resource>,
-    started: Instant,
-    progress: ProgressInfo,
+    ctx: &ReplaceContext<'_>,
     observer: &dyn ExecutionObserver,
 ) -> SingleEffectResult {
-    let identifier = from.identifier.as_deref().unwrap_or("");
+    let identifier = ctx.from.identifier.as_deref().unwrap_or("");
     let mut refreshes = Vec::new();
 
-    match provider.delete(id, identifier, lifecycle).await {
+    match provider.delete(ctx.id, identifier, ctx.lifecycle).await {
         Ok(()) => {
-            let resolve_source = unresolved.get(&to.id).unwrap_or(to);
-            let resolved = match resolve_resource_with_source(to, resolve_source, binding_map) {
-                Ok(r) => r,
-                Err(e) => {
-                    observer.on_event(&ExecutionEvent::EffectFailed {
-                        effect,
-                        error: &e,
-                        duration: started.elapsed(),
-                        progress,
-                    });
-                    refreshes.push((to.id.clone(), identifier.to_string()));
-                    return SingleEffectResult::Replace {
-                        success: false,
-                        state: None,
-                        resource_id: to.id.clone(),
-                        resolved_attrs: None,
-                        binding: effect.binding_name(),
-                        refreshes,
-                        permanent_overrides: None,
-                    };
-                }
-            };
+            let resolve_source = ctx.unresolved.get(&ctx.to.id).unwrap_or(ctx.to);
+            let resolved =
+                match resolve_resource_with_source(ctx.to, resolve_source, ctx.binding_map) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        observer.on_event(&ExecutionEvent::EffectFailed {
+                            effect: ctx.effect,
+                            error: &e,
+                            duration: ctx.started.elapsed(),
+                            progress: ctx.progress,
+                        });
+                        refreshes.push((ctx.to.id.clone(), identifier.to_string()));
+                        return SingleEffectResult::Replace {
+                            success: false,
+                            state: None,
+                            resource_id: ctx.to.id.clone(),
+                            resolved_attrs: None,
+                            binding: ctx.effect.binding_name(),
+                            refreshes,
+                            permanent_overrides: None,
+                        };
+                    }
+                };
             match provider.create(&resolved).await {
                 Ok(state) => {
                     observer.on_event(&ExecutionEvent::EffectSucceeded {
-                        effect,
+                        effect: ctx.effect,
                         state: Some(&state),
-                        duration: started.elapsed(),
-                        progress,
+                        duration: ctx.started.elapsed(),
+                        progress: ctx.progress,
                     });
                     SingleEffectResult::Replace {
                         success: true,
                         state: Some(state),
-                        resource_id: to.id.clone(),
+                        resource_id: ctx.to.id.clone(),
                         resolved_attrs: Some(resolved.attributes),
-                        binding: to.binding.clone(),
+                        binding: ctx.to.binding.clone(),
                         refreshes,
 
                         permanent_overrides: None,
@@ -1349,18 +1323,18 @@ async fn execute_dbd_replace_parallel(
                 Err(e) => {
                     let error_str = e.to_string();
                     observer.on_event(&ExecutionEvent::EffectFailed {
-                        effect,
+                        effect: ctx.effect,
                         error: &error_str,
-                        duration: started.elapsed(),
-                        progress,
+                        duration: ctx.started.elapsed(),
+                        progress: ctx.progress,
                     });
-                    refreshes.push((to.id.clone(), identifier.to_string()));
+                    refreshes.push((ctx.to.id.clone(), identifier.to_string()));
                     SingleEffectResult::Replace {
                         success: false,
                         state: None,
-                        resource_id: to.id.clone(),
+                        resource_id: ctx.to.id.clone(),
                         resolved_attrs: None,
-                        binding: effect.binding_name(),
+                        binding: ctx.effect.binding_name(),
                         refreshes,
 
                         permanent_overrides: None,
@@ -1371,18 +1345,18 @@ async fn execute_dbd_replace_parallel(
         Err(e) => {
             let error_str = e.to_string();
             observer.on_event(&ExecutionEvent::EffectFailed {
-                effect,
+                effect: ctx.effect,
                 error: &error_str,
-                duration: started.elapsed(),
-                progress,
+                duration: ctx.started.elapsed(),
+                progress: ctx.progress,
             });
-            refreshes.push((id.clone(), identifier.to_string()));
+            refreshes.push((ctx.id.clone(), identifier.to_string()));
             SingleEffectResult::Replace {
                 success: false,
                 state: None,
-                resource_id: to.id.clone(),
+                resource_id: ctx.to.id.clone(),
                 resolved_attrs: None,
-                binding: effect.binding_name(),
+                binding: ctx.effect.binding_name(),
                 refreshes,
 
                 permanent_overrides: None,
@@ -1597,13 +1571,15 @@ async fn execute_effects_phased(
                 PhaseEffectResult::Basic(basic) => {
                     process_basic_result(
                         basic,
-                        &mut success_count,
-                        &mut failure_count,
-                        &mut applied_states,
-                        &mut failed_bindings,
-                        &mut successfully_deleted,
-                        &mut pending_refreshes,
-                        &mut input.binding_map,
+                        &mut ExecutionState {
+                            success_count: &mut success_count,
+                            failure_count: &mut failure_count,
+                            applied_states: &mut applied_states,
+                            failed_bindings: &mut failed_bindings,
+                            successfully_deleted: &mut successfully_deleted,
+                            pending_refreshes: &mut pending_refreshes,
+                            binding_map: &mut input.binding_map,
+                        },
                     );
                 }
                 _ => unreachable!(),

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -257,6 +257,16 @@ impl TypedDependencyGraph {
 }
 
 /// ANSI color codes for terminal output
+/// Shared state for recursive dependency tree drawing.
+///
+/// Groups the output buffer, visited set, and color configuration that are
+/// threaded through every recursive call of `display_creates_tree_colored`.
+struct TreeDrawState<'a> {
+    output: &'a mut String,
+    visited: &'a mut HashSet<String>,
+    colors: &'a Colors,
+}
+
 struct Colors {
     bold: &'static str,
     reset: &'static str,
@@ -525,16 +535,13 @@ impl RootConfigSignature {
                 }
             } else {
                 let mut visited = HashSet::new();
+                let mut draw = TreeDrawState {
+                    output: &mut output,
+                    visited: &mut visited,
+                    colors: &c,
+                };
                 for root in roots {
-                    self.display_creates_tree_colored(
-                        &mut output,
-                        &root,
-                        "  ",
-                        true,
-                        &mut visited,
-                        true,
-                        &c,
-                    );
+                    self.display_creates_tree_colored(&mut draw, &root, "  ", true, true);
                 }
             }
 
@@ -576,22 +583,20 @@ impl RootConfigSignature {
         roots
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn display_creates_tree_colored(
         &self,
-        output: &mut String,
+        state: &mut TreeDrawState<'_>,
         node: &str,
         prefix: &str,
         is_last: bool,
-        visited: &mut HashSet<String>,
         is_root: bool,
-        c: &Colors,
     ) {
-        if visited.contains(node) {
+        if state.visited.contains(node) {
             return;
         }
-        visited.insert(node.to_string());
+        state.visited.insert(node.to_string());
 
+        let c = state.colors;
         let connector = if is_root {
             ""
         } else if is_last {
@@ -613,7 +618,9 @@ impl RootConfigSignature {
             })
             .unwrap_or_else(|| node.to_string());
 
-        output.push_str(&format!("{}{}{}\n", prefix, connector, node_display));
+        state
+            .output
+            .push_str(&format!("{}{}{}\n", prefix, connector, node_display));
 
         // Find children (nodes that depend on this node)
         // Filter out nodes that have a more specific path through another resource
@@ -651,15 +658,7 @@ impl RootConfigSignature {
 
         for (i, child) in children.iter().enumerate() {
             let child_is_last = i == children.len() - 1;
-            self.display_creates_tree_colored(
-                output,
-                child,
-                &new_prefix,
-                child_is_last,
-                visited,
-                false,
-                c,
-            );
+            self.display_creates_tree_colored(state, child, &new_prefix, child_is_last, false);
         }
     }
 }
@@ -995,16 +994,13 @@ impl ModuleSignature {
                 }
             } else {
                 let mut visited = HashSet::new();
+                let mut draw = TreeDrawState {
+                    output: &mut output,
+                    visited: &mut visited,
+                    colors: &c,
+                };
                 for root in roots {
-                    self.display_creates_tree_colored(
-                        &mut output,
-                        &root,
-                        "  ",
-                        true,
-                        &mut visited,
-                        true,
-                        &c,
-                    );
+                    self.display_creates_tree_colored(&mut draw, &root, "  ", true, true);
                 }
             }
         }
@@ -1056,22 +1052,20 @@ impl ModuleSignature {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn display_creates_tree_colored(
         &self,
-        output: &mut String,
+        state: &mut TreeDrawState<'_>,
         node: &str,
         prefix: &str,
         is_last: bool,
-        visited: &mut HashSet<String>,
         is_root: bool,
-        c: &Colors,
     ) {
-        if visited.contains(node) {
+        if state.visited.contains(node) {
             return;
         }
-        visited.insert(node.to_string());
+        state.visited.insert(node.to_string());
 
+        let c = state.colors;
         let connector = if is_root {
             ""
         } else if is_last {
@@ -1093,7 +1087,9 @@ impl ModuleSignature {
             node.to_string()
         };
 
-        output.push_str(&format!("{}{}{}\n", prefix, connector, node_display));
+        state
+            .output
+            .push_str(&format!("{}{}{}\n", prefix, connector, node_display));
 
         // Find children (nodes that depend on this node)
         // Filter out nodes that have a more specific path through another resource
@@ -1131,15 +1127,7 @@ impl ModuleSignature {
 
         for (i, child) in children.iter().enumerate() {
             let child_is_last = i == children.len() - 1;
-            self.display_creates_tree_colored(
-                output,
-                child,
-                &new_prefix,
-                child_is_last,
-                visited,
-                false,
-                c,
-            );
+            self.display_creates_tree_colored(state, child, &new_prefix, child_is_last, false);
         }
     }
 


### PR DESCRIPTION
## Summary

- Introduce 5 context structs (`ExecutionState`, `ReplaceContext`, `TreeDrawState`, `FinalizeApplyInput`, `TypeResolutionContext`) to group related function parameters
- Remove all 9 `#[allow(clippy::too_many_arguments)]` annotations across executor.rs, module.rs, apply.rs, and codegen
- No behavioral changes; all existing tests continue to pass

Closes #1309

## Test plan

- [x] `cargo test -p carina-core` passes (7 tests)
- [x] `cargo test -p carina-cli` passes (10 tests)
- [x] `cargo clippy --workspace` clean (no warnings)
- [x] `cargo fmt` applied
- [x] No `#[allow(clippy::too_many_arguments)]` annotations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)