### PR TITLE
style(docs): match nav bar background to page background

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -15,6 +15,9 @@
   --sl-color-gray-6: hsl(222, 47%, 11%); /* #0f172a Slate 900 */
   --sl-color-black: hsl(229, 84%, 5%);   /* #020617 Slate 950 */
 
+  /* Nav bar: match page background */
+  --sl-color-bg-nav: var(--sl-color-black);
+
   /* Accent: Canopus Gold (Amber/Yellow) */
   --sl-color-accent-low: hsl(32, 60%, 15%);   /* dark amber */
   --sl-color-accent: hsl(43, 96%, 56%);        /* ~#fbbf24 Yellow 400 */


### PR DESCRIPTION
## Summary
- Set `--sl-color-bg-nav` to match `--sl-color-black` so the header bar blends with the page background instead of being slightly lighter

## Test plan
- [ ] Nav bar color matches page background on carina-rs.github.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)