### PR TITLE
fix: preserve dependency_bindings through provider refresh

### DIFF
--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -641,6 +641,26 @@ pub async fn create_plan_from_parsed_with_remote(
         // In identifier-based approach, if there's no identifier in state, the resource doesn't exist.
         // Skip virtual resources (module attribute containers) — they have no infrastructure.
         let provider_ref = &provider;
+        // Pre-build a map of dependency_bindings from the state file so we can
+        // restore them after refresh. Provider.read() returns fresh attributes but
+        // doesn't know about dependency_bindings (carina-only metadata).
+        let saved_dep_bindings: HashMap<ResourceId, Vec<String>> = state_file
+            .as_ref()
+            .map(|sf| {
+                sorted_resources
+                    .iter()
+                    .filter_map(|r| {
+                        let rs =
+                            sf.find_resource(&r.id.provider, &r.id.resource_type, &r.id.name)?;
+                        if rs.dependency_bindings.is_empty() {
+                            None
+                        } else {
+                            Some((r.id.clone(), rs.dependency_bindings.clone()))
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         let results: Vec<Result<(ResourceId, State), AppError>> =
             stream::iter(sorted_resources.iter().filter(|r| !r.is_virtual()))
                 .map(|resource| {
@@ -648,11 +668,16 @@ pub async fn create_plan_from_parsed_with_remote(
                     let identifier = state_file
                         .as_ref()
                         .and_then(|sf| sf.get_identifier_for_resource(resource));
+                    let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
                     async move {
-                        let state =
+                        let mut state =
                             read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                                 .await
                                 .map_err(AppError::Provider)?;
+                        // Restore dependency_bindings from state file (#1565).
+                        if let Some(deps) = dep_bindings {
+                            state.dependency_bindings = deps;
+                        }
                         progress.finish();
                         Ok((resource.id.clone(), state))
                     }
@@ -677,9 +702,10 @@ pub async fn create_plan_from_parsed_with_remote(
                 stream::iter(orphan_states)
                     .map(|(id, state)| {
                         let progress = RefreshProgress::begin_multi(&multi, &id);
-                        // Preserve _binding metadata from state file so orphan
-                        // Delete effects retain their binding after refresh (#1548).
+                        // Preserve _binding and dependency_bindings from state file
+                        // so orphan Delete effects retain metadata after refresh (#1548, #1565).
                         let binding = state.attributes.get("_binding").cloned();
+                        let dep_bindings = state.dependency_bindings.clone();
                         async move {
                             let mut refreshed =
                                 read_with_retry(provider_ref, &id, state.identifier.as_deref())
@@ -687,6 +713,9 @@ pub async fn create_plan_from_parsed_with_remote(
                                     .map_err(AppError::Provider)?;
                             if let Some(b) = binding {
                                 refreshed.attributes.insert("_binding".to_string(), b);
+                            }
+                            if !dep_bindings.is_empty() {
+                                refreshed.dependency_bindings = dep_bindings;
                             }
                             progress.finish();
                             Ok((id, refreshed))


### PR DESCRIPTION
Closes #1565

## Summary

- Preserve `dependency_bindings` from state file after provider refresh for both desired resources and orphans
- Root cause: `provider.read()` returns State with empty `dependency_bindings` (carina-only metadata the provider doesn't know about), so Replace(CBD) effects lost their `from.dependency_bindings`
- Without `from.dependency_bindings`, `build_dependency_map()` couldn't create the reverse dependency (Delete must wait for Replace), causing Delete to run in parallel with Replace

## Impact

This caused the CBD acceptance test to hang because:
1. Delete(tgw_a) ran immediately instead of waiting for Replace(attachment)
2. Two new TGW Creates also ran in parallel
3. Combined with the 2 existing TGWs, this exceeded the account's TGW quota (5)
4. Creates failed, Replace was skipped, but Deletes continued — leaving orphaned resources

## Test plan

- [x] All carina-core tests pass (1108)
- [x] All carina-cli tests pass
- [x] Clippy clean
- [x] Debug logging confirmed `from.dependency_bindings=[]` before fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)