### PR TITLE
fix: correct state lock filename in benchmark script

### DIFF
--- a/scripts/benchmark-providers.sh
+++ b/scripts/benchmark-providers.sh
@@ -61,7 +61,7 @@ run_benchmark() {
 
     for i in $(seq 1 "$ITERATIONS"); do
         # Clean state
-        rm -f "$workdir/carina.state.json" "$workdir/.carina.lock"
+        rm -f "$workdir/carina.state.json" "$workdir/carina.state.lock"
 
         # Create (apply)
         local t


### PR DESCRIPTION
## Summary

- Changed `.carina.lock` to `carina.state.lock` in benchmark cleanup
- `.carina.lock` was never created by any carina operation; the actual state lock is `carina.state.lock`

Closes #1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)