### PR TITLE
fix: preserve Union type through WIT roundtrip

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -234,6 +234,8 @@ enum AttrTypeJson {
         name: String,
         fields: Vec<StructFieldJson>,
     },
+    #[serde(rename = "union")]
+    Union { members: Vec<AttrTypeJson> },
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -270,7 +272,9 @@ fn core_attr_type_to_json(t: &CoreAttributeType) -> AttrTypeJson {
             fields: fields.iter().map(core_struct_field_to_json).collect(),
         },
         CoreAttributeType::Custom { base, .. } => core_attr_type_to_json(base),
-        CoreAttributeType::Union(_) => AttrTypeJson::String, // degrade to String
+        CoreAttributeType::Union(members) => AttrTypeJson::Union {
+            members: members.iter().map(core_attr_type_to_json).collect(),
+        },
     }
 }
 
@@ -297,6 +301,9 @@ fn json_to_core_attr_type(t: &AttrTypeJson) -> CoreAttributeType {
             name: name.clone(),
             fields: fields.iter().map(json_to_core_struct_field).collect(),
         },
+        AttrTypeJson::Union { members } => {
+            CoreAttributeType::Union(members.iter().map(json_to_core_attr_type).collect())
+        }
     }
 }
 
@@ -353,7 +360,12 @@ pub fn core_to_wit_attribute_type(t: &CoreAttributeType) -> wit::AttributeType {
             })
         }
         CoreAttributeType::Custom { base, .. } => core_to_wit_attribute_type(base),
-        CoreAttributeType::Union(_) => wit::AttributeType::StringType,
+        CoreAttributeType::Union(members) => {
+            let json_members: Vec<AttrTypeJson> =
+                members.iter().map(core_attr_type_to_json).collect();
+            let json = serde_json::to_string(&json_members).unwrap();
+            wit::AttributeType::UnionType(json)
+        }
     }
 }
 
@@ -390,6 +402,14 @@ pub fn wit_to_core_attribute_type(t: &wit::AttributeType) -> CoreAttributeType {
             CoreAttributeType::Struct {
                 name: struct_def.name.clone(),
                 fields: fields.iter().map(json_to_core_struct_field).collect(),
+            }
+        }
+        wit::AttributeType::UnionType(json) => {
+            if let Ok(members) = serde_json::from_str::<Vec<AttrTypeJson>>(json) {
+                CoreAttributeType::Union(members.iter().map(json_to_core_attr_type).collect())
+            } else {
+                // Fallback: single-member union of String
+                CoreAttributeType::Union(vec![CoreAttributeType::String])
             }
         }
     }
@@ -834,15 +854,53 @@ mod tests {
         assert!(matches!(wit, wit::AttributeType::StringType));
     }
 
-    // -- Union degrades to String --
+    // -- Union type roundtrip --
 
     #[test]
-    fn test_union_degrades_to_string() {
+    fn test_union_type_roundtrip() {
         let core_type =
             CoreAttributeType::Union(vec![CoreAttributeType::String, CoreAttributeType::Int]);
 
         let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::StringType));
+        assert!(matches!(wit, wit::AttributeType::UnionType(_)));
+
+        let back = wit_to_core_attribute_type(&wit);
+        if let CoreAttributeType::Union(members) = &back {
+            assert_eq!(members.len(), 2);
+            assert!(matches!(members[0], CoreAttributeType::String));
+            assert!(matches!(members[1], CoreAttributeType::Int));
+        } else {
+            panic!("Expected Union type, got {:?}", back);
+        }
+    }
+
+    #[test]
+    fn test_union_with_struct_roundtrip() {
+        // Simulates IAM principal: Union(Struct, String)
+        let struct_type = CoreAttributeType::Struct {
+            name: "Principal".into(),
+            fields: vec![CoreStructField {
+                name: "service".into(),
+                field_type: CoreAttributeType::String,
+                required: false,
+                description: None,
+                provider_name: None,
+                block_name: None,
+            }],
+        };
+        let core_type = CoreAttributeType::Union(vec![struct_type, CoreAttributeType::String]);
+
+        let wit = core_to_wit_attribute_type(&core_type);
+        assert!(matches!(wit, wit::AttributeType::UnionType(_)));
+
+        let back = wit_to_core_attribute_type(&wit);
+        if let CoreAttributeType::Union(members) = &back {
+            assert_eq!(members.len(), 2);
+            assert!(matches!(members[0], CoreAttributeType::Struct { .. }));
+            assert!(matches!(members[1], CoreAttributeType::String));
+        } else {
+            panic!("Expected Union type, got {:?}", back);
+        }
     }
 
     // -- Map type roundtrip --

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -78,6 +78,8 @@ pub enum AttrTypeJson {
         name: std::string::String,
         fields: Vec<StructFieldJson>,
     },
+    #[serde(rename = "union")]
+    Union { members: Vec<AttrTypeJson> },
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -117,7 +119,9 @@ pub fn proto_attr_type_to_json(t: &proto::AttributeType) -> AttrTypeJson {
                 })
                 .collect(),
         },
-        proto::AttributeType::Union { .. } => AttrTypeJson::String,
+        proto::AttributeType::Union { members } => AttrTypeJson::Union {
+            members: members.iter().map(proto_attr_type_to_json).collect(),
+        },
     }
 }
 
@@ -373,8 +377,11 @@ macro_rules! export_provider {
                             fields: serde_json::to_string(&fields_json).unwrap(),
                         })
                     }
-                    proto::AttributeType::Union { .. } => {
-                        wit_types::AttributeType::StringType
+                    proto::AttributeType::Union { members } => {
+                        let json_members: Vec<helpers::AttrTypeJson> =
+                            members.iter().map(helpers::proto_attr_type_to_json).collect();
+                        let json = serde_json::to_string(&json_members).unwrap();
+                        wit_types::AttributeType::UnionType(json)
                     }
                 }
             }
@@ -748,8 +755,11 @@ macro_rules! export_provider {
                             fields: serde_json::to_string(&fields_json).unwrap(),
                         })
                     }
-                    proto::AttributeType::Union { .. } => {
-                        wit_types::AttributeType::StringType
+                    proto::AttributeType::Union { members } => {
+                        let json_members: Vec<helpers::AttrTypeJson> =
+                            members.iter().map(helpers::proto_attr_type_to_json).collect();
+                        let json = serde_json::to_string(&json_members).unwrap();
+                        wit_types::AttributeType::UnionType(json)
                     }
                 }
             }

--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -71,6 +71,8 @@ interface types {
         /// JSON-encoded attribute-type for the value type
         map-type(string),
         struct-type(struct-def),
+        /// JSON-encoded list of member attribute-types
+        union-type(string),
     }
 
     record struct-def {


### PR DESCRIPTION
## Summary
- Add `union-type(string)` variant to WIT `attribute-type` in `types.wit`
- Update `wasm_convert.rs` to encode/decode Union members as JSON instead of degrading to `StringType`
- Update `wasm_guest.rs` (SDK) with matching Union support for provider-side encoding
- Add roundtrip tests for Union with simple types and Union with Struct (IAM principal case)

## Context
`AttributeType::Union` was degraded to `StringType` during WASM schema conversion, causing CLI-side validation to reject valid `.crn` files where a Union field (like IAM `principal`) accepts both String and Map/Struct values.

Error: `Struct field 'principal': Type mismatch: expected String, got Map`

The fix uses the same JSON-encoding pattern already used for `list-type` and `map-type` recursive types.

## Test plan
- [x] `cargo test -p carina-plugin-host` — all 33 tests pass (including 2 new Union roundtrip tests)
- [x] `cargo check -p carina-plugin-sdk` — compiles clean
- [ ] CI passes
- [ ] IAM role acceptance tests pass with WASM provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)