### PR TITLE
fix: skip unused-binding warnings for if/for/read expressions

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -660,6 +660,7 @@ fn test_find_state_bucket_resource_matching_type() {
         user_functions: HashMap::new(),
         remote_states: vec![],
         requires: vec![],
+        structural_bindings: HashSet::new(),
     };
 
     // Matching resource type
@@ -1936,6 +1937,7 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
         user_functions: HashMap::new(),
         remote_states: vec![],
         requires: vec![],
+        structural_bindings: HashSet::new(),
     };
 
     // MockProvider returns not_found for both resources (simulates external deletion)

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -1,6 +1,6 @@
 //! Configuration loading and .crn file discovery utilities
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -65,6 +65,7 @@ pub fn load_configuration_with_config(
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         };
         let mut merged = empty_parsed();
         let mut unresolved_merged = empty_parsed();
@@ -103,6 +104,9 @@ pub fn load_configuration_with_config(
                     unresolved_merged
                         .remote_states
                         .extend(unresolved.remote_states);
+                    unresolved_merged
+                        .structural_bindings
+                        .extend(unresolved.structural_bindings);
 
                     // Merge resolved
                     merged.providers.extend(parsed.providers);
@@ -116,6 +120,9 @@ pub fn load_configuration_with_config(
                     merged.user_functions.extend(parsed.user_functions);
                     merged.remote_states.extend(parsed.remote_states);
                     merged.requires.extend(parsed.requires);
+                    merged
+                        .structural_bindings
+                        .extend(parsed.structural_bindings);
                     // Merge backend (only one allowed)
                     if let Some(backend) = parsed.backend {
                         if merged.backend.is_some() {

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -191,6 +191,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         };
 
         // Read all .crn files in the directory
@@ -218,6 +219,9 @@ impl<'cfg> ModuleResolver<'cfg> {
             merged.user_functions.extend(parsed.user_functions);
             merged.remote_states.extend(parsed.remote_states);
             merged.requires.extend(parsed.requires);
+            merged
+                .structural_bindings
+                .extend(parsed.structural_bindings);
         }
 
         Ok(merged)
@@ -1100,6 +1104,7 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
         user_functions: HashMap::new(),
         remote_states: vec![],
         requires: vec![],
+        structural_bindings: HashSet::new(),
     };
 
     for entry in entries.flatten() {
@@ -1118,6 +1123,9 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
             merged.user_functions.extend(parsed.user_functions);
             merged.remote_states.extend(parsed.remote_states);
             merged.requires.extend(parsed.requires);
+            merged
+                .structural_bindings
+                .extend(parsed.structural_bindings);
         }
     }
 
@@ -1182,6 +1190,7 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
         user_functions: HashMap::new(),
         remote_states: vec![],
         requires: vec![],
+        structural_bindings: HashSet::new(),
     };
 
     for entry in entries {
@@ -1205,6 +1214,9 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
             merged.user_functions.extend(parsed.user_functions);
             merged.remote_states.extend(parsed.remote_states);
             merged.requires.extend(parsed.requires);
+            merged
+                .structural_bindings
+                .extend(parsed.structural_bindings);
         }
     }
 
@@ -1267,6 +1279,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -1399,6 +1412,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -1522,6 +1536,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -1868,6 +1883,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -2151,6 +2167,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -2319,6 +2336,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {
@@ -2380,6 +2398,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: vec![],
             requires: vec![],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {
@@ -2469,6 +2488,7 @@ mod tests {
                 ),
                 error_message: "cert_arn is required when HTTPS is enabled".to_string(),
             }],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {
@@ -2534,6 +2554,7 @@ mod tests {
                 ),
                 error_message: "cert is required when HTTPS is enabled".to_string(),
             }],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {
@@ -2596,6 +2617,7 @@ mod tests {
                 },
                 error_message: "ALB requires at least two subnets".to_string(),
             }],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {
@@ -2684,6 +2706,7 @@ mod tests {
                 },
                 error_message: "min_size must be <= max_size".to_string(),
             }],
+            structural_bindings: HashSet::new(),
         };
 
         let resolver = {

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -12,7 +12,7 @@ use crate::schema::{
 };
 use pest::Parser;
 use pest_derive::Parser;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Parser)]
 #[grammar = "parser/carina.pest"]
@@ -345,6 +345,9 @@ pub struct ParsedFile {
     pub remote_states: Vec<RemoteState>,
     /// Require blocks (cross-argument constraints)
     pub requires: Vec<RequireBlock>,
+    /// Binding names that are structurally required (if/for/read expressions)
+    /// and should not trigger unused-binding warnings.
+    pub structural_bindings: HashSet<String>,
 }
 
 impl ParsedFile {
@@ -376,6 +379,8 @@ struct ParseContext<'cfg> {
     evaluating_functions: Vec<String>,
     /// Parser configuration (decryptor, custom validators)
     config: &'cfg ProviderContext,
+    /// Binding names from structurally-required expressions (if/for/read)
+    structural_bindings: HashSet<String>,
 }
 
 impl<'cfg> ParseContext<'cfg> {
@@ -387,6 +392,7 @@ impl<'cfg> ParseContext<'cfg> {
             user_functions: HashMap::new(),
             evaluating_functions: Vec::new(),
             config,
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -551,7 +557,11 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                     expanded_module_calls,
                                     maybe_import,
                                     maybe_remote_state,
+                                    is_structural,
                                 ) = parse_let_binding_extended(stmt, &ctx)?;
+                                if is_structural {
+                                    ctx.structural_bindings.insert(name.clone());
+                                }
                                 let is_discard = name == "_";
                                 if !is_discard {
                                     if ctx.variables.contains_key(&name)
@@ -641,6 +651,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         user_functions: ctx.user_functions,
         remote_states,
         requires,
+        structural_bindings: ctx.structural_bindings,
     })
 }
 
@@ -1075,6 +1086,10 @@ type LetBindingRhs = (
 
 /// Extended parse_let_binding that also handles module calls, imports, for expressions,
 /// and remote_state blocks.
+///
+/// Returns `(name, value, resources, module_calls, import, remote_state, is_structural)`.
+/// `is_structural` is true when the RHS is an if/for/read expression, meaning the
+/// `let` binding is structurally required and should not trigger unused-binding warnings.
 #[allow(clippy::type_complexity)]
 fn parse_let_binding_extended(
     pair: pest::iterators::Pair<Rule>,
@@ -1087,6 +1102,7 @@ fn parse_let_binding_extended(
         Vec<ModuleCall>,
         Option<ImportStatement>,
         Option<RemoteState>,
+        bool,
     ),
     ParseError,
 > {
@@ -1095,6 +1111,9 @@ fn parse_let_binding_extended(
         .as_str()
         .to_string();
     let expr_pair = next_pair(&mut inner, "expression", "let binding")?;
+
+    // Detect if the RHS is a structurally-required expression (if/for/read)
+    let is_structural = detect_structural_rhs(&expr_pair);
 
     // Check if it's a module call, resource expression, import, for expression, or remote_state
     let (value, expanded_resources, module_calls, maybe_import, maybe_remote_state) =
@@ -1107,7 +1126,31 @@ fn parse_let_binding_extended(
         module_calls,
         maybe_import,
         maybe_remote_state,
+        is_structural,
     ))
+}
+
+/// Detect if an expression pair's innermost primary is an if/for/read expression.
+fn detect_structural_rhs(pair: &pest::iterators::Pair<Rule>) -> bool {
+    // Walk into expression -> pipe_expr -> compose_expr -> primary -> inner
+    fn find_inner_rule(pair: &pest::iterators::Pair<Rule>) -> Option<Rule> {
+        let inner = pair.clone().into_inner().next()?;
+        match inner.as_rule() {
+            Rule::if_expr | Rule::for_expr | Rule::read_resource_expr => Some(inner.as_rule()),
+            Rule::pipe_expr | Rule::compose_expr | Rule::expression => find_inner_rule(&inner),
+            Rule::primary => {
+                let primary_inner = inner.into_inner().next()?;
+                match primary_inner.as_rule() {
+                    Rule::if_expr | Rule::for_expr | Rule::read_resource_expr => {
+                        Some(primary_inner.as_rule())
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+    find_inner_rule(pair).is_some()
 }
 
 /// Parse expression with potential resource, module call, import, or remote_state

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -270,10 +270,15 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
         }
     }
 
-    // Return unused binding names
+    // Return unused binding names, skipping structurally-required bindings
+    // (if/for/read expressions) and for-generated indexed bindings (e.g., vpcs[0])
     defined_bindings
         .into_iter()
-        .filter(|binding| !referenced.contains(binding))
+        .filter(|binding| {
+            !referenced.contains(binding)
+                && !parsed.structural_bindings.contains(binding)
+                && !binding.contains('[')
+        })
         .collect()
 }
 
@@ -382,6 +387,7 @@ mod tests {
             user_functions: HashMap::new(),
             remote_states: Vec::new(),
             requires: Vec::new(),
+            structural_bindings: HashSet::new(),
         }
     }
 
@@ -575,6 +581,100 @@ let route = awscc.ec2.route {
             "igw_attachment should not be unused"
         );
         assert_eq!(unused, vec!["route"]);
+    }
+
+    #[test]
+    fn if_expression_binding_not_warned() {
+        let input = r#"
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let enabled = true
+
+let vpc = if enabled {
+  awscc.ec2.vpc {
+    cidr_block = "10.0.0.0/16"
+  }
+}
+"#;
+        let parsed = crate::parser::parse(input, &ProviderContext::default()).unwrap();
+        assert!(
+            parsed.structural_bindings.contains("vpc"),
+            "vpc should be in structural_bindings"
+        );
+        let unused = check_unused_bindings(&parsed);
+        assert!(
+            !unused.contains(&"vpc".to_string()),
+            "if-expression binding should not be warned as unused"
+        );
+    }
+
+    #[test]
+    fn for_expression_binding_not_warned() {
+        let input = r#"
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpcs = for (i, env) in ["dev", "stg"] {
+  awscc.ec2.vpc {
+    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
+  }
+}
+"#;
+        let parsed = crate::parser::parse(input, &ProviderContext::default()).unwrap();
+        assert!(
+            parsed.structural_bindings.contains("vpcs"),
+            "vpcs should be in structural_bindings"
+        );
+        let unused = check_unused_bindings(&parsed);
+        assert!(
+            unused.is_empty(),
+            "for-expression bindings should not be warned as unused, got: {:?}",
+            unused
+        );
+    }
+
+    #[test]
+    fn read_expression_binding_not_warned() {
+        let input = r#"
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+
+let caller = read aws.sts.caller_identity {}
+"#;
+        let parsed = crate::parser::parse(input, &ProviderContext::default()).unwrap();
+        assert!(
+            parsed.structural_bindings.contains("caller"),
+            "caller should be in structural_bindings"
+        );
+        let unused = check_unused_bindings(&parsed);
+        assert!(
+            !unused.contains(&"caller".to_string()),
+            "read-expression binding should not be warned as unused"
+        );
+    }
+
+    #[test]
+    fn genuinely_unused_binding_still_warns() {
+        let input = r#"
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+"#;
+        let parsed = crate::parser::parse(input, &ProviderContext::default()).unwrap();
+        let unused = check_unused_bindings(&parsed);
+        assert_eq!(
+            unused,
+            vec!["vpc"],
+            "genuinely unused binding should still be warned"
+        );
     }
 
     /// Helper to create a simple ResourceSchema with given attributes.

--- a/scripts/check-example-warnings.sh
+++ b/scripts/check-example-warnings.sh
@@ -16,13 +16,8 @@ DIRS=(
     "carina-provider-awscc/acceptance-tests"
 )
 
-# Files with unavoidable warnings (for expressions, if expressions, read data sources)
+# Files that require runtime environment (env vars, KMS) and cannot be validated in CI
 SKIP_FILES=(
-    "carina-provider-aws/acceptance-tests/sts_caller_identity/basic.crn"
-    "carina-provider-awscc/acceptance-tests/for_expression/for_list.crn"
-    "carina-provider-awscc/acceptance-tests/for_expression/for_map.crn"
-    "carina-provider-awscc/acceptance-tests/for_expression/index_access.crn"
-    "carina-provider-awscc/acceptance-tests/if_expression/if_true.crn"
     "carina-provider-awscc/acceptance-tests/secret_env/decrypt_tag.crn"
     "carina-provider-awscc/acceptance-tests/secret_env/env_tag.crn"
     "carina-provider-awscc/acceptance-tests/secret_env/secret_tag.crn"


### PR DESCRIPTION
## Summary

- Track structurally-required `let` bindings (`if`/`for`/`read` expression RHS) in `ParsedFile.structural_bindings` during parsing, and exclude them from unused-binding warnings
- Skip for-generated indexed bindings (e.g., `vpcs[0]`, `vpcs["key"]`) from unused-binding checks
- Remove 5 files from the CI `SKIP_FILES` list that no longer produce false-positive warnings

## Test plan

- [x] New tests: `if_expression_binding_not_warned`, `for_expression_binding_not_warned`, `read_expression_binding_not_warned`
- [x] Existing test: `genuinely_unused_binding_still_warns` confirms real unused bindings still warn
- [x] Full `cargo test` passes
- [x] `scripts/check-example-warnings.sh` passes with 264 files, 0 warnings

Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)