### PR TITLE
feat: Provider::read_data_source for input-taking data sources

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -36,8 +36,8 @@ use crate::display::{format_effect, print_plan};
 use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, create_providers_from_configs,
-    get_provider_with_ctx, read_with_retry, reconcile_anonymous_identifiers_with_ctx,
-    reconcile_prefixed_names, resolve_names_with_ctx,
+    get_provider_with_ctx, read_data_source_with_retry, read_with_retry,
+    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names, resolve_names_with_ctx,
 };
 
 /// Format a duration as a human-readable string like "3.2s" or "1m 5.3s".
@@ -1049,10 +1049,19 @@ async fn run_apply_locked(
                         .and_then(|sf| sf.get_identifier_for_resource(resource));
                     let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
                     async move {
-                        let mut state =
+                        // Data sources need the full Resource so providers
+                        // can see user-supplied inputs (e.g. `user_name`
+                        // for `aws.identitystore.user`). Regular resources
+                        // route through the identifier-based refresh.
+                        let mut state = if resource.is_data_source() {
+                            read_data_source_with_retry(provider_ref, resource)
+                                .await
+                                .map_err(AppError::Provider)?
+                        } else {
                             read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                                 .await
-                                .map_err(AppError::Provider)?;
+                                .map_err(AppError::Provider)?
+                        };
                         if let Some(deps) = dep_bindings {
                             state.dependency_bindings = deps;
                         }

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -739,10 +739,19 @@ pub async fn create_plan_from_parsed_with_remote(
                         .and_then(|sf| sf.get_identifier_for_resource(resource));
                     let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
                     async move {
-                        let mut state =
+                        // Data sources carry user-supplied inputs that need
+                        // to reach the provider — route them through
+                        // `read_data_source_with_retry` instead of the
+                        // identifier-based refresh.
+                        let mut state = if resource.is_data_source() {
+                            read_data_source_with_retry(provider_ref, resource)
+                                .await
+                                .map_err(AppError::Provider)?
+                        } else {
                             read_with_retry(provider_ref, &resource.id, identifier.as_deref())
                                 .await
-                                .map_err(AppError::Provider)?;
+                                .map_err(AppError::Provider)?
+                        };
                         // Restore dependency_bindings from state file (#1565).
                         if let Some(deps) = dep_bindings {
                             state.dependency_bindings = deps;
@@ -1182,6 +1191,34 @@ pub async fn read_with_retry(
                 eprintln!(
                     "  Throttled reading {}, retrying in {}s...",
                     id,
+                    delay.as_secs()
+                );
+                tokio::time::sleep(delay).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!()
+}
+
+/// Read a data source resource via the provider with retry on throttling errors.
+///
+/// Same backoff policy as [`read_with_retry`] but uses [`Provider::read_data_source`]
+/// so the provider receives the full [`Resource`] (including user-supplied input
+/// attributes) rather than just the identifier.
+pub async fn read_data_source_with_retry(
+    provider: &dyn Provider,
+    resource: &Resource,
+) -> Result<State, ProviderError> {
+    let max_retries = 3;
+    for attempt in 0..=max_retries {
+        match provider.read_data_source(resource).await {
+            Ok(state) => return Ok(state),
+            Err(e) if attempt < max_retries && is_throttling_error(&e) => {
+                let delay = Duration::from_secs(1 << attempt); // 1s, 2s, 4s
+                eprintln!(
+                    "  Throttled reading {}, retrying in {}s...",
+                    resource.id,
                     delay.as_secs()
                 );
                 tokio::time::sleep(delay).await;

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -96,6 +96,42 @@ pub trait Provider: Send + Sync {
         identifier: Option<&str>,
     ) -> BoxFuture<'_, ProviderResult<State>>;
 
+    /// Read a data source resource.
+    ///
+    /// Unlike [`Provider::read`], this receives the full [`Resource`] so the
+    /// provider can see the user-supplied input attributes (e.g. the
+    /// `identity_store_id` + `user_name` that `aws.identitystore.user`
+    /// needs to resolve itself via the AWS SDK).
+    ///
+    /// The default implementation falls back to `read(&resource.id, None)`
+    /// for zero-input data sources such as `aws.sts.caller_identity`. If the
+    /// resource carries any user-supplied input attributes (keys not
+    /// starting with `_`, which marks parser-internal fields like `_type`
+    /// and `_data_source`), the default implementation returns an error
+    /// rather than silently dropping the inputs. Providers whose data
+    /// sources require inputs must override this method and dispatch on
+    /// `resource.id.resource_type`.
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        let user_input_count = resource
+            .attributes
+            .keys()
+            .filter(|k| !k.starts_with('_'))
+            .count();
+        if user_input_count > 0 {
+            let id = resource.id.clone();
+            let provider_name = self.name().to_string();
+            return Box::pin(async move {
+                Err(ProviderError::new(format!(
+                    "data source {id} has {user_input_count} input attribute(s) but provider \
+                     '{provider_name}' does not implement read_data_source for this resource type"
+                ))
+                .for_resource(id))
+            });
+        }
+        let id = resource.id.clone();
+        Box::pin(async move { self.read(&id, None).await })
+    }
+
     /// Create a resource
     ///
     /// Returns State with identifier set to the AWS internal ID (e.g., vpc-xxx)
@@ -297,6 +333,13 @@ impl Provider for ProviderRouter {
     ) -> BoxFuture<'_, ProviderResult<State>> {
         match self.get_provider_or_error(&id.provider) {
             Ok(provider) => provider.read(id, identifier),
+            Err(e) => Box::pin(async move { Err(e) }),
+        }
+    }
+
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        match self.get_provider_or_error(&resource.id.provider) {
+            Ok(provider) => provider.read_data_source(resource),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -515,6 +558,10 @@ impl Provider for Box<dyn Provider> {
         (**self).read(id, identifier)
     }
 
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        (**self).read_data_source(resource)
+    }
+
     fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         (**self).create(resource)
     }
@@ -604,6 +651,190 @@ mod tests {
         let id = ResourceId::new("test", "example");
         let state = provider.read(&id, None).await.unwrap();
         assert!(!state.exists);
+    }
+
+    /// A provider that only accepts a data source when the full `Resource`
+    /// carrying its input attributes is delivered. Exercises the new
+    /// `read_data_source` path introduced to enable resources like
+    /// `identitystore.user` that look themselves up by user-provided inputs.
+    struct InputAwareProvider;
+
+    impl Provider for InputAwareProvider {
+        fn name(&self) -> &str {
+            "input-aware"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            _identifier: Option<&str>,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            // Intentionally fails if the data source path doesn't deliver
+            // the full Resource — the legacy `read(&id, None)` route has no
+            // access to input attributes.
+            Box::pin(async move {
+                Err(ProviderError::new("read(&id, None) cannot see inputs").for_resource(id))
+            })
+        }
+
+        fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            // Echoes the resource's input attributes back into state so the
+            // test can assert they were delivered.
+            let id = resource.id.clone();
+            let attrs = resource.attributes.clone();
+            Box::pin(async move {
+                Ok(State::existing(
+                    id,
+                    crate::resource::Expr::resolve_map(&attrs),
+                ))
+            })
+        }
+
+        fn create(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::new("not supported")) })
+        }
+
+        fn update(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _from: &State,
+            _to: &Resource,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::new("not supported")) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _lifecycle: &LifecycleConfig,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn read_data_source_default_delegates_to_read_for_zero_input() {
+        // MockProvider doesn't override read_data_source — the default impl
+        // must fall back to read(&resource.id, None). For MockProvider this
+        // returns not_found. Preserves backward compatibility for existing
+        // zero-input data sources like sts.caller_identity.
+        let provider = MockProvider;
+        let resource = Resource::new("test", "example");
+        let state = provider.read_data_source(&resource).await.unwrap();
+        assert!(!state.exists);
+    }
+
+    #[tokio::test]
+    async fn read_data_source_default_ignores_internal_markers() {
+        // The parser writes `_type` and `_data_source` into attributes for
+        // every `read ...` expression. These are not user inputs and must
+        // not trigger the "missing override" error in the default impl.
+        let provider = MockProvider;
+        let mut resource = Resource::new("sts.caller_identity", "caller");
+        resource.set_attr(
+            "_type".to_string(),
+            Value::String("aws.sts.caller_identity".to_string()),
+        );
+        resource.set_attr("_data_source".to_string(), Value::Bool(true));
+        let state = provider.read_data_source(&resource).await.unwrap();
+        assert!(!state.exists);
+    }
+
+    #[tokio::test]
+    async fn read_data_source_default_errors_with_user_inputs() {
+        // A resource carrying real user inputs reached the default impl —
+        // that means the provider forgot to override read_data_source for
+        // this resource type. The default impl must return a clear error
+        // rather than silently discarding the inputs and calling read().
+        let provider = MockProvider;
+        let mut resource = Resource::new("identitystore.user", "mizzy");
+        resource.set_attr(
+            "_type".to_string(),
+            Value::String("aws.identitystore.user".to_string()),
+        );
+        resource.set_attr("_data_source".to_string(), Value::Bool(true));
+        resource.set_attr(
+            "user_name".to_string(),
+            Value::String("gosukenator@gmail.com".to_string()),
+        );
+        let err = provider.read_data_source(&resource).await.unwrap_err();
+        assert!(
+            err.message.contains("does not implement read_data_source"),
+            "err={err:?}"
+        );
+        assert!(
+            err.message.contains("mock"),
+            "err should include provider name: {err:?}"
+        );
+        assert!(
+            err.message.contains("identitystore.user"),
+            "err should include resource id: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_data_source_override_receives_full_resource() {
+        // InputAwareProvider's override echoes the resource attributes into
+        // state. If dispatch actually uses the override, the echoed input is
+        // visible; if it falls through to read() by mistake, the test fails
+        // because InputAwareProvider::read returns an error.
+        let provider = InputAwareProvider;
+        let mut resource = Resource::new("identitystore.user", "mizzy");
+        resource.set_attr(
+            "identity_store_id".to_string(),
+            Value::String("d-9567916d09".to_string()),
+        );
+        resource.set_attr(
+            "user_name".to_string(),
+            Value::String("gosukenator@gmail.com".to_string()),
+        );
+
+        let state = provider.read_data_source(&resource).await.unwrap();
+        assert!(state.exists);
+        assert_eq!(
+            state.attributes.get("identity_store_id"),
+            Some(&Value::String("d-9567916d09".to_string()))
+        );
+        assert_eq!(
+            state.attributes.get("user_name"),
+            Some(&Value::String("gosukenator@gmail.com".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn box_dyn_provider_forwards_read_data_source_override() {
+        // When the provider is held as Box<dyn Provider>, the override must
+        // still be called. Without explicit forwarding in the impl, Rust
+        // would use the trait's default impl and bypass the override.
+        let provider: Box<dyn Provider> = Box::new(InputAwareProvider);
+        let mut resource = Resource::new("identitystore.user", "mizzy");
+        resource.set_attr("user_name".to_string(), Value::String("x".to_string()));
+        let state = provider.read_data_source(&resource).await.unwrap();
+        assert!(state.exists);
+        assert_eq!(
+            state.attributes.get("user_name"),
+            Some(&Value::String("x".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_router_dispatches_read_data_source_to_override() {
+        // The router must route read_data_source to the underlying provider
+        // so that overrides work across provider boundaries.
+        let mut router = ProviderRouter::new();
+        router.add_provider("input-aware".to_string(), Box::new(InputAwareProvider));
+
+        let mut resource = Resource::with_provider("input-aware", "identitystore.user", "mizzy");
+        resource.set_attr("user_name".to_string(), Value::String("x".to_string()));
+        let state = router.read_data_source(&resource).await.unwrap();
+        assert!(state.exists);
+        assert_eq!(
+            state.attributes.get("user_name"),
+            Some(&Value::String("x".to_string()))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds `Provider::read_data_source(&self, resource: &Resource)` trait method with a default implementation, enabling data sources that require user-supplied input attributes (e.g. `aws.identitystore.user { identity_store_id = '...', user_name = '...' }`).
- Routes data source refresh through the new method in both the `carina apply` and `carina plan` refresh loops, preserving throttling backoff via a new `read_data_source_with_retry` helper.
- Non-breaking: existing zero-input data sources like `aws.sts.caller_identity` inherit the default impl unchanged.

This is the enabler for carina-rs/carina-provider-aws#80. The provider-side implementation of `identitystore.user` will follow in a separate PR.

## Why

`Provider::read(&id, identifier: Option<&str>)` only carries the resource identifier — the desired-state attributes on the `Resource` never reach the provider. That's fine for refreshing regular resources (identifier comes from state) and for zero-input data sources (`sts.caller_identity`), but it prevents any data source that needs to look itself up by user-supplied inputs from being implemented at all. Approach comparison with Option 1 (extending `read`'s signature) is in the issue body; Option 2 was selected because it's non-breaking across carina / carina-provider-aws / carina-provider-awscc / WASM plugin protocol.

## How

1. **New trait method** (`carina-core/src/provider.rs:99-133`) — `read_data_source(&self, resource: &Resource)` with a default impl that:
   - Counts user-supplied input attributes (non-`_`-prefixed keys), ignoring parser-internal markers `_type` and `_data_source`.
   - Falls back to `self.read(&resource.id, None)` when zero inputs. Preserves `sts.caller_identity` behaviour byte-for-byte.
   - Returns a hard `ProviderError` when inputs are present — fail-loud is safer than silently discarding them.
2. **Explicit forwarding** in `impl Provider for Box<dyn Provider>` and `impl Provider for ProviderRouter`. Without this, the trait's default impl would bypass provider overrides held as trait objects.
3. **Refresh dispatch** in:
   - `carina-cli/src/commands/apply.rs:1056-1065` — the `carina apply` refresh loop
   - `carina-cli/src/wiring.rs:741-753` — the `carina plan` refresh loop
   
   Both branch on `resource.is_data_source()`.
4. **`read_data_source_with_retry`** (`carina-cli/src/wiring.rs:1204-1230`) — sibling of `read_with_retry` with the same 1s/2s/4s throttling backoff. Without it, data sources would have lost the retry that `sts.caller_identity` previously had when routed through `read_with_retry`.

## Test plan

- [x] `cargo test -p carina-core -p carina-cli` — **1138 + 209 passed** (7 new identifier/provider tests)
- [x] `cargo clippy -p carina-core -p carina-cli --all-targets -- -D warnings`
- [x] `cargo fmt -p carina-core -p carina-cli -- --check`
- [x] Unit tests cover:
  - Default impl delegates to `read` for zero-input data sources
  - Default impl ignores `_`-prefixed parser markers (`_type`, `_data_source`)
  - Default impl errors with a clear message when inputs are present but override is missing
  - Override receives the full `Resource` and its attributes
  - `Box<dyn Provider>` forwards to the override (not the default impl)
  - `ProviderRouter` dispatches `read_data_source` to the right underlying provider
- [ ] End-to-end verification against `sts.caller_identity` (no behaviour change expected; existing acceptance test in carina-provider-aws should continue to pass when this lands and carina-provider-aws bumps the git dep).

## Follow-up

carina-rs/carina-provider-aws#80 will override `read_data_source` in `impl Provider for AwsProvider` for the `identitystore.user` case, calling the AWS SDK's `GetUserId` / `DescribeUser` via the full `Resource` that this enabler now delivers.

Closes #1673
Enables: carina-rs/carina-provider-aws#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)