### PR TITLE
fix: retry destroy on CloudControl 'Exceeded attempts to wait' error

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -911,6 +911,9 @@ fn is_retryable_delete_error(e: &carina_core::provider::ProviderError) -> bool {
         "resource has dependencies",
         "mapped public address",
         "Failed to detach",
+        // CloudControl operation timeout — often caused by dependent resources
+        // still being deleted (e.g., NAT Gateway blocking VPCGatewayAttachment)
+        "Exceeded attempts to wait",
     ];
     retryable_patterns.iter().any(|p| msg.contains(p))
 }


### PR DESCRIPTION
## Summary

Add `"Exceeded attempts to wait"` to the retryable delete error patterns in the destroy loop. CloudControl operations can time out (~15 min) when dependent resources are still being deleted (e.g., VPCGatewayAttachment fails while NAT Gateway is still active). The retry allows the destroy loop to wait for the dependency deletion to complete and retry successfully.

closes #1443

## Root Cause

The `ec2_route/nat_gateway` acceptance test consistently failed at destroy phase:
```
✗ Delete awscc.ec2.vpc_gateway_attachment [15m 24.8s]
  → Operation failed: Exceeded attempts to wait
```

CloudControl API returns this error when the VPCGatewayAttachment delete operation times out internally. This happens because NAT Gateway (which uses the IGW) is being deleted in parallel and takes 5-10 minutes, blocking the IGW detach.

## Fix

1 line: add `"Exceeded attempts to wait"` to `is_retryable_delete_error()`. The existing retry mechanism waits for another resource deletion to complete before retrying, so by the time VPCGatewayAttachment is retried, the NAT Gateway has been deleted.

## Test Plan

- [x] `./carina-provider-awscc/acceptance-tests/run-tests.sh full ec2_route/nat_gateway` — PASS (apply + plan-verify + destroy)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)