### PR TITLE
feat: add workspace .crn file discovery to LSP

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use carina_core::formatter::{self, FormatConfig};
@@ -37,6 +38,7 @@ pub struct Backend {
     hover_provider: HoverProvider,
     semantic_tokens_provider: SemanticTokensProvider,
     provider_context: Arc<ProviderContext>,
+    workspace_root: tokio::sync::OnceCell<Option<PathBuf>>,
 }
 
 impl Backend {
@@ -79,7 +81,13 @@ impl Backend {
             semantic_tokens_provider: SemanticTokensProvider::new(&region_completions),
             hover_provider: HoverProvider::new(Arc::clone(&schemas), region_completions),
             provider_context,
+            workspace_root: tokio::sync::OnceCell::new(),
         }
+    }
+
+    /// Returns the workspace root path, if available.
+    pub fn workspace_root(&self) -> Option<&PathBuf> {
+        self.workspace_root.get().and_then(|opt| opt.as_ref())
     }
 
     async fn update_diagnostics(&self, uri: Url) {
@@ -100,7 +108,21 @@ impl Backend {
 
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
-    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        // Capture workspace root from rootUri or workspaceFolders
+        let root = params
+            .root_uri
+            .as_ref()
+            .and_then(|uri| uri.to_file_path().ok())
+            .or_else(|| {
+                params
+                    .workspace_folders
+                    .as_ref()
+                    .and_then(|folders| folders.first())
+                    .and_then(|f| f.uri.to_file_path().ok())
+            });
+        let _ = self.workspace_root.set(root);
+
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(

--- a/carina-lsp/src/lib.rs
+++ b/carina-lsp/src/lib.rs
@@ -5,5 +5,6 @@ pub mod document;
 pub mod hover;
 pub mod position;
 pub mod semantic_tokens;
+pub mod workspace;
 
 pub use backend::Backend;

--- a/carina-lsp/src/workspace.rs
+++ b/carina-lsp/src/workspace.rs
@@ -1,0 +1,155 @@
+//! Workspace scanning: discover and parse provider configurations from .crn files.
+
+use std::fs;
+use std::path::Path;
+
+use carina_core::parser::{self, ProviderConfig, ProviderContext};
+
+/// Discover all provider configurations from .crn files in a workspace directory.
+///
+/// Scans the directory (non-recursively) for files ending in `.crn`,
+/// parses each one, and collects all `provider` blocks. Duplicate provider
+/// names are deduplicated (first occurrence wins). Unreadable or unparseable
+/// files are silently skipped.
+pub fn discover_providers(workspace_root: &Path) -> Vec<ProviderConfig> {
+    let entries = match fs::read_dir(workspace_root) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut seen_names = std::collections::HashSet::new();
+    let mut providers = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "crn")
+            && path.is_file()
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            let ctx = ProviderContext::default();
+            if let Ok(parsed) = parser::parse(&content, &ctx) {
+                for provider in parsed.providers {
+                    if seen_names.insert(provider.name.clone()) {
+                        providers.push(provider);
+                    }
+                }
+            }
+        }
+    }
+
+    providers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discover_providers_from_crn_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("main.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].name, "aws");
+    }
+
+    #[test]
+    fn discover_providers_multiple_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("a.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.crn"),
+            "provider awscc {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 2);
+        let names: Vec<&str> = providers.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"aws"));
+        assert!(names.contains(&"awscc"));
+    }
+
+    #[test]
+    fn discover_providers_deduplicates() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("a.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.crn"),
+            "provider aws {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].name, "aws");
+    }
+
+    #[test]
+    fn discover_providers_empty_directory() {
+        let dir = TempDir::new().unwrap();
+        let providers = discover_providers(dir.path());
+        assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn discover_providers_no_provider_blocks() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("main.crn"),
+            "aws.s3.bucket {\n  bucket_name = 'test'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn discover_providers_skips_unparseable_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("bad.crn"), "this is not valid crn {{{").unwrap();
+        fs::write(
+            dir.path().join("good.crn"),
+            "provider awscc {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].name, "awscc");
+    }
+
+    #[test]
+    fn discover_providers_skips_non_crn_files() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("readme.md"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn discover_providers_nonexistent_directory() {
+        let providers = discover_providers(Path::new("/nonexistent/path"));
+        assert!(providers.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #1557

## Summary

- New `workspace.rs` module: `discover_providers()` scans workspace for `.crn` files and extracts provider configurations
- Backend captures `rootUri` / `workspaceFolders` from LSP initialize params via `workspace_root` field
- Gracefully handles missing dirs, unreadable files, unparseable content, and duplicate provider names
- 8 unit tests covering all edge cases

## Test plan

- [x] 8 workspace tests pass (discovery, dedup, error handling)
- [x] All 164 existing LSP tests pass
- [x] Integration test passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)