### PR TITLE
fix: pre-commit hook disables sccache for clippy

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -112,8 +112,18 @@ main() {
         exit 0
     fi
 
-    # Ensure incremental compilation for faster checks.
-    export CARGO_INCREMENTAL=1
+    # sccache (configured via .cargo/config.toml) is incompatible with cargo's
+    # incremental compilation: cargo sets CARGO_INCREMENTAL=1 internally for dev
+    # profile, and sccache refuses to run when it's set. Disable sccache for
+    # pre-commit checks by overriding RUSTC_WRAPPER, and enable incremental
+    # compilation directly for faster checks.
+    clippy_env=()
+    if [[ "$RUSTC_WRAPPER" == *sccache* ]] || { [ -f .cargo/config.toml ] && grep -q 'sccache' .cargo/config.toml 2>/dev/null; }; then
+        clippy_env=(env RUSTC_WRAPPER="")
+        export CARGO_INCREMENTAL=1
+    else
+        export CARGO_INCREMENTAL=1
+    fi
 
     fmt_log=$(mktemp)
     clippy_log=$(mktemp)
@@ -128,7 +138,7 @@ main() {
         clippy_pid=""
     else
         clippy_start=$(date +%s)
-        cargo clippy "${clippy_scope[@]}" --no-deps -- -D warnings >"$clippy_log" 2>&1 &
+        "${clippy_env[@]}" cargo clippy "${clippy_scope[@]}" --no-deps -- -D warnings >"$clippy_log" 2>&1 &
         clippy_pid=$!
     fi
 


### PR DESCRIPTION
## Summary

- Fix pre-commit hook conflict between sccache and cargo clippy's incremental compilation
- sccache rejects `CARGO_INCREMENTAL` (set internally by cargo for dev profile), causing clippy to always fail when `.cargo/config.toml` configures sccache as `rustc-wrapper`
- The hook now overrides `RUSTC_WRAPPER=""` for the clippy invocation only

## Context

All subagent commits in today's session used `SKIP_CLIPPY=1` to work around this issue. This fix eliminates the need for that workaround.

## Test plan

- [x] `git commit` with sccache in `.cargo/config.toml` succeeds (clippy passes)
- [x] Formatting check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)