### PR TITLE
docs: add design plans and specs for docs refresh, hero landing, and OGP

### DIFF
--- a/docs/superpowers/plans/2026-03-31-docs-design-refresh.md
+++ b/docs/superpowers/plans/2026-03-31-docs-design-refresh.md
@@ -1,0 +1,244 @@
+# Documentation Site Design Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the default Starlight purple theme with an Ocean/Teal (Deep Navy) color scheme and improve code blocks, feature cards, and table styling.
+
+**Architecture:** All changes go into `docs/src/styles/custom.css` by overriding Starlight's CSS custom properties. No HTML, config, or component changes needed. Starlight uses a `--sl-color-*` variable system where gray-1 is lightest and gray-6/black are darkest in dark mode (inverted in light mode).
+
+**Tech Stack:** CSS custom properties, Starlight/Astro theming
+
+---
+
+### Task 1: Dark mode color scheme
+
+**Files:**
+- Modify: `docs/src/styles/custom.css`
+
+- [ ] **Step 1: Add dark mode color overrides at the top of custom.css (before existing table rules)**
+
+Add this CSS block at the very beginning of `docs/src/styles/custom.css`, before the existing `/* Provider doc table styling */` comment:
+
+```css
+/* ============================================
+   Ocean/Teal Deep Navy Theme
+   ============================================ */
+
+/* Dark mode (default) */
+:root {
+  /* Gray scale: Slate palette (hue 215) */
+  --sl-color-white: hsl(0, 0%, 100%);
+  --sl-color-gray-1: hsl(214, 32%, 91%); /* #e2e8f0 Slate 200 */
+  --sl-color-gray-2: hsl(215, 16%, 62%); /* #94a3b8 Slate 400 */
+  --sl-color-gray-3: hsl(215, 14%, 46%); /* #64748b Slate 500 */
+  --sl-color-gray-4: hsl(217, 19%, 35%); /* #475569 Slate 600 */
+  --sl-color-gray-5: hsl(217, 33%, 17%); /* #1e293b Slate 800 */
+  --sl-color-gray-6: hsl(222, 47%, 11%); /* #0f172a Slate 900 */
+  --sl-color-black: hsl(229, 84%, 5%);   /* #020617 Slate 950 */
+
+  /* Accent: Cyan */
+  --sl-color-accent-low: hsl(192, 70%, 15%);  /* ~#164e63 Cyan 900 */
+  --sl-color-accent: hsl(192, 91%, 36%);       /* ~#0891b2 Cyan 600 */
+  --sl-color-accent-high: hsl(186, 78%, 58%);  /* ~#22d3ee Cyan 400 */
+}
+```
+
+- [ ] **Step 2: Add light mode color overrides immediately after the dark mode block**
+
+```css
+/* Light mode */
+:root[data-theme='light'] {
+  /* Gray scale: Slate palette (light) */
+  --sl-color-white: hsl(210, 40%, 8%);   /* #0f172a Slate 900 */
+  --sl-color-gray-1: hsl(215, 25%, 17%); /* #1e293b Slate 800 */
+  --sl-color-gray-2: hsl(215, 14%, 34%); /* #475569 Slate 600 */
+  --sl-color-gray-3: hsl(215, 14%, 46%); /* #64748b Slate 500 */
+  --sl-color-gray-4: hsl(215, 16%, 62%); /* #94a3b8 Slate 400 */
+  --sl-color-gray-5: hsl(214, 32%, 91%); /* #e2e8f0 Slate 200 */
+  --sl-color-gray-6: hsl(210, 40%, 96%); /* #f1f5f9 Slate 100 */
+  --sl-color-gray-7: hsl(210, 40%, 98%); /* #f8fafc Slate 50 */
+  --sl-color-black: hsl(0, 0%, 100%);    /* white */
+
+  /* Accent: Cyan (darker for contrast on light BG) */
+  --sl-color-accent-low: hsl(189, 94%, 93%);  /* ~#ecfeff Cyan 50 */
+  --sl-color-accent: hsl(192, 82%, 31%);       /* ~#0e7490 Cyan 700 */
+  --sl-color-accent-high: hsl(192, 91%, 36%);  /* ~#0891b2 Cyan 600 */
+}
+```
+
+- [ ] **Step 3: Start dev server and verify colors**
+
+Run: `cd docs && npm run dev`
+
+Open http://localhost:4321 and check:
+- Dark mode: deep navy background, cyan accent links, sidebar navigation
+- Light mode (toggle in top right): light slate background, darker cyan links
+- "Soon" badges should automatically be cyan (they use `--sl-color-accent-*`)
+
+Expected: All accent-colored elements use cyan instead of purple. Gray tones are slate-tinted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/styles/custom.css
+git commit -m "style(docs): apply Ocean/Teal Deep Navy color scheme
+
+Override Starlight CSS variables with Slate gray scale and
+Cyan accent for both dark and light modes."
+```
+
+---
+
+### Task 2: Code block theme
+
+**Files:**
+- Modify: `docs/src/styles/custom.css`
+
+- [ ] **Step 1: Add code block overrides after the light mode block**
+
+Add this CSS after the light mode `:root[data-theme='light']` block:
+
+```css
+/* Code block theme */
+:root {
+  --astro-code-color-background: hsl(217, 33%, 17%); /* Slate 800 - matches sidebar */
+}
+:root[data-theme='light'] {
+  --astro-code-color-background: hsl(210, 40%, 96%); /* Slate 100 */
+}
+```
+
+- [ ] **Step 2: Verify code blocks**
+
+Open http://localhost:4321 and navigate to a provider reference page (e.g., AWSCC EC2 VPC).
+
+Expected: Code blocks blend with the page — dark mode uses Slate 800 background (same as sidebar), light mode uses Slate 100.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/src/styles/custom.css
+git commit -m "style(docs): match code block background to site palette"
+```
+
+---
+
+### Task 3: Feature card styling
+
+**Files:**
+- Modify: `docs/src/styles/custom.css`
+
+- [ ] **Step 1: Add card overrides after code block section**
+
+Starlight's `Card` component uses `.card` class with `--sl-card-border` and `--sl-card-bg` CSS variables per nth-child. Override to use consistent cyan accent:
+
+```css
+/* Feature cards: consistent cyan accent */
+.card {
+  --sl-card-border: var(--sl-color-accent);
+  --sl-card-bg: var(--sl-color-accent-low);
+  border-color: var(--sl-color-gray-5);
+  transition: border-color 0.2s ease;
+}
+.card:hover {
+  border-color: var(--sl-color-accent);
+}
+/* Override per-card color rotation to use consistent cyan */
+.card:nth-child(4n + 1) {
+  --sl-card-border: var(--sl-color-accent);
+  --sl-card-bg: var(--sl-color-accent-low);
+}
+.card:nth-child(4n + 3) {
+  --sl-card-border: var(--sl-color-accent);
+  --sl-card-bg: var(--sl-color-accent-low);
+}
+.card:nth-child(4n + 4) {
+  --sl-card-border: var(--sl-color-accent);
+  --sl-card-bg: var(--sl-color-accent-low);
+}
+.card:nth-child(4n + 5) {
+  --sl-card-border: var(--sl-color-accent);
+  --sl-card-bg: var(--sl-color-accent-low);
+}
+```
+
+- [ ] **Step 2: Verify cards on the top page**
+
+Open http://localhost:4321 (the splash/home page).
+
+Expected: All 4 feature cards (Custom DSL, Effects as Values, Provider Architecture, Modules) have cyan-tinted icon borders/backgrounds. On hover, the card border brightens to cyan. Both dark and light modes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/src/styles/custom.css
+git commit -m "style(docs): unify feature card colors to cyan accent"
+```
+
+---
+
+### Task 4: Table styling
+
+**Files:**
+- Modify: `docs/src/styles/custom.css`
+
+- [ ] **Step 1: Add table styling improvements after the existing table rules**
+
+Add after the existing `td, th { word-wrap: ... }` block (around line 19 of current custom.css):
+
+```css
+/* Table header and stripe rows */
+table thead th {
+  background-color: var(--sl-color-accent-low);
+  color: var(--sl-color-white);
+}
+table tbody tr:nth-child(even) {
+  background-color: var(--sl-color-gray-6);
+}
+table td, table th {
+  border-color: var(--sl-color-hairline-light);
+}
+```
+
+- [ ] **Step 2: Verify tables on a provider reference page**
+
+Open a provider page with tables, e.g., http://localhost:4321/reference/providers/awscc/ec2/vpc/
+
+Expected:
+- Table header row has a subtle cyan-tinted background (accent-low)
+- Even rows have a subtle alternating background
+- Borders use the site's hairline color
+- Works in both dark and light modes
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/src/styles/custom.css
+git commit -m "style(docs): add table header background and stripe rows"
+```
+
+---
+
+### Task 5: Final visual check and squash
+
+- [ ] **Step 1: Full visual review**
+
+Open http://localhost:4321 and check all pages in both dark and light modes:
+
+| Page | Check |
+|------|-------|
+| Home (splash) | Hero, feature cards, provider link cards |
+| Provider index | Sidebar items, "Soon" badges |
+| Provider resource (e.g., VPC) | Tables, code blocks, inline code |
+| Search | Search bar colors |
+| Theme toggle | Smooth transition between modes |
+
+- [ ] **Step 2: Build to verify no errors**
+
+Run: `cd docs && npm run build`
+
+Expected: Build completes with no errors.
+
+- [ ] **Step 3: If any issues found, fix and commit**
+
+Fix CSS issues discovered in visual review and commit with an appropriate message.

--- a/docs/superpowers/plans/2026-03-31-hero-landing-page.md
+++ b/docs/superpowers/plans/2026-03-31-hero-landing-page.md
@@ -1,0 +1,531 @@
+# Hero & Landing Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the default Starlight Hero with a custom design featuring side-by-side code/plan panels with Canopus gold accents, and add a "Why Carina?" section.
+
+**Architecture:** Create a custom `Hero.astro` component that overrides Starlight's default Hero via the `components` config. Hero-specific CSS goes in `custom.css`. The "Why Carina?" section is added directly in `index.mdx` using HTML. No new dependencies.
+
+**Tech Stack:** Astro components, CSS, Starlight component overrides
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `docs/src/components/Hero.astro` | Create | Custom Hero with code/plan panels and Canopus colors |
+| `docs/astro.config.mjs` | Modify | Register Hero component override |
+| `docs/src/content/docs/index.mdx` | Modify | Add "Why Carina?" section, keep existing cards |
+| `docs/src/styles/custom.css` | Modify | "Why Carina?" section styles |
+
+---
+
+### Task 1: Custom Hero component
+
+**Files:**
+- Create: `docs/src/components/Hero.astro`
+- Modify: `docs/astro.config.mjs`
+
+- [ ] **Step 1: Create the custom Hero component**
+
+Create `docs/src/components/Hero.astro`:
+
+```astro
+---
+/**
+ * Custom Hero component for Carina docs landing page.
+ * Replaces Starlight's default Hero with code/plan panels and Canopus gold accent.
+ */
+import { PAGE_TITLE_ID } from '@astrojs/starlight/constants';
+---
+
+<div class="hero-custom">
+  <div class="hero-header">
+    <div class="hero-star"></div>
+    <h1 id={PAGE_TITLE_ID} data-page-title>Carina</h1>
+    <p class="hero-tagline">A strongly typed infrastructure management tool written in Rust.</p>
+  </div>
+
+  <div class="hero-panels">
+    {/* Left: DSL code */}
+    <div class="hero-panel">
+      <div class="panel-header">
+        <span class="panel-tab">main.crn</span>
+      </div>
+      <div class="panel-body">
+        <pre><code><span class="kw">provider</span> <span class="id">aws</span> {'{'}{'\n'}  <span class="attr">region:</span> <span class="enum">aws.Region.ap_northeast_1</span>{'\n'}{'}'}{'\n'}{'\n'}<span class="kw">let</span> <span class="id">vpc</span> = <span class="type">awscc.ec2.vpc</span> {'{'}{'\n'}  <span class="attr">cidr_block:</span> <span class="str">"10.0.0.0/16"</span>{'\n'}  <span class="attr">enable_dns_support:</span> <span class="bool">true</span>{'\n'}{'}'}{'\n'}{'\n'}<span class="type">awscc.ec2.subnet</span> {'{'}{'\n'}  <span class="attr">vpc_id:</span> <span class="id">vpc</span>.vpc_id{'\n'}  <span class="attr">cidr_block:</span> <span class="str">"10.0.1.0/24"</span>{'\n'}{'}'}</code></pre>
+      </div>
+    </div>
+
+    {/* Right: Plan output */}
+    <div class="hero-panel">
+      <div class="panel-header terminal-header">
+        <span class="terminal-dot red"></span>
+        <span class="terminal-dot yellow"></span>
+        <span class="terminal-dot green"></span>
+        <span class="panel-tab-terminal">terminal</span>
+      </div>
+      <div class="panel-body">
+        <pre><code><span class="prompt">$</span> carina plan main.crn{'\n'}<span class="muted">Planning...</span>{'\n'}{'\n'}<span class="add">+</span> <span class="id">awscc.ec2.vpc</span>{'\n'}  <span class="attr">cidr_block:</span> <span class="str">"10.0.0.0/16"</span>{'\n'}  <span class="attr">enable_dns_support:</span> <span class="bool">true</span>{'\n'}{'\n'}<span class="add">+</span> <span class="id">awscc.ec2.subnet</span>{'\n'}  <span class="attr">vpc_id:</span> <span class="computed">(computed)</span>{'\n'}  <span class="attr">cidr_block:</span> <span class="str">"10.0.1.0/24"</span>{'\n'}{'\n'}<span class="plan-summary">Plan: 2 to create, 0 to update, 0 to delete.</span></code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="hero-actions">
+    <a href="/getting-started/installation/" class="hero-btn primary">Get Started</a>
+    <a href="https://github.com/carina-rs/carina" class="hero-btn secondary">GitHub</a>
+  </div>
+</div>
+
+<style>
+  .hero-custom {
+    padding: clamp(2rem, 6vw, 4rem) 0 2rem;
+    text-align: center;
+  }
+
+  /* Canopus star */
+  .hero-star {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #fef3c7;
+    box-shadow: 0 0 16px #fde68a, 0 0 40px rgba(253, 230, 138, 0.3);
+    margin: 0 auto 1rem;
+  }
+
+  h1 {
+    font-size: clamp(var(--sl-text-4xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+    font-weight: 700;
+    line-height: var(--sl-line-height-headings);
+    color: #fbbf24;
+    margin: 0;
+  }
+
+  .hero-tagline {
+    font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+    color: var(--sl-color-gray-2);
+    margin: 0.5rem 0 0;
+  }
+
+  /* Panels */
+  .hero-panels {
+    display: flex;
+    gap: 0.75rem;
+    margin: 2rem auto 0;
+    max-width: 52rem;
+    padding: 0 1rem;
+  }
+
+  .hero-panel {
+    flex: 1;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    text-align: left;
+  }
+
+  .panel-header {
+    background: #162032;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid #334155;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .panel-tab {
+    color: #22d3ee;
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+  }
+
+  .terminal-header {
+    gap: 0.25rem;
+  }
+
+  .terminal-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+  }
+  .terminal-dot.red { background: #f43f5e; }
+  .terminal-dot.yellow { background: #f59e0b; }
+  .terminal-dot.green { background: #10b981; }
+
+  .panel-tab-terminal {
+    color: var(--sl-color-gray-3);
+    font-size: var(--sl-text-xs);
+    margin-left: 0.25rem;
+  }
+
+  .panel-body {
+    padding: 0.75rem;
+  }
+
+  .panel-body pre {
+    margin: 0;
+    background: transparent !important;
+    border: none !important;
+    padding: 0 !important;
+  }
+
+  .panel-body code {
+    font-family: var(--__sl-font-mono);
+    font-size: var(--sl-text-xs);
+    line-height: 1.7;
+    color: #e2e8f0;
+  }
+
+  /* Syntax colors */
+  .kw { color: #22d3ee; }
+  .id { color: #e2e8f0; }
+  .attr { color: #94a3b8; }
+  .str { color: #86efac; }
+  .bool { color: #fbbf24; }
+  .enum { color: #a5f3fc; }
+  .type { color: #94a3b8; }
+  .prompt { color: #22d3ee; }
+  .muted { color: #64748b; }
+  .add { color: #10b981; font-weight: 700; }
+  .computed { color: #67e8f9; }
+  .plan-summary { color: #22d3ee; font-weight: 600; }
+
+  /* CTA buttons */
+  .hero-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .hero-btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 0.375rem;
+    font-size: var(--sl-text-sm);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.2s ease;
+  }
+
+  .hero-btn.primary {
+    background: #d97706;
+    color: #fff;
+  }
+  .hero-btn.primary:hover {
+    background: #f59e0b;
+  }
+
+  .hero-btn.secondary {
+    border: 1px solid #475569;
+    color: #94a3b8;
+  }
+  .hero-btn.secondary:hover {
+    border-color: #64748b;
+    color: #e2e8f0;
+  }
+
+  /* Mobile: stack panels */
+  @media (max-width: 50rem) {
+    .hero-panels {
+      flex-direction: column;
+    }
+  }
+
+  /* Light mode overrides */
+  :global([data-theme='light']) .hero-panel {
+    background: #f1f5f9;
+    border-color: #e2e8f0;
+  }
+  :global([data-theme='light']) .panel-header {
+    background: #e2e8f0;
+    border-color: #cbd5e1;
+  }
+  :global([data-theme='light']) .panel-body code {
+    color: #0f172a;
+  }
+  :global([data-theme='light']) .kw { color: #0891b2; }
+  :global([data-theme='light']) .id { color: #0f172a; }
+  :global([data-theme='light']) .attr { color: #475569; }
+  :global([data-theme='light']) .str { color: #16a34a; }
+  :global([data-theme='light']) .bool { color: #d97706; }
+  :global([data-theme='light']) .enum { color: #0e7490; }
+  :global([data-theme='light']) .type { color: #475569; }
+  :global([data-theme='light']) .prompt { color: #0891b2; }
+  :global([data-theme='light']) .muted { color: #94a3b8; }
+  :global([data-theme='light']) .add { color: #16a34a; }
+  :global([data-theme='light']) .computed { color: #0891b2; }
+  :global([data-theme='light']) .plan-summary { color: #0891b2; }
+  :global([data-theme='light']) h1 { color: #d97706; }
+  :global([data-theme='light']) .hero-star {
+    box-shadow: 0 0 16px #fbbf24, 0 0 40px rgba(251, 191, 36, 0.3);
+  }
+  :global([data-theme='light']) .hero-btn.secondary {
+    border-color: #cbd5e1;
+    color: #475569;
+  }
+  :global([data-theme='light']) .hero-btn.secondary:hover {
+    border-color: #94a3b8;
+    color: #0f172a;
+  }
+</style>
+```
+
+- [ ] **Step 2: Register the Hero override in astro.config.mjs**
+
+In `docs/astro.config.mjs`, add `components` to the starlight config. Change the starlight() call from:
+
+```js
+    starlight({
+      title: 'Carina',
+```
+
+to:
+
+```js
+    starlight({
+      title: 'Carina',
+      components: {
+        Hero: './src/components/Hero.astro',
+      },
+```
+
+- [ ] **Step 3: Remove the hero frontmatter from index.mdx**
+
+The custom Hero component reads from `Astro.locals.starlightRoute.entry.data.hero`. The existing `index.mdx` frontmatter defines `hero` with title, tagline, and actions. Since our custom component hard-codes these, remove the `hero` key from frontmatter but keep the `template: splash`.
+
+Replace the full frontmatter in `docs/src/content/docs/index.mdx` from:
+
+```yaml
+---
+title: Carina
+description: A strongly typed infrastructure management tool written in Rust.
+template: splash
+hero:
+  title: Carina
+  tagline: A strongly typed infrastructure management tool written in Rust.
+  actions:
+    - text: Getting Started
+      link: /getting-started/installation/
+      icon: rocket
+    - text: GitHub
+      link: https://github.com/carina-rs/carina
+      icon: github
+      variant: minimal
+---
+```
+
+to:
+
+```yaml
+---
+title: Carina
+description: A strongly typed infrastructure management tool written in Rust.
+template: splash
+hero:
+  title: Carina
+  tagline: ''
+---
+```
+
+Note: We keep `hero` with a title so Starlight still renders the splash template and invokes our Hero override. The tagline is empty because our component provides its own.
+
+- [ ] **Step 4: Verify the Hero renders**
+
+Run: `cd docs && npm run dev`
+
+Open http://localhost:4321 and check:
+- Canopus gold title with star glow dot above it
+- Two panels side by side: DSL code (left) and Plan output (right)
+- "Get Started" button in amber, "GitHub" button outlined
+- Toggle light/dark mode — both should work
+- Resize to mobile width — panels should stack vertically
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/components/Hero.astro docs/astro.config.mjs docs/src/content/docs/index.mdx
+git commit -m "feat(docs): add custom Hero with code/plan panels and Canopus accent"
+```
+
+---
+
+### Task 2: "Why Carina?" section
+
+**Files:**
+- Modify: `docs/src/content/docs/index.mdx`
+- Modify: `docs/src/styles/custom.css`
+
+- [ ] **Step 1: Add the "Why Carina?" HTML to index.mdx**
+
+In `docs/src/content/docs/index.mdx`, add this block AFTER the frontmatter closing `---` and the component import, but BEFORE the existing `<CardGrid>`:
+
+```mdx
+<div class="why-carina">
+  <h2>Why Carina?</h2>
+  <div class="why-grid">
+    <div class="why-item">
+      <div class="why-icon">🔒</div>
+      <h3>Type Safe</h3>
+      <p>DSL validates at parse time. Catch errors before any infrastructure is touched.</p>
+    </div>
+    <div class="why-item">
+      <div class="why-icon">📋</div>
+      <h3>Effects as Values</h3>
+      <p>Side effects are data. Inspect your Plan before execution, not after.</p>
+    </div>
+    <div class="why-item">
+      <div class="why-icon">🔌</div>
+      <h3>Pluggable Providers</h3>
+      <p>AWS Cloud Control API, native AWS SDK, and more. One DSL, multiple backends.</p>
+    </div>
+  </div>
+</div>
+```
+
+The full `index.mdx` should look like:
+
+```mdx
+---
+title: Carina
+description: A strongly typed infrastructure management tool written in Rust.
+template: splash
+hero:
+  title: Carina
+  tagline: ''
+---
+
+import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+<div class="why-carina">
+  <h2>Why Carina?</h2>
+  <div class="why-grid">
+    <div class="why-item">
+      <div class="why-icon">🔒</div>
+      <h3>Type Safe</h3>
+      <p>DSL validates at parse time. Catch errors before any infrastructure is touched.</p>
+    </div>
+    <div class="why-item">
+      <div class="why-icon">📋</div>
+      <h3>Effects as Values</h3>
+      <p>Side effects are data. Inspect your Plan before execution, not after.</p>
+    </div>
+    <div class="why-item">
+      <div class="why-icon">🔌</div>
+      <h3>Pluggable Providers</h3>
+      <p>AWS Cloud Control API, native AWS SDK, and more. One DSL, multiple backends.</p>
+    </div>
+  </div>
+</div>
+
+<CardGrid>
+  <Card title="Custom DSL" icon="pencil">
+    Infrastructure definition with `.crn` files — strongly typed, validated at parse time.
+  </Card>
+  <Card title="Effects as Values" icon="list-format">
+    Side effects are represented as data, inspectable before execution.
+  </Card>
+  <Card title="Provider Architecture" icon="setting">
+    Pluggable providers — AWSCC (Cloud Control API) and AWS.
+  </Card>
+  <Card title="Modules" icon="puzzle">
+    Reusable infrastructure components with typed arguments and attributes.
+  </Card>
+</CardGrid>
+
+## Providers
+
+<CardGrid>
+  <LinkCard title="AWSCC Provider" description="AWS Cloud Control API — EC2, S3, IAM, CloudWatch Logs" href="/reference/providers/awscc/" />
+  <LinkCard title="AWS Provider" description="AWS SDK — EC2, S3, STS" href="/reference/providers/aws/" />
+</CardGrid>
+```
+
+- [ ] **Step 2: Add "Why Carina?" styles to custom.css**
+
+Add at the end of `docs/src/styles/custom.css`:
+
+```css
+/* "Why Carina?" section */
+.why-carina {
+  text-align: center;
+  padding: 2rem 0;
+  margin-bottom: 1rem;
+}
+.why-carina h2 {
+  font-size: var(--sl-text-2xl);
+  color: var(--sl-color-white);
+  margin-bottom: 1.5rem;
+}
+.why-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  text-align: left;
+}
+.why-item {
+  padding: 1.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  background: var(--sl-color-black);
+}
+.why-icon {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.why-item h3 {
+  font-size: var(--sl-text-lg);
+  color: var(--sl-color-white);
+  margin: 0 0 0.5rem;
+}
+.why-item p {
+  font-size: var(--sl-text-sm);
+  color: var(--sl-color-gray-2);
+  margin: 0;
+  line-height: 1.6;
+}
+@media (max-width: 50rem) {
+  .why-grid {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+- [ ] **Step 3: Verify the full landing page**
+
+Open http://localhost:4321 and check:
+- Hero at the top with code/plan panels
+- "Why Carina?" section with 3 items in a row
+- Existing Feature cards below
+- Provider links at the bottom
+- Both dark and light modes
+- Mobile responsive (why-grid stacks to 1 column)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/content/docs/index.mdx docs/src/styles/custom.css
+git commit -m "feat(docs): add Why Carina section to landing page"
+```
+
+---
+
+### Task 3: Build verification
+
+- [ ] **Step 1: Run the build**
+
+Run: `cd docs && npm run build`
+
+Expected: Build completes with no errors, 38+ pages built.
+
+- [ ] **Step 2: Visual check of built output**
+
+Run: `cd docs && npm run preview`
+
+Open the preview URL and verify the same items as Task 2 Step 3.
+
+- [ ] **Step 3: Commit any fixes if needed**
+
+If any issues were found, fix and commit with an appropriate message.

--- a/docs/superpowers/plans/2026-03-31-ogp-image-generation.md
+++ b/docs/superpowers/plans/2026-03-31-ogp-image-generation.md
@@ -1,0 +1,647 @@
+# OGP Image Generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate per-page OGP images at Astro build time so each documentation page has a unique social sharing preview.
+
+**Architecture:** An Astro integration hooks into `astro:build:done`, iterates over generated pages, and renders a 1200x630 PNG for each using satori (HTML→SVG) + @resvg/resvg-js (SVG→PNG) + sharp (logo compositing). A Head.astro component override injects the per-page `og:image` meta tag.
+
+**Tech Stack:** Astro 5.5.5, Starlight 0.32.5, satori, @resvg/resvg-js, sharp (already installed), Inter font (bundled .woff)
+
+**Spec:** `docs/superpowers/specs/2026-03-31-ogp-image-design.md`
+
+---
+
+### Task 1: Install Dependencies and Bundle Font
+
+**Files:**
+- Modify: `docs/package.json`
+- Create: `docs/src/ogp/fonts/inter-bold.woff`
+- Create: `docs/src/ogp/fonts/inter-regular.woff`
+
+- [ ] **Step 1: Install satori and @resvg/resvg-js**
+
+```bash
+cd docs && npm install satori @resvg/resvg-js
+```
+
+Expected: Both packages added to `dependencies` in package.json.
+
+- [ ] **Step 2: Download Inter font files**
+
+satori requires `.woff` font data. Download Inter Bold (for titles) and Inter Regular (for body text) from Google Fonts:
+
+```bash
+mkdir -p docs/src/ogp/fonts
+curl -o docs/src/ogp/fonts/inter-bold.woff "https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZhrib2Bg-4.woff"
+curl -o docs/src/ogp/fonts/inter-regular.woff "https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZhrib2Bg-4.woff"
+```
+
+- [ ] **Step 3: Verify font files are valid**
+
+```bash
+file docs/src/ogp/fonts/inter-bold.woff
+file docs/src/ogp/fonts/inter-regular.woff
+```
+
+Expected: Both reported as "Web Open Font Format" or binary data (not HTML error pages).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/package.json docs/package-lock.json docs/src/ogp/fonts/
+git commit -m "feat(docs): add satori, resvg-js deps and Inter font files for OGP generation"
+```
+
+---
+
+### Task 2: OGP Template Functions
+
+**Files:**
+- Create: `docs/src/ogp/templates.ts`
+
+These functions return satori-compatible JSX markup (plain objects with `type`, `props`, `children`) for each layout variant.
+
+- [ ] **Step 1: Create the templates file**
+
+Create `docs/src/ogp/templates.ts`:
+
+```typescript
+// satori uses a React-like element tree: { type, props, children }
+// We use plain objects instead of JSX to avoid React dependency.
+
+type SatoriNode = {
+  type: string;
+  props: Record<string, unknown> & { children?: (SatoriNode | string)[] | string };
+};
+
+const COLORS = {
+  bgDark: '#0f172a',
+  bgLight: '#1e293b',
+  gold: '#fbbf24',
+  white: '#f1f5f9',
+  slate: '#94a3b8',
+  cyan: '#0891b2',
+  cyanFaint: 'rgba(8,145,178,0.2)',
+  goldFaint: 'rgba(251,191,36,0.05)',
+};
+
+/**
+ * Regular page layout: 2-column split with logo left, text right.
+ * logoBase64 is a data URI string for the logo PNG.
+ */
+export function regularPageTemplate(pageTitle: string, logoBase64: string): SatoriNode {
+  return {
+    type: 'div',
+    props: {
+      style: {
+        width: '1200px',
+        height: '630px',
+        display: 'flex',
+        background: `linear-gradient(135deg, ${COLORS.bgDark} 0%, ${COLORS.bgLight} 100%)`,
+      },
+      children: [
+        // Left panel: logo
+        {
+          type: 'div',
+          props: {
+            style: {
+              width: '420px',
+              height: '630px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRight: `1px solid ${COLORS.cyanFaint}`,
+              position: 'relative',
+            },
+            children: [
+              {
+                type: 'img',
+                props: {
+                  src: logoBase64,
+                  width: 200,
+                  height: 200,
+                  style: { objectFit: 'contain' },
+                },
+              },
+            ],
+          },
+        },
+        // Right panel: text
+        {
+          type: 'div',
+          props: {
+            style: {
+              width: '780px',
+              height: '630px',
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              padding: '0 60px',
+            },
+            children: [
+              // Project name
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    fontSize: '20px',
+                    color: COLORS.gold,
+                    letterSpacing: '3px',
+                    textTransform: 'uppercase',
+                    fontWeight: 700,
+                    marginBottom: '16px',
+                  },
+                  children: 'Carina',
+                },
+              },
+              // Page title
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    fontSize: '48px',
+                    color: COLORS.white,
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                    marginBottom: '24px',
+                  },
+                  children: pageTitle,
+                },
+              },
+              // Cyan separator
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    width: '80px',
+                    height: '3px',
+                    background: COLORS.cyan,
+                    marginBottom: '24px',
+                  },
+                  children: [],
+                },
+              },
+              // Tagline
+              {
+                type: 'div',
+                props: {
+                  style: {
+                    fontSize: '20px',
+                    color: COLORS.slate,
+                    lineHeight: 1.5,
+                  },
+                  children: 'Strongly Typed Infrastructure as Code',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Top page layout: centered logo + project name + tagline.
+ */
+export function topPageTemplate(logoBase64: string): SatoriNode {
+  return {
+    type: 'div',
+    props: {
+      style: {
+        width: '1200px',
+        height: '630px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: `linear-gradient(160deg, ${COLORS.bgDark} 0%, ${COLORS.bgLight} 50%, ${COLORS.bgDark} 100%)`,
+        position: 'relative',
+      },
+      children: [
+        // Top gold border
+        {
+          type: 'div',
+          props: {
+            style: {
+              position: 'absolute',
+              top: '0',
+              left: '10%',
+              right: '10%',
+              height: '3px',
+              background: `linear-gradient(90deg, transparent, ${COLORS.gold}, transparent)`,
+            },
+            children: [],
+          },
+        },
+        // Logo
+        {
+          type: 'img',
+          props: {
+            src: logoBase64,
+            width: 160,
+            height: 160,
+            style: { objectFit: 'contain', marginBottom: '28px' },
+          },
+        },
+        // Project name
+        {
+          type: 'div',
+          props: {
+            style: {
+              fontSize: '28px',
+              color: COLORS.gold,
+              letterSpacing: '4px',
+              textTransform: 'uppercase',
+              fontWeight: 700,
+              marginBottom: '20px',
+            },
+            children: 'Carina',
+          },
+        },
+        // Tagline
+        {
+          type: 'div',
+          props: {
+            style: {
+              fontSize: '22px',
+              color: COLORS.slate,
+              letterSpacing: '1px',
+            },
+            children: 'Strongly Typed Infrastructure as Code',
+          },
+        },
+        // Bottom cyan border
+        {
+          type: 'div',
+          props: {
+            style: {
+              position: 'absolute',
+              bottom: '0',
+              left: '10%',
+              right: '10%',
+              height: '3px',
+              background: `linear-gradient(90deg, transparent, ${COLORS.cyan}, transparent)`,
+            },
+            children: [],
+          },
+        },
+      ],
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/src/ogp/templates.ts
+git commit -m "feat(docs): add OGP image layout templates (regular + top page)"
+```
+
+---
+
+### Task 3: Core Image Generation Function
+
+**Files:**
+- Create: `docs/src/ogp/generate.ts`
+
+This file loads fonts, reads the logo, and renders a PNG using satori → resvg.
+
+- [ ] **Step 1: Create the generate module**
+
+Create `docs/src/ogp/generate.ts`:
+
+```typescript
+import satori from 'satori';
+import { Resvg } from '@resvg/resvg-js';
+import sharp from 'sharp';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { regularPageTemplate, topPageTemplate } from './templates.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load fonts once at module level
+const interBold = readFileSync(join(__dirname, 'fonts', 'inter-bold.woff'));
+const interRegular = readFileSync(join(__dirname, 'fonts', 'inter-regular.woff'));
+
+// Load logo and convert to base64 data URI
+const logoPng = readFileSync(join(__dirname, '..', 'assets', 'favicon.png'));
+const logoBase64 = `data:image/png;base64,${logoPng.toString('base64')}`;
+
+const FONTS = [
+  { name: 'Inter', data: interBold, weight: 700 as const, style: 'normal' as const },
+  { name: 'Inter', data: interRegular, weight: 400 as const, style: 'normal' as const },
+];
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+/**
+ * Render an OGP image for a regular documentation page.
+ * Returns a PNG buffer.
+ */
+export async function generateRegularOgp(pageTitle: string): Promise<Buffer> {
+  const markup = regularPageTemplate(pageTitle, logoBase64);
+
+  const svg = await satori(markup as any, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: FONTS,
+  });
+
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: WIDTH },
+  });
+  return Buffer.from(resvg.render().asPng());
+}
+
+/**
+ * Render an OGP image for the top/index page.
+ * Returns a PNG buffer.
+ */
+export async function generateTopOgp(): Promise<Buffer> {
+  const markup = topPageTemplate(logoBase64);
+
+  const svg = await satori(markup as any, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: FONTS,
+  });
+
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: 'width', value: WIDTH },
+  });
+  return Buffer.from(resvg.render().asPng());
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/src/ogp/generate.ts
+git commit -m "feat(docs): add core OGP image generation (satori + resvg pipeline)"
+```
+
+---
+
+### Task 4: Astro Integration for Build-Time Generation
+
+**Files:**
+- Create: `docs/src/ogp/integration.ts`
+- Modify: `docs/astro.config.mjs`
+
+The integration hooks into `astro:build:done`, iterates over generated pages, and writes OGP PNGs to the output directory.
+
+- [ ] **Step 1: Create the Astro integration**
+
+Create `docs/src/ogp/integration.ts`:
+
+```typescript
+import type { AstroIntegration } from 'astro';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { generateRegularOgp, generateTopOgp } from './generate.js';
+
+/**
+ * Extract a human-readable page title from a route pathname.
+ * "/reference/providers/awscc/" → "AWSCC"
+ * "/getting-started/installation/" → "Installation"
+ */
+function titleFromPath(pathname: string): string {
+  // Remove leading/trailing slashes, take the last segment
+  const segments = pathname.replace(/^\/|\/$/g, '').split('/');
+  const last = segments[segments.length - 1] || 'Home';
+
+  // Convert kebab-case to Title Case
+  return last
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export function ogpIntegration(): AstroIntegration {
+  return {
+    name: 'carina-ogp',
+    hooks: {
+      'astro:build:done': async ({ dir, pages }) => {
+        const outDir = dir.pathname;
+
+        for (const page of pages) {
+          const pathname = '/' + page.pathname; // e.g., "" or "reference/providers/awscc/"
+          const isIndex = pathname === '/' || pathname === '/index' || page.pathname === '';
+
+          // Determine output path
+          const ogDir = isIndex
+            ? join(outDir, 'og')
+            : join(outDir, 'og', page.pathname);
+          const ogPath = isIndex
+            ? join(outDir, 'og', 'index.png')
+            : join(ogDir, 'index.png');
+
+          await mkdir(dirname(ogPath), { recursive: true });
+
+          // Generate image
+          const png = isIndex
+            ? await generateTopOgp()
+            : await generateRegularOgp(titleFromPath(pathname));
+
+          await writeFile(ogPath, png);
+          console.log(`  OGP: ${ogPath.replace(outDir, '')}`);
+        }
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Register the integration in astro.config.mjs**
+
+Add the import at the top of `docs/astro.config.mjs`, after the existing imports:
+
+```javascript
+import { ogpIntegration } from './src/ogp/integration.ts';
+```
+
+Add `ogpIntegration()` to the `integrations` array, after the `starlight(...)` entry:
+
+```javascript
+export default defineConfig({
+  integrations: [
+    starlight({
+      // ... existing config ...
+    }),
+    ogpIntegration(),
+  ],
+});
+```
+
+- [ ] **Step 3: Remove the global og:image from Starlight head config**
+
+In `docs/astro.config.mjs`, remove the static og:image meta tag from the `head` array since per-page tags will be injected by the Head component (Task 5):
+
+Change:
+```javascript
+head: [
+  { tag: 'meta', attrs: { property: 'og:image', content: '/og.png' } },
+],
+```
+To:
+```javascript
+head: [],
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/ogp/integration.ts docs/astro.config.mjs
+git commit -m "feat(docs): add Astro integration for build-time OGP image generation"
+```
+
+---
+
+### Task 5: Per-Page og:image Meta Tag Injection
+
+**Files:**
+- Create: `docs/src/components/Head.astro`
+- Modify: `docs/astro.config.mjs`
+
+Override Starlight's `<Head>` component to inject a page-specific `og:image` meta tag.
+
+- [ ] **Step 1: Create the Head component override**
+
+Create `docs/src/components/Head.astro`:
+
+```astro
+---
+// Override Starlight's Head to inject per-page og:image meta tag.
+// Re-exports default Starlight Head and appends our og:image tag.
+import Default from '@astrojs/starlight/components/Head.astro';
+
+const pathname = Astro.url.pathname; // e.g., "/" or "/reference/providers/awscc/"
+const isIndex = pathname === '/' || pathname === '/index';
+
+const ogImagePath = isIndex ? '/og/index.png' : `/og${pathname}index.png`;
+---
+
+<Default {...Astro.props}><slot /></Default>
+<meta property="og:image" content={ogImagePath} />
+```
+
+- [ ] **Step 2: Register the Head override in astro.config.mjs**
+
+Add `Head` to the `components` object in the Starlight config:
+
+Change:
+```javascript
+components: {
+  Hero: './src/components/Hero.astro',
+},
+```
+To:
+```javascript
+components: {
+  Hero: './src/components/Hero.astro',
+  Head: './src/components/Head.astro',
+},
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/src/components/Head.astro docs/astro.config.mjs
+git commit -m "feat(docs): add Head override for per-page og:image meta tags"
+```
+
+---
+
+### Task 6: Build Verification and Manual Testing
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the Astro build**
+
+```bash
+cd docs && npm run build
+```
+
+Expected: Build completes without errors. Console output shows `OGP: /og/index.png` and similar lines for each page.
+
+- [ ] **Step 2: Verify generated OGP images exist**
+
+```bash
+find docs/dist/og -name "*.png" | head -20
+```
+
+Expected: PNG files at paths like:
+- `docs/dist/og/index.png`
+- `docs/dist/og/reference/providers/awscc/index.png`
+- etc.
+
+- [ ] **Step 3: Verify image dimensions**
+
+```bash
+file docs/dist/og/index.png
+file docs/dist/og/reference/providers/awscc/index.png
+```
+
+Expected: PNG images, 1200x630.
+
+- [ ] **Step 4: Verify og:image meta tags in HTML output**
+
+```bash
+grep -r 'og:image' docs/dist/ --include="*.html" | head -5
+```
+
+Expected: Each HTML file contains `<meta property="og:image" content="/og/...">` with the correct path.
+
+- [ ] **Step 5: Visual check with dev preview**
+
+```bash
+cd docs && npm run preview
+```
+
+Open the site in a browser, view page source, and confirm `og:image` meta tags point to correct paths. Optionally check the generated PNGs directly (e.g., open `http://localhost:4321/og/index.png`).
+
+- [ ] **Step 6: Commit any fixes if needed, then final commit**
+
+If everything looks good with no changes needed:
+```bash
+echo "Build verification passed — no changes needed"
+```
+
+If fixes were made, commit them with an appropriate message.
+
+---
+
+### Task 7: Clean Up and Final Verification
+
+**Files:**
+- Modify: `docs/public/og.png` (keep as fallback, no change needed)
+
+- [ ] **Step 1: Verify fallback og.png is still in place**
+
+```bash
+ls -la docs/public/og.png
+```
+
+Expected: File exists. This serves as a fallback for any edge cases where the generated image is missing.
+
+- [ ] **Step 2: Run full build one more time**
+
+```bash
+cd docs && npm run build
+```
+
+Expected: Clean build with no warnings or errors.
+
+- [ ] **Step 3: Commit all remaining changes**
+
+```bash
+git status
+```
+
+If there are uncommitted changes, stage and commit them. Otherwise, the implementation is complete.

--- a/docs/superpowers/specs/2026-03-31-docs-color-scheme-design.md
+++ b/docs/superpowers/specs/2026-03-31-docs-color-scheme-design.md
@@ -1,0 +1,104 @@
+# Documentation Site Design: Deep Navy / Ocean Teal
+
+## Background
+
+Carina's documentation site uses Starlight (Astro) with the default purple accent theme. The default colors don't convey the tool's identity as an infrastructure management CLI. Beyond the color scheme, several UI elements (code blocks, tables, cards, badges) use default styling that could be improved for a more polished, cohesive look.
+
+## Goal
+
+1. Replace the default Starlight purple accent with an Ocean/Teal color scheme (Deep Navy variant) for both dark and light modes
+2. Improve the visual design of code blocks, feature cards, tables, and badges to match the new color identity
+
+## Design Decisions
+
+- **Color direction**: Ocean / Teal — cool, trustworthy, infrastructure-tooling feel
+- **Tone**: Deep Navy — subdued Cyan 600 accent, understated and professional
+- **Scope**: Both dark and light modes customized
+- **Implementation**: CSS custom property overrides only (no HTML or config changes)
+
+## Color Palette
+
+### Dark Mode
+
+| Role | Color | Token |
+|------|-------|-------|
+| Background | `#0f172a` | Slate 900 |
+| Sidebar BG | `#1e293b` | Slate 800 |
+| Surface | `#334155` | Slate 700 |
+| Accent | `#0891b2` | Cyan 600 |
+| Accent hover | `#22d3ee` | Cyan 400 |
+| Accent low (subtle BG) | `#164e63` | Cyan 900 |
+| Text | `#e2e8f0` | Slate 200 |
+| Text muted | `#94a3b8` | Slate 400 |
+
+### Light Mode
+
+| Role | Color | Token |
+|------|-------|-------|
+| Background | `#f8fafc` | Slate 50 |
+| Sidebar BG | `#f1f5f9` | Slate 100 |
+| Surface | `#e2e8f0` | Slate 200 |
+| Accent | `#0e7490` | Cyan 700 |
+| Accent hover | `#0891b2` | Cyan 600 |
+| Accent low (subtle BG) | `#ecfeff` | Cyan 50 |
+| Text | `#0f172a` | Slate 900 |
+| Text muted | `#64748b` | Slate 500 |
+
+## Changes
+
+### 1. Color scheme (accent, background, text)
+
+Override Starlight's CSS custom properties in `docs/src/styles/custom.css`:
+
+- `--sl-color-accent-high` / `--sl-color-accent` / `--sl-color-accent-low` — accent colors (links, buttons, badges)
+- `--sl-color-white` through `--sl-color-black` — gray scale (Slate hues instead of default 224-hue)
+- `--sl-color-bg-nav` / `--sl-color-bg-sidebar` — navigation backgrounds
+- `--sl-color-hairline-light` / `--sl-color-hairline-shade` — borders
+
+### 2. Code blocks
+
+Override ExpressiveCode/Shiki CSS variables to match the site palette:
+
+- `--astro-code-background` — use Slate 800 (dark) / Slate 100 (light) to blend with the page
+- `--astro-code-token-keyword` — use Cyan accent instead of default purple
+- Keep other token colors (string=green, comment=gray) as reasonable defaults
+
+### 3. Feature cards (top page)
+
+Style the Starlight `<Card>` components on the splash page:
+
+- Add a subtle left border in accent color
+- Add hover effect: slight background color shift + border brightens
+- Icon color inherits accent
+
+### 4. Tables
+
+Improve Provider reference tables (existing `custom.css` table rules are preserved):
+
+- Table header row: accent-low background color
+- Alternating row stripes for readability
+- Border color using hairline variables for consistency
+
+### 5. "Soon" badges
+
+Override the badge color to use Cyan accent instead of the default purple:
+
+- Background: accent-low
+- Text: accent-high
+- Consistent in both dark and light modes
+
+## File to modify
+
+`docs/src/styles/custom.css` — all changes in this single file.
+
+No changes to `astro.config.mjs`, HTML templates, or other config files.
+
+## Testing
+
+- `npm run dev` in `docs/` and visually confirm:
+  - Dark mode and light mode toggle
+  - Top page: hero, feature cards, provider link cards
+  - Sidebar: navigation items, "Soon" badges, active state
+  - Provider reference pages: tables, code blocks, inline code
+  - Search bar styling
+  - Callouts/admonitions if present

--- a/docs/superpowers/specs/2026-03-31-hero-landing-design.md
+++ b/docs/superpowers/specs/2026-03-31-hero-landing-design.md
@@ -1,0 +1,80 @@
+# Hero & Landing Page Design
+
+## Background
+
+Carina's documentation site has the Ocean/Teal Deep Navy color scheme applied, but the landing page (splash) is still minimal — a plain title, tagline, two buttons, four feature cards, and two provider links. The first impression doesn't convey what the tool does or why it's interesting.
+
+## Goal
+
+1. Replace the default Hero with a custom design featuring side-by-side DSL code and Plan output
+2. Use Canopus (α Carinae) star colors for the Hero accent, keeping Cyan for the rest of the docs
+3. Add a "Why Carina?" section between the Hero and existing Feature cards
+
+## Design Decisions
+
+### Hero Section
+
+- **Layout**: Centered title + subtitle at top, then two panels side by side:
+  - Left: DSL code (`main.crn`) with syntax highlighting — shows a VPC + Subnet definition
+  - Right: Terminal mockup with `carina plan main.crn` output — shows Create effects with computed references
+- **Background**: Dark gradient (`#020617` → `#0f172a`)
+- **Canopus color**: Hero title and star accent use warm gold (`#fbbf24` Yellow 400, `#fef3c7` Yellow 100). This is applied only to the Hero section, not the rest of the site.
+- **CTA buttons**: "Get Started" (filled, gold accent) + "GitHub" (outline)
+- **Code panels**: Slate 800 background (`#1e293b`) with Slate 700 border, matching the site's code block style. Tab-like headers showing filename (`main.crn`) and terminal indicator.
+
+### "Why Carina?" Section
+
+Three features presented as icon + title + short description:
+
+1. **Type Safe** — DSL validates at parse time. Catch errors before any infrastructure is touched.
+2. **Effects as Values** — Side effects are data. Inspect your Plan before execution, not after.
+3. **Pluggable Providers** — AWS Cloud Control API, native AWS SDK, and more. One DSL, multiple backends.
+
+### Existing Content
+
+Feature cards (Custom DSL, Effects as Values, Provider Architecture, Modules) and Provider link cards are preserved as-is below the new sections.
+
+## Color Palette (Hero only)
+
+| Role | Color | Token |
+|------|-------|-------|
+| Star glow | `#fef3c7` | Yellow 100 |
+| Title accent | `#fbbf24` | Yellow 400 |
+| CTA button | `#d97706` | Amber 600 |
+| CTA hover | `#f59e0b` | Amber 500 |
+
+The rest of the site continues to use the existing Cyan/Slate palette.
+
+## Implementation
+
+### Files to modify
+
+- `docs/src/content/docs/index.mdx` — Replace default Hero with custom HTML content, add "Why Carina?" section
+- `docs/src/styles/custom.css` — Add Hero-specific styles (gradient background, code panels, Canopus colors, "Why Carina?" layout)
+
+### Files to create
+
+- `docs/src/components/Hero.astro` — Custom Hero component (Starlight supports component overrides via `components` config in `astro.config.mjs`)
+
+### Config change
+
+- `docs/astro.config.mjs` — Register the custom Hero component override if needed
+
+### Approach
+
+Starlight's splash template uses a Hero component. Two options:
+
+1. **Component override**: Create a custom `Hero.astro` and register it in `astro.config.mjs` under `components: { Hero: './src/components/Hero.astro' }`. This replaces the Hero across all splash pages.
+2. **MDX inline**: Write the Hero content directly in `index.mdx` using HTML/Astro components, disabling the default Hero.
+
+Option 1 is cleaner — it keeps the MDX file simple and the Hero logic isolated.
+
+## Testing
+
+- `npm run dev` in `docs/` and visually confirm:
+  - Hero: gradient background, Canopus gold title, code + plan panels side by side
+  - "Why Carina?" section with three features
+  - Existing feature cards and provider links unchanged below
+  - Dark and light mode both work
+  - Mobile responsive: panels stack vertically on narrow screens
+- `npm run build` passes with no errors

--- a/docs/superpowers/specs/2026-03-31-ogp-image-design.md
+++ b/docs/superpowers/specs/2026-03-31-ogp-image-design.md
@@ -1,0 +1,129 @@
+# OGP Image Design Spec
+
+## Overview
+
+Generate per-page OGP (Open Graph Protocol) images at build time for the Carina documentation site. Each page gets a unique 1200x630px PNG image that includes the Carina logo, project name, page title, and tagline.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Text content | Project name + page title + tagline | Balances brand identity with page-specific context |
+| Tagline | "Strongly Typed Infrastructure as Code" | Shortened from hero tagline; fits small OGP previews |
+| Generation method | Build-time (satori + resvg) | GitHub Pages is static-only; no server-side processing |
+| Layout (pages) | 2-column split | Logo prominence + clear information hierarchy |
+| Layout (top page) | Centered logo + tagline only | Brand-focused for project-level shares |
+
+## Layout Specifications
+
+### Regular Pages (2-Column Split)
+
+```
+┌──────────────┬──────────────────────────────┐
+│              │                              │
+│              │  CARINA          (Gold, 13px)│
+│              │                              │
+│   [Logo]     │  Page Title     (White, 30px)│
+│   (large)    │  ───── (Cyan line)           │
+│              │  Strongly Typed  (Slate, 14px)│
+│              │  Infrastructure as Code      │
+│              │                              │
+└──────────────┴──────────────────────────────┘
+ Left: 35%      Right: 65%
+```
+
+- Left panel: Logo centered, subtle radial glow behind it
+- Right panel: Text left-aligned, vertical rhythm with Cyan separator line
+- Divider: 1px `rgba(8,145,178,0.2)` vertical line between panels
+
+### Top Page (Centered)
+
+```
+┌─────────────────────────────────────────────┐
+│         ─── Gold gradient border ───        │
+│                                             │
+│              [Logo]                         │
+│              (large)                        │
+│                                             │
+│              CARINA                         │
+│   Strongly Typed Infrastructure as Code     │
+│                                             │
+│         ─── Cyan gradient border ───        │
+└─────────────────────────────────────────────┘
+```
+
+- Logo centered, larger than regular pages
+- Top border: Gold gradient (`transparent → #fbbf24 → transparent`)
+- Bottom border: Cyan gradient (`transparent → #0891b2 → transparent`)
+
+## Color Palette
+
+| Element | Color | Value |
+|---------|-------|-------|
+| Background | Deep Navy gradient | `#0f172a` → `#1e293b` |
+| Project name | Canopus Gold | `#fbbf24` |
+| Page title | Slate 100 | `#f1f5f9` |
+| Tagline | Slate 400 | `#94a3b8` |
+| Accent / separator | Cyan 600 | `#0891b2` |
+| Left panel divider | Cyan 600 @ 20% | `rgba(8,145,178,0.2)` |
+
+## Image Specifications
+
+- **Size**: 1200 x 630px (standard OGP)
+- **Format**: PNG
+- **Logo source**: `/docs/src/assets/favicon.png` (512x512)
+
+## Technical Architecture
+
+### Dependencies
+
+- `satori` — Converts JSX/HTML-like markup to SVG. Supports a subset of CSS flexbox.
+- `@resvg/resvg-js` — Converts SVG to PNG. Faster and more portable than sharp for SVG rendering.
+- `sharp` — Already in package.json. Used for compositing the logo PNG onto the satori-generated background (satori cannot embed raster images directly).
+
+### Build Integration
+
+Create an Astro integration that runs during the build:
+
+1. **Collect pages** — Hook into `astro:build:done` to get all generated routes from the `pages` list
+2. **Generate images** — For each page, render OGP image using satori → resvg pipeline
+3. **Write files** — Save PNGs to the `dist/` output directory (e.g., `dist/og/getting-started/installation.png`)
+4. **Inject meta tags** — Use Starlight's `head` config or a `<Head>` component override to set the correct `og:image` URL per page
+
+### File Structure
+
+```
+docs/
+├── src/
+│   ├── ogp/
+│   │   ├── generate.ts       # Core generation logic (satori + resvg)
+│   │   ├── templates.ts      # Layout templates (regular + top page)
+│   │   └── integration.ts    # Astro integration hook
+│   └── ...
+├── public/
+│   └── og.png                # Keep as fallback (existing)
+└── ...
+```
+
+### OGP Meta Tag Strategy
+
+Current state: A single global `og:image` meta tag in `astro.config.mjs` pointing to `/og.png`.
+
+Target: Per-page `og:image` tags pointing to generated images (e.g., `/og/getting-started/installation.png`).
+
+Approach:
+- Override Starlight's `<Head>` component to inject page-specific `og:image` meta tag
+- Use the page's slug/path to construct the image URL
+- Top page uses `/og/index.png`
+- Fallback: Keep `/public/og.png` for any page that fails generation
+
+### Font
+
+Use Inter (or a similar clean sans-serif) loaded via Google Fonts `.woff` file. satori requires font data as an ArrayBuffer at render time. Bundle the font file in the repo or download during build.
+
+## Out of Scope
+
+- Light mode variant (site is dark-only)
+- Twitter/X-specific card images (use same OGP image)
+- Dynamic runtime generation
+- Localized images (docs are English-only)


### PR DESCRIPTION
## Summary
- Add implementation plans and design specs for documentation site design refresh, hero landing page, and OGP image generation (2026-03-31)
- Also deleted stale `docs/book/` directory (old mdBook build output, no longer used after Astro migration)

## Test plan
- [ ] Verify no existing docs or CI references are broken by the `docs/book/` removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)