### PR TITLE
fix: use contains_resource_ref for deep ResourceRef protection in normalizer

### DIFF
--- a/carina-plugin-host/src/normalizer.rs
+++ b/carina-plugin-host/src/normalizer.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use carina_core::provider::{ProviderNormalizer, SavedAttrs};
-use carina_core::resource::{Expr, Resource, ResourceId, State, Value};
+use carina_core::resource::{Expr, Resource, ResourceId, State, Value, contains_resource_ref};
 use carina_core::schema::ResourceSchema;
 use carina_provider_protocol::methods;
 
@@ -46,18 +46,10 @@ impl ProviderNormalizer for ProcessProviderNormalizer {
                 for (core_res, proto_res) in resources.iter_mut().zip(result.resources.iter()) {
                     let resolved = convert::proto_to_core_value_map(&proto_res.attributes);
                     for (key, value) in resolved {
-                        // Only update attributes that were literal values.
-                        // Non-literal expressions (ResourceRef, Interpolation, etc.)
-                        // get corrupted during proto conversion and must be preserved.
+                        // Skip attributes containing unresolved references.
+                        // These get corrupted during proto conversion and must be preserved.
                         if let Some(Expr(v)) = core_res.attributes.get(&key)
-                            && matches!(
-                                v,
-                                Value::ResourceRef { .. }
-                                    | Value::Interpolation(_)
-                                    | Value::FunctionCall { .. }
-                                    | Value::Closure { .. }
-                                    | Value::Secret(_)
-                            )
+                            && contains_resource_ref(v)
                         {
                             continue;
                         }


### PR DESCRIPTION
## Summary

- Replace shallow `matches!` check with recursive `contains_resource_ref()` in ProcessProviderNormalizer
- Fixes ResourceRef corruption when references are nested inside List or Map values (e.g., `route_table_ids: [rt.route_table_id]`)
- Net -8 lines (simpler code using existing utility)

## Problem

PR #1437 added protection for top-level ResourceRef values in `normalize_desired` and `merge_default_tags`, but missed cases where ResourceRef is nested inside `Value::List` or `Value::Map`. This caused apply failures for resources with list attributes containing references (e.g., `ec2_vpc_endpoint`, `ec2_transit_gateway_attachment`).

## Test Plan

- [x] `./carina-provider-awscc/acceptance-tests/run-tests.sh full ec2_vpc_endpoint/gateway` — PASS
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)