### PR TITLE
feat: support `let _ =` discard pattern

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -124,8 +124,10 @@ fn_body_content = _{ trivia | fn_local_let | expression }
 fn_local_let = { kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ expression }
 
 // Variable/resource definition: let name = value
+// discard_pattern allows `let _ = expr` to suppress unused binding warnings
+discard_pattern = @{ "_" }
 let_binding = {
-    kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ expression
+    kw_let ~ trivia+ ~ (discard_pattern | identifier) ~ trivia* ~ equals ~ trivia* ~ expression
 }
 
 // Block content: local let bindings, attributes, trivia, nested blocks, or nested elements

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -210,7 +210,9 @@ impl<'a> CstBuilder<'a> {
             Rule::namespaced_id => {
                 Some(CstChild::Token(Token::new(pair.as_str().to_string(), span)))
             }
-            Rule::identifier => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
+            Rule::identifier | Rule::discard_pattern => {
+                Some(CstChild::Token(Token::new(pair.as_str().to_string(), span)))
+            }
             Rule::string => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::float => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::number => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -102,7 +102,9 @@ provider_block = {
 }
 
 // Variable/resource definition: let name = value
-let_binding = { "let" ~ identifier ~ "=" ~ expression }
+// discard_pattern allows `let _ = expr` to suppress unused binding warnings
+let_binding = { "let" ~ (discard_pattern | identifier) ~ "=" ~ expression }
+discard_pattern = @{ "_" }
 
 // Block content: a local let binding, an attribute (key = value), or a nested block (key { ... })
 block_content = { local_binding | attribute | nested_block }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -453,19 +453,24 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                     expanded_module_calls,
                                     maybe_import,
                                 ) = parse_let_binding_extended(stmt, &ctx)?;
-                                if ctx.variables.contains_key(&name)
-                                    || ctx.resource_bindings.contains_key(&name)
-                                {
-                                    return Err(ParseError::DuplicateBinding { name, line });
+                                let is_discard = name == "_";
+                                if !is_discard {
+                                    if ctx.variables.contains_key(&name)
+                                        || ctx.resource_bindings.contains_key(&name)
+                                    {
+                                        return Err(ParseError::DuplicateBinding { name, line });
+                                    }
+                                    ctx.set_variable(name.clone(), value);
                                 }
-                                ctx.set_variable(name.clone(), value);
                                 if !expanded_resources.is_empty() {
-                                    // Register the binding name as a resource binding
-                                    // (use the first resource as placeholder)
-                                    ctx.set_resource_binding(
-                                        name.clone(),
-                                        expanded_resources[0].clone(),
-                                    );
+                                    if !is_discard {
+                                        // Register the binding name as a resource binding
+                                        // (use the first resource as placeholder)
+                                        ctx.set_resource_binding(
+                                            name.clone(),
+                                            expanded_resources[0].clone(),
+                                        );
+                                    }
                                     resources.extend(expanded_resources);
                                 }
                                 if !expanded_module_calls.is_empty() {
@@ -475,10 +480,12 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                         }
                                         module_calls.push(call);
                                     }
-                                    // Register as a resource binding so that
-                                    // `name.attr` resolves as ResourceRef
-                                    let placeholder = Resource::new("_module_binding", &name);
-                                    ctx.set_resource_binding(name.clone(), placeholder);
+                                    if !is_discard {
+                                        // Register as a resource binding so that
+                                        // `name.attr` resolves as ResourceRef
+                                        let placeholder = Resource::new("_module_binding", &name);
+                                        ctx.set_resource_binding(name.clone(), placeholder);
+                                    }
                                 }
                                 if let Some(import) = maybe_import {
                                     ctx.imported_modules
@@ -7510,5 +7517,24 @@ arguments {
             },
             other => panic!("Expected List, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn parse_let_discard_read_resource() {
+        let input = r#"
+            provider aws {
+                region = aws.Region.ap_northeast_1
+            }
+
+            let _ = read aws.sts.caller_identity {}
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.resources.len(), 1);
+        assert_eq!(result.resources[0].id.resource_type, "sts.caller_identity");
+        assert_eq!(
+            result.resources[0].kind,
+            crate::resource::ResourceKind::DataSource
+        );
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -236,10 +236,13 @@ pub fn validate_module_calls(
 /// A binding is unused if its name never appears as a `ResourceRef.binding_name`
 /// in any resource attribute, module call argument, or attribute parameter value.
 pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
-    // Collect all defined binding names
+    // Collect all defined binding names (skip discard pattern `_`)
     let mut defined_bindings: Vec<String> = Vec::new();
     for resource in &parsed.resources {
         if let Some(ref binding_name) = resource.binding {
+            if binding_name == "_" {
+                continue;
+            }
             defined_bindings.push(binding_name.clone());
         }
     }
@@ -1044,5 +1047,16 @@ let route = awscc.ec2.route {
         let result = validate_type_expr_value(&schema_type, &Value::Int(42));
         assert!(result.is_some());
         assert!(result.unwrap().contains("expected awscc.ec2.VpcId"));
+    }
+
+    #[test]
+    fn discard_binding_no_warning() {
+        let mut parsed = empty_parsed();
+
+        let caller = Resource::with_provider("aws", "sts.caller_identity", "caller_identity")
+            .with_binding("_");
+        parsed.resources.push(caller);
+
+        assert!(check_unused_bindings(&parsed).is_empty());
     }
 }

--- a/carina-provider-aws/examples/sts_caller_identity/main.crn
+++ b/carina-provider-aws/examples/sts_caller_identity/main.crn
@@ -7,4 +7,4 @@ provider aws {
   region = aws.Region.ap_northeast_1
 }
 
-let caller = read aws.sts.caller_identity {}
+let _ = read aws.sts.caller_identity {}


### PR DESCRIPTION
## Summary

- Add `discard_pattern` rule to the DSL grammar so `let _ = expr` is valid syntax
- The `_` binding skips duplicate checks, variable registration, and unused-binding warnings
- Matches Rust's convention for intentionally ignored values
- Update `sts_caller_identity` example to use `let _ =` instead of `let caller =`

Closes #1343

## Test plan

- [x] Parser test: `let _ = read aws.sts.caller_identity {}` parses correctly
- [x] Validation test: `_` binding does not trigger unused warning
- [x] All existing `carina-core` tests pass
- [x] LSP tests pass
- [x] Snapshot tests pass
- [x] `cargo run -- validate` on updated example passes without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)