### PR TITLE
feat: add Value::Closure variant for partially applied functions

### DIFF
--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -181,6 +181,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
         Value::Secret(_) => "Secret",
+        Value::Closure { .. } => "Closure",
     }
 }
 

--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -197,6 +197,22 @@ fn deterministic_value_string(value: &Value) -> String {
         Value::Secret(inner) => {
             format!("Secret({})", deterministic_value_string(inner))
         }
+        Value::Closure {
+            name,
+            captured_args,
+            remaining_arity,
+        } => {
+            let arg_strs: Vec<String> = captured_args
+                .iter()
+                .map(deterministic_value_string)
+                .collect();
+            format!(
+                "Closure({}({}) remaining={})",
+                name,
+                arg_strs.join(", "),
+                remaining_arity
+            )
+        }
     }
 }
 

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -175,6 +175,19 @@ fn format_value(value: &Value) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
+        Value::Closure {
+            name,
+            captured_args,
+            remaining_arity,
+        } => {
+            let total = captured_args.len() + remaining_arity;
+            format!(
+                "<closure: {}({}/{} args)>",
+                name,
+                captured_args.len(),
+                total
+            )
+        }
     }
 }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1375,6 +1375,7 @@ fn is_static_value(value: &Value) -> bool {
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
         Value::ResourceRef { .. } | Value::Interpolation(_) => false,
         Value::Secret(inner) => is_static_value(inner),
+        Value::Closure { .. } => false,
     }
 }
 
@@ -2242,6 +2243,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "string",
         Value::FunctionCall { .. } => "function call",
         Value::Secret(_) => "secret",
+        Value::Closure { .. } => "closure",
     }
 }
 

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -202,6 +202,21 @@ pub fn resolve_ref_value(
             let resolved_inner = resolve_ref_value(inner, binding_map)?;
             Ok(Value::Secret(Box::new(resolved_inner)))
         }
+        Value::Closure {
+            name,
+            captured_args,
+            remaining_arity,
+        } => {
+            let resolved_args: Result<Vec<Value>, String> = captured_args
+                .iter()
+                .map(|a| resolve_ref_value(a, binding_map))
+                .collect();
+            Ok(Value::Closure {
+                name: name.clone(),
+                captured_args: resolved_args?,
+                remaining_arity: *remaining_arity,
+            })
+        }
         _ => Ok(value.clone()),
     }
 }
@@ -218,6 +233,7 @@ fn contains_resource_ref(value: &Value) -> bool {
         }),
         Value::FunctionCall { args, .. } => args.iter().any(contains_resource_ref),
         Value::Secret(inner) => contains_resource_ref(inner),
+        Value::Closure { captured_args, .. } => captured_args.iter().any(contains_resource_ref),
         _ => false,
     }
 }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -200,6 +200,19 @@ pub enum Value {
     /// A secret value. The inner value is sent to the provider but stored as a
     /// SHA256 hash in state. Plan output displays `(secret)` instead of the value.
     Secret(Box<Value>),
+    /// A partially applied function (closure).
+    ///
+    /// Exists only during expression evaluation; never serialized to state.
+    /// Created when a function receives fewer arguments than it needs.
+    #[serde(skip)]
+    Closure {
+        /// Original function name
+        name: String,
+        /// Arguments already provided
+        captured_args: Vec<Value>,
+        /// How many more arguments are needed
+        remaining_arity: usize,
+    },
 }
 
 /// A part of a string interpolation expression
@@ -227,6 +240,24 @@ impl Value {
         Value::ResourceRef {
             path: AccessPath::from_ref(binding_name, attribute_name, field_path),
         }
+    }
+
+    /// Create a `Closure` value representing a partially applied function.
+    pub fn closure(
+        name: impl Into<String>,
+        captured_args: Vec<Value>,
+        remaining_arity: usize,
+    ) -> Self {
+        Value::Closure {
+            name: name.into(),
+            captured_args,
+            remaining_arity,
+        }
+    }
+
+    /// Returns true if this value is a `Closure`.
+    pub fn is_closure(&self) -> bool {
+        matches!(self, Value::Closure { .. })
     }
 
     /// If this is a `ResourceRef`, returns the binding name.
@@ -328,6 +359,7 @@ pub fn contains_resource_ref(value: &Value) -> bool {
         }),
         Value::FunctionCall { args, .. } => args.iter().any(contains_resource_ref),
         Value::Secret(inner) => contains_resource_ref(inner),
+        Value::Closure { captured_args, .. } => captured_args.iter().any(contains_resource_ref),
         _ => false,
     }
 }
@@ -413,6 +445,18 @@ impl Value {
             }
             Value::Secret(inner) => {
                 inner.hash_into(hasher);
+            }
+            Value::Closure {
+                name,
+                captured_args,
+                remaining_arity,
+            } => {
+                name.hash(hasher);
+                captured_args.len().hash(hasher);
+                for arg in captured_args {
+                    arg.hash_into(hasher);
+                }
+                remaining_arity.hash(hasher);
             }
         }
     }
@@ -1610,5 +1654,60 @@ mod tests {
 
         let non_ref = Value::String("hello".to_string());
         assert_eq!(non_ref.ref_binding(), None);
+    }
+
+    #[test]
+    fn closure_constructor() {
+        let closure = Value::closure("map", vec![Value::String(".subnet_id".to_string())], 1);
+        match &closure {
+            Value::Closure {
+                name,
+                captured_args,
+                remaining_arity,
+            } => {
+                assert_eq!(name, "map");
+                assert_eq!(captured_args.len(), 1);
+                assert_eq!(*remaining_arity, 1);
+            }
+            _ => panic!("Expected Closure variant"),
+        }
+    }
+
+    #[test]
+    fn closure_is_closure_helper() {
+        let closure = Value::closure("map", vec![], 2);
+        assert!(closure.is_closure());
+
+        let not_closure = Value::String("hello".to_string());
+        assert!(!not_closure.is_closure());
+    }
+
+    #[test]
+    fn closure_serde_serialize_fails() {
+        // Closure with #[serde(skip)] cannot be serialized — serde rejects it.
+        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
+        let result = serde_json::to_string(&closure);
+        assert!(result.is_err(), "Closure must not be serializable");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("cannot be serialized"),
+            "Error should mention serialization: {err}"
+        );
+    }
+
+    #[test]
+    fn closure_not_in_contains_resource_ref() {
+        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
+        assert!(!contains_resource_ref(&closure));
+    }
+
+    #[test]
+    fn closure_with_resource_ref_in_captured_args() {
+        let closure = Value::Closure {
+            name: "map".to_string(),
+            captured_args: vec![Value::resource_ref("vpc", "id", vec![])],
+            remaining_arity: 1,
+        };
+        assert!(contains_resource_ref(&closure));
     }
 }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -500,6 +500,7 @@ impl Value {
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),
+            Value::Closure { name, .. } => format!("Closure({})", name),
         }
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -140,6 +140,16 @@ pub fn value_to_json_with_context(
                 "{SECRET_PREFIX}{hash_hex}",
             )))
         }
+        Value::Closure {
+            name,
+            captured_args,
+            remaining_arity,
+        } => Err(format!(
+            "Closure values cannot be serialized: <closure: {}({}/{} args)>",
+            name,
+            captured_args.len(),
+            captured_args.len() + remaining_arity,
+        )),
     }
 }
 
@@ -233,6 +243,19 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
+        Value::Closure {
+            name,
+            captured_args,
+            remaining_arity,
+        } => {
+            let total = captured_args.len() + remaining_arity;
+            format!(
+                "<closure: {}({}/{} args)>",
+                name,
+                captured_args.len(),
+                total
+            )
+        }
     }
 }
 
@@ -1029,5 +1052,29 @@ mod tests {
             json
         );
         assert!(json.contains("my-bucket"));
+    }
+
+    #[test]
+    fn closure_format_value_display() {
+        let closure = Value::closure("map", vec![Value::String(".subnet_id".to_string())], 1);
+        let display = format_value(&closure);
+        assert_eq!(display, "<closure: map(1/2 args)>");
+    }
+
+    #[test]
+    fn closure_format_value_no_captured_args() {
+        let closure = Value::closure("join", vec![], 2);
+        let display = format_value(&closure);
+        assert_eq!(display, "<closure: join(0/2 args)>");
+    }
+
+    #[test]
+    fn closure_value_to_json_errors() {
+        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
+        let result = value_to_json(&closure);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("Closure values cannot be serialized"));
+        assert!(err.contains("map"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `Value::Closure` variant to represent partially applied functions (data model for #1377)
- Closure stores function name, captured arguments, and remaining arity
- NOT serializable (`#[serde(skip)]`) — exists only during expression evaluation, never in state
- `value_to_json` returns a clear error if serialization is attempted
- `format_value` displays as `<closure: name(captured/total args)>`
- All exhaustive `match` sites across the codebase updated to handle the new variant
- Resolver propagates reference resolution through captured args

## Test plan

- [x] Closure construction and helper methods (`is_closure`)
- [x] Serialization rejection (serde and value_to_json)
- [x] Display formatting
- [x] `contains_resource_ref` with and without refs in captured args
- [x] All existing tests pass (`cargo test -p carina-core`)
- [x] Snapshot tests unaffected (`cargo test -p carina-cli plan_snapshot`)

Closes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)