### PR TITLE
fix: preserve ordered, provider_name, removable across process boundary

### DIFF
--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -892,3 +892,266 @@ fn orphan_delete_preserves_binding_and_dependencies() {
         _ => unreachable!(),
     }
 }
+
+/// Regression test for issue #1439: security_group_egress struct list should
+/// be idempotent after apply -> plan-verify when saved state contains
+/// namespaced enum values that differ from alias-resolved values.
+///
+/// Scenario: After apply, the state file stores ip_protocol values in
+/// namespaced format (e.g., "awscc.ec2.security_group.IpProtocol.tcp"),
+/// while plan-time alias resolution converts "all" to "-1".
+/// The differ should see no changes when comparing merged-desired vs current.
+#[test]
+fn diff_no_change_for_struct_list_with_saved_state_egress_rules() {
+    use crate::schema::{ResourceSchema, StructField};
+
+    // Build a schema that matches ec2.security_group's security_group_egress attribute
+    let egress_struct = AttributeType::Struct {
+        name: "Egress".to_string(),
+        fields: vec![
+            StructField::new("cidr_ip", AttributeType::String),
+            StructField::new("description", AttributeType::String),
+            StructField::new("from_port", AttributeType::Int),
+            StructField::new(
+                "ip_protocol",
+                AttributeType::StringEnum {
+                    name: "IpProtocol".to_string(),
+                    values: vec![
+                        "tcp".to_string(),
+                        "udp".to_string(),
+                        "icmp".to_string(),
+                        "-1".to_string(),
+                        "all".to_string(),
+                    ],
+                    namespace: Some("awscc.ec2.security_group".to_string()),
+                    to_dsl: Some(|s: &str| match s {
+                        "-1" => "all".to_string(),
+                        _ => s.to_string(),
+                    }),
+                },
+            ),
+            StructField::new("to_port", AttributeType::Int),
+        ],
+    };
+    let schema = ResourceSchema::new("awscc.ec2.security_group").attribute(
+        crate::schema::AttributeSchema::new(
+            "security_group_egress",
+            AttributeType::unordered_list(egress_struct),
+        ),
+    );
+
+    // Desired state (post-normalization, post-alias-resolution)
+    // "all" -> "-1" (alias resolved), "tcp" stays as namespaced identifier
+    let desired = Resource::with_provider("awscc", "ec2.security_group", "test-sg").with_attribute(
+        "security_group_egress",
+        Value::List(vec![
+            Value::Map(HashMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::String("awscc.ec2.security_group.IpProtocol.tcp".to_string()),
+                ),
+                ("from_port".to_string(), Value::Int(443)),
+                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("0.0.0.0/0".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow HTTPS outbound".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([
+                ("ip_protocol".to_string(), Value::String("-1".to_string())),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("10.0.0.0/8".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow all to private ranges".to_string()),
+                ),
+            ])),
+        ]),
+    );
+
+    // Current state (from AWS read, post-normalization, post-alias-resolution)
+    // Same as desired, but the "all" rule also has from_port: -1, to_port: -1 from AWS
+    let current_attrs = HashMap::from([(
+        "security_group_egress".to_string(),
+        Value::List(vec![
+            Value::Map(HashMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::String("awscc.ec2.security_group.IpProtocol.tcp".to_string()),
+                ),
+                ("from_port".to_string(), Value::Int(443)),
+                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("0.0.0.0/0".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow HTTPS outbound".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([
+                ("ip_protocol".to_string(), Value::String("-1".to_string())),
+                ("from_port".to_string(), Value::Int(-1)),
+                ("to_port".to_string(), Value::Int(-1)),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("10.0.0.0/8".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow all to private ranges".to_string()),
+                ),
+            ])),
+        ]),
+    )]);
+    let current = State::existing(
+        ResourceId::with_provider("awscc", "ec2.security_group", "test-sg"),
+        current_attrs,
+    );
+
+    // Saved state (from state file, NOT alias-resolved)
+    // This is the state as written after apply: namespaced enum values, AWS-returned fields
+    let saved = HashMap::from([(
+        "security_group_egress".to_string(),
+        Value::List(vec![
+            Value::Map(HashMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::String("awscc.ec2.security_group.IpProtocol.tcp".to_string()),
+                ),
+                ("from_port".to_string(), Value::Int(443)),
+                ("to_port".to_string(), Value::Int(443)),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("0.0.0.0/0".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow HTTPS outbound".to_string()),
+                ),
+            ])),
+            Value::Map(HashMap::from([
+                (
+                    "ip_protocol".to_string(),
+                    Value::String("awscc.ec2.security_group.IpProtocol.all".to_string()),
+                ),
+                ("from_port".to_string(), Value::Int(-1)),
+                ("to_port".to_string(), Value::Int(-1)),
+                (
+                    "cidr_ip".to_string(),
+                    Value::String("10.0.0.0/8".to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    Value::String("Allow all to private ranges".to_string()),
+                ),
+            ])),
+        ]),
+    )]);
+
+    let result = diff(&desired, &current, Some(&saved), None, Some(&schema));
+    assert!(
+        matches!(result, Diff::NoChange(_)),
+        "Expected NoChange for idempotent egress rules, got: {:?}",
+        result
+    );
+}
+
+/// Regression test for the root cause of issue #1439: when the schema
+/// has `ordered: true` (as it would be after losing `ordered` info in the
+/// protocol roundtrip), struct lists are compared positionally instead of
+/// as multisets. If AWS returns items in a different order, positional
+/// comparison fails and falsely detects changes.
+#[test]
+fn diff_false_positive_when_ordered_true_for_struct_list() {
+    use crate::schema::{ResourceSchema, StructField};
+
+    let egress_struct = AttributeType::Struct {
+        name: "Egress".to_string(),
+        fields: vec![
+            StructField::new("cidr_ip", AttributeType::String),
+            StructField::new("description", AttributeType::String),
+            StructField::new("from_port", AttributeType::Int),
+            StructField::new("ip_protocol", AttributeType::String),
+            StructField::new("to_port", AttributeType::Int),
+        ],
+    };
+
+    // Bug: ordered: true causes positional comparison of struct list items
+    let schema_ordered = ResourceSchema::new("awscc.ec2.security_group").attribute(
+        crate::schema::AttributeSchema::new(
+            "security_group_egress",
+            AttributeType::List {
+                inner: Box::new(egress_struct.clone()),
+                ordered: true,
+            },
+        ),
+    );
+
+    // Same items in different order
+    let item_a = Value::Map(HashMap::from([
+        ("ip_protocol".to_string(), Value::String("tcp".to_string())),
+        ("from_port".to_string(), Value::Int(443)),
+        ("to_port".to_string(), Value::Int(443)),
+        (
+            "cidr_ip".to_string(),
+            Value::String("0.0.0.0/0".to_string()),
+        ),
+        (
+            "description".to_string(),
+            Value::String("HTTPS".to_string()),
+        ),
+    ]));
+    let item_b = Value::Map(HashMap::from([
+        ("ip_protocol".to_string(), Value::String("-1".to_string())),
+        (
+            "cidr_ip".to_string(),
+            Value::String("10.0.0.0/8".to_string()),
+        ),
+        ("description".to_string(), Value::String("All".to_string())),
+        ("from_port".to_string(), Value::Int(-1)),
+        ("to_port".to_string(), Value::Int(-1)),
+    ]));
+
+    let desired = Resource::with_provider("awscc", "ec2.security_group", "test-sg").with_attribute(
+        "security_group_egress",
+        Value::List(vec![item_a.clone(), item_b.clone()]),
+    );
+    let current = State::existing(
+        ResourceId::with_provider("awscc", "ec2.security_group", "test-sg"),
+        HashMap::from([(
+            "security_group_egress".to_string(),
+            // AWS returns items in reversed order
+            Value::List(vec![item_b.clone(), item_a.clone()]),
+        )]),
+    );
+
+    // With ordered: true, differ falsely detects changes (reordered items)
+    let result = diff(&desired, &current, None, None, Some(&schema_ordered));
+    assert!(
+        matches!(result, Diff::Update { .. }),
+        "Expected false positive Update with ordered:true, got: {:?}",
+        result
+    );
+
+    // With ordered: false (unordered_list), differ correctly sees no change
+    let schema_unordered = ResourceSchema::new("awscc.ec2.security_group").attribute(
+        crate::schema::AttributeSchema::new(
+            "security_group_egress",
+            AttributeType::unordered_list(egress_struct),
+        ),
+    );
+    let result = diff(&desired, &current, None, None, Some(&schema_unordered));
+    assert!(
+        matches!(result, Diff::NoChange(_)),
+        "Expected NoChange with ordered:false, got: {:?}",
+        result
+    );
+}

--- a/carina-plugin-host/src/convert.rs
+++ b/carina-plugin-host/src/convert.rs
@@ -152,9 +152,9 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             namespace: None,
             to_dsl: None,
         },
-        ProtoAttributeType::List { inner } => CoreAttributeType::List {
+        ProtoAttributeType::List { inner, ordered } => CoreAttributeType::List {
             inner: Box::new(proto_to_core_attribute_type(inner)),
-            ordered: true,
+            ordered: *ordered,
         },
         ProtoAttributeType::Map { inner } => {
             CoreAttributeType::Map(Box::new(proto_to_core_attribute_type(inner)))
@@ -175,7 +175,7 @@ fn proto_to_core_struct_field(f: &ProtoStructField) -> CoreStructField {
         field_type: proto_to_core_attribute_type(&f.field_type),
         required: f.required,
         description: f.description.clone(),
-        provider_name: None,
+        provider_name: f.provider_name.clone(),
         block_name: f.block_name.clone(),
     }
 }
@@ -188,10 +188,10 @@ fn proto_to_core_attribute_schema(a: &ProtoAttributeSchema) -> CoreAttributeSche
         default: a.default.as_ref().map(proto_to_core_value),
         description: a.description.clone(),
         completions: None,
-        provider_name: None,
+        provider_name: a.provider_name.clone(),
         create_only: a.create_only,
         read_only: a.read_only,
-        removable: None,
+        removable: a.removable,
         block_name: a.block_name.clone(),
         write_only: a.write_only,
     }
@@ -222,8 +222,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::StringEnum { values, .. } => ProtoAttributeType::StringEnum {
             values: values.clone(),
         },
-        CoreAttributeType::List { inner, .. } => ProtoAttributeType::List {
+        CoreAttributeType::List { inner, ordered } => ProtoAttributeType::List {
             inner: Box::new(core_to_proto_attribute_type(inner)),
+            ordered: *ordered,
         },
         CoreAttributeType::Map(inner) => ProtoAttributeType::Map {
             inner: Box::new(core_to_proto_attribute_type(inner)),
@@ -247,6 +248,7 @@ fn core_to_proto_struct_field(f: &CoreStructField) -> ProtoStructField {
         required: f.required,
         description: f.description.clone(),
         block_name: f.block_name.clone(),
+        provider_name: f.provider_name.clone(),
     }
 }
 
@@ -261,6 +263,8 @@ fn core_to_proto_attribute_schema(a: &CoreAttributeSchema) -> ProtoAttributeSche
         read_only: a.read_only,
         write_only: a.write_only,
         block_name: a.block_name.clone(),
+        provider_name: a.provider_name.clone(),
+        removable: a.removable,
     }
 }
 
@@ -461,6 +465,114 @@ mod tests {
             );
         } else {
             panic!("Expected Struct type");
+        }
+    }
+
+    #[test]
+    fn test_list_ordered_roundtrip() {
+        // ordered flag on List types must survive core->proto->core roundtrip.
+        // Without this, unordered lists (ordered=false) become ordered lists
+        // (ordered=true), causing the differ to compare items positionally
+        // instead of as multisets. This was the root cause of issue #1439.
+        let ordered_list = CoreAttributeType::List {
+            inner: Box::new(CoreAttributeType::String),
+            ordered: true,
+        };
+        let unordered_list = CoreAttributeType::List {
+            inner: Box::new(CoreAttributeType::Struct {
+                name: "Egress".into(),
+                fields: vec![],
+            }),
+            ordered: false,
+        };
+
+        let proto_ordered = core_to_proto_attribute_type(&ordered_list);
+        let back_ordered = proto_to_core_attribute_type(&proto_ordered);
+        if let CoreAttributeType::List { ordered, .. } = back_ordered {
+            assert!(ordered, "ordered=true must survive roundtrip");
+        } else {
+            panic!("Expected List type");
+        }
+
+        let proto_unordered = core_to_proto_attribute_type(&unordered_list);
+        let back_unordered = proto_to_core_attribute_type(&proto_unordered);
+        if let CoreAttributeType::List { ordered, .. } = back_unordered {
+            assert!(!ordered, "ordered=false must survive roundtrip");
+        } else {
+            panic!("Expected List type");
+        }
+    }
+
+    #[test]
+    fn test_provider_name_roundtrip() {
+        // provider_name on attribute schemas and struct fields must survive roundtrip.
+        let core_schema = CoreResourceSchema {
+            resource_type: "ec2.security_group".into(),
+            attributes: HashMap::from([(
+                "security_group_egress".into(),
+                CoreAttributeSchema {
+                    name: "security_group_egress".into(),
+                    attr_type: CoreAttributeType::unordered_list(CoreAttributeType::Struct {
+                        name: "Egress".into(),
+                        fields: vec![CoreStructField {
+                            name: "ip_protocol".into(),
+                            field_type: CoreAttributeType::String,
+                            required: true,
+                            description: None,
+                            provider_name: Some("IpProtocol".into()),
+                            block_name: None,
+                        }],
+                    }),
+                    required: false,
+                    default: None,
+                    description: None,
+                    completions: None,
+                    provider_name: Some("SecurityGroupEgress".into()),
+                    create_only: false,
+                    read_only: false,
+                    removable: Some(false),
+                    block_name: None,
+                    write_only: false,
+                },
+            )]),
+            description: None,
+            validator: None,
+            data_source: false,
+            name_attribute: None,
+            force_replace: false,
+        };
+
+        let proto = core_to_proto_schema(&core_schema);
+        let back = proto_to_core_schema(&proto);
+
+        let attr = &back.attributes["security_group_egress"];
+        assert_eq!(
+            attr.provider_name,
+            Some("SecurityGroupEgress".into()),
+            "attribute provider_name must survive roundtrip"
+        );
+        assert_eq!(
+            attr.removable,
+            Some(false),
+            "attribute removable must survive roundtrip"
+        );
+
+        if let CoreAttributeType::List { inner, ordered, .. } = &attr.attr_type {
+            assert!(
+                !ordered,
+                "unordered_list must survive roundtrip as ordered=false"
+            );
+            if let CoreAttributeType::Struct { fields, .. } = inner.as_ref() {
+                assert_eq!(
+                    fields[0].provider_name,
+                    Some("IpProtocol".into()),
+                    "struct field provider_name must survive roundtrip"
+                );
+            } else {
+                panic!("Expected Struct type inside List");
+            }
+        } else {
+            panic!("Expected List type");
         }
     }
 }

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -5,6 +5,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+fn default_true() -> bool {
+    true
+}
+
 /// Mirrors `carina_core::resource::ResourceId`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResourceId {
@@ -164,6 +168,13 @@ pub struct AttributeSchema {
     pub write_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_name: Option<String>,
+    /// Provider-side property name (e.g., "VpcId" for AWS Cloud Control)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_name: Option<String>,
+    /// Override for removability detection.
+    /// `None` = auto-detect, `Some(false)` = explicitly non-removable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub removable: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,6 +191,10 @@ pub enum AttributeType {
     #[serde(rename = "list")]
     List {
         inner: Box<AttributeType>,
+        /// Whether list elements are ordered (positional comparison).
+        /// When false, elements are compared as multisets (order-insensitive).
+        #[serde(default = "default_true")]
+        ordered: bool,
     },
     #[serde(rename = "map")]
     Map {
@@ -205,6 +220,9 @@ pub struct StructField {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_name: Option<String>,
+    /// Provider-side property name (e.g., "IpProtocol" for AWS Cloud Control)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_name: Option<String>,
 }
 
 #[cfg(test)]
@@ -259,6 +277,7 @@ mod tests {
                 required: true,
                 description: None,
                 block_name: None,
+                provider_name: None,
             }],
         };
 
@@ -279,6 +298,7 @@ mod tests {
                         required: false,
                         description: None,
                         block_name: None,
+                        provider_name: None,
                     }],
                 },
                 AttributeType::String,


### PR DESCRIPTION
## Summary

- Fix `List.ordered` flag being hardcoded to `true` in the protocol roundtrip, causing unordered struct lists (like `security_group_egress`) to use positional comparison instead of multiset comparison. When AWS returns items in a different order than the DSL, the differ falsely detects changes.
- Fix `StructField.provider_name` and `AttributeSchema.provider_name`/`removable` being dropped when crossing the process boundary.

## Root Cause

The `carina-plugin-host` conversion layer (`proto_to_core_attribute_type`) hardcoded `ordered: true` for all `List` types. The protocol type (`carina-provider-protocol`) lacked the `ordered` field entirely. This meant all lists from external providers were treated as ordered, even when the schema specified `unordered_list`.

For `security_group_egress`, the schema defines it as an unordered list of structs. After apply, AWS returns the egress rules in an arbitrary order. With `ordered: true`, the differ compared items positionally (index 0 vs index 0), which failed when the order differed.

## Changes

- `carina-provider-protocol/src/types.rs`: Add `ordered` field to `AttributeType::List`, `provider_name` to `StructField` and `AttributeSchema`, `removable` to `AttributeSchema`
- `carina-plugin-host/src/convert.rs`: Preserve all new fields in both core-to-proto and proto-to-core conversions
- `carina-core/src/differ/diff_tests.rs`: Add regression tests demonstrating the ordered vs unordered comparison difference

## Test plan

- [x] Unit tests pass (`cargo test`)
- [x] Protocol roundtrip tests verify `ordered`, `provider_name`, and `removable` survive
- [x] Manual verification: apply + plan-verify for `ec2_security_group/with_egress` shows "No changes"
- [ ] Full acceptance test: `./carina-provider-awscc/acceptance-tests/run-tests.sh full ec2_security_group/with_egress`

Closes #1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)