### PR TITLE
style: use single quotes for literal strings in documentation code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,22 @@ provider aws {
 }
 
 let main_vpc = aws.vpc {
-  name       = "main-vpc"
-  cidr_block = "10.0.0.0/16"
+  name       = 'main-vpc'
+  cidr_block = '10.0.0.0/16'
 }
 
 let web_sg = aws.security_group {
-  name   = "web-sg"
+  name   = 'web-sg'
   vpc_id = main_vpc.id
 }
 
 aws.security_group.ingress_rule {
-  name              = "http"
+  name              = 'http'
   security_group_id = web_sg.id
   from_port         = 80
   to_port           = 80
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  protocol          = 'tcp'
+  cidr_blocks       = ['0.0.0.0/0']
 }
 ```
 
@@ -124,11 +124,11 @@ provider aws {
 
 ```hcl
 aws.security_group.ingress_rule {
-  name              = "http"
+  name              = 'http'
   security_group_id = web_sg.id
   from_port         = 80
   to_port           = 80
-  protocol          = "tcp"
+  protocol          = 'tcp'
 }
 ```
 
@@ -136,7 +136,7 @@ aws.security_group.ingress_rule {
 
 ```hcl
 let web_sg = aws.security_group {
-  name   = "web-sg"
+  name   = 'web-sg'
   vpc_id = main_vpc.id
 }
 ```
@@ -148,14 +148,14 @@ Use the `read` keyword to reference existing infrastructure without managing its
 ```hcl
 # Read an existing VPC (data source)
 let existing_vpc = read aws.vpc {
-  name = "production-vpc"
+  name = 'production-vpc'
 }
 
 # Create a new subnet that references the existing VPC
 let app_subnet = aws.subnet {
-  name              = "app-subnet"
+  name              = 'app-subnet'
   vpc_id            = existing_vpc.id
-  cidr_block        = "10.0.100.0/24"
+  cidr_block        = '10.0.100.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 }
 ```
@@ -183,22 +183,22 @@ Some resources support nested objects for inline configuration. Use repeated blo
 
 ```hcl
 awscc.ec2.security_group {
-  name              = "web-sg"
+  name              = 'web-sg'
   vpc_id            = vpc.vpc_id
-  group_description = "Web server security group"
+  group_description = 'Web server security group'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
+    cidr_ip     = '0.0.0.0/0'
   }
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
+    cidr_ip     = '0.0.0.0/0'
   }
 }
 ```
@@ -208,10 +208,10 @@ Array syntax is also supported:
 ```hcl
   security_group_ingress = [
     {
-      ip_protocol = "tcp"
+      ip_protocol = 'tcp'
       from_port   = 80
       to_port     = 80
-      cidr_ip     = "0.0.0.0/0"
+      cidr_ip     = '0.0.0.0/0'
     }
   ]
 ```
@@ -234,25 +234,25 @@ output {
 }
 
 let web_sg = aws.security_group {
-  name        = "web-sg"
+  name        = 'web-sg'
   vpc_id      = input.vpc
-  description = "Security group for web servers"
+  description = 'Security group for web servers'
 }
 ```
 
 **Using modules**:
 
 ```hcl
-let web_tier = import "./modules/web_tier"
+let web_tier = import './modules/web_tier'
 
 let main_vpc = aws.vpc {
-  name       = "main-vpc"
-  cidr_block = "10.0.0.0/16"
+  name       = 'main-vpc'
+  cidr_block = '10.0.0.0/16'
 }
 
 web_tier {
   vpc         = main_vpc.id
-  cidr_blocks = ["10.0.1.0/24", "10.0.2.0/25"]
+  cidr_blocks = ['10.0.1.0/24', '10.0.2.0/25']
 }
 ```
 
@@ -428,8 +428,8 @@ Store state in an S3 bucket:
 
 ```hcl
 backend s3 {
-  bucket      = "my-carina-state"
-  key         = "infra/prod/carina.crnstate"
+  bucket      = 'my-carina-state'
+  key         = 'infra/prod/carina.crnstate'
   region      = aws.Region.ap_northeast_1
   encrypt     = true
   auto_create = true  # Automatically create the bucket if it doesn't exist
@@ -440,7 +440,7 @@ provider aws {
 }
 
 aws.s3.bucket {
-  name = "my-app-data"
+  name = 'my-app-data'
 }
 ```
 

--- a/docs/src/content/docs/getting-started/core-concepts.md
+++ b/docs/src/content/docs/getting-started/core-concepts.md
@@ -39,9 +39,9 @@ Configure a provider in your `.crn` file:
 
 ```crn
 provider awscc {
-  source  = "file:///path/to/carina_provider_awscc.wasm"
-  version = "0.2.0"
-  region  = "ap-northeast-1"
+  source  = 'file:///path/to/carina_provider_awscc.wasm'
+  version = '0.2.0'
+  region  = 'ap-northeast-1'
 }
 ```
 
@@ -85,7 +85,7 @@ When no other resource needs to reference it:
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 ```
 
@@ -95,12 +95,12 @@ When you need to reference a resource's attributes:
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id     = vpc.vpc_id
-  cidr_block = "10.0.1.0/24"
+  cidr_block = '10.0.1.0/24'
 }
 ```
 
@@ -118,7 +118,7 @@ Control resource behavior during updates and deletions:
 
 ```crn
 awscc.s3.bucket {
-  bucket_name = "my-bucket"
+  bucket_name = 'my-bucket'
 
   lifecycle {
     force_delete = true

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -48,9 +48,9 @@ Carina uses WASM-based provider plugins. When you specify a `source` and `versio
 
 ```crn
 provider awscc {
-    source = "github.com/carina-rs/carina-provider-awscc"
-    version = "0.2.0"
-    region = "ap-northeast-1"
+    source = 'github.com/carina-rs/carina-provider-awscc'
+    version = '0.2.0'
+    region = 'ap-northeast-1'
 }
 ```
 

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -16,16 +16,16 @@ mkdir my-infra && cd my-infra
 ```crn
 // main.crn
 provider awscc {
-  source  = "github.com/carina-rs/carina-provider-awscc"
-  version = "0.2.0"
-  region  = "ap-northeast-1"
+  source  = 'github.com/carina-rs/carina-provider-awscc'
+  version = '0.2.0'
+  region  = 'ap-northeast-1'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "my-first-vpc"
+    Name = 'my-first-vpc'
   }
 }
 ```

--- a/docs/src/content/docs/guides/for-if-expressions.md
+++ b/docs/src/content/docs/guides/for-if-expressions.md
@@ -18,9 +18,9 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpcs = for env in ["dev", "stg"] {
+let vpcs = for env in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
       Name        = "vpc-${env}"
@@ -37,9 +37,9 @@ This creates two VPCs, one for each environment.
 Use the `(index, value)` form to access the iteration index:
 
 ```crn
-let vpcs = for (i, env) in ["dev", "stg"] {
+let vpcs = for (i, env) in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
 
     tags = {
       Name        = "vpc-${env}"
@@ -57,8 +57,8 @@ Use `key, value` binding to iterate over map entries:
 
 ```crn
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let vpcs = for name, cidr in cidrs {
@@ -78,9 +78,9 @@ let vpcs = for name, cidr in cidrs {
 The result of a `for` expression is a list. You can access individual elements with index syntax:
 
 ```crn
-let vpcs = for env in ["dev", "stg"] {
+let vpcs = for env in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
       Name = "vpc-${env}"
@@ -91,11 +91,11 @@ let vpcs = for env in ["dev", "stg"] {
 # Reference the first VPC's attributes
 awscc.ec2.subnet {
   vpc_id            = vpcs[0].vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name = "dev-subnet"
+    Name = 'dev-subnet'
   }
 }
 ```
@@ -106,11 +106,11 @@ You can define local `let` bindings inside a `for` body:
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
-let subnets = for (i, az) in ["ap-northeast-1a", "ap-northeast-1c"] {
-  let cidr = cidr_subnet("10.0.0.0/16", 8, i)
+let subnets = for (i, az) in ['ap-northeast-1a', 'ap-northeast-1c'] {
+  let cidr = cidr_subnet('10.0.0.0/16', 8, i)
 
   awscc.ec2.subnet {
     vpc_id            = vpc.vpc_id
@@ -141,10 +141,10 @@ let enabled = true
 
 let vpc = if enabled {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
-      Name = "conditional-vpc"
+      Name = 'conditional-vpc'
     }
   }
 }
@@ -160,10 +160,10 @@ Use `if`/`else` as a value expression to choose between two values:
 let is_production = true
 
 awscc.ec2.vpc {
-  cidr_block = if is_production { "10.0.0.0/16" } else { "172.16.0.0/16" }
+  cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
 
   tags = {
-    Name = if is_production { "prod-vpc" } else { "dev-vpc" }
+    Name = if is_production { 'prod-vpc' } else { 'dev-vpc' }
   }
 }
 ```
@@ -176,15 +176,15 @@ You can use `if` expressions inside `for` bodies and vice versa:
 
 ```crn
 let environments = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
-  prd = "10.2.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+  prd = '10.2.0.0/16'
 }
 
 let vpcs = for name, cidr in environments {
   awscc.ec2.vpc {
     cidr_block           = cidr
-    enable_dns_hostnames = if name == "prd" { true } else { false }
+    enable_dns_hostnames = if name == 'prd' { true } else { false }
 
     tags = {
       Name        = "vpc-${name}"

--- a/docs/src/content/docs/guides/functions.md
+++ b/docs/src/content/docs/guides/functions.md
@@ -22,12 +22,12 @@ Examples:
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = upper("my-vpc")              # "MY-VPC"
-    Env  = replace("_", "-", "my_env")  # "my-env"
-    Id   = join("-", ["vpc", "prod"])    # "vpc-prod"
+    Name = upper('my-vpc')              # 'MY-VPC'
+    Env  = replace('_', '-', 'my_env')  # 'my-env'
+    Id   = join('-', ['vpc', 'prod'])    # 'vpc-prod'
   }
 }
 ```
@@ -47,14 +47,14 @@ awscc.ec2.vpc {
 Examples:
 
 ```crn
-let parts1 = ["web", "test"]
-let parts2 = ["vpc"]
+let parts1 = ['web', 'test']
+let parts2 = ['vpc']
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = join("-", concat(parts2, parts1))  # "web-test-vpc"
+    Name = join('-', concat(parts2, parts1))  # 'web-test-vpc'
   }
 }
 ```
@@ -75,10 +75,10 @@ awscc.ec2.vpc {
 Example:
 
 ```crn
-let vpcs = for (i, env) in ["dev", "stg"] {
+let vpcs = for (i, env) in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
-    # i=0 -> "10.0.0.0/16", i=1 -> "10.1.0.0/16"
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
+    # i=0 -> '10.0.0.0/16', i=1 -> '10.1.0.0/16'
 
     tags = {
       Name = "vpc-${env}"
@@ -101,14 +101,14 @@ Define reusable logic with the `fn` keyword:
 
 ```crn
 fn tag_name(env: string, service: string): string {
-  join("-", [env, service, "vpc"])
+  join('-', [env, service, 'vpc'])
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = tag_name("production", "web")  # "production-web-vpc"
+    Name = tag_name('production', 'web')  # 'production-web-vpc'
   }
 }
 ```
@@ -141,7 +141,7 @@ fn subnet_name(env: string, tier: string, index: int): string {
 Parameters can have default values:
 
 ```crn
-fn make_tags(name: string, env: string = "dev"): map(string) {
+fn make_tags(name: string, env: string = 'dev'): map(string) {
   {
     Name        = name
     Environment = env
@@ -155,20 +155,20 @@ The pipe operator `|>` passes the result of the left side as the **last** argume
 
 ```crn
 # Without pipe
-let result = join("-", split("_", upper("hello_world")))
+let result = join('-', split('_', upper('hello_world')))
 
 # With pipe -- reads left to right
-let result = "hello_world" |> upper() |> split("_") |> join("-")
-# Result: "HELLO-WORLD"
+let result = 'hello_world' |> upper() |> split('_') |> join('-')
+# Result: 'HELLO-WORLD'
 ```
 
 The pipe operator is especially useful with collection functions:
 
 ```crn
-let names = ["web", "api", "worker"]
+let names = ['web', 'api', 'worker']
 
 # Extract and transform
-let result = names |> join(", ")
+let result = names |> join(', ')
 ```
 
 ## Compose operator
@@ -176,9 +176,9 @@ let result = names |> join(", ")
 The compose operator `>>` creates a new function by chaining two partially applied functions (closures). Both sides must be closures:
 
 ```crn
-# split("_") is a closure (1 of 2 args provided)
-# join("-") is a closure (1 of 2 args provided)
-let transform = split("_") >> join("-")
+# split('_') is a closure (1 of 2 args provided)
+# join('-') is a closure (1 of 2 args provided)
+let transform = split('_') >> join('-')
 ```
 
 The resulting function applies the left function first, then passes the result to the right function.
@@ -189,10 +189,10 @@ When you call a built-in function with fewer arguments than it expects, you get 
 
 ```crn
 # replace expects 3 args; giving 2 returns a closure
-let dashify = replace("_", "-")
+let dashify = replace('_', '-')
 
 # The closure is called when the last argument arrives (via pipe)
-let result = "hello_world" |> dashify()  # "hello-world"
+let result = 'hello_world' |> dashify()  # 'hello-world'
 ```
 
 This works naturally with the pipe operator, since the piped value fills in the last argument.

--- a/docs/src/content/docs/guides/state-management.md
+++ b/docs/src/content/docs/guides/state-management.md
@@ -17,9 +17,9 @@ Add a `backend` block to your `.crn` file:
 
 ```crn
 backend s3 {
-  bucket = "my-carina-state"
-  key    = "production/carina.state.json"
-  region = "ap-northeast-1"
+  bucket = 'my-carina-state'
+  key    = 'production/carina.state.json'
+  region = 'ap-northeast-1'
 }
 
 provider awscc {
@@ -27,10 +27,10 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "my-vpc"
+    Name = 'my-vpc'
   }
 }
 ```
@@ -43,9 +43,9 @@ By default, `carina apply` automatically creates the S3 bucket if it doesn't exi
 
 ```crn
 backend s3 {
-  bucket      = "my-carina-state"
-  key         = "production/carina.state.json"
-  region      = "ap-northeast-1"
+  bucket      = 'my-carina-state'
+  key         = 'production/carina.state.json'
+  region      = 'ap-northeast-1'
   auto_create = true  # This is the default; can be omitted
 }
 ```
@@ -74,15 +74,15 @@ To bring an existing cloud resource under Carina management, use the `import` bl
 
 ```crn
 import {
-  to = awscc.ec2.vpc "my-vpc"
-  id = "vpc-0abc123def456"
+  to = awscc.ec2.vpc 'my-vpc'
+  id = 'vpc-0abc123def456'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "my-vpc"
+    Name = 'my-vpc'
   }
 }
 ```
@@ -98,15 +98,15 @@ When you rename a resource or reorganize your code, use the `moved` block to upd
 
 ```crn
 moved {
-  from = awscc.ec2.vpc "vpc"
-  to   = awscc.ec2.vpc "main_vpc"
+  from = awscc.ec2.vpc 'vpc'
+  to   = awscc.ec2.vpc 'main_vpc'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "my-vpc"
+    Name = 'my-vpc'
   }
 }
 ```
@@ -119,7 +119,7 @@ To stop managing a resource without destroying it in the cloud, use the `removed
 
 ```crn
 removed {
-  from = awscc.ec2.vpc "main_vpc"
+  from = awscc.ec2.vpc 'main_vpc'
 }
 ```
 
@@ -131,15 +131,15 @@ To read outputs from another Carina project's state, use `remote_state`:
 
 ```crn
 let network = remote_state {
-  path = "network.state.json"
+  path = 'network.state.json'
 }
 
 awscc.ec2.security_group {
-  group_description = "Web security group"
+  group_description = 'Web security group'
   vpc_id            = network.vpc.vpc_id
 
   tags = {
-    Name = "web-sg"
+    Name = 'web-sg'
   }
 }
 ```
@@ -149,10 +149,10 @@ The `remote_state` block loads another project's state file and makes its resour
 You can also specify the backend type explicitly:
 
 ```crn
-let network = remote_state "s3" {
-  bucket = "carina-state"
-  key    = "network/carina.state.json"
-  region = "ap-northeast-1"
+let network = remote_state 's3' {
+  bucket = 'carina-state'
+  key    = 'network/carina.state.json'
+  region = 'ap-northeast-1'
 }
 ```
 

--- a/docs/src/content/docs/guides/using-modules.md
+++ b/docs/src/content/docs/guides/using-modules.md
@@ -22,7 +22,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = cidr_block
 
   tags = {
-    Name = "module-vpc"
+    Name = 'module-vpc'
   }
 }
 
@@ -32,7 +32,7 @@ let subnet = awscc.ec2.subnet {
   availability_zone = az
 
   tags = {
-    Name = "module-subnet"
+    Name = 'module-subnet'
   }
 }
 
@@ -77,12 +77,12 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import "./modules/network"
+let network = import './modules/network'
 
 network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }
 ```
 
@@ -93,18 +93,18 @@ The `import` expression loads the module and binds it to a name. You then call t
 To use a module's output attributes, bind the module call with `let`:
 
 ```crn
-let network = import "./modules/network"
+let network = import './modules/network'
 
 let net = network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }
 
 # Use module output to create another resource
 awscc.ec2.route_table {
   vpc_id = net.vpc_id
-  tags   = { Name = "my-route-table" }
+  tags   = { Name = 'my-route-table' }
 }
 ```
 
@@ -122,7 +122,7 @@ Directory modules are useful when a module grows large or needs helper files. Th
 Both forms are imported the same way:
 
 ```crn
-let network = import "./modules/network"
+let network = import './modules/network'
 ```
 
 ## Nested modules
@@ -132,7 +132,7 @@ A module can import other modules. This lets you compose infrastructure from sma
 For example, `modules/network_with_rt/main.crn` can import the network module:
 
 ```crn
-let network = import "../network"
+let network = import '../network'
 
 arguments {
   cidr_block : string
@@ -150,7 +150,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = net.vpc_id
 
   tags = {
-    Name = "nested-module-rt"
+    Name = 'nested-module-rt'
   }
 }
 
@@ -167,11 +167,11 @@ Import paths are relative to the module file's location.
 Modules can be called inside `for` expressions to create multiple instances:
 
 ```crn
-let vpc_mod = import "./modules/vpc_only"
+let vpc_mod = import './modules/vpc_only'
 
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let networks = for name, cidr in cidrs {

--- a/docs/src/content/docs/guides/writing-resources.md
+++ b/docs/src/content/docs/guides/writing-resources.md
@@ -21,13 +21,13 @@ The simplest way to define a resource is an **anonymous resource**. Use this whe
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = default
 
   tags = {
-    Environment = "production"
+    Environment = 'production'
   }
 }
 ```
@@ -40,13 +40,13 @@ When another resource needs to reference attributes from a resource, use a `let`
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 ```
 
@@ -61,7 +61,7 @@ Resource attributes support several value types:
 ```crn
 awscc.ec2.vpc {
   # String
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   # Boolean
   enable_dns_support = true
@@ -74,8 +74,8 @@ awscc.ec2.vpc {
 
   # Map
   tags = {
-    Name        = "my-vpc"
-    Environment = "production"
+    Name        = 'my-vpc'
+    Environment = 'production'
   }
 }
 ```
@@ -85,10 +85,10 @@ awscc.ec2.vpc {
 Strings support interpolation with `${}`:
 
 ```crn
-let env = "production"
+let env = 'production'
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name = "vpc-${env}"
@@ -102,31 +102,31 @@ Some resources have nested configuration blocks. Repeat the block name to add mu
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Web server security group"
+  group_description = 'Web server security group'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTP"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTP'
   }
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTPS"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTPS'
   }
 
   tags = {
-    Name = "web-sg"
+    Name = 'web-sg'
   }
 }
 ```
@@ -137,10 +137,10 @@ You can define local variables inside a resource block with `let`. These are sco
 
 ```crn
 awscc.ec2.vpc {
-  let env  = "production"
+  let env  = 'production'
   let name = "local-let-${env}"
 
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name = name
@@ -171,7 +171,7 @@ Carina supports line comments with `//` or `#`, and block comments with `/* ... 
    block comment */
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"  # inline comment
+  cidr_block = '10.0.0.0/16'  # inline comment
 }
 ```
 
@@ -185,23 +185,23 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Name = "my-vpc"
+    Name = 'my-vpc'
   }
 }
 
 awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "public-subnet"
+    Name = 'public-subnet'
   }
 }
 
@@ -209,7 +209,7 @@ awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "public-rt"
+    Name = 'public-rt'
   }
 }
 ```

--- a/docs/src/content/docs/reference/dsl/built-in-functions.md
+++ b/docs/src/content/docs/reference/dsl/built-in-functions.md
@@ -16,8 +16,8 @@ upper(string: string) -> string
 ```
 
 ```crn
-upper("hello")        # => "HELLO"
-upper("Hello World")  # => "HELLO WORLD"
+upper('hello')        # => 'HELLO'
+upper('Hello World')  # => 'HELLO WORLD'
 ```
 
 ### `lower`
@@ -29,8 +29,8 @@ lower(string: string) -> string
 ```
 
 ```crn
-lower("HELLO")        # => "hello"
-lower("Hello World")  # => "hello world"
+lower('HELLO')        # => 'hello'
+lower('Hello World')  # => 'hello world'
 ```
 
 ### `trim`
@@ -42,8 +42,8 @@ trim(string: string) -> string
 ```
 
 ```crn
-trim("  hello  ")   # => "hello"
-trim("\n hello \t")  # => "hello"
+trim('  hello  ')   # => 'hello'
+trim('\n hello \t')  # => 'hello'
 ```
 
 ### `replace`
@@ -55,9 +55,9 @@ replace(search: string, replacement: string, string: string) -> string
 ```
 
 ```crn
-replace("-", "_", "hello-world")      # => "hello_world"
-"hello-world" |> replace("-", "_")    # => "hello_world" (pipe form)
-replace("::", ".", "foo::bar::baz")   # => "foo.bar.baz"
+replace('-', '_', 'hello-world')      # => 'hello_world'
+'hello-world' |> replace('-', '_')    # => 'hello_world' (pipe form)
+replace('::', '.', 'foo::bar::baz')   # => 'foo.bar.baz'
 ```
 
 ### `split`
@@ -69,9 +69,9 @@ split(separator: string, string: string) -> list
 ```
 
 ```crn
-split("-", "a-b-c")      # => ["a", "b", "c"]
-"a-b-c" |> split("-")    # => ["a", "b", "c"] (pipe form)
-split("::", "a::b::c")   # => ["a", "b", "c"]
+split('-', 'a-b-c')      # => ['a', 'b', 'c']
+'a-b-c' |> split('-')    # => ['a', 'b', 'c'] (pipe form)
+split('::', 'a::b::c')   # => ['a', 'b', 'c']
 ```
 
 ### `join`
@@ -83,9 +83,9 @@ join(separator: string, list: list) -> string
 ```
 
 ```crn
-join("-", ["a", "b", "c"])    # => "a-b-c"
-["a", "b", "c"] |> join("-") # => "a-b-c" (pipe form)
-join(", ", ["hello", 42])     # => "hello, 42"
+join('-', ['a', 'b', 'c'])    # => 'a-b-c'
+['a', 'b', 'c'] |> join('-') # => 'a-b-c' (pipe form)
+join(', ', ['hello', 42])     # => 'hello, 42'
 ```
 
 ## List Functions
@@ -101,7 +101,7 @@ concat(items: list, base_list: list) -> list
 ```crn
 concat([3, 4], [1, 2])          # => [1, 2, 3, 4]
 [1, 2] |> concat([3, 4])        # => [1, 2, 3, 4] (pipe form)
-concat(["c"], ["a", "b"])        # => ["a", "b", "c"]
+concat(['c'], ['a', 'b'])        # => ['a', 'b', 'c']
 ```
 
 ### `flatten`
@@ -114,7 +114,7 @@ flatten(list: list) -> list
 
 ```crn
 flatten([[1, 2], [3, 4]])     # => [1, 2, 3, 4]
-flatten([["a", "b"], ["c"]])  # => ["a", "b", "c"]
+flatten([['a', 'b'], ['c']])  # => ['a', 'b', 'c']
 flatten([[1, 2], 3, [4]])     # => [1, 2, 3, 4]
 ```
 
@@ -135,7 +135,7 @@ length(value: list | map | string) -> int
 ```crn
 length([1, 2, 3])       # => 3
 length({a = 1, b = 2})  # => 2
-length("hello")         # => 5
+length('hello')         # => 5
 length([])              # => 0
 ```
 
@@ -151,23 +151,23 @@ When applied to a list of maps, returns a list of the extracted values:
 
 ```crn
 let subnets = [
-  { name = "a", subnet_id = "id-1" },
-  { name = "b", subnet_id = "id-2" },
+  { name = 'a', subnet_id = 'id-1' },
+  { name = 'b', subnet_id = 'id-2' },
 ]
 
-map(".subnet_id", subnets)       # => ["id-1", "id-2"]
-subnets |> map(".subnet_id")     # => ["id-1", "id-2"] (pipe form)
+map('.subnet_id', subnets)       # => ['id-1', 'id-2']
+subnets |> map('.subnet_id')     # => ['id-1', 'id-2'] (pipe form)
 ```
 
 When applied to a map of maps, returns a map with the same keys and extracted values:
 
 ```crn
 let envs = {
-  dev = { cidr = "10.0.0.0/16", name = "development" }
-  stg = { cidr = "10.1.0.0/16", name = "staging" }
+  dev = { cidr = '10.0.0.0/16', name = 'development' }
+  stg = { cidr = '10.1.0.0/16', name = 'staging' }
 }
 
-envs |> map(".cidr")  # => { dev = "10.0.0.0/16", stg = "10.1.0.0/16" }
+envs |> map('.cidr')  # => { dev = '10.0.0.0/16', stg = '10.1.0.0/16' }
 ```
 
 ## Map Functions
@@ -181,7 +181,7 @@ keys(map: map) -> list
 ```
 
 ```crn
-keys({ b = 2, a = 1, c = 3 })  # => ["a", "b", "c"]
+keys({ b = 2, a = 1, c = 3 })  # => ['a', 'b', 'c']
 keys({})                         # => []
 ```
 
@@ -207,8 +207,8 @@ lookup(map: map, key: string, default: any) -> any
 ```
 
 ```crn
-lookup({ a = "one", b = "two" }, "a", "default")  # => "one"
-lookup({ a = "one", b = "two" }, "c", "default")  # => "default"
+lookup({ a = 'one', b = 'two' }, 'a', 'default')  # => 'one'
+lookup({ a = 'one', b = 'two' }, 'c', 'default')  # => 'default'
 ```
 
 ## Numeric Functions
@@ -256,18 +256,18 @@ cidr_subnet(prefix: string, newbits: int, netnum: int) -> string
 - `netnum`: subnet number within the new address space
 
 ```crn
-cidr_subnet("10.0.0.0/16", 8, 0)    # => "10.0.0.0/24"
-cidr_subnet("10.0.0.0/16", 8, 1)    # => "10.0.1.0/24"
-cidr_subnet("10.0.0.0/16", 8, 255)  # => "10.0.255.0/24"
-cidr_subnet("10.0.0.0/8", 8, 10)    # => "10.10.0.0/16"
+cidr_subnet('10.0.0.0/16', 8, 0)    # => '10.0.0.0/24'
+cidr_subnet('10.0.0.0/16', 8, 1)    # => '10.0.1.0/24'
+cidr_subnet('10.0.0.0/16', 8, 255)  # => '10.0.255.0/24'
+cidr_subnet('10.0.0.0/8', 8, 10)    # => '10.10.0.0/16'
 ```
 
 This is commonly used with `for` expressions to allocate subnets:
 
 ```crn
-let vpcs = for (i, env) in ["dev", "stg"] {
+let vpcs = for (i, env) in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
   }
 }
 ```
@@ -283,8 +283,8 @@ env(name: string) -> string
 ```
 
 ```crn
-let home = env("HOME")
-let db_host = env("DB_HOST")
+let home = env('HOME')
+let db_host = env('DB_HOST')
 ```
 
 ## Security Functions
@@ -299,7 +299,7 @@ secret(value: any) -> secret
 
 ```crn
 awscc.rds.db_instance {
-  master_user_password = secret(env("DB_PASSWORD"))
+  master_user_password = secret(env('DB_PASSWORD'))
 }
 ```
 
@@ -313,14 +313,14 @@ decrypt(ciphertext: string, key?: string) -> string
 
 ```crn
 # Key embedded in ciphertext (e.g., AWS KMS encrypted blob)
-let password = decrypt("AQICAHh...")
+let password = decrypt('AQICAHh...')
 
 # Explicit key
-let password = decrypt("AQICAHh...", "alias/my-key")
+let password = decrypt('AQICAHh...', 'alias/my-key')
 
 # Combined with secret() to prevent storing the decrypted value in state
 awscc.rds.db_instance {
-  master_user_password = secret(decrypt("AQICAHh..."))
+  master_user_password = secret(decrypt('AQICAHh...'))
 }
 ```
 

--- a/docs/src/content/docs/reference/dsl/expressions.md
+++ b/docs/src/content/docs/reference/dsl/expressions.md
@@ -12,9 +12,9 @@ The `for` expression iterates over a list or map to create multiple resources or
 ### Iterating Over a List
 
 ```crn
-let vpcs = for env in ["dev", "stg"] {
+let vpcs = for env in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
       Name        = "vpc-${env}"
@@ -29,9 +29,9 @@ let vpcs = for env in ["dev", "stg"] {
 Use `(index, value)` to access both the index and the element:
 
 ```crn
-let vpcs = for (i, env) in ["dev", "stg"] {
+let vpcs = for (i, env) in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
 
     tags = {
       Name        = "for-list-test-${env}"
@@ -47,8 +47,8 @@ Use `key, value` to iterate over map entries:
 
 ```crn
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let vpcs = for name, cidr in cidrs {
@@ -74,7 +74,7 @@ let networks = for name, cidr in cidrs {
   network {
     cidr_block  = cidr
     subnet_cidr = subnet_cidr
-    az          = "ap-northeast-1a"
+    az          = 'ap-northeast-1a'
   }
 }
 ```
@@ -106,10 +106,10 @@ if is_production {
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block = if is_production { "10.0.0.0/16" } else { "172.16.0.0/16" }
+  cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
 
   tags = {
-    Name = if is_production { "prod-vpc" } else { "dev-vpc" }
+    Name = if is_production { 'prod-vpc' } else { 'dev-vpc' }
   }
 }
 ```
@@ -120,7 +120,7 @@ awscc.ec2.vpc {
 
 ```crn
 if is_production {
-  let cidr = "10.0.0.0/16"
+  let cidr = '10.0.0.0/16'
 
   awscc.ec2.vpc {
     cidr_block = cidr
@@ -134,20 +134,20 @@ if is_production {
 
 ```crn
 # Top-level value binding
-let env = "prod"
-let zones = ["ap-northeast-1a", "ap-northeast-1c"]
+let env = 'prod'
+let zones = ['ap-northeast-1a', 'ap-northeast-1c']
 
 # Top-level resource binding
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 # Module import binding
-let network = import "./modules/network"
+let network = import './modules/network'
 
 # Remote state binding
 let shared = remote_state {
-  path = "shared.state.json"
+  path = 'shared.state.json'
 }
 ```
 
@@ -159,26 +159,26 @@ The pipe operator passes the result of the left expression as the last argument 
 
 ```crn
 # Without pipe: nested calls are hard to read
-let result = join("-", concat(["vpc"], ["prod", "web"]))
+let result = join('-', concat(['vpc'], ['prod', 'web']))
 
 # With pipe: reads left to right
-let result = ["prod", "web"] |> concat(["vpc"]) |> join("-")
+let result = ['prod', 'web'] |> concat(['vpc']) |> join('-')
 ```
 
 The pipe operator works with any built-in function. The piped value becomes the last argument:
 
 ```crn
 # These are equivalent:
-join("-", ["a", "b", "c"])
-["a", "b", "c"] |> join("-")
+join('-', ['a', 'b', 'c'])
+['a', 'b', 'c'] |> join('-')
 
 # These are equivalent:
-replace("-", "_", "hello-world")
-"hello-world" |> replace("-", "_")
+replace('-', '_', 'hello-world')
+'hello-world' |> replace('-', '_')
 
 # These are equivalent:
-split(",", "a,b,c")
-"a,b,c" |> split(",")
+split(',', 'a,b,c')
+'a,b,c' |> split(',')
 ```
 
 ### Chaining Multiple Pipes
@@ -186,9 +186,9 @@ split(",", "a,b,c")
 Multiple pipe operations can be chained for complex transformations:
 
 ```crn
-let result = ["prod", "web"]
-  |> concat(["vpc"])
-  |> join("-")
+let result = ['prod', 'web']
+  |> concat(['vpc'])
+  |> join('-')
   |> upper()
 ```
 
@@ -198,26 +198,26 @@ The compose operator (`>>`) combines two partially applied functions into a new 
 
 ```crn
 # Compose split and join into a single function
-let transform = split(",") >> join("-")
+let transform = split(',') >> join('-')
 
 # Apply the composed function via pipe
-let result = "a,b,c" |> transform()
-# => "a-b-c"
+let result = 'a,b,c' |> transform()
+# => 'a-b-c'
 ```
 
 Compose works with any partially applied built-in function:
 
 ```crn
 # Extract IDs from a list of maps, then join them
-let pipeline = map(".id") >> join(", ")
-let result = [{ id = "1" }, { id = "2" }] |> pipeline()
-# => "1, 2"
+let pipeline = map('.id') >> join(', ')
+let result = [{ id = '1' }, { id = '2' }] |> pipeline()
+# => '1, 2'
 ```
 
 Three or more functions can be composed:
 
 ```crn
-let transform = split(",") >> join("-") >> split("-")
+let transform = split(',') >> join('-') >> split('-')
 ```
 
 The compose operator binds tighter than the pipe operator, so `f >> g |> h` means `(f >> g) |> h`.
@@ -228,8 +228,8 @@ Functions are called with parentheses:
 
 ```crn
 let len = length(zones)
-let subnet = cidr_subnet("10.0.0.0/16", 8, 1)
-let name = join("-", ["prod", "web", "vpc"])
+let subnet = cidr_subnet('10.0.0.0/16', 8, 1)
+let name = join('-', ['prod', 'web', 'vpc'])
 ```
 
 ### Partial Application
@@ -239,18 +239,18 @@ When a built-in function is called with fewer arguments than it expects, it retu
 ```crn
 # split expects 2 args: split(separator, string)
 # Providing only 1 creates a closure
-let split_by_comma = split(",")
+let split_by_comma = split(',')
 
 # The closure can be used with pipe (parentheses are required)
-let parts = "a,b,c" |> split_by_comma()
+let parts = 'a,b,c' |> split_by_comma()
 ```
 
 This is particularly useful with the pipe operator:
 
 ```crn
-let result = "hello-world" |> replace("-", "_")
-# replace(search, replacement, string) gets "-" and "_" captured,
-# then "hello-world" is supplied as the third argument via pipe
+let result = 'hello-world' |> replace('-', '_')
+# replace(search, replacement, string) gets '-' and '_' captured,
+# then 'hello-world' is supplied as the third argument via pipe
 ```
 
 ## User-Defined Functions
@@ -259,7 +259,7 @@ Define functions with `fn`. Parameters can have optional type annotations and de
 
 ```crn
 fn tag_name(env: string, service: string): string {
-  join("-", [env, service, "vpc"])
+  join('-', [env, service, 'vpc'])
 }
 ```
 
@@ -271,7 +271,7 @@ Function parameters support:
 - No annotation: `name` (any type accepted)
 
 ```crn
-fn make_tags(env: string, service: string, team: string = "platform") {
+fn make_tags(env: string, service: string, team: string = 'platform') {
   {
     Environment = env
     Service     = service
@@ -286,7 +286,7 @@ Functions can contain `let` bindings before the return expression:
 
 ```crn
 fn subnet_name(env: string, az: string): string {
-  let short_az = replace("ap-northeast-1", "", az)
+  let short_az = replace('ap-northeast-1', '', az)
   "${env}-subnet-${short_az}"
 }
 ```
@@ -297,7 +297,7 @@ The optional return type annotation follows the parameter list with a colon:
 
 ```crn
 fn cidr_for_env(env: string): string {
-  lookup({ dev = "10.0.0.0/16", stg = "10.1.0.0/16" }, env, "10.99.0.0/16")
+  lookup({ dev = '10.0.0.0/16', stg = '10.1.0.0/16' }, env, '10.99.0.0/16')
 }
 ```
 
@@ -329,11 +329,11 @@ Validate expressions are boolean expressions used in `arguments` blocks for inpu
 ```crn
 arguments {
   instance_count: int {
-    description = "Number of instances to create"
+    description = 'Number of instances to create'
     default     = 1
     validation {
       condition     = instance_count >= 1 && instance_count <= 10
-      error_message = "Instance count must be between 1 and 10"
+      error_message = 'Instance count must be between 1 and 10'
     }
   }
 }
@@ -346,7 +346,7 @@ arguments {
   name: string {
     validation {
       condition     = length(name) > 0
-      error_message = "Name must not be empty"
+      error_message = 'Name must not be empty'
     }
   }
 }

--- a/docs/src/content/docs/reference/dsl/modules.md
+++ b/docs/src/content/docs/reference/dsl/modules.md
@@ -22,7 +22,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = cidr_block
 
   tags = {
-    Name = "module-test"
+    Name = 'module-test'
   }
 }
 
@@ -32,7 +32,7 @@ let subnet = awscc.ec2.subnet {
   availability_zone = az
 
   tags = {
-    Name = "module-test-subnet"
+    Name = 'module-test-subnet'
   }
 }
 
@@ -65,7 +65,7 @@ Parameters can have default values:
 ```crn
 arguments {
   cidr_block: string
-  az        : string = "ap-northeast-1a"
+  az        : string = 'ap-northeast-1a'
   enable_dns: bool   = true
 }
 ```
@@ -77,19 +77,19 @@ Parameters can use an expanded block form for description, default values, and v
 ```crn
 arguments {
   instance_count: int {
-    description = "Number of instances to create"
+    description = 'Number of instances to create'
     default     = 1
     validation {
       condition     = instance_count >= 1 && instance_count <= 10
-      error_message = "Instance count must be between 1 and 10"
+      error_message = 'Instance count must be between 1 and 10'
     }
   }
 
   cidr_block: string {
-    description = "The CIDR block for the VPC"
+    description = 'The CIDR block for the VPC'
     validation {
       condition     = length(cidr_block) > 0
-      error_message = "CIDR block cannot be empty"
+      error_message = 'CIDR block cannot be empty'
     }
   }
 }
@@ -139,12 +139,12 @@ attributes {
 Use `import` to load a module, then call it by name with arguments:
 
 ```crn
-let network = import "./modules/network"
+let network = import './modules/network'
 
 network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }
 ```
 
@@ -153,12 +153,12 @@ network {
 When a module call is bound with `let`, its `attributes` values can be accessed with dot notation:
 
 ```crn
-let network = import "./modules/network"
+let network = import './modules/network'
 
 let net = network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }
 
 awscc.ec2.security_group {
@@ -181,10 +181,10 @@ Import paths are resolved relative to the file containing the `import` statement
 
 ```crn
 # From project/main.crn, imports project/modules/network/main.crn
-let network = import "./modules/network"
+let network = import './modules/network'
 
 # Relative path from current file
-let helper = import "../shared/helper"
+let helper = import '../shared/helper'
 ```
 
 ## Nested Modules
@@ -194,7 +194,7 @@ Modules can import and use other modules:
 ```crn
 # modules/network_with_rt/main.crn
 
-let network = import "../network"
+let network = import '../network'
 
 arguments {
   cidr_block : string
@@ -212,7 +212,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = net.vpc_id
 
   tags = {
-    Name = "nested-module-test-rt"
+    Name = 'nested-module-test-rt'
   }
 }
 
@@ -227,18 +227,18 @@ attributes {
 Modules can be used inside `for` expressions to create multiple instances:
 
 ```crn
-let network = import "./modules/network"
+let network = import './modules/network'
 
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let networks = for name, cidr in cidrs {
   network {
     cidr_block  = cidr
     subnet_cidr = cidr_subnet(cidr, 8, 1)
-    az          = "ap-northeast-1a"
+    az          = 'ap-northeast-1a'
   }
 }
 ```

--- a/docs/src/content/docs/reference/dsl/syntax.md
+++ b/docs/src/content/docs/reference/dsl/syntax.md
@@ -17,23 +17,23 @@ provider awscc {
 
 # Backend configuration (optional)
 backend s3 {
-  bucket = "my-state-bucket"
-  key    = "infra/carina.state.json"
-  region = "ap-northeast-1"
+  bucket = 'my-state-bucket'
+  key    = 'infra/carina.state.json'
+  region = 'ap-northeast-1'
 }
 
 # Resource declarations
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 
 awscc.ec2.internet_gateway {
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 ```
@@ -90,10 +90,10 @@ When you do not need to reference a resource elsewhere, declare it without a bin
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 ```
@@ -106,28 +106,28 @@ Use `let` to bind a name to a resource so you can reference its attributes:
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 ```
 
 The `let` keyword is also used to bind non-resource values:
 
 ```crn
-let cidr = "10.0.0.0/16"
-let environments = ["dev", "stg", "prod"]
+let cidr = '10.0.0.0/16'
+let environments = ['dev', 'stg', 'prod']
 let config = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 ```
 
@@ -168,7 +168,7 @@ Attributes are key-value pairs inside a resource block:
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -183,7 +183,7 @@ awscc.ec2.ipam {
   tier = advanced
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 ```
@@ -194,7 +194,7 @@ Use `let` inside a resource block to create block-scoped variables. These are ev
 
 ```crn
 awscc.ec2.vpc {
-  let base_cidr = "10.0.0.0/16"
+  let base_cidr = '10.0.0.0/16'
 
   cidr_block = base_cidr
 
@@ -210,9 +210,9 @@ The `backend` block configures where Carina stores state:
 
 ```crn
 backend s3 {
-  bucket = "my-state-bucket"
-  key    = "infra/carina.state.json"
-  region = "ap-northeast-1"
+  bucket = 'my-state-bucket'
+  key    = 'infra/carina.state.json'
+  region = 'ap-northeast-1'
 }
 ```
 
@@ -226,15 +226,15 @@ Import an existing cloud resource into Carina's state:
 
 ```crn
 import {
-  to = awscc.ec2.vpc "imported_vpc"
-  id = "vpc-0123456789abcdef0"
+  to = awscc.ec2.vpc 'imported_vpc'
+  id = 'vpc-0123456789abcdef0'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "imported"
+    Name = 'imported'
   }
 }
 ```
@@ -245,8 +245,8 @@ Rename a resource in state without destroying and recreating it:
 
 ```crn
 moved {
-  from = awscc.ec2.vpc "old_name"
-  to   = awscc.ec2.vpc "new_name"
+  from = awscc.ec2.vpc 'old_name'
+  to   = awscc.ec2.vpc 'new_name'
 }
 ```
 
@@ -256,7 +256,7 @@ Remove a resource from Carina's state without deleting the actual cloud resource
 
 ```crn
 removed {
-  from = awscc.ec2.vpc "old_vpc"
+  from = awscc.ec2.vpc 'old_vpc'
 }
 ```
 
@@ -266,7 +266,7 @@ Reference resources managed by another Carina project:
 
 ```crn
 let network = remote_state {
-  path = "network.state.json"
+  path = 'network.state.json'
 }
 
 awscc.ec2.security_group {
@@ -277,10 +277,10 @@ awscc.ec2.security_group {
 Remote state with an S3 backend:
 
 ```crn
-let network = remote_state "s3" {
-  bucket = "my-state-bucket"
-  key    = "network/carina.state.json"
-  region = "ap-northeast-1"
+let network = remote_state 's3' {
+  bucket = 'my-state-bucket'
+  key    = 'network/carina.state.json'
+  region = 'ap-northeast-1'
 }
 ```
 
@@ -306,14 +306,14 @@ Define reusable functions with `fn`:
 
 ```crn
 fn tag_name(env: string, service: string): string {
-  join("-", [env, service, "vpc"])
+  join('-', [env, service, 'vpc'])
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = tag_name("prod", "web")
+    Name = tag_name('prod', 'web')
   }
 }
 ```
@@ -325,8 +325,8 @@ See [Expressions](/reference/dsl/expressions/) for details on function definitio
 Assert conditions that must be true, with a custom error message if they fail:
 
 ```crn
-require length(subnets) > 0, "At least one subnet must be specified"
-require cidr_block != "", "CIDR block cannot be empty"
+require length(subnets) > 0, 'At least one subnet must be specified'
+require cidr_block != '', 'CIDR block cannot be empty'
 ```
 
 The condition is a [validate expression](/reference/dsl/expressions/#validate-expressions) that supports comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`) and logical operators (`&&`, `||`, `!`).

--- a/docs/src/content/docs/reference/dsl/types-and-values.md
+++ b/docs/src/content/docs/reference/dsl/types-and-values.md
@@ -12,8 +12,8 @@ The Carina DSL is a statically-aware language with the following value types.
 Strings are enclosed in double quotes:
 
 ```crn
-let name = "my-vpc"
-let region = "ap-northeast-1"
+let name = 'my-vpc'
+let region = 'ap-northeast-1'
 ```
 
 #### Escape Sequences
@@ -34,10 +34,10 @@ Strings support the following escape sequences:
 Embed expressions inside strings with `${}`:
 
 ```crn
-let env = "prod"
-let name = "vpc-${env}"           # => "vpc-prod"
+let env = 'prod'
+let name = "vpc-${env}"           # => 'vpc-prod'
 let cidr = "${base_cidr}"         # => value of base_cidr
-let tag = "${env}-${service}"     # => "prod-web"
+let tag = "${env}-${service}"     # => 'prod-web'
 ```
 
 Any expression can appear inside `${}`, including function calls:
@@ -81,7 +81,7 @@ let public = false
 Ordered sequences enclosed in square brackets:
 
 ```crn
-let zones = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
+let zones = ['ap-northeast-1a', 'ap-northeast-1c', 'ap-northeast-1d']
 let ports = [80, 443, 8080]
 let empty = []
 ```
@@ -90,7 +90,7 @@ Lists can contain mixed types and a trailing comma is allowed:
 
 ```crn
 let mixed = [
-  "hello",
+  'hello',
   42,
   true,
 ]
@@ -102,8 +102,8 @@ Key-value collections enclosed in curly braces. Keys are identifiers (unquoted),
 
 ```crn
 let config = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 ```
 
@@ -111,11 +111,11 @@ Maps are also used for resource tags and nested configuration:
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name        = "main"
-    Environment = "prod"
+    Name        = 'main'
+    Environment = 'prod'
   }
 }
 ```
@@ -165,12 +165,12 @@ When a resource is bound with `let`, its attributes can be accessed using dot no
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id     = vpc.vpc_id      # Reference vpc's vpc_id attribute
-  cidr_block = "10.0.1.0/24"
+  cidr_block = '10.0.1.0/24'
 }
 ```
 
@@ -188,7 +188,7 @@ Use square brackets to access list elements or map values:
 
 ```crn
 let first_zone = zones[0]
-let dev_cidr = config["dev"]
+let dev_cidr = config['dev']
 ```
 
 Index and field access can be combined:
@@ -242,5 +242,5 @@ attributes {
 The `null` literal represents the absence of a value. It can only appear in [validate expressions](/reference/dsl/expressions/#validate-expressions) such as `require` statements and argument validation:
 
 ```crn
-require value != null, "Value must not be null"
+require value != null, 'Value must not be null'
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/internet_gateway.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/internet_gateway.md
@@ -12,10 +12,10 @@ Describes an internet gateway.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -23,7 +23,7 @@ aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/route.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/route.md
@@ -12,10 +12,10 @@ Describes a route in a route table.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -23,7 +23,7 @@ let igw = aws.ec2.internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -31,13 +31,13 @@ let rt = aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw.internet_gateway_id
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/route_table.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/route_table.md
@@ -12,10 +12,10 @@ Describes a route table.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
@@ -23,7 +23,7 @@ aws.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/security_group.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/security_group.md
@@ -12,20 +12,20 @@ Describes a security group.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group {
-  group_name  = "carina-example-sg"
-  description = "Example security group"
+  group_name  = 'carina-example-sg'
+  description = 'Example security group'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/security_group_egress.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/security_group_egress.md
@@ -12,30 +12,30 @@ Describes a security group rule.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-example-sg-egress"
-  description = "SG for egress rule example"
+  group_name  = 'carina-example-sg-egress'
+  description = 'SG for egress rule example'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow HTTPS outbound"
+  description = 'Allow HTTPS outbound'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }
 ```
 

--- a/docs/src/content/docs/reference/providers/aws/ec2/security_group_ingress.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/security_group_ingress.md
@@ -12,30 +12,30 @@ Describes a security group rule.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 let sg = aws.ec2.security_group {
-  group_name  = "carina-example-sg-ingress"
-  description = "SG for ingress rule example"
+  group_name  = 'carina-example-sg-ingress'
+  description = 'SG for ingress rule example'
   vpc_id      = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
+  description = 'Allow HTTPS from VPC'
   ip_protocol = tcp
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }
 ```
 

--- a/docs/src/content/docs/reference/providers/aws/ec2/subnet.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/subnet.md
@@ -12,20 +12,20 @@ Describes a subnet.
 
 ```crn
 let vpc = aws.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 
 aws.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = '10.0.1.0/24'
   availability_zone = aws.AvailabilityZone.ap_northeast_1a
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/ec2/vpc.md
+++ b/docs/src/content/docs/reference/providers/aws/ec2/vpc.md
@@ -12,13 +12,13 @@ Describes a VPC.
 
 ```crn
 aws.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = aws.ec2.vpc.InstanceTenancy.default
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/aws/s3/bucket.md
+++ b/docs/src/content/docs/reference/providers/aws/s3/bucket.md
@@ -10,12 +10,12 @@ CloudFormation Type: `AWS::S3::Bucket`
 
 ```crn
 aws.s3.bucket {
-  bucket = "carina-example-s3-bucket"
+  bucket = 'carina-example-s3-bucket'
 
   versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/egress_only_internet_gateway.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/egress_only_internet_gateway.md
@@ -12,14 +12,14 @@ Resource Type definition for AWS::EC2::EgressOnlyInternetGateway
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/eip.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/eip.md
@@ -14,10 +14,10 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
 
 ```crn
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/flow_log.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/flow_log.md
@@ -12,7 +12,7 @@ Specifies a VPC flow log, which enables you to capture IP traffic for a specific
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.flow_log {
@@ -20,10 +20,10 @@ awscc.ec2.flow_log {
   resource_type        = VPC
   traffic_type         = ALL
   log_destination_type = s3
-  log_destination      = "arn:aws:s3:::example-flow-logs-bucket"
+  log_destination      = 'arn:aws:s3:::example-flow-logs-bucket'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/internet_gateway.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/internet_gateway.md
@@ -13,7 +13,7 @@ Allocates an internet gateway for use with a VPC. After creating the Internet ga
 ```crn
 awscc.ec2.internet_gateway {
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/ipam.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/ipam.md
@@ -12,15 +12,15 @@ Resource Schema of AWS::EC2::IPAM Type
 
 ```crn
 awscc.ec2.ipam {
-  description = "Example IPAM"
+  description = 'Example IPAM'
   tier        = free
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/ipam_pool.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/ipam_pool.md
@@ -12,26 +12,26 @@ Resource Schema of AWS::EC2::IPAMPool Type
 
 ```crn
 let ipam = awscc.ec2.ipam {
-  description = "Example IPAM"
+  description = 'Example IPAM'
   tier        = free
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 
 awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = "IPv4"
-  locale         = "ap-northeast-1"
-  description    = "Example IPv4 IPAM Pool"
+  address_family = 'IPv4'
+  locale         = 'ap-northeast-1'
+  description    = 'Example IPv4 IPAM Pool'
 
   provisioned_cidr {
-    cidr = "10.0.0.0/8"
+    cidr = '10.0.0.0/8'
   }
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/nat_gateway.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/nat_gateway.md
@@ -15,20 +15,20 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -36,7 +36,7 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/route.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/route.md
@@ -14,7 +14,7 @@ Specifies a route in a route table. For more information, see [Routes](https://d
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -32,7 +32,7 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/route_table.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/route_table.md
@@ -13,7 +13,7 @@ Specifies a route table for the specified VPC. After you create a route table, y
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -22,7 +22,7 @@ awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/security_group.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/security_group.md
@@ -12,29 +12,29 @@ Resource Type definition for AWS::EC2::SecurityGroup
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Example security group"
+  group_description = 'Example security group'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
+    cidr_ip     = '0.0.0.0/0'
   }
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
+    cidr_ip     = '0.0.0.0/0'
   }
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/security_group_egress.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/security_group_egress.md
@@ -16,19 +16,19 @@ Adds the specified outbound (egress) rule to a security group.
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Example security group"
+  group_description = 'Example security group'
 }
 
 awscc.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all outbound traffic"
+  description = 'Allow all outbound traffic'
   ip_protocol = all
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }
 ```
 

--- a/docs/src/content/docs/reference/providers/awscc/ec2/security_group_ingress.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/security_group_ingress.md
@@ -12,21 +12,21 @@ Resource Type definition for AWS::EC2::SecurityGroupIngress
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Example security group"
+  group_description = 'Example security group'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }
 ```
 

--- a/docs/src/content/docs/reference/providers/awscc/ec2/subnet.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/subnet.md
@@ -14,19 +14,19 @@ Specifies a subnet for the specified VPC.
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/subnet_route_table_association.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/subnet_route_table_association.md
@@ -12,15 +12,15 @@ Associates a subnet with a route table. The subnet and route table must be in th
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let rt = awscc.ec2.route_table {

--- a/docs/src/content/docs/reference/providers/awscc/ec2/transit_gateway.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/transit_gateway.md
@@ -12,10 +12,10 @@ Resource Type definition for AWS::EC2::TransitGateway
 
 ```crn
 awscc.ec2.transit_gateway {
-  description = "Example Transit Gateway"
+  description = 'Example Transit Gateway'
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/transit_gateway_attachment.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/transit_gateway_attachment.md
@@ -12,17 +12,17 @@ Resource Type definition for AWS::EC2::TransitGatewayAttachment
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let tgw = awscc.ec2.transit_gateway {
-  description = "Example Transit Gateway"
+  description = 'Example Transit Gateway'
 }
 
 awscc.ec2.transit_gateway_attachment {
@@ -31,7 +31,7 @@ awscc.ec2.transit_gateway_attachment {
   subnet_ids         = [subnet.subnet_id]
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/vpc.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/vpc.md
@@ -14,13 +14,13 @@ Specifies a virtual private cloud (VPC).
 
 ```crn
 awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = default
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/vpc_endpoint.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/vpc_endpoint.md
@@ -15,35 +15,35 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.100.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.100.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for VPC Endpoint"
+  group_description = 'SG for VPC Endpoint'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [subnet.subnet_id]
   security_group_ids  = [sg.group_id]
   private_dns_enabled = true

--- a/docs/src/content/docs/reference/providers/awscc/ec2/vpc_gateway_attachment.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/vpc_gateway_attachment.md
@@ -12,7 +12,7 @@ Resource Type definition for AWS::EC2::VPCGatewayAttachment
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }

--- a/docs/src/content/docs/reference/providers/awscc/ec2/vpc_peering_connection.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/vpc_peering_connection.md
@@ -12,11 +12,11 @@ Resource Type definition for AWS::EC2::VPCPeeringConnection
 
 ```crn
 let vpc1 = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let vpc2 = awscc.ec2.vpc {
-  cidr_block = "10.1.0.0/16"
+  cidr_block = '10.1.0.0/16'
 }
 
 awscc.ec2.vpc_peering_connection {
@@ -24,7 +24,7 @@ awscc.ec2.vpc_peering_connection {
   peer_vpc_id = vpc2.vpc_id
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/ec2/vpn_gateway.md
+++ b/docs/src/content/docs/reference/providers/awscc/ec2/vpn_gateway.md
@@ -16,7 +16,7 @@ awscc.ec2.vpn_gateway {
   type = awscc.ec2.vpn_gateway.Type.ipsec.1
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/iam/role.md
+++ b/docs/src/content/docs/reference/providers/awscc/iam/role.md
@@ -13,23 +13,23 @@ Creates a new role for your AWS-account.
 
 ```crn
 awscc.iam.role {
-  role_name = "my-example-role"
+  role_name = 'my-example-role'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/logs/log_group.md
+++ b/docs/src/content/docs/reference/providers/awscc/logs/log_group.md
@@ -16,11 +16,11 @@ The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines 
 
 ```crn
 awscc.logs.log_group {
-  log_group_name    = "/example/my-app"
+  log_group_name    = '/example/my-app'
   retention_in_days = 30
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```

--- a/docs/src/content/docs/reference/providers/awscc/s3/bucket.md
+++ b/docs/src/content/docs/reference/providers/awscc/s3/bucket.md
@@ -14,14 +14,14 @@ The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Reg
 
 ```crn
 awscc.s3.bucket {
-  bucket_name = "my-example-bucket"
+  bucket_name = 'my-example-bucket'
 
   versioning_configuration = {
     status = Enabled
   }
 
   tags = {
-    Environment = "example"
+    Environment = 'example'
   }
 }
 ```


### PR DESCRIPTION
Closes #1550

## Summary

- Convert double-quoted literal strings to single quotes in all `.crn` code blocks across documentation files (47 files)
- Matches the convention established in test fixtures (ee23f13, 51f090b)
- Interpolated strings containing `${...}` are preserved with double quotes

## Scope

- `README.md`
- `docs/src/content/docs/getting-started/` (3 files)
- `docs/src/content/docs/guides/` (5 files)
- `docs/src/content/docs/reference/dsl/` (5 files)
- `docs/src/content/docs/reference/providers/` (34 files)

## Quote Convention

- **Single quotes** (`'...'`): Literal strings (no interpolation)
- **Double quotes** (`"..."`): Strings with interpolation (e.g., `"vpc-${env}"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)