### PR TITLE
fix: pass lifecycle config through WIT boundary

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -187,11 +187,11 @@ pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
 
 // -- LifecycleConfig --
 
-pub fn core_to_wit_lifecycle(_lifecycle: &CoreLifecycle) -> wit::LifecycleConfig {
-    // WIT LifecycleConfig only has prevent_destroy; core LifecycleConfig has
-    // force_delete and create_before_destroy. No direct mapping exists.
+pub fn core_to_wit_lifecycle(lifecycle: &CoreLifecycle) -> wit::LifecycleConfig {
     wit::LifecycleConfig {
         prevent_destroy: false,
+        force_delete: lifecycle.force_delete,
+        create_before_destroy: lifecycle.create_before_destroy,
     }
 }
 
@@ -921,6 +921,51 @@ mod tests {
     }
 
     #[test]
+    fn test_deeply_nested_list_map_roundtrip() {
+        // Simulates IAM role policies: List<Map<String, Map<String, List<Map>>>>
+        let policy_document = CoreValue::Map(
+            vec![
+                (
+                    "version".to_string(),
+                    CoreValue::String("2012-10-17".into()),
+                ),
+                (
+                    "statement".to_string(),
+                    CoreValue::List(vec![CoreValue::Map(
+                        vec![
+                            ("effect".to_string(), CoreValue::String("Allow".into())),
+                            (
+                                "action".to_string(),
+                                CoreValue::String("logs:CreateLogGroup".into()),
+                            ),
+                            ("resource".to_string(), CoreValue::String("*".into())),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    )]),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        let policies = CoreValue::List(vec![CoreValue::Map(
+            vec![
+                (
+                    "policy_name".to_string(),
+                    CoreValue::String("test-policy".into()),
+                ),
+                ("policy_document".to_string(), policy_document),
+            ]
+            .into_iter()
+            .collect(),
+        )]);
+
+        let wit = core_to_wit_value(&policies);
+        let back = wit_to_core_value(&wit);
+        assert_eq!(policies, back);
+    }
+
+    #[test]
     fn test_struct_field_block_name_roundtrip() {
         let core_type = CoreAttributeType::Struct {
             name: "Transition".into(),
@@ -953,5 +998,38 @@ mod tests {
         } else {
             panic!("Expected Struct type");
         }
+    }
+
+    // -- LifecycleConfig --
+
+    #[test]
+    fn test_lifecycle_force_delete_preserved() {
+        let core = CoreLifecycle {
+            force_delete: true,
+            create_before_destroy: false,
+        };
+        let wit = core_to_wit_lifecycle(&core);
+        assert!(wit.force_delete);
+        assert!(!wit.create_before_destroy);
+    }
+
+    #[test]
+    fn test_lifecycle_create_before_destroy_preserved() {
+        let core = CoreLifecycle {
+            force_delete: false,
+            create_before_destroy: true,
+        };
+        let wit = core_to_wit_lifecycle(&core);
+        assert!(!wit.force_delete);
+        assert!(wit.create_before_destroy);
+    }
+
+    #[test]
+    fn test_lifecycle_default_all_false() {
+        let core = CoreLifecycle::default();
+        let wit = core_to_wit_lifecycle(&core);
+        assert!(!wit.force_delete);
+        assert!(!wit.create_before_destroy);
+        assert!(!wit.prevent_destroy);
     }
 }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -325,9 +325,12 @@ macro_rules! export_provider {
             }
 
             fn wit_to_proto_lifecycle(
-                _lc: &wit_types::LifecycleConfig,
+                lc: &wit_types::LifecycleConfig,
             ) -> proto::LifecycleConfig {
-                proto::LifecycleConfig::default()
+                proto::LifecycleConfig {
+                    force_delete: lc.force_delete,
+                    create_before_destroy: lc.create_before_destroy,
+                }
             }
 
             fn proto_to_wit_provider_error(
@@ -728,9 +731,12 @@ macro_rules! export_provider {
             }
 
             fn wit_to_proto_lifecycle(
-                _lc: &wit_types::LifecycleConfig,
+                lc: &wit_types::LifecycleConfig,
             ) -> proto::LifecycleConfig {
-                proto::LifecycleConfig::default()
+                proto::LifecycleConfig {
+                    force_delete: lc.force_delete,
+                    create_before_destroy: lc.create_before_destroy,
+                }
             }
 
             fn proto_to_wit_provider_error(

--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -31,6 +31,8 @@ interface types {
 
     record lifecycle-config {
         prevent-destroy: bool,
+        force-delete: bool,
+        create-before-destroy: bool,
     }
 
     record provider-error {


### PR DESCRIPTION
## Summary
- Add `force-delete` and `create-before-destroy` fields to the WIT `lifecycle-config` record, which previously only had `prevent-destroy`
- Update host-side (`wasm_convert.rs`) and guest-side (`wasm_guest.rs`) lifecycle conversions to preserve these flags across the WASM boundary
- Add roundtrip tests for deeply nested `List<Map>` values and lifecycle config preservation

## Context

The WIT `lifecycle-config` type was missing `force-delete` and `create-before-destroy`, causing these flags to be silently dropped when crossing the WASM boundary. This directly caused the `ec2_flow_log/s3` acceptance test failure: the AWSCC provider never received the `force_delete` flag, so it couldn't empty the S3 bucket before deletion.

For the `iam_role/with_policy` and `ec2_ipam/basic` plan-verify failures, the WIT value roundtrip for nested `List<Map>` structures was verified to work correctly (new test confirms this). These failures likely require investigation in the AWSCC provider repo.

## Test plan
- [x] All existing unit tests pass (28 in carina-plugin-host, full workspace green)
- [x] New `test_deeply_nested_list_map_roundtrip` confirms WIT roundtrip for IAM role policy structure
- [x] New lifecycle tests confirm `force_delete` and `create_before_destroy` are preserved
- [ ] AWSCC provider needs to be rebuilt against updated WIT types
- [ ] Re-run acceptance tests after provider rebuild

Refs #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)