### PR TITLE
perf: hoist resolved_attributes() calls to avoid duplicate clones

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -440,7 +440,8 @@ impl DiagnosticEngine {
                     }
 
                     // Run resource-level validator (e.g., mutually exclusive required fields)
-                    if let Err(errors) = schema.validate(&resource.resolved_attributes()) {
+                    let resolved_attrs = resource.resolved_attributes();
+                    if let Err(errors) = schema.validate(&resolved_attrs) {
                         for error in errors {
                             // Skip errors that are already reported with precise positions
                             // by the attribute-level checks above.
@@ -478,7 +479,7 @@ impl DiagnosticEngine {
                     // Lint: prefer block syntax for List<Struct> attributes
                     diagnostics.extend(self.check_list_struct_syntax(
                         doc,
-                        &resource.resolved_attributes(),
+                        &resolved_attrs,
                         &schema,
                     ));
                 }

--- a/carina-provider-aws/src/services/ec2/subnet.rs
+++ b/carina-provider-aws/src/services/ec2/subnet.rs
@@ -93,16 +93,12 @@ impl AwsProvider {
         })?;
 
         // Apply tags
-        self.apply_ec2_tags(
-            &resource.id,
-            subnet_id,
-            &resource.resolved_attributes(),
-            None,
-        )
-        .await?;
+        let attrs = resource.resolved_attributes();
+        self.apply_ec2_tags(&resource.id, subnet_id, &attrs, None)
+            .await?;
 
         // Apply subnet attributes that require ModifySubnetAttribute
-        self.modify_subnet_attributes(&resource.id, subnet_id, &resource.resolved_attributes())
+        self.modify_subnet_attributes(&resource.id, subnet_id, &attrs)
             .await?;
 
         // Read back using subnet ID (reliable identifier)
@@ -118,17 +114,13 @@ impl AwsProvider {
         to: Resource,
     ) -> ProviderResult<State> {
         // Apply subnet attributes that require ModifySubnetAttribute
-        self.modify_subnet_attributes(&id, identifier, &to.resolved_attributes())
+        let attrs = to.resolved_attributes();
+        self.modify_subnet_attributes(&id, identifier, &attrs)
             .await?;
 
         // Update tags
-        self.apply_ec2_tags(
-            &id,
-            identifier,
-            &to.resolved_attributes(),
-            Some(&from.attributes),
-        )
-        .await?;
+        self.apply_ec2_tags(&id, identifier, &attrs, Some(&from.attributes))
+            .await?;
 
         self.read_ec2_subnet(&id, Some(identifier)).await
     }

--- a/carina-provider-aws/src/services/s3/bucket.rs
+++ b/carina-provider-aws/src/services/s3/bucket.rs
@@ -145,15 +145,12 @@ impl AwsProvider {
         })?;
 
         // Configure versioning
-        self.write_s3_bucket_versioning(
-            &resource.id,
-            &bucket_name,
-            &resource.resolved_attributes(),
-        )
-        .await?;
+        let attrs = resource.resolved_attributes();
+        self.write_s3_bucket_versioning(&resource.id, &bucket_name, &attrs)
+            .await?;
 
         // Set tags
-        self.write_s3_bucket_tags(&resource.id, &bucket_name, &resource.resolved_attributes())
+        self.write_s3_bucket_tags(&resource.id, &bucket_name, &attrs)
             .await?;
 
         // Return state after creation
@@ -171,16 +168,16 @@ impl AwsProvider {
         let bucket_name = identifier.to_string();
 
         // Update versioning status
-        self.write_s3_bucket_versioning(&id, &bucket_name, &to.resolved_attributes())
+        let attrs = to.resolved_attributes();
+        self.write_s3_bucket_versioning(&id, &bucket_name, &attrs)
             .await?;
 
         // Update object ownership
-        self.write_s3_bucket_ownership_controls(&id, &bucket_name, &to.resolved_attributes())
+        self.write_s3_bucket_ownership_controls(&id, &bucket_name, &attrs)
             .await?;
 
         // Update ACL
-        self.write_s3_bucket_acl(&id, &bucket_name, &to.resolved_attributes())
-            .await?;
+        self.write_s3_bucket_acl(&id, &bucket_name, &attrs).await?;
 
         // Update tags: if tags were removed entirely, delete all tags
         if from.attributes.contains_key("tags") && !to.attributes.contains_key("tags") {
@@ -195,8 +192,7 @@ impl AwsProvider {
                         .for_resource(id.clone())
                 })?;
         } else {
-            self.write_s3_bucket_tags(&id, &bucket_name, &to.resolved_attributes())
-                .await?;
+            self.write_s3_bucket_tags(&id, &bucket_name, &attrs).await?;
         }
 
         self.read_s3_bucket(&id, Some(&bucket_name)).await


### PR DESCRIPTION
## Summary

- Hoist `resolved_attributes()` calls into local variables in S3 bucket (create: 2→1 clone, update: 4→1 clone), EC2 subnet (create: 2→1, update: 2→1), and LSP diagnostics (2→1 per resource per keystroke)
- No behavioral changes; pure performance optimization

Closes #1349

## Test plan

- [x] `cargo test -p carina-provider-aws` — all 121 tests pass
- [x] `cargo test -p carina-lsp` — all 194 tests pass
- [x] `cargo test -p carina-core` — all 982 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)