### PR TITLE
fix: reject double-namespace in validate_enum_namespace

### DIFF
--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -301,6 +301,17 @@ pub fn validate_enum_namespace(s: &str, type_name: &str, namespace: &str) -> Res
             if parts[ns_parts.len()] != type_name {
                 return Err(format!("expected format {}.{}.value", namespace, type_name));
             }
+            // Reject double-namespace: if the value portion repeats the
+            // namespace+type_name pattern (e.g., "awscc.Region.awscc.Region.x"),
+            // the type_name appears again in a position that would start a
+            // second namespace.
+            let value_parts = &parts[ns_parts.len() + 1..];
+            if value_parts.contains(&type_name) {
+                return Err(format!(
+                    "repeated namespace (contains '{}' twice)",
+                    type_name
+                ));
+            }
         }
         _ => {
             return Err(format!(
@@ -736,6 +747,23 @@ mod tests {
                 "awscc.ec2.vpn_gateway"
             )
             .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_namespace_rejects_double_namespace() {
+        // "awscc.Region.awscc.Region.ap_northeast_1" has Region repeated
+        assert!(
+            validate_enum_namespace(
+                "awscc.Region.awscc.Region.ap_northeast_1",
+                "Region",
+                "awscc"
+            )
+            .is_err()
+        );
+        // Same pattern with aws provider
+        assert!(
+            validate_enum_namespace("aws.Region.aws.Region.us_west_2", "Region", "aws").is_err()
         );
     }
 


### PR DESCRIPTION
Refs #1650

## Summary

`validate_enum_namespace` now rejects double-namespace patterns like `awscc.Region.awscc.Region.ap_northeast_1`. The value portion (after namespace + type_name) is checked for repeated type_name occurrences.

This is the root cause of #1648: the double-namespace `region = awscc.Region.awscc.Region.ap_northeast_1` passed validation and produced the invalid region string `awscc.Region.ap-northeast-1`, causing the AWS SDK to connect to a non-existent endpoint.

## What changed

- `validate_enum_namespace` in `carina-core/src/utils.rs`: after matching namespace+type_name prefix, reject if type_name appears again in the value portion
- Existing dotted-value test (`ipsec.1`) continues to pass — only repeated type_name is rejected

## Test plan

- [x] `cargo test -p carina-core` — all tests pass including new double-namespace rejection tests
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — full workspace passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)