### PR TITLE
docs: fix incorrect doc comments on Expr type

### DIFF
--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -59,9 +59,10 @@ impl std::fmt::Display for ResourceId {
 
 /// An unevaluated expression in the DSL.
 ///
-/// `Expr` represents values that may need resolution before becoming final `Value`s.
-/// The parser produces `Expr` values for resource attributes; the resolver converts
-/// them to `Expr::Literal(Value)` by resolving references, interpolations, and function calls.
+/// `Expr` is a newtype wrapper around `Value` that represents values which may need
+/// resolution before becoming final. The parser produces `Expr` values for resource
+/// attributes; the resolver resolves references within the inner `Value` (e.g.,
+/// replacing `ResourceRef` variants with concrete values).
 ///
 /// `Expr` wraps `Value` to enforce a type-level distinction between pre-resolution
 /// and post-resolution data. This prevents downstream code from accidentally receiving
@@ -114,7 +115,7 @@ pub enum InterpolationPart {
     Expr(Value),
 }
 
-/// Alias for ExprPart (legacy name)
+/// Legacy alias for `InterpolationPart`.
 pub type ExprPart = InterpolationPart;
 
 impl Expr {
@@ -128,8 +129,12 @@ impl Expr {
         self.0
     }
 
-    /// Returns true if the inner value is a resolved (non-expression) type.
-    /// A resolved value has no ResourceRef, Interpolation, or FunctionCall variants.
+    /// Returns true if the inner value contains no `ResourceRef` variants.
+    ///
+    /// This checks recursively: `ResourceRef`s nested inside `List`, `Map`,
+    /// `Interpolation`, `FunctionCall`, or `Secret` are detected.
+    /// Note that `Interpolation` and `FunctionCall` variants without nested
+    /// `ResourceRef`s are considered resolved by this method.
     pub fn is_resolved(&self) -> bool {
         !contains_resource_ref(&self.0)
     }


### PR DESCRIPTION
## Summary

- Fix `Expr` doc comment that incorrectly references `Expr::Literal` variant (Expr is a newtype struct, not an enum)
- Fix `ExprPart` type alias comment that describes the alias relationship backwards
- Fix `is_resolved()` docstring to accurately describe that it only checks for `ResourceRef` absence, not `Interpolation` or `FunctionCall`

Closes #1348

## Test plan

- [x] `cargo test -p carina-core` passes (982 tests)
- [x] `cargo clippy -p carina-core` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)