### PR TITLE
fix: plumb read_data_source through WASM plugin boundary

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -390,6 +390,25 @@ impl WasmBindings {
         }
     }
 
+    async fn call_read_data_source(
+        &self,
+        store: &mut Store<HostState>,
+        resource: &wit_types::ResourceDef,
+    ) -> wasmtime::Result<Result<wit_types::State, String>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                b.carina_provider_provider()
+                    .call_read_data_source(store, resource)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                b.carina_provider_provider()
+                    .call_read_data_source(store, resource)
+                    .await
+            }
+        }
+    }
+
     async fn call_create(
         &self,
         store: &mut Store<HostState>,
@@ -1224,6 +1243,36 @@ impl Provider for WasmProvider {
                         .timeout()
                     } else {
                         ProviderError::new(format!("WASM trap in read: {e}"))
+                    }
+                })?;
+            match result {
+                Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
+                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
+            }
+        })
+    }
+
+    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        let wit_resource = wasm_convert::core_to_wit_resource(resource);
+        let id = resource.id.clone();
+        Box::pin(async move {
+            let mut store = self.instance.store.lock().await;
+            store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
+            let result = self
+                .instance
+                .bindings
+                .call_read_data_source(&mut store, &wit_resource)
+                .await
+                .map_err(|e| {
+                    let msg = format!("{e}");
+                    if is_epoch_trap_message(&msg) {
+                        ProviderError::new(format!(
+                            "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in \
+                             read_data_source (check AWS credentials)"
+                        ))
+                        .timeout()
+                    } else {
+                        ProviderError::new(format!("WASM trap in read_data_source: {e}"))
                     }
                 })?;
             match result {

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -204,3 +204,55 @@ async fn test_wasm_mock_provider_normalizer() {
         Some(&Value::String("value".into()))
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
+    // Regression test for carina-rs/carina#1677: the plugin boundary must
+    // route `read_data_source` through to the guest's override so
+    // providers can see user-supplied input attributes. Without the WIT
+    // plumbing in place, the host's trait-default implementation runs
+    // instead and rejects any resource with non-`_` attributes.
+    //
+    // The mock provider's `read_data_source` override echoes input
+    // attributes back into state plus a sentinel
+    // `__mock_read_data_source__` flag. If that flag shows up, the
+    // override ran — meaning the WASM bridge forwarded the call.
+    let path = skip_if_no_wasm!();
+    let factory = WasmProviderFactory::new(path)
+        .await
+        .expect("Failed to load WASM provider");
+    let provider = factory.create_provider(&HashMap::new()).await;
+
+    let mut resource = Resource::with_provider("mock", "test.data_source", "example");
+    resource.attributes = HashMap::from([
+        (
+            "identity_store_id".into(),
+            Expr(Value::String("d-1234567890".into())),
+        ),
+        (
+            "user_name".into(),
+            Expr(Value::String("alice@example.com".into())),
+        ),
+    ]);
+
+    let state = provider
+        .read_data_source(&resource)
+        .await
+        .expect("read_data_source should dispatch to the plugin override");
+
+    assert!(state.exists, "state should be marked as existing");
+    assert_eq!(
+        state.attributes.get("__mock_read_data_source__"),
+        Some(&Value::Bool(true)),
+        "sentinel attribute must be present — proves the plugin override ran"
+    );
+    assert_eq!(
+        state.attributes.get("identity_store_id"),
+        Some(&Value::String("d-1234567890".into())),
+        "input attributes must cross the WASM boundary unchanged"
+    );
+    assert_eq!(
+        state.attributes.get("user_name"),
+        Some(&Value::String("alice@example.com".into())),
+    );
+}

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -88,6 +88,45 @@ pub trait CarinaProvider {
     /// Read current state of a resource.
     fn read(&self, id: &ResourceId, identifier: Option<&str>) -> Result<State, ProviderError>;
 
+    /// Read a data source resource.
+    ///
+    /// Unlike [`CarinaProvider::read`], this receives the full [`Resource`]
+    /// so the plugin can see user-supplied input attributes (e.g. the
+    /// `user_name` for `aws.identitystore.user`). The default falls back
+    /// to `read(&resource.id, None)` for zero-input data sources such as
+    /// `aws.sts.caller_identity`. If the resource carries any non-`_`-
+    /// prefixed input attributes, the default returns an error instead of
+    /// silently dropping them — the plugin must override this method for
+    /// data sources whose reads require those inputs. This mirrors the
+    /// `carina_core::provider::Provider::read_data_source` default
+    /// behaviour so both native and WASM plugins have the same semantics.
+    fn read_data_source(&self, resource: &Resource) -> Result<State, ProviderError> {
+        // Mirrors `carina_core::provider::Provider::read_data_source`'s
+        // default: reject any resource carrying non-`_` user inputs to
+        // avoid silently dropping them. The error message can't include a
+        // provider name here because the `CarinaProvider` trait has no
+        // `name()` accessor (unlike `carina_core::provider::Provider`) —
+        // the plugin's info is carried separately via `info()`.
+        let user_input_count = resource
+            .attributes
+            .keys()
+            .filter(|k| !k.starts_with('_'))
+            .count();
+        if user_input_count > 0 {
+            return Err(ProviderError {
+                message: format!(
+                    "plugin provider does not implement read_data_source for '{}' \
+                     but the resource has {user_input_count} user-supplied input \
+                     attribute(s); refusing to drop them",
+                    resource.id.resource_type
+                ),
+                resource_id: Some(resource.id.clone()),
+                is_timeout: false,
+            });
+        }
+        self.read(&resource.id, None)
+    }
+
     /// Create a new resource.
     fn create(&self, resource: &Resource) -> Result<State, ProviderError>;
 

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -276,6 +276,17 @@ macro_rules! export_provider {
                     }
                 }
 
+                fn read_data_source(
+                    res: wit_types::ResourceDef,
+                ) -> Result<wit_types::State, String> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_res = wit_to_proto_resource(&res);
+                    match $crate::CarinaProvider::read_data_source(&*provider, &proto_res) {
+                        Ok(state) => Ok(proto_to_wit_state(&state)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                    }
+                }
+
                 fn create(
                     res: wit_types::ResourceDef,
                 ) -> Result<wit_types::State, String> {
@@ -598,6 +609,17 @@ macro_rules! export_provider {
                         &proto_id,
                         identifier.as_deref(),
                     ) {
+                        Ok(state) => Ok(proto_to_wit_state(&state)),
+                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                    }
+                }
+
+                fn read_data_source(
+                    res: wit_types::ResourceDef,
+                ) -> Result<wit_types::State, String> {
+                    let provider = get_provider().lock().unwrap();
+                    let proto_res = wit_to_proto_resource(&res);
+                    match $crate::CarinaProvider::read_data_source(&*provider, &proto_res) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
                         Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
                     }

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -18,6 +18,14 @@ interface provider {
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 
     read: func(id: resource-id, identifier: option<string>) -> result<state, string>;
+
+    /// Read a data source resource. Receives the full `resource-def` so
+    /// providers can see user-supplied input attributes (e.g. the
+    /// `user_name` for `aws.identitystore.user`). Zero-input data sources
+    /// should still route through `read` on the host side — callers
+    /// dispatch on `resource.is_data_source()` before picking this path.
+    read-data-source: func(res: resource-def) -> result<state, string>;
+
     create: func(res: resource-def) -> result<state, string>;
     update: func(id: resource-id, identifier: string, current: state, to: resource-def) -> result<state, string>;
 

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -64,6 +64,21 @@ impl CarinaProvider for MockProcessProvider {
         }
     }
 
+    /// Exercise the `read_data_source` path end-to-end through the WASM
+    /// bridge: echo the user-supplied inputs back into state plus a
+    /// sentinel `__mock_read_data_source__` flag so integration tests can
+    /// verify the override actually ran (rather than the trait default).
+    fn read_data_source(&self, resource: &Resource) -> Result<State, ProviderError> {
+        let mut attributes = resource.attributes.clone();
+        attributes.insert("__mock_read_data_source__".to_string(), Value::Bool(true));
+        Ok(State {
+            id: resource.id.clone(),
+            identifier: Some("mock-id".into()),
+            attributes,
+            exists: true,
+        })
+    }
+
     fn create(&self, resource: &Resource) -> Result<State, ProviderError> {
         let mut states = self.states.lock().unwrap();
         let key = Self::resource_key(&resource.id);


### PR DESCRIPTION
## Summary

- Adds `read-data-source` to the plugin WIT interface and plumbs it through `carina-plugin-sdk` (trait + WASM guest bridge) and `carina-plugin-host` (bindings dispatcher + `WasmProvider` impl).
- Without this, `Provider::read_data_source` (added in carina-rs/carina#1674) was silently bypassed whenever the provider was loaded as a WASM plugin — the host's trait default ran instead of the plugin's override, so any data source with user-supplied input attributes errored out.
- Unblocks `aws.identitystore.user` from carina-rs/carina-provider-aws#82 under the WASM plugin path (the normal `carina init` → `carina plan` flow).

## Why

The enabler in carina-rs/carina#1674 added `Provider::read_data_source` with a default implementation that errors on any resource carrying user-supplied inputs. Native-linked providers can override the method, but the WASM plugin boundary never forwarded it:

```bash
$ grep -rn "read_data_source" carina-plugin-wit carina-plugin-sdk carina-plugin-host
# (no matches)
```

So when carina-rs/carina-provider-aws#82 shipped `aws.identitystore.user` with its `read_data_source` override, `carina plan` via the WASM loader still failed with:

```
Error: data source aws.identitystore.user.mizzy has 2 input attribute(s) but
provider 'aws' does not implement read_data_source for this resource type
```

That error comes from the host's trait default (`carina-core/src/provider.rs:121`), not the plugin.

## How

1. **WIT** (`carina-plugin-wit/wit/provider.wit`) — declare
   ```wit
   read-data-source: func(res: resource-def) -> result<state, string>;
   ```
   Same shape as `create`. Both worlds (`carina-provider` and `carina-provider-with-http`) export it through the same interface.
2. **SDK trait** (`carina-plugin-sdk/src/lib.rs`) — add `CarinaProvider::read_data_source` with a default impl that mirrors `carina_core::Provider::read_data_source`:
   - reject non-`_`-prefixed inputs (fail-loud instead of silent drop)
   - fall through to `self.read(&resource.id, None)` for zero-input data sources
   - A comment notes why the error message diverges (SDK trait has no `name()` accessor).
3. **SDK WASM guest bridge** (`carina-plugin-sdk/src/wasm_guest.rs`) — add `fn read_data_source` to both macro arms (basic + WASI-HTTP).
4. **Host dispatcher + impl** (`carina-plugin-host/src/wasm_factory.rs`):
   - `WasmBindings::call_read_data_source` across `Basic`/`Http` bindings variants
   - `impl Provider for WasmProvider::read_data_source` with epoch-deadline timeout handling identical to `create`.
5. **Mock provider** (`carina-provider-mock/src/main.rs`) — override `read_data_source` in `MockProcessProvider` to echo inputs back into state plus a sentinel `__mock_read_data_source__: true` flag, giving the integration test an unambiguous signal that the override actually ran (versus the trait default).
6. **Integration test** (`carina-plugin-host/tests/wasm_integration_test.rs`) — `test_wasm_mock_provider_read_data_source_dispatches_override` loads the mock WASM, calls `read_data_source` with user inputs, and asserts both the sentinel and the echoed input attributes appear in state.

## Test plan

- [x] `cargo test -p carina-plugin-sdk -p carina-plugin-host -p carina-provider-mock` — **47 + 5 + 6 + 6 passed** (1 new integration test)
- [x] `cargo clippy -p carina-plugin-sdk -p carina-plugin-host -p carina-provider-mock --all-targets -- -D warnings`
- [x] `cargo fmt ... -- --check`
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` → integration test loads the built `.wasm` and verifies the override dispatches through the boundary.

## Backwards compatibility

Adding a required export to the WIT interface means **existing WASM plugin binaries that don't export `read-data-source` will fail to load**. Per the project's experimental-phase policy, no compat shim is added. The two downstream providers (`carina-provider-aws` and `carina-provider-awscc`) pick up the default impl automatically on their next rebuild against this SDK; `carina-provider-aws` already has a `read_data_source` override for `identitystore.user` which will start working end-to-end once it rebuilds against this PR's SDK.

Closes #1677
Unblocks: carina-rs/carina-provider-aws#82 (under the WASM plugin path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)