### PR TITLE
fix: always print apply errors to stderr

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -183,6 +183,8 @@ impl ExecutionObserver for CliObserver {
                 if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
                     pb.finish_with_message(msg);
+                } else {
+                    eprintln!("  {msg}");
                 }
             }
             ExecutionEvent::EffectFailed {
@@ -206,8 +208,11 @@ impl ExecutionObserver for CliObserver {
                 let mut bars = self.bars.lock().unwrap();
                 if let Some(pb) = bars.remove(&key) {
                     pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg);
+                    pb.finish_with_message(msg.clone());
                 }
+                // Always print errors to stderr so they're visible even when
+                // indicatif's MultiProgress swallows progress bar output.
+                eprintln!("  {msg}");
             }
             ExecutionEvent::EffectSkipped {
                 effect,


### PR DESCRIPTION
## Summary
The indicatif `MultiProgress` can swallow progress bar output in some environments. Always `eprintln` errors in the `EffectFailed` handler so they're visible regardless.

Before:
```
Applying changes...

Error: Apply failed. 0 succeeded, 1 failed.
```

After:
```
Applying changes...

  ✗ Create awscc.ec2.subnet.ec2_subnet_xxx [5.5s] 1/1
      → The vpc ID 'vpc-nonexistent' does not exist

Error: Apply failed. 0 succeeded, 1 failed.
```

Fixes #1482

## Test plan
- [x] E2E test with intentionally failing resource shows error message
- [x] `cargo test -p carina-cli` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)