### PR TITLE
fix: preserve block_name and add hydrate_read_state to WASM provider interface

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -919,4 +919,39 @@ mod tests {
             panic!("Expected Map type");
         }
     }
+
+    #[test]
+    fn test_struct_field_block_name_roundtrip() {
+        let core_type = CoreAttributeType::Struct {
+            name: "Transition".into(),
+            fields: vec![CoreStructField {
+                name: "transitions".into(),
+                field_type: CoreAttributeType::list(CoreAttributeType::Struct {
+                    name: "TransitionItem".into(),
+                    fields: vec![CoreStructField {
+                        name: "days".into(),
+                        field_type: CoreAttributeType::Int,
+                        required: true,
+                        description: None,
+                        provider_name: Some("Days".into()),
+                        block_name: None,
+                    }],
+                }),
+                required: false,
+                description: Some("Lifecycle transitions".into()),
+                provider_name: Some("Transitions".into()),
+                block_name: Some("transition".into()),
+            }],
+        };
+
+        let wit = core_to_wit_attribute_type(&core_type);
+        let back = wit_to_core_attribute_type(&wit);
+
+        if let CoreAttributeType::Struct { fields, .. } = &back {
+            assert_eq!(fields[0].block_name, Some("transition".into()));
+            assert_eq!(fields[0].provider_name, Some("Transitions".into()));
+        } else {
+            panic!("Expected Struct type");
+        }
+    }
 }

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -15,6 +15,7 @@ use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 
 use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
+    SavedAttrs,
 };
 use carina_core::resource::{
     Expr, LifecycleConfig, Resource, ResourceId, State, Value, contains_resource_ref,
@@ -240,6 +241,26 @@ impl WasmBindings {
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
                     .call_normalize_state(store, states)
+                    .await
+            }
+        }
+    }
+
+    async fn call_hydrate_read_state(
+        &self,
+        store: &mut Store<HostState>,
+        states: &[(String, wit_types::State)],
+        saved_attrs: &[(String, Vec<(String, wit_types::Value)>)],
+    ) -> wasmtime::Result<Vec<(String, wit_types::State)>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                b.carina_provider_provider()
+                    .call_hydrate_read_state(store, states, saved_attrs)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                b.carina_provider_provider()
+                    .call_hydrate_read_state(store, states, saved_attrs)
                     .await
             }
         }
@@ -835,6 +856,44 @@ impl ProviderNormalizer for WasmProviderNormalizer {
                 }
             }
             Err(e) => log::error!("WASM trap in normalize_state: {e}"),
+        }
+    }
+
+    fn hydrate_read_state(
+        &self,
+        current_states: &mut HashMap<ResourceId, State>,
+        saved_attrs: &SavedAttrs,
+    ) {
+        let wit_states: Vec<(String, _)> = current_states
+            .iter()
+            .map(|(id, state)| (id.to_string(), wasm_convert::core_to_wit_state(state)))
+            .collect();
+
+        let wit_saved: Vec<(String, Vec<(String, _)>)> = saved_attrs
+            .iter()
+            .map(|(id, attrs)| (id.to_string(), wasm_convert::core_to_wit_value_map(attrs)))
+            .collect();
+
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let mut store = self.store.lock().await;
+                self.bindings
+                    .call_hydrate_read_state(&mut store, &wit_states, &wit_saved)
+                    .await
+            })
+        });
+
+        match result {
+            Ok(result) => {
+                for state in current_states.values_mut() {
+                    let key = state.id.to_string();
+                    if let Some((_, wit_state)) = result.iter().find(|(k, _)| k == &key) {
+                        state.attributes =
+                            wasm_convert::wit_to_core_value_map(&wit_state.attributes);
+                    }
+                }
+            }
+            Err(e) => log::error!("WASM trap in hydrate_read_state: {e}"),
         }
     }
 }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -89,6 +89,10 @@ pub struct StructFieldJson {
     pub required: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<std::string::String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_name: Option<std::string::String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_name: Option<std::string::String>,
 }
 
 pub fn proto_attr_type_to_json(t: &proto::AttributeType) -> AttrTypeJson {
@@ -116,6 +120,8 @@ pub fn proto_attr_type_to_json(t: &proto::AttributeType) -> AttrTypeJson {
                     field_type: proto_attr_type_to_json(&f.field_type),
                     required: f.required,
                     description: f.description.clone(),
+                    provider_name: f.provider_name.clone(),
+                    block_name: f.block_name.clone(),
                 })
                 .collect(),
         },
@@ -370,6 +376,8 @@ macro_rules! export_provider {
                                 field_type: helpers::proto_attr_type_to_json(&f.field_type),
                                 required: f.required,
                                 description: f.description.clone(),
+                                provider_name: f.provider_name.clone(),
+                                block_name: f.block_name.clone(),
                             })
                             .collect();
                         wit_types::AttributeType::StructType(wit_types::StructDef {
@@ -517,6 +525,37 @@ macro_rules! export_provider {
                     let result =
                         $crate::CarinaProvider::normalize_state(&*provider, proto_states);
                     result
+                        .into_iter()
+                        .map(|(k, s)| (k, proto_to_wit_state(&s)))
+                        .collect()
+                }
+
+                fn hydrate_read_state(
+                    states: Vec<(String, wit_types::State)>,
+                    saved_attrs: Vec<(String, Vec<(String, wit_types::Value)>)>,
+                ) -> Vec<(String, wit_types::State)> {
+                    let provider = get_provider().lock().unwrap();
+                    let mut proto_states: HashMap<String, proto::State> = states
+                        .iter()
+                        .map(|(k, s)| {
+                            let dummy_id = proto::ResourceId {
+                                provider: String::new(),
+                                resource_type: String::new(),
+                                name: k.clone(),
+                            };
+                            (k.clone(), wit_to_proto_state(&dummy_id, s))
+                        })
+                        .collect();
+                    let proto_saved: HashMap<String, HashMap<String, proto::Value>> = saved_attrs
+                        .iter()
+                        .map(|(k, attrs)| (k.clone(), wit_to_proto_value_map(attrs)))
+                        .collect();
+                    $crate::CarinaProvider::hydrate_read_state(
+                        &*provider,
+                        &mut proto_states,
+                        &proto_saved,
+                    );
+                    proto_states
                         .into_iter()
                         .map(|(k, s)| (k, proto_to_wit_state(&s)))
                         .collect()
@@ -748,6 +787,8 @@ macro_rules! export_provider {
                                 field_type: helpers::proto_attr_type_to_json(&f.field_type),
                                 required: f.required,
                                 description: f.description.clone(),
+                                provider_name: f.provider_name.clone(),
+                                block_name: f.block_name.clone(),
                             })
                             .collect();
                         wit_types::AttributeType::StructType(wit_types::StructDef {
@@ -897,6 +938,37 @@ macro_rules! export_provider {
                     let result =
                         $crate::CarinaProvider::normalize_state(&*provider, proto_states);
                     result
+                        .into_iter()
+                        .map(|(k, s)| (k, proto_to_wit_state(&s)))
+                        .collect()
+                }
+
+                fn hydrate_read_state(
+                    states: Vec<(String, wit_types::State)>,
+                    saved_attrs: Vec<(String, Vec<(String, wit_types::Value)>)>,
+                ) -> Vec<(String, wit_types::State)> {
+                    let provider = get_provider().lock().unwrap();
+                    let mut proto_states: HashMap<String, proto::State> = states
+                        .iter()
+                        .map(|(k, s)| {
+                            let dummy_id = proto::ResourceId {
+                                provider: String::new(),
+                                resource_type: String::new(),
+                                name: k.clone(),
+                            };
+                            (k.clone(), wit_to_proto_state(&dummy_id, s))
+                        })
+                        .collect();
+                    let proto_saved: HashMap<String, HashMap<String, proto::Value>> = saved_attrs
+                        .iter()
+                        .map(|(k, attrs)| (k.clone(), wit_to_proto_value_map(attrs)))
+                        .collect();
+                    $crate::CarinaProvider::hydrate_read_state(
+                        &*provider,
+                        &mut proto_states,
+                        &proto_saved,
+                    );
+                    proto_states
                         .into_iter()
                         .map(|(k, s)| (k, proto_to_wit_state(&s)))
                         .collect()

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -34,4 +34,9 @@ interface provider {
     normalize-state: func(
         states: list<tuple<string, state>>,
     ) -> list<tuple<string, state>>;
+
+    hydrate-read-state: func(
+        states: list<tuple<string, state>>,
+        saved-attrs: list<tuple<string, list<tuple<string, value>>>>,
+    ) -> list<tuple<string, state>>;
 }


### PR DESCRIPTION
## Summary
- Add `provider_name` and `block_name` fields to `StructFieldJson` in SDK's `wasm_guest.rs` so these metadata fields survive the WASM roundtrip (previously lost during conversion)
- Add `hydrate-read-state` function to the WIT provider interface, with full wiring through `WasmBindings`, `WasmProviderNormalizer`, and both `export_provider!` macro variants
- Add roundtrip test for `block_name` through WIT struct field conversion

## Test plan
- [x] `cargo test -p carina-plugin-host` -- 34 tests pass including new `test_struct_field_block_name_roundtrip`
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` -- WASM build succeeds with new WIT interface
- [x] WASM integration tests pass (4 tests)

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)