### PR TITLE
fix: update wasi interface versions in export_provider HTTP macro to @0.2.6

### DIFF
--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -151,12 +151,12 @@ macro_rules! export_provider {
                 path: "../carina-plugin-wit/wit",
                 world: "carina-provider-with-http",
                 with: {
-                    "wasi:io/poll@0.2.0": ::wasi::io::poll,
-                    "wasi:io/error@0.2.0": ::wasi::io::error,
-                    "wasi:io/streams@0.2.0": ::wasi::io::streams,
-                    "wasi:clocks/monotonic-clock@0.2.0": ::wasi::clocks::monotonic_clock,
-                    "wasi:http/types@0.2.0": ::wasi::http::types,
-                    "wasi:http/outgoing-handler@0.2.0": ::wasi::http::outgoing_handler,
+                    "wasi:io/poll@0.2.6": ::wasi::io::poll,
+                    "wasi:io/error@0.2.6": ::wasi::io::error,
+                    "wasi:io/streams@0.2.6": ::wasi::io::streams,
+                    "wasi:clocks/monotonic-clock@0.2.6": ::wasi::clocks::monotonic_clock,
+                    "wasi:http/types@0.2.6": ::wasi::http::types,
+                    "wasi:http/outgoing-handler@0.2.6": ::wasi::http::outgoing_handler,
                 },
             });
 


### PR DESCRIPTION
## Summary
- Update `with:` mappings in the `export_provider!` HTTP macro from `@0.2.0` to `@0.2.6` to match the WIT files updated in PR #1493
- Without this fix, provider WASM builds fail because the interface versions in the macro don't match the WIT definitions

## Test plan
- [ ] CI passes
- [ ] Provider repos can build WASM targets after picking up this change via `cargo update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)