### PR TITLE
fix: stop propagating write-only from nested sub-properties to parent attributes

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1897,10 +1897,13 @@ pub fn {}() -> AwsccSchemaConfig {{
             || create_only
                 .iter()
                 .any(|p| p.starts_with(&format!("{}/", prop_name)));
-        let is_write_only = write_only.contains(prop_name)
-            || write_only
-                .iter()
-                .any(|p| p.starts_with(&format!("{}/", prop_name)));
+        // Write-only: only mark the attribute itself as write-only, NOT when
+        // only nested sub-properties are write-only. Unlike create-only (where
+        // a nested create-only property forces re-creation of the parent), a
+        // nested write-only property doesn't make the entire parent write-only.
+        // The parent is still returned by the CloudControl API read; only the
+        // specific nested sub-properties are omitted.
+        let is_write_only = write_only.contains(prop_name);
 
         let attr_type = if let Some(enum_info) = enums.get(prop_name) {
             // Use shared schema enum type for constrained strings.
@@ -9473,6 +9476,54 @@ mod tests {
                 .unwrap_or("")
                 .contains("Write-only"),
             "Name should not have write-only annotation: {md}"
+        );
+    }
+
+    #[test]
+    fn test_nested_write_only_does_not_propagate_to_parent() {
+        // Regression test for #1346: when only nested sub-properties are write-only,
+        // the parent attribute should NOT be marked write-only.
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "Config".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("object".to_string())),
+                description: Some("A configuration object.".to_string()),
+                properties: Some(BTreeMap::from([(
+                    "SecretField".to_string(),
+                    CfnProperty {
+                        prop_type: Some(TypeValue::Single("string".to_string())),
+                        description: Some("A secret nested field.".to_string()),
+                        ..Default::default()
+                    },
+                )])),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Nested".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            // Only the nested sub-property is write-only, NOT the parent
+            write_only_properties: vec!["/properties/Config/SecretField".to_string()],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+        };
+
+        let code = generate_schema_code(&schema, "AWS::Test::Nested").unwrap();
+
+        // Config should NOT have .write_only() because only its child is write-only
+        assert!(
+            !code.contains(".write_only()"),
+            "Parent attribute should NOT be marked write-only when only nested \
+             sub-properties are write-only. Generated code:\n{code}"
         );
     }
 }

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -1062,6 +1062,130 @@ mod tests {
     }
 
     #[test]
+    fn test_lifecycle_configuration_roundtrip_no_spurious_diff() {
+        // Regression test for #1346: lifecycle_configuration round-trip through
+        // CloudControl API should produce values matching the DSL parser output.
+        let config = crate::schemas::generated::s3::bucket::s3_bucket_config();
+        let attr_schema = config
+            .schema
+            .attributes
+            .get("lifecycle_configuration")
+            .unwrap();
+
+        // lifecycle_configuration must NOT be write-only — only nested sub-properties
+        // (Transition singular, ExpiredObjectDeleteMarker, etc.) are write-only in the
+        // CloudFormation schema, not the parent attribute itself.
+        assert!(
+            !attr_schema.write_only,
+            "lifecycle_configuration should NOT be marked write-only; \
+             only nested sub-properties are write-only in the CFN schema"
+        );
+
+        // Simulate AWS CloudControl API response for lifecycle rules.
+        // The API returns PascalCase keys and raw enum values.
+        let aws_json = serde_json::json!({
+            "Rules": [
+                {
+                    "ExpirationInDays": 90,
+                    "Id": "expire-old-objects",
+                    "Status": "Enabled"
+                },
+                {
+                    "Id": "transition-to-glacier",
+                    "Status": "Enabled",
+                    "Transitions": [
+                        {
+                            "StorageClass": "GLACIER",
+                            "TransitionInDays": 30
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // Read path: convert AWS JSON to DSL value
+        let dsl_value = aws_value_to_dsl(
+            "lifecycle_configuration",
+            &aws_json,
+            &attr_schema.attr_type,
+            "s3.bucket",
+        )
+        .expect("aws_value_to_dsl should succeed for lifecycle_configuration");
+
+        // Verify the converted value has the expected structure
+        let Value::Map(top_map) = &dsl_value else {
+            panic!("Expected Value::Map, got: {:?}", dsl_value);
+        };
+        let Some(Value::List(rules)) = top_map.get("rules") else {
+            panic!("Expected 'rules' key with Value::List, got: {:?}", top_map);
+        };
+        assert_eq!(rules.len(), 2, "Should have 2 lifecycle rules");
+
+        // Verify enum values are converted to namespaced format
+        if let Value::Map(rule0) = &rules[0] {
+            assert_eq!(
+                rule0.get("status"),
+                Some(&Value::String(
+                    "awscc.s3.bucket.RuleStatus.Enabled".to_string()
+                )),
+                "status should be namespaced enum"
+            );
+            assert_eq!(
+                rule0.get("expiration_in_days"),
+                Some(&Value::Int(90)),
+                "expiration_in_days should be Int"
+            );
+            assert_eq!(
+                rule0.get("id"),
+                Some(&Value::String("expire-old-objects".to_string())),
+            );
+        } else {
+            panic!("Expected rule[0] to be a Map");
+        }
+
+        if let Value::Map(rule1) = &rules[1] {
+            assert_eq!(
+                rule1.get("status"),
+                Some(&Value::String(
+                    "awscc.s3.bucket.RuleStatus.Enabled".to_string()
+                )),
+            );
+            if let Some(Value::List(transitions)) = rule1.get("transitions") {
+                assert_eq!(transitions.len(), 1);
+                if let Value::Map(t) = &transitions[0] {
+                    assert_eq!(
+                        t.get("storage_class"),
+                        Some(&Value::String(
+                            "awscc.s3.bucket.TransitionStorageClass.GLACIER".to_string()
+                        )),
+                    );
+                    assert_eq!(t.get("transition_in_days"), Some(&Value::Int(30)),);
+                } else {
+                    panic!("Expected transition to be a Map");
+                }
+            } else {
+                panic!("Expected 'transitions' to be a List in rule[1]");
+            }
+        } else {
+            panic!("Expected rule[1] to be a Map");
+        }
+
+        // Write path: convert DSL value back to AWS JSON
+        let written_json = dsl_value_to_aws(
+            &dsl_value,
+            &attr_schema.attr_type,
+            "s3.bucket",
+            "lifecycle_configuration",
+        )
+        .expect("dsl_value_to_aws should succeed");
+
+        assert_eq!(
+            written_json, aws_json,
+            "Round-trip should produce original AWS JSON"
+        );
+    }
+
+    #[test]
     fn test_dsl_value_to_aws_list_with_nan_drops_nan_items() {
         let value = Value::List(vec![
             Value::Float(1.0),

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -625,7 +625,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).with_description("Indicates which default minimum object size behavior is applied to the lifecycle configuration. This parameter applies to general purpose buckets only. It isn't supported for directory bucket lifecycle configurations. + ``all_storage_classes_128K`` - Objects smaller than 128 KB will not transition to any storage class by default. + ``varies_by_storage_class`` - Objects smaller than 128 KB will transition to Glacier Flexible Retrieval or Glacier Deep Archive storage classes. By default, all other storage classes will prevent transitions smaller than 128 KB. To customize the minimum object size for any transition you can add a filter that specifies a custom ``ObjectSizeGreaterThan`` or ``ObjectSizeLessThan`` in the body of your transition rule. Custom filters always take precedence over the default transition behavior.").with_provider_name("TransitionDefaultMinimumObjectSize")
                     ],
                 })
-                .write_only()
                 .with_description("Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) in the *Amazon S3 User Guide*.")
                 .with_provider_name("LifecycleConfiguration")
                 .with_block_name("lifecycle_configuration"),
@@ -736,7 +735,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("The journal table configuration for a metadata configuration.").with_provider_name("JournalTableConfiguration")
                     ],
                 })
-                .write_only()
                 .with_description("The S3 Metadata configuration for a general purpose bucket.")
                 .with_provider_name("MetadataConfiguration"),
         )
@@ -1105,7 +1103,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 })).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 })
-                .write_only()
                 .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration`` property. Amazon S3 can store replicated objects in a single destination bucket or multiple destination buckets. The destination bucket or buckets must already exist.")
                 .with_provider_name("ReplicationConfiguration")
                 .with_block_name("replication_configuration"),


### PR DESCRIPTION
## Summary

- Fix codegen to only mark an attribute as write-only when the attribute itself is listed in `writeOnlyProperties`, not when only nested sub-properties are write-only
- Remove incorrect `.write_only()` from S3 bucket's `lifecycle_configuration`, `metadata_configuration`, and `replication_configuration` attributes
- Add codegen regression test verifying nested write-only properties don't propagate to parent
- Add lifecycle_configuration round-trip conversion test verifying AWS JSON -> DSL -> AWS JSON fidelity

The root cause was that the codegen used `starts_with` matching to check if any write-only property path began with the attribute name. This incorrectly marked parent attributes as write-only when only nested sub-properties (e.g., `LifecycleConfiguration/Rules/*/Transition`) were write-only in the CloudFormation schema. The CloudControl API does return these parent attributes on read, so marking them write-only caused state reconciliation to fail.

Closes #1346

## Test plan

- [x] `cargo test -p carina-provider-awscc` — all 160 tests pass including new round-trip test
- [x] `cargo test -p carina-core` — all tests pass
- [x] `cargo test -p carina-cli plan_snapshot` — all snapshot tests pass
- [ ] Acceptance test: `s3_bucket/lifecycle.crn` should now pass plan-verify (apply -> plan shows no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)