### PR TITLE
style(docs): improve code block text contrast

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
       },
       customCss: ['./src/styles/custom.css'],
       expressiveCode: {
+        themes: ['github-dark-high-contrast'],
         shiki: {
           langs: [crnGrammar],
         },

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -196,16 +196,16 @@ const planHtml = `<span class="prompt">$</span> carina plan main.crn
     font-family: var(--__sl-font-mono);
     font-size: var(--sl-text-xs);
     line-height: 1.7;
-    color: var(--hero-code-color, #e2e8f0);
+    color: var(--hero-code-color, #f1f5f9);
   }
 
   :global(.kw) { color: #fbbf24; }
-  :global(.id) { color: #e2e8f0; }
-  :global(.attr) { color: #94a3b8; }
+  :global(.id) { color: #f1f5f9; }
+  :global(.attr) { color: #cbd5e1; }
   :global(.str) { color: #86efac; }
   :global(.bool) { color: #fde68a; }
   :global(.enum) { color: #fef3c7; }
-  :global(.type) { color: #94a3b8; }
+  :global(.type) { color: #cbd5e1; }
   :global(.prompt) { color: #fbbf24; }
   :global(.muted) { color: #64748b; }
   :global(.add) { color: #10b981; font-weight: 700; }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -44,7 +44,7 @@
   --astro-code-background: #1e293b;
   --astro-code-token-keyword: var(--sl-color-accent-high);
 }
-/* Override Expressive Code frame backgrounds (loaded after custom.css, so need !important) */
+/* Override Expressive Code frame backgrounds and text color (loaded after custom.css, so need !important) */
 .expressive-code .frame pre {
   background: #1e293b !important;
 }
@@ -56,6 +56,13 @@
 }
 .expressive-code pre {
   border-color: #334155 !important;
+}
+/* Boost default code foreground for readability against #1e293b */
+.expressive-code .frame pre code {
+  color: #f1f5f9 !important; /* Slate 100 — high contrast on Slate 800 */
+}
+.expressive-code {
+  --ec-codeFg: #f1f5f9 !important;
 }
 
 /* "Soon" badge: improve contrast in sidebar */


### PR DESCRIPTION
## Summary

- Increase Expressive Code default text color (`--ec-codeFg`) to `#f1f5f9` (Slate 100) for high contrast against the `#1e293b` (Slate 800) background on documentation pages
- Bump Hero code panel colors: base text `#e2e8f0` -> `#f1f5f9`, `.attr`/`.type` `#94a3b8` (Slate 400) -> `#cbd5e1` (Slate 300), `.id` `#e2e8f0` -> `#f1f5f9`
- All punctuation (braces, colons) and attribute names are now clearly readable

Closes #1409

## Test plan

- [ ] Verify code blocks on provider reference pages (e.g., `/reference/providers/awscc/`) have readable text
- [ ] Verify Hero code panels on landing page have readable text including braces and attribute names
- [ ] Run `cd docs && npm run build` to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)