### PR TITLE
fix: fall back to local backend in force-unlock when no backend configured

### DIFF
--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1142,7 +1142,7 @@ mod tests {
         // Should get LockNotFound (the local backend works), not a config error
         match &result {
             Err(AppError::Config(msg)) if msg.contains("Lock with ID") => {
-                // This is the expected LockNotFound error mapped to AppError::Config
+                // Expected: local backend found no lock file for the dummy ID
             }
             Err(AppError::Config(msg)) if msg.contains("No backend configuration found") => {
                 panic!(
@@ -1150,8 +1150,11 @@ mod tests {
                     msg
                 );
             }
+            Ok(()) => {
+                panic!("expected LockNotFound error for dummy lock ID, got Ok");
+            }
             other => {
-                panic!("unexpected result: {:?}", other);
+                panic!("unexpected error: {:?}", other);
             }
         }
     }


### PR DESCRIPTION
## Summary
- `force-unlock` now falls back to `create_local_backend()` when no backend block is configured, matching the behavior of `apply`
- Previously, `force-unlock` required a backend configuration and errored with "No backend configuration found", making it impossible to unlock stale local locks
- Added test to verify the fallback behavior

## Test plan
- [x] `cargo test -p carina-cli force_unlock_without_backend` passes
- [x] All existing `cargo test -p carina-cli` tests pass
- [x] `cargo clippy` and `cargo fmt` clean

closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)