### PR TITLE
fix: cap HTTP timeouts for all WASM plugin requests to prevent hang

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -49,11 +49,16 @@ const METADATA_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 
 /// Timeout for individual WASM plugin operations (in seconds).
 ///
-/// If a WASM call (read, create, update, delete) does not complete within this
-/// duration, wasmtime's epoch interruption mechanism traps the execution.
-/// This prevents indefinite hangs when, for example, the AWS SDK blocks
-/// during credential resolution inside the WASM guest.
+/// Used for two layers of timeout enforcement:
+/// 1. Epoch interruption: traps WASM computation that exceeds this budget.
+/// 2. HTTP request cap: limits host-side HTTP calls that epochs cannot reach
+///    (epochs only fire during WASM execution, not during host I/O waits).
 const WASM_OPERATION_TIMEOUT_SECS: u64 = 30;
+
+/// [`WASM_OPERATION_TIMEOUT_SECS`] as a `Duration`, used to cap per-request
+/// HTTP timeouts in the [`AllowListHttpHooks`] layer.
+const HTTP_API_REQUEST_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(WASM_OPERATION_TIMEOUT_SECS);
 
 /// Build the standard wasmtime Config used for all WASM plugin engines.
 ///
@@ -182,19 +187,15 @@ impl wasmtime_wasi_http::p2::WasiHttpHooks for AllowListHttpHooks {
                 wasmtime_wasi_http::p2::bindings::http::types::ErrorCode::HttpRequestDenied.into(),
             );
         }
-        // Cap timeouts for metadata endpoints so non-EC2/ECS environments fail fast.
-        // On EC2, IMDS responds in <10ms; 1s is generous.
-        if is_metadata_host(authority) {
-            if config.connect_timeout > METADATA_PROBE_TIMEOUT {
-                config.connect_timeout = METADATA_PROBE_TIMEOUT;
-            }
-            if config.first_byte_timeout > METADATA_PROBE_TIMEOUT {
-                config.first_byte_timeout = METADATA_PROBE_TIMEOUT;
-            }
-            if config.between_bytes_timeout > METADATA_PROBE_TIMEOUT {
-                config.between_bytes_timeout = METADATA_PROBE_TIMEOUT;
-            }
-        }
+        // Metadata gets 1s; all other requests get the epoch budget.
+        let cap = if is_metadata_host(authority) {
+            METADATA_PROBE_TIMEOUT
+        } else {
+            HTTP_API_REQUEST_TIMEOUT
+        };
+        config.connect_timeout = config.connect_timeout.min(cap);
+        config.first_byte_timeout = config.first_byte_timeout.min(cap);
+        config.between_bytes_timeout = config.between_bytes_timeout.min(cap);
         Ok(wasmtime_wasi_http::p2::default_send_request(
             request, config,
         ))
@@ -1661,6 +1662,12 @@ mod tests {
         assert!(is_epoch_trap_message("epoch deadline reached"));
         assert!(!is_epoch_trap_message("out of memory"));
         assert!(!is_epoch_trap_message("unreachable code"));
+    }
+
+    #[test]
+    fn test_http_api_request_timeout_is_longer_than_metadata() {
+        // API requests need more time than metadata probes.
+        assert!(HTTP_API_REQUEST_TIMEOUT > METADATA_PROBE_TIMEOUT);
     }
 
     #[test]

--- a/carina-plugin-sdk/src/wasi_http.rs
+++ b/carina-plugin-sdk/src/wasi_http.rs
@@ -8,6 +8,7 @@
 //! This module is only compiled for `target_arch = "wasm32"`.
 
 use std::fmt;
+use std::time::Duration;
 
 use aws_smithy_runtime_api::client::http::{
     HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpClient,
@@ -20,7 +21,9 @@ use aws_smithy_runtime_api::http::Response;
 use aws_smithy_types::body::SdkBody;
 
 use wasi::http::outgoing_handler;
-use wasi::http::types::{Fields, IncomingBody, Method, OutgoingBody, OutgoingRequest, Scheme};
+use wasi::http::types::{
+    Fields, IncomingBody, Method, OutgoingBody, OutgoingRequest, RequestOptions, Scheme,
+};
 use wasi::io::streams::StreamError;
 
 /// An HTTP client that uses wasi:http/outgoing-handler for making requests.
@@ -58,22 +61,66 @@ impl Default for WasiHttpClient {
 impl HttpClient for WasiHttpClient {
     fn http_connector(
         &self,
-        _settings: &HttpConnectorSettings,
+        settings: &HttpConnectorSettings,
         _components: &RuntimeComponents,
     ) -> SharedHttpConnector {
-        SharedHttpConnector::new(self.clone())
+        SharedHttpConnector::new(WasiHttpConnector {
+            connect_timeout: settings.connect_timeout(),
+            read_timeout: settings.read_timeout(),
+        })
     }
 }
 
-impl HttpConnector for WasiHttpClient {
-    fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
-        HttpConnectorFuture::ready(make_request(request))
+/// An HTTP connector that carries SDK-supplied timeouts into wasi:http requests.
+#[derive(Clone)]
+struct WasiHttpConnector {
+    connect_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+}
+
+impl fmt::Debug for WasiHttpConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WasiHttpConnector")
+            .field("connect_timeout", &self.connect_timeout)
+            .field("read_timeout", &self.read_timeout)
+            .finish()
     }
+}
+
+impl HttpConnector for WasiHttpConnector {
+    fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+        let options = build_request_options(self.connect_timeout, self.read_timeout);
+        HttpConnectorFuture::ready(make_request(request, options))
+    }
+}
+
+/// Build wasi:http RequestOptions from SDK-supplied timeouts.
+///
+/// wasi:http Duration is nanoseconds (u64), so we convert from std::time::Duration.
+fn build_request_options(
+    connect_timeout: Option<Duration>,
+    read_timeout: Option<Duration>,
+) -> Option<RequestOptions> {
+    if connect_timeout.is_none() && read_timeout.is_none() {
+        return None;
+    }
+    let opts = RequestOptions::new();
+    if let Some(t) = connect_timeout {
+        let _ = opts.set_connect_timeout(Some(t.as_nanos() as u64));
+    }
+    if let Some(t) = read_timeout {
+        let _ = opts.set_first_byte_timeout(Some(t.as_nanos() as u64));
+        let _ = opts.set_between_bytes_timeout(Some(t.as_nanos() as u64));
+    }
+    Some(opts)
 }
 
 /// Convert an AWS SDK HttpRequest to a wasi:http outgoing request, execute it,
 /// and convert the response back.
-fn make_request(request: HttpRequest) -> Result<Response<SdkBody>, ConnectorError> {
+fn make_request(
+    request: HttpRequest,
+    options: Option<RequestOptions>,
+) -> Result<Response<SdkBody>, ConnectorError> {
     // Parse the URI
     let uri = request.uri().to_string();
     let parsed = uri
@@ -145,8 +192,8 @@ fn make_request(request: HttpRequest) -> Result<Response<SdkBody>, ConnectorErro
     OutgoingBody::finish(outgoing_body, None)
         .map_err(|e| ConnectorError::other(format!("Failed to finish body: {e:?}").into(), None))?;
 
-    // Send the request
-    let future_response = outgoing_handler::handle(outgoing_req, None).map_err(|e| {
+    // Send the request (with timeout options if provided)
+    let future_response = outgoing_handler::handle(outgoing_req, options).map_err(|e| {
         ConnectorError::other(format!("outgoing-handler error: {e:?}").into(), None)
     })?;
 


### PR DESCRIPTION
Closes #1648

## Summary

Two-layer fix for indefinite hangs when WASM plugin HTTP requests are unresponsive:

1. **Host-side timeout cap** (`carina-plugin-host`): Cap `connect_timeout`, `first_byte_timeout`, and `between_bytes_timeout` for all WASM plugin HTTP requests (not just metadata endpoints) to `WASM_OPERATION_TIMEOUT_SECS` (30s). Wasmtime epoch interruption cannot fire while the guest is suspended waiting for host I/O, so this acts as a safety net.

2. **Guest-side timeout propagation** (`carina-plugin-sdk`): `WasiHttpClient` was ignoring the AWS SDK's `HttpConnectorSettings` and passing `None` as `RequestOptions` to `outgoing_handler::handle`, causing wasmtime to use 600s default timeouts. Now creates `WasiHttpConnector` that carries SDK timeouts into wasi:http `RequestOptions`.

## Root cause

- `WasiHttpClient::http_connector()` discarded `HttpConnectorSettings` (`_settings`)
- `outgoing_handler::handle(request, None)` used no request options
- wasmtime defaults to 600s timeouts when options are `None`
- epoch interruption only fires during WASM computation, not during host-side HTTP waits
- Result: HTTP requests could block for up to 10 minutes with no way to interrupt

## Test plan

- [x] `cargo test` — full workspace passes
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: `aws-vault exec carina-rs -- carina apply --auto-approve .` on `infra/aws/management/carina-state/` — verify operation either succeeds or times out within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)