### PR TITLE
fix: use ipv4_address() for ec2.eip public_ip and arn() for ec2.flow_log log_destination

### DIFF
--- a/carina-codegen-aws/src/main.rs
+++ b/carina-codegen-aws/src/main.rs
@@ -2383,6 +2383,8 @@ fn known_string_type_overrides() -> &'static HashMap<&'static str, &'static str>
         m.insert("SecurityGroupRuleId", "super::security_group_rule_id()");
         m.insert("Locale", "super::aws_region()");
         m.insert("BucketAccountId", "super::aws_account_id()");
+        m.insert("PublicIp", "types::ipv4_address()");
+        m.insert("LogDestination", "super::arn()");
         m
     });
     &OVERRIDES

--- a/carina-provider-aws/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/eip.rs
@@ -6,7 +6,7 @@
 
 use super::AwsSchemaConfig;
 use super::tags_type;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 /// Returns the schema config for ec2.eip (Smithy: com.amazonaws.ec2)
 pub fn ec2_eip_config() -> AwsSchemaConfig {
@@ -36,7 +36,7 @@ pub fn ec2_eip_config() -> AwsSchemaConfig {
                 .with_provider_name("Domain"),
             )
             .attribute(
-                AttributeSchema::new("public_ip", AttributeType::String)
+                AttributeSchema::new("public_ip", types::ipv4_address())
                     .with_description("The Elastic IP address. (read-only)")
                     .with_provider_name("PublicIp"),
             )

--- a/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-aws/src/schemas/generated/ec2/flow_log.rs
@@ -30,7 +30,7 @@ pub fn ec2_flow_log_config() -> AwsSchemaConfig {
                     .with_provider_name("FlowLogId"),
             )
             .attribute(
-                AttributeSchema::new("log_destination", AttributeType::String)
+                AttributeSchema::new("log_destination", super::arn())
                     .create_only()
                     .with_description(
                         "The destination to which the flow log data is to be published.",


### PR DESCRIPTION
## Summary

- Add `PublicIp` → `types::ipv4_address()` and `LogDestination` → `super::arn()` to `known_string_type_overrides()` in codegen
- Update generated `ec2/eip.rs` to use `types::ipv4_address()` for `public_ip` field
- Update generated `ec2/flow_log.rs` to use `super::arn()` for `log_destination` field

## Root cause (issue #1337)

The `infer_string_type()` logic correctly matches `PublicIp` via `ends_with("ip")`, but ec2.eip is not in the Smithy `resource_defs` pipeline — so the inference was never invoked. Adding an explicit override ensures correct typing when these resources are eventually added to the Smithy codegen pipeline.

closes #1337, closes #1336

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 115 tests pass
- [x] `cargo clippy -p carina-provider-aws` — no warnings
- [x] `cargo clippy -p carina-codegen-aws` — no warnings
- [x] Verified `ec2/eip.rs` uses `types::ipv4_address()` for `public_ip`
- [x] Verified `ec2/flow_log.rs` uses `super::arn()` for `log_destination`

🤖 Generated with [Claude Code](https://claude.com/claude-code)