### PR TITLE
docs: clarify that carina-lsp is included in Homebrew and GitHub Releases

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -9,15 +9,17 @@ description: How to install Carina and set up provider plugins.
 brew install carina-rs/tap/carina
 ```
 
+This installs both `carina` (CLI) and `carina-lsp` (Language Server).
+
 ## GitHub Releases
 
-Download pre-built binaries from [GitHub Releases](https://github.com/carina-rs/carina/releases/latest). Available for macOS (aarch64, x86_64) and Linux (aarch64, x86_64).
+Download pre-built binaries from [GitHub Releases](https://github.com/carina-rs/carina/releases/latest). Available for macOS (aarch64, x86_64) and Linux (aarch64, x86_64). Each archive contains both `carina` and `carina-lsp`.
 
 ```bash
 # macOS (Apple Silicon)
 curl -LO https://github.com/carina-rs/carina/releases/latest/download/carina-0.2.0-macos-aarch64.tar.gz
 tar xzf carina-0.2.0-macos-aarch64.tar.gz
-sudo mv carina /usr/local/bin/
+sudo mv carina carina-lsp /usr/local/bin/
 ```
 
 ## Build from source

--- a/docs/src/content/docs/guides/lsp-setup.md
+++ b/docs/src/content/docs/guides/lsp-setup.md
@@ -17,13 +17,15 @@ The Carina LSP (`carina-lsp`) provides:
 
 ## Installation
 
-Build the LSP server from source:
+If you installed Carina via Homebrew or GitHub Releases, `carina-lsp` is already included -- no additional installation is needed.
+
+To build from source instead:
 
 ```bash
 cargo install --path carina-lsp
 ```
 
-This installs the `carina-lsp` binary. Make sure it is in your `PATH`.
+Make sure the `carina-lsp` binary is in your `PATH`.
 
 ## VS Code setup
 


### PR DESCRIPTION
## Summary
- **installation.md**: Homebrew と GitHub Releases で `carina-lsp` も一緒にインストールされることを明記
- **lsp-setup.md**: Homebrew/GitHub Releases でインストール済みなら追加インストール不要であることを案内し、`cargo install` はソースビルドの代替手段として記載

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>