### PR TITLE
fix: detect local → remote backend transition

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -35,19 +35,23 @@ use crate::wiring::{
 ///   explaining the change and asking the user to re-run with `--reconfigure`.
 /// - If `reconfigure` is `true`, overwrites the lock with the new config.
 ///
-/// When `backend_config` is `None` (local default backend), no check is
-/// performed — local state lives alongside the `.crn` files and is not
-/// subject to silent redirection.
+/// When no `backend` block is configured, the implicit local backend is
+/// still recorded in the lock. This makes it possible to detect the
+/// local → remote transition (user adds a backend block after having
+/// run carina against local state) — otherwise the lock would be silently
+/// created with the new remote config and the local state abandoned.
 pub fn check_backend_lock(
     base_dir: &Path,
     backend_config: Option<&BackendConfig>,
     reconfigure: bool,
 ) -> Result<(), AppError> {
-    let Some(config) = backend_config else {
-        return Ok(());
+    let current = match backend_config {
+        Some(config) => {
+            let state_config = StateBackendConfig::from(config);
+            BackendLock::from_config(&state_config)
+        }
+        None => BackendLock::local_default(),
     };
-    let state_config = StateBackendConfig::from(config);
-    let current = BackendLock::from_config(&state_config);
     let existing = BackendLock::load(base_dir).map_err(AppError::Backend)?;
 
     match existing {
@@ -225,12 +229,43 @@ mod tests {
     }
 
     #[test]
-    fn check_backend_lock_skips_when_no_backend_configured() {
+    fn check_backend_lock_records_local_default_when_no_backend_configured() {
         let tmp = tempfile::tempdir().unwrap();
         let result = check_backend_lock(tmp.path(), None, false);
         assert!(result.is_ok());
-        // No lock file should be created for local-only setups
-        assert!(!tmp.path().join(".carina/backend-lock.json").exists());
+        // A lock file is created with the implicit local backend, so that a
+        // subsequent transition to a remote backend can be detected.
+        let lock_path = tmp.path().join(".carina/backend-lock.json");
+        assert!(lock_path.exists());
+        let contents = std::fs::read_to_string(&lock_path).unwrap();
+        assert!(contents.contains("\"local\""));
+    }
+
+    #[test]
+    fn check_backend_lock_blocks_local_to_remote_transition() {
+        let tmp = tempfile::tempdir().unwrap();
+        // First run: local default (no backend block)
+        check_backend_lock(tmp.path(), None, false).unwrap();
+        // Second run: user adds an S3 backend
+        let new = s3_backend_config("my-bucket", "us-east-1");
+        let err = check_backend_lock(tmp.path(), Some(&new), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Backend configuration has changed"));
+        assert!(msg.contains("local"));
+        assert!(msg.contains("s3"));
+        assert!(msg.contains("--reconfigure"));
+    }
+
+    #[test]
+    fn check_backend_lock_allows_local_to_remote_with_reconfigure() {
+        let tmp = tempfile::tempdir().unwrap();
+        check_backend_lock(tmp.path(), None, false).unwrap();
+        let new = s3_backend_config("my-bucket", "us-east-1");
+        let result = check_backend_lock(tmp.path(), Some(&new), true);
+        assert!(result.is_ok());
+        // Subsequent run with the new backend should now pass
+        let result2 = check_backend_lock(tmp.path(), Some(&new), false);
+        assert!(result2.is_ok());
     }
 
     fn empty_parsed_file() -> ParsedFile {

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -53,6 +53,16 @@ impl BackendLock {
         }
     }
 
+    /// Build a lock snapshot representing the implicit local backend that
+    /// is used when no `backend` block is configured. Allows
+    /// `check_backend_lock` to detect local → remote transitions.
+    pub fn local_default() -> Self {
+        Self {
+            backend_type: "local".to_string(),
+            attributes: BTreeMap::new(),
+        }
+    }
+
     /// Path to the lock file under `base_dir`.
     pub fn lock_path(base_dir: &Path) -> PathBuf {
         base_dir.join(LOCK_DIR).join(LOCK_FILE)
@@ -193,5 +203,18 @@ mod tests {
         let a = BackendLock::from_config(&make_config("b", "us-east-1"));
         let b = BackendLock::from_config(&make_config("b", "us-east-1"));
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn local_default_differs_from_remote() {
+        let local = BackendLock::local_default();
+        assert_eq!(local.backend_type, "local");
+        assert!(local.attributes.is_empty());
+        let s3 = BackendLock::from_config(&make_config("b", "us-east-1"));
+        assert_ne!(local, s3);
+        let diff = local.describe_diff(&s3);
+        assert!(diff.contains("backend type"));
+        assert!(diff.contains("local"));
+        assert!(diff.contains("s3"));
     }
 }


### PR DESCRIPTION
Closes #1663

## Summary

- Add `BackendLock::local_default()` returning `{backend_type: "local", attributes: {}}`
- Update `check_backend_lock()` to use `local_default()` when no `backend` block is configured, instead of skipping the check
- Update tests to cover the local → remote transition

## Root cause

PR #1662 introduced backend-change detection but skipped the check entirely when `backend_config` was `None`:

\`\`\`rust
let Some(config) = backend_config else {
    return Ok(());  // ← skipped for local
};
\`\`\`

This missed the local → remote transition: a user running against local state who later adds a `backend s3 { ... }` block would silently switch to S3 and abandon the local state file.

## After

1. First run with no backend → lock file created with `{backend_type: "local"}`
2. User adds `backend s3 { ... }` → lock mismatch detected → error asking for `--reconfigure`
3. Re-run with `--reconfigure` → lock overwritten with the new S3 config

## Test plan

- [x] `cargo test -p carina-state` — 86 tests pass (1 new for `local_default`)
- [x] `cargo test -p carina-cli` — 209 tests pass (2 new for local → remote transition)
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)