### PR TITLE
chore: remove temporary e2e-wasm-test directory

### DIFF
--- a/e2e-wasm-test/main.crn
+++ b/e2e-wasm-test/main.crn
@@ -1,6 +1,0 @@
-provider aws {
-    source = "file:///Users/mizzy/src/github.com/carina-rs/carina-provider-aws/target/wasm32-wasip2/release/carina-provider-aws.wasm"
-    region = "ap-northeast-1"
-}
-
-let identity = read aws.sts.caller_identity {}


### PR DESCRIPTION
## Summary
- Remove `e2e-wasm-test/` directory accidentally committed during Phase 2 E2E testing

## Test plan
- [ ] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)