### PR TITLE
fix: use state dependency_bindings for Delete vs Replace(CBD) ordering

### DIFF
--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2427,6 +2427,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
                 Value::String("10.0.0.0/16".to_string()),
             )]),
             exists: true,
+            dependency_bindings: Vec::new(),
         },
     )]);
 
@@ -2501,6 +2502,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
                 Value::String("10.0.0.0/24".to_string()),
             )]),
             exists: true,
+            dependency_bindings: Vec::new(),
         },
     )]);
 

--- a/carina-core/src/executor.rs
+++ b/carina-core/src/executor.rs
@@ -691,14 +691,7 @@ fn build_dependency_map(
                     dep_indices.insert(dep_idx);
                 }
             }
-            // For non-Replace effects, also consider unresolved resource dependencies.
-            // For Replace effects, unresolved deps represent the OLD resource's
-            // dependencies (before resolution). These are handled as reverse deps
-            // below (for delete ordering) rather than forward deps, to avoid
-            // deadlocks where a Replace waits for a Delete that also waits for it.
-            if !matches!(effect, Effect::Replace { .. })
-                && let Some(unresolved) = unresolved_resources.get(effect.resource_id())
-            {
+            if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
                 let unresolved_deps = get_resource_dependencies(unresolved);
                 for dep_binding in &unresolved_deps {
                     if let Some(&dep_idx) = binding_to_idx.get(dep_binding) {
@@ -721,23 +714,17 @@ fn build_dependency_map(
                 }
             }
         }
-        // For Replace effects (especially CBD), the old resource (from) may depend
-        // on a resource that is being deleted. The delete of that parent must wait
-        // for this Replace to complete first (old resource deleted during Replace).
-        // Use unresolved_resources to get the original (pre-resolution) dependencies.
-        if let Effect::Replace { .. } = effect {
-            let unresolved_deps: HashSet<String> =
-                if let Some(unresolved) = unresolved_resources.get(effect.resource_id()) {
-                    get_resource_dependencies(unresolved)
-                } else {
-                    HashSet::new()
-                };
-            for dep_binding in &unresolved_deps {
-                if let Some(&dep_idx) = binding_to_idx.get(dep_binding) {
-                    // Only add reverse dep if the dependency is a Delete effect
-                    if matches!(&effects[dep_idx], Effect::Delete { .. }) {
-                        reverse_deps.push((dep_idx, idx));
-                    }
+        // For Replace effects (especially CBD), the old resource (from) may have
+        // depended on a resource that is now being deleted. The delete of that
+        // parent must wait for this Replace to complete first (the old resource
+        // is deleted during the Replace's delete phase).
+        // Use from.dependency_bindings (recorded in state) for the old dependencies.
+        if let Effect::Replace { from, .. } = effect {
+            for dep_binding in &from.dependency_bindings {
+                if let Some(&dep_idx) = binding_to_idx.get(dep_binding)
+                    && matches!(&effects[dep_idx], Effect::Delete { .. })
+                {
+                    reverse_deps.push((dep_idx, idx));
                 }
             }
         }
@@ -3785,10 +3772,11 @@ mod tests {
         let tgw_a_deps: HashSet<String> = HashSet::new();
 
         // attachment: Replace (CBD)
-        // from: depends on tgw_a
-        let attachment_from =
-            State::existing(attachment_id.clone(), HashMap::new()).with_identifier("attach-old");
-        // to: depends on tgw_b (different TGW)
+        // from: depends on tgw_a (recorded in state's dependency_bindings)
+        let attachment_from = State::existing(attachment_id.clone(), HashMap::new())
+            .with_identifier("attach-old")
+            .with_dependency_bindings(vec!["tgw_a".to_string()]);
+        // to: depends on tgw_b (different TGW — dependency changed)
         let mut attachment_to = Resource::new("test", "attachment");
         attachment_to.binding = Some("attachment".to_string());
         attachment_to.dependency_bindings = vec!["tgw_b".to_string()];
@@ -3835,14 +3823,9 @@ mod tests {
         // tgw_a: delete (should happen AFTER attachment replace completes)
         provider.push_delete(Ok(()));
 
-        // The from resource of the attachment depends on tgw_a
-        let mut attachment_unresolved = Resource::new("test", "attachment");
-        attachment_unresolved.binding = Some("attachment".to_string());
-        attachment_unresolved.dependency_bindings = vec!["tgw_a".to_string()];
-
         let input = ExecutionInput {
             plan: &plan,
-            unresolved_resources: &HashMap::from([(attachment_id.clone(), attachment_unresolved)]),
+            unresolved_resources: &HashMap::new(),
             binding_map: HashMap::new(),
             current_states: HashMap::new(),
         };

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -421,6 +421,7 @@ mod tests {
                 attributes: vec![("vpc_id".to_string(), Value::String("vpc-abc".to_string()))]
                     .into_iter()
                     .collect(),
+                dependency_bindings: Vec::new(),
             },
         );
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -906,6 +906,9 @@ pub struct State {
     pub attributes: HashMap<String, Value>,
     /// Whether this state exists
     pub exists: bool,
+    /// Binding names this resource depended on when it was last applied.
+    /// Used by the executor to determine delete ordering during replace operations.
+    pub dependency_bindings: Vec<String>,
 }
 
 impl State {
@@ -915,6 +918,7 @@ impl State {
             identifier: None,
             attributes: HashMap::new(),
             exists: false,
+            dependency_bindings: Vec::new(),
         }
     }
 
@@ -924,11 +928,17 @@ impl State {
             identifier: None,
             attributes,
             exists: true,
+            dependency_bindings: Vec::new(),
         }
     }
 
     pub fn with_identifier(mut self, identifier: impl Into<String>) -> Self {
         self.identifier = Some(identifier.into());
+        self
+    }
+
+    pub fn with_dependency_bindings(mut self, deps: Vec<String>) -> Self {
+        self.dependency_bindings = deps;
         self
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -408,6 +408,7 @@ pub fn redact_secrets_in_state(state: &crate::resource::State) -> crate::resourc
         identifier: state.identifier.clone(),
         attributes: redact_secrets_in_attributes(&state.attributes),
         exists: state.exists,
+        dependency_bindings: state.dependency_bindings.clone(),
     }
 }
 

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -173,6 +173,7 @@ impl StateFile {
                 identifier: Some(identifier.to_string()),
                 attributes: attrs,
                 exists: true,
+                dependency_bindings: rs.unwrap().dependency_bindings.clone(),
             };
         }
         State::not_found(resource.id.clone())
@@ -207,6 +208,7 @@ impl StateFile {
                     identifier: Some(identifier.clone()),
                     attributes: attrs,
                     exists: true,
+                    dependency_bindings: rs.dependency_bindings.clone(),
                 };
                 result.insert(id, state);
             }
@@ -750,6 +752,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let existing = ResourceState::new("s3.bucket", "my-bucket", "awscc").with_protected(true);
@@ -779,6 +782,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -971,6 +975,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1159,6 +1164,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1202,6 +1208,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1237,6 +1244,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1308,6 +1316,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1359,6 +1368,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1417,6 +1427,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1471,6 +1482,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
+            dependency_bindings: Vec::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();


### PR DESCRIPTION
## Summary

Fix the executor's delete ordering for create_before_destroy by using state-recorded dependency_bindings instead of unresolved_resources.

PR #1544 attempted this fix using `unresolved_resources`, but those contain the NEW resource's dependencies. When a dependency changes during replacement (TGW attachment moves from tgw_a to tgw_b), the old dependency (tgw_a) wasn't captured.

## Changes

- Add `dependency_bindings` field to core `State` struct
- Populate from state file in `carina-state`
- Use `from.dependency_bindings` in `build_dependency_map()` for reverse deps
- Revert `unresolved_resources` skip for Replace effects (no longer needed)

Closes #1548
Refs carina-rs/carina-provider-awscc#47

## Test plan

- [x] `test_delete_waits_for_replace_cbd_of_dependent` passes (now uses `from.dependency_bindings`)
- [x] All 1108 carina-core tests pass
- [x] Full workspace test suite passes
- [x] Pre-commit (fmt + clippy) passes
- [ ] Acceptance test: `create_before_destroy` Test 3 (TGW Attachment) — requires live AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)