### PR TITLE
feat: detect and block backend configuration changes

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -753,6 +753,7 @@ pub async fn run_apply(
     path: &PathBuf,
     auto_approve: bool,
     lock: bool,
+    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let loaded = load_configuration_with_config(path, provider_context)?;
@@ -763,6 +764,9 @@ pub async fn run_apply(
     let (factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(factories);
     validate_and_resolve_with_config(&mut parsed, base_dir, false, provider_context)?;
+
+    // Detect backend reconfiguration before touching any state
+    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
 
     // Check for backend configuration - use local backend by default
     let backend_config = parsed.backend.as_ref();

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -34,18 +34,23 @@ use crate::wiring::{
     reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
 };
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_destroy(
     path: &PathBuf,
     auto_approve: bool,
     lock: bool,
     refresh: bool,
     force: bool,
+    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
 
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, true, provider_context)?;
+
+    // Detect backend reconfiguration before touching any state
+    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
 
     // Don't exit early when resources are empty -- orphaned resources in the
     // state file may still need to be destroyed.

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -14,7 +14,9 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use carina_core::module_resolver;
-use carina_core::parser::{ParsedFile, ProviderContext};
+use carina_core::parser::{BackendConfig, ParsedFile, ProviderContext};
+use carina_state::BackendLock;
+use carina_state::backend::BackendConfig as StateBackendConfig;
 
 use crate::error::AppError;
 use crate::wiring::{
@@ -22,6 +24,55 @@ use crate::wiring::{
     resolve_names_with_ctx, validate_module_calls, validate_provider_region_with_ctx,
     validate_resource_ref_types_with_ctx, validate_resources_with_ctx,
 };
+
+/// Detect whether the `backend` block in the current configuration has
+/// changed since the last run, by comparing against `.carina/backend-lock.json`
+/// under `base_dir`.
+///
+/// - If no lock exists yet, the current config is written as the new lock.
+/// - If the lock matches, nothing happens.
+/// - If the lock differs and `reconfigure` is `false`, returns an error
+///   explaining the change and asking the user to re-run with `--reconfigure`.
+/// - If `reconfigure` is `true`, overwrites the lock with the new config.
+///
+/// When `backend_config` is `None` (local default backend), no check is
+/// performed — local state lives alongside the `.crn` files and is not
+/// subject to silent redirection.
+pub fn check_backend_lock(
+    base_dir: &Path,
+    backend_config: Option<&BackendConfig>,
+    reconfigure: bool,
+) -> Result<(), AppError> {
+    let Some(config) = backend_config else {
+        return Ok(());
+    };
+    let state_config = StateBackendConfig::from(config);
+    let current = BackendLock::from_config(&state_config);
+    let existing = BackendLock::load(base_dir).map_err(AppError::Backend)?;
+
+    match existing {
+        Some(existing) if existing != current => {
+            if reconfigure {
+                current.save(base_dir).map_err(AppError::Backend)?;
+                Ok(())
+            } else {
+                Err(AppError::Config(format!(
+                    "Backend configuration has changed since the last run:\n\n{}\n\n\
+                     Changing backend settings can silently redirect Carina at a \
+                     different state file, which may cause state loss or drift. \
+                     If this change is intentional, re-run with --reconfigure to \
+                     accept the new configuration.",
+                    existing.describe_diff(&current)
+                )))
+            }
+        }
+        Some(_) => Ok(()),
+        None => {
+            current.save(base_dir).map_err(AppError::Backend)?;
+            Ok(())
+        }
+    }
+}
 
 /// Run the common validation and module resolution pipeline.
 ///
@@ -114,7 +165,73 @@ pub fn validate_and_resolve_with_config(
 mod tests {
     use super::*;
     use carina_core::parser::ProviderConfig;
+    use carina_core::resource::Value;
     use std::collections::{HashMap, HashSet};
+
+    fn s3_backend_config(bucket: &str, region: &str) -> BackendConfig {
+        let mut attributes = HashMap::new();
+        attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+        attributes.insert("region".to_string(), Value::String(region.to_string()));
+        BackendConfig {
+            backend_type: "s3".to_string(),
+            attributes,
+        }
+    }
+
+    #[test]
+    fn check_backend_lock_creates_lock_on_first_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = s3_backend_config("my-bucket", "us-east-1");
+        let result = check_backend_lock(tmp.path(), Some(&config), false);
+        assert!(result.is_ok());
+        assert!(tmp.path().join(".carina/backend-lock.json").exists());
+    }
+
+    #[test]
+    fn check_backend_lock_passes_when_config_unchanged() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = s3_backend_config("my-bucket", "us-east-1");
+        check_backend_lock(tmp.path(), Some(&config), false).unwrap();
+        let result = check_backend_lock(tmp.path(), Some(&config), false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn check_backend_lock_blocks_on_bucket_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = s3_backend_config("old-bucket", "us-east-1");
+        let new = s3_backend_config("new-bucket", "us-east-1");
+        check_backend_lock(tmp.path(), Some(&old), false).unwrap();
+        let err = check_backend_lock(tmp.path(), Some(&new), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Backend configuration has changed"));
+        assert!(msg.contains("bucket"));
+        assert!(msg.contains("old-bucket"));
+        assert!(msg.contains("new-bucket"));
+        assert!(msg.contains("--reconfigure"));
+    }
+
+    #[test]
+    fn check_backend_lock_accepts_change_with_reconfigure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = s3_backend_config("old-bucket", "us-east-1");
+        let new = s3_backend_config("new-bucket", "us-east-1");
+        check_backend_lock(tmp.path(), Some(&old), false).unwrap();
+        let result = check_backend_lock(tmp.path(), Some(&new), true);
+        assert!(result.is_ok());
+        // Subsequent check with new config should now pass without reconfigure
+        let result2 = check_backend_lock(tmp.path(), Some(&new), false);
+        assert!(result2.is_ok());
+    }
+
+    #[test]
+    fn check_backend_lock_skips_when_no_backend_configured() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = check_backend_lock(tmp.path(), None, false);
+        assert!(result.is_ok());
+        // No lock file should be created for local-only setups
+        assert!(!tmp.path().join(".carina/backend-lock.json").exists());
+    }
 
     fn empty_parsed_file() -> ParsedFile {
         ParsedFile {

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -96,6 +96,7 @@ fn build_plan_file(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_plan(
     path: &PathBuf,
     out: Option<&PathBuf>,
@@ -103,12 +104,16 @@ pub async fn run_plan(
     tui: bool,
     refresh: bool,
     json: bool,
+    reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
     let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
 
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, false, provider_context)?;
+
+    // Detect backend reconfiguration before touching any state
+    crate::commands::check_backend_lock(base_dir, parsed.backend.as_ref(), reconfigure)?;
 
     // Check for backend configuration and load state
     // Use local backend by default if no backend is configured

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -94,6 +94,10 @@ enum Commands {
         /// Output plan as JSON
         #[arg(long)]
         json: bool,
+
+        /// Accept a changed backend configuration and overwrite the local backend lock
+        #[arg(long)]
+        reconfigure: bool,
     },
     /// Apply changes to reach the desired state
     Apply {
@@ -108,6 +112,10 @@ enum Commands {
         /// Enable/disable state locking (default: true)
         #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
         lock: bool,
+
+        /// Accept a changed backend configuration and overwrite the local backend lock
+        #[arg(long)]
+        reconfigure: bool,
     },
     /// Destroy all resources defined in the configuration file
     Destroy {
@@ -130,6 +138,10 @@ enum Commands {
         /// Force destroy even if resources have prevent_destroy set
         #[arg(long)]
         force: bool,
+
+        /// Accept a changed backend configuration and overwrite the local backend lock
+        #[arg(long)]
+        reconfigure: bool,
     },
     /// Format .crn files
     Fmt {
@@ -301,6 +313,7 @@ async fn main() {
         tui,
         refresh,
         json,
+        reconfigure,
     } = cli.command
     {
         match run_plan(
@@ -310,6 +323,7 @@ async fn main() {
             tui,
             refresh,
             json,
+            reconfigure,
             &provider_context,
         )
         .await
@@ -334,11 +348,12 @@ async fn main() {
             path,
             auto_approve,
             lock,
+            reconfigure,
         } => {
             if path.extension().is_some_and(|ext| ext == "json") {
                 run_apply_from_plan(&path, auto_approve, lock).await
             } else {
-                run_apply(&path, auto_approve, lock, &provider_context).await
+                run_apply(&path, auto_approve, lock, reconfigure, &provider_context).await
             }
         }
         Commands::Destroy {
@@ -347,7 +362,19 @@ async fn main() {
             lock,
             refresh,
             force,
-        } => run_destroy(&path, auto_approve, lock, refresh, force, &provider_context).await,
+            reconfigure,
+        } => {
+            run_destroy(
+                &path,
+                auto_approve,
+                lock,
+                refresh,
+                force,
+                reconfigure,
+                &provider_context,
+            )
+            .await
+        }
         Commands::Fmt {
             path,
             check,

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -1,0 +1,197 @@
+//! Local backend-configuration lock file for change detection.
+//!
+//! Carina stores a hash of the current `backend` block in a local file
+//! (`.carina/backend-lock.json`) next to the user's `.crn` files. Before
+//! each plan/apply, the stored hash is compared against the current
+//! configuration — a mismatch indicates that the backend has been
+//! reconfigured (for example, the bucket or key was changed), and Carina
+//! refuses to proceed without an explicit `--reconfigure` override.
+//!
+//! This prevents silently pointing state operations at a different state
+//! file, which could lead to resources being treated as unmanaged or
+//! data loss.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::{BackendConfig, BackendError, BackendResult};
+
+/// Name of the lock directory, relative to the configuration root.
+pub const LOCK_DIR: &str = ".carina";
+
+/// Name of the lock file, relative to `LOCK_DIR`.
+pub const LOCK_FILE: &str = "backend-lock.json";
+
+/// Snapshot of the backend configuration that was last used for a given
+/// configuration root. Persisted to disk as JSON.
+///
+/// Attribute values are stored as `serde_json::Value` so that any DSL
+/// type can be serialized (strings, bools, numbers). Keys are sorted in
+/// a `BTreeMap` so the serialized form is deterministic regardless of
+/// `HashMap` iteration order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackendLock {
+    /// Backend type identifier (e.g., `"s3"`, `"local"`).
+    pub backend_type: String,
+    /// Sorted snapshot of backend attributes for stable comparison.
+    pub attributes: BTreeMap<String, serde_json::Value>,
+}
+
+impl BackendLock {
+    /// Build a lock snapshot from the current backend configuration.
+    pub fn from_config(config: &BackendConfig) -> Self {
+        let attributes = config
+            .attributes
+            .iter()
+            .map(|(k, v)| (k.clone(), value_to_json(v)))
+            .collect();
+        Self {
+            backend_type: config.backend_type.clone(),
+            attributes,
+        }
+    }
+
+    /// Path to the lock file under `base_dir`.
+    pub fn lock_path(base_dir: &Path) -> PathBuf {
+        base_dir.join(LOCK_DIR).join(LOCK_FILE)
+    }
+
+    /// Load an existing lock from `base_dir`, returning `None` if no
+    /// lock file exists yet.
+    pub fn load(base_dir: &Path) -> BackendResult<Option<Self>> {
+        let path = Self::lock_path(base_dir);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(&path)
+            .map_err(|e| BackendError::Io(format!("Failed to read {}: {}", path.display(), e)))?;
+        let lock: Self = serde_json::from_str(&contents).map_err(|e| {
+            BackendError::Serialization(format!(
+                "Failed to parse backend lock at {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        Ok(Some(lock))
+    }
+
+    /// Persist this lock snapshot under `base_dir`, creating the
+    /// `.carina` directory if it does not yet exist.
+    pub fn save(&self, base_dir: &Path) -> BackendResult<()> {
+        let lock_dir = base_dir.join(LOCK_DIR);
+        std::fs::create_dir_all(&lock_dir).map_err(|e| {
+            BackendError::Io(format!("Failed to create {}: {}", lock_dir.display(), e))
+        })?;
+        let path = lock_dir.join(LOCK_FILE);
+        let contents = serde_json::to_string_pretty(self)
+            .map_err(|e| BackendError::Serialization(e.to_string()))?;
+        std::fs::write(&path, contents)
+            .map_err(|e| BackendError::Io(format!("Failed to write {}: {}", path.display(), e)))?;
+        Ok(())
+    }
+
+    /// Produce a human-readable diff description for error messages.
+    pub fn describe_diff(&self, other: &Self) -> String {
+        let mut lines = Vec::new();
+        if self.backend_type != other.backend_type {
+            lines.push(format!(
+                "  backend type: {} → {}",
+                self.backend_type, other.backend_type
+            ));
+        }
+        let all_keys: std::collections::BTreeSet<&String> = self
+            .attributes
+            .keys()
+            .chain(other.attributes.keys())
+            .collect();
+        for key in all_keys {
+            let old_val = self.attributes.get(key);
+            let new_val = other.attributes.get(key);
+            if old_val != new_val {
+                lines.push(format!(
+                    "  {}: {} → {}",
+                    key,
+                    old_val.map_or("(unset)".to_string(), ToString::to_string),
+                    new_val.map_or("(unset)".to_string(), ToString::to_string),
+                ));
+            }
+        }
+        lines.join("\n")
+    }
+}
+
+/// Convert a `carina_core::resource::Value` into a `serde_json::Value`
+/// for persistence in the lock file. Only scalar types are expected in
+/// backend configurations, but complex types fall back to `null`.
+fn value_to_json(value: &carina_core::resource::Value) -> serde_json::Value {
+    use carina_core::resource::Value;
+    match value {
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int(i) => serde_json::Value::Number((*i).into()),
+        _ => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::resource::Value;
+    use std::collections::HashMap;
+
+    fn make_config(bucket: &str, region: &str) -> BackendConfig {
+        let mut attributes = HashMap::new();
+        attributes.insert("bucket".to_string(), Value::String(bucket.to_string()));
+        attributes.insert("region".to_string(), Value::String(region.to_string()));
+        BackendConfig {
+            backend_type: "s3".to_string(),
+            attributes,
+        }
+    }
+
+    #[test]
+    fn from_config_captures_type_and_attributes() {
+        let config = make_config("my-bucket", "us-east-1");
+        let lock = BackendLock::from_config(&config);
+        assert_eq!(lock.backend_type, "s3");
+        assert_eq!(
+            lock.attributes.get("bucket"),
+            Some(&serde_json::Value::String("my-bucket".to_string()))
+        );
+    }
+
+    #[test]
+    fn lock_roundtrip_via_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = BackendLock::from_config(&make_config("b", "us-east-1"));
+        lock.save(tmp.path()).unwrap();
+        let loaded = BackendLock::load(tmp.path()).unwrap().unwrap();
+        assert_eq!(lock, loaded);
+    }
+
+    #[test]
+    fn load_returns_none_when_lock_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(BackendLock::load(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn detects_bucket_change() {
+        let a = BackendLock::from_config(&make_config("old-bucket", "us-east-1"));
+        let b = BackendLock::from_config(&make_config("new-bucket", "us-east-1"));
+        assert_ne!(a, b);
+        let diff = a.describe_diff(&b);
+        assert!(diff.contains("bucket"));
+        assert!(diff.contains("old-bucket"));
+        assert!(diff.contains("new-bucket"));
+    }
+
+    #[test]
+    fn equal_configs_do_not_differ() {
+        let a = BackendLock::from_config(&make_config("b", "us-east-1"));
+        let b = BackendLock::from_config(&make_config("b", "us-east-1"));
+        assert_eq!(a, b);
+    }
+}

--- a/carina-state/src/lib.rs
+++ b/carina-state/src/lib.rs
@@ -44,12 +44,14 @@
 //! ```
 
 pub mod backend;
+pub mod backend_lock;
 pub mod backends;
 pub mod lock;
 pub mod state;
 
 // Re-export main types for convenience
 pub use backend::{BackendConfig, BackendError, BackendResult, StateBackend};
+pub use backend_lock::BackendLock;
 pub use backends::{LocalBackend, create_backend, create_local_backend, resolve_backend};
 pub use lock::LockInfo;
 pub use state::{ResourceState, StateFile, check_and_migrate, check_and_migrate_bytes};


### PR DESCRIPTION
Closes #1660

## Summary

- Add `BackendLock` module in `carina-state` that persists a snapshot of the current `backend` config to `.carina/backend-lock.json`
- Add `check_backend_lock()` helper in `carina-cli` that compares current config against the saved lock
- Call the check from `run_plan`, `run_apply`, and `run_destroy` before touching any state
- Add `--reconfigure` flag to plan/apply/destroy to explicitly accept a changed backend config
- `.carina/` is already gitignored

## Behavior

**First run**: lock file is created under `.carina/backend-lock.json`.

**Subsequent runs with unchanged config**: no-op.

**Subsequent runs with changed config** (e.g., `bucket` or `region`):
```
Error: Backend configuration has changed since the last run:

  bucket: "old-bucket" → "new-bucket"

Changing backend settings can silently redirect Carina at a different
state file, which may cause state loss or drift. If this change is
intentional, re-run with --reconfigure to accept the new configuration.
```

**With `--reconfigure`**: the lock is overwritten with the new config.

**Local-only setups** (no backend block): check is skipped entirely — local state lives alongside the .crn files and cannot be silently redirected.

## Test plan

- [x] `cargo test -p carina-state` — 85 tests pass (5 new for `BackendLock`)
- [x] `cargo test -p carina-cli` — 202 tests pass (5 new for `check_backend_lock`)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test` — full workspace passes

## Related

- #1658 (state migration command) — this PR only detects changes; actual migration between backends is a separate feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)