### PR TITLE
fix: atomic precompile cache writes to prevent race conditions

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -349,16 +349,30 @@ impl WasmProviderFactory {
         let cwasm_name = Self::cache_key(&wasm_path);
         let cwasm_path = cache_dir.join(&cwasm_name);
 
-        // Try loading from existing cache
+        // Try loading from existing cache.
+        // On failure, retry once after a short delay — another process may be
+        // writing the cache file atomically (write to .tmp then rename).
         if cwasm_path.exists() {
             match Self::from_precompiled(&cwasm_path).await {
                 Ok(mut factory) => {
                     factory.wasm_path = wasm_path;
                     return Ok(factory);
                 }
-                Err(e) => {
-                    eprintln!("Precompile cache invalid, recompiling: {e}");
-                    let _ = std::fs::remove_file(&cwasm_path);
+                Err(_) => {
+                    // Another process may be writing; wait briefly and retry
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    if cwasm_path.exists() {
+                        match Self::from_precompiled(&cwasm_path).await {
+                            Ok(mut factory) => {
+                                factory.wasm_path = wasm_path;
+                                return Ok(factory);
+                            }
+                            Err(e) => {
+                                eprintln!("Precompile cache invalid, recompiling: {e}");
+                                let _ = std::fs::remove_file(&cwasm_path);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -446,8 +460,21 @@ impl WasmProviderFactory {
             .map_err(|e| format!("Precompile error: {e}"))?;
         if let Some(parent) = cwasm_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("Mkdir error: {e}"))?;
+            // Write to a temp file and atomically rename to avoid race conditions
+            // when multiple processes precompile the same component concurrently.
+            let tmp_path = parent.join(format!(
+                ".{}.tmp.{}",
+                cwasm_path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("cwasm"),
+                std::process::id()
+            ));
+            std::fs::write(&tmp_path, &serialized).map_err(|e| format!("Write error: {e}"))?;
+            std::fs::rename(&tmp_path, cwasm_path).map_err(|e| format!("Rename error: {e}"))?;
+        } else {
+            std::fs::write(cwasm_path, &serialized).map_err(|e| format!("Write error: {e}"))?;
         }
-        std::fs::write(cwasm_path, &serialized).map_err(|e| format!("Write error: {e}"))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Fix race condition when multiple processes precompile the same WASM provider concurrently.

- Write cache to temp file (`.tmp.<pid>`) then atomic `rename()`
- Retry cache read once after 500ms on failure (another process may be writing)

Fixes #1489

## Test plan
- [x] All precompile tests pass (6/6)
- [ ] Parallel acceptance tests no longer fail with cache errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)