### PR TITLE
feat: add sccache + shared target-dir setup for faster worktree builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Rust build artifacts
 /target/
 
+# Local cargo config (contains machine-specific paths)
+/.cargo/config.toml
+
 # Carina state files
 .carina/
 carina.state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,29 @@ Key rules:
 - For `cargo check`, prefer `cargo check -p <crate-name>` as well
 - Provider crates (aws, awscc) are in separate repositories — changes here may require updating those repos
 
+### Build Cache Setup (sccache + shared target)
+
+To speed up builds across git worktrees, set up sccache and a shared target directory. Without this, each worktree recompiles all dependencies from scratch.
+
+```bash
+# Install sccache
+brew install sccache
+
+# Create .cargo/config.toml (gitignored, local only)
+mkdir -p .cargo
+cat > .cargo/config.toml << 'EOF'
+[build]
+rustc-wrapper = "sccache"
+target-dir = "/Users/mizzy/.cargo-target/carina"
+EOF
+```
+
+This configuration:
+- **sccache**: Caches compiled artifacts globally. New worktrees hit the cache instead of recompiling.
+- **shared target-dir**: All worktrees share one target directory. Cargo uses file locks to handle concurrent access (builds are serialized, not parallel).
+
+Note: `.cargo/config.toml` is gitignored because it contains machine-specific paths. Each new worktree needs this file copied or recreated.
+
 ## Architecture
 
 Carina is a functional infrastructure management tool that treats side effects as values (Effects) rather than immediately executing them.


### PR DESCRIPTION
## Summary

- Add `.cargo/config.toml` to `.gitignore` (contains machine-specific paths like absolute target-dir)
- Document sccache + shared target-dir setup in CLAUDE.md for faster builds across git worktrees
- Each worktree was recompiling all dependencies from scratch (~115GB target/). With sccache and shared target-dir, new worktrees can reuse cached artifacts.

Closes #1487

## Setup (manual, one-time)

```bash
brew install sccache
mkdir -p .cargo
cat > .cargo/config.toml << 'CONF'
[build]
rustc-wrapper = "sccache"
target-dir = "/Users/mizzy/.cargo-target/carina"
CONF
```

## Test plan

- [x] `brew install sccache` succeeds
- [x] `cargo check -p carina-core` works with sccache wrapper
- [x] `sccache --show-stats` shows compile results being cached
- [ ] New worktree build hits sccache cache for previously compiled crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)