### PR TITLE
style(docs): apply Ocean/Teal Deep Navy theme

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -41,10 +41,11 @@
 
 /* Code block theme */
 :root {
-  --astro-code-color-background: hsl(217, 33%, 17%); /* Slate 800 - matches sidebar */
+  --astro-code-background: hsl(217, 33%, 17%); /* Slate 800 - matches sidebar */
+  --astro-code-token-keyword: var(--sl-color-accent-high); /* Cyan instead of purple */
 }
 :root[data-theme='light'] {
-  --astro-code-color-background: hsl(210, 40%, 96%); /* Slate 100 */
+  --astro-code-background: hsl(210, 40%, 96%); /* Slate 100 */
 }
 
 /* Provider doc table styling */
@@ -78,15 +79,19 @@ table td, table th {
   border-color: var(--sl-color-hairline-light);
 }
 
-/* Feature cards: consistent cyan accent */
+/* Feature cards: consistent cyan accent with left border */
 .card {
   --sl-card-border: var(--sl-color-accent);
   --sl-card-bg: var(--sl-color-accent-low);
   border-color: var(--sl-color-gray-5);
+  border-left: 3px solid var(--sl-color-accent);
   transition: border-color 0.2s ease;
 }
 .card:hover {
   border-color: var(--sl-color-accent);
+}
+.card .icon {
+  color: var(--sl-color-accent);
 }
 /* Override per-card color rotation to use consistent cyan */
 .card:nth-child(4n + 1) {


### PR DESCRIPTION
## Summary
- Replace default Starlight purple accent with Ocean/Teal (Deep Navy) color scheme for both dark and light modes
- Improve code block backgrounds and keyword highlighting to match site palette
- Unify feature card colors with cyan accent, left border, and hover effect
- Add table header backgrounds and alternating stripe rows for provider reference pages

## Test plan
- [ ] `npm run build` in `docs/` passes
- [ ] Visual check: dark mode — deep navy background, cyan accent links, sidebar
- [ ] Visual check: light mode — light slate background, darker cyan links
- [ ] Feature cards on home page show cyan accent with hover effect
- [ ] Provider reference tables have styled headers and stripe rows
- [ ] "Soon" badges use cyan instead of purple

🤖 Generated with [Claude Code](https://claude.com/claude-code)