### PR TITLE
fix: redirect progress draw target to stderr in non-terminal contexts

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -106,11 +106,12 @@ impl RefreshProgress {
 
 /// Create a `MultiProgress` for concurrent refresh spinners.
 ///
-/// Hides the draw target when stdout is not a terminal (e.g., in CI).
+/// Redirects the draw target to stderr when stdout is not a terminal (e.g., in CI),
+/// so that spinner animations are suppressed but `println` messages still appear.
 pub(crate) fn refresh_multi_progress() -> MultiProgress {
     let multi = MultiProgress::new();
     if !std::io::stdout().is_terminal() {
-        multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+        multi.set_draw_target(indicatif::ProgressDrawTarget::stderr());
     }
     multi
 }
@@ -132,7 +133,7 @@ impl CliObserver {
     fn new(_plan: &Plan) -> Self {
         let multi = MultiProgress::new();
         if !std::io::stdout().is_terminal() {
-            multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+            multi.set_draw_target(indicatif::ProgressDrawTarget::stderr());
         }
 
         Self {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -379,7 +379,7 @@ async fn run_destroy_locked(
     // Set up multi-progress for concurrent spinners
     let multi = MultiProgress::new();
     if !std::io::stdout().is_terminal() {
-        multi.set_draw_target(indicatif::ProgressDrawTarget::hidden());
+        multi.set_draw_target(indicatif::ProgressDrawTarget::stderr());
     }
 
     // Map from resource index to its spinner (populated lazily on dispatch)


### PR DESCRIPTION
## Summary

- `MultiProgress` was set to `ProgressDrawTarget::hidden()` when stdout is not a terminal (piped output, CI), which silently discarded all `multi.println()` error and status messages
- Changed to `ProgressDrawTarget::stderr()` in all three affected locations: `apply.rs` (`refresh_multi_progress` and `CliObserver::new`) and `destroy.rs`
- Spinner animations are still suppressed in non-terminal contexts, but error/status messages now appear on stderr as expected

## Test plan

- [x] `cargo build -p carina-cli` — clean build
- [x] `cargo test -p carina-cli` — 172 tests pass
- [x] `cargo fmt` — no formatting changes
- [x] `cargo clippy -p carina-cli` — no warnings

closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)