### PR TITLE
fix: add single-quote string highlighting to docs grammar

### DIFF
--- a/docs/custom-grammars/crn.tmLanguage.json
+++ b/docs/custom-grammars/crn.tmLanguage.json
@@ -48,6 +48,17 @@
               ]
             }
           ]
+        },
+        {
+          "name": "string.quoted.single.crn",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.crn",
+              "match": "\\\\."
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Refs #1550

## Summary

- Add `string.quoted.single.crn` pattern to the TextMate grammar (`docs/custom-grammars/crn.tmLanguage.json`)
- After #1552 converted documentation code examples to single quotes, single-quoted strings had no syntax highlighting
- Single-quoted strings support escape sequences but not interpolation (by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)