### PR TITLE
fix: Homebrew formula SHA256 extraction in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,17 +122,17 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
 
-          MACOS_ARM_SHA256=$(grep "macos-aarch64" artifacts/*.sha256 | awk '{print $1}')
-          MACOS_X86_SHA256=$(grep "macos-x86_64" artifacts/*.sha256 | awk '{print $1}')
-          LINUX_ARM_SHA256=$(grep "linux-aarch64" artifacts/*.sha256 | awk '{print $1}')
-          LINUX_X86_SHA256=$(grep "linux-x86_64" artifacts/*.sha256 | awk '{print $1}')
+          MACOS_ARM_SHA256=$(cat artifacts/carina-*-macos-aarch64.tar.gz.sha256 | awk '{print $1}')
+          MACOS_X86_SHA256=$(cat artifacts/carina-*-macos-x86_64.tar.gz.sha256 | awk '{print $1}')
+          LINUX_ARM_SHA256=$(cat artifacts/carina-*-linux-aarch64.tar.gz.sha256 | awk '{print $1}')
+          LINUX_X86_SHA256=$(cat artifacts/carina-*-linux-x86_64.tar.gz.sha256 | awk '{print $1}')
 
           sed \
-            -e "s/{{VERSION}}/${VERSION}/g" \
-            -e "s/{{MACOS_ARM_SHA256}}/${MACOS_ARM_SHA256}/g" \
-            -e "s/{{MACOS_X86_SHA256}}/${MACOS_X86_SHA256}/g" \
-            -e "s/{{LINUX_ARM_SHA256}}/${LINUX_ARM_SHA256}/g" \
-            -e "s/{{LINUX_X86_SHA256}}/${LINUX_X86_SHA256}/g" \
+            -e "s|{{VERSION}}|${VERSION}|g" \
+            -e "s|{{MACOS_ARM_SHA256}}|${MACOS_ARM_SHA256}|g" \
+            -e "s|{{MACOS_X86_SHA256}}|${MACOS_X86_SHA256}|g" \
+            -e "s|{{LINUX_ARM_SHA256}}|${LINUX_ARM_SHA256}|g" \
+            -e "s|{{LINUX_X86_SHA256}}|${LINUX_X86_SHA256}|g" \
             packaging/homebrew/carina.rb.template > carina.rb
 
       - name: Push to Homebrew tap


### PR DESCRIPTION
## Summary

Fix the Homebrew tap update step in the release workflow that failed with `sed: unknown option to 's'`.

**Root cause**: `grep "macos-aarch64" artifacts/*.sha256 | awk '{print $1}'` produces output like `artifacts/carina-0.1.0-macos-aarch64.tar.gz.sha256:abc123...` — the filename prefix contains `/` which breaks `sed`'s `/` delimiter.

**Fix**:
1. Use `cat artifacts/carina-*-macos-aarch64.tar.gz.sha256` to read files directly (no grep filename prefix)
2. Use `|` as sed delimiter instead of `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)