### PR TITLE
fix: remove unnecessary let bindings from AWS provider examples

### DIFF
--- a/carina-provider-aws/examples/ec2_internet_gateway/main.crn
+++ b/carina-provider-aws/examples/ec2_internet_gateway/main.crn
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let igw = aws.ec2.internet_gateway {
+aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-aws/examples/ec2_route/main.crn
+++ b/carina-provider-aws/examples/ec2_route/main.crn
@@ -30,7 +30,7 @@ let rt = aws.ec2.route_table {
   }
 }
 
-let route = aws.ec2.route {
+aws.ec2.route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = igw.internet_gateway_id

--- a/carina-provider-aws/examples/ec2_route_table/main.crn
+++ b/carina-provider-aws/examples/ec2_route_table/main.crn
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let rt = aws.ec2.route_table {
+aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/carina-provider-aws/examples/ec2_security_group/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group/main.crn
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let sg = aws.ec2.security_group {
+aws.ec2.security_group {
   group_name  = "carina-example-sg"
   description = "Example security group"
   vpc_id      = vpc.vpc_id

--- a/carina-provider-aws/examples/ec2_security_group_egress/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group_egress/main.crn
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-let egress = aws.ec2.security_group_egress {
+aws.ec2.security_group_egress {
   group_id    = sg.group_id
   description = "Allow HTTPS outbound"
   ip_protocol = tcp

--- a/carina-provider-aws/examples/ec2_security_group_ingress/main.crn
+++ b/carina-provider-aws/examples/ec2_security_group_ingress/main.crn
@@ -24,7 +24,7 @@ let sg = aws.ec2.security_group {
   }
 }
 
-let ingress = aws.ec2.security_group_ingress {
+aws.ec2.security_group_ingress {
   group_id    = sg.group_id
   description = "Allow HTTPS from VPC"
   ip_protocol = tcp

--- a/carina-provider-aws/examples/ec2_subnet/main.crn
+++ b/carina-provider-aws/examples/ec2_subnet/main.crn
@@ -14,7 +14,7 @@ let vpc = aws.ec2.vpc {
   }
 }
 
-let subnet = aws.ec2.subnet {
+aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = "10.0.1.0/24"
   availability_zone = aws.AvailabilityZone.ap_northeast_1a

--- a/carina-provider-aws/examples/ec2_vpc/main.crn
+++ b/carina-provider-aws/examples/ec2_vpc/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let vpc = aws.ec2.vpc {
+aws.ec2.vpc {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/carina-provider-aws/examples/s3_bucket/main.crn
+++ b/carina-provider-aws/examples/s3_bucket/main.crn
@@ -6,7 +6,7 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let bucket = aws.s3.bucket {
+aws.s3.bucket {
   bucket = "carina-example-s3-bucket"
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled


### PR DESCRIPTION
## Summary

- Remove unused `let` bindings from 9 AWS provider example files where the bound variable is never referenced by other resources
- The `sts_caller_identity` example retains its `let caller =` binding because the DSL grammar does not currently support anonymous `read` resources at the top level (only inside `let`, `for`, and `if` blocks)

## Affected files

| File | Removed binding |
|------|----------------|
| `ec2_internet_gateway/main.crn` | `igw` |
| `ec2_route/main.crn` | `route` |
| `ec2_route_table/main.crn` | `rt` |
| `ec2_security_group/main.crn` | `sg` |
| `ec2_security_group_egress/main.crn` | `egress` |
| `ec2_security_group_ingress/main.crn` | `ingress` |
| `ec2_subnet/main.crn` | `subnet` |
| `ec2_vpc/main.crn` | `vpc` |
| `s3_bucket/main.crn` | `bucket` |

## Note

`sts_caller_identity/main.crn` uses `let caller = read aws.sts.caller_identity {}`. The `read` keyword is only valid inside `let_binding`, `for_body`, and `if_body` in the pest grammar — not as a standalone top-level statement. Fixing this requires a grammar change (adding `read_resource_expr` to the `anonymous_resource` or `statement` rule), which is out of scope for this PR.

## Test plan

- [x] Verified all 9 modified files pass `cargo run --bin carina -- validate` with no warnings
- [x] Verified `sts_caller_identity` still parses correctly (with expected unused binding warning)
- [x] Pre-commit hooks (fmt + clippy) pass

Closes #1333

🤖 Generated with [Claude Code](https://claude.com/claude-code)