### PR TITLE
feat: add final 4 EC2 resources to AWS provider (batch 4/4)

### DIFF
--- a/carina-provider-aws/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -1,0 +1,19 @@
+# EC2 Egress-Only Internet Gateway - Basic test
+#
+# Tests: Egress-Only Internet Gateway creation
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+aws.ec2.egress_only_internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -1,0 +1,15 @@
+# EC2 Transit Gateway - Basic test
+#
+# Tests: Transit Gateway creation with description, tags
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+aws.ec2.transit_gateway {
+  description = "Acceptance test Transit Gateway"
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -1,0 +1,31 @@
+# EC2 Transit Gateway Attachment - Basic test
+#
+# Tests: Transit Gateway VPC Attachment creation
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = aws.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = aws.AvailabilityZone.ap_northeast_1a
+}
+
+let tgw = aws.ec2.transit_gateway {
+  description = "Acceptance test Transit Gateway"
+}
+
+aws.ec2.transit_gateway_attachment {
+  subnet_ids         = [subnet.subnet_id]
+  transit_gateway_id = tgw.transit_gateway_id
+  vpc_id             = vpc.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/carina-provider-aws/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -1,0 +1,24 @@
+# EC2 VPC Peering Connection - Basic test
+#
+# Tests: VPC Peering Connection creation
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc1 = aws.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let vpc2 = aws.ec2.vpc {
+  cidr_block = "10.1.0.0/16"
+}
+
+aws.ec2.vpc_peering_connection {
+  vpc_id      = vpc1.vpc_id
+  peer_vpc_id = vpc2.vpc_id
+
+  tags = {
+    Environment = "acceptance-test"
+  }
+}

--- a/carina-provider-aws/src/provider.rs
+++ b/carina-provider-aws/src/provider.rs
@@ -54,6 +54,22 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "ec2.vpn_gateway" => self.read_ec2_vpn_gateway(&id, identifier.as_deref()).await,
+                "ec2.transit_gateway" => {
+                    self.read_ec2_transit_gateway(&id, identifier.as_deref())
+                        .await
+                }
+                "ec2.transit_gateway_attachment" => {
+                    self.read_ec2_transit_gateway_attachment(&id, identifier.as_deref())
+                        .await
+                }
+                "ec2.vpc_peering_connection" => {
+                    self.read_ec2_vpc_peering_connection(&id, identifier.as_deref())
+                        .await
+                }
+                "ec2.egress_only_internet_gateway" => {
+                    self.read_ec2_egress_only_internet_gateway(&id, identifier.as_deref())
+                        .await
+                }
                 "iam.role" => self.read_iam_role(&id, identifier.as_deref()).await,
                 "logs.log_group" => self.read_logs_log_group(&id, identifier.as_deref()).await,
                 "sts.caller_identity" => self.read_sts_caller_identity(&id).await,
@@ -102,6 +118,16 @@ impl Provider for AwsProvider {
                     self.create_ec2_vpc_gateway_attachment(resource).await
                 }
                 "ec2.vpn_gateway" => self.create_ec2_vpn_gateway(resource).await,
+                "ec2.transit_gateway" => self.create_ec2_transit_gateway(resource).await,
+                "ec2.transit_gateway_attachment" => {
+                    self.create_ec2_transit_gateway_attachment(resource).await
+                }
+                "ec2.vpc_peering_connection" => {
+                    self.create_ec2_vpc_peering_connection(resource).await
+                }
+                "ec2.egress_only_internet_gateway" => {
+                    self.create_ec2_egress_only_internet_gateway(resource).await
+                }
                 "iam.role" => self.create_iam_role(resource).await,
                 "logs.log_group" => self.create_logs_log_group(resource).await,
                 _ => Err(ProviderError::new(format!(
@@ -172,6 +198,22 @@ impl Provider for AwsProvider {
                     self.update_ec2_vpn_gateway(id, &identifier, &from, to)
                         .await
                 }
+                "ec2.transit_gateway" => {
+                    self.update_ec2_transit_gateway(id, &identifier, &from, to)
+                        .await
+                }
+                "ec2.transit_gateway_attachment" => {
+                    self.update_ec2_transit_gateway_attachment(id, &identifier, &from, to)
+                        .await
+                }
+                "ec2.vpc_peering_connection" => {
+                    self.update_ec2_vpc_peering_connection(id, &identifier, &from, to)
+                        .await
+                }
+                "ec2.egress_only_internet_gateway" => {
+                    self.update_ec2_egress_only_internet_gateway(id, &identifier, &from, to)
+                        .await
+                }
                 "iam.role" => self.update_iam_role(id, &identifier, &from, to).await,
                 "logs.log_group" => self.update_logs_log_group(id, &identifier, &from, to).await,
                 _ => Err(ProviderError::new(format!(
@@ -221,6 +263,19 @@ impl Provider for AwsProvider {
                         .await
                 }
                 "ec2.vpn_gateway" => self.delete_ec2_vpn_gateway(id, &identifier).await,
+                "ec2.transit_gateway" => self.delete_ec2_transit_gateway(id, &identifier).await,
+                "ec2.transit_gateway_attachment" => {
+                    self.delete_ec2_transit_gateway_attachment(id, &identifier)
+                        .await
+                }
+                "ec2.vpc_peering_connection" => {
+                    self.delete_ec2_vpc_peering_connection(id, &identifier)
+                        .await
+                }
+                "ec2.egress_only_internet_gateway" => {
+                    self.delete_ec2_egress_only_internet_gateway(id, &identifier)
+                        .await
+                }
                 "iam.role" => self.delete_iam_role(id, &identifier).await,
                 "logs.log_group" => self.delete_logs_log_group(id, &identifier).await,
                 _ => Err(ProviderError::new(format!(

--- a/carina-provider-aws/src/provider_generated.rs
+++ b/carina-provider-aws/src/provider_generated.rs
@@ -628,6 +628,138 @@ impl AwsProvider {
         obj.vpn_gateway_id().map(String::from)
     }
 
+    /// Extract ec2.transit_gateway attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_transit_gateway_attributes(
+        obj: &aws_sdk_ec2::types::TransitGateway,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.transit_gateway_id() {
+            attributes.insert(
+                "transit_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.description() {
+            attributes.insert("description".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(opts) = obj.options() {
+            if let Some(v) = opts.amazon_side_asn() {
+                attributes.insert("amazon_side_asn".to_string(), Value::Int(v));
+            }
+            if let Some(v) = opts.auto_accept_shared_attachments() {
+                attributes.insert(
+                    "auto_accept_shared_attachments".to_string(),
+                    Value::String(v.as_str().to_string()),
+                );
+            }
+            if let Some(v) = opts.default_route_table_association() {
+                attributes.insert(
+                    "default_route_table_association".to_string(),
+                    Value::String(v.as_str().to_string()),
+                );
+            }
+            if let Some(v) = opts.default_route_table_propagation() {
+                attributes.insert(
+                    "default_route_table_propagation".to_string(),
+                    Value::String(v.as_str().to_string()),
+                );
+            }
+            if let Some(v) = opts.dns_support() {
+                attributes.insert(
+                    "dns_support".to_string(),
+                    Value::String(v.as_str().to_string()),
+                );
+            }
+            if let Some(v) = opts.vpn_ecmp_support() {
+                attributes.insert(
+                    "vpn_ecmp_support".to_string(),
+                    Value::String(v.as_str().to_string()),
+                );
+            }
+        }
+        obj.transit_gateway_id().map(String::from)
+    }
+
+    /// Extract ec2.transit_gateway_attachment attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_transit_gateway_attachment_attributes(
+        obj: &aws_sdk_ec2::types::TransitGatewayVpcAttachment,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.transit_gateway_attachment_id() {
+            attributes.insert(
+                "transit_gateway_attachment_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.transit_gateway_id() {
+            attributes.insert(
+                "transit_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(v) = obj.vpc_id() {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        {
+            let ids = obj.subnet_ids();
+            if !ids.is_empty() {
+                let list: Vec<Value> = ids.iter().map(|s| Value::String(s.to_string())).collect();
+                attributes.insert("subnet_ids".to_string(), Value::List(list));
+            }
+        }
+        obj.transit_gateway_attachment_id().map(String::from)
+    }
+
+    /// Extract ec2.vpc_peering_connection attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_vpc_peering_connection_attributes(
+        obj: &aws_sdk_ec2::types::VpcPeeringConnection,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.vpc_peering_connection_id() {
+            attributes.insert(
+                "vpc_peering_connection_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        if let Some(requester) = obj.requester_vpc_info()
+            && let Some(v) = requester.vpc_id()
+        {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        if let Some(accepter) = obj.accepter_vpc_info() {
+            if let Some(v) = accepter.vpc_id() {
+                attributes.insert("peer_vpc_id".to_string(), Value::String(v.to_string()));
+            }
+            if let Some(v) = accepter.owner_id() {
+                attributes.insert("peer_owner_id".to_string(), Value::String(v.to_string()));
+            }
+            if let Some(v) = accepter.region() {
+                attributes.insert("peer_region".to_string(), Value::String(v.to_string()));
+            }
+        }
+        obj.vpc_peering_connection_id().map(String::from)
+    }
+
+    /// Extract ec2.egress_only_internet_gateway attributes from SDK response type (generated)
+    pub(crate) fn extract_ec2_egress_only_internet_gateway_attributes(
+        obj: &aws_sdk_ec2::types::EgressOnlyInternetGateway,
+        attributes: &mut HashMap<String, Value>,
+    ) -> Option<String> {
+        if let Some(v) = obj.egress_only_internet_gateway_id() {
+            attributes.insert(
+                "egress_only_internet_gateway_id".to_string(),
+                Value::String(v.to_string()),
+            );
+        }
+        // Extract vpc_id from attachments
+        if let Some(att) = obj.attachments().first()
+            && let Some(v) = att.vpc_id()
+        {
+            attributes.insert("vpc_id".to_string(), Value::String(v.to_string()));
+        }
+        obj.egress_only_internet_gateway_id().map(String::from)
+    }
+
     /// Extract ec2.security_group_egress attributes from SDK response type (generated)
     pub(crate) fn extract_ec2_security_group_egress_attributes(
         obj: &aws_sdk_ec2::types::SecurityGroupRule,

--- a/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -1,0 +1,56 @@
+//! egress_only_internet_gateway schema definition for AWS
+//!
+//! Auto-generated from Smithy model: com.amazonaws.ec2
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, ResourceSchema};
+
+/// Returns the schema config for ec2.egress_only_internet_gateway (Smithy: com.amazonaws.ec2)
+pub fn ec2_egress_only_internet_gateway_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::EC2::EgressOnlyInternetGateway",
+        resource_type_name: "ec2.egress_only_internet_gateway",
+        has_tags: true,
+        schema: ResourceSchema::new("aws.ec2.egress_only_internet_gateway")
+            .with_description("Describes an egress-only internet gateway.")
+            .attribute(
+                AttributeSchema::new(
+                    "egress_only_internet_gateway_id",
+                    super::egress_only_internet_gateway_id(),
+                )
+                .with_description("The ID of the egress-only internet gateway. (read-only)")
+                .with_provider_name("EgressOnlyInternetGatewayId"),
+            )
+            .attribute(
+                AttributeSchema::new("tags", tags_type())
+                    .with_description("Any tags assigned to the egress-only internet gateway.")
+                    .with_provider_name("Tags"),
+            )
+            .attribute(
+                AttributeSchema::new("vpc_id", super::vpc_id())
+                    .required()
+                    .create_only()
+                    .with_description(
+                        "The ID of the VPC for which to create the egress-only internet gateway.",
+                    )
+                    .with_provider_name("VpcId"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("ec2.egress_only_internet_gateway", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/mod.rs
@@ -6,6 +6,7 @@
 // Re-export parent types so resource modules can use `super::` to access them.
 pub use super::*;
 
+pub mod egress_only_internet_gateway;
 pub mod eip;
 pub mod flow_log;
 pub mod internet_gateway;
@@ -17,7 +18,10 @@ pub mod security_group_egress;
 pub mod security_group_ingress;
 pub mod subnet;
 pub mod subnet_route_table_association;
+pub mod transit_gateway;
+pub mod transit_gateway_attachment;
 pub mod vpc;
 pub mod vpc_endpoint;
 pub mod vpc_gateway_attachment;
+pub mod vpc_peering_connection;
 pub mod vpn_gateway;

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway.rs
@@ -1,0 +1,150 @@
+//! transit_gateway schema definition for AWS
+//!
+//! Auto-generated from Smithy model: com.amazonaws.ec2
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+const VALID_AUTO_ACCEPT_SHARED_ATTACHMENTS: &[&str] = &["enable", "disable"];
+
+const VALID_DEFAULT_ROUTE_TABLE_ASSOCIATION: &[&str] = &["enable", "disable"];
+
+const VALID_DEFAULT_ROUTE_TABLE_PROPAGATION: &[&str] = &["enable", "disable"];
+
+const VALID_DNS_SUPPORT: &[&str] = &["enable", "disable"];
+
+const VALID_VPN_ECMP_SUPPORT: &[&str] = &["enable", "disable"];
+
+/// Returns the schema config for ec2.transit_gateway (Smithy: com.amazonaws.ec2)
+pub fn ec2_transit_gateway_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::EC2::TransitGateway",
+        resource_type_name: "ec2.transit_gateway",
+        has_tags: true,
+        schema: ResourceSchema::new("aws.ec2.transit_gateway")
+            .with_description("Describes a transit gateway.")
+            .attribute(
+                AttributeSchema::new("amazon_side_asn", AttributeType::Int)
+                    .create_only()
+                    .with_description(
+                        "The private Autonomous System Number (ASN) for the Amazon side of a BGP session.",
+                    )
+                    .with_provider_name("AmazonSideAsn"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "auto_accept_shared_attachments",
+                    AttributeType::StringEnum {
+                        name: "AutoAcceptSharedAttachments".to_string(),
+                        values: vec!["enable".to_string(), "disable".to_string()],
+                        namespace: Some("aws.ec2.transit_gateway".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_description("Enable or disable automatic acceptance of attachment requests.")
+                .with_provider_name("AutoAcceptSharedAttachments"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "default_route_table_association",
+                    AttributeType::StringEnum {
+                        name: "DefaultRouteTableAssociation".to_string(),
+                        values: vec!["enable".to_string(), "disable".to_string()],
+                        namespace: Some("aws.ec2.transit_gateway".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_description("Enable or disable automatic association with the default association route table.")
+                .with_provider_name("DefaultRouteTableAssociation"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "default_route_table_propagation",
+                    AttributeType::StringEnum {
+                        name: "DefaultRouteTablePropagation".to_string(),
+                        values: vec!["enable".to_string(), "disable".to_string()],
+                        namespace: Some("aws.ec2.transit_gateway".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_description("Enable or disable automatic propagation of routes to the default propagation route table.")
+                .with_provider_name("DefaultRouteTablePropagation"),
+            )
+            .attribute(
+                AttributeSchema::new("description", AttributeType::String)
+                    .with_description("A description for the transit gateway.")
+                    .with_provider_name("Description"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "dns_support",
+                    AttributeType::StringEnum {
+                        name: "DnsSupport".to_string(),
+                        values: vec!["enable".to_string(), "disable".to_string()],
+                        namespace: Some("aws.ec2.transit_gateway".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_description("Enable or disable DNS support.")
+                .with_provider_name("DnsSupport"),
+            )
+            .attribute(
+                AttributeSchema::new("tags", tags_type())
+                    .with_description("Any tags assigned to the transit gateway.")
+                    .with_provider_name("Tags"),
+            )
+            .attribute(
+                AttributeSchema::new("transit_gateway_id", super::transit_gateway_id())
+                    .with_description("The ID of the transit gateway. (read-only)")
+                    .with_provider_name("TransitGatewayId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "vpn_ecmp_support",
+                    AttributeType::StringEnum {
+                        name: "VpnEcmpSupport".to_string(),
+                        values: vec!["enable".to_string(), "disable".to_string()],
+                        namespace: Some("aws.ec2.transit_gateway".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .with_description("Enable or disable Equal Cost Multipath Protocol support.")
+                .with_provider_name("VpnEcmpSupport"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    (
+        "ec2.transit_gateway",
+        &[
+            (
+                "auto_accept_shared_attachments",
+                VALID_AUTO_ACCEPT_SHARED_ATTACHMENTS,
+            ),
+            (
+                "default_route_table_association",
+                VALID_DEFAULT_ROUTE_TABLE_ASSOCIATION,
+            ),
+            (
+                "default_route_table_propagation",
+                VALID_DEFAULT_ROUTE_TABLE_PROPAGATION,
+            ),
+            ("dns_support", VALID_DNS_SUPPORT),
+            ("vpn_ecmp_support", VALID_VPN_ECMP_SUPPORT),
+        ],
+    )
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -1,0 +1,70 @@
+//! transit_gateway_attachment schema definition for AWS
+//!
+//! Auto-generated from Smithy model: com.amazonaws.ec2
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for ec2.transit_gateway_attachment (Smithy: com.amazonaws.ec2)
+pub fn ec2_transit_gateway_attachment_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::EC2::TransitGatewayAttachment",
+        resource_type_name: "ec2.transit_gateway_attachment",
+        has_tags: true,
+        schema: ResourceSchema::new("aws.ec2.transit_gateway_attachment")
+            .with_description("Describes a transit gateway VPC attachment.")
+            .attribute(
+                AttributeSchema::new(
+                    "subnet_ids",
+                    AttributeType::unordered_list(super::subnet_id()),
+                )
+                .required()
+                .with_description("The IDs of one or more subnets.")
+                .with_provider_name("SubnetIds"),
+            )
+            .attribute(
+                AttributeSchema::new("tags", tags_type())
+                    .with_description("Any tags assigned to the transit gateway attachment.")
+                    .with_provider_name("Tags"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "transit_gateway_attachment_id",
+                    super::transit_gateway_attachment_id(),
+                )
+                .with_description("The ID of the transit gateway attachment. (read-only)")
+                .with_provider_name("TransitGatewayAttachmentId"),
+            )
+            .attribute(
+                AttributeSchema::new("transit_gateway_id", super::transit_gateway_id())
+                    .required()
+                    .create_only()
+                    .with_description("The ID of the transit gateway.")
+                    .with_provider_name("TransitGatewayId"),
+            )
+            .attribute(
+                AttributeSchema::new("vpc_id", super::vpc_id())
+                    .required()
+                    .create_only()
+                    .with_description("The ID of the VPC.")
+                    .with_provider_name("VpcId"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("ec2.transit_gateway_attachment", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -1,0 +1,75 @@
+//! vpc_peering_connection schema definition for AWS
+//!
+//! Auto-generated from Smithy model: com.amazonaws.ec2
+//!
+//! DO NOT EDIT MANUALLY - regenerate with smithy-codegen
+
+use super::AwsSchemaConfig;
+use super::tags_type;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+/// Returns the schema config for ec2.vpc_peering_connection (Smithy: com.amazonaws.ec2)
+pub fn ec2_vpc_peering_connection_config() -> AwsSchemaConfig {
+    AwsSchemaConfig {
+        aws_type_name: "AWS::EC2::VPCPeeringConnection",
+        resource_type_name: "ec2.vpc_peering_connection",
+        has_tags: true,
+        schema: ResourceSchema::new("aws.ec2.vpc_peering_connection")
+            .with_description("Describes a VPC peering connection.")
+            .attribute(
+                AttributeSchema::new("peer_owner_id", AttributeType::String)
+                    .create_only()
+                    .with_description("The AWS account ID of the owner of the accepter VPC.")
+                    .with_provider_name("PeerOwnerId"),
+            )
+            .attribute(
+                AttributeSchema::new("peer_region", AttributeType::String)
+                    .create_only()
+                    .with_description("The Region code for the accepter VPC.")
+                    .with_provider_name("PeerRegion"),
+            )
+            .attribute(
+                AttributeSchema::new("peer_vpc_id", super::vpc_id())
+                    .required()
+                    .create_only()
+                    .with_description(
+                        "The ID of the VPC with which you are creating the VPC peering connection.",
+                    )
+                    .with_provider_name("PeerVpcId"),
+            )
+            .attribute(
+                AttributeSchema::new("tags", tags_type())
+                    .with_description("Any tags assigned to the VPC peering connection.")
+                    .with_provider_name("Tags"),
+            )
+            .attribute(
+                AttributeSchema::new("vpc_id", super::vpc_id())
+                    .required()
+                    .create_only()
+                    .with_description("The ID of the VPC.")
+                    .with_provider_name("VpcId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "vpc_peering_connection_id",
+                    super::vpc_peering_connection_id(),
+                )
+                .with_description("The ID of the VPC peering connection. (read-only)")
+                .with_provider_name("VpcPeeringConnectionId"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("ec2.vpc_peering_connection", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-aws/src/schemas/generated/mod.rs
+++ b/carina-provider-aws/src/schemas/generated/mod.rs
@@ -16,6 +16,7 @@ pub mod sts;
 /// Returns all generated schema configs
 pub fn configs() -> Vec<AwsSchemaConfig> {
     vec![
+        ec2::egress_only_internet_gateway::ec2_egress_only_internet_gateway_config(),
         ec2::eip::ec2_eip_config(),
         ec2::flow_log::ec2_flow_log_config(),
         ec2::internet_gateway::ec2_internet_gateway_config(),
@@ -27,9 +28,12 @@ pub fn configs() -> Vec<AwsSchemaConfig> {
         ec2::security_group_ingress::ec2_security_group_ingress_config(),
         ec2::subnet::ec2_subnet_config(),
         ec2::subnet_route_table_association::ec2_subnet_route_table_association_config(),
+        ec2::transit_gateway::ec2_transit_gateway_config(),
+        ec2::transit_gateway_attachment::ec2_transit_gateway_attachment_config(),
         ec2::vpc::ec2_vpc_config(),
         ec2::vpc_endpoint::ec2_vpc_endpoint_config(),
         ec2::vpc_gateway_attachment::ec2_vpc_gateway_attachment_config(),
+        ec2::vpc_peering_connection::ec2_vpc_peering_connection_config(),
         ec2::vpn_gateway::ec2_vpn_gateway_config(),
         iam::role::iam_role_config(),
         logs::log_group::logs_log_group_config(),
@@ -48,6 +52,7 @@ pub fn get_enum_valid_values(
     attr_name: &str,
 ) -> Option<&'static [&'static str]> {
     let modules: &[(&str, &[(&str, &[&str])])] = &[
+        ec2::egress_only_internet_gateway::enum_valid_values(),
         ec2::eip::enum_valid_values(),
         ec2::flow_log::enum_valid_values(),
         ec2::internet_gateway::enum_valid_values(),
@@ -59,9 +64,12 @@ pub fn get_enum_valid_values(
         ec2::security_group_ingress::enum_valid_values(),
         ec2::subnet::enum_valid_values(),
         ec2::subnet_route_table_association::enum_valid_values(),
+        ec2::transit_gateway::enum_valid_values(),
+        ec2::transit_gateway_attachment::enum_valid_values(),
         ec2::vpc::enum_valid_values(),
         ec2::vpc_endpoint::enum_valid_values(),
         ec2::vpc_gateway_attachment::enum_valid_values(),
+        ec2::vpc_peering_connection::enum_valid_values(),
         ec2::vpn_gateway::enum_valid_values(),
         iam::role::enum_valid_values(),
         logs::log_group::enum_valid_values(),
@@ -88,6 +96,9 @@ pub fn get_enum_alias_reverse(
     attr_name: &str,
     value: &str,
 ) -> Option<&'static str> {
+    if resource_type == "ec2.egress_only_internet_gateway" {
+        return ec2::egress_only_internet_gateway::enum_alias_reverse(attr_name, value);
+    }
     if resource_type == "ec2.eip" {
         return ec2::eip::enum_alias_reverse(attr_name, value);
     }
@@ -121,6 +132,12 @@ pub fn get_enum_alias_reverse(
     if resource_type == "ec2.subnet_route_table_association" {
         return ec2::subnet_route_table_association::enum_alias_reverse(attr_name, value);
     }
+    if resource_type == "ec2.transit_gateway" {
+        return ec2::transit_gateway::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2.transit_gateway_attachment" {
+        return ec2::transit_gateway_attachment::enum_alias_reverse(attr_name, value);
+    }
     if resource_type == "ec2.vpc" {
         return ec2::vpc::enum_alias_reverse(attr_name, value);
     }
@@ -129,6 +146,9 @@ pub fn get_enum_alias_reverse(
     }
     if resource_type == "ec2.vpc_gateway_attachment" {
         return ec2::vpc_gateway_attachment::enum_alias_reverse(attr_name, value);
+    }
+    if resource_type == "ec2.vpc_peering_connection" {
+        return ec2::vpc_peering_connection::enum_alias_reverse(attr_name, value);
     }
     if resource_type == "ec2.vpn_gateway" {
         return ec2::vpn_gateway::enum_alias_reverse(attr_name, value);

--- a/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/egress_only_internet_gateway.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+
+impl AwsProvider {
+    /// Read an EC2 Egress-Only Internet Gateway
+    pub(crate) async fn read_ec2_egress_only_internet_gateway(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(identifier) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .ec2_client
+            .describe_egress_only_internet_gateways()
+            .egress_only_internet_gateway_ids(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to describe egress-only internet gateways")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        if let Some(eigw) = result.egress_only_internet_gateways().first() {
+            let mut attributes = HashMap::new();
+
+            let identifier_value =
+                Self::extract_ec2_egress_only_internet_gateway_attributes(eigw, &mut attributes);
+
+            // Extract user-defined tags
+            if let Some(tags_value) = Self::ec2_tags_to_value(eigw.tags()) {
+                attributes.insert("tags".to_string(), tags_value);
+            }
+
+            let state = State::existing(id.clone(), attributes);
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
+            } else {
+                state
+            })
+        } else {
+            Ok(State::not_found(id.clone()))
+        }
+    }
+
+    /// Create an EC2 Egress-Only Internet Gateway
+    pub(crate) async fn create_ec2_egress_only_internet_gateway(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let vpc_id = match resource.attributes.get("vpc_id") {
+            Some(Value::String(s)) => s.clone(),
+            _ => {
+                return Err(
+                    ProviderError::new("vpc_id is required").for_resource(resource.id.clone())
+                );
+            }
+        };
+
+        let mut req = self
+            .ec2_client
+            .create_egress_only_internet_gateway()
+            .vpc_id(&vpc_id);
+
+        // Apply tags via TagSpecifications
+        if let Some(Value::Map(tags)) = resource.attributes.get("tags") {
+            use aws_sdk_ec2::types::{Tag, TagSpecification};
+            let mut tag_spec = TagSpecification::builder()
+                .resource_type(aws_sdk_ec2::types::ResourceType::EgressOnlyInternetGateway);
+            for (key, val) in tags {
+                if let Value::String(v) = val {
+                    tag_spec = tag_spec.tags(Tag::builder().key(key).value(v).build());
+                }
+            }
+            req = req.tag_specifications(tag_spec.build());
+        }
+
+        let result = req.send().await.map_err(|e| {
+            ProviderError::new("Failed to create egress-only internet gateway")
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+        })?;
+
+        let eigw_id = result
+            .egress_only_internet_gateway()
+            .and_then(|eigw| eigw.egress_only_internet_gateway_id())
+            .ok_or_else(|| {
+                ProviderError::new("Egress-Only Internet Gateway created but no ID returned")
+                    .for_resource(resource.id.clone())
+            })?;
+
+        // Read back
+        self.read_ec2_egress_only_internet_gateway(&resource.id, Some(eigw_id))
+            .await
+    }
+
+    /// Update an EC2 Egress-Only Internet Gateway (tags only)
+    pub(crate) async fn update_ec2_egress_only_internet_gateway(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))
+            .await?;
+        self.read_ec2_egress_only_internet_gateway(&id, Some(identifier))
+            .await
+    }
+
+    /// Delete an EC2 Egress-Only Internet Gateway
+    pub(crate) async fn delete_ec2_egress_only_internet_gateway(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.ec2_client
+            .delete_egress_only_internet_gateway()
+            .egress_only_internet_gateway_id(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to delete egress-only internet gateway")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+        Ok(())
+    }
+}

--- a/carina-provider-aws/src/services/ec2/mod.rs
+++ b/carina-provider-aws/src/services/ec2/mod.rs
@@ -1,3 +1,4 @@
+pub mod egress_only_internet_gateway;
 pub mod eip;
 pub mod flow_log;
 pub mod internet_gateway;
@@ -9,7 +10,10 @@ pub mod security_group_egress;
 pub mod security_group_ingress;
 pub mod subnet;
 pub mod subnet_route_table_association;
+pub mod transit_gateway;
+pub mod transit_gateway_attachment;
 pub mod vpc;
 pub mod vpc_endpoint;
 pub mod vpc_gateway_attachment;
+pub mod vpc_peering_connection;
 pub mod vpn_gateway;

--- a/carina-provider-aws/src/services/ec2/transit_gateway.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::utils::extract_enum_value;
+
+use crate::AwsProvider;
+
+impl AwsProvider {
+    /// Read an EC2 Transit Gateway
+    pub(crate) async fn read_ec2_transit_gateway(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(identifier) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .ec2_client
+            .describe_transit_gateways()
+            .transit_gateway_ids(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to describe transit gateways")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        if let Some(tgw) = result.transit_gateways().first() {
+            // Skip deleted transit gateways
+            if tgw.state().map(|s| s.as_str()) == Some("deleted") {
+                return Ok(State::not_found(id.clone()));
+            }
+
+            let mut attributes = HashMap::new();
+
+            let identifier_value =
+                Self::extract_ec2_transit_gateway_attributes(tgw, &mut attributes);
+
+            // Extract user-defined tags
+            if let Some(tags_value) = Self::ec2_tags_to_value(tgw.tags()) {
+                attributes.insert("tags".to_string(), tags_value);
+            }
+
+            let state = State::existing(id.clone(), attributes);
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
+            } else {
+                state
+            })
+        } else {
+            Ok(State::not_found(id.clone()))
+        }
+    }
+
+    /// Create an EC2 Transit Gateway
+    pub(crate) async fn create_ec2_transit_gateway(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let mut req = self.ec2_client.create_transit_gateway();
+
+        if let Some(Value::String(desc)) = resource.attributes.get("description") {
+            req = req.description(desc);
+        }
+
+        // Build options
+        let mut options = aws_sdk_ec2::types::TransitGatewayRequestOptions::builder();
+        let mut has_options = false;
+
+        if let Some(Value::Int(asn)) = resource.attributes.get("amazon_side_asn") {
+            options = options.amazon_side_asn(*asn);
+            has_options = true;
+        }
+
+        if let Some(Value::String(v)) = resource.attributes.get("auto_accept_shared_attachments") {
+            use aws_sdk_ec2::types::AutoAcceptSharedAttachmentsValue;
+            options = options.auto_accept_shared_attachments(
+                AutoAcceptSharedAttachmentsValue::from(extract_enum_value(v)),
+            );
+            has_options = true;
+        }
+
+        if let Some(Value::String(v)) = resource.attributes.get("default_route_table_association") {
+            use aws_sdk_ec2::types::DefaultRouteTableAssociationValue;
+            options = options.default_route_table_association(
+                DefaultRouteTableAssociationValue::from(extract_enum_value(v)),
+            );
+            has_options = true;
+        }
+
+        if let Some(Value::String(v)) = resource.attributes.get("default_route_table_propagation") {
+            use aws_sdk_ec2::types::DefaultRouteTablePropagationValue;
+            options = options.default_route_table_propagation(
+                DefaultRouteTablePropagationValue::from(extract_enum_value(v)),
+            );
+            has_options = true;
+        }
+
+        if let Some(Value::String(v)) = resource.attributes.get("dns_support") {
+            use aws_sdk_ec2::types::DnsSupportValue;
+            options = options.dns_support(DnsSupportValue::from(extract_enum_value(v)));
+            has_options = true;
+        }
+
+        if let Some(Value::String(v)) = resource.attributes.get("vpn_ecmp_support") {
+            use aws_sdk_ec2::types::VpnEcmpSupportValue;
+            options = options.vpn_ecmp_support(VpnEcmpSupportValue::from(extract_enum_value(v)));
+            has_options = true;
+        }
+
+        if has_options {
+            req = req.options(options.build());
+        }
+
+        // Apply tags via TagSpecifications
+        if let Some(Value::Map(tags)) = resource.attributes.get("tags") {
+            use aws_sdk_ec2::types::{Tag, TagSpecification};
+            let mut tag_spec = TagSpecification::builder()
+                .resource_type(aws_sdk_ec2::types::ResourceType::TransitGateway);
+            for (key, val) in tags {
+                if let Value::String(v) = val {
+                    tag_spec = tag_spec.tags(Tag::builder().key(key).value(v).build());
+                }
+            }
+            req = req.tag_specifications(tag_spec.build());
+        }
+
+        let result = req.send().await.map_err(|e| {
+            ProviderError::new("Failed to create transit gateway")
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+        })?;
+
+        let tgw_id = result
+            .transit_gateway()
+            .and_then(|tgw| tgw.transit_gateway_id())
+            .ok_or_else(|| {
+                ProviderError::new("Transit Gateway created but no ID returned")
+                    .for_resource(resource.id.clone())
+            })?;
+
+        // Wait for transit gateway to become available
+        self.wait_for_transit_gateway_available(&resource.id, tgw_id)
+            .await?;
+
+        // Read back
+        self.read_ec2_transit_gateway(&resource.id, Some(tgw_id))
+            .await
+    }
+
+    /// Update an EC2 Transit Gateway (tags only for now)
+    pub(crate) async fn update_ec2_transit_gateway(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))
+            .await?;
+        self.read_ec2_transit_gateway(&id, Some(identifier)).await
+    }
+
+    /// Delete an EC2 Transit Gateway
+    pub(crate) async fn delete_ec2_transit_gateway(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.ec2_client
+            .delete_transit_gateway()
+            .transit_gateway_id(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to delete transit gateway")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        // Wait for transit gateway to be deleted
+        self.wait_for_transit_gateway_deleted(&id, identifier)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Wait for a transit gateway to reach the "available" state
+    async fn wait_for_transit_gateway_available(
+        &self,
+        id: &ResourceId,
+        transit_gateway_id: &str,
+    ) -> ProviderResult<()> {
+        use std::time::Duration;
+        use tokio::time::sleep;
+
+        for _ in 0..60 {
+            let result = self
+                .ec2_client
+                .describe_transit_gateways()
+                .transit_gateway_ids(transit_gateway_id)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new("Failed to describe transit gateway")
+                        .with_cause(e)
+                        .for_resource(id.clone())
+                })?;
+
+            if let Some(tgw) = result.transit_gateways().first()
+                && let Some(state) = tgw.state()
+            {
+                if state.as_str() == "available" {
+                    return Ok(());
+                }
+                if state.as_str() == "failed" || state.as_str() == "deleted" {
+                    return Err(ProviderError::new("Transit gateway creation failed")
+                        .for_resource(id.clone()));
+                }
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+
+        Err(
+            ProviderError::new("Timeout waiting for transit gateway to become available")
+                .for_resource(id.clone()),
+        )
+    }
+
+    /// Wait for a transit gateway to be deleted
+    async fn wait_for_transit_gateway_deleted(
+        &self,
+        id: &ResourceId,
+        transit_gateway_id: &str,
+    ) -> ProviderResult<()> {
+        use std::time::Duration;
+        use tokio::time::sleep;
+
+        for _ in 0..60 {
+            let result = self
+                .ec2_client
+                .describe_transit_gateways()
+                .transit_gateway_ids(transit_gateway_id)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new("Failed to describe transit gateway")
+                        .with_cause(e)
+                        .for_resource(id.clone())
+                })?;
+
+            if let Some(tgw) = result.transit_gateways().first() {
+                if tgw.state().map(|s| s.as_str()) == Some("deleted") {
+                    return Ok(());
+                }
+            } else {
+                return Ok(());
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+
+        Err(
+            ProviderError::new("Timeout waiting for transit gateway to be deleted")
+                .for_resource(id.clone()),
+        )
+    }
+}

--- a/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-aws/src/services/ec2/transit_gateway_attachment.rs
@@ -1,0 +1,268 @@
+use std::collections::HashMap;
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+
+impl AwsProvider {
+    /// Read an EC2 Transit Gateway VPC Attachment
+    pub(crate) async fn read_ec2_transit_gateway_attachment(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(identifier) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .ec2_client
+            .describe_transit_gateway_vpc_attachments()
+            .transit_gateway_attachment_ids(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to describe transit gateway VPC attachments")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        if let Some(att) = result.transit_gateway_vpc_attachments().first() {
+            // Skip deleted attachments
+            if att.state().map(|s| s.as_str()) == Some("deleted") {
+                return Ok(State::not_found(id.clone()));
+            }
+
+            let mut attributes = HashMap::new();
+
+            let identifier_value =
+                Self::extract_ec2_transit_gateway_attachment_attributes(att, &mut attributes);
+
+            // Extract user-defined tags
+            if let Some(tags_value) = Self::ec2_tags_to_value(att.tags()) {
+                attributes.insert("tags".to_string(), tags_value);
+            }
+
+            let state = State::existing(id.clone(), attributes);
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
+            } else {
+                state
+            })
+        } else {
+            Ok(State::not_found(id.clone()))
+        }
+    }
+
+    /// Create an EC2 Transit Gateway VPC Attachment
+    pub(crate) async fn create_ec2_transit_gateway_attachment(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let transit_gateway_id = match resource.attributes.get("transit_gateway_id") {
+            Some(Value::String(s)) => s.clone(),
+            _ => {
+                return Err(ProviderError::new("transit_gateway_id is required")
+                    .for_resource(resource.id.clone()));
+            }
+        };
+
+        let vpc_id = match resource.attributes.get("vpc_id") {
+            Some(Value::String(s)) => s.clone(),
+            _ => {
+                return Err(
+                    ProviderError::new("vpc_id is required").for_resource(resource.id.clone())
+                );
+            }
+        };
+
+        let subnet_ids = match resource.attributes.get("subnet_ids") {
+            Some(Value::List(ids)) => {
+                let mut result = Vec::new();
+                for id_val in ids {
+                    if let Value::String(s) = id_val {
+                        result.push(s.clone());
+                    }
+                }
+                if result.is_empty() {
+                    return Err(ProviderError::new("subnet_ids must not be empty")
+                        .for_resource(resource.id.clone()));
+                }
+                result
+            }
+            _ => {
+                return Err(
+                    ProviderError::new("subnet_ids is required").for_resource(resource.id.clone())
+                );
+            }
+        };
+
+        let mut req = self
+            .ec2_client
+            .create_transit_gateway_vpc_attachment()
+            .transit_gateway_id(&transit_gateway_id)
+            .vpc_id(&vpc_id);
+
+        for subnet_id in &subnet_ids {
+            req = req.subnet_ids(subnet_id);
+        }
+
+        // Apply tags via TagSpecifications
+        if let Some(Value::Map(tags)) = resource.attributes.get("tags") {
+            use aws_sdk_ec2::types::{Tag, TagSpecification};
+            let mut tag_spec = TagSpecification::builder()
+                .resource_type(aws_sdk_ec2::types::ResourceType::TransitGatewayAttachment);
+            for (key, val) in tags {
+                if let Value::String(v) = val {
+                    tag_spec = tag_spec.tags(Tag::builder().key(key).value(v).build());
+                }
+            }
+            req = req.tag_specifications(tag_spec.build());
+        }
+
+        let result = req.send().await.map_err(|e| {
+            ProviderError::new("Failed to create transit gateway VPC attachment")
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+        })?;
+
+        let att_id = result
+            .transit_gateway_vpc_attachment()
+            .and_then(|att| att.transit_gateway_attachment_id())
+            .ok_or_else(|| {
+                ProviderError::new("Transit Gateway Attachment created but no ID returned")
+                    .for_resource(resource.id.clone())
+            })?;
+
+        // Wait for attachment to become available
+        self.wait_for_transit_gateway_attachment_available(&resource.id, att_id)
+            .await?;
+
+        // Read back
+        self.read_ec2_transit_gateway_attachment(&resource.id, Some(att_id))
+            .await
+    }
+
+    /// Update an EC2 Transit Gateway VPC Attachment (tags only)
+    pub(crate) async fn update_ec2_transit_gateway_attachment(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))
+            .await?;
+        self.read_ec2_transit_gateway_attachment(&id, Some(identifier))
+            .await
+    }
+
+    /// Delete an EC2 Transit Gateway VPC Attachment
+    pub(crate) async fn delete_ec2_transit_gateway_attachment(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.ec2_client
+            .delete_transit_gateway_vpc_attachment()
+            .transit_gateway_attachment_id(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to delete transit gateway VPC attachment")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        // Wait for attachment to be deleted
+        self.wait_for_transit_gateway_attachment_deleted(&id, identifier)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Wait for a transit gateway attachment to reach the "available" state
+    async fn wait_for_transit_gateway_attachment_available(
+        &self,
+        id: &ResourceId,
+        attachment_id: &str,
+    ) -> ProviderResult<()> {
+        use std::time::Duration;
+        use tokio::time::sleep;
+
+        for _ in 0..60 {
+            let result = self
+                .ec2_client
+                .describe_transit_gateway_vpc_attachments()
+                .transit_gateway_attachment_ids(attachment_id)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new("Failed to describe transit gateway VPC attachment")
+                        .with_cause(e)
+                        .for_resource(id.clone())
+                })?;
+
+            if let Some(att) = result.transit_gateway_vpc_attachments().first()
+                && let Some(state) = att.state()
+            {
+                if state.as_str() == "available" {
+                    return Ok(());
+                }
+                if state.as_str() == "failed" || state.as_str() == "deleted" {
+                    return Err(
+                        ProviderError::new("Transit gateway attachment creation failed")
+                            .for_resource(id.clone()),
+                    );
+                }
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+
+        Err(ProviderError::new(
+            "Timeout waiting for transit gateway attachment to become available",
+        )
+        .for_resource(id.clone()))
+    }
+
+    /// Wait for a transit gateway attachment to be deleted
+    async fn wait_for_transit_gateway_attachment_deleted(
+        &self,
+        id: &ResourceId,
+        attachment_id: &str,
+    ) -> ProviderResult<()> {
+        use std::time::Duration;
+        use tokio::time::sleep;
+
+        for _ in 0..60 {
+            let result = self
+                .ec2_client
+                .describe_transit_gateway_vpc_attachments()
+                .transit_gateway_attachment_ids(attachment_id)
+                .send()
+                .await
+                .map_err(|e| {
+                    ProviderError::new("Failed to describe transit gateway VPC attachment")
+                        .with_cause(e)
+                        .for_resource(id.clone())
+                })?;
+
+            if let Some(att) = result.transit_gateway_vpc_attachments().first() {
+                if att.state().map(|s| s.as_str()) == Some("deleted") {
+                    return Ok(());
+                }
+            } else {
+                return Ok(());
+            }
+
+            sleep(Duration::from_secs(5)).await;
+        }
+
+        Err(
+            ProviderError::new("Timeout waiting for transit gateway attachment to be deleted")
+                .for_resource(id.clone()),
+        )
+    }
+}

--- a/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
+++ b/carina-provider-aws/src/services/ec2/vpc_peering_connection.rs
@@ -1,0 +1,166 @@
+use std::collections::HashMap;
+
+use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::resource::{Resource, ResourceId, State, Value};
+
+use crate::AwsProvider;
+
+impl AwsProvider {
+    /// Read an EC2 VPC Peering Connection
+    pub(crate) async fn read_ec2_vpc_peering_connection(
+        &self,
+        id: &ResourceId,
+        identifier: Option<&str>,
+    ) -> ProviderResult<State> {
+        let Some(identifier) = identifier else {
+            return Ok(State::not_found(id.clone()));
+        };
+
+        let result = self
+            .ec2_client
+            .describe_vpc_peering_connections()
+            .vpc_peering_connection_ids(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to describe VPC peering connections")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+
+        if let Some(pcx) = result.vpc_peering_connections().first() {
+            // Skip deleted/failed peering connections
+            let status_code = pcx
+                .status()
+                .and_then(|s| s.code())
+                .map(|c| c.as_str().to_string());
+            if matches!(
+                status_code.as_deref(),
+                Some("deleted") | Some("failed") | Some("rejected") | Some("expired")
+            ) {
+                return Ok(State::not_found(id.clone()));
+            }
+
+            let mut attributes = HashMap::new();
+
+            let identifier_value =
+                Self::extract_ec2_vpc_peering_connection_attributes(pcx, &mut attributes);
+
+            // Extract user-defined tags
+            if let Some(tags_value) = Self::ec2_tags_to_value(pcx.tags()) {
+                attributes.insert("tags".to_string(), tags_value);
+            }
+
+            let state = State::existing(id.clone(), attributes);
+            Ok(if let Some(id_val) = identifier_value {
+                state.with_identifier(id_val)
+            } else {
+                state
+            })
+        } else {
+            Ok(State::not_found(id.clone()))
+        }
+    }
+
+    /// Create an EC2 VPC Peering Connection
+    pub(crate) async fn create_ec2_vpc_peering_connection(
+        &self,
+        resource: Resource,
+    ) -> ProviderResult<State> {
+        let vpc_id = match resource.attributes.get("vpc_id") {
+            Some(Value::String(s)) => s.clone(),
+            _ => {
+                return Err(
+                    ProviderError::new("vpc_id is required").for_resource(resource.id.clone())
+                );
+            }
+        };
+
+        let peer_vpc_id = match resource.attributes.get("peer_vpc_id") {
+            Some(Value::String(s)) => s.clone(),
+            _ => {
+                return Err(
+                    ProviderError::new("peer_vpc_id is required").for_resource(resource.id.clone())
+                );
+            }
+        };
+
+        let mut req = self
+            .ec2_client
+            .create_vpc_peering_connection()
+            .vpc_id(&vpc_id)
+            .peer_vpc_id(&peer_vpc_id);
+
+        if let Some(Value::String(owner_id)) = resource.attributes.get("peer_owner_id") {
+            req = req.peer_owner_id(owner_id);
+        }
+
+        if let Some(Value::String(region)) = resource.attributes.get("peer_region") {
+            req = req.peer_region(region);
+        }
+
+        // Apply tags via TagSpecifications
+        if let Some(Value::Map(tags)) = resource.attributes.get("tags") {
+            use aws_sdk_ec2::types::{Tag, TagSpecification};
+            let mut tag_spec = TagSpecification::builder()
+                .resource_type(aws_sdk_ec2::types::ResourceType::VpcPeeringConnection);
+            for (key, val) in tags {
+                if let Value::String(v) = val {
+                    tag_spec = tag_spec.tags(Tag::builder().key(key).value(v).build());
+                }
+            }
+            req = req.tag_specifications(tag_spec.build());
+        }
+
+        let result = req.send().await.map_err(|e| {
+            ProviderError::new("Failed to create VPC peering connection")
+                .with_cause(e)
+                .for_resource(resource.id.clone())
+        })?;
+
+        let pcx_id = result
+            .vpc_peering_connection()
+            .and_then(|pcx| pcx.vpc_peering_connection_id())
+            .ok_or_else(|| {
+                ProviderError::new("VPC Peering Connection created but no ID returned")
+                    .for_resource(resource.id.clone())
+            })?;
+
+        // Read back
+        self.read_ec2_vpc_peering_connection(&resource.id, Some(pcx_id))
+            .await
+    }
+
+    /// Update an EC2 VPC Peering Connection (tags only)
+    pub(crate) async fn update_ec2_vpc_peering_connection(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+        from: &State,
+        to: Resource,
+    ) -> ProviderResult<State> {
+        self.apply_ec2_tags(&id, identifier, &to.attributes, Some(&from.attributes))
+            .await?;
+        self.read_ec2_vpc_peering_connection(&id, Some(identifier))
+            .await
+    }
+
+    /// Delete an EC2 VPC Peering Connection
+    pub(crate) async fn delete_ec2_vpc_peering_connection(
+        &self,
+        id: ResourceId,
+        identifier: &str,
+    ) -> ProviderResult<()> {
+        self.ec2_client
+            .delete_vpc_peering_connection()
+            .vpc_peering_connection_id(identifier)
+            .send()
+            .await
+            .map_err(|e| {
+                ProviderError::new("Failed to delete VPC peering connection")
+                    .with_cause(e)
+                    .for_resource(id.clone())
+            })?;
+        Ok(())
+    }
+}

--- a/carina-provider-aws/src/tests.rs
+++ b/carina-provider-aws/src/tests.rs
@@ -999,3 +999,192 @@ fn test_extract_iam_role_attributes_minimal() {
     assert_eq!(attributes.get("description"), None);
     assert_eq!(attributes.get("max_session_duration"), None);
 }
+
+// --- extract_ec2_transit_gateway_attributes tests ---
+
+#[test]
+fn test_extract_ec2_transit_gateway_attributes() {
+    let options = aws_sdk_ec2::types::TransitGatewayOptions::builder()
+        .amazon_side_asn(64512)
+        .auto_accept_shared_attachments(
+            aws_sdk_ec2::types::AutoAcceptSharedAttachmentsValue::Enable,
+        )
+        .default_route_table_association(
+            aws_sdk_ec2::types::DefaultRouteTableAssociationValue::Enable,
+        )
+        .default_route_table_propagation(
+            aws_sdk_ec2::types::DefaultRouteTablePropagationValue::Enable,
+        )
+        .dns_support(aws_sdk_ec2::types::DnsSupportValue::Enable)
+        .vpn_ecmp_support(aws_sdk_ec2::types::VpnEcmpSupportValue::Enable)
+        .build();
+    let tgw = aws_sdk_ec2::types::TransitGateway::builder()
+        .transit_gateway_id("tgw-12345678")
+        .description("Test TGW")
+        .options(options)
+        .build();
+    let mut attributes = HashMap::new();
+    let identifier = AwsProvider::extract_ec2_transit_gateway_attributes(&tgw, &mut attributes);
+    assert_eq!(identifier, Some("tgw-12345678".to_string()));
+    assert_eq!(
+        attributes.get("transit_gateway_id"),
+        Some(&Value::String("tgw-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("description"),
+        Some(&Value::String("Test TGW".to_string()))
+    );
+    assert_eq!(attributes.get("amazon_side_asn"), Some(&Value::Int(64512)));
+    assert_eq!(
+        attributes.get("auto_accept_shared_attachments"),
+        Some(&Value::String("enable".to_string()))
+    );
+    assert_eq!(
+        attributes.get("dns_support"),
+        Some(&Value::String("enable".to_string()))
+    );
+    assert_eq!(
+        attributes.get("vpn_ecmp_support"),
+        Some(&Value::String("enable".to_string()))
+    );
+}
+
+#[test]
+fn test_extract_ec2_transit_gateway_attributes_minimal() {
+    let tgw = aws_sdk_ec2::types::TransitGateway::builder().build();
+    let mut attributes = HashMap::new();
+    let identifier = AwsProvider::extract_ec2_transit_gateway_attributes(&tgw, &mut attributes);
+    assert_eq!(identifier, None);
+}
+
+// --- extract_ec2_transit_gateway_attachment_attributes tests ---
+
+#[test]
+fn test_extract_ec2_transit_gateway_attachment_attributes() {
+    let att = aws_sdk_ec2::types::TransitGatewayVpcAttachment::builder()
+        .transit_gateway_attachment_id("tgw-attach-12345678")
+        .transit_gateway_id("tgw-12345678")
+        .vpc_id("vpc-12345678")
+        .subnet_ids("subnet-12345678")
+        .subnet_ids("subnet-87654321")
+        .build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_transit_gateway_attachment_attributes(&att, &mut attributes);
+    assert_eq!(identifier, Some("tgw-attach-12345678".to_string()));
+    assert_eq!(
+        attributes.get("transit_gateway_attachment_id"),
+        Some(&Value::String("tgw-attach-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("transit_gateway_id"),
+        Some(&Value::String("tgw-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("vpc_id"),
+        Some(&Value::String("vpc-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("subnet_ids"),
+        Some(&Value::List(vec![
+            Value::String("subnet-12345678".to_string()),
+            Value::String("subnet-87654321".to_string()),
+        ]))
+    );
+}
+
+#[test]
+fn test_extract_ec2_transit_gateway_attachment_attributes_minimal() {
+    let att = aws_sdk_ec2::types::TransitGatewayVpcAttachment::builder().build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_transit_gateway_attachment_attributes(&att, &mut attributes);
+    assert_eq!(identifier, None);
+}
+
+// --- extract_ec2_vpc_peering_connection_attributes tests ---
+
+#[test]
+fn test_extract_ec2_vpc_peering_connection_attributes() {
+    let requester = aws_sdk_ec2::types::VpcPeeringConnectionVpcInfo::builder()
+        .vpc_id("vpc-11111111")
+        .build();
+    let accepter = aws_sdk_ec2::types::VpcPeeringConnectionVpcInfo::builder()
+        .vpc_id("vpc-22222222")
+        .owner_id("123456789012")
+        .region("ap-northeast-1")
+        .build();
+    let pcx = aws_sdk_ec2::types::VpcPeeringConnection::builder()
+        .vpc_peering_connection_id("pcx-12345678")
+        .requester_vpc_info(requester)
+        .accepter_vpc_info(accepter)
+        .build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_vpc_peering_connection_attributes(&pcx, &mut attributes);
+    assert_eq!(identifier, Some("pcx-12345678".to_string()));
+    assert_eq!(
+        attributes.get("vpc_peering_connection_id"),
+        Some(&Value::String("pcx-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("vpc_id"),
+        Some(&Value::String("vpc-11111111".to_string()))
+    );
+    assert_eq!(
+        attributes.get("peer_vpc_id"),
+        Some(&Value::String("vpc-22222222".to_string()))
+    );
+    assert_eq!(
+        attributes.get("peer_owner_id"),
+        Some(&Value::String("123456789012".to_string()))
+    );
+    assert_eq!(
+        attributes.get("peer_region"),
+        Some(&Value::String("ap-northeast-1".to_string()))
+    );
+}
+
+#[test]
+fn test_extract_ec2_vpc_peering_connection_attributes_minimal() {
+    let pcx = aws_sdk_ec2::types::VpcPeeringConnection::builder().build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_vpc_peering_connection_attributes(&pcx, &mut attributes);
+    assert_eq!(identifier, None);
+}
+
+// --- extract_ec2_egress_only_internet_gateway_attributes tests ---
+
+#[test]
+fn test_extract_ec2_egress_only_internet_gateway_attributes() {
+    let attachment = aws_sdk_ec2::types::InternetGatewayAttachment::builder()
+        .vpc_id("vpc-12345678")
+        .state(aws_sdk_ec2::types::AttachmentStatus::from("attached"))
+        .build();
+    let eigw = aws_sdk_ec2::types::EgressOnlyInternetGateway::builder()
+        .egress_only_internet_gateway_id("eigw-12345678")
+        .attachments(attachment)
+        .build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_egress_only_internet_gateway_attributes(&eigw, &mut attributes);
+    assert_eq!(identifier, Some("eigw-12345678".to_string()));
+    assert_eq!(
+        attributes.get("egress_only_internet_gateway_id"),
+        Some(&Value::String("eigw-12345678".to_string()))
+    );
+    assert_eq!(
+        attributes.get("vpc_id"),
+        Some(&Value::String("vpc-12345678".to_string()))
+    );
+}
+
+#[test]
+fn test_extract_ec2_egress_only_internet_gateway_attributes_minimal() {
+    let eigw = aws_sdk_ec2::types::EgressOnlyInternetGateway::builder().build();
+    let mut attributes = HashMap::new();
+    let identifier =
+        AwsProvider::extract_ec2_egress_only_internet_gateway_attributes(&eigw, &mut attributes);
+    assert_eq!(identifier, None);
+}


### PR DESCRIPTION
## Summary

- Add `ec2.transit_gateway` with create/read/update/delete, waiters for available/deleted states, and transit gateway options (ASN, DNS support, VPN ECMP, etc.)
- Add `ec2.transit_gateway_attachment` (Transit Gateway VPC Attachment) with subnet_ids list, waiters for available/deleted states
- Add `ec2.vpc_peering_connection` with requester/accepter VPC info extraction, peer_owner_id and peer_region support
- Add `ec2.egress_only_internet_gateway` (IPv6 egress-only IGW) with vpc_id extraction from attachments

Each resource includes: schema, CRUD, provider routing, extract attributes helper, acceptance test CRN, and unit tests. All 115 unit tests pass, all 261 CRN files validate.

After this PR, the AWS provider supports the same 23 resources as the AWSCC provider.

closes #1323

## Test plan

- [x] `cargo test -p carina-provider-aws` -- 115 tests pass
- [x] `cargo clippy -p carina-provider-aws` -- no warnings
- [x] `cargo run --bin carina -- validate` for all 4 new acceptance test CRN files
- [x] `scripts/validate-crn-files.sh` -- 261 CRN files pass
- [x] `cargo test -p carina-cli plan_snapshot` -- 19 snapshot tests pass
- [ ] Acceptance tests with real AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)