### PR TITLE
ci: validate example .crn files and fail on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: bash scripts/validate-crn-files.sh
 
+  check-example-warnings:
+    name: Check Example Warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: bash scripts/check-example-warnings.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/scripts/check-example-warnings.sh
+++ b/scripts/check-example-warnings.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Check that example .crn files produce no warnings when validated.
+#
+# The `carina validate` command exits 0 even when warnings are emitted,
+# so this script inspects the output text for warning indicators.
+#
+# Usage (from project root):
+#   ./scripts/check-example-warnings.sh
+
+set -euo pipefail
+
+DIRS=(
+    "carina-provider-aws/examples"
+    "carina-provider-awscc/examples"
+)
+
+# Build the CLI binary
+cargo build --bin carina --quiet || {
+    echo "ERROR: Could not build carina binary"
+    exit 1
+}
+
+CARINA="target/debug/carina"
+WARNINGS=0
+PASSED=0
+
+for dir in "${DIRS[@]}"; do
+    if [ ! -d "$dir" ]; then
+        echo "SKIP: $dir (not found)"
+        continue
+    fi
+
+    while IFS= read -r -d '' file; do
+        output=$("$CARINA" validate "$file" 2>&1) || {
+            echo "ERROR: $file (non-zero exit)"
+            echo "$output"
+            echo ""
+            WARNINGS=$((WARNINGS + 1))
+            continue
+        }
+
+        # Check for warning indicators in output
+        if echo "$output" | grep -qE '⚠|^warning:'; then
+            echo "WARNING: $file"
+            echo "$output" | grep -E '⚠|^warning:'
+            echo ""
+            WARNINGS=$((WARNINGS + 1))
+        else
+            PASSED=$((PASSED + 1))
+        fi
+    done < <(find "$dir" -name '*.crn' -print0)
+done
+
+echo ""
+echo "Results: $PASSED passed, $WARNINGS with warnings"
+
+if [ "$WARNINGS" -gt 0 ]; then
+    echo ""
+    echo "Fix the warnings above before merging."
+    echo "Common fixes:"
+    echo "  - Unused let binding: remove 'let <name> =' and use anonymous resource"
+    exit 1
+fi
+
+echo "All example .crn files are warning-free."


### PR DESCRIPTION
## Summary
- Add `scripts/check-example-warnings.sh` that runs `carina validate` on all example `.crn` files and fails if any warnings are emitted
- Add "Check Example Warnings" CI job in `.github/workflows/ci.yml`
- No existing example files needed fixing (all are currently warning-free)

The `validate` command exits 0 even when warnings are present, so the script checks output text for warning indicators (`⚠` and `warning:` prefixes).

Closes #1334

## Test plan
- [ ] CI "Check Example Warnings" job passes
- [ ] Verify the script catches warnings by temporarily adding an unused `let` binding to an example file

🤖 Generated with [Claude Code](https://claude.com/claude-code)