### PR TITLE
fix: implement region_completions() for WasmProviderFactory

### DIFF
--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 doctest = false
 
 [dependencies]
+carina-aws-types = { path = "../carina-aws-types" }
 carina-core = { path = "../carina-core" }
 carina-provider-protocol = { path = "../carina-provider-protocol" }
 semver = "1"

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -954,6 +954,10 @@ impl ProviderFactory for WasmProviderFactory {
         })
     }
 
+    fn region_completions(&self) -> Vec<carina_core::schema::CompletionValue> {
+        carina_aws_types::region_completions(self.name_static)
+    }
+
     fn extract_region(&self, attributes: &HashMap<String, Value>) -> String {
         if let Some(Value::String(region)) = attributes.get("region") {
             carina_core::utils::convert_region_value(region)


### PR DESCRIPTION
Closes #1573

## Summary

Override `region_completions()` in `WasmProviderFactory` to call `carina_aws_types::region_completions()`. Previously used the default empty implementation, so LSP had no region suggestions with WASM providers.

2-line fix + 1 Cargo.toml dep addition.

## Test plan

- [x] carina-plugin-host: 6 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)