### PR TITLE
fix: report both HTTP and basic instantiation errors in WasmProviderFactory

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -675,6 +675,33 @@ async fn create_instance_with_http(
     Ok((store, WasmBindings::Http(bindings)))
 }
 
+/// Try HTTP instantiation first, then basic. On double failure, report
+/// both errors: the basic fallback's "wasi:http/types not found" is
+/// misleading when the real cause is in the HTTP path.
+async fn create_instance_auto(
+    engine: &Engine,
+    component: &Component,
+) -> Result<(Store<HostState>, WasmBindings, bool), String> {
+    match create_instance_with_http(engine, component).await {
+        Ok((store, bindings)) => Ok((store, bindings, true)),
+        Err(http_err) => match create_instance(engine, component).await {
+            Ok((store, bindings)) => Ok((store, bindings, false)),
+            Err(basic_err) => Err(format_dual_instantiation_error(&http_err, &basic_err)),
+        },
+    }
+}
+
+/// Format the combined error message when both the HTTP and basic
+/// instantiation attempts fail. Extracted so regressions in the format
+/// (or accidentally dropping one of the two errors) can be unit-tested.
+fn format_dual_instantiation_error(http_err: &str, basic_err: &str) -> String {
+    format!(
+        "Failed to instantiate WASM component; \
+         HTTP-enabled world failed: {http_err}; \
+         basic fallback also failed: {basic_err}"
+    )
+}
+
 // -- SharedWasmInstance --
 
 /// A single WASM instance (store + bindings) shared between `WasmProvider`
@@ -873,16 +900,7 @@ impl WasmProviderFactory {
             )
         })?;
 
-        // Detect whether the component needs HTTP by trying HTTP instantiation first,
-        // then falling back to basic.
-        let (mut store, bindings, enable_http) =
-            match create_instance_with_http(&engine, &component).await {
-                Ok((store, bindings)) => (store, bindings, true),
-                Err(_) => {
-                    let (store, bindings) = create_instance(&engine, &component).await?;
-                    (store, bindings, false)
-                }
-            };
+        let (mut store, bindings, enable_http) = create_instance_auto(&engine, &component).await?;
         let info_json = bindings
             .call_info(&mut store)
             .await
@@ -971,14 +989,7 @@ impl WasmProviderFactory {
                 )
             })?;
 
-        let (mut store, bindings, enable_http) =
-            match create_instance_with_http(&engine, &component).await {
-                Ok((store, bindings)) => (store, bindings, true),
-                Err(_) => {
-                    let (store, bindings) = create_instance(&engine, &component).await?;
-                    (store, bindings, false)
-                }
-            };
+        let (mut store, bindings, enable_http) = create_instance_auto(&engine, &component).await?;
         let info_json = bindings
             .call_info(&mut store)
             .await
@@ -1800,5 +1811,21 @@ mod tests {
         let key2 = WasmProviderFactory::cache_key(&wasm_path);
 
         assert_eq!(key1, key2, "cache key should be stable for same content");
+    }
+
+    /// Regression guard for carina#1681: when both HTTP and basic
+    /// instantiation fail, the combined error must preserve *both* causes.
+    /// Dropping either side re-introduces the misdiagnosis pattern that
+    /// caused the recurring false "wasi:http/types not found" reports.
+    #[test]
+    fn format_dual_instantiation_error_preserves_both_causes() {
+        let msg = format_dual_instantiation_error(
+            "HTTP cause: missing export `foo`",
+            "BASIC cause: wasi:http/types not in linker",
+        );
+        assert!(msg.contains("HTTP cause: missing export `foo`"));
+        assert!(msg.contains("BASIC cause: wasi:http/types not in linker"));
+        assert!(msg.contains("HTTP-enabled world failed"));
+        assert!(msg.contains("basic fallback also failed"));
     }
 }

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -675,20 +675,34 @@ async fn create_instance_with_http(
     Ok((store, WasmBindings::Http(bindings)))
 }
 
+/// Output of `create_instance_auto`: the instantiated store, the
+/// bindings, and whether the HTTP-enabled world was used.
+type CreateInstanceResult = Result<(Store<HostState>, WasmBindings, bool), String>;
+
 /// Try HTTP instantiation first, then basic. On double failure, report
 /// both errors: the basic fallback's "wasi:http/types not found" is
 /// misleading when the real cause is in the HTTP path.
-async fn create_instance_auto(
-    engine: &Engine,
-    component: &Component,
-) -> Result<(Store<HostState>, WasmBindings, bool), String> {
-    match create_instance_with_http(engine, component).await {
-        Ok((store, bindings)) => Ok((store, bindings, true)),
-        Err(http_err) => match create_instance(engine, component).await {
-            Ok((store, bindings)) => Ok((store, bindings, false)),
-            Err(basic_err) => Err(format_dual_instantiation_error(&http_err, &basic_err)),
-        },
-    }
+///
+/// Returns a boxed future (not `async fn`) to erase the future type at
+/// this call site. Inlining this helper as a plain `async fn` composes
+/// `CarinaProviderWithHttp::instantiate_async` and
+/// `CarinaProvider::instantiate_async` into one anonymous future,
+/// which combined with the deep call chain from `carina-cli` trips
+/// rustc's layout-computation query depth limit on recent stable
+/// toolchains (observed in `cargo check --all-features` CI).
+fn create_instance_auto<'a>(
+    engine: &'a Engine,
+    component: &'a Component,
+) -> BoxFuture<'a, CreateInstanceResult> {
+    Box::pin(async move {
+        match create_instance_with_http(engine, component).await {
+            Ok((store, bindings)) => Ok((store, bindings, true)),
+            Err(http_err) => match create_instance(engine, component).await {
+                Ok((store, bindings)) => Ok((store, bindings, false)),
+                Err(basic_err) => Err(format_dual_instantiation_error(&http_err, &basic_err)),
+            },
+        }
+    })
 }
 
 /// Format the combined error message when both the HTTP and basic

--- a/carina-plugin-host/tests/wasm_error_reporting_test.rs
+++ b/carina-plugin-host/tests/wasm_error_reporting_test.rs
@@ -1,0 +1,39 @@
+//! Regression test for carina-rs/carina#1681: when a provider wasm
+//! cannot instantiate under either the HTTP-enabled or the basic world,
+//! the returned error must include *both* underlying causes — not just
+//! the fallback's misleading "wasi:http/types not found" linker message.
+
+use carina_plugin_host::WasmProviderFactory;
+
+/// Minimal component that imports a fake interface which is registered
+/// in neither the HTTP-enabled nor the basic wasi linker, so both
+/// instantiation attempts must fail. The fake namespace is chosen to
+/// not collide with any real wasi/carina import.
+const FAKE_COMPONENT_WAT: &str = r#"
+(component
+  (type $i (instance))
+  (import "bogus:fake-1681/iface@99.0.0" (instance (type $i)))
+)
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn both_worlds_failing_error_includes_both_causes() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let wasm_path = dir.path().join("fake.wasm");
+    std::fs::write(&wasm_path, FAKE_COMPONENT_WAT).expect("write wat file");
+
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    let err = match WasmProviderFactory::new_with_cache_dir(wasm_path, cache_dir.path()).await {
+        Ok(_) => panic!("fake component should have failed to instantiate"),
+        Err(e) => e,
+    };
+
+    assert!(
+        err.contains("HTTP-enabled world failed"),
+        "missing HTTP-path cause in error: {err}"
+    );
+    assert!(
+        err.contains("basic fallback also failed"),
+        "missing basic-path cause in error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1681.

`WasmProviderFactory` tries the HTTP-enabled world first, then falls back to the basic world when HTTP instantiation fails. Two previously-duplicated sites silently discarded the HTTP-path error via `Err(_) =>` and returned only the basic fallback's error — which, for any provider that actually imports `wasi:http`, is always the misleading *"wasi:http/types not found in linker"* message (the basic linker does not register `wasi:http`).

This bad diagnostic handling is the root cause of the recurring misdiagnosis chain **#1492 → #1564 → (#1641) → #1680** — all filed as "wasmtime version mismatch" when the actual root cause was a stale provider wasm built against an older WIT.

## Changes

- **Extract** the duplicated `match create_instance_with_http { Err(_) => create_instance(..)? }` fallback into a single `create_instance_auto` helper used by both `new_uncached` and `from_precompiled`.
- **Preserve** the HTTP-path error; when the basic fallback also fails, report both causes combined by `format_dual_instantiation_error`.
- **Extract** the format string into its own pure function so format drift is unit-testable.
- **Add** a regression integration test (`wasm_error_reporting_test`) that loads a synthetic component importing a bogus interface, forcing both worlds to fail, and asserts the combined error contains both `"HTTP-enabled world failed"` and `"basic fallback also failed"` substrings.

## Test plan

- [x] `cargo test -p carina-plugin-host` (48 unit + 1 new integration + 5 mock + 6 precompile, all pass)
- [x] `cargo test` workspace-wide (1700+ tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] Regression integration test **verified to fail** against a temp-reverted `Err(_)` version — i.e. it would catch a future re-introduction of the bug.
- [ ] Manual verification: on a system exhibiting #1680 with a stale awscc.wasm, the new combined error surfaces the real `does not have export 'provider-config-attribute-types'` message alongside (no longer hidden behind) the linker fallback error.

## Out of scope

- wasmtime / wasi-http version upgrades — not needed, wasmtime 43 correctly registers `wasi:http@0.2.6`.
- WIT drift prevention between host and provider repos — tracked separately in carina-rs/carina-provider-awscc#91 and carina-rs/carina-provider-aws#84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)