### PR TITLE
test: block_name attribute roundtrip tests for issue #1499

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1689,6 +1689,351 @@ mod tests {
     }
 
     #[test]
+    fn build_state_after_apply_preserves_block_name_attribute() {
+        // When a block_name attribute (e.g., "policies" with block_name "policy")
+        // is carried over by the provider because CloudControl doesn't return it,
+        // the state after apply should include the attribute under the canonical name.
+        // This is the scenario in issue #1499 (iam_role/with_policy).
+        use carina_core::schema::StructField;
+
+        let mut schemas = HashMap::new();
+        let schema = ResourceSchema::new("iam.role")
+            .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
+            .attribute(
+                AttributeSchema::new(
+                    "policies",
+                    AttributeType::unordered_list(AttributeType::Struct {
+                        name: "Policy".to_string(),
+                        fields: vec![
+                            StructField::new("policy_name", AttributeType::String).required(),
+                            StructField::new("policy_document", AttributeType::String).required(),
+                        ],
+                    }),
+                )
+                .with_block_name("policy"),
+            );
+        schemas.insert("awscc.iam.role".to_string(), schema);
+
+        // Resource with resolved block name (policy -> policies)
+        let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
+        resource.set_attr(
+            "role_name".to_string(),
+            Value::String("test-role".to_string()),
+        );
+        resource.set_attr(
+            "policies".to_string(),
+            Value::List(vec![Value::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::String("test-policy".to_string()),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::String("{}".to_string()),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+
+        let sorted_resources = vec![resource];
+
+        // Simulate provider returning state WITH carried-over policies attribute
+        // (This is what AwsccProvider::create_resource does in the carry-over logic)
+        let mut applied_attrs = HashMap::new();
+        applied_attrs.insert(
+            "role_name".to_string(),
+            Value::String("test-role".to_string()),
+        );
+        applied_attrs.insert(
+            "policies".to_string(),
+            Value::List(vec![Value::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::String("test-policy".to_string()),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::String("{}".to_string()),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+        let applied_state = State::existing(sorted_resources[0].id.clone(), applied_attrs)
+            .with_identifier("some-identifier");
+        let mut applied_states = HashMap::new();
+        applied_states.insert(sorted_resources[0].id.clone(), applied_state);
+
+        let current_states = HashMap::new();
+        let permanent_name_overrides = HashMap::new();
+        let plan = Plan::new();
+        let successfully_deleted = HashSet::new();
+        let failed_refreshes = HashSet::new();
+
+        let state = build_state_after_apply(ApplyStateSave {
+            state_file: None,
+            sorted_resources: &sorted_resources,
+            current_states: &current_states,
+            applied_states: &applied_states,
+            permanent_name_overrides: &permanent_name_overrides,
+            plan: &plan,
+            successfully_deleted: &successfully_deleted,
+            failed_refreshes: &failed_refreshes,
+            schemas: &schemas,
+        })
+        .unwrap();
+
+        // Verify state has the policies attribute
+        let saved = state
+            .find_resource("awscc", "iam.role", "test-role")
+            .expect("resource should exist in state");
+        assert!(
+            saved.attributes.contains_key("policies"),
+            "state should contain 'policies' attribute (carried over from desired)"
+        );
+
+        // Verify desired_keys includes "policies" (canonical name, not "policy")
+        assert!(
+            saved.desired_keys.contains(&"policies".to_string()),
+            "desired_keys should contain 'policies': {:?}",
+            saved.desired_keys
+        );
+
+        // Now simulate second plan: build_saved_attrs should return the policies
+        let saved_attrs = state.build_saved_attrs();
+        let id = carina_core::resource::ResourceId::with_provider("awscc", "iam.role", "test-role");
+        let attrs = saved_attrs.get(&id).unwrap();
+        assert!(
+            attrs.contains_key("policies"),
+            "saved_attrs should contain 'policies': {:?}",
+            attrs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn block_name_attribute_no_diff_when_hydrated() {
+        // After apply, the state file contains the block_name attribute (canonical name).
+        // On re-plan, if hydrate_read_state restores it into current_states,
+        // the differ should see no changes.
+        //
+        // This tests the scenario from issue #1499 where plan-verify fails
+        // because the block_name attribute shows as an addition.
+        use carina_core::differ::diff;
+        use carina_core::schema::StructField;
+
+        let schema = ResourceSchema::new("awscc.iam.role")
+            .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
+            .attribute(
+                AttributeSchema::new(
+                    "policies",
+                    AttributeType::unordered_list(AttributeType::Struct {
+                        name: "Policy".to_string(),
+                        fields: vec![
+                            StructField::new("policy_name", AttributeType::String).required(),
+                            StructField::new("policy_document", AttributeType::String).required(),
+                        ],
+                    }),
+                )
+                .with_block_name("policy"),
+            );
+
+        // Desired resource (after resolve_block_names: "policy" -> "policies")
+        let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
+        resource.set_attr(
+            "role_name".to_string(),
+            Value::String("test-role".to_string()),
+        );
+        resource.set_attr(
+            "policies".to_string(),
+            Value::List(vec![Value::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::String("test-policy".to_string()),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::String("{}".to_string()),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+
+        // Current state: simulate hydration restoring the policies attribute
+        let mut state_attrs = HashMap::new();
+        state_attrs.insert(
+            "role_name".to_string(),
+            Value::String("test-role".to_string()),
+        );
+        state_attrs.insert(
+            "policies".to_string(),
+            Value::List(vec![Value::Map(
+                vec![
+                    (
+                        "policy_name".to_string(),
+                        Value::String("test-policy".to_string()),
+                    ),
+                    (
+                        "policy_document".to_string(),
+                        Value::String("{}".to_string()),
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+        let current = State::existing(resource.id.clone(), state_attrs).with_identifier("some-id");
+
+        // Saved attrs: same as current (from previous apply)
+        let saved: HashMap<String, Value> = current.attributes.clone();
+
+        // Previous desired keys: what was in the resource on first apply
+        let prev_desired_keys = vec!["policies".to_string(), "role_name".to_string()];
+
+        let d = diff(
+            &resource,
+            &current,
+            Some(&saved),
+            Some(&prev_desired_keys),
+            Some(&schema),
+        );
+
+        assert!(
+            matches!(d, carina_core::differ::Diff::NoChange(_)),
+            "Expected no change, but got: {:?}",
+            d
+        );
+    }
+
+    #[test]
+    fn block_name_attribute_state_roundtrip() {
+        // Verify that block_name attributes (saved under canonical name in state)
+        // roundtrip correctly through state save/load, meaning the saved_attrs
+        // returned by build_saved_attrs have the correct canonical key.
+        //
+        // This covers the ec2_ipam case (operating_region -> operating_regions)
+        // from issue #1499.
+        use carina_core::schema::StructField;
+
+        let mut schemas = HashMap::new();
+        let schema = ResourceSchema::new("ec2.ipam")
+            .attribute(
+                AttributeSchema::new(
+                    "operating_regions",
+                    AttributeType::unordered_list(AttributeType::Struct {
+                        name: "IpamOperatingRegion".to_string(),
+                        fields: vec![
+                            StructField::new("region_name", AttributeType::String).required(),
+                        ],
+                    }),
+                )
+                .with_block_name("operating_region"),
+            )
+            .attribute(AttributeSchema::new("description", AttributeType::String));
+        schemas.insert("awscc.ec2.ipam".to_string(), schema);
+
+        // Resource with resolved block name
+        let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");
+        resource.set_attr(
+            "operating_regions".to_string(),
+            Value::List(vec![Value::Map(
+                vec![(
+                    "region_name".to_string(),
+                    Value::String("ap-northeast-1".to_string()),
+                )]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+        resource.set_attr(
+            "description".to_string(),
+            Value::String("test IPAM".to_string()),
+        );
+
+        let sorted_resources = vec![resource];
+
+        // Simulate provider state with carried-over operating_regions
+        let mut applied_attrs = HashMap::new();
+        applied_attrs.insert(
+            "description".to_string(),
+            Value::String("test IPAM".to_string()),
+        );
+        applied_attrs.insert(
+            "operating_regions".to_string(),
+            Value::List(vec![Value::Map(
+                vec![(
+                    "region_name".to_string(),
+                    Value::String("ap-northeast-1".to_string()),
+                )]
+                .into_iter()
+                .collect(),
+            )]),
+        );
+        let applied_state = State::existing(sorted_resources[0].id.clone(), applied_attrs)
+            .with_identifier("ipam-12345");
+        let mut applied_states = HashMap::new();
+        applied_states.insert(sorted_resources[0].id.clone(), applied_state);
+
+        let state = build_state_after_apply(ApplyStateSave {
+            state_file: None,
+            sorted_resources: &sorted_resources,
+            current_states: &HashMap::new(),
+            applied_states: &applied_states,
+            permanent_name_overrides: &HashMap::new(),
+            plan: &Plan::new(),
+            successfully_deleted: &HashSet::new(),
+            failed_refreshes: &HashSet::new(),
+            schemas: &schemas,
+        })
+        .unwrap();
+
+        // Verify state contains operating_regions
+        let saved_rs = state
+            .find_resource("awscc", "ec2.ipam", "test-ipam")
+            .expect("resource should exist");
+        assert!(
+            saved_rs.attributes.contains_key("operating_regions"),
+            "state should contain 'operating_regions'"
+        );
+        assert!(
+            saved_rs
+                .desired_keys
+                .contains(&"operating_regions".to_string()),
+            "desired_keys should contain 'operating_regions'"
+        );
+
+        // Verify roundtrip through saved_attrs
+        let saved_attrs = state.build_saved_attrs();
+        let id = carina_core::resource::ResourceId::with_provider("awscc", "ec2.ipam", "test-ipam");
+        let attrs = saved_attrs.get(&id).unwrap();
+        let operating_regions = attrs
+            .get("operating_regions")
+            .expect("should have operating_regions");
+
+        // Verify the value structure is preserved
+        if let Value::List(items) = operating_regions {
+            assert_eq!(items.len(), 1);
+            if let Value::Map(map) = &items[0] {
+                assert_eq!(
+                    map.get("region_name"),
+                    Some(&Value::String("ap-northeast-1".to_string()))
+                );
+            } else {
+                panic!("Expected Map in list, got {:?}", items[0]);
+            }
+        } else {
+            panic!("Expected List, got {:?}", operating_regions);
+        }
+    }
+
+    #[test]
     fn format_duration_sub_second() {
         let d = Duration::from_millis(500);
         assert_eq!(format_duration(d), "0.5s");

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -13,6 +13,38 @@ pub mod wasm_guest;
 #[cfg(target_arch = "wasm32")]
 pub mod wasi_http;
 
+/// Parse a ResourceId string (provider.resource_type.name) into a ResourceId.
+///
+/// Format: "provider.service.type.name" where provider is the first segment,
+/// name is the last segment, and resource_type is everything in between.
+///
+/// This is also used by the WASM guest SDK via `wasm_guest::parse_resource_id_string`.
+pub fn parse_resource_id_string(key: &str) -> carina_provider_protocol::types::ResourceId {
+    let parts: Vec<&str> = key.splitn(2, '.').collect();
+    if parts.len() < 2 {
+        return carina_provider_protocol::types::ResourceId {
+            provider: String::new(),
+            resource_type: String::new(),
+            name: key.to_string(),
+        };
+    }
+    let provider = parts[0].to_string();
+    let rest = parts[1];
+    if let Some(dot_pos) = rest.rfind('.') {
+        carina_provider_protocol::types::ResourceId {
+            provider,
+            resource_type: rest[..dot_pos].to_string(),
+            name: rest[dot_pos + 1..].to_string(),
+        }
+    } else {
+        carina_provider_protocol::types::ResourceId {
+            provider,
+            resource_type: String::new(),
+            name: rest.to_string(),
+        }
+    }
+}
+
 use carina_provider_protocol::jsonrpc::{Notification, Request, Response};
 use carina_provider_protocol::methods;
 use carina_provider_protocol::types::*;
@@ -288,5 +320,58 @@ fn parse_params<T: serde::de::DeserializeOwned>(
         Some(v) => serde_json::from_value(v.clone()).map_err(|e| format!("Invalid params: {e}")),
         None => serde_json::from_value(serde_json::json!({}))
             .map_err(|e| format!("Missing params: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_resource_id_standard() {
+        let id = parse_resource_id_string("awscc.iam.role.my-role");
+        assert_eq!(id.provider, "awscc");
+        assert_eq!(id.resource_type, "iam.role");
+        assert_eq!(id.name, "my-role");
+    }
+
+    #[test]
+    fn parse_resource_id_three_part_type() {
+        let id = parse_resource_id_string("awscc.ec2.ipam.test-ipam");
+        assert_eq!(id.provider, "awscc");
+        assert_eq!(id.resource_type, "ec2.ipam");
+        assert_eq!(id.name, "test-ipam");
+    }
+
+    #[test]
+    fn parse_resource_id_with_prefix_name() {
+        let id = parse_resource_id_string("awscc.s3.bucket.carina-acc-test-abc123");
+        assert_eq!(id.provider, "awscc");
+        assert_eq!(id.resource_type, "s3.bucket");
+        assert_eq!(id.name, "carina-acc-test-abc123");
+    }
+
+    #[test]
+    fn parse_resource_id_aws_provider() {
+        let id = parse_resource_id_string("aws.s3.bucket.my-bucket");
+        assert_eq!(id.provider, "aws");
+        assert_eq!(id.resource_type, "s3.bucket");
+        assert_eq!(id.name, "my-bucket");
+    }
+
+    #[test]
+    fn parse_resource_id_no_dots() {
+        let id = parse_resource_id_string("simple");
+        assert_eq!(id.provider, "");
+        assert_eq!(id.resource_type, "");
+        assert_eq!(id.name, "simple");
+    }
+
+    #[test]
+    fn parse_resource_id_two_parts() {
+        let id = parse_resource_id_string("provider.name");
+        assert_eq!(id.provider, "provider");
+        assert_eq!(id.resource_type, "");
+        assert_eq!(id.name, "name");
     }
 }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -54,33 +54,9 @@ pub fn proto_value_to_json(v: &proto::Value) -> serde_json::Value {
 
 /// Parse a ResourceId string (provider.resource_type.name) into a proto::ResourceId.
 ///
-/// Format: "provider.service.type.name" where provider is the first segment,
-/// name is the last segment, and resource_type is everything in between.
+/// Delegates to `crate::parse_resource_id_string` which is available on all targets.
 pub fn parse_resource_id_string(key: &str) -> crate::types::ResourceId {
-    let parts: Vec<&str> = key.splitn(2, '.').collect();
-    if parts.len() < 2 {
-        return crate::types::ResourceId {
-            provider: String::new(),
-            resource_type: String::new(),
-            name: key.to_string(),
-        };
-    }
-    let provider = parts[0].to_string();
-    let rest = parts[1];
-    // rest = "service.type.name" — split from the end to get name
-    if let Some(dot_pos) = rest.rfind('.') {
-        crate::types::ResourceId {
-            provider,
-            resource_type: rest[..dot_pos].to_string(),
-            name: rest[dot_pos + 1..].to_string(),
-        }
-    } else {
-        crate::types::ResourceId {
-            provider,
-            resource_type: String::new(),
-            name: rest.to_string(),
-        }
-    }
+    crate::parse_resource_id_string(key)
 }
 
 /// Macro to export a `CarinaProvider` implementation as a WASM component.


### PR DESCRIPTION
## Summary
- Add tests covering block_name attribute scenarios from issue #1499 (iam_role/with_policy and ec2_ipam/basic plan-verify failures)
- Move `parse_resource_id_string` from wasm32-only `wasm_guest` module to the main SDK module so it can be tested on native targets
- The wasm_guest version now delegates to the shared implementation

## Investigation findings

The root cause of the AWSCC plan-verify failures was the empty ResourceId bug fixed in PR #1498. Before that fix, `hydrate_read_state` in the WIT guest created dummy ResourceIds with empty provider/resource_type, causing `restore_unreturned_attrs_impl` to skip all AWSCC resources (the `resource_id.provider != "awscc"` check failed).

After PR #1498 and #1500 are included in the AWSCC provider's WASM binary (by rebuilding with updated carina-plugin-sdk), the block_name attribute carry-over and hydration should work correctly:
1. `resolve_block_names` renames `policy` -> `policies` (canonical name)
2. Provider carry-over preserves `policies` in create state
3. State file stores `policies` under canonical name with correct `desired_keys`
4. On re-plan, `hydrate_read_state` restores `policies` from saved attrs
5. Differ sees matching values and produces no-change

The ec2_flow_log/s3 issue (#4) is out of scope (separate force_delete problem).

## Test plan
- [x] `build_state_after_apply_preserves_block_name_attribute` - verifies state save with block_name attrs
- [x] `block_name_attribute_no_diff_when_hydrated` - verifies differ with hydrated state
- [x] `block_name_attribute_state_roundtrip` - verifies operating_regions roundtrip through state
- [x] `parse_resource_id_string` tests (6 cases) - covers various ResourceId formats
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)