### PR TITLE
fix: iterate workflow runs to find WASM artifact across workflows

### DIFF
--- a/carina-provider-resolver/src/revision_resolver.rs
+++ b/carina-provider-resolver/src/revision_resolver.rs
@@ -1,8 +1,35 @@
 //! Resolve provider binaries from GitHub Actions CI artifacts by git revision.
 
+use serde::Deserialize;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+
+/// GitHub Actions artifact metadata (subset used by the resolver).
+#[derive(Deserialize)]
+struct Artifact {
+    id: u64,
+    name: String,
+    #[serde(default)]
+    expired: bool,
+}
+
+#[derive(Deserialize)]
+struct ArtifactsResponse {
+    #[serde(default)]
+    artifacts: Vec<Artifact>,
+}
+
+#[derive(Deserialize)]
+struct WorkflowRun {
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct WorkflowRunsResponse {
+    #[serde(default)]
+    workflow_runs: Vec<WorkflowRun>,
+}
 
 /// Obtain a GitHub token for API authentication.
 ///
@@ -78,9 +105,14 @@ pub fn resolve_ref_to_sha(source: &str, revision: &str, token: &str) -> Result<S
         .ok_or_else(|| format!("No SHA found for revision '{revision}' in {source}"))
 }
 
-/// Find the most recent successful workflow run for a given commit SHA.
-/// Returns the run ID.
-fn find_workflow_run(source: &str, sha: &str, token: &str) -> Result<u64, String> {
+/// Find all successful workflow runs for a given commit SHA.
+/// Returns run IDs newest-first, matching GitHub's default ordering.
+///
+/// Multiple workflows may run on the same commit (e.g. `ci.yml` and `docs.yml`
+/// both triggered on push to main). The caller is responsible for picking the
+/// run that actually contains the expected artifact — see
+/// [`select_artifact_from_runs`].
+fn find_workflow_run_ids(source: &str, sha: &str, token: &str) -> Result<Vec<u64>, String> {
     let (owner, repo) = parse_source(source)?;
     let url = format!(
         "https://api.github.com/repos/{owner}/{repo}/actions/runs?head_sha={sha}&status=success&per_page=10"
@@ -104,33 +136,15 @@ fn find_workflow_run(source: &str, sha: &str, token: &str) -> Result<u64, String
         .into_body()
         .read_to_string()
         .map_err(|e| format!("Failed to read response body: {e}"))?;
-    let data: serde_json::Value =
+    let data: WorkflowRunsResponse =
         serde_json::from_str(&body).map_err(|e| format!("Failed to parse response: {e}"))?;
 
-    let runs = data
-        .get("workflow_runs")
-        .and_then(|r| r.as_array())
-        .ok_or_else(|| format!("No workflow_runs in response for {source}@{sha}"))?;
-
-    if runs.is_empty() {
-        return Err(format!(
-            "No successful workflow runs found for {source}@{sha}. \
-             Ensure CI has run successfully for this revision."
-        ));
-    }
-
-    // Return the most recent run
-    runs[0]
-        .get("id")
-        .and_then(|id| id.as_u64())
-        .ok_or_else(|| "Failed to extract run ID".to_string())
+    Ok(data.workflow_runs.into_iter().map(|r| r.id).collect())
 }
 
-/// Find the artifact ID for a WASM provider binary in a workflow run.
-/// Looks for an artifact named `{repo}.wasm`.
-fn find_wasm_artifact(source: &str, run_id: u64, token: &str) -> Result<u64, String> {
+/// Fetch the artifacts list for a single workflow run.
+fn fetch_run_artifacts(source: &str, run_id: u64, token: &str) -> Result<Vec<Artifact>, String> {
     let (owner, repo) = parse_source(source)?;
-    let expected_name = format!("{repo}.wasm");
     let url =
         format!("https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts");
 
@@ -152,34 +166,90 @@ fn find_wasm_artifact(source: &str, run_id: u64, token: &str) -> Result<u64, Str
         .into_body()
         .read_to_string()
         .map_err(|e| format!("Failed to read response body: {e}"))?;
-    let data: serde_json::Value =
+    let data: ArtifactsResponse =
         serde_json::from_str(&body).map_err(|e| format!("Failed to parse response: {e}"))?;
+    Ok(data.artifacts)
+}
 
-    let artifacts = data
-        .get("artifacts")
-        .and_then(|a| a.as_array())
-        .ok_or_else(|| "No artifacts in response".to_string())?;
+/// Result of looking for a specific artifact inside a single run's artifact list.
+#[derive(Debug, PartialEq, Eq)]
+enum ArtifactMatch {
+    /// A non-expired artifact with the expected name was found.
+    Found(u64),
+    /// The expected artifact exists in this run but has expired.
+    Expired,
+    /// No artifact with the expected name is in this run.
+    NotFound,
+}
 
+/// Pure: scan a run's artifacts list for one matching `expected_name`.
+/// Expired artifacts are reported separately so callers can surface a
+/// targeted error message when every candidate run is expired.
+fn pick_artifact_id(artifacts: &[Artifact], expected_name: &str) -> ArtifactMatch {
+    let mut saw_expired = false;
     for artifact in artifacts {
-        let name = artifact.get("name").and_then(|n| n.as_str()).unwrap_or("");
-        if name == expected_name {
-            if let Some(true) = artifact.get("expired").and_then(|e| e.as_bool()) {
-                return Err(format!(
-                    "Artifact '{expected_name}' has expired. \
-                     Re-run CI for this revision or use `file://` for local builds."
-                ));
-            }
-            return artifact
-                .get("id")
-                .and_then(|id| id.as_u64())
-                .ok_or_else(|| "Failed to extract artifact ID".to_string());
+        if artifact.name != expected_name {
+            continue;
+        }
+        if artifact.expired {
+            saw_expired = true;
+            continue;
+        }
+        return ArtifactMatch::Found(artifact.id);
+    }
+    if saw_expired {
+        ArtifactMatch::Expired
+    } else {
+        ArtifactMatch::NotFound
+    }
+}
+
+/// Iterate candidate workflow runs and return the first artifact ID that
+/// matches `expected_name` and is not expired.
+///
+/// When a repo has multiple workflows on push (e.g. `ci.yml` producing a WASM
+/// artifact and `docs.yml` producing nothing), GitHub returns all successful
+/// runs for the same SHA. Taking only `runs[0]` picks whichever finished last,
+/// which may not be the run that uploaded the artifact. Iterating the full
+/// list removes the dependency on workflow ordering.
+fn select_artifact_from_runs<F>(
+    run_ids: &[u64],
+    expected_name: &str,
+    source: &str,
+    sha: &str,
+    mut fetch: F,
+) -> Result<u64, String>
+where
+    F: FnMut(u64) -> Result<Vec<Artifact>, String>,
+{
+    if run_ids.is_empty() {
+        return Err(format!(
+            "No successful workflow runs found for {source}@{sha}. \
+             Ensure CI has run successfully. Expected artifact: '{expected_name}'."
+        ));
+    }
+
+    let mut saw_expired = false;
+    for &run_id in run_ids {
+        let artifacts = fetch(run_id)?;
+        match pick_artifact_id(&artifacts, expected_name) {
+            ArtifactMatch::Found(id) => return Ok(id),
+            ArtifactMatch::Expired => saw_expired = true,
+            ArtifactMatch::NotFound => {}
         }
     }
 
-    Err(format!(
-        "No artifact named '{expected_name}' found in workflow run {run_id}. \
-         Ensure CI uploads an artifact named '{expected_name}'."
-    ))
+    if saw_expired {
+        Err(format!(
+            "Artifact '{expected_name}' has expired in every successful workflow run for {source}@{sha}. \
+             Re-run CI for this revision or use `file://` for local builds."
+        ))
+    } else {
+        Err(format!(
+            "No artifact named '{expected_name}' found in any successful workflow run for {source}@{sha}. \
+             Ensure CI uploads an artifact named '{expected_name}'."
+        ))
+    }
 }
 
 /// Download a GitHub Actions artifact (ZIP) and extract the WASM file.
@@ -314,8 +384,15 @@ pub fn resolve_provider_by_revision(
         &sha[..sha.len().min(12)]
     );
 
-    let run_id = find_workflow_run(source, &sha, &token)?;
-    let artifact_id = find_wasm_artifact(source, run_id, &token)?;
+    let run_ids = find_workflow_run_ids(source, &sha, &token)?;
+    let expected_name = format!(
+        "{}.wasm",
+        source.split('/').next_back().unwrap_or("provider")
+    );
+    let artifact_id =
+        select_artifact_from_runs(&run_ids, &expected_name, source, &sha, |run_id| {
+            fetch_run_artifacts(source, run_id, &token)
+        })?;
     download_artifact(source, artifact_id, &wasm_path, &token)?;
 
     let hash = super::provider_resolver::sha256_file(&wasm_path)
@@ -390,5 +467,182 @@ mod tests {
         let token = get_github_token().unwrap();
         assert_eq!(token, "test-token-123");
         unsafe { std::env::remove_var("GITHUB_TOKEN") };
+    }
+
+    const TEST_SOURCE: &str = "github.com/carina-rs/carina-provider-aws";
+    const TEST_SHA: &str = "abc123def456";
+
+    fn artifact(name: &str, id: u64, expired: bool) -> Artifact {
+        Artifact {
+            id,
+            name: name.to_string(),
+            expired,
+        }
+    }
+
+    #[test]
+    fn test_pick_artifact_id_found() {
+        let artifacts = vec![
+            artifact("other.wasm", 1, false),
+            artifact("carina-provider-aws.wasm", 42, false),
+        ];
+        assert_eq!(
+            pick_artifact_id(&artifacts, "carina-provider-aws.wasm"),
+            ArtifactMatch::Found(42)
+        );
+    }
+
+    #[test]
+    fn test_pick_artifact_id_not_found() {
+        let artifacts = vec![artifact("other.wasm", 1, false)];
+        assert_eq!(
+            pick_artifact_id(&artifacts, "carina-provider-aws.wasm"),
+            ArtifactMatch::NotFound
+        );
+    }
+
+    #[test]
+    fn test_pick_artifact_id_expired() {
+        let artifacts = vec![artifact("carina-provider-aws.wasm", 42, true)];
+        assert_eq!(
+            pick_artifact_id(&artifacts, "carina-provider-aws.wasm"),
+            ArtifactMatch::Expired
+        );
+    }
+
+    #[test]
+    fn test_pick_artifact_id_prefers_non_expired_over_expired() {
+        // Same name, expired first then valid — must not short-circuit on expired.
+        let artifacts = vec![artifact("my.wasm", 1, true), artifact("my.wasm", 2, false)];
+        assert_eq!(
+            pick_artifact_id(&artifacts, "my.wasm"),
+            ArtifactMatch::Found(2)
+        );
+    }
+
+    #[test]
+    fn test_select_artifact_iterates_past_run_without_match() {
+        // Regression for the multi-workflow case:
+        // Run 200 is a docs workflow (no artifacts), run 100 is CI (has artifact).
+        // GitHub returns them newest-first, so 200 comes first. The resolver
+        // must iterate past 200 and find the artifact in 100.
+        let run_ids = vec![200u64, 100u64];
+        let fetch = |run_id: u64| -> Result<Vec<Artifact>, String> {
+            match run_id {
+                200 => Ok(vec![]),
+                100 => Ok(vec![artifact("carina-provider-aws.wasm", 999, false)]),
+                other => panic!("unexpected run_id {other}"),
+            }
+        };
+
+        let result = select_artifact_from_runs(
+            &run_ids,
+            "carina-provider-aws.wasm",
+            TEST_SOURCE,
+            TEST_SHA,
+            fetch,
+        );
+        assert_eq!(result.unwrap(), 999);
+    }
+
+    #[test]
+    fn test_select_artifact_found_in_first_run() {
+        let run_ids = vec![100u64];
+        let fetch = |_| Ok(vec![artifact("my.wasm", 7, false)]);
+        assert_eq!(
+            select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn test_select_artifact_prefers_later_run_when_earlier_is_expired() {
+        // First run's artifact has expired, second run has a valid one.
+        // The `saw_expired` flag must not suppress a later `Found`.
+        let run_ids = vec![200u64, 100u64];
+        let fetch = |run_id: u64| -> Result<Vec<Artifact>, String> {
+            match run_id {
+                200 => Ok(vec![artifact("my.wasm", 1, true)]),
+                100 => Ok(vec![artifact("my.wasm", 2, false)]),
+                other => panic!("unexpected run_id {other}"),
+            }
+        };
+        assert_eq!(
+            select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch).unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_select_artifact_not_found_anywhere() {
+        let run_ids = vec![200u64, 100u64];
+        let fetch = |_| Ok(vec![artifact("other.wasm", 1, false)]);
+        let err = select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch)
+            .unwrap_err();
+        assert!(err.contains("No artifact named 'my.wasm'"), "err={err}");
+        assert!(
+            err.contains(TEST_SOURCE),
+            "err should include source: {err}"
+        );
+        assert!(err.contains(TEST_SHA), "err should include sha: {err}");
+    }
+
+    #[test]
+    fn test_select_artifact_expired_in_all_runs() {
+        let run_ids = vec![200u64, 100u64];
+        let fetch = |_| Ok(vec![artifact("my.wasm", 1, true)]);
+        let err = select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch)
+            .unwrap_err();
+        assert!(err.contains("expired"), "err={err}");
+        assert!(
+            err.contains(TEST_SOURCE),
+            "err should include source: {err}"
+        );
+        assert!(err.contains(TEST_SHA), "err should include sha: {err}");
+    }
+
+    #[test]
+    fn test_select_artifact_propagates_fetch_error() {
+        // A transient fetch error on the first run must be surfaced, not
+        // silently swallowed so that later runs are tried.
+        let run_ids = vec![200u64, 100u64];
+        let fetch = |run_id: u64| -> Result<Vec<Artifact>, String> {
+            Err(format!("network error for run {run_id}"))
+        };
+        let err = select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch)
+            .unwrap_err();
+        assert!(err.contains("network error for run 200"), "err={err}");
+    }
+
+    #[test]
+    fn test_select_artifact_no_runs() {
+        let run_ids: Vec<u64> = vec![];
+        let fetch = |_| -> Result<Vec<Artifact>, String> {
+            panic!("fetch should not be called when there are no runs")
+        };
+        let err = select_artifact_from_runs(&run_ids, "my.wasm", TEST_SOURCE, TEST_SHA, fetch)
+            .unwrap_err();
+        assert!(err.contains("No successful workflow runs"), "err={err}");
+        assert!(
+            err.contains(TEST_SOURCE),
+            "err should include source: {err}"
+        );
+        assert!(err.contains(TEST_SHA), "err should include sha: {err}");
+    }
+
+    #[test]
+    fn test_artifact_deserialize() {
+        // Sanity check the serde mapping against a realistic GitHub payload.
+        let json = r#"{
+            "artifacts": [
+                {"id": 12345, "name": "carina-provider-aws.wasm", "expired": false,
+                 "node_id": "ignored", "size_in_bytes": 1024}
+            ]
+        }"#;
+        let parsed: ArtifactsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.artifacts.len(), 1);
+        assert_eq!(parsed.artifacts[0].id, 12345);
+        assert_eq!(parsed.artifacts[0].name, "carina-provider-aws.wasm");
+        assert!(!parsed.artifacts[0].expired);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes `carina init` failing to resolve revision-based providers when the target repo has more than one successful workflow on push to main (e.g. `ci.yml` + `docs.yml`).
- Replaces the `runs[0]`-only lookup in `revision_resolver.rs` with an iteration over all successful runs, returning the first one that actually contains the expected artifact.
- Switches raw `serde_json::Value` scraping in the touched functions to typed `Artifact`, `ArtifactsResponse`, `WorkflowRun`, and `WorkflowRunsResponse` structs.
- Threads `source` + `sha` into `select_artifact_from_runs` so every error message surfaces the revision being resolved.

Root cause in detail: GitHub's `actions/runs?head_sha=…&status=success` returns every successful workflow for the SHA, newest-first. The docs workflow (`docs.yml`) finishes *after* `ci.yml`, so it had a higher run ID and won `runs[0]`. It has zero artifacts, so the subsequent `find_wasm_artifact` lookup failed with "No artifact named 'carina-provider-aws.wasm' found in workflow run 24235254421" — even though `ci.yml` had uploaded the artifact as expected.

The original report was carina-rs/carina-provider-aws#81; closing it there directed the fix to this repo.

## Test plan

- [x] `cargo test -p carina-provider-resolver` — 37 tests pass (12 new)
- [x] `cargo clippy -p carina-provider-resolver --all-targets -- -D warnings`
- [x] `cargo fmt -p carina-provider-resolver -- --check`
- [x] New unit test `test_select_artifact_iterates_past_run_without_match` reproduces the #1668 scenario with run 200 (empty) + run 100 (has artifact) and asserts the resolver returns the artifact from run 100
- [x] Coverage: `pick_artifact_id` (found / not_found / expired / mixed), `select_artifact_from_runs` (found_in_first / iterates_past_empty / later_run_after_expired / not_found_anywhere / expired_in_all / no_runs / propagates_fetch_error), `test_artifact_deserialize` verifies serde mapping against a realistic payload with extra fields
- [ ] End-to-end verification by running `carina init` against a real `revision = "main"` provider (requires AWS/GH access; not run in this worktree)

Closes #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)