### PR TITLE
fix: add wasi:http and wasi:io type mappings to HTTP bindgen

### DIFF
--- a/carina-plugin-host/src/lib.rs
+++ b/carina-plugin-host/src/lib.rs
@@ -19,6 +19,8 @@ pub mod wasm_bindings_http {
         with: {
             "carina:provider/types": super::wasm_bindings::carina::provider::types,
             "carina:provider/provider": super::wasm_bindings::exports::carina::provider::provider,
+            "wasi:http": wasmtime_wasi_http::p2::bindings::http,
+            "wasi:io": wasmtime_wasi::p2::bindings::io,
         },
     });
 }


### PR DESCRIPTION
## Summary

- Add missing `wasi:http` and `wasi:io` type mappings to the `carina-provider-with-http` bindgen configuration
- Fixes `component imports instance wasi:http/types@0.2.6, but a matching implementation was not found in the linker`

## Root cause

The `bindgen!` macro for `carina-provider-with-http` world generated its own types for `wasi:http` and `wasi:io` interfaces, which didn't match the types registered by `wasmtime_wasi_http::p2::add_only_http_to_linker_async`. Adding `with` mappings tells bindgen to reuse wasmtime's types instead.

## Change

2 lines added to `carina-plugin-host/src/lib.rs`:
```rust
"wasi:http": wasmtime_wasi_http::p2::bindings::http,
"wasi:io": wasmtime_wasi::p2::bindings::io,
```

## Provider repo impact

After this is merged, provider repos need to:
1. Update their local `carina-plugin-wit/wit/` files to match carina main (JSON passthrough WIT from #1503)
2. Add `prevent_destroy` field to LifecycleConfig initializers (#1504)
3. `cargo update` carina dependencies
4. Rebuild WASM binary

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` all pass
- [x] End-to-end: `carina validate` with AWSCC WASM provider loads successfully (no linker error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)