### PR TITLE
fix: add IMDS (169.254.169.254) to WASM plugin HTTP allow-list

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -32,10 +32,10 @@ use crate::wasm_convert;
 
 // -- HTTP allow-list hooks --
 
-/// HTTP allow-list patterns for outgoing requests from WASM plugins.
+/// HTTP allow-list suffix patterns for outgoing requests from WASM plugins.
 ///
-/// Only hosts matching these suffix patterns are permitted. All other
-/// requests are rejected with `ErrorCode::HttpRequestDenied`.
+/// Hosts matching these suffix patterns are permitted. See also
+/// [`HTTP_ALLOWED_EXACT_HOSTS`] for exact-match entries.
 const HTTP_ALLOWED_HOST_SUFFIXES: &[&str] = &[".amazonaws.com", ".amazonaws.com.cn"];
 
 /// Exact hosts that are always permitted (e.g., EC2 Instance Metadata Service).
@@ -53,7 +53,7 @@ fn is_host_allowed(host: &str) -> bool {
 }
 
 /// Custom `WasiHttpHooks` that restricts outgoing HTTP requests to
-/// hosts matching [`HTTP_ALLOWED_HOST_SUFFIXES`].
+/// hosts matching [`HTTP_ALLOWED_HOST_SUFFIXES`] or [`HTTP_ALLOWED_EXACT_HOSTS`].
 struct AllowListHttpHooks;
 
 impl wasmtime_wasi_http::p2::WasiHttpHooks for AllowListHttpHooks {


### PR DESCRIPTION
## Summary

- Add `169.254.169.254` (EC2 Instance Metadata Service) to the WASM plugin HTTP allow-list
- On EC2 instances, this allows WASM plugins to obtain credentials from instance profiles via IMDS
- Off EC2 (without credentials), the IMDS connection times out naturally and the SDK returns a clear "no credentials found" error instead of repeated "blocked" warnings

Closes #1527

## Test plan

- [x] New test `test_http_allowlist_permits_imds` verifies IMDS host (with and without port) is allowed
- [x] Existing tests still pass — other blocked hosts remain blocked
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)