### PR TITLE
style(docs): match header background to page background

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -15,8 +15,6 @@
   --sl-color-gray-6: hsl(222, 47%, 11%); /* #0f172a Slate 900 */
   --sl-color-black: hsl(229, 84%, 5%);   /* #020617 Slate 950 */
 
-  /* Nav bar: match page background */
-  --sl-color-bg-nav: var(--sl-color-black);
 
   /* Accent: Canopus Gold (Amber/Yellow) */
   --sl-color-accent-low: hsl(32, 60%, 15%);   /* dark amber */
@@ -50,6 +48,11 @@
 /* Hide theme toggle */
 starlight-theme-select {
   display: none;
+}
+
+/* Nav bar: match page background */
+.header {
+  background-color: var(--sl-color-black) !important;
 }
 
 /* Provider doc table styling */


### PR DESCRIPTION
## Summary
- Override header background to use `--sl-color-black` so it matches the page body
- Remove unused `--sl-color-bg-nav` override that was ineffective due to Starlight's CSS load order

## Test plan
- [ ] Header bar is the same color as the page background

🤖 Generated with [Claude Code](https://claude.com/claude-code)