### PR TITLE
feat: add S3 backend support for remote_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
+ "aws-sdk-s3",
  "base64",
  "carina-core",
  "carina-provider-aws",

--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -17,6 +17,7 @@ carina-state = { path = "../carina-state" }
 carina-tui = { path = "../carina-tui" }
 aws-config = "1"
 aws-sdk-kms = "1"
+aws-sdk-s3 = "1"
 base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1082,7 +1082,7 @@ async fn run_apply_locked(
     }
 
     // Load remote state data sources
-    let remote_bindings = super::plan::load_remote_states(&parsed.remote_states, base_dir)?;
+    let remote_bindings = super::plan::load_remote_states(&parsed.remote_states, base_dir).await?;
 
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use carina_core::config_loader::{get_base_dir, load_configuration_with_config};
 use carina_core::effect::Effect;
-use carina_core::parser::{BackendConfig, ProviderConfig, ProviderContext, RemoteState};
+use carina_core::parser::{
+    BackendConfig, ProviderConfig, ProviderContext, RemoteState, RemoteStateBackend,
+};
 use carina_core::plan::Plan;
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::{
@@ -182,7 +184,7 @@ pub async fn run_plan(
     }
 
     // Load remote state data sources
-    let remote_bindings = load_remote_states(&parsed.remote_states, base_dir)?;
+    let remote_bindings = load_remote_states(&parsed.remote_states, base_dir).await?;
 
     let ctx = create_plan_from_parsed_with_remote(&parsed, &state_file, refresh, &remote_bindings)
         .await?;
@@ -275,40 +277,106 @@ pub async fn run_plan(
 /// map of resource bindings to their attributes. The result maps each remote_state
 /// binding name to a `HashMap<String, Value>` where keys are resource binding names
 /// and values are `Value::Map` of that resource's attributes.
-pub(crate) fn load_remote_states(
+pub(crate) async fn load_remote_states(
     remote_states: &[RemoteState],
     base_dir: &Path,
 ) -> Result<HashMap<String, HashMap<String, Value>>, AppError> {
     let mut result = HashMap::new();
 
     for rs in remote_states {
-        let state_path = if Path::new(&rs.path).is_absolute() {
-            PathBuf::from(&rs.path)
-        } else {
-            base_dir.join(&rs.path)
+        let state_file = match &rs.backend {
+            RemoteStateBackend::Local { path } => {
+                load_remote_state_local(path, &rs.binding, base_dir)?
+            }
+            RemoteStateBackend::S3 {
+                bucket,
+                key,
+                region,
+            } => load_remote_state_s3(bucket, key, region, &rs.binding).await?,
         };
-
-        let content = fs::read_to_string(&state_path).map_err(|e| {
-            AppError::Config(format!(
-                "Failed to read remote state file '{}' for remote_state '{}': {}",
-                state_path.display(),
-                rs.binding,
-                e
-            ))
-        })?;
-
-        let state_file = check_and_migrate(&content).map_err(|e| {
-            AppError::Config(format!(
-                "Failed to parse remote state file '{}' for remote_state '{}': {}",
-                state_path.display(),
-                rs.binding,
-                e
-            ))
-        })?;
 
         let bindings = state_file.build_remote_bindings();
         result.insert(rs.binding.clone(), bindings);
     }
 
     Ok(result)
+}
+
+/// Load a remote state file from a local path.
+fn load_remote_state_local(
+    path: &str,
+    binding: &str,
+    base_dir: &Path,
+) -> Result<StateFile, AppError> {
+    let state_path = if Path::new(path).is_absolute() {
+        PathBuf::from(path)
+    } else {
+        base_dir.join(path)
+    };
+
+    let content = fs::read_to_string(&state_path).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to read remote state file '{}' for remote_state '{}': {}",
+            state_path.display(),
+            binding,
+            e
+        ))
+    })?;
+
+    check_and_migrate(&content).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to parse remote state file '{}' for remote_state '{}': {}",
+            state_path.display(),
+            binding,
+            e
+        ))
+    })
+}
+
+/// Load a remote state file from S3.
+async fn load_remote_state_s3(
+    bucket: &str,
+    key: &str,
+    region: &str,
+    binding: &str,
+) -> Result<StateFile, AppError> {
+    use carina_core::utils::convert_region_value;
+
+    let aws_region = convert_region_value(region);
+
+    let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(aws_config::Region::new(aws_region))
+        .load()
+        .await;
+
+    let client = aws_sdk_s3::Client::new(&aws_config);
+
+    let output = client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| {
+            AppError::Config(format!(
+                "Failed to read remote state from s3://{}/{} for remote_state '{}': {}",
+                bucket, key, binding, e
+            ))
+        })?;
+
+    let body = output.body.collect().await.map_err(|e| {
+        AppError::Config(format!(
+            "Failed to read response body from s3://{}/{} for remote_state '{}': {}",
+            bucket, key, binding, e
+        ))
+    })?;
+
+    let bytes = body.into_bytes();
+
+    carina_state::check_and_migrate_bytes(&bytes).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to parse remote state from s3://{}/{} for remote_state '{}': {}",
+            bucket, key, binding, e
+        ))
+    })
 }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -107,15 +107,17 @@ fn build_plan_and_states_from_fixture(
     // Load remote state files if any
     let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for rs in &parsed.remote_states {
-        let remote_path = if std::path::Path::new(&rs.path).is_absolute() {
-            std::path::PathBuf::from(&rs.path)
-        } else {
-            base_dir.join(&rs.path)
-        };
-        if let Ok(content) = std::fs::read_to_string(&remote_path)
-            && let Ok(sf) = check_and_migrate(&content)
-        {
-            remote_bindings.insert(rs.binding.clone(), sf.build_remote_bindings());
+        if let carina_core::parser::RemoteStateBackend::Local { ref path } = rs.backend {
+            let remote_path = if std::path::Path::new(path).is_absolute() {
+                std::path::PathBuf::from(path)
+            } else {
+                base_dir.join(path)
+            };
+            if let Ok(content) = std::fs::read_to_string(&remote_path)
+                && let Ok(sf) = check_and_migrate(&content)
+            {
+                remote_bindings.insert(rs.binding.clone(), sf.build_remote_bindings());
+            }
         }
     }
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -5,9 +5,9 @@ file = { SOI ~ statement* ~ EOI }
 
 statement = { backend_block | provider_block | arguments_block | attributes_block | import_state_block | removed_block | moved_block | if_expr | for_expr | fn_def | let_binding | module_call | anonymous_resource }
 
-// Remote state block: remote_state { path = "..." }
+// Remote state block: remote_state { path = "..." } or remote_state "s3" { bucket = "...", ... }
 // Only valid as a let binding RHS: let network = remote_state { path = "..." }
-remote_state_block = { "remote_state" ~ "{" ~ attribute* ~ "}" }
+remote_state_block = { "remote_state" ~ string? ~ "{" ~ attribute* ~ "}" }
 
 // User-defined function: fn name(params) { body }
 fn_def = { "fn" ~ identifier ~ "(" ~ fn_params? ~ ")" ~ (":" ~ type_expr)? ~ "{" ~ fn_body ~ "}" }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -294,8 +294,21 @@ pub struct BackendConfig {
 pub struct RemoteState {
     /// The binding name from the `let` binding (e.g., "network")
     pub binding: String,
-    /// Path to the state file (local file path)
-    pub path: String,
+    /// Backend configuration
+    pub backend: RemoteStateBackend,
+}
+
+/// Backend type for remote state
+#[derive(Debug, Clone)]
+pub enum RemoteStateBackend {
+    /// Local file path
+    Local { path: String },
+    /// S3 bucket
+    S3 {
+        bucket: String,
+        key: String,
+        region: String,
+    },
 }
 
 /// Parse result
@@ -2367,43 +2380,124 @@ fn parse_backend_block(
     })
 }
 
-/// Parse a remote_state block: remote_state { path = "..." }
+/// Parse a remote_state block: remote_state { path = "..." } or remote_state "s3" { ... }
 fn parse_remote_state_block(
     pair: pest::iterators::Pair<Rule>,
     binding_name: &str,
 ) -> Result<RemoteState, ParseError> {
-    let mut path = None;
+    let mut backend_name: Option<String> = None;
+    let mut attrs: HashMap<String, String> = HashMap::new();
 
-    for attr_pair in pair.into_inner() {
-        if attr_pair.as_rule() == Rule::attribute {
-            let mut attr_inner = attr_pair.into_inner();
-            let key = next_pair(&mut attr_inner, "attribute name", "remote_state block")?
-                .as_str()
-                .to_string();
-            let value_pair = next_pair(&mut attr_inner, "attribute value", "remote_state block")?;
-            // Only parse string literals for now
-            let value_str = extract_string_from_pair(value_pair)?;
-            match key.as_str() {
-                "path" => path = Some(value_str),
-                other => {
+    for inner_pair in pair.into_inner() {
+        match inner_pair.as_rule() {
+            Rule::string => {
+                // Optional backend name string (e.g., "s3")
+                backend_name = Some(extract_string_from_string_pair(inner_pair)?);
+            }
+            Rule::attribute => {
+                let mut attr_inner = inner_pair.into_inner();
+                let key = next_pair(&mut attr_inner, "attribute name", "remote_state block")?
+                    .as_str()
+                    .to_string();
+                let value_pair =
+                    next_pair(&mut attr_inner, "attribute value", "remote_state block")?;
+                let value_str = extract_string_from_pair(value_pair)?;
+                attrs.insert(key, value_str);
+            }
+            _ => {}
+        }
+    }
+
+    let backend = match backend_name.as_deref() {
+        None | Some("local") => {
+            // Local backend: requires "path"
+            let valid_keys: &[&str] = &["path"];
+            for key in attrs.keys() {
+                if !valid_keys.contains(&key.as_str()) {
                     return Err(ParseError::InvalidExpression {
                         line: 0,
-                        message: format!("unknown attribute '{}' in remote_state block", other),
+                        message: format!("unknown attribute '{}' in remote_state block", key),
                     });
+                }
+            }
+            let path = attrs
+                .remove("path")
+                .ok_or_else(|| ParseError::InvalidExpression {
+                    line: 0,
+                    message: "remote_state block requires a 'path' attribute".to_string(),
+                })?;
+            RemoteStateBackend::Local { path }
+        }
+        Some("s3") => {
+            // S3 backend: requires "bucket", "key", "region"
+            let valid_keys: &[&str] = &["bucket", "key", "region"];
+            for key in attrs.keys() {
+                if !valid_keys.contains(&key.as_str()) {
+                    return Err(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "unknown attribute '{}' in remote_state \"s3\" block",
+                            key
+                        ),
+                    });
+                }
+            }
+            let bucket = attrs
+                .remove("bucket")
+                .ok_or_else(|| ParseError::InvalidExpression {
+                    line: 0,
+                    message: "remote_state \"s3\" block requires a 'bucket' attribute".to_string(),
+                })?;
+            let key = attrs
+                .remove("key")
+                .ok_or_else(|| ParseError::InvalidExpression {
+                    line: 0,
+                    message: "remote_state \"s3\" block requires a 'key' attribute".to_string(),
+                })?;
+            let region = attrs
+                .remove("region")
+                .ok_or_else(|| ParseError::InvalidExpression {
+                    line: 0,
+                    message: "remote_state \"s3\" block requires a 'region' attribute".to_string(),
+                })?;
+            RemoteStateBackend::S3 {
+                bucket,
+                key,
+                region,
+            }
+        }
+        Some(other) => {
+            return Err(ParseError::InvalidExpression {
+                line: 0,
+                message: format!(
+                    "unsupported remote_state backend '{}' (supported: local, s3)",
+                    other
+                ),
+            });
+        }
+    };
+
+    Ok(RemoteState {
+        binding: binding_name.to_string(),
+        backend,
+    })
+}
+
+/// Extract a string value directly from a Rule::string pair
+fn extract_string_from_string_pair(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<String, ParseError> {
+    let mut result = String::new();
+    for inner in pair.into_inner() {
+        if inner.as_rule() == Rule::string_part {
+            for part in inner.into_inner() {
+                if part.as_rule() == Rule::string_literal {
+                    result.push_str(part.as_str());
                 }
             }
         }
     }
-
-    let path = path.ok_or_else(|| ParseError::InvalidExpression {
-        line: 0,
-        message: "remote_state block requires a 'path' attribute".to_string(),
-    })?;
-
-    Ok(RemoteState {
-        binding: binding_name.to_string(),
-        path,
-    })
+    Ok(result)
 }
 
 /// Extract a string value from a pair (expression -> pipe_expr -> primary -> string)
@@ -8048,7 +8142,12 @@ arguments {
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.remote_states.len(), 1);
         assert_eq!(result.remote_states[0].binding, "network");
-        assert_eq!(result.remote_states[0].path, "../network/carina.state.json");
+        match &result.remote_states[0].backend {
+            RemoteStateBackend::Local { path } => {
+                assert_eq!(path, "../network/carina.state.json");
+            }
+            other => panic!("Expected Local backend, got: {:?}", other),
+        }
     }
 
     #[test]
@@ -8115,5 +8214,175 @@ arguments {
             "Error should mention 'unknown attribute', got: {}",
             err
         );
+    }
+
+    #[test]
+    fn parse_remote_state_s3_backend() {
+        let input = r#"
+            let network = remote_state "s3" {
+                bucket = "carina-state"
+                key    = "network/carina.state.json"
+                region = "ap-northeast-1"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.remote_states.len(), 1);
+        assert_eq!(result.remote_states[0].binding, "network");
+        match &result.remote_states[0].backend {
+            RemoteStateBackend::S3 {
+                bucket,
+                key,
+                region,
+            } => {
+                assert_eq!(bucket, "carina-state");
+                assert_eq!(key, "network/carina.state.json");
+                assert_eq!(region, "ap-northeast-1");
+            }
+            other => panic!("Expected S3 backend, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_remote_state_s3_with_resource_ref() {
+        let input = r#"
+            let network = remote_state "s3" {
+                bucket = "carina-state"
+                key    = "network/carina.state.json"
+                region = "ap-northeast-1"
+            }
+
+            awscc.ec2.security_group {
+                name   = "web-sg"
+                vpc_id = network.vpc.vpc_id
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.remote_states.len(), 1);
+        assert_eq!(result.resources.len(), 1);
+        let vpc_id_attr = result.resources[0].get_attr("vpc_id").unwrap();
+        match vpc_id_attr {
+            Value::ResourceRef { path } => {
+                assert_eq!(path.binding(), "network");
+                assert_eq!(path.attribute(), "vpc");
+                assert_eq!(path.field_path(), vec!["vpc_id"]);
+            }
+            other => panic!("Expected ResourceRef, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_remote_state_s3_missing_bucket() {
+        let input = r#"
+            let network = remote_state "s3" {
+                key    = "network/carina.state.json"
+                region = "ap-northeast-1"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("bucket"),
+            "Error should mention 'bucket', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_remote_state_s3_missing_key() {
+        let input = r#"
+            let network = remote_state "s3" {
+                bucket = "carina-state"
+                region = "ap-northeast-1"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("key"),
+            "Error should mention 'key', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_remote_state_s3_missing_region() {
+        let input = r#"
+            let network = remote_state "s3" {
+                bucket = "carina-state"
+                key    = "network/carina.state.json"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("region"),
+            "Error should mention 'region', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_remote_state_s3_unknown_attribute() {
+        let input = r#"
+            let network = remote_state "s3" {
+                bucket  = "carina-state"
+                key     = "network/carina.state.json"
+                region  = "ap-northeast-1"
+                encrypt = "true"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unknown attribute"),
+            "Error should mention 'unknown attribute', got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_remote_state_unsupported_backend() {
+        let input = r#"
+            let network = remote_state "gcs" {
+                bucket = "carina-state"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported remote_state backend"),
+            "Error should mention unsupported backend, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_remote_state_explicit_local_backend() {
+        let input = r#"
+            let network = remote_state "local" {
+                path = "../network/carina.state.json"
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.remote_states.len(), 1);
+        match &result.remote_states[0].backend {
+            RemoteStateBackend::Local { path } => {
+                assert_eq!(path, "../network/carina.state.json");
+            }
+            other => panic!("Expected Local backend, got: {:?}", other),
+        }
     }
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -319,10 +319,22 @@ impl CompletionProvider {
                 if let Some(after_rs) = after_eq.strip_prefix("remote_state")
                     && (after_rs.is_empty()
                         || after_rs.starts_with(char::is_whitespace)
-                        || after_rs.starts_with('{'))
+                        || after_rs.starts_with('{')
+                        || after_rs.starts_with('"'))
                 {
+                    // Skip optional backend name string (e.g., "s3")
                     let after_rs = after_rs.trim();
-                    if let Some(after_brace) = after_rs.strip_prefix('{') {
+                    let after_backend = if let Some(stripped) = after_rs.strip_prefix('"') {
+                        // Skip past the closing quote of the backend name
+                        if let Some(end_quote) = stripped.find('"') {
+                            stripped[end_quote + 1..].trim()
+                        } else {
+                            after_rs
+                        }
+                    } else {
+                        after_rs
+                    };
+                    if let Some(after_brace) = after_backend.strip_prefix('{') {
                         current_binding = Some(name.to_string());
                         in_remote_state_block = true;
                         brace_depth = 1;


### PR DESCRIPTION
## Summary

- Extend `remote_state` grammar to accept an optional backend name string: `remote_state "s3" { ... }`
- Add `RemoteStateBackend` enum (`Local`/`S3`) to replace the flat `path` field on `RemoteState`
- Implement async S3 state loading in `load_remote_state_s3` using `aws-sdk-s3`, reusing the same region-conversion logic as the state backend
- Update LSP completion to recognize the new `remote_state "backend" { ... }` syntax
- Add 8 new parser tests covering S3 parsing, missing attributes, unknown attributes, unsupported backends, and explicit `"local"` backend

Closes #1184

## Test plan

- [x] All 12 `parse_remote_state*` tests pass (including 8 new S3 tests)
- [x] All 20 plan snapshot tests pass
- [x] All carina-core tests pass (1004+ tests)
- [x] All carina-cli tests pass
- [x] All carina-lsp tests pass
- [ ] Manual test with real S3 bucket containing a state file

🤖 Generated with [Claude Code](https://claude.com/claude-code)