### PR TITLE
fix: resolve ResourceRef in data source inputs before refresh

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -37,7 +37,8 @@ use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, create_providers_from_configs,
     get_provider_with_ctx, read_data_source_with_retry, read_with_retry,
-    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names, resolve_names_with_ctx,
+    reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
+    resolve_data_source_refs_for_refresh, resolve_names_with_ctx,
 };
 
 /// Format a duration as a human-readable string like "3.2s" or "1m 5.3s".
@@ -1014,6 +1015,10 @@ async fn run_apply_locked(
     // Select appropriate Provider based on configuration
     let provider = get_provider_with_ctx(ctx, parsed, base_dir).await;
 
+    // Remote state bindings are loaded up front so data source refs that
+    // reference `remote_state` blocks can be resolved during refresh (#1683).
+    let remote_bindings = super::plan::load_remote_states(&parsed.remote_states, base_dir).await?;
+
     // Read states for all resources using identifier from state
     // In identifier-based approach, if there's no identifier in state, the resource doesn't exist
     // Skip virtual resources (module attribute containers) — they have no infrastructure.
@@ -1040,28 +1045,52 @@ async fn run_apply_locked(
                     .collect()
             })
             .unwrap_or_default();
-        let results: Vec<Result<(ResourceId, State), AppError>> =
-            stream::iter(sorted_resources.iter().filter(|r| !r.is_virtual()))
+
+        // Phase 1: refresh managed (non-data-source) resources in parallel.
+        let phase1_results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(
+            sorted_resources
+                .iter()
+                .filter(|r| !r.is_virtual() && !r.is_data_source()),
+        )
+        .map(|resource| {
+            let progress = RefreshProgress::begin_multi(&multi, &resource.id);
+            let identifier = state_file
+                .as_ref()
+                .and_then(|sf| sf.get_identifier_for_resource(resource));
+            let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
+            async move {
+                let mut state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
+                    .await
+                    .map_err(AppError::Provider)?;
+                if let Some(deps) = dep_bindings {
+                    state.dependency_bindings = deps;
+                }
+                progress.finish();
+                Ok((resource.id.clone(), state))
+            }
+        })
+        .buffer_unordered(5)
+        .collect()
+        .await;
+        let mut states = HashMap::new();
+        for result in phase1_results {
+            let (id, state) = result?;
+            states.insert(id, state);
+        }
+
+        // Phase 2: resolve data source inputs against phase 1 state and
+        // refresh them via `read_data_source` (#1683).
+        let resolved_data_sources =
+            resolve_data_source_refs_for_refresh(&sorted_resources, &states, &remote_bindings)?;
+        let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
+            stream::iter(resolved_data_sources.iter())
                 .map(|resource| {
                     let progress = RefreshProgress::begin_multi(&multi, &resource.id);
-                    let identifier = state_file
-                        .as_ref()
-                        .and_then(|sf| sf.get_identifier_for_resource(resource));
                     let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
                     async move {
-                        // Data sources need the full Resource so providers
-                        // can see user-supplied inputs (e.g. `user_name`
-                        // for `aws.identitystore.user`). Regular resources
-                        // route through the identifier-based refresh.
-                        let mut state = if resource.is_data_source() {
-                            read_data_source_with_retry(provider_ref, resource)
-                                .await
-                                .map_err(AppError::Provider)?
-                        } else {
-                            read_with_retry(provider_ref, &resource.id, identifier.as_deref())
-                                .await
-                                .map_err(AppError::Provider)?
-                        };
+                        let mut state = read_data_source_with_retry(provider_ref, resource)
+                            .await
+                            .map_err(AppError::Provider)?;
                         if let Some(deps) = dep_bindings {
                             state.dependency_bindings = deps;
                         }
@@ -1072,8 +1101,7 @@ async fn run_apply_locked(
                 .buffer_unordered(5)
                 .collect()
                 .await;
-        let mut states = HashMap::new();
-        for result in results {
+        for result in phase2_results {
             let (id, state) = result?;
             states.insert(id, state);
         }
@@ -1147,9 +1175,6 @@ async fn run_apply_locked(
             binding_map.insert(binding_name.clone(), attrs);
         }
     }
-
-    // Load remote state data sources
-    let remote_bindings = super::plan::load_remote_states(&parsed.remote_states, base_dir).await?;
 
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -730,29 +730,57 @@ pub async fn create_plan_from_parsed_with_remote(
                     .collect()
             })
             .unwrap_or_default();
-        let results: Vec<Result<(ResourceId, State), AppError>> =
-            stream::iter(sorted_resources.iter().filter(|r| !r.is_virtual()))
+        // Refresh in two phases so data sources can see concrete values
+        // from their dependencies (#1683). Phase 1: managed resources in
+        // parallel. Phase 2: data sources whose input attributes have
+        // been resolved against phase 1's `current_states`.
+        let phase1_results: Vec<Result<(ResourceId, State), AppError>> = stream::iter(
+            sorted_resources
+                .iter()
+                .filter(|r| !r.is_virtual() && !r.is_data_source()),
+        )
+        .map(|resource| {
+            let progress = RefreshProgress::begin_multi(&multi, &resource.id);
+            let identifier = state_file
+                .as_ref()
+                .and_then(|sf| sf.get_identifier_for_resource(resource));
+            let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
+            async move {
+                let mut state = read_with_retry(provider_ref, &resource.id, identifier.as_deref())
+                    .await
+                    .map_err(AppError::Provider)?;
+                // Restore dependency_bindings from state file (#1565).
+                if let Some(deps) = dep_bindings {
+                    state.dependency_bindings = deps;
+                }
+                progress.finish();
+                Ok((resource.id.clone(), state))
+            }
+        })
+        .buffer_unordered(5)
+        .collect()
+        .await;
+        for result in phase1_results {
+            let (id, state) = result?;
+            current_states.insert(id, state);
+        }
+
+        // Phase 2: resolve data source refs against phase 1's state,
+        // then refresh them via `read_data_source`.
+        let resolved_data_sources = resolve_data_source_refs_for_refresh(
+            &sorted_resources,
+            &current_states,
+            remote_bindings,
+        )?;
+        let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
+            stream::iter(resolved_data_sources.iter())
                 .map(|resource| {
                     let progress = RefreshProgress::begin_multi(&multi, &resource.id);
-                    let identifier = state_file
-                        .as_ref()
-                        .and_then(|sf| sf.get_identifier_for_resource(resource));
                     let dep_bindings = saved_dep_bindings.get(&resource.id).cloned();
                     async move {
-                        // Data sources carry user-supplied inputs that need
-                        // to reach the provider — route them through
-                        // `read_data_source_with_retry` instead of the
-                        // identifier-based refresh.
-                        let mut state = if resource.is_data_source() {
-                            read_data_source_with_retry(provider_ref, resource)
-                                .await
-                                .map_err(AppError::Provider)?
-                        } else {
-                            read_with_retry(provider_ref, &resource.id, identifier.as_deref())
-                                .await
-                                .map_err(AppError::Provider)?
-                        };
-                        // Restore dependency_bindings from state file (#1565).
+                        let mut state = read_data_source_with_retry(provider_ref, resource)
+                            .await
+                            .map_err(AppError::Provider)?;
                         if let Some(deps) = dep_bindings {
                             state.dependency_bindings = deps;
                         }
@@ -763,7 +791,7 @@ pub async fn create_plan_from_parsed_with_remote(
                 .buffer_unordered(5)
                 .collect()
                 .await;
-        for result in results {
+        for result in phase2_results {
             let (id, state) = result?;
             current_states.insert(id, state);
         }
@@ -1229,6 +1257,28 @@ pub async fn read_data_source_with_retry(
     unreachable!()
 }
 
+/// Resolve `ResourceRef` values in data source input attributes against
+/// already-refreshed `current_states`, returning the data sources ready
+/// to pass to `read_data_source_with_retry` (#1683).
+///
+/// The full `sorted_resources` slice must be passed (not a pre-filtered
+/// data-sources-only slice) because `resolve_refs_with_state_and_remote`
+/// builds its binding map from every resource with a `binding`, including
+/// managed ones that data sources reference.
+pub(crate) fn resolve_data_source_refs_for_refresh(
+    sorted_resources: &[Resource],
+    current_states: &HashMap<ResourceId, State>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+) -> Result<Vec<Resource>, AppError> {
+    let mut resolved = sorted_resources.to_vec();
+    resolve_refs_with_state_and_remote(&mut resolved, current_states, remote_bindings)
+        .map_err(AppError::Validation)?;
+    Ok(resolved
+        .into_iter()
+        .filter(|r| !r.is_virtual() && r.is_data_source())
+        .collect())
+}
+
 /// Convenience wrappers for tests. Each creates a fresh `WiringContext` internally,
 /// which is acceptable in test code where the overhead is negligible.
 #[cfg(test)]
@@ -1688,6 +1738,69 @@ mod tests {
             plan.effects().len(),
             0,
             "Import should be skipped when fallback-matched resource is already in state"
+        );
+    }
+
+    /// Regression test for carina#1683: data source input attributes that
+    /// reference another resource must be resolved against current state
+    /// *before* being passed to `read_data_source_with_retry`. Without
+    /// resolution the provider receives a debug-formatted `ResourceRef`
+    /// string and ships it to the remote API as a literal.
+    #[test]
+    fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
+        use carina_core::resource::{AccessPath, Expr, PathSegment, ResourceKind};
+
+        let identity_store_id = "d-9067c29a4b";
+
+        // Managed resource with a binding — phase 1 would have refreshed it.
+        let mut sso = Resource::with_provider("awscc", "sso.instance", "carina-rs");
+        sso.binding = Some("sso".to_string());
+
+        // Data source referencing `sso.identity_store_id`.
+        let mut mizzy = Resource::with_provider("aws", "identitystore.user", "mizzy");
+        mizzy.kind = ResourceKind::DataSource;
+        mizzy.attributes.insert(
+            "identity_store_id".to_string(),
+            Expr(Value::ResourceRef {
+                path: AccessPath(vec![
+                    PathSegment::Field("sso".into()),
+                    PathSegment::Field("identity_store_id".into()),
+                ]),
+            }),
+        );
+        mizzy.attributes.insert(
+            "user_name".to_string(),
+            Expr(Value::String("gosukenator@gmail.com".into())),
+        );
+
+        // current_states after phase 1: sso has been refreshed and its
+        // state carries the concrete identity_store_id.
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        let sso_state = State::existing(
+            sso.id.clone(),
+            HashMap::from([(
+                "identity_store_id".to_string(),
+                Value::String(identity_store_id.into()),
+            )]),
+        );
+        current_states.insert(sso.id.clone(), sso_state);
+
+        let resolved =
+            resolve_data_source_refs_for_refresh(&[sso, mizzy], &current_states, &HashMap::new())
+                .expect("resolution should succeed");
+
+        assert_eq!(resolved.len(), 1, "only the data source should be returned");
+        let resolved_mizzy = &resolved[0];
+        assert_eq!(
+            resolved_mizzy.get_attr("identity_store_id"),
+            Some(&Value::String(identity_store_id.into())),
+            "identity_store_id should be resolved to the concrete state value, \
+             not a ResourceRef"
+        );
+        assert_eq!(
+            resolved_mizzy.get_attr("user_name"),
+            Some(&Value::String("gosukenator@gmail.com".into())),
+            "literal inputs should pass through untouched"
         );
     }
 }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -306,7 +306,15 @@ impl Expr {
         !contains_resource_ref(&self.0)
     }
 
-    /// Extract a resolved `HashMap<String, Value>` from an `Expr` attribute map.
+    /// Extract the inner `Value` of each entry in an `Expr` attribute map.
+    ///
+    /// Despite the legacy name, this method does **not** resolve
+    /// `Value::ResourceRef` / `Value::Interpolation` / `Value::FunctionCall`
+    /// / `Value::Closure` / `Value::Secret` — it simply unwraps
+    /// `Expr` → `Value`. Callers that need concrete values must run
+    /// `carina_core::resolver::resolve_refs_with_state_and_remote` (or an
+    /// equivalent) first. See #1683 for a regression caused by assuming
+    /// this method performed resolution.
     pub fn resolve_map(attrs: &HashMap<String, Expr>) -> HashMap<String, Value> {
         attrs
             .iter()

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -21,6 +21,14 @@ use crate::wasm_bindings::carina::provider::types as wit;
 ///
 /// List and Map values are serialized to JSON strings because WIT does not
 /// support recursive types.
+///
+/// `ResourceRef`, `Interpolation`, `FunctionCall`, `Closure`, and `Secret`
+/// are expected to have been resolved by the planner/refresh path before
+/// reaching the provider. Hitting one here is a *bug* in an upstream
+/// stage (see #1683 for an example where data source inputs were not
+/// resolved before refresh). In debug/test builds we panic so the bug
+/// is caught at its source; in release builds we log and fall back to
+/// the debug format to avoid crashing a user's plan/apply mid-run.
 pub fn core_to_wit_value(v: &CoreValue) -> wit::Value {
     match v {
         CoreValue::String(s) => wit::Value::StrVal(s.clone()),
@@ -38,9 +46,19 @@ pub fn core_to_wit_value(v: &CoreValue) -> wit::Value {
                 .collect();
             wit::Value::MapVal(serde_json::to_string(&json_map).unwrap())
         }
-        // ResourceRef, Interpolation, FunctionCall, Closure, Secret
-        // should be resolved before reaching the provider.
-        _ => wit::Value::StrVal(format!("{v:?}")),
+        _ => {
+            debug_assert!(
+                false,
+                "core_to_wit_value received unresolved value {v:?}; \
+                 ResourceRef/Interpolation/FunctionCall/Closure/Secret \
+                 must be resolved before reaching the provider"
+            );
+            log::error!(
+                "core_to_wit_value received unresolved value {v:?}; \
+                 passing debug format to the provider — this is a bug"
+            );
+            wit::Value::StrVal(format!("{v:?}"))
+        }
     }
 }
 
@@ -475,6 +493,24 @@ mod tests {
         let wit = core_to_wit_value(&core);
         let back = wit_to_core_value(&wit);
         assert_eq!(core, back);
+    }
+
+    /// Regression guard for carina#1683: `core_to_wit_value` must fail
+    /// loud in debug/test builds when handed an unresolved value. The
+    /// previous silent `format!("{v:?}")` fallback let a raw
+    /// `ResourceRef` flow into the WASM plugin as a literal debug string,
+    /// which the provider then forwarded to the AWS API verbatim.
+    #[test]
+    #[should_panic(expected = "unresolved value")]
+    fn core_to_wit_value_panics_on_unresolved_resource_ref() {
+        use carina_core::resource::{AccessPath, PathSegment};
+        let v = CoreValue::ResourceRef {
+            path: AccessPath(vec![
+                PathSegment::Field("sso".into()),
+                PathSegment::Field("identity_store_id".into()),
+            ]),
+        };
+        let _ = core_to_wit_value(&v);
     }
 
     // -- ResourceId roundtrip --


### PR DESCRIPTION
## Summary

Closes #1683.

Reading a data source whose input attribute references another resource was handing the provider a raw `Value::ResourceRef`. The WASM plugin host's `core_to_wit_value` silently stringified the debug representation, the provider passed that string to the AWS API, and the user saw:

```
Failed to look up user_id for user_name 'gosukenator@gmail.com' in store 'ResourceRef { path: AccessPath([Field("sso"), Field("identity_store_id")]) }': service error
```

Two bugs combined:

1. **`wiring::create_plan_from_parsed_with_remote`** and **`apply::run_apply_locked`** refreshed every resource (managed + data source) in a single `buffer_unordered(5)` pool, and only called `resolve_refs_with_state_and_remote` *after* refresh — so `read_data_source` never saw concrete values.
2. **`core_to_wit_value`** had a silent `_ => wit::Value::StrVal(format!("{v:?}"))` fallback for unresolved variants, with no warning, no error, and a comment admitting "should be resolved before reaching the provider" — the invariant was never enforced.

## Changes

- **Split refresh into two phases** in both `wiring.rs` and `apply.rs`:
  - Phase 1: refresh managed (non-data-source) resources in parallel.
  - Phase 2: resolve `ResourceRef`s in data source inputs against phase 1 state via a new `resolve_data_source_refs_for_refresh` helper, then refresh them via `read_data_source_with_retry`.
  - `apply.rs` also moves `load_remote_states` earlier so phase 2 can resolve refs targeting `remote_state` blocks.
- **New helper `wiring::resolve_data_source_refs_for_refresh`** — a thin wrapper around the existing `resolve_refs_with_state_and_remote` that clones `sorted_resources`, runs the resolver, and filters to data sources. Shared between both call sites. Unit-tested directly against the #1683 scenario.
- **Fail loud in `core_to_wit_value`** — silent fallback → `debug_assert!(false, ...)` in debug/test builds + `log::error!(...)` in release builds. Regression test `core_to_wit_value_panics_on_unresolved_resource_ref` guards this.
- **Document `Expr::resolve_map`** — the legacy name implies it resolves references, but it only unwraps `Expr → Value`. Updated doc warns callers that resolution is their responsibility.

## Test plan

- [x] `cargo test` workspace-wide: 1700+ tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] New unit test `resolve_data_source_refs_replaces_resource_ref_with_concrete_value` reproduces the #1683 scenario and asserts the concrete value flows through
- [x] New `#[should_panic]` test `core_to_wit_value_panics_on_unresolved_resource_ref` guards the fail-loud behavior
- [ ] Manual verification: `carina plan` against a `.crn` with the `sso`/`mizzy` example from #1683 now succeeds

## Out of scope

- **Data-source-to-data-source chains** (`ds2` references `ds1`'s computed output). The 2-phase split resolves data source inputs against phase 1 state only; `ds1`'s computed state isn't available before phase 2 starts. Same pre-existing limitation, but now surfaces as a `debug_assert!` panic in tests instead of silently corrupting requests. Worth a follow-up issue if anyone hits it in the wild.
- **Extracting a shared `refresh_states` helper** between `wiring.rs` and `apply.rs`. The refresh loops were near-duplicate before this fix and remain so; unifying them is a legitimate cleanup but orthogonal to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)