### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/carina-rs/carina"
 homepage = "https://github.com/carina-rs/carina"

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-plugin-host"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 

--- a/carina-plugin-sdk/Cargo.toml
+++ b/carina-plugin-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-plugin-sdk"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 

--- a/carina-provider-protocol/Cargo.toml
+++ b/carina-provider-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-provider-protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
## Release v0.2.0

Bump version from 0.1.0 to 0.2.0.

### Highlights since v0.1.0

**Features:**
- `prevent_destroy` lifecycle enforcement (#1504, #1506) — blocks deletion/replacement of protected resources
- Plan error reporting — `PlanError` type collects lifecycle violations

**Architecture:**
- WIT transport layer (#1503) — JSON passthrough for provider-specific types, reducing 3-layer conversion to 2-layer
- wasi:http bindgen type mappings (#1513) — fixes WASM provider HTTP loading

**Security (WASM sandbox hardening):**
- Restrict env vars exposed to plugins (#1518) — explicit allowlist of 8 vars
- HTTP allow-list (#1519) — only `*.amazonaws.com` permitted
- Resource limits (#1520) — 256MB memory, 20k table elements, 10 instances
- Socket restriction (#1521) — TCP/UDP excluded from WASM linker

**Performance:**
- WASM precompile cache — automatic `.cwasm` caching at `~/.carina/cache/`
- Instance reuse (#1517) — factory init instance reused for validate_config
- Shared instances (#1522) — provider and normalizer share single WASM instance (4→2 per load)

**Testing:**
- Acceptance tests: 88/88 full tests (100%), 42/43 multi-step tests (98%)

### Breaking Changes

- Provider WASM binaries must be rebuilt with updated `carina-plugin-sdk` and `carina-plugin-wit`
- `LifecycleConfig` gains `prevent_destroy: bool` field (backward compatible via `serde(default)`)
- WIT interface uses JSON strings for schema/error/info types

🤖 Generated with [Claude Code](https://claude.com/claude-code)