### PR TITLE
LSP: load provider schemas from workspace .crn files

### DIFF
--- a/docs/specs/2026-04-06-lsp-provider-schema-loading-design.md
+++ b/docs/specs/2026-04-06-lsp-provider-schema-loading-design.md
@@ -1,0 +1,80 @@
+# LSP Provider Schema Loading
+
+## Goal
+
+Enable the LSP to load provider schemas from WASM plugins so that completions, diagnostics, hover, and semantic tokens work with real resource type information. Currently, the LSP initializes with an empty factories vector, making all schema-dependent features non-functional.
+
+## Chosen Approach
+
+**Read provider configuration from workspace `.crn` files** — the same approach the CLI uses.
+
+### Rationale
+
+- `.crn` files are the single source of truth for provider configuration
+- `build_factories_from_providers()` in `carina-cli/src/wiring.rs` already implements the full pipeline (parse → resolve WASM → create factory)
+- WASM binaries are typically already cached from prior CLI usage (`carina plan`, etc.)
+- No additional editor configuration required — opening a workspace "just works"
+
+### Rejected Alternatives
+
+- **LSP `initializationOptions`**: Requires users to configure providers in both `.crn` and editor settings. Violates DRY.
+- **Embedded/bundled schemas**: Would require LSP rebuilds for every provider schema change. Not scalable.
+
+## Design
+
+### Initialization Flow
+
+1. Client sends `initialize` with `rootUri` / `workspaceFolders`
+2. LSP scans workspace root for `.crn` files
+3. Parse `provider` blocks from found files (reuse `carina-core` parser)
+4. For each provider with a `source` attribute:
+   - Resolve WASM binary path (check cache only — no auto-download)
+   - If binary exists: load `WasmProviderFactory` and collect schemas
+   - If binary missing: skip, log warning via `window/logMessage`
+5. Build `CompletionProvider`, `DiagnosticEngine`, `HoverProvider`, `SemanticTokensProvider` with collected schemas
+
+### Key Design Decisions
+
+1. **No auto-download of WASM binaries** — LSP should not have network side effects. If a provider binary is not cached, the LSP degrades gracefully and logs a message suggesting the user run `carina plan` (or a future `carina init` command) to download providers.
+
+2. **Schema reload on file change** — Watch `.crn` files via `didChangeWatchedFiles`. When a provider block changes, re-parse and reload schemas. This requires rebuilding the completion/diagnostic/hover providers, which means they need to be behind `Arc<RwLock<>>` or similar.
+
+3. **Reuse existing code** — Extract provider resolution logic from `carina-cli` into a shared location (or add `carina-cli` as a dependency of `carina-lsp`, or extract a `carina-provider-resolver` crate) so the LSP can call `build_factories_from_providers()` and the provider cache resolution.
+
+### Architecture Changes
+
+#### Option A: Extract `carina-provider-resolver` crate
+
+Move provider resolution logic (`provider_resolver.rs`, relevant parts of `wiring.rs`) into a new crate that both `carina-cli` and `carina-lsp` depend on.
+
+#### Option B: LSP depends on `carina-cli`
+
+Simpler but creates an unusual dependency direction (LSP depending on CLI).
+
+#### Option C: Duplicate minimal resolution logic in LSP
+
+Only need cache lookup (no download), so the code is small. But risks drift.
+
+**Recommended: Option A** — cleanest separation of concerns.
+
+### File Changes
+
+- **New crate**: `carina-provider-resolver/` — extracted from `carina-cli/src/provider_resolver.rs` and factory-building logic from `wiring.rs`
+- **`carina-lsp/src/main.rs`**: Use workspace root to find `.crn` files, parse providers, build factories
+- **`carina-lsp/src/backend.rs`**: Support schema reload (providers behind `Arc<RwLock<>>`)
+- **`carina-lsp/Cargo.toml`**: Add dependencies on `carina-provider-resolver`, `carina-plugin-host`
+- **`carina-cli/Cargo.toml`**: Replace inlined resolver with `carina-provider-resolver` dependency
+
+### Edge Cases
+
+- **No `.crn` files in workspace**: Operate in schema-less mode (current behavior)
+- **Multiple `.crn` files with different providers**: Merge all provider configs
+- **WASM load failure**: Skip provider, log warning, continue with remaining providers
+- **Workspace root not available**: Fall back to schema-less mode
+- **Lock file validation**: LSP should validate lock constraints same as CLI
+
+## Constraints
+
+- LSP must remain responsive during initialization — WASM loading should not block the event loop
+- No network access from LSP
+- Graceful degradation when providers are unavailable

--- a/docs/specs/2026-04-06-lsp-provider-schema-loading-plan.md
+++ b/docs/specs/2026-04-06-lsp-provider-schema-loading-plan.md
@@ -1,0 +1,104 @@
+# LSP Provider Schema Loading — Implementation Plan
+
+## Task Breakdown
+
+### Task 1: Extract `carina-provider-resolver` crate
+
+Extract provider resolution logic from `carina-cli` into a shared crate.
+
+**Files:**
+- New: `carina-provider-resolver/Cargo.toml`, `carina-provider-resolver/src/lib.rs`
+- Move from: `carina-cli/src/provider_resolver.rs` → `carina-provider-resolver/src/lib.rs`
+- Extract from: `carina-cli/src/wiring.rs` — `build_factories_from_providers()` function
+- Update: `carina-cli/Cargo.toml` — add `carina-provider-resolver` dependency
+- Update: `carina-cli/src/wiring.rs` — use `carina_provider_resolver::build_factories_from_providers()`
+- Update: `Cargo.toml` (workspace) — add new crate member
+
+**Test approach:**
+- Existing `carina-cli` tests must continue to pass (no behavior change)
+- Add unit tests in new crate for cache path resolution and factory building
+
+**Acceptance criteria:**
+- `cargo test -p carina-cli` passes
+- `cargo test -p carina-provider-resolver` passes
+- No duplicate code between CLI and resolver crate
+
+### Task 2: Add workspace `.crn` file discovery to LSP
+
+Parse provider configurations from workspace `.crn` files during LSP initialization.
+
+**Files:**
+- New: `carina-lsp/src/workspace.rs` — workspace scanning and provider config extraction
+- Update: `carina-lsp/src/main.rs` — read `rootUri` from init params, scan workspace
+- Update: `carina-lsp/src/backend.rs` — accept `rootUri` in constructor or init
+
+**Test approach:**
+- Unit test: given a temp directory with `.crn` files containing provider blocks, verify correct `ProviderConfig` extraction
+- Unit test: empty directory returns empty configs
+- Unit test: `.crn` file without provider blocks returns empty configs
+
+**Acceptance criteria:**
+- LSP correctly discovers and parses provider blocks from workspace `.crn` files
+- Missing or unreadable files are skipped gracefully
+
+### Task 3: Load WASM provider factories in LSP
+
+Use the extracted resolver to build `WasmProviderFactory` instances from discovered provider configs.
+
+**Files:**
+- Update: `carina-lsp/Cargo.toml` — add `carina-provider-resolver`, `carina-plugin-host` dependencies
+- Update: `carina-lsp/src/main.rs` — call `build_factories_from_providers()` with discovered configs
+- Update: `carina-lsp/src/backend.rs` — pass real factories to `Backend::new()`
+
+**Test approach:**
+- Integration test: LSP initialized with a workspace containing a mock provider `.crn` file and cached WASM binary provides completions
+- Test: missing WASM binary results in graceful degradation (no crash, warning logged)
+
+**Acceptance criteria:**
+- LSP loads schemas from cached WASM providers
+- Missing WASM binaries produce a log warning, not an error
+- Previously `#[ignore = "requires provider schemas"]` tests can be un-ignored or replaced
+
+### Task 4: Support schema reload on `.crn` file changes
+
+Re-parse provider configs and reload schemas when workspace `.crn` files change.
+
+**Files:**
+- Update: `carina-lsp/src/backend.rs` — register file watcher for `**/*.crn`, wrap providers in `Arc<RwLock<>>`
+- Update: `carina-lsp/src/backend.rs` — implement `did_change_watched_files` handler
+- Update: completion/diagnostics/hover providers to read from shared mutable state
+
+**Test approach:**
+- Integration test: modify `.crn` file, verify schema set is updated
+- Test: adding a new provider triggers schema reload
+- Test: removing a provider block removes its schemas
+
+**Acceptance criteria:**
+- Editing provider blocks in `.crn` files triggers schema reload without LSP restart
+- All LSP features (completion, diagnostics, hover, semantic tokens) use updated schemas
+
+### Task 5: Handle async WASM loading without blocking LSP
+
+Ensure WASM provider loading does not block the LSP event loop.
+
+**Files:**
+- Update: `carina-lsp/src/main.rs` or `backend.rs` — use `tokio::task::spawn_blocking` for WASM loading
+- Update: `carina-lsp/src/backend.rs` — initialize with empty schemas, populate asynchronously, notify client when ready
+
+**Test approach:**
+- Verify LSP responds to `initialize` promptly even with slow WASM loading
+- Verify basic features (syntax highlighting, parse errors) work before WASM loading completes
+
+**Acceptance criteria:**
+- LSP `initialize` response is not delayed by WASM loading
+- Schema-dependent features become available after WASM loading completes
+- Client receives progress notification or log message when schemas are loaded
+
+## Dependency Order
+
+```
+Task 1 (extract crate) → Task 2 (workspace discovery) → Task 3 (WASM loading) → Task 4 (reload)
+                                                                                → Task 5 (async loading)
+```
+
+Tasks 4 and 5 are independent of each other but both depend on Task 3.


### PR DESCRIPTION
## Summary

- Design document and implementation plan for enabling provider schema loading in the LSP
- Currently the LSP initializes with empty provider factories, making completions, diagnostics, hover, and semantic tokens non-functional for resource types
- Proposes reading provider config from workspace `.crn` files and loading cached WASM plugins (no auto-download)

## Design

See `docs/specs/2026-04-06-lsp-provider-schema-loading-design.md`

## Implementation Plan

5 tasks decomposed in `docs/specs/2026-04-06-lsp-provider-schema-loading-plan.md`:

1. Extract `carina-provider-resolver` crate from CLI
2. Add workspace `.crn` file discovery to LSP
3. Load WASM provider factories in LSP
4. Support schema reload on `.crn` file changes
5. Handle async WASM loading without blocking LSP

GitHub Issues will be created for each task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)