### PR TITLE
refactor: extract resolve_backend() helper to reduce duplication

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -24,10 +24,7 @@ use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{Expr, Resource, ResourceId, State, Value};
 use carina_core::schema::ResourceSchema;
 use carina_core::value::format_value;
-use carina_state::{
-    BackendConfig as StateBackendConfig, LockInfo, ResourceState, StateBackend, StateFile,
-    create_backend, create_local_backend,
-};
+use carina_state::{LockInfo, ResourceState, StateBackend, StateFile, resolve_backend};
 
 use carina_core::parser::ProviderContext;
 
@@ -769,14 +766,9 @@ pub async fn run_apply(
 
     // Check for backend configuration - use local backend by default
     let backend_config = parsed.backend.as_ref();
-    let backend: Box<dyn StateBackend> = if let Some(config) = backend_config {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(backend_config)
+        .await
+        .map_err(AppError::Backend)?;
 
     // Handle bootstrap if S3 backend is configured
     #[allow(unused_assignments)]
@@ -1337,14 +1329,9 @@ pub async fn run_apply_from_plan(
     );
 
     // Set up backend
-    let backend: Box<dyn StateBackend> = if let Some(config) = plan_file.backend_config.as_ref() {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(plan_file.backend_config.as_ref())
+        .await
+        .map_err(AppError::Backend)?;
 
     // Acquire lock (unless --lock=false)
     let lock_info: Option<LockInfo> = if lock {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -17,10 +17,7 @@ use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::provider::Provider;
 use carina_core::resource::{Resource, ResourceId, State, Value};
-use carina_state::{
-    BackendConfig as StateBackendConfig, LockInfo, StateBackend, create_backend,
-    create_local_backend,
-};
+use carina_state::{LockInfo, StateBackend, resolve_backend};
 
 use carina_core::parser::ProviderContext;
 
@@ -55,14 +52,9 @@ pub async fn run_destroy(
 
     // Check for backend configuration - use local backend by default
     let backend_config = parsed.backend.as_ref();
-    let backend: Box<dyn StateBackend> = if let Some(config) = backend_config {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(backend_config)
+        .await
+        .map_err(AppError::Backend)?;
 
     let mut protected_bucket: Option<String> = None;
 

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -15,7 +15,7 @@ use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::{format_value, json_to_dsl_value};
 use carina_state::{
     BackendConfig as StateBackendConfig, BackendError, LockInfo, ResourceState, StateBackend,
-    StateFile, create_backend, create_local_backend,
+    StateFile, create_backend, resolve_backend,
 };
 
 use super::validate_and_resolve_with_config;
@@ -190,14 +190,9 @@ pub async fn run_force_unlock(
 ) -> Result<(), AppError> {
     let parsed = load_configuration_with_config(path, provider_context)?.parsed;
 
-    let backend: Box<dyn StateBackend> = if let Some(config) = parsed.backend.as_ref() {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+        .await
+        .map_err(AppError::Backend)?;
 
     println!("{}", "Force unlocking state...".yellow().bold());
     println!("Lock ID: {}", lock_id);
@@ -227,14 +222,9 @@ async fn load_state_file(
     let loaded = load_configuration_with_config(path, provider_context)?;
     let parsed = loaded.parsed;
 
-    let backend: Box<dyn StateBackend> = if let Some(config) = parsed.backend.as_ref() {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+        .await
+        .map_err(AppError::Backend)?;
 
     let state_file = backend.read_state().await.map_err(AppError::Backend)?;
     state_file.ok_or_else(|| AppError::Config("No state file found.".to_string()))
@@ -553,15 +543,9 @@ pub async fn run_state_refresh(
     validate_and_resolve_with_config(&mut parsed, base_dir, true, provider_context)?;
 
     // Create backend
-    let backend_config = parsed.backend.as_ref();
-    let backend: Box<dyn StateBackend> = if let Some(config) = backend_config {
-        let state_config = StateBackendConfig::from(config);
-        create_backend(&state_config)
-            .await
-            .map_err(AppError::Backend)?
-    } else {
-        create_local_backend()
-    };
+    let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
+        .await
+        .map_err(AppError::Backend)?;
 
     // Acquire lock (unless --lock=false)
     let lock_info: Option<LockInfo> = if lock {

--- a/carina-state/src/backends/mod.rs
+++ b/carina-state/src/backends/mod.rs
@@ -36,6 +36,21 @@ pub fn create_local_backend() -> Box<dyn StateBackend> {
     Box::new(LocalBackend::new())
 }
 
+/// Resolve a backend from an optional parser BackendConfig.
+///
+/// If a config is provided, converts it to a StateBackendConfig and creates the
+/// appropriate backend. If no config is provided, falls back to a local backend.
+pub async fn resolve_backend(
+    backend_config: Option<&carina_core::parser::BackendConfig>,
+) -> BackendResult<Box<dyn StateBackend>> {
+    if let Some(config) = backend_config {
+        let state_config = BackendConfig::from(config);
+        create_backend(&state_config).await
+    } else {
+        Ok(create_local_backend())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,6 +64,34 @@ mod tests {
         };
 
         let result = create_backend(&config).await;
+        assert!(result.is_err());
+
+        if let Err(BackendError::UnsupportedBackend(name)) = result {
+            assert_eq!(name, "unsupported");
+        } else {
+            panic!("Expected UnsupportedBackend error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_backend_none_returns_local() {
+        let backend = resolve_backend(None).await;
+        assert!(backend.is_ok(), "None config should return a local backend");
+        // Local backend read_state returns Ok(None) when no state file exists
+        let state = backend.unwrap().read_state().await;
+        assert!(state.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_backend_invalid_config_returns_error() {
+        use carina_core::parser::BackendConfig as ParserBackendConfig;
+
+        let config = ParserBackendConfig {
+            backend_type: "unsupported".to_string(),
+            attributes: HashMap::new(),
+        };
+
+        let result = resolve_backend(Some(&config)).await;
         assert!(result.is_err());
 
         if let Err(BackendError::UnsupportedBackend(name)) = result {

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -50,6 +50,6 @@ pub mod state;
 
 // Re-export main types for convenience
 pub use backend::{BackendConfig, BackendError, BackendResult, StateBackend};
-pub use backends::{LocalBackend, create_backend, create_local_backend};
+pub use backends::{LocalBackend, create_backend, create_local_backend, resolve_backend};
 pub use lock::LockInfo;
 pub use state::{ResourceState, StateFile, check_and_migrate, check_and_migrate_bytes};


### PR DESCRIPTION
## Summary

- Extract `resolve_backend()` helper in `carina-state` that encapsulates the "create backend from config or fall back to local" pattern
- Replace 6 duplicated call sites in `carina-cli` (apply.rs x2, destroy.rs x1, state.rs x3) with one-liner calls
- Add unit tests for `resolve_backend()`: None returns local backend, invalid config returns error

## Test plan

- [x] `cargo test -p carina-state` passes (77 tests including 2 new)
- [x] `cargo test -p carina-cli` passes (190 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

closes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)