### PR TITLE
docs: fix carina-lsp cargo install command

### DIFF
--- a/docs/src/content/docs/guides/lsp-setup.md
+++ b/docs/src/content/docs/guides/lsp-setup.md
@@ -22,7 +22,7 @@ If you installed Carina via Homebrew or GitHub Releases, `carina-lsp` is already
 To build from source instead:
 
 ```bash
-cargo install --path carina-lsp
+cargo install --git https://github.com/carina-rs/carina.git carina-lsp
 ```
 
 Make sure the `carina-lsp` binary is in your `PATH`.


### PR DESCRIPTION
## Summary
- LSP setup ガイドの `cargo install --path carina-lsp` を `cargo install --git` に変更
- `--path` はローカルにリポジトリがある前提で、一般ユーザー向けの手順として不適切だった

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>