### PR TITLE
fix: ensure Delete waits for dependent Replace(CBD) to complete

### DIFF
--- a/carina-core/src/executor.rs
+++ b/carina-core/src/executor.rs
@@ -696,13 +696,13 @@ fn build_dependency_map(
             // dependencies (before resolution). These are handled as reverse deps
             // below (for delete ordering) rather than forward deps, to avoid
             // deadlocks where a Replace waits for a Delete that also waits for it.
-            if !matches!(effect, Effect::Replace { .. }) {
-                if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
-                    let unresolved_deps = get_resource_dependencies(unresolved);
-                    for dep_binding in &unresolved_deps {
-                        if let Some(&dep_idx) = binding_to_idx.get(dep_binding) {
-                            dep_indices.insert(dep_idx);
-                        }
+            if !matches!(effect, Effect::Replace { .. })
+                && let Some(unresolved) = unresolved_resources.get(effect.resource_id())
+            {
+                let unresolved_deps = get_resource_dependencies(unresolved);
+                for dep_binding in &unresolved_deps {
+                    if let Some(&dep_idx) = binding_to_idx.get(dep_binding) {
+                        dep_indices.insert(dep_idx);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Fix parallel execution ordering: when a resource is deleted and a dependent resource is replaced (CBD), the delete now waits for the replace to complete
- Prevent deadlocks by not adding old resource dependencies as forward deps for Replace effects

## Problem

During `create_before_destroy` of a Transit Gateway Attachment (changing `transit_gateway_id`), the old TGW deletion ran in parallel with the attachment's Replace operation. The TGW delete failed because the old attachment (referencing that TGW) was still being detached.

```
✗ Delete awscc.ec2.transit_gateway.tgw_a [22m 33.2s]
  → Operation failed: tgw has non-deleted VPC Attachments
```

## Root Cause

In `build_dependency_map()`:

1. Replace effects' `unresolved_resources` dependencies (representing the **old** resource's deps) were incorrectly added as **forward** dependencies — causing the Replace to wait for the Delete, while the Delete also waited for the Replace → deadlock
2. No **reverse** dependency was added from the Delete to the Replace — so parent deletes ran in parallel with child replaces

## Fix

- For Replace effects, skip `unresolved_resources` dependencies in forward dep construction (they represent old resource deps, not new)
- Add reverse dependencies: when a Replace's old resource depends on a resource being Deleted, the Delete waits for the Replace

Refs carina-rs/carina-provider-awscc#47

## Test plan

- [x] New test: `test_delete_waits_for_replace_cbd_of_dependent` — verifies tgw_a Delete waits for attachment Replace(CBD)
- [x] All 1105 carina-core tests pass
- [x] Full workspace test suite passes
- [ ] Acceptance test: `create_before_destroy` Test 3 (TGW Attachment) — requires live AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)