### PR TITLE
fix: remove incorrect write_only flag from security_group_ingress

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -138,7 +138,6 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
             }).with_provider_name("ToPort")
                     ],
                 }))
-                .write_only()
                 .with_description("The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group.")
                 .with_provider_name("SecurityGroupIngress")
                 .with_block_name("security_group_ingress"),


### PR DESCRIPTION
## Summary

Remove the incorrectly applied `.write_only()` flag from `security_group_ingress` on `ec2.security_group` schema.

## Details

The codegen was propagating write-only from a nested sub-property (`SourceSecurityGroupName`) to the parent `SecurityGroupIngress` attribute. This was the same root cause as #1346. The codegen fix in that PR prevents future regenerations from reintroducing this bug, but the existing generated file still had the flag.

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)