### PR TITLE
fix: check prevent_destroy when cascade promotes dependent to Replace

### DIFF
--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -901,3 +901,216 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
         }
     }
 }
+
+#[test]
+fn cascade_prevent_destroy_blocks_promotion_to_replace() {
+    // When resource A is being replaced and resource B depends on A
+    // via a create-only attribute, B would normally be promoted to Replace.
+    // But if B has prevent_destroy: true, it should generate a PlanError instead.
+
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.vpc", "my-vpc");
+    let subnet_id = ResourceId::new("ec2.subnet", "my-subnet");
+
+    let vpc = Resource::new("ec2.vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+
+    let mut subnet = Resource::new("ec2.subnet", "my-subnet")
+        .with_binding("subnet")
+        .with_attribute(
+            "vpc_id",
+            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+        )
+        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+    subnet.lifecycle.prevent_destroy = true;
+
+    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.0.0.0/16".to_string()),
+    );
+    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut subnet_attrs = HashMap::new();
+    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.1.1.0/24".to_string()),
+    );
+    current_states.insert(
+        subnet_id.clone(),
+        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
+    );
+
+    // Schema: vpc_id is create-only on ec2.subnet
+    let subnet_schema = ResourceSchema::new("ec2.subnet")
+        .attribute(
+            AttributeSchema::new("vpc_id", AttributeType::String)
+                .required()
+                .create_only(),
+        )
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
+
+    let mut schemas = HashMap::new();
+    schemas.insert("ec2.subnet".to_string(), subnet_schema);
+
+    // Build a plan with Replace for VPC (create_before_destroy)
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        lifecycle: LifecycleConfig {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: vec!["cidr_block".to_string()],
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+
+    // Apply cascade
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    // The subnet should NOT be promoted to Replace because it has prevent_destroy.
+    // Instead, a PlanError should be generated.
+    assert!(
+        plan.has_errors(),
+        "Expected PlanError for subnet with prevent_destroy, but got no errors"
+    );
+
+    let errors = plan.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].resource_id, subnet_id);
+    assert!(
+        errors[0].message.contains("prevent_destroy"),
+        "Error message should mention prevent_destroy, got: {}",
+        errors[0].message
+    );
+
+    // The subnet should NOT appear as a Replace effect in the plan
+    let subnet_effects: Vec<_> = plan
+        .effects()
+        .iter()
+        .filter(|e| *e.resource_id() == subnet_id)
+        .collect();
+    assert!(
+        subnet_effects.is_empty(),
+        "Subnet should not have any effect when prevent_destroy blocks promotion"
+    );
+}
+
+#[test]
+fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
+    // When resource B already has an Update effect in the plan and would be
+    // upgraded to Replace via cascade (merge path), prevent_destroy should block it.
+
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let vpc_id = ResourceId::new("ec2.vpc", "my-vpc");
+    let subnet_id = ResourceId::new("ec2.subnet", "my-subnet");
+
+    let vpc = Resource::new("ec2.vpc", "my-vpc")
+        .with_binding("vpc")
+        .with_attribute("cidr_block", Value::String("10.1.0.0/16".to_string()));
+
+    let mut subnet = Resource::new("ec2.subnet", "my-subnet")
+        .with_binding("subnet")
+        .with_attribute(
+            "vpc_id",
+            Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+        )
+        .with_attribute("tags", Value::String("new-tag".to_string()))
+        .with_attribute("cidr_block", Value::String("10.1.1.0/24".to_string()));
+    subnet.lifecycle.prevent_destroy = true;
+
+    let unresolved_resources = vec![vpc.clone(), subnet.clone()];
+
+    let mut current_states = HashMap::new();
+    let mut vpc_attrs = HashMap::new();
+    vpc_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.0.0.0/16".to_string()),
+    );
+    vpc_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    current_states.insert(
+        vpc_id.clone(),
+        State::existing(vpc_id.clone(), vpc_attrs).with_identifier("vpc-old"),
+    );
+
+    let mut subnet_attrs = HashMap::new();
+    subnet_attrs.insert("vpc_id".to_string(), Value::String("vpc-old".to_string()));
+    subnet_attrs.insert("tags".to_string(), Value::String("old-tag".to_string()));
+    subnet_attrs.insert(
+        "cidr_block".to_string(),
+        Value::String("10.1.1.0/24".to_string()),
+    );
+    current_states.insert(
+        subnet_id.clone(),
+        State::existing(subnet_id.clone(), subnet_attrs).with_identifier("subnet-123"),
+    );
+
+    // Schema: vpc_id is create-only, tags is NOT
+    let subnet_schema = ResourceSchema::new("ec2.subnet")
+        .attribute(
+            AttributeSchema::new("vpc_id", AttributeType::String)
+                .required()
+                .create_only(),
+        )
+        .attribute(AttributeSchema::new("tags", AttributeType::String))
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
+
+    let mut schemas = HashMap::new();
+    schemas.insert("ec2.subnet".to_string(), subnet_schema);
+
+    // Build a plan with Replace for VPC and Update for subnet (tags changed)
+    let mut plan = Plan::new();
+    plan.add(Effect::Replace {
+        id: vpc_id.clone(),
+        from: Box::new(current_states.get(&vpc_id).unwrap().clone()),
+        to: vpc.clone().with_binding("vpc"),
+        lifecycle: LifecycleConfig {
+            create_before_destroy: true,
+            ..Default::default()
+        },
+        changed_create_only: vec!["cidr_block".to_string()],
+        cascading_updates: vec![],
+        temporary_name: None,
+        cascade_ref_hints: vec![],
+    });
+    plan.add(Effect::Update {
+        id: subnet_id.clone(),
+        from: Box::new(current_states.get(&subnet_id).unwrap().clone()),
+        to: subnet.clone().with_binding("subnet"),
+        changed_attributes: vec!["tags".to_string()],
+    });
+
+    // Apply cascade
+    cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
+
+    // The subnet should NOT be upgraded to Replace because it has prevent_destroy.
+    // A PlanError should be generated instead.
+    assert!(
+        plan.has_errors(),
+        "Expected PlanError for subnet with prevent_destroy on merge upgrade"
+    );
+
+    let errors = plan.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].resource_id, subnet_id);
+    assert!(
+        errors[0].message.contains("prevent_destroy"),
+        "Error message should mention prevent_destroy, got: {}",
+        errors[0].message
+    );
+}

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -518,6 +518,22 @@ pub fn cascade_dependent_updates(
             );
 
             if !create_only_refs.is_empty() {
+                // Check if this merge would upgrade an Update to Replace.
+                // If the resource has prevent_destroy, block the upgrade.
+                let is_update_in_plan = plan
+                    .effects()
+                    .iter()
+                    .any(|e| matches!(e, Effect::Update { id, .. } if *id == resource.id));
+                if is_update_in_plan && resource.lifecycle.prevent_destroy {
+                    plan.add_error(PlanError {
+                        resource_id: resource.id.clone(),
+                        message:
+                            "resource has prevent_destroy set, but cascade from a replaced dependency would replace it (which requires destroying the old resource)"
+                                .to_string(),
+                    });
+                    continue;
+                }
+
                 // Only keep hints for attributes that are actually create-only
                 let filtered_hints: Vec<(String, String)> = ref_hints
                     .into_iter()
@@ -590,6 +606,15 @@ pub fn cascade_dependent_updates(
                             from: Box::new(from),
                             to: (*unresolved).clone(),
                         });
+                } else if unresolved.lifecycle.prevent_destroy {
+                    // Cascade would promote to Replace (destroy + recreate),
+                    // but prevent_destroy blocks this.
+                    plan.add_error(PlanError {
+                        resource_id: unresolved.id.clone(),
+                        message:
+                            "resource has prevent_destroy set, but cascade from a replaced dependency would replace it (which requires destroying the old resource)"
+                                .to_string(),
+                    });
                 } else {
                     // Extract ref hints for attributes being promoted
                     let ref_hints: Vec<(String, String)> = unresolved


### PR DESCRIPTION
## Summary

- When `cascade_dependent_updates()` promotes a dependent resource to Replace (because a referenced resource is being replaced and the dependent's referencing attribute is create-only), the `prevent_destroy` lifecycle was not checked
- Adds prevent_destroy check in both code paths: the direct promotion path (new Replace effect added to plan) and the merge path (upgrading an existing Update effect to Replace)
- If prevent_destroy is set, a PlanError is generated instead of promoting to Replace

## Test plan

- [x] Added `cascade_prevent_destroy_blocks_promotion_to_replace` test: dependent resource with prevent_destroy and create-only ref to replaced resource generates PlanError
- [x] Added `cascade_prevent_destroy_blocks_merge_upgrade_to_replace` test: dependent resource already in plan as Update, with prevent_destroy, generates PlanError when cascade would upgrade to Replace
- [x] All existing cascade tests pass (no regressions)
- [x] `cargo test -p carina-core` passes (1093 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)