### PR TITLE
fix: use eprintln for error messages in destroy/apply (non-terminal visibility)

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -223,14 +223,13 @@ impl ExecutionObserver for CliObserver {
                     reason,
                     counter
                 );
-                // Skipped effects may not have a spinner (they were never started),
-                // so print directly via multi.println().
+                // Skipped effects may not have a spinner (they were never started).
                 let mut bars = self.bars.lock().unwrap();
                 if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 } else {
-                    self.multi.println(format!("  {}", msg)).ok();
+                    eprintln!("  {}", msg);
                 }
             }
             ExecutionEvent::CascadeUpdateSucceeded { id } => {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -500,7 +500,7 @@ async fn run_destroy_locked(
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 } else {
-                    multi.println(format!("  {}", msg)).ok();
+                    eprintln!("  {}", msg);
                 }
                 skip_count += 1;
                 failed_bindings.insert(binding.clone());
@@ -599,7 +599,7 @@ async fn run_destroy_locked(
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 } else {
-                    multi.println(format!("  {}", msg)).ok();
+                    eprintln!("  {}", msg);
                 }
                 skip_count += 1;
                 failed_bindings.insert(binding.clone());
@@ -666,7 +666,7 @@ async fn run_destroy_locked(
                         pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                         pb.finish_with_message(msg);
                     } else {
-                        multi.println(format!("  {}", msg)).ok();
+                        eprintln!("  {}", msg);
                     }
                     let binding = &resource_info[idx].0;
                     failed_bindings.insert(binding.clone());
@@ -705,7 +705,7 @@ async fn run_destroy_locked(
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
                 } else {
-                    multi.println(format!("  {}", msg)).ok();
+                    eprintln!("  {}", msg);
                 }
             };
 


### PR DESCRIPTION
## Summary

Replace `multi.println()` with `eprintln!()` for error/status messages in destroy and apply commands. `indicatif::MultiProgress::println()` is silently suppressed when the draw target is non-terminal (piped output, `$(...)`), making resource-level error messages invisible in test runners and scripts.

closes #1445

## Test Plan

- [x] `cargo build -p carina-cli`
- [x] `cargo test -p carina-cli`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)