### PR TITLE
refactor: WIT transport layer - JSON passthrough for provider-specific types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ name = "carina-plugin-host"
 version = "0.1.0"
 dependencies = [
  "carina-core",
+ "carina-provider-protocol",
  "dirs",
  "log",
  "serde",

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -11,7 +11,7 @@ use carina_core::effect::Effect;
 use carina_core::parser::ProviderContext;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
@@ -521,7 +521,11 @@ async fn run_state_bucket_delete(
     let bucket_id =
         ResourceId::with_provider(backend_provider_name, backend_resource_type, bucket_name);
     match bucket_provider
-        .delete(&bucket_id, bucket_name, &LifecycleConfig::default())
+        .delete(
+            &bucket_id,
+            bucket_name,
+            &carina_core::resource::LifecycleConfig::default(),
+        )
         .await
     {
         Ok(()) => {

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1664,8 +1664,8 @@ async fn rename_failure_in_create_before_destroy_counts_as_failure() {
         from: Box::new(old_state.clone()),
         to: new_resource.clone(),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["bucket_name".to_string()],
         cascading_updates: vec![],
@@ -1772,8 +1772,8 @@ async fn update_effect_resolves_refs_against_post_replacement_binding_map() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc_unresolved.clone().with_binding("vpc"),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -55,8 +55,8 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -142,8 +142,8 @@ fn cascade_skips_resources_already_in_plan() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone(),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -293,8 +293,8 @@ fn cascade_transitive_dependencies() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone(),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -363,8 +363,8 @@ fn cascade_anonymous_resource_dependent() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone(),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -461,8 +461,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -617,8 +617,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],
@@ -857,8 +857,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
         from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
         to: vpc.clone().with_binding("vpc"),
         lifecycle: LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         },
         changed_create_only: vec!["cidr_block".to_string()],
         cascading_updates: vec![],

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -2926,9 +2926,11 @@ fn extract_lifecycle_config(attributes: &mut HashMap<String, Value>) -> Lifecycl
             let force_delete = matches!(map.get("force_delete"), Some(Value::Bool(true)));
             let create_before_destroy =
                 matches!(map.get("create_before_destroy"), Some(Value::Bool(true)));
+            let prevent_destroy = matches!(map.get("prevent_destroy"), Some(Value::Bool(true)));
             return LifecycleConfig {
                 force_delete,
                 create_before_destroy,
+                prevent_destroy,
             };
         }
     }
@@ -4760,6 +4762,7 @@ mod tests {
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.resources.len(), 1);
         assert!(!result.resources[0].lifecycle.force_delete);
+        assert!(!result.resources[0].lifecycle.prevent_destroy);
     }
 
     #[test]

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -688,7 +688,7 @@ mod tests {
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
         let id = ResourceId::with_provider("mock", "test", "example");
-        let lifecycle = LifecycleConfig::default();
+        let lifecycle = crate::resource::LifecycleConfig::default();
         let result = router.delete(&id, "mock-id-123", &lifecycle).await;
         assert!(result.is_ok());
     }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -704,12 +704,15 @@ fn similarity_score(a: &Value, b: &Value) -> usize {
 /// Lifecycle configuration for a resource
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct LifecycleConfig {
-    /// If true, force-delete the resource (e.g., empty S3 bucket before deletion)
+    /// If true, force-delete the resource (e.g., non-empty S3 buckets)
     #[serde(default)]
     pub force_delete: bool,
     /// If true, create the new resource before destroying the old one during replacement
     #[serde(default)]
     pub create_before_destroy: bool,
+    /// If true, prevent the resource from being destroyed
+    #[serde(default)]
+    pub prevent_destroy: bool,
 }
 
 /// Source of a resource (root or from a module)
@@ -1007,8 +1010,8 @@ mod tests {
     #[test]
     fn lifecycle_config_serde_with_create_before_destroy() {
         let config = LifecycleConfig {
-            force_delete: false,
             create_before_destroy: true,
+            ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: LifecycleConfig = serde_json::from_str(&json).unwrap();
@@ -1018,11 +1021,25 @@ mod tests {
 
     #[test]
     fn lifecycle_config_backward_compatible_deserialize() {
-        // Old JSON without create_before_destroy field should deserialize with default (false)
-        let json = r#"{"force_delete":true}"#;
+        // Old JSON without all fields should deserialize with defaults
+        let json = r#"{"create_before_destroy":true}"#;
         let config: LifecycleConfig = serde_json::from_str(json).unwrap();
-        assert!(config.force_delete);
-        assert!(!config.create_before_destroy);
+        assert!(config.create_before_destroy);
+        assert!(!config.force_delete);
+        assert!(!config.prevent_destroy);
+    }
+
+    #[test]
+    fn lifecycle_config_with_force_delete() {
+        let config = LifecycleConfig {
+            force_delete: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: LifecycleConfig = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.force_delete);
+        assert!(!deserialized.create_before_destroy);
+        assert!(!deserialized.prevent_destroy);
     }
 
     #[test]

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 carina-core = { path = "../carina-core" }
+carina-provider-protocol = { path = "../carina-provider-protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -3,13 +3,15 @@
 use std::collections::HashMap;
 
 use carina_core::resource::{
-    Expr, LifecycleConfig as CoreLifecycle, Resource as CoreResource, ResourceId as CoreResourceId,
+    Expr, LifecycleConfig, Resource as CoreResource, ResourceId as CoreResourceId,
     State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
     ResourceSchema as CoreResourceSchema, StructField as CoreStructField,
 };
+
+use carina_provider_protocol::types as proto;
 
 use crate::wasm_bindings::carina::provider::types as wit;
 
@@ -185,295 +187,121 @@ pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
     core_resource
 }
 
-// -- LifecycleConfig --
+// -- JSON passthrough functions for provider-specific types --
 
-pub fn core_to_wit_lifecycle(lifecycle: &CoreLifecycle) -> wit::LifecycleConfig {
-    wit::LifecycleConfig {
-        prevent_destroy: false,
-        force_delete: lifecycle.force_delete,
-        create_before_destroy: lifecycle.create_before_destroy,
-    }
+/// Serialize LifecycleConfig to JSON string for the WIT boundary.
+pub fn lifecycle_to_json(lifecycle: &LifecycleConfig) -> String {
+    serde_json::to_string(lifecycle).unwrap_or_else(|_| "{}".to_string())
 }
 
-// -- ProviderError --
-
-pub fn wit_to_core_provider_error(e: &wit::ProviderError) -> carina_core::provider::ProviderError {
-    carina_core::provider::ProviderError {
-        message: e.message.clone(),
-        resource_id: e.resource_id.as_ref().map(wit_to_core_resource_id),
-        cause: None,
-        is_timeout: e.is_timeout,
-    }
-}
-
-// -- AttributeType --
-
-/// JSON-serializable representation of an attribute type for WIT encoding.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type")]
-enum AttrTypeJson {
-    #[serde(rename = "string")]
-    String,
-    #[serde(rename = "int")]
-    Int,
-    #[serde(rename = "float")]
-    Float,
-    #[serde(rename = "bool")]
-    Bool,
-    #[serde(rename = "string-enum")]
-    StringEnum { values: Vec<String> },
-    #[serde(rename = "list")]
-    List {
-        inner: Box<AttrTypeJson>,
-        ordered: bool,
-    },
-    #[serde(rename = "map")]
-    Map { inner: Box<AttrTypeJson> },
-    #[serde(rename = "struct")]
-    Struct {
-        name: String,
-        fields: Vec<StructFieldJson>,
-    },
-    #[serde(rename = "union")]
-    Union { members: Vec<AttrTypeJson> },
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct StructFieldJson {
-    name: String,
-    field_type: AttrTypeJson,
-    required: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    provider_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    block_name: Option<String>,
-}
-
-fn core_attr_type_to_json(t: &CoreAttributeType) -> AttrTypeJson {
-    match t {
-        CoreAttributeType::String => AttrTypeJson::String,
-        CoreAttributeType::Int => AttrTypeJson::Int,
-        CoreAttributeType::Float => AttrTypeJson::Float,
-        CoreAttributeType::Bool => AttrTypeJson::Bool,
-        CoreAttributeType::StringEnum { values, .. } => AttrTypeJson::StringEnum {
-            values: values.clone(),
-        },
-        CoreAttributeType::List { inner, ordered } => AttrTypeJson::List {
-            inner: Box::new(core_attr_type_to_json(inner)),
-            ordered: *ordered,
-        },
-        CoreAttributeType::Map(inner) => AttrTypeJson::Map {
-            inner: Box::new(core_attr_type_to_json(inner)),
-        },
-        CoreAttributeType::Struct { name, fields } => AttrTypeJson::Struct {
-            name: name.clone(),
-            fields: fields.iter().map(core_struct_field_to_json).collect(),
-        },
-        CoreAttributeType::Custom { base, .. } => core_attr_type_to_json(base),
-        CoreAttributeType::Union(members) => AttrTypeJson::Union {
-            members: members.iter().map(core_attr_type_to_json).collect(),
-        },
-    }
-}
-
-fn json_to_core_attr_type(t: &AttrTypeJson) -> CoreAttributeType {
-    match t {
-        AttrTypeJson::String => CoreAttributeType::String,
-        AttrTypeJson::Int => CoreAttributeType::Int,
-        AttrTypeJson::Float => CoreAttributeType::Float,
-        AttrTypeJson::Bool => CoreAttributeType::Bool,
-        AttrTypeJson::StringEnum { values } => CoreAttributeType::StringEnum {
-            name: String::new(),
-            values: values.clone(),
-            namespace: None,
-            to_dsl: None,
-        },
-        AttrTypeJson::List { inner, ordered } => CoreAttributeType::List {
-            inner: Box::new(json_to_core_attr_type(inner)),
-            ordered: *ordered,
-        },
-        AttrTypeJson::Map { inner } => {
-            CoreAttributeType::Map(Box::new(json_to_core_attr_type(inner)))
+/// Deserialize a JSON error string to a core ProviderError.
+pub fn json_to_provider_error(json: &str) -> carina_core::provider::ProviderError {
+    if let Ok(proto_err) = serde_json::from_str::<proto::ProviderError>(json) {
+        carina_core::provider::ProviderError {
+            message: proto_err.message,
+            resource_id: proto_err.resource_id.map(|pid| {
+                CoreResourceId::with_provider(&pid.provider, &pid.resource_type, &pid.name)
+            }),
+            cause: None,
+            is_timeout: proto_err.is_timeout,
         }
-        AttrTypeJson::Struct { name, fields } => CoreAttributeType::Struct {
-            name: name.clone(),
-            fields: fields.iter().map(json_to_core_struct_field).collect(),
-        },
-        AttrTypeJson::Union { members } => {
-            CoreAttributeType::Union(members.iter().map(json_to_core_attr_type).collect())
+    } else {
+        carina_core::provider::ProviderError {
+            message: json.to_string(),
+            resource_id: None,
+            cause: None,
+            is_timeout: false,
         }
     }
 }
 
-fn core_struct_field_to_json(f: &CoreStructField) -> StructFieldJson {
-    StructFieldJson {
-        name: f.name.clone(),
-        field_type: core_attr_type_to_json(&f.field_type),
-        required: f.required,
-        description: f.description.clone(),
-        provider_name: f.provider_name.clone(),
-        block_name: f.block_name.clone(),
+/// Deserialize JSON to (name, display_name) tuple from ProviderInfo.
+pub fn json_to_provider_info(json: &str) -> (String, String) {
+    if let Ok(info) = serde_json::from_str::<proto::ProviderInfo>(json) {
+        (info.name, info.display_name)
+    } else {
+        ("unknown".to_string(), "Unknown Provider".to_string())
     }
 }
 
-fn json_to_core_struct_field(f: &StructFieldJson) -> CoreStructField {
-    CoreStructField {
-        name: f.name.clone(),
-        field_type: json_to_core_attr_type(&f.field_type),
-        required: f.required,
-        description: f.description.clone(),
-        provider_name: f.provider_name.clone(),
-        block_name: f.block_name.clone(),
-    }
+/// Deserialize JSON to a Vec of core ResourceSchemas.
+pub fn json_to_schemas(json: &str) -> Vec<CoreResourceSchema> {
+    let proto_schemas: Vec<proto::ResourceSchema> = serde_json::from_str(json).unwrap_or_default();
+    proto_schemas.iter().map(proto_schema_to_core).collect()
 }
 
-pub fn core_to_wit_attribute_type(t: &CoreAttributeType) -> wit::AttributeType {
-    match t {
-        CoreAttributeType::String => wit::AttributeType::StringType,
-        CoreAttributeType::Int => wit::AttributeType::IntType,
-        CoreAttributeType::Float => wit::AttributeType::FloatType,
-        CoreAttributeType::Bool => wit::AttributeType::BoolType,
-        CoreAttributeType::StringEnum { values, .. } => {
-            wit::AttributeType::StringEnum(values.clone())
-        }
-        CoreAttributeType::List { inner, ordered } => {
-            let json = AttrTypeJson::List {
-                inner: Box::new(core_attr_type_to_json(inner)),
-                ordered: *ordered,
-            };
-            wit::AttributeType::ListType(serde_json::to_string(&json).unwrap())
-        }
-        CoreAttributeType::Map(inner) => {
-            let json = AttrTypeJson::Map {
-                inner: Box::new(core_attr_type_to_json(inner)),
-            };
-            wit::AttributeType::MapType(serde_json::to_string(&json).unwrap())
-        }
-        CoreAttributeType::Struct { name, fields } => {
-            let fields_json: Vec<StructFieldJson> =
-                fields.iter().map(core_struct_field_to_json).collect();
-            wit::AttributeType::StructType(wit::StructDef {
-                name: name.clone(),
-                fields: serde_json::to_string(&fields_json).unwrap(),
-            })
-        }
-        CoreAttributeType::Custom { base, .. } => core_to_wit_attribute_type(base),
-        CoreAttributeType::Union(members) => {
-            let json_members: Vec<AttrTypeJson> =
-                members.iter().map(core_attr_type_to_json).collect();
-            let json = serde_json::to_string(&json_members).unwrap();
-            wit::AttributeType::UnionType(json)
-        }
-    }
-}
+// -- Protocol schema to core schema conversion --
 
-pub fn wit_to_core_attribute_type(t: &wit::AttributeType) -> CoreAttributeType {
-    match t {
-        wit::AttributeType::StringType => CoreAttributeType::String,
-        wit::AttributeType::IntType => CoreAttributeType::Int,
-        wit::AttributeType::FloatType => CoreAttributeType::Float,
-        wit::AttributeType::BoolType => CoreAttributeType::Bool,
-        wit::AttributeType::StringEnum(values) => CoreAttributeType::StringEnum {
-            name: String::new(),
-            values: values.clone(),
-            namespace: None,
-            to_dsl: None,
-        },
-        wit::AttributeType::ListType(json) => {
-            if let Ok(attr_json) = serde_json::from_str::<AttrTypeJson>(json) {
-                json_to_core_attr_type(&attr_json)
-            } else {
-                // Fallback: treat the JSON string as the inner type descriptor
-                CoreAttributeType::list(CoreAttributeType::String)
-            }
-        }
-        wit::AttributeType::MapType(json) => {
-            if let Ok(attr_json) = serde_json::from_str::<AttrTypeJson>(json) {
-                json_to_core_attr_type(&attr_json)
-            } else {
-                CoreAttributeType::Map(Box::new(CoreAttributeType::String))
-            }
-        }
-        wit::AttributeType::StructType(struct_def) => {
-            let fields: Vec<StructFieldJson> =
-                serde_json::from_str(&struct_def.fields).unwrap_or_default();
-            CoreAttributeType::Struct {
-                name: struct_def.name.clone(),
-                fields: fields.iter().map(json_to_core_struct_field).collect(),
-            }
-        }
-        wit::AttributeType::UnionType(json) => {
-            if let Ok(members) = serde_json::from_str::<Vec<AttrTypeJson>>(json) {
-                CoreAttributeType::Union(members.iter().map(json_to_core_attr_type).collect())
-            } else {
-                // Fallback: single-member union of String
-                CoreAttributeType::Union(vec![CoreAttributeType::String])
-            }
-        }
-    }
-}
-
-// -- Schema --
-
-fn core_to_wit_attribute_schema(a: &CoreAttributeSchema) -> wit::AttributeSchema {
-    wit::AttributeSchema {
-        name: a.name.clone(),
-        attr_type: core_to_wit_attribute_type(&a.attr_type),
-        required: a.required,
-        description: a.description.clone(),
-        create_only: a.create_only,
-        read_only: a.read_only,
-        write_only: a.write_only,
-    }
-}
-
-fn wit_to_core_attribute_schema(a: &wit::AttributeSchema) -> CoreAttributeSchema {
-    CoreAttributeSchema {
-        name: a.name.clone(),
-        attr_type: wit_to_core_attribute_type(&a.attr_type),
-        required: a.required,
-        default: None,
-        description: a.description.clone(),
-        completions: None,
-        provider_name: None,
-        create_only: a.create_only,
-        read_only: a.read_only,
-        removable: None,
-        block_name: None,
-        write_only: a.write_only,
-    }
-}
-
-pub fn core_to_wit_schema(s: &CoreResourceSchema) -> wit::ResourceSchema {
-    wit::ResourceSchema {
-        resource_type: s.resource_type.clone(),
-        attributes: s
-            .attributes
-            .values()
-            .map(core_to_wit_attribute_schema)
-            .collect(),
-        description: s.description.clone(),
-        data_source: s.data_source,
-        name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
-    }
-}
-
-pub fn wit_to_core_schema(s: &wit::ResourceSchema) -> CoreResourceSchema {
+fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
     CoreResourceSchema {
         resource_type: s.resource_type.clone(),
         attributes: s
             .attributes
             .iter()
-            .map(|a| (a.name.clone(), wit_to_core_attribute_schema(a)))
+            .map(|(name, a)| (name.clone(), proto_attr_schema_to_core(a)))
             .collect(),
         description: s.description.clone(),
         validator: None,
         data_source: s.data_source,
         name_attribute: s.name_attribute.clone(),
         force_replace: s.force_replace,
+    }
+}
+
+fn proto_attr_schema_to_core(a: &proto::AttributeSchema) -> CoreAttributeSchema {
+    CoreAttributeSchema {
+        name: a.name.clone(),
+        attr_type: proto_attr_type_to_core(&a.attr_type),
+        required: a.required,
+        default: None,
+        description: a.description.clone(),
+        completions: None,
+        provider_name: a.provider_name.clone(),
+        create_only: a.create_only,
+        read_only: a.read_only,
+        removable: a.removable,
+        block_name: a.block_name.clone(),
+        write_only: a.write_only,
+    }
+}
+
+fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
+    match t {
+        proto::AttributeType::String => CoreAttributeType::String,
+        proto::AttributeType::Int => CoreAttributeType::Int,
+        proto::AttributeType::Float => CoreAttributeType::Float,
+        proto::AttributeType::Bool => CoreAttributeType::Bool,
+        proto::AttributeType::StringEnum { values } => CoreAttributeType::StringEnum {
+            name: String::new(),
+            values: values.clone(),
+            namespace: None,
+            to_dsl: None,
+        },
+        proto::AttributeType::List { inner, ordered } => CoreAttributeType::List {
+            inner: Box::new(proto_attr_type_to_core(inner)),
+            ordered: *ordered,
+        },
+        proto::AttributeType::Map { inner } => {
+            CoreAttributeType::Map(Box::new(proto_attr_type_to_core(inner)))
+        }
+        proto::AttributeType::Struct { name, fields } => CoreAttributeType::Struct {
+            name: name.clone(),
+            fields: fields.iter().map(proto_struct_field_to_core).collect(),
+        },
+        proto::AttributeType::Union { members } => {
+            CoreAttributeType::Union(members.iter().map(proto_attr_type_to_core).collect())
+        }
+    }
+}
+
+fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
+    CoreStructField {
+        name: f.name.clone(),
+        field_type: proto_attr_type_to_core(&f.field_type),
+        required: f.required,
+        description: f.description.clone(),
+        provider_name: f.provider_name.clone(),
+        block_name: f.block_name.clone(),
     }
 }
 
@@ -664,265 +492,222 @@ mod tests {
         assert_eq!(back.resolved_attributes(), resource.resolved_attributes());
     }
 
-    // -- Schema with basic string attribute --
+    // -- JSON passthrough tests --
 
     #[test]
-    fn test_schema_basic_string_roundtrip() {
-        let core_schema = CoreResourceSchema {
-            resource_type: "ec2.vpc".into(),
-            attributes: HashMap::from([(
-                "cidr_block".into(),
-                CoreAttributeSchema {
-                    name: "cidr_block".into(),
-                    attr_type: CoreAttributeType::String,
-                    required: true,
-                    default: None,
-                    description: Some("CIDR block".into()),
-                    completions: None,
-                    provider_name: None,
-                    create_only: true,
-                    read_only: false,
-                    removable: None,
-                    block_name: None,
-                    write_only: false,
+    fn test_lifecycle_to_json() {
+        let lifecycle = LifecycleConfig {
+            force_delete: true,
+            create_before_destroy: false,
+            prevent_destroy: false,
+        };
+        let json = lifecycle_to_json(&lifecycle);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["force_delete"], true);
+        assert_eq!(parsed["create_before_destroy"], false);
+        assert_eq!(parsed["prevent_destroy"], false);
+    }
+
+    #[test]
+    fn test_json_to_provider_error_valid() {
+        let json = r#"{"message":"something failed","resource_id":{"provider":"aws","resource_type":"s3.bucket","name":"test"},"is_timeout":true}"#;
+        let err = json_to_provider_error(json);
+        assert_eq!(err.message, "something failed");
+        assert!(err.is_timeout);
+        assert_eq!(err.resource_id.as_ref().unwrap().provider, "aws");
+    }
+
+    #[test]
+    fn test_json_to_provider_error_plain_string() {
+        let err = json_to_provider_error("some error message");
+        assert_eq!(err.message, "some error message");
+        assert!(!err.is_timeout);
+        assert!(err.resource_id.is_none());
+    }
+
+    #[test]
+    fn test_json_to_provider_info_valid() {
+        let json = r#"{"name":"aws","display_name":"AWS Provider"}"#;
+        let (name, display) = json_to_provider_info(json);
+        assert_eq!(name, "aws");
+        assert_eq!(display, "AWS Provider");
+    }
+
+    #[test]
+    fn test_json_to_schemas_empty() {
+        let schemas = json_to_schemas("[]");
+        assert!(schemas.is_empty());
+    }
+
+    #[test]
+    fn test_json_to_schemas_with_complex_attributes() {
+        let json = r#"[
+          {
+            "resource_type": "ec2.security_group",
+            "description": "EC2 Security Group",
+            "data_source": false,
+            "name_attribute": "group_name",
+            "force_replace": true,
+            "attributes": {
+              "ingress": {
+                "name": "ingress",
+                "attr_type": {
+                  "type": "list",
+                  "inner": {
+                    "type": "union",
+                    "members": [
+                      {
+                        "type": "struct",
+                        "name": "IngressRule",
+                        "fields": [
+                          {
+                            "name": "from_port",
+                            "field_type": { "type": "Int" },
+                            "required": true,
+                            "description": "Start of port range",
+                            "block_name": "from_port_block",
+                            "provider_name": "FromPort"
+                          },
+                          {
+                            "name": "protocol",
+                            "field_type": { "type": "String" },
+                            "required": true,
+                            "description": null,
+                            "block_name": null,
+                            "provider_name": null
+                          }
+                        ]
+                      },
+                      { "type": "String" }
+                    ]
+                  },
+                  "ordered": false
                 },
-            )]),
-            description: Some("VPC".into()),
-            validator: None,
-            data_source: false,
-            name_attribute: None,
-            force_replace: false,
-        };
+                "required": false,
+                "description": "Ingress rules",
+                "create_only": false,
+                "read_only": false,
+                "write_only": false,
+                "block_name": "ingress_block",
+                "provider_name": "IpPermissions",
+                "removable": false
+              },
+              "description": {
+                "name": "description",
+                "attr_type": { "type": "String" },
+                "required": true,
+                "description": "Group description",
+                "create_only": false,
+                "read_only": false,
+                "write_only": false
+              },
+              "enabled": {
+                "name": "enabled",
+                "attr_type": { "type": "Bool" },
+                "required": false,
+                "description": null,
+                "create_only": false,
+                "read_only": false,
+                "write_only": false
+              },
+              "priority": {
+                "name": "priority",
+                "attr_type": { "type": "Int" },
+                "required": false,
+                "description": null,
+                "create_only": false,
+                "read_only": false,
+                "write_only": false
+              }
+            }
+          }
+        ]"#;
 
-        let wit = core_to_wit_schema(&core_schema);
-        assert_eq!(wit.resource_type, "ec2.vpc");
-        assert_eq!(wit.attributes.len(), 1);
+        let schemas = json_to_schemas(json);
+        assert_eq!(schemas.len(), 1);
 
-        let back = wit_to_core_schema(&wit);
-        assert_eq!(back.resource_type, "ec2.vpc");
-        let attr = &back.attributes["cidr_block"];
-        assert_eq!(attr.name, "cidr_block");
-        assert!(attr.required);
-        assert!(attr.create_only);
-        assert_eq!(attr.description, Some("CIDR block".into()));
-    }
+        let schema = &schemas[0];
+        assert_eq!(schema.resource_type, "ec2.security_group");
+        assert_eq!(schema.description.as_deref(), Some("EC2 Security Group"));
+        assert!(!schema.data_source);
+        assert_eq!(schema.name_attribute.as_deref(), Some("group_name"));
+        assert!(schema.force_replace);
 
-    // -- Schema with enum attribute --
+        // Basic attribute types
+        let desc_attr = schema
+            .attributes
+            .get("description")
+            .expect("description attribute");
+        assert_eq!(desc_attr.name, "description");
+        assert!(matches!(desc_attr.attr_type, CoreAttributeType::String));
+        assert!(desc_attr.required);
 
-    #[test]
-    fn test_schema_enum_roundtrip() {
-        let core_type = CoreAttributeType::StringEnum {
-            name: "VersioningStatus".into(),
-            values: vec!["Enabled".into(), "Suspended".into()],
-            namespace: Some("aws.s3".into()),
-            to_dsl: None,
-        };
+        let enabled_attr = schema.attributes.get("enabled").expect("enabled attribute");
+        assert!(matches!(enabled_attr.attr_type, CoreAttributeType::Bool));
 
-        let wit = core_to_wit_attribute_type(&core_type);
-        if let wit::AttributeType::StringEnum(values) = &wit {
-            assert_eq!(values, &["Enabled", "Suspended"]);
-        } else {
-            panic!("Expected StringEnum");
-        }
+        let priority_attr = schema
+            .attributes
+            .get("priority")
+            .expect("priority attribute");
+        assert!(matches!(priority_attr.attr_type, CoreAttributeType::Int));
 
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::StringEnum { values, .. } = &back {
-            assert_eq!(values, &["Enabled", "Suspended"]);
-        } else {
-            panic!("Expected StringEnum");
-        }
-    }
+        // Ingress attribute: list with ordered=false, provider_name, block_name, removable
+        let ingress_attr = schema.attributes.get("ingress").expect("ingress attribute");
+        assert_eq!(ingress_attr.provider_name.as_deref(), Some("IpPermissions"));
+        assert_eq!(ingress_attr.block_name.as_deref(), Some("ingress_block"));
+        assert_eq!(ingress_attr.removable, Some(false));
 
-    // -- Schema with list attribute type --
+        // List with ordered: false
+        match &ingress_attr.attr_type {
+            CoreAttributeType::List { inner, ordered } => {
+                assert!(!ordered, "list should be unordered");
 
-    #[test]
-    fn test_schema_list_type_roundtrip() {
-        let core_type = CoreAttributeType::List {
-            inner: Box::new(CoreAttributeType::String),
-            ordered: true,
-        };
+                // Union inside list
+                match inner.as_ref() {
+                    CoreAttributeType::Union(members) => {
+                        assert_eq!(members.len(), 2);
 
-        let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::ListType(_)));
+                        // First member: struct with block_name and provider_name on fields
+                        match &members[0] {
+                            CoreAttributeType::Struct { name, fields } => {
+                                assert_eq!(name, "IngressRule");
+                                assert_eq!(fields.len(), 2);
 
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::List { inner, ordered } = &back {
-            assert!(matches!(inner.as_ref(), CoreAttributeType::String));
-            assert!(*ordered);
-        } else {
-            panic!("Expected List type");
-        }
-    }
+                                let from_port = &fields[0];
+                                assert_eq!(from_port.name, "from_port");
+                                assert!(matches!(from_port.field_type, CoreAttributeType::Int));
+                                assert!(from_port.required);
+                                assert_eq!(
+                                    from_port.description.as_deref(),
+                                    Some("Start of port range")
+                                );
+                                assert_eq!(
+                                    from_port.block_name.as_deref(),
+                                    Some("from_port_block")
+                                );
+                                assert_eq!(from_port.provider_name.as_deref(), Some("FromPort"));
 
-    #[test]
-    fn test_schema_unordered_list_roundtrip() {
-        let core_type = CoreAttributeType::List {
-            inner: Box::new(CoreAttributeType::Int),
-            ordered: false,
-        };
+                                let protocol = &fields[1];
+                                assert_eq!(protocol.name, "protocol");
+                                assert!(matches!(protocol.field_type, CoreAttributeType::String));
+                                assert!(protocol.block_name.is_none());
+                                assert!(protocol.provider_name.is_none());
+                            }
+                            other => panic!("expected Struct, got {:?}", other),
+                        }
 
-        let wit = core_to_wit_attribute_type(&core_type);
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::List { ordered, .. } = &back {
-            assert!(!ordered, "ordered=false must survive roundtrip");
-        } else {
-            panic!("Expected List type");
-        }
-    }
-
-    // -- Schema with struct attribute type --
-
-    #[test]
-    fn test_schema_struct_type_roundtrip() {
-        let core_type = CoreAttributeType::Struct {
-            name: "Tag".into(),
-            fields: vec![
-                CoreStructField {
-                    name: "key".into(),
-                    field_type: CoreAttributeType::String,
-                    required: true,
-                    description: Some("Tag key".into()),
-                    provider_name: Some("Key".into()),
-                    block_name: None,
-                },
-                CoreStructField {
-                    name: "value".into(),
-                    field_type: CoreAttributeType::String,
-                    required: false,
-                    description: None,
-                    provider_name: Some("Value".into()),
-                    block_name: None,
-                },
-            ],
-        };
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        if let wit::AttributeType::StructType(struct_def) = &wit {
-            assert_eq!(struct_def.name, "Tag");
-        } else {
-            panic!("Expected StructType");
-        }
-
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::Struct { name, fields } = &back {
-            assert_eq!(name, "Tag");
-            assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].name, "key");
-            assert!(fields[0].required);
-            assert_eq!(fields[0].description, Some("Tag key".into()));
-            assert_eq!(fields[0].provider_name, Some("Key".into()));
-            assert_eq!(fields[1].name, "value");
-            assert!(!fields[1].required);
-        } else {
-            panic!("Expected Struct type");
-        }
-    }
-
-    // -- ProviderError conversion --
-
-    #[test]
-    fn test_provider_error_conversion() {
-        let wit_err = wit::ProviderError {
-            message: "something failed".into(),
-            resource_id: Some(wit::ResourceId {
-                provider: "aws".into(),
-                resource_type: "s3.bucket".into(),
-                name: "test".into(),
-            }),
-            is_timeout: true,
-        };
-
-        let core_err = wit_to_core_provider_error(&wit_err);
-        assert_eq!(core_err.message, "something failed");
-        assert!(core_err.is_timeout);
-        assert_eq!(core_err.resource_id.as_ref().unwrap().provider, "aws");
-    }
-
-    // -- Custom type degrades to base --
-
-    #[test]
-    fn test_custom_type_degrades_to_base() {
-        let core_type = CoreAttributeType::Custom {
-            name: "Region".into(),
-            base: Box::new(CoreAttributeType::String),
-            validate: |_| Ok(()),
-            namespace: None,
-            to_dsl: None,
-        };
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::StringType));
-    }
-
-    // -- Union type roundtrip --
-
-    #[test]
-    fn test_union_type_roundtrip() {
-        let core_type =
-            CoreAttributeType::Union(vec![CoreAttributeType::String, CoreAttributeType::Int]);
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::UnionType(_)));
-
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::Union(members) = &back {
-            assert_eq!(members.len(), 2);
-            assert!(matches!(members[0], CoreAttributeType::String));
-            assert!(matches!(members[1], CoreAttributeType::Int));
-        } else {
-            panic!("Expected Union type, got {:?}", back);
-        }
-    }
-
-    #[test]
-    fn test_union_with_struct_roundtrip() {
-        // Simulates IAM principal: Union(Struct, String)
-        let struct_type = CoreAttributeType::Struct {
-            name: "Principal".into(),
-            fields: vec![CoreStructField {
-                name: "service".into(),
-                field_type: CoreAttributeType::String,
-                required: false,
-                description: None,
-                provider_name: None,
-                block_name: None,
-            }],
-        };
-        let core_type = CoreAttributeType::Union(vec![struct_type, CoreAttributeType::String]);
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::UnionType(_)));
-
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::Union(members) = &back {
-            assert_eq!(members.len(), 2);
-            assert!(matches!(members[0], CoreAttributeType::Struct { .. }));
-            assert!(matches!(members[1], CoreAttributeType::String));
-        } else {
-            panic!("Expected Union type, got {:?}", back);
-        }
-    }
-
-    // -- Map type roundtrip --
-
-    #[test]
-    fn test_schema_map_type_roundtrip() {
-        let core_type = CoreAttributeType::Map(Box::new(CoreAttributeType::String));
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        assert!(matches!(wit, wit::AttributeType::MapType(_)));
-
-        let back = wit_to_core_attribute_type(&wit);
-        if let CoreAttributeType::Map(inner) = &back {
-            assert!(matches!(inner.as_ref(), CoreAttributeType::String));
-        } else {
-            panic!("Expected Map type");
+                        // Second member: String
+                        assert!(matches!(members[1], CoreAttributeType::String));
+                    }
+                    other => panic!("expected Union inside list, got {:?}", other),
+                }
+            }
+            other => panic!("expected List, got {:?}", other),
         }
     }
 
     #[test]
     fn test_deeply_nested_list_map_roundtrip() {
-        // Simulates IAM role policies: List<Map<String, Map<String, List<Map>>>>
         let policy_document = CoreValue::Map(
             vec![
                 (
@@ -963,73 +748,5 @@ mod tests {
         let wit = core_to_wit_value(&policies);
         let back = wit_to_core_value(&wit);
         assert_eq!(policies, back);
-    }
-
-    #[test]
-    fn test_struct_field_block_name_roundtrip() {
-        let core_type = CoreAttributeType::Struct {
-            name: "Transition".into(),
-            fields: vec![CoreStructField {
-                name: "transitions".into(),
-                field_type: CoreAttributeType::list(CoreAttributeType::Struct {
-                    name: "TransitionItem".into(),
-                    fields: vec![CoreStructField {
-                        name: "days".into(),
-                        field_type: CoreAttributeType::Int,
-                        required: true,
-                        description: None,
-                        provider_name: Some("Days".into()),
-                        block_name: None,
-                    }],
-                }),
-                required: false,
-                description: Some("Lifecycle transitions".into()),
-                provider_name: Some("Transitions".into()),
-                block_name: Some("transition".into()),
-            }],
-        };
-
-        let wit = core_to_wit_attribute_type(&core_type);
-        let back = wit_to_core_attribute_type(&wit);
-
-        if let CoreAttributeType::Struct { fields, .. } = &back {
-            assert_eq!(fields[0].block_name, Some("transition".into()));
-            assert_eq!(fields[0].provider_name, Some("Transitions".into()));
-        } else {
-            panic!("Expected Struct type");
-        }
-    }
-
-    // -- LifecycleConfig --
-
-    #[test]
-    fn test_lifecycle_force_delete_preserved() {
-        let core = CoreLifecycle {
-            force_delete: true,
-            create_before_destroy: false,
-        };
-        let wit = core_to_wit_lifecycle(&core);
-        assert!(wit.force_delete);
-        assert!(!wit.create_before_destroy);
-    }
-
-    #[test]
-    fn test_lifecycle_create_before_destroy_preserved() {
-        let core = CoreLifecycle {
-            force_delete: false,
-            create_before_destroy: true,
-        };
-        let wit = core_to_wit_lifecycle(&core);
-        assert!(!wit.force_delete);
-        assert!(wit.create_before_destroy);
-    }
-
-    #[test]
-    fn test_lifecycle_default_all_false() {
-        let core = CoreLifecycle::default();
-        let wit = core_to_wit_lifecycle(&core);
-        assert!(!wit.force_delete);
-        assert!(!wit.create_before_destroy);
-        assert!(!wit.prevent_destroy);
     }
 }

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -68,20 +68,14 @@ enum WasmBindings {
 use crate::wasm_bindings::carina::provider::types as wit_types;
 
 impl WasmBindings {
-    async fn call_info(
-        &self,
-        store: &mut Store<HostState>,
-    ) -> wasmtime::Result<wit_types::ProviderInfo> {
+    async fn call_info(&self, store: &mut Store<HostState>) -> wasmtime::Result<String> {
         match self {
             WasmBindings::Basic(b) => b.carina_provider_provider().call_info(store).await,
             WasmBindings::Http(b) => b.carina_provider_provider().call_info(store).await,
         }
     }
 
-    async fn call_schemas(
-        &self,
-        store: &mut Store<HostState>,
-    ) -> wasmtime::Result<Vec<wit_types::ResourceSchema>> {
+    async fn call_schemas(&self, store: &mut Store<HostState>) -> wasmtime::Result<String> {
         match self {
             WasmBindings::Basic(b) => b.carina_provider_provider().call_schemas(store).await,
             WasmBindings::Http(b) => b.carina_provider_provider().call_schemas(store).await,
@@ -131,7 +125,7 @@ impl WasmBindings {
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
         identifier: Option<&str>,
-    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
+    ) -> wasmtime::Result<Result<wit_types::State, String>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -150,7 +144,7 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         resource: &wit_types::ResourceDef,
-    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
+    ) -> wasmtime::Result<Result<wit_types::State, String>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -172,7 +166,7 @@ impl WasmBindings {
         identifier: &str,
         from: &wit_types::State,
         to: &wit_types::ResourceDef,
-    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
+    ) -> wasmtime::Result<Result<wit_types::State, String>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -192,17 +186,17 @@ impl WasmBindings {
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
         identifier: &str,
-        lifecycle: wit_types::LifecycleConfig,
-    ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
+        options: &str,
+    ) -> wasmtime::Result<Result<(), String>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_delete(store, id, identifier, lifecycle)
+                    .call_delete(store, id, identifier, options)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_delete(store, id, identifier, lifecycle)
+                    .call_delete(store, id, identifier, options)
                     .await
             }
         }
@@ -439,23 +433,21 @@ impl WasmProviderFactory {
                     (store, bindings, false)
                 }
             };
-        let info = bindings
+        let info_json = bindings
             .call_info(&mut store)
             .await
             .map_err(|e| format!("Failed to call info(): {e}"))?;
 
-        let wit_schemas = bindings
+        let schemas_json = bindings
             .call_schemas(&mut store)
             .await
             .map_err(|e| format!("Failed to call schemas(): {e}"))?;
 
-        let schemas: Vec<ResourceSchema> = wit_schemas
-            .iter()
-            .map(wasm_convert::wit_to_core_schema)
-            .collect();
+        let (name, display_name) = wasm_convert::json_to_provider_info(&info_json);
+        let schemas: Vec<ResourceSchema> = wasm_convert::json_to_schemas(&schemas_json);
 
-        let name_static: &'static str = Box::leak(info.name.into_boxed_str());
-        let display_name_static: &'static str = Box::leak(info.display_name.into_boxed_str());
+        let name_static: &'static str = Box::leak(name.into_boxed_str());
+        let display_name_static: &'static str = Box::leak(display_name.into_boxed_str());
 
         // Drop the temporary instance
         drop(store);
@@ -531,23 +523,21 @@ impl WasmProviderFactory {
                     (store, bindings, false)
                 }
             };
-        let info = bindings
+        let info_json = bindings
             .call_info(&mut store)
             .await
             .map_err(|e| format!("Failed to call info(): {e}"))?;
 
-        let wit_schemas = bindings
+        let schemas_json = bindings
             .call_schemas(&mut store)
             .await
             .map_err(|e| format!("Failed to call schemas(): {e}"))?;
 
-        let schemas: Vec<ResourceSchema> = wit_schemas
-            .iter()
-            .map(wasm_convert::wit_to_core_schema)
-            .collect();
+        let (name, display_name) = wasm_convert::json_to_provider_info(&info_json);
+        let schemas: Vec<ResourceSchema> = wasm_convert::json_to_schemas(&schemas_json);
 
-        let name_static: &'static str = Box::leak(info.name.into_boxed_str());
-        let display_name_static: &'static str = Box::leak(info.display_name.into_boxed_str());
+        let name_static: &'static str = Box::leak(name.into_boxed_str());
+        let display_name_static: &'static str = Box::leak(display_name.into_boxed_str());
 
         drop(store);
 
@@ -708,7 +698,7 @@ impl Provider for WasmProvider {
                 .map_err(|e| ProviderError::new(format!("WASM trap in read: {e}")))?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(&wit_err)),
+                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
             }
         })
     }
@@ -725,7 +715,7 @@ impl Provider for WasmProvider {
                 .map_err(|e| ProviderError::new(format!("WASM trap in create: {e}")))?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(&wit_err)),
+                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
             }
         })
     }
@@ -751,7 +741,7 @@ impl Provider for WasmProvider {
                 .map_err(|e| ProviderError::new(format!("WASM trap in update: {e}")))?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(&wit_err)),
+                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
             }
         })
     }
@@ -764,17 +754,17 @@ impl Provider for WasmProvider {
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
         let identifier = identifier.to_string();
-        let wit_lifecycle = wasm_convert::core_to_wit_lifecycle(lifecycle);
+        let options_json = wasm_convert::lifecycle_to_json(lifecycle);
         Box::pin(async move {
             let mut store = self.store.lock().await;
             let result = self
                 .bindings
-                .call_delete(&mut store, &wit_id, &identifier, wit_lifecycle)
+                .call_delete(&mut store, &wit_id, &identifier, &options_json)
                 .await
                 .map_err(|e| ProviderError::new(format!("WASM trap in delete: {e}")))?;
             match result {
                 Ok(()) => Ok(()),
-                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(&wit_err)),
+                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
             }
         })
     }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -52,85 +52,6 @@ pub fn proto_value_to_json(v: &proto::Value) -> serde_json::Value {
     }
 }
 
-/// JSON-serializable representation for encoding recursive attribute types.
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type")]
-pub enum AttrTypeJson {
-    #[serde(rename = "string")]
-    String,
-    #[serde(rename = "int")]
-    Int,
-    #[serde(rename = "float")]
-    Float,
-    #[serde(rename = "bool")]
-    Bool,
-    #[serde(rename = "string-enum")]
-    StringEnum { values: Vec<std::string::String> },
-    #[serde(rename = "list")]
-    List {
-        inner: Box<AttrTypeJson>,
-        ordered: bool,
-    },
-    #[serde(rename = "map")]
-    Map { inner: Box<AttrTypeJson> },
-    #[serde(rename = "struct")]
-    Struct {
-        name: std::string::String,
-        fields: Vec<StructFieldJson>,
-    },
-    #[serde(rename = "union")]
-    Union { members: Vec<AttrTypeJson> },
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct StructFieldJson {
-    pub name: std::string::String,
-    pub field_type: AttrTypeJson,
-    pub required: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<std::string::String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider_name: Option<std::string::String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub block_name: Option<std::string::String>,
-}
-
-pub fn proto_attr_type_to_json(t: &proto::AttributeType) -> AttrTypeJson {
-    match t {
-        proto::AttributeType::String => AttrTypeJson::String,
-        proto::AttributeType::Int => AttrTypeJson::Int,
-        proto::AttributeType::Float => AttrTypeJson::Float,
-        proto::AttributeType::Bool => AttrTypeJson::Bool,
-        proto::AttributeType::StringEnum { values } => AttrTypeJson::StringEnum {
-            values: values.clone(),
-        },
-        proto::AttributeType::List { inner, ordered } => AttrTypeJson::List {
-            inner: Box::new(proto_attr_type_to_json(inner)),
-            ordered: *ordered,
-        },
-        proto::AttributeType::Map { inner } => AttrTypeJson::Map {
-            inner: Box::new(proto_attr_type_to_json(inner)),
-        },
-        proto::AttributeType::Struct { name, fields } => AttrTypeJson::Struct {
-            name: name.clone(),
-            fields: fields
-                .iter()
-                .map(|f| StructFieldJson {
-                    name: f.name.clone(),
-                    field_type: proto_attr_type_to_json(&f.field_type),
-                    required: f.required,
-                    description: f.description.clone(),
-                    provider_name: f.provider_name.clone(),
-                    block_name: f.block_name.clone(),
-                })
-                .collect(),
-        },
-        proto::AttributeType::Union { members } => AttrTypeJson::Union {
-            members: members.iter().map(proto_attr_type_to_json).collect(),
-        },
-    }
-}
-
 /// Parse a ResourceId string (provider.resource_type.name) into a proto::ResourceId.
 ///
 /// Format: "provider.service.type.name" where provider is the first segment,
@@ -324,126 +245,19 @@ macro_rules! export_provider {
                 }
             }
 
-            fn wit_to_proto_lifecycle(
-                lc: &wit_types::LifecycleConfig,
-            ) -> proto::LifecycleConfig {
-                proto::LifecycleConfig {
-                    force_delete: lc.force_delete,
-                    create_before_destroy: lc.create_before_destroy,
-                }
-            }
-
-            fn proto_to_wit_provider_error(
-                e: &proto::ProviderError,
-            ) -> wit_types::ProviderError {
-                wit_types::ProviderError {
-                    message: e.message.clone(),
-                    resource_id: e.resource_id.as_ref().map(proto_to_wit_resource_id),
-                    is_timeout: e.is_timeout,
-                }
-            }
-
-            fn proto_to_wit_resource_schema(
-                s: &proto::ResourceSchema,
-            ) -> wit_types::ResourceSchema {
-                wit_types::ResourceSchema {
-                    resource_type: s.resource_type.clone(),
-                    attributes: s
-                        .attributes
-                        .values()
-                        .map(proto_to_wit_attribute_schema)
-                        .collect(),
-                    description: s.description.clone(),
-                    data_source: s.data_source,
-                    name_attribute: s.name_attribute.clone(),
-                    force_replace: s.force_replace,
-                }
-            }
-
-            fn proto_to_wit_attribute_schema(
-                a: &proto::AttributeSchema,
-            ) -> wit_types::AttributeSchema {
-                wit_types::AttributeSchema {
-                    name: a.name.clone(),
-                    attr_type: proto_to_wit_attribute_type(&a.attr_type),
-                    required: a.required,
-                    description: a.description.clone(),
-                    create_only: a.create_only,
-                    read_only: a.read_only,
-                    write_only: a.write_only,
-                }
-            }
-
-            fn proto_to_wit_attribute_type(
-                t: &proto::AttributeType,
-            ) -> wit_types::AttributeType {
-                match t {
-                    proto::AttributeType::String => wit_types::AttributeType::StringType,
-                    proto::AttributeType::Int => wit_types::AttributeType::IntType,
-                    proto::AttributeType::Float => wit_types::AttributeType::FloatType,
-                    proto::AttributeType::Bool => wit_types::AttributeType::BoolType,
-                    proto::AttributeType::StringEnum { values } => {
-                        wit_types::AttributeType::StringEnum(values.clone())
-                    }
-                    proto::AttributeType::List { inner, ordered } => {
-                        let json = helpers::AttrTypeJson::List {
-                            inner: Box::new(helpers::proto_attr_type_to_json(inner)),
-                            ordered: *ordered,
-                        };
-                        wit_types::AttributeType::ListType(
-                            serde_json::to_string(&json).unwrap(),
-                        )
-                    }
-                    proto::AttributeType::Map { inner } => {
-                        let json = helpers::AttrTypeJson::Map {
-                            inner: Box::new(helpers::proto_attr_type_to_json(inner)),
-                        };
-                        wit_types::AttributeType::MapType(
-                            serde_json::to_string(&json).unwrap(),
-                        )
-                    }
-                    proto::AttributeType::Struct { name, fields } => {
-                        let fields_json: Vec<helpers::StructFieldJson> = fields
-                            .iter()
-                            .map(|f| helpers::StructFieldJson {
-                                name: f.name.clone(),
-                                field_type: helpers::proto_attr_type_to_json(&f.field_type),
-                                required: f.required,
-                                description: f.description.clone(),
-                                provider_name: f.provider_name.clone(),
-                                block_name: f.block_name.clone(),
-                            })
-                            .collect();
-                        wit_types::AttributeType::StructType(wit_types::StructDef {
-                            name: name.clone(),
-                            fields: serde_json::to_string(&fields_json).unwrap(),
-                        })
-                    }
-                    proto::AttributeType::Union { members } => {
-                        let json_members: Vec<helpers::AttrTypeJson> =
-                            members.iter().map(helpers::proto_attr_type_to_json).collect();
-                        let json = serde_json::to_string(&json_members).unwrap();
-                        wit_types::AttributeType::UnionType(json)
-                    }
-                }
-            }
-
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
-                fn info() -> wit_types::ProviderInfo {
+                fn info() -> String {
                     let provider = get_provider().lock().unwrap();
                     let info = $crate::CarinaProvider::info(&*provider);
-                    wit_types::ProviderInfo {
-                        name: info.name,
-                        display_name: info.display_name,
-                    }
+                    serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string())
                 }
 
-                fn schemas() -> Vec<wit_types::ResourceSchema> {
+                fn schemas() -> String {
                     let provider = get_provider().lock().unwrap();
                     let schemas = $crate::CarinaProvider::schemas(&*provider);
-                    schemas.iter().map(proto_to_wit_resource_schema).collect()
+                    serde_json::to_string(&schemas).unwrap_or_else(|_| "[]".to_string())
                 }
 
                 fn validate_config(
@@ -465,7 +279,7 @@ macro_rules! export_provider {
                 fn read(
                     id: wit_types::ResourceId,
                     identifier: Option<String>,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     match $crate::CarinaProvider::read(
@@ -474,18 +288,18 @@ macro_rules! export_provider {
                         identifier.as_deref(),
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
                 fn create(
                     res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_res = wit_to_proto_resource(&res);
                     match $crate::CarinaProvider::create(&*provider, &proto_res) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
@@ -494,7 +308,7 @@ macro_rules! export_provider {
                     identifier: String,
                     current: wit_types::State,
                     to: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     let proto_from = wit_to_proto_state(&proto_id, &current);
@@ -507,26 +321,27 @@ macro_rules! export_provider {
                         &proto_to,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
                 fn delete(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    lifecycle: wit_types::LifecycleConfig,
-                ) -> Result<(), wit_types::ProviderError> {
+                    options: String,
+                ) -> Result<(), String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let proto_lc = wit_to_proto_lifecycle(&lifecycle);
+                    let lifecycle: proto::LifecycleConfig =
+                        serde_json::from_str(&options).unwrap_or_default();
                     match $crate::CarinaProvider::delete(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &proto_lc,
+                        &lifecycle,
                     ) {
                         Ok(()) => Ok(()),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
@@ -730,128 +545,21 @@ macro_rules! export_provider {
                 }
             }
 
-            fn wit_to_proto_lifecycle(
-                lc: &wit_types::LifecycleConfig,
-            ) -> proto::LifecycleConfig {
-                proto::LifecycleConfig {
-                    force_delete: lc.force_delete,
-                    create_before_destroy: lc.create_before_destroy,
-                }
-            }
-
-            fn proto_to_wit_provider_error(
-                e: &proto::ProviderError,
-            ) -> wit_types::ProviderError {
-                wit_types::ProviderError {
-                    message: e.message.clone(),
-                    resource_id: e.resource_id.as_ref().map(proto_to_wit_resource_id),
-                    is_timeout: e.is_timeout,
-                }
-            }
-
-            fn proto_to_wit_resource_schema(
-                s: &proto::ResourceSchema,
-            ) -> wit_types::ResourceSchema {
-                wit_types::ResourceSchema {
-                    resource_type: s.resource_type.clone(),
-                    attributes: s
-                        .attributes
-                        .values()
-                        .map(proto_to_wit_attribute_schema)
-                        .collect(),
-                    description: s.description.clone(),
-                    data_source: s.data_source,
-                    name_attribute: s.name_attribute.clone(),
-                    force_replace: s.force_replace,
-                }
-            }
-
-            fn proto_to_wit_attribute_schema(
-                a: &proto::AttributeSchema,
-            ) -> wit_types::AttributeSchema {
-                wit_types::AttributeSchema {
-                    name: a.name.clone(),
-                    attr_type: proto_to_wit_attribute_type(&a.attr_type),
-                    required: a.required,
-                    description: a.description.clone(),
-                    create_only: a.create_only,
-                    read_only: a.read_only,
-                    write_only: a.write_only,
-                }
-            }
-
-            fn proto_to_wit_attribute_type(
-                t: &proto::AttributeType,
-            ) -> wit_types::AttributeType {
-                match t {
-                    proto::AttributeType::String => wit_types::AttributeType::StringType,
-                    proto::AttributeType::Int => wit_types::AttributeType::IntType,
-                    proto::AttributeType::Float => wit_types::AttributeType::FloatType,
-                    proto::AttributeType::Bool => wit_types::AttributeType::BoolType,
-                    proto::AttributeType::StringEnum { values } => {
-                        wit_types::AttributeType::StringEnum(values.clone())
-                    }
-                    proto::AttributeType::List { inner, ordered } => {
-                        let json = helpers::AttrTypeJson::List {
-                            inner: Box::new(helpers::proto_attr_type_to_json(inner)),
-                            ordered: *ordered,
-                        };
-                        wit_types::AttributeType::ListType(
-                            serde_json::to_string(&json).unwrap(),
-                        )
-                    }
-                    proto::AttributeType::Map { inner } => {
-                        let json = helpers::AttrTypeJson::Map {
-                            inner: Box::new(helpers::proto_attr_type_to_json(inner)),
-                        };
-                        wit_types::AttributeType::MapType(
-                            serde_json::to_string(&json).unwrap(),
-                        )
-                    }
-                    proto::AttributeType::Struct { name, fields } => {
-                        let fields_json: Vec<helpers::StructFieldJson> = fields
-                            .iter()
-                            .map(|f| helpers::StructFieldJson {
-                                name: f.name.clone(),
-                                field_type: helpers::proto_attr_type_to_json(&f.field_type),
-                                required: f.required,
-                                description: f.description.clone(),
-                                provider_name: f.provider_name.clone(),
-                                block_name: f.block_name.clone(),
-                            })
-                            .collect();
-                        wit_types::AttributeType::StructType(wit_types::StructDef {
-                            name: name.clone(),
-                            fields: serde_json::to_string(&fields_json).unwrap(),
-                        })
-                    }
-                    proto::AttributeType::Union { members } => {
-                        let json_members: Vec<helpers::AttrTypeJson> =
-                            members.iter().map(helpers::proto_attr_type_to_json).collect();
-                        let json = serde_json::to_string(&json_members).unwrap();
-                        wit_types::AttributeType::UnionType(json)
-                    }
-                }
-            }
-
             // -- Guest trait implementation --
 
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
-                fn info() -> wit_types::ProviderInfo {
+                fn info() -> String {
                     let provider = get_provider().lock().unwrap();
                     let info = $crate::CarinaProvider::info(&*provider);
-                    wit_types::ProviderInfo {
-                        name: info.name,
-                        display_name: info.display_name,
-                    }
+                    serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string())
                 }
 
-                fn schemas() -> Vec<wit_types::ResourceSchema> {
+                fn schemas() -> String {
                     let provider = get_provider().lock().unwrap();
                     let schemas = $crate::CarinaProvider::schemas(&*provider);
-                    schemas.iter().map(proto_to_wit_resource_schema).collect()
+                    serde_json::to_string(&schemas).unwrap_or_else(|_| "[]".to_string())
                 }
 
                 fn validate_config(
@@ -873,7 +581,7 @@ macro_rules! export_provider {
                 fn read(
                     id: wit_types::ResourceId,
                     identifier: Option<String>,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     match $crate::CarinaProvider::read(
@@ -882,18 +590,18 @@ macro_rules! export_provider {
                         identifier.as_deref(),
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
                 fn create(
                     res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_res = wit_to_proto_resource(&res);
                     match $crate::CarinaProvider::create(&*provider, &proto_res) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
@@ -902,7 +610,7 @@ macro_rules! export_provider {
                     identifier: String,
                     current: wit_types::State,
                     to: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, wit_types::ProviderError> {
+                ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     let proto_from = wit_to_proto_state(&proto_id, &current);
@@ -915,26 +623,27 @@ macro_rules! export_provider {
                         &proto_to,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 
                 fn delete(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    lifecycle: wit_types::LifecycleConfig,
-                ) -> Result<(), wit_types::ProviderError> {
+                    options: String,
+                ) -> Result<(), String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let proto_lc = wit_to_proto_lifecycle(&lifecycle);
+                    let lifecycle: proto::LifecycleConfig =
+                        serde_json::from_str(&options).unwrap_or_default();
                     match $crate::CarinaProvider::delete(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &proto_lc,
+                        &lifecycle,
                     ) {
                         Ok(()) => Ok(()),
-                        Err(e) => Err(proto_to_wit_provider_error(&e)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }
                 }
 

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -1,40 +1,26 @@
 interface provider {
-    use types.{
-        resource-id, state, resource-def, lifecycle-config,
-        provider-error, resource-schema, value, provider-info,
-    };
+    use types.{ resource-id, state, resource-def, value };
 
-    info: func() -> provider-info;
+    /// Returns JSON-serialized ProviderInfo
+    info: func() -> string;
 
-    schemas: func() -> list<resource-schema>;
+    /// Returns JSON-serialized Vec<ResourceSchema>
+    schemas: func() -> string;
 
     validate-config: func(attrs: list<tuple<string, value>>) -> result<_, string>;
-
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 
-    read: func(id: resource-id, identifier: option<string>) -> result<state, provider-error>;
+    read: func(id: resource-id, identifier: option<string>) -> result<state, string>;
+    create: func(res: resource-def) -> result<state, string>;
+    update: func(id: resource-id, identifier: string, current: state, to: resource-def) -> result<state, string>;
 
-    create: func(res: resource-def) -> result<state, provider-error>;
-
-    update: func(
-        id: resource-id,
-        identifier: string,
-        current: state,
-        to: resource-def,
-    ) -> result<state, provider-error>;
-
-    delete: func(
-        id: resource-id,
-        identifier: string,
-        lifecycle: lifecycle-config,
-    ) -> result<_, provider-error>;
+    /// options is JSON-serialized provider options map
+    delete: func(id: resource-id, identifier: string, options: string) -> result<_, string>;
 
     normalize-desired: func(resources: list<resource-def>) -> list<resource-def>;
-
     normalize-state: func(
         states: list<tuple<string, state>>,
     ) -> list<tuple<string, state>>;
-
     hydrate-read-state: func(
         states: list<tuple<string, state>>,
         saved-attrs: list<tuple<string, list<tuple<string, value>>>>,

--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -6,7 +6,6 @@ interface types {
     }
 
     /// Attribute values serialized as JSON strings for complex/nested types.
-    /// Simple scalar values use typed variants; list and map values are JSON-encoded strings.
     variant value {
         bool-val(bool),
         int-val(s64),
@@ -27,64 +26,5 @@ interface types {
     record resource-def {
         id: resource-id,
         attributes: list<tuple<string, value>>,
-    }
-
-    record lifecycle-config {
-        prevent-destroy: bool,
-        force-delete: bool,
-        create-before-destroy: bool,
-    }
-
-    record provider-error {
-        message: string,
-        resource-id: option<resource-id>,
-        is-timeout: bool,
-    }
-
-    record resource-schema {
-        resource-type: string,
-        attributes: list<attribute-schema>,
-        description: option<string>,
-        data-source: bool,
-        name-attribute: option<string>,
-        force-replace: bool,
-    }
-
-    record attribute-schema {
-        name: string,
-        attr-type: attribute-type,
-        required: bool,
-        description: option<string>,
-        create-only: bool,
-        read-only: bool,
-        write-only: bool,
-    }
-
-    /// Attribute type descriptor. Recursive list/map/struct types are encoded
-    /// as JSON strings to avoid WIT's restriction on recursive type definitions.
-    variant attribute-type {
-        string-type,
-        int-type,
-        float-type,
-        bool-type,
-        string-enum(list<string>),
-        /// JSON-encoded attribute-type for the element type
-        list-type(string),
-        /// JSON-encoded attribute-type for the value type
-        map-type(string),
-        struct-type(struct-def),
-        /// JSON-encoded list of member attribute-types
-        union-type(string),
-    }
-
-    record struct-def {
-        name: string,
-        /// JSON-encoded list of struct-field records
-        fields: string,
-    }
-
-    record provider-info {
-        name: string,
-        display-name: string,
     }
 }

--- a/carina-provider-protocol/src/methods.rs
+++ b/carina-provider-protocol/src/methods.rs
@@ -89,6 +89,7 @@ pub struct UpdateResult {
 pub struct DeleteParams {
     pub id: ResourceId,
     pub identifier: String,
+    #[serde(default)]
     pub lifecycle: LifecycleConfig,
 }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -103,11 +103,15 @@ pub struct State {
     pub exists: bool,
 }
 
-/// Mirrors `carina_core::resource::LifecycleConfig`.
+/// Lifecycle configuration for a resource.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LifecycleConfig {
+    #[serde(default)]
     pub force_delete: bool,
+    #[serde(default)]
     pub create_before_destroy: bool,
+    #[serde(default)]
+    pub prevent_destroy: bool,
 }
 
 /// Simplified resource for the process boundary.
@@ -116,6 +120,7 @@ pub struct LifecycleConfig {
 pub struct Resource {
     pub id: ResourceId,
     pub attributes: HashMap<String, Value>,
+    #[serde(default)]
     pub lifecycle: LifecycleConfig,
 }
 

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -862,8 +862,7 @@ mod tests {
         let mut state = StateFile::new();
         let mut aws_rs = ResourceState::new("s3.bucket", "main", "aws");
         aws_rs.lifecycle.force_delete = true;
-        let mut awscc_rs = ResourceState::new("s3.bucket", "main", "awscc");
-        awscc_rs.lifecycle.force_delete = false;
+        let awscc_rs = ResourceState::new("s3.bucket", "main", "awscc");
 
         state.upsert_resource(aws_rs);
         state.upsert_resource(awscc_rs);

--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -889,8 +889,8 @@ mod tests {
             from: from.clone(),
             to: Resource::new("ec2.vpc", "my-vpc"),
             lifecycle: LifecycleConfig {
-                force_delete: false,
                 create_before_destroy: true,
+                ..Default::default()
             },
             changed_create_only: vec!["cidr".to_string()],
             cascading_updates: vec![],


### PR DESCRIPTION
## Summary

- Reduce WIT to a transport layer by replacing provider-specific typed WIT records with JSON strings across the WASM boundary
- Eliminates the 3-layer type conversion (Core↔WIT↔Protocol) for schema, error, info, and lifecycle types, replacing with 2-layer (Core↔Protocol→JSON↔WIT string)
- Add `prevent_destroy` field to `LifecycleConfig` (refs #1502)

## Changes

- Remove typed WIT records from `types.wit`: `lifecycle-config`, `provider-error`, `resource-schema`, `attribute-schema`, `attribute-type`, `struct-def`, `provider-info`
- Core types (`resource-id`, `value`, `state`, `resource-def`) remain as typed WIT records
- `LifecycleConfig` remains as a typed Rust struct in both `carina-core` and `carina-provider-protocol` — only the WIT record is removed; it is serialized to JSON at the WASM boundary
- Plugin host uses JSON passthrough (serde) instead of manual WIT type conversions
- Plugin SDK serializes/deserializes JSON at the WASM boundary
- Add `carina-provider-protocol` dependency to `carina-plugin-host`

## Breaking changes

- **WIT interface changed** — all provider WASM components need recompilation
- **Protocol crate `LifecycleConfig`** gains `prevent_destroy` field (backward compatible via `#[serde(default)]`)
- **State file `lifecycle` format** — `prevent_destroy` field added (backward compatible)

## Provider repo impact

`carina-provider-aws` and `carina-provider-awscc` need recompilation against the new `carina-plugin-sdk`. No code changes should be needed — the SDK macro handles the WIT boundary changes.

## Design spec

`docs/superpowers/specs/2026-04-04-wit-transport-layer-design.md`

## Test plan

- [x] Full workspace `cargo build` passes
- [x] Full workspace `cargo test` passes (all crates, 0 failures)
- [x] Clippy passes
- [x] Complex schema JSON deserialization test covers struct/union/list/block_name/provider_name/removable roundtrip
- [ ] Provider repos recompile successfully against new SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)