### PR TITLE
fix: stop converting underscores to hyphens in enum values

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -2192,10 +2192,12 @@ mod tests {
         );
 
         let hint = extract_compact_hint(&r, None);
+        // Displays DSL form (underscored) until provider alias tables include
+        // to_dsl reverse mappings (see issue #1675).
         assert_eq!(
             hint,
-            Some("availability_zone: ap-northeast-1a".to_string()),
-            "DSL enum identifiers should be resolved to provider values"
+            Some("availability_zone: ap_northeast_1a".to_string()),
+            "DSL enum identifiers should be stripped of namespace prefix"
         );
     }
 

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -475,8 +475,7 @@ fn resolve_value_alias(
     match value {
         Value::String(s) if utils::is_dsl_enum_format(s) => {
             let raw = utils::convert_enum_value(s);
-            if let Some(canonical) = factory.get_enum_alias_reverse(resource_type, attr_name, &raw)
-            {
+            if let Some(canonical) = factory.get_enum_alias_reverse(resource_type, attr_name, raw) {
                 *s = canonical;
             }
         }

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -275,9 +275,9 @@ pub fn extract_compact_hint(
             && !s.is_empty()
         {
             let short_key = shorten_attr_name(key);
-            // Resolve DSL enum identifiers (e.g., awscc.AvailabilityZone.ap_northeast_1a -> "ap-northeast-1a")
+            // Strip namespace from DSL enum identifiers (e.g., awscc.AvailabilityZone.ap_northeast_1a -> "ap_northeast_1a")
             let resolved = if is_dsl_enum_format(s) {
-                Cow::Owned(convert_enum_value(s))
+                Cow::Borrowed(convert_enum_value(s))
             } else {
                 Cow::Borrowed(s.as_str())
             };

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -88,16 +88,16 @@ pub fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> 
     extract_enum_value(s)
 }
 
-/// Convert DSL enum value to provider SDK format.
+/// Strip the namespace prefix from a DSL enum identifier and return the raw value.
 ///
 /// Handles the following patterns:
-/// - 2-part: `TypeName.value_name` -> `value-name`
-/// - 3-part: `provider.TypeName.value_name` -> `value-name`
-/// - 4-part: `provider.resource.TypeName.value_name` -> `value-name`
-/// - 5-part: `provider.service.resource.TypeName.value_name` -> `value-name`
+/// - 2-part: `TypeName.value_name` -> `value_name`
+/// - 3-part: `provider.TypeName.value_name` -> `value_name`
+/// - 4-part: `provider.resource.TypeName.value_name` -> `value_name`
+/// - 5-part: `provider.service.resource.TypeName.value_name` -> `value_name`
 ///
 /// The first component of TypeName must be uppercase.
-/// Underscores in the extracted value are replaced with hyphens.
+/// The extracted value is returned as-is without any transformation.
 /// Returns the original value unchanged if it doesn't match any pattern.
 ///
 /// # Examples
@@ -105,20 +105,20 @@ pub fn extract_enum_value_with_values<'a>(s: &'a str, valid_values: &[&str]) -> 
 /// ```
 /// use carina_core::utils::convert_enum_value;
 ///
-/// assert_eq!(convert_enum_value("aws.Region.ap_northeast_1"), "ap-northeast-1");
-/// assert_eq!(convert_enum_value("Region.ap_northeast_1"), "ap-northeast-1");
+/// assert_eq!(convert_enum_value("aws.Region.ap_northeast_1"), "ap_northeast_1");
+/// assert_eq!(convert_enum_value("Region.ap_northeast_1"), "ap_northeast_1");
 /// assert_eq!(convert_enum_value("awscc.ec2.ipam.Tier.advanced"), "advanced");
 /// assert_eq!(convert_enum_value("eu-west-1"), "eu-west-1");
 /// ```
-pub fn convert_enum_value(value: &str) -> String {
+pub fn convert_enum_value(value: &str) -> &str {
     let parts: Vec<&str> = value.split('.').collect();
-    let raw_value = match parts.len() {
+    match parts.len() {
         2 => {
             // TypeName.value pattern
             if parts[0].chars().next().is_some_and(|c| c.is_uppercase()) {
                 parts[1]
             } else {
-                return value.to_string();
+                value
             }
         }
         3 => {
@@ -130,7 +130,7 @@ pub fn convert_enum_value(value: &str) -> String {
             {
                 parts[2]
             } else {
-                return value.to_string();
+                value
             }
         }
         // 4-part: provider.resource.TypeName.value
@@ -143,7 +143,7 @@ pub fn convert_enum_value(value: &str) -> String {
             {
                 parts[3]
             } else {
-                return value.to_string();
+                value
             }
         }
         // 5+ part: provider.service.resource.TypeName.value (value may contain dots)
@@ -157,14 +157,13 @@ pub fn convert_enum_value(value: &str) -> String {
             {
                 // Rejoin all parts after TypeName (index 3) to handle values with dots
                 let value_start = parts[..4].iter().map(|p| p.len() + 1).sum::<usize>();
-                return value[value_start..].replace('_', "-");
+                &value[value_start..]
             } else {
-                return value.to_string();
+                value
             }
         }
-        _ => return value.to_string(),
-    };
-    raw_value.replace('_', "-")
+        _ => value,
+    }
 }
 
 /// Check if a string is in DSL enum format (a namespaced identifier).
@@ -433,7 +432,7 @@ mod tests {
     fn test_convert_enum_value_2_part() {
         assert_eq!(
             convert_enum_value("Region.ap_northeast_1"),
-            "ap-northeast-1"
+            "ap_northeast_1"
         );
     }
 
@@ -441,16 +440,16 @@ mod tests {
     fn test_convert_enum_value_3_part() {
         assert_eq!(
             convert_enum_value("aws.Region.ap_northeast_1"),
-            "ap-northeast-1"
+            "ap_northeast_1"
         );
-        assert_eq!(convert_enum_value("aws.Region.us_east_1"), "us-east-1");
+        assert_eq!(convert_enum_value("aws.Region.us_east_1"), "us_east_1");
         assert_eq!(
             convert_enum_value("aws.AvailabilityZone.ap_northeast_1a"),
-            "ap-northeast-1a"
+            "ap_northeast_1a"
         );
         assert_eq!(
             convert_enum_value("aws.AvailabilityZone.us_east_1b"),
-            "us-east-1b"
+            "us_east_1b"
         );
     }
 
@@ -761,6 +760,22 @@ mod tests {
         assert_eq!(
             convert_enum_value("awscc.ec2.vpn_gateway.Type.ipsec.1"),
             "ipsec.1"
+        );
+    }
+
+    // convert_enum_value: underscores in enum values must be preserved (#1675)
+
+    #[test]
+    fn test_convert_enum_value_preserves_underscores() {
+        // Enum values like AWS_ACCOUNT must not have underscores converted to hyphens
+        assert_eq!(
+            convert_enum_value("awscc.sso.assignment.TargetType.AWS_ACCOUNT"),
+            "AWS_ACCOUNT"
+        );
+        assert_eq!(convert_enum_value("TargetType.AWS_ACCOUNT"), "AWS_ACCOUNT");
+        assert_eq!(
+            convert_enum_value("awscc.sso.assignment.PrincipalType.GROUP"),
+            "GROUP"
         );
     }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -701,8 +701,10 @@ mod tests {
 
     #[test]
     fn test_format_value_dsl_enum_region() {
+        // Region displays in DSL form (underscored) until provider alias tables
+        // are extended to include to_dsl reverse mappings (see issue #1675).
         let v = Value::String("aws.Region.ap_northeast_1".to_string());
-        assert_eq!(format_value(&v), "\"ap-northeast-1\"");
+        assert_eq!(format_value(&v), "\"ap_northeast_1\"");
     }
 
     #[test]

--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -1325,10 +1325,10 @@ mod tests {
             "\"Enabled\""
         );
 
-        // 3-part DSL enum with underscore-to-hyphen conversion
+        // 3-part DSL enum: namespace stripped, value returned as-is
         assert_eq!(
             format_value(&Value::String("aws.Region.ap_northeast_1".to_string())),
-            "\"ap-northeast-1\""
+            "\"ap_northeast_1\""
         );
 
         // Regular string should be quoted as-is


### PR DESCRIPTION
Closes #1675

## Summary

- Remove unconditional `replace('_', '-')` from `convert_enum_value()` — the function now only strips the namespace prefix and returns the raw value as-is
- Change return type from `String` to `&str` (zero-copy, no allocation needed since no transformation occurs)
- Update `plan_tree.rs` to use `Cow::Borrowed` instead of `Cow::Owned`

## Trade-off

Region-like values temporarily display in DSL form (`ap_northeast_1` instead of `ap-northeast-1`) until provider alias tables are extended with `to_dsl` reverse mappings. The underscore-to-hyphen conversion is attribute-specific (driven by `to_dsl` in schema), but `to_dsl` is lost during WIT serialization (`wasm_convert.rs:353`), so the host cannot perform schema-aware conversion today.

Follow-up work needed in provider repos:
- Extend codegen to generate `to_dsl` reverse mappings as alias entries
- Implement `CarinaProvider::enum_aliases()` (currently returns empty HashMap)

## Test plan

- [x] `cargo test -p carina-core` — all 1139 tests pass
- [x] `cargo test -p carina-cli plan_snapshot` — all 21 snapshot tests pass
- [x] `cargo test` — full workspace passes (0 failures)
- [x] `cargo clippy --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)