### PR TITLE
fix: block direct commits to main/master in pre-commit hook

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -5,6 +5,14 @@
 # Environment variables:
 #   SKIP_CLIPPY=1  - Skip clippy check (useful for WIP commits)
 
+# Block direct commits to main/master
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
+    echo "ERROR: Direct commits to '$current_branch' are not allowed."
+    echo "Create a feature branch first: git wt <branch-name> main"
+    exit 1
+fi
+
 changed_crates=()
 fmt_scope=()
 clippy_scope=()


### PR DESCRIPTION
## Summary

Add a guard at the top of the pre-commit hook that blocks commits directly to `main` or `master`. This prevents accidental direct commits that can't be pushed.

```
ERROR: Direct commits to 'main' are not allowed.
Create a feature branch first: git wt <branch-name> main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)