### PR TITLE
feat: add OperationConfig to ResourceSchema for per-resource timeouts

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -681,6 +681,27 @@ impl AttributeSchema {
     }
 }
 
+/// Per-resource operational configuration for provider-specific timeouts and retries.
+///
+/// Providers can set these on individual resource schemas to override default
+/// polling/retry behavior. This avoids hardcoding resource-type string matches
+/// in provider implementations.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OperationConfig {
+    /// Polling timeout for delete operations in seconds.
+    /// Default: provider-specific (e.g., 600s for CloudControl).
+    pub delete_timeout_secs: Option<u64>,
+    /// Maximum retry attempts for retryable delete errors.
+    /// Default: provider-specific (e.g., 12 for CloudControl).
+    pub delete_max_retries: Option<u32>,
+    /// Polling timeout for create operations in seconds.
+    /// Default: provider-specific (e.g., 600s for CloudControl).
+    pub create_timeout_secs: Option<u64>,
+    /// Maximum retry attempts for retryable create errors.
+    /// Default: provider-specific (e.g., 12 for CloudControl).
+    pub create_max_retries: Option<u32>,
+}
+
 /// Resource schema
 #[derive(Debug, Clone)]
 pub struct ResourceSchema {
@@ -701,6 +722,9 @@ pub struct ResourceSchema {
     /// Used for resource types where the provider API rejects updates
     /// despite the schema indicating update support.
     pub force_replace: bool,
+    /// Per-resource operational config (timeouts, retries).
+    /// When None, provider defaults are used.
+    pub operation_config: Option<OperationConfig>,
 }
 
 impl ResourceSchema {
@@ -713,6 +737,7 @@ impl ResourceSchema {
             data_source: false,
             name_attribute: None,
             force_replace: false,
+            operation_config: None,
         }
     }
 
@@ -743,6 +768,11 @@ impl ResourceSchema {
 
     pub fn force_replace(mut self) -> Self {
         self.force_replace = true;
+        self
+    }
+
+    pub fn with_operation_config(mut self, config: OperationConfig) -> Self {
+        self.operation_config = Some(config);
         self
     }
 
@@ -2882,5 +2912,34 @@ mod tests {
             Some(Value::List(items)) => assert_eq!(items.len(), 1),
             other => panic!("expected List, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_operation_config_default() {
+        let config = OperationConfig::default();
+        assert_eq!(config.delete_timeout_secs, None);
+        assert_eq!(config.delete_max_retries, None);
+        assert_eq!(config.create_timeout_secs, None);
+        assert_eq!(config.create_max_retries, None);
+    }
+
+    #[test]
+    fn test_resource_schema_with_operation_config() {
+        let schema =
+            ResourceSchema::new("ec2.transit_gateway").with_operation_config(OperationConfig {
+                delete_timeout_secs: Some(1800),
+                delete_max_retries: Some(24),
+                ..Default::default()
+            });
+        let config = schema.operation_config.unwrap();
+        assert_eq!(config.delete_timeout_secs, Some(1800));
+        assert_eq!(config.delete_max_retries, Some(24));
+        assert_eq!(config.create_timeout_secs, None);
+    }
+
+    #[test]
+    fn test_resource_schema_without_operation_config() {
+        let schema = ResourceSchema::new("ec2.vpc");
+        assert!(schema.operation_config.is_none());
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -715,6 +715,7 @@ let vpc = awscc.ec2.vpc {
             data_source: false,
             name_attribute: None,
             force_replace: false,
+            operation_config: None,
         }
     }
 

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -249,6 +249,14 @@ fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
         data_source: s.data_source,
         name_attribute: s.name_attribute.clone(),
         force_replace: s.force_replace,
+        operation_config: s.operation_config.as_ref().map(|c| {
+            carina_core::schema::OperationConfig {
+                delete_timeout_secs: c.delete_timeout_secs,
+                delete_max_retries: c.delete_max_retries,
+                create_timeout_secs: c.create_timeout_secs,
+                create_max_retries: c.create_max_retries,
+            }
+        }),
     }
 }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -157,6 +157,21 @@ pub struct ResourceSchema {
     pub name_attribute: Option<String>,
     #[serde(default)]
     pub force_replace: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_config: Option<OperationConfig>,
+}
+
+/// Per-resource operational configuration for timeouts and retries.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OperationConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delete_timeout_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delete_max_retries: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_timeout_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_max_retries: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,5 +355,39 @@ mod tests {
         let json = serde_json::to_string(&attr).unwrap();
         let back: AttributeType = serde_json::from_str(&json).unwrap();
         assert_eq!(json, serde_json::to_string(&back).unwrap());
+    }
+
+    #[test]
+    fn test_operation_config_serialization() {
+        let config = OperationConfig {
+            delete_timeout_secs: Some(1800),
+            delete_max_retries: Some(24),
+            create_timeout_secs: None,
+            create_max_retries: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"delete_timeout_secs\":1800"));
+        assert!(!json.contains("create_timeout_secs"));
+
+        let back: OperationConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.delete_timeout_secs, Some(1800));
+        assert_eq!(back.create_timeout_secs, None);
+    }
+
+    #[test]
+    fn test_resource_schema_with_operation_config() {
+        let json = r#"{"resource_type":"ec2.tgw","attributes":{},"operation_config":{"delete_timeout_secs":1800}}"#;
+        let schema: ResourceSchema = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            schema.operation_config.unwrap().delete_timeout_secs,
+            Some(1800)
+        );
+    }
+
+    #[test]
+    fn test_resource_schema_without_operation_config() {
+        let json = r#"{"resource_type":"ec2.vpc","attributes":{}}"#;
+        let schema: ResourceSchema = serde_json::from_str(json).unwrap();
+        assert!(schema.operation_config.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Add `OperationConfig` struct to `ResourceSchema` in carina-core
- Add matching `OperationConfig` to protocol types (carina-provider-protocol) with serde support
- Add conversion in carina-plugin-host (proto → core)
- Builder method: `schema.with_operation_config(OperationConfig { ... })`

Providers can now declare per-resource operational parameters directly in schema definitions:

```rust
ResourceSchema::new("ec2.transit_gateway")
    .with_operation_config(OperationConfig {
        delete_timeout_secs: Some(1800),
        delete_max_retries: Some(24),
        ..Default::default()
    })
```

This replaces hardcoded type-name string matching in provider implementations.

Refs #1543

## Test plan

- [x] 3 new tests in carina-core (OperationConfig default, with_operation_config, without)
- [x] 3 new tests in carina-provider-protocol (serialization, with/without config)
- [x] All 1108 carina-core tests pass
- [x] Full workspace test suite passes
- [x] Pre-commit (fmt + clippy) passes

## Next steps (separate PRs)

- [ ] awscc provider: populate OperationConfig on TGW/IPAM/NatGW schemas
- [ ] awscc provider: read config from schema instead of hardcoded string matches in cloudcontrol.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)