### PR TITLE
fix: point validation errors to the specific attribute line in LSP

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -454,7 +454,11 @@ pub enum TypeError {
     ValidationFailed { message: String },
 
     #[error("Resource validation failed: {message}")]
-    ResourceValidationFailed { message: String },
+    ResourceValidationFailed {
+        message: String,
+        /// Optional attribute name for precise diagnostic positioning.
+        attribute: Option<String>,
+    },
 
     #[error("Required attribute '{name}' is missing")]
     MissingRequired { name: String },
@@ -537,6 +541,7 @@ pub mod validators {
         match present_fields.len() {
             0 => Err(vec![TypeError::ResourceValidationFailed {
                 message: format!("Exactly one of [{}] must be specified", fields.join(", ")),
+                attribute: None,
             }]),
             1 => Ok(()),
             _ => Err(vec![TypeError::ResourceValidationFailed {
@@ -545,6 +550,7 @@ pub mod validators {
                     fields.join(", "),
                     present_fields.join(", ")
                 ),
+                attribute: present_fields.first().map(|s| s.to_string()),
             }]),
         }
     }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -481,15 +481,35 @@ impl DiagnosticEngine {
                             ) {
                                 continue;
                             }
-                            if let Some((line, _col)) =
+                            // Try attribute-level position first, fall back to resource position
+                            let position =
+                                if let carina_core::schema::TypeError::ResourceValidationFailed {
+                                    attribute: Some(attr),
+                                    ..
+                                } = &error
+                                {
+                                    self.find_attribute_position(doc, attr)
+                                } else {
+                                    None
+                                };
+                            let position = position.or_else(|| {
                                 self.find_resource_position(doc, &resource.id.resource_type)
-                            {
+                            });
+                            if let Some((line, col)) = position {
                                 diagnostics.push(carina_diagnostic_range(
                                     Range {
-                                        start: Position { line, character: 0 },
+                                        start: Position {
+                                            line,
+                                            character: col,
+                                        },
                                         end: Position {
-                                            line: line + 1,
-                                            character: 0,
+                                            line,
+                                            character: col
+                                                + doc
+                                                    .text()
+                                                    .lines()
+                                                    .nth(line as usize)
+                                                    .map_or(0, |l| l.trim_end().len() as u32),
                                         },
                                     },
                                     DiagnosticSeverity::ERROR,

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1333,3 +1333,55 @@ attributes {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn resource_validation_failed_with_attribute_points_to_attribute_line() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, TypeError};
+    use std::collections::HashMap;
+
+    let schema = ResourceSchema::new("mock.test.resource")
+        .attribute(AttributeSchema::new("name", AttributeType::String).required())
+        .attribute(AttributeSchema::new(
+            "tags",
+            AttributeType::Map(Box::new(AttributeType::String)),
+        ))
+        .with_validator(|attrs| {
+            if let Some(carina_core::resource::Value::Map(map)) = attrs.get("tags") {
+                let has_key = map.keys().any(|k| k.eq_ignore_ascii_case("key"));
+                let has_value = map.keys().any(|k| k.eq_ignore_ascii_case("value"));
+                if has_key && has_value {
+                    return Err(vec![TypeError::ResourceValidationFailed {
+                        message: "tags key/value error".to_string(),
+                        attribute: Some("tags".to_string()),
+                    }]);
+                }
+            }
+            Ok(())
+        });
+
+    let mut schemas = HashMap::new();
+    schemas.insert("mock.test.resource".to_string(), schema);
+    let engine = custom_engine(schemas);
+
+    let doc = create_document(
+        "mock.test.resource {\n  name = 'test'\n  tags = {\n    key = 'Project'\n    value = 'carina'\n  }\n}",
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+    let tags_diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("tags key/value error"));
+    assert!(
+        tags_diag.is_some(),
+        "Should have a tags validation error. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let diag = tags_diag.unwrap();
+    // The diagnostic should point to the "tags" line (line 2, 0-indexed),
+    // not the resource declaration line (line 0).
+    assert_eq!(
+        diag.range.start.line, 2,
+        "Diagnostic should point to the 'tags' attribute line (line 2), not the resource line. Got line {}",
+        diag.range.start.line
+    );
+}

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -290,6 +290,7 @@ fn validate_tags_key_value(
             if has_key && has_value {
                 return Err(vec![carina_core::schema::TypeError::ResourceValidationFailed {
                     message: "tags map contains both 'key' and 'value' as keys, which looks like a Key/Value pair list. Use flat map syntax instead: tags = { Name = '...' }".to_string(),
+                    attribute: Some("tags".to_string()),
                 }]);
             }
         }


### PR DESCRIPTION
Closes #1646

## Summary

- Add `attribute: Option<String>` field to `TypeError::ResourceValidationFailed` for precise diagnostic positioning
- Update LSP diagnostic engine to use attribute-level position when available, falling back to resource position
- Update `validate_tags_key_value` to report `attribute: Some("tags")`
- Update `validate_exclusive_required` to report the first conflicting attribute

## Context

LSP validation errors from resource validators (like `TagsKeyValueCheck`) were displayed on the resource declaration line (e.g., `awscc.s3.bucket {`) instead of on the specific attribute that caused the error. Now validators can optionally specify which attribute the error relates to.

## Test plan

- [x] `cargo test -p carina-lsp` — all 165 tests pass (1 new)
- [x] `cargo test -p carina-core` — all tests pass
- [x] `cargo test` — full workspace passes
- [x] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)