### PR TITLE
feat: flip plan tree direction — dependencies shown as children

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -1604,48 +1604,6 @@ mod tests {
         (roots, dependents, graph.effect_bindings, graph.effect_types)
     }
 
-    /// Helper: walk the tree from roots in print order and collect binding names
-    /// in the order they would be printed. This replicates the traversal logic
-    /// from print_effect_tree.
-    fn collect_print_order(
-        roots: &[usize],
-        dependents: &HashMap<usize, Vec<usize>>,
-        effect_bindings: &HashMap<usize, String>,
-    ) -> Vec<String> {
-        let mut printed: HashSet<usize> = HashSet::new();
-        let mut result: Vec<String> = Vec::new();
-
-        fn walk(
-            idx: usize,
-            dependents: &HashMap<usize, Vec<usize>>,
-            effect_bindings: &HashMap<usize, String>,
-            printed: &mut HashSet<usize>,
-            result: &mut Vec<String>,
-        ) {
-            if printed.contains(&idx) {
-                return;
-            }
-            printed.insert(idx);
-            if let Some(binding) = effect_bindings.get(&idx) {
-                result.push(binding.clone());
-            }
-            let children = dependents.get(&idx).cloned().unwrap_or_default();
-            let unprinted: Vec<_> = children
-                .iter()
-                .filter(|c| !printed.contains(c))
-                .cloned()
-                .collect();
-            for child in unprinted {
-                walk(child, dependents, effect_bindings, printed, result);
-            }
-        }
-
-        for &root in roots {
-            walk(root, dependents, effect_bindings, &mut printed, &mut result);
-        }
-        result
-    }
-
     /// Issue #933 (part 1): Siblings under the same parent should be sorted
     /// by (resource_type, binding_name) for deterministic, grouped output.
     ///
@@ -1654,8 +1612,9 @@ mod tests {
     /// sorted by binding name.
     #[test]
     fn test_siblings_sorted_by_resource_type_and_binding() {
-        // VPC is root. Under it: 2 subnets and 2 route tables, added in
-        // interleaved order to expose HashMap non-determinism.
+        // VPC has no deps. 2 route tables and 2 subnets all depend on vpc.
+        // With the flipped tree, the 4 dependents are roots (nothing depends
+        // on them) and they should be sorted by (resource_type, binding_name).
         let vpc = make_resource("ec2.vpc", "vpc", "vpc", &[]);
         let rt_b = make_resource("ec2.route_table", "rt_b", "rt_b", &["vpc"]);
         let subnet_b = make_resource("ec2.subnet", "subnet_b", "subnet_b", &["vpc"]);
@@ -1669,13 +1628,10 @@ mod tests {
         plan.add(Effect::Create(rt_a));
         plan.add(Effect::Create(subnet_a));
 
-        let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
+        let (roots, _dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
 
-        assert_eq!(roots, vec![0], "VPC should be the only root");
-
-        // Get the children of VPC (index 0)
-        let vpc_children = dependents.get(&0).unwrap();
-        let child_labels: Vec<(String, String)> = vpc_children
+        // Roots should be rt_a, rt_b, subnet_a, subnet_b (nothing depends on them)
+        let root_labels: Vec<(String, String)> = roots
             .iter()
             .map(|&idx| {
                 let binding = effect_bindings.get(&idx).unwrap().clone();
@@ -1689,7 +1645,6 @@ mod tests {
             .collect();
 
         // Expected: sorted by (resource_type, binding_name)
-        // ec2.route_table comes before ec2.subnet alphabetically
         let expected = vec![
             ("ec2.route_table".to_string(), "rt_a".to_string()),
             ("ec2.route_table".to_string(), "rt_b".to_string()),
@@ -1698,27 +1653,24 @@ mod tests {
         ];
 
         assert_eq!(
-            child_labels, expected,
-            "Siblings should be sorted by (resource_type, binding_name). \
+            root_labels, expected,
+            "Roots should be sorted by (resource_type, binding_name). \
              Got: {:?}",
-            child_labels
+            root_labels
         );
     }
 
-    /// Issue #933 (part 2): When a resource depends on multiple resources in
-    /// the tree, it should be placed under the dependency that is closest to
-    /// the root (most ancestral), not an arbitrary one.
+    /// When a dependency is referenced by multiple resources, it should be
+    /// placed under the shallowest dependent (closest to root).
     ///
     /// Scenario:
-    ///   - vpc (root)
-    ///   - sg depends on vpc
-    ///   - vpc_endpoint depends on both vpc and sg
+    ///   - vpc: no deps (depended on by sg and endpoint)
+    ///   - sg: depends on vpc (depended on by endpoint)
+    ///   - endpoint: depends on vpc and sg (nothing depends on it)
     ///
-    /// VPC is an ancestor of SG. The endpoint should be placed under VPC
-    /// (closer to root), not under SG. Currently, the endpoint is added as
-    /// a child of BOTH vpc and sg in the dependents map, and whichever is
-    /// traversed first claims it. This test verifies deterministic placement
-    /// under the most ancestral dependency.
+    /// With flipped tree: endpoint is the only root. Both sg and vpc are
+    /// its dependencies. VPC is depended on by both endpoint (depth 0) and
+    /// sg (depth 1), so VPC should be placed under endpoint (shallowest).
     #[test]
     fn test_parent_selection_prefers_most_ancestral_dependency() {
         let vpc = make_resource("ec2.vpc", "vpc", "vpc", &[]);
@@ -1731,40 +1683,25 @@ mod tests {
         plan.add(Effect::Create(endpoint));
 
         let (roots, dependents, effect_bindings, _) = build_plan_tree(&plan);
-        let _print_order = collect_print_order(&roots, &dependents, &effect_bindings);
 
-        assert_eq!(roots, vec![0], "VPC should be the only root");
+        assert_eq!(roots, vec![2], "endpoint should be the only root");
 
-        // The endpoint (idx 2) should be a direct child of VPC (idx 0),
-        // NOT a child of SG (idx 1). VPC is the most ancestral dependency.
-        //
-        // Expected tree:
-        //   vpc
-        //   ├── sg
-        //   └── endpoint
-        //
-        // NOT:
-        //   vpc
-        //   └── sg
-        //       └── endpoint
-        //
-        // Check via print order: vpc -> sg -> endpoint (sg has no children
-        // because endpoint is under vpc). If endpoint were under sg, we'd
-        // get vpc -> sg -> endpoint too, but we verify via direct children.
-        let vpc_children: Vec<String> = dependents
-            .get(&0)
+        // VPC (idx 0) should be a direct child of endpoint (idx 2),
+        // not nested under sg. endpoint is at depth 0 (shallowest dependent).
+        let endpoint_children: Vec<String> = dependents
+            .get(&2)
             .unwrap()
             .iter()
             .filter_map(|&idx| effect_bindings.get(&idx).cloned())
             .collect();
         assert!(
-            vpc_children.contains(&"endpoint".to_string()),
-            "endpoint should be a direct child of vpc (most ancestral), \
-             not nested under sg. VPC children: {:?}",
-            vpc_children
+            endpoint_children.contains(&"vpc".to_string()),
+            "vpc should be a direct child of endpoint (shallowest dependent). \
+             endpoint children: {:?}",
+            endpoint_children
         );
 
-        // sg should NOT have endpoint as a child (it should only be under vpc)
+        // sg should NOT have vpc as a child (vpc is under endpoint instead)
         let sg_children: Vec<String> = dependents
             .get(&1)
             .unwrap()
@@ -1772,28 +1709,25 @@ mod tests {
             .filter_map(|&idx| effect_bindings.get(&idx).cloned())
             .collect();
         assert!(
-            !sg_children.contains(&"endpoint".to_string()),
-            "endpoint should NOT be a child of sg. SG children: {:?}. \
-             When a resource depends on multiple resources, it should only \
-             be placed under the most ancestral one (vpc), not all of them.",
+            !sg_children.contains(&"vpc".to_string()),
+            "vpc should NOT be a child of sg. SG children: {:?}. \
+             When a dependency is depended on by multiple resources, it should \
+             be placed under the shallowest dependent (endpoint, depth 0).",
             sg_children
         );
     }
 
-    /// Issue #928: A resource that has no dependencies but IS referenced by
-    /// other resources should NOT appear as a disconnected root-level item.
-    /// It should be nested under the resource that references it.
+    /// With the flipped tree, roots are effects that nothing depends on.
     ///
-    /// Scenario (from the issue):
-    ///   - vpc: no deps
-    ///   - rt: depends on vpc
-    ///   - route: depends on rt, igw
-    ///   - igw_attachment: depends on vpc, igw
-    ///   - igw: no deps (but referenced by route and igw_attachment)
+    /// Scenario:
+    ///   - vpc: no deps (depended on by rt, igw_attachment)
+    ///   - rt: depends on vpc (depended on by route)
+    ///   - igw: no deps (depended on by route, igw_attachment)
+    ///   - route: depends on rt, igw (nothing depends on route)
+    ///   - igw_attachment: depends on vpc, igw (nothing depends on igw_attachment)
     ///
-    /// Current (buggy): igw appears as a separate root alongside vpc.
-    /// Expected: igw should be nested under igw_attachment (or route),
-    ///           so only vpc is a root.
+    /// Roots = route and igw_attachment (nothing depends on them).
+    /// VPC and IGW should NOT be roots.
     #[test]
     fn test_referenced_resource_without_deps_should_not_be_root() {
         let vpc = make_resource("ec2.vpc", "vpc", "vpc", &[]);
@@ -1816,29 +1750,30 @@ mod tests {
 
         let roots = compute_roots(&plan);
 
-        // IGW (index 2) should NOT be a root because it is referenced by
-        // other resources in the plan (route and igw_attachment).
-        // Only VPC (index 0) should be a root.
+        // route (idx 3) and igw_attachment (idx 4) are roots.
+        // VPC and IGW are NOT roots (they are depended on by other resources).
         assert_eq!(
             roots,
-            vec![0],
-            "Only vpc should be a root. igw (index 2) is referenced by other resources \
-             and should be nested, not a disconnected root. Got roots: {:?}",
+            vec![3, 4],
+            "route and igw_attachment should be the roots (nothing depends on them). \
+             Got roots: {:?}",
             roots
         );
     }
 
-    /// Issue #933: A dependency-free resource that is referenced by multiple
-    /// resources should be nested under the shallowest referencing resource.
+    /// A dependency referenced by multiple resources should be placed under
+    /// the shallowest dependent (closest to root).
     ///
-    /// Scenario:
-    ///   - vpc (root, depth 0)
-    ///   - rt depends on vpc (depth 1)
-    ///   - igw_attachment depends on vpc, igw (depth 1)
-    ///   - route depends on rt, igw (depth 2, under rt)
-    ///   - igw: no deps (referenced by route at depth 2, igw_attachment at depth 1)
+    /// Scenario (flipped tree):
+    ///   - route (root, depth 0): depends on rt, igw
+    ///   - igw_attachment (root, depth 0): depends on vpc, igw
+    ///   - rt (depth 1): depends on vpc
+    ///   - igw (depth 1): depended on by route and igw_attachment (both depth 0)
+    ///   - vpc (depth 1 or 2): depended on by rt and igw_attachment
     ///
-    /// IGW should be nested under igw_attachment (depth 1), not route (depth 2).
+    /// IGW is depended on by route (depth 0) and igw_attachment (depth 0).
+    /// Both are at the same depth, so tiebreak by sort: ec2.route < ec2.vpc_gateway_attachment.
+    /// IGW should be placed under route.
     #[test]
     fn test_dependency_free_resource_nested_under_shallowest_referencing_resource() {
         let vpc = make_resource("ec2.vpc", "vpc", "vpc", &[]);
@@ -1861,23 +1796,14 @@ mod tests {
 
         let (roots, dependents, effect_bindings, _) = build_plan_tree(&plan);
 
-        assert_eq!(roots, vec![0], "Only vpc should be root");
-
-        // igw_attachment is index 4, route is index 3, igw is index 2
-        // igw should be a child of igw_attachment (depth 1), NOT route (depth 2)
-        let igw_attachment_children: Vec<String> = dependents
-            .get(&4)
-            .unwrap()
-            .iter()
-            .filter_map(|&idx| effect_bindings.get(&idx).cloned())
-            .collect();
-        assert!(
-            igw_attachment_children.contains(&"igw".to_string()),
-            "igw should be nested under igw_attachment (shallowest referencing resource at depth 1). \
-             igw_attachment children: {:?}",
-            igw_attachment_children
+        assert_eq!(
+            roots,
+            vec![3, 4],
+            "route and igw_attachment should be roots"
         );
 
+        // route (idx 3) should have igw as a child (both roots are at depth 0,
+        // route wins tiebreak by resource_type sort)
         let route_children: Vec<String> = dependents
             .get(&3)
             .unwrap()
@@ -1885,10 +1811,24 @@ mod tests {
             .filter_map(|&idx| effect_bindings.get(&idx).cloned())
             .collect();
         assert!(
-            !route_children.contains(&"igw".to_string()),
-            "igw should NOT be nested under route (deeper at depth 2). \
+            route_children.contains(&"igw".to_string()),
+            "igw should be nested under route (shallowest dependent, tiebreak by sort). \
              route children: {:?}",
             route_children
+        );
+
+        // igw_attachment should NOT have igw as a child
+        let igw_attachment_children: Vec<String> = dependents
+            .get(&4)
+            .unwrap()
+            .iter()
+            .filter_map(|&idx| effect_bindings.get(&idx).cloned())
+            .collect();
+        assert!(
+            !igw_attachment_children.contains(&"igw".to_string()),
+            "igw should NOT be under igw_attachment (lost tiebreak). \
+             igw_attachment children: {:?}",
+            igw_attachment_children
         );
     }
 
@@ -2618,35 +2558,27 @@ mod tests {
 
         let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
 
-        // VPC (idx 0) should be the only root
-        assert_eq!(
-            roots,
-            vec![0],
-            "VPC should be the only root. Got roots: {:?} (bindings: {:?})",
-            roots,
-            roots
-                .iter()
-                .filter_map(|i| effect_bindings.get(i))
-                .collect::<Vec<_>>()
+        // SG (idx 1) and Subnet Delete (idx 2) are roots (nothing depends on them).
+        // VPC (idx 0) is depended on by both, so it's a child.
+        let root_bindings: Vec<String> = roots
+            .iter()
+            .filter_map(|&i| effect_bindings.get(&i).cloned())
+            .collect();
+        assert!(
+            !root_bindings.contains(&"vpc".to_string()),
+            "VPC should NOT be a root (it's depended on). Roots: {:?}",
+            root_bindings
         );
 
-        // SG (idx 1) should be a child of VPC
-        let vpc_children: Vec<usize> = dependents.get(&0).cloned().unwrap_or_default();
+        // VPC (idx 0) should be a child of one of the roots
+        let vpc_is_child = roots
+            .iter()
+            .any(|&r| dependents.get(&r).is_some_and(|c| c.contains(&0)));
         assert!(
-            vpc_children.contains(&1),
-            "SG (idx 1) should be a child of VPC. VPC children: {:?}",
-            vpc_children
-        );
-
-        // Subnet Delete (idx 2) should also be a child of VPC.
-        // Currently fails because Delete effects have no binding/dependency info.
-        assert!(
-            vpc_children.contains(&2),
-            "Subnet Delete (idx 2) should be a child of VPC, but Delete effects \
-             have no resource/binding/dependency info so the tree cannot place them. \
-             VPC children: {:?}, all roots: {:?}",
-            vpc_children,
-            roots
+            vpc_is_child,
+            "VPC (idx 0) should be a child of one of the roots. \
+             Roots: {:?}",
+            root_bindings
         );
     }
 
@@ -2705,14 +2637,13 @@ mod tests {
 
         let (roots, dependents, effect_bindings, _effect_types) = build_plan_tree(&plan);
 
-        // VPC (idx 0) should be the only root.
-        // SG has _dependency_bindings metadata that preserves the dependency
-        // on "vpc", so get_resource_dependencies() recovers it.
+        // SG (idx 1) should be the only root (nothing depends on it).
+        // VPC is depended on by SG via dependency_bindings.
         assert_eq!(
             roots,
-            vec![0],
-            "VPC should be the only root. SG should be nested under VPC \
-             because it references vpc.vpc_id in the DSL. Got roots: {:?} \
+            vec![1],
+            "SG should be the only root. VPC should be nested under SG \
+             because SG depends on vpc via dependency_bindings. Got roots: {:?} \
              (bindings: {:?})",
             roots,
             roots
@@ -2721,12 +2652,12 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
-        // SG (idx 1) should be a child of VPC (idx 0)
-        let vpc_children: Vec<usize> = dependents.get(&0).cloned().unwrap_or_default();
+        // VPC (idx 0) should be a child of SG (idx 1)
+        let sg_children: Vec<usize> = dependents.get(&1).cloned().unwrap_or_default();
         assert!(
-            vpc_children.contains(&1),
-            "SG (idx 1) should be a child of VPC. VPC children: {:?}",
-            vpc_children
+            sg_children.contains(&0),
+            "VPC (idx 0) should be a child of SG. SG children: {:?}",
+            sg_children
         );
     }
 

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_all_create.snap
@@ -4,23 +4,22 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.vpc vpc
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
+  + awscc.ec2.route_table 
       tags:
-        Name: "test-vpc"
+        Name: "test-route-table"
+      vpc_id: vpc.vpc_id
         │
-        ├─ + awscc.ec2.route_table 
-        │     tags:
-        │       Name: "test-route-table"
-        │     vpc_id: vpc.vpc_id
-        │
-        └─ + awscc.ec2.subnet 
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
+        └─ + awscc.ec2.vpc vpc
+              cidr_block: "10.0.0.0/16"
+              enable_dns_hostnames: true
+              enable_dns_support: true
               tags:
-                Name: "test-subnet"
-              vpc_id: vpc.vpc_id
+                Name: "test-vpc"
+  + awscc.ec2.subnet 
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      tags:
+        Name: "test-subnet"
+      vpc_id: vpc.vpc_id
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_compact.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_compact.snap
@@ -4,8 +4,8 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.vpc vpc
-        ├─ + awscc.ec2.route_table 
-        └─ + awscc.ec2.subnet (availability_zone: ap-northeast-1a)
+  + awscc.ec2.route_table (vpc: vpc)
+        └─ + awscc.ec2.vpc vpc
+  + awscc.ec2.subnet (availability_zone: ap-northeast-1a)
 
 Plan: 3 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_tags.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_default_tags.snap
@@ -4,13 +4,13 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.vpc vpc
-      cidr_block: "10.0.0.0/16"
-      tags:
-        Environment: "staging"
-        Name: "main-vpc"
+  + awscc.ec2.route_table 
+      vpc_id: vpc.vpc_id
         │
-        └─ + awscc.ec2.route_table 
-              vpc_id: vpc.vpc_id
+        └─ + awscc.ec2.vpc vpc
+              cidr_block: "10.0.0.0/16"
+              tags:
+                Environment: "staging"
+                Name: "main-vpc"
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_delete_orphan.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_delete_orphan.snap
@@ -4,26 +4,26 @@ expression: output
 ---
 Execution Plan:
 
+  - awscc.ec2.subnet my_subnet
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      subnet_id: "subnet-0123456789abcdef0"
+      tags:
+        Name: "test-subnet"
+      vpc_id: "vpc-0123456789abcdef0"
+        │
+        └─ - awscc.ec2.vpc ec2_vpc_fb75c929
+              cidr_block: "10.0.0.0/16"
+              enable_dns_hostnames: true
+              enable_dns_support: true
+              tags:
+                Name: "test-vpc"
+              vpc_id: "vpc-0123456789abcdef0"
   + awscc.ec2.vpc 
       cidr_block: "10.0.0.0/16"
       enable_dns_hostnames: true
       enable_dns_support: true
       tags:
         Name: "test-vpc"
-  - awscc.ec2.vpc ec2_vpc_fb75c929
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
-      tags:
-        Name: "test-vpc"
-      vpc_id: "vpc-0123456789abcdef0"
-        │
-        └─ - awscc.ec2.subnet my_subnet
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
-              subnet_id: "subnet-0123456789abcdef0"
-              tags:
-                Name: "test-subnet"
-              vpc_id: "vpc-0123456789abcdef0"
 
 Plan: 1 to add, 0 to change, 2 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_full.snap
@@ -4,18 +4,18 @@ expression: output
 ---
 Destroy Plan:
 
-  - awscc.ec2.vpc ec2_vpc_fb75c929
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
+  - awscc.ec2.subnet ec2_subnet_f5269366
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      subnet_id: "subnet-0123456789abcdef0"
       tags:
-        Name: "test-vpc"
+        Name: "test-subnet"
       vpc_id: "vpc-0123456789abcdef0"
         │
-        └─ - awscc.ec2.subnet ec2_subnet_f5269366
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
-              subnet_id: "subnet-0123456789abcdef0"
+        └─ - awscc.ec2.vpc ec2_vpc_fb75c929
+              cidr_block: "10.0.0.0/16"
+              enable_dns_hostnames: true
+              enable_dns_support: true
               tags:
-                Name: "test-subnet"
+                Name: "test-vpc"
               vpc_id: "vpc-0123456789abcdef0"

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_destroy_orphans.snap
@@ -4,18 +4,18 @@ expression: output
 ---
 Destroy Plan:
 
-  - awscc.ec2.vpc my_vpc
-      cidr_block: "10.0.0.0/16"
-      enable_dns_hostnames: true
-      enable_dns_support: true
+  - awscc.ec2.subnet my_subnet
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      subnet_id: "subnet-0123456789abcdef0"
       tags:
-        Name: "test-vpc"
+        Name: "test-subnet"
       vpc_id: "vpc-0123456789abcdef0"
         │
-        └─ - awscc.ec2.subnet my_subnet
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
-              subnet_id: "subnet-0123456789abcdef0"
+        └─ - awscc.ec2.vpc my_vpc
+              cidr_block: "10.0.0.0/16"
+              enable_dns_hostnames: true
+              enable_dns_support: true
               tags:
-                Name: "test-subnet"
+                Name: "test-vpc"
               vpc_id: "vpc-0123456789abcdef0"

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_explicit.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_explicit.snap
@@ -4,16 +4,15 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.vpc vpc
+  + awscc.ec2.security_group 
+      group_description: "Test security group"
       tags:
-        + Environment: "staging"
+        Name: "test-sg"
+      vpc_id: "vpc-0123456789abcdef0"
         │
-        ├─ + awscc.ec2.security_group 
-        │     group_description: "Test security group"
-        │     tags:
-        │       Name: "test-sg"
-        │     vpc_id: "vpc-0123456789abcdef0"
-        │
-        └─ - awscc.ec2.subnet my_subnet
+        └─ ~ awscc.ec2.vpc vpc
+              tags:
+                + Environment: "staging"
+  - awscc.ec2.subnet my_subnet
 
 Plan: 1 to add, 1 to change, 1 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_mixed_operations.snap
@@ -4,17 +4,16 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.vpc vpc
+  + awscc.ec2.security_group 
+      group_description: "Test security group"
       tags:
-        + Environment: "staging"
-      # (3 unchanged attributes hidden)
+        Name: "test-sg"
+      vpc_id: "vpc-0123456789abcdef0"
         │
-        ├─ + awscc.ec2.security_group 
-        │     group_description: "Test security group"
-        │     tags:
-        │       Name: "test-sg"
-        │     vpc_id: "vpc-0123456789abcdef0"
-        │
-        └─ - awscc.ec2.subnet my_subnet
+        └─ ~ awscc.ec2.vpc vpc
+              tags:
+                + Environment: "staging"
+              # (3 unchanged attributes hidden)
+  - awscc.ec2.subnet my_subnet
 
 Plan: 1 to add, 1 to change, 1 to destroy.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_prev_keys.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_prev_keys.snap
@@ -4,12 +4,12 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.vpc new_vpc (moved from: awscc.ec2.vpc.old_vpc)
-      tags: [{key: "Name", value: "old"}] → (removed)
-      # (1 unchanged attribute hidden)
+  + awscc.ec2.subnet 
+      cidr_block: "10.0.1.0/24"
+      vpc_id: new_vpc.vpc_id
         │
-        └─ + awscc.ec2.subnet 
-              cidr_block: "10.0.1.0/24"
-              vpc_id: new_vpc.vpc_id
+        └─ ~ awscc.ec2.vpc new_vpc (moved from: awscc.ec2.vpc.old_vpc)
+              tags: [{key: "Name", value: "old"}] → (removed)
+              # (1 unchanged attribute hidden)
 
 Plan: 1 to add, 1 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_moved_with_changes.snap
@@ -4,12 +4,12 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.vpc new_vpc (moved from: awscc.ec2.vpc.old_vpc)
-      tags: (none) → {Name: "updated"}
-      # (1 unchanged attribute hidden)
+  + awscc.ec2.subnet 
+      cidr_block: "10.0.1.0/24"
+      vpc_id: new_vpc.vpc_id
         │
-        └─ + awscc.ec2.subnet 
-              cidr_block: "10.0.1.0/24"
-              vpc_id: new_vpc.vpc_id
+        └─ ~ awscc.ec2.vpc new_vpc (moved from: awscc.ec2.vpc.old_vpc)
+              tags: (none) → {Name: "updated"}
+              # (1 unchanged attribute hidden)
 
 Plan: 1 to add, 1 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_read_only_attrs.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_read_only_attrs.snap
@@ -4,14 +4,14 @@ expression: output
 ---
 Execution Plan:
 
-  + awscc.ec2.vpc vpc
-      cidr_block: "10.0.0.0/16"
-      tags:
-        Name: "read-only-test"
+  + awscc.ec2.subnet 
+      availability_zone: "ap-northeast-1a"
+      cidr_block: "10.0.1.0/24"
+      vpc_id: vpc.vpc_id
         │
-        └─ + awscc.ec2.subnet 
-              availability_zone: "ap-northeast-1a"
-              cidr_block: "10.0.1.0/24"
-              vpc_id: vpc.vpc_id
+        └─ + awscc.ec2.vpc vpc
+              cidr_block: "10.0.0.0/16"
+              tags:
+                Name: "read-only-test"
 
 Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-core/src/plan_tree.rs
+++ b/carina-core/src/plan_tree.rs
@@ -93,12 +93,16 @@ pub fn build_dependency_graph(plan: &Plan) -> DependencyGraph {
 
 /// Build a single-parent tree from the dependency graph.
 ///
-/// Each resource is assigned to exactly one parent (or is a root). When a
-/// resource depends on multiple resources in the plan, it is placed under the
-/// shallowest (most ancestral) dependency. Ties are broken by
+/// The tree shows dependencies as children: a resource's children are the
+/// resources it depends on (which must be created first). Roots are resources
+/// that no other resource depends on (the "outermost" consumers).
+///
+/// Each resource is assigned to exactly one parent (or is a root). When
+/// multiple resources depend on the same resource, it is placed under the
+/// shallowest (most ancestral) dependent. Ties are broken by
 /// (resource_type, binding_name) for determinism.
 ///
-/// Returns (roots, dependents) where roots are sorted and each parent's
+/// Returns (roots, children) where roots are sorted and each parent's
 /// children are sorted by (resource_type, binding_name).
 pub fn build_single_parent_tree(
     plan: &Plan,
@@ -109,30 +113,26 @@ pub fn build_single_parent_tree(
     let effect_bindings = &graph.effect_bindings;
     let effect_types = &graph.effect_types;
 
-    let effect_binding_set: HashSet<&str> = binding_to_effect.keys().map(|s| s.as_str()).collect();
-
-    // Step 1: Build the full reverse dependency map (all parents)
+    // Step 1: Build forward and reverse dependency maps by resolving binding
+    // names to effect indices in a single pass.
+    let mut all_dependencies: HashMap<usize, Vec<usize>> = HashMap::new();
     let mut all_dependents: HashMap<usize, Vec<usize>> = HashMap::new();
-    for idx in 0..plan.effects().len() {
-        all_dependents.insert(idx, Vec::new());
-    }
     for (idx, deps) in effect_deps {
         for dep in deps {
             if let Some(&dep_idx) = binding_to_effect.get(dep) {
+                all_dependencies.entry(*idx).or_default().push(dep_idx);
                 all_dependents.entry(dep_idx).or_default().push(*idx);
             }
         }
     }
 
-    // Step 2: Identify initial roots (no deps in plan)
-    let mut initial_roots: Vec<usize> = Vec::new();
-    for (idx, deps) in effect_deps {
-        let has_dep_in_plan = deps.iter().any(|d| binding_to_effect.contains_key(d));
-        if !has_dep_in_plan {
-            initial_roots.push(*idx);
+    // Step 2: Identify roots — effects that no other effect depends on
+    let mut roots: Vec<usize> = Vec::new();
+    for idx in 0..plan.effects().len() {
+        if all_dependents.get(&idx).is_none_or(|v| v.is_empty()) {
+            roots.push(idx);
         }
     }
-    initial_roots.sort();
 
     let sort_key = |idx: &usize| -> (String, String) {
         let rtype = effect_types.get(idx).cloned().unwrap_or_default();
@@ -140,114 +140,54 @@ pub fn build_single_parent_tree(
         (rtype, binding)
     };
 
-    // Step 3: Nest no-dep resources under their first dependent (Issue #928)
-    // A no-dep resource can be nested only if every dependent has at least one
-    // other dependency in the plan (besides this resource).
-    let mut nested_under_dependent: HashSet<usize> = HashSet::new();
-    for &idx in &initial_roots {
-        let mut children = all_dependents.get(&idx).cloned().unwrap_or_default();
-        children.sort_by_key(|a| sort_key(a));
-        if !children.is_empty() {
-            let binding_of_idx = effect_bindings.get(&idx).map(|s| s.as_str());
-            let all_dependents_have_other_deps = children.iter().all(|&child_idx| {
-                effect_deps.get(&child_idx).is_some_and(|child_deps| {
-                    child_deps.iter().any(|d| {
-                        effect_binding_set.contains(d.as_str())
-                            && Some(d.as_str()) != binding_of_idx
-                    })
-                })
-            });
-            if all_dependents_have_other_deps {
-                nested_under_dependent.insert(idx);
-            }
-        }
-    }
-
-    // Step 4: Compute final roots
-    let roots: Vec<usize> = initial_roots
-        .iter()
-        .filter(|idx| !nested_under_dependent.contains(idx))
-        .cloned()
-        .collect();
-
-    // Step 5: Compute depth for each resource via BFS from roots
+    // Step 4: Compute depth via BFS from roots through dependencies
     let mut depth: HashMap<usize, usize> = HashMap::new();
     let mut queue: VecDeque<usize> = VecDeque::new();
     for &root in &roots {
         depth.insert(root, 0);
         queue.push_back(root);
     }
-    // Also set depth for nested-under-dependent resources (they will be
-    // children of some non-root resource, but we need them reachable)
     while let Some(node) = queue.pop_front() {
         let d = depth[&node];
-        if let Some(children) = all_dependents.get(&node) {
-            for &child in children {
-                if let std::collections::hash_map::Entry::Vacant(e) = depth.entry(child) {
+        if let Some(deps) = all_dependencies.get(&node) {
+            for &dep in deps {
+                if let std::collections::hash_map::Entry::Vacant(e) = depth.entry(dep) {
                     e.insert(d + 1);
-                    queue.push_back(child);
+                    queue.push_back(dep);
                 }
             }
         }
     }
 
-    // Step 6: For each non-root resource, select a single parent:
-    // the dependency with the shallowest depth (most ancestral).
-    // For nested-under-dependent resources, their parent is the first
-    // dependent (by sort order).
-    let mut dependents: HashMap<usize, Vec<usize>> = HashMap::new();
+    // Step 5: For each non-root effect, select a single parent:
+    // the shallowest effect that depends on it (from all_dependents).
+    let mut children_map: HashMap<usize, Vec<usize>> = HashMap::new();
     for idx in 0..plan.effects().len() {
-        dependents.insert(idx, Vec::new());
-    }
-
-    for (idx, deps) in effect_deps {
-        if roots.contains(idx) || nested_under_dependent.contains(idx) {
+        if roots.contains(&idx) {
             continue;
         }
-        // Find deps that are in the plan
-        let mut parent_candidates: Vec<usize> = deps
-            .iter()
-            .filter_map(|d| binding_to_effect.get(d).cloned())
-            .collect();
-        if parent_candidates.is_empty() {
+        let Some(dependents) = all_dependents.get(&idx) else {
             continue;
-        }
-        // Pick the shallowest parent; break ties by (resource_type, binding_name)
-        parent_candidates.sort_by(|a, b| {
+        };
+        let parent = dependents.iter().copied().min_by(|a, b| {
             let da = depth.get(a).copied().unwrap_or(usize::MAX);
             let db = depth.get(b).copied().unwrap_or(usize::MAX);
             da.cmp(&db).then_with(|| sort_key(a).cmp(&sort_key(b)))
         });
-        let parent = parent_candidates[0];
-        dependents.entry(parent).or_default().push(*idx);
-    }
-
-    // Add nested-under-dependent resources as children of the shallowest
-    // referencing resource. This ensures resources like IGW are nested under
-    // igw_attachment (depth 1) rather than route (depth 2+).
-    for &idx in &nested_under_dependent {
-        let mut children = all_dependents.get(&idx).cloned().unwrap_or_default();
-        // Pick the shallowest dependent; break ties by (resource_type, binding_name)
-        children.sort_by(|a, b| {
-            let da = depth.get(a).copied().unwrap_or(usize::MAX);
-            let db = depth.get(b).copied().unwrap_or(usize::MAX);
-            da.cmp(&db).then_with(|| sort_key(a).cmp(&sort_key(b)))
-        });
-        if let Some(&best_dependent) = children.first() {
-            dependents.entry(best_dependent).or_default().push(idx);
+        if let Some(parent) = parent {
+            children_map.entry(parent).or_default().push(idx);
         }
     }
 
-    // Step 7: Sort each parent's children by (resource_type, binding_name)
-    for children in dependents.values_mut() {
+    // Step 6: Sort each parent's children by (resource_type, binding_name)
+    for children in children_map.values_mut() {
         children.sort_by_key(|a| sort_key(a));
     }
 
     // Also sort roots by (resource_type, binding_name)
-    let mut sorted_roots = roots;
-    sorted_roots.sort_by_key(|a| sort_key(a));
+    roots.sort_by_key(|a| sort_key(a));
 
-    (sorted_roots, dependents)
+    (roots, children_map)
 }
 
 /// Extract a compact hint for anonymous resources.
@@ -341,4 +281,127 @@ pub fn shorten_service_name<'a>(attr_name: &str, value: &'a str) -> Cow<'a, str>
         }
     }
     Cow::Borrowed(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::{Resource, Value};
+
+    /// Helper: build plan, graph, and tree, then return (roots, children_map).
+    fn tree_from_plan(plan: &Plan) -> (Vec<usize>, HashMap<usize, Vec<usize>>) {
+        let graph = build_dependency_graph(plan);
+        build_single_parent_tree(plan, &graph)
+    }
+
+    #[test]
+    fn dependencies_are_children() {
+        // vpc has no deps; route_table depends on vpc; subnet depends on vpc.
+        // After flip: route_table and subnet are roots (nothing depends on them),
+        // vpc is a child.
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(
+            Resource::new("ec2.vpc", "my-vpc")
+                .with_binding("vpc")
+                .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.route_table", "my-rt")
+                .with_binding("rt")
+                .with_attribute(
+                    "vpc_id",
+                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+                ),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.subnet", "my-subnet")
+                .with_binding("subnet")
+                .with_attribute(
+                    "vpc_id",
+                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+                ),
+        ));
+
+        let (roots, children) = tree_from_plan(&plan);
+
+        // Roots should be route_table and subnet (nothing depends on them)
+        let root_bindings: Vec<String> = roots
+            .iter()
+            .map(|&i| plan.effects()[i].binding_name().unwrap())
+            .collect();
+        assert!(root_bindings.contains(&"rt".to_string()));
+        assert!(root_bindings.contains(&"subnet".to_string()));
+        assert!(!root_bindings.contains(&"vpc".to_string()));
+
+        // vpc should be a child of one of the roots
+        let vpc_idx = plan
+            .effects()
+            .iter()
+            .position(|e| e.binding_name() == Some("vpc".to_string()))
+            .unwrap();
+        let vpc_is_child_of_a_root = roots
+            .iter()
+            .any(|&r| children.get(&r).is_some_and(|c| c.contains(&vpc_idx)));
+        assert!(vpc_is_child_of_a_root);
+    }
+
+    #[test]
+    fn chain_dependency_becomes_nested_children() {
+        // A depends on B, B depends on C.
+        // After flip: A is root, B is child of A, C is child of B.
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(
+            Resource::new("ec2.vpc", "c").with_binding("c"),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.subnet", "b")
+                .with_binding("b")
+                .with_attribute(
+                    "ref_c",
+                    Value::resource_ref("c".to_string(), "id".to_string(), vec![]),
+                ),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("ec2.instance", "a")
+                .with_binding("a")
+                .with_attribute(
+                    "ref_b",
+                    Value::resource_ref("b".to_string(), "id".to_string(), vec![]),
+                ),
+        ));
+
+        let (roots, children) = tree_from_plan(&plan);
+
+        // A is the only root (nothing depends on A)
+        assert_eq!(roots.len(), 1);
+        let a_idx = roots[0];
+        assert_eq!(plan.effects()[a_idx].binding_name().unwrap(), "a");
+
+        // B is child of A
+        let a_children = children.get(&a_idx).unwrap();
+        assert_eq!(a_children.len(), 1);
+        let b_idx = a_children[0];
+        assert_eq!(plan.effects()[b_idx].binding_name().unwrap(), "b");
+
+        // C is child of B
+        let b_children = children.get(&b_idx).unwrap();
+        assert_eq!(b_children.len(), 1);
+        let c_idx = b_children[0];
+        assert_eq!(plan.effects()[c_idx].binding_name().unwrap(), "c");
+    }
+
+    #[test]
+    fn no_deps_resources_are_roots() {
+        // Two independent resources with no deps → both are roots.
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(
+            Resource::new("s3.bucket", "a").with_binding("a"),
+        ));
+        plan.add(Effect::Create(
+            Resource::new("s3.bucket", "b").with_binding("b"),
+        ));
+
+        let (roots, _children) = tree_from_plan(&plan);
+        assert_eq!(roots.len(), 2);
+    }
 }

--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -990,15 +990,16 @@ mod tests {
 
         let app = App::new(&plan, &HashMap::new());
 
-        // VPC should be root (depth 0) with subnet as child
-        assert_eq!(app.nodes[0].depth, 0);
-        assert!(app.nodes[0].parent.is_none());
-        assert_eq!(app.nodes[0].children, vec![1]);
+        // Subnet should be root (depth 0) with vpc as child
+        // (subnet depends on vpc, so vpc is its child in the tree)
+        assert_eq!(app.nodes[1].depth, 0);
+        assert!(app.nodes[1].parent.is_none());
+        assert_eq!(app.nodes[1].children, vec![0]);
 
-        // Subnet should be child (depth 1) with VPC as parent
-        assert_eq!(app.nodes[1].depth, 1);
-        assert_eq!(app.nodes[1].parent, Some(0));
-        assert!(app.nodes[1].children.is_empty());
+        // VPC should be child (depth 1) with subnet as parent
+        assert_eq!(app.nodes[0].depth, 1);
+        assert_eq!(app.nodes[0].parent, Some(1));
+        assert!(app.nodes[0].children.is_empty());
     }
 
     #[test]
@@ -1169,12 +1170,13 @@ mod tests {
         // Before search, all 3 nodes visible
         assert_eq!(app.visible_count(), 3);
 
-        // Search for "subnet" - should show subnet + its parent vpc
-        app.search_query = "subnet".to_string();
+        // Search for "vpc" - should show vpc + its ancestor subnet
+        // (subnet is root, vpc is its child in the flipped tree)
+        app.search_query = "vpc".to_string();
         app.update_search_matches();
 
         let visible = app.visible_nodes();
-        assert_eq!(visible.len(), 2); // vpc (ancestor) + subnet (match)
+        assert_eq!(visible.len(), 2); // subnet (ancestor) + vpc (match)
 
         // The s3.bucket should not be visible
         for &idx in &visible {
@@ -1187,23 +1189,23 @@ mod tests {
         let plan = make_tree_plan();
         let mut app = App::new(&plan, &HashMap::new());
 
-        app.search_query = "subnet".to_string();
+        app.search_query = "vpc".to_string();
         app.update_search_matches();
 
         let visible = app.visible_nodes();
-        // vpc is ancestor-only (dimmed)
-        let vpc_idx = visible
-            .iter()
-            .find(|&&idx| app.nodes[idx].resource_type == "ec2.vpc")
-            .unwrap();
-        assert!(app.is_ancestor_only(*vpc_idx));
-
-        // subnet is a match (not dimmed)
+        // subnet is ancestor-only (dimmed) — it's the root parent of vpc
         let subnet_idx = visible
             .iter()
             .find(|&&idx| app.nodes[idx].resource_type == "ec2.subnet")
             .unwrap();
-        assert!(!app.is_ancestor_only(*subnet_idx));
+        assert!(app.is_ancestor_only(*subnet_idx));
+
+        // vpc is a match (not dimmed)
+        let vpc_idx = visible
+            .iter()
+            .find(|&&idx| app.nodes[idx].resource_type == "ec2.vpc")
+            .unwrap();
+        assert!(!app.is_ancestor_only(*vpc_idx));
     }
 
     #[test]
@@ -1211,7 +1213,7 @@ mod tests {
         let plan = make_tree_plan();
         let mut app = App::new(&plan, &HashMap::new());
 
-        app.search_query = "subnet".to_string();
+        app.search_query = "vpc".to_string();
         app.update_search_matches();
         assert_eq!(app.visible_count(), 2);
 
@@ -1238,15 +1240,15 @@ mod tests {
         let plan = make_tree_plan();
         let mut app = App::new(&plan, &HashMap::new());
 
-        app.search_query = "subnet".to_string();
+        app.search_query = "vpc".to_string();
         app.update_search_matches();
 
-        // search_matches should contain only the visible index of the subnet node
+        // search_matches should contain only the visible index of the vpc node
         assert_eq!(app.search_matches.len(), 1);
         let visible = app.visible_nodes();
         let match_vis_idx = app.search_matches[0];
         let match_node_idx = visible[match_vis_idx];
-        assert_eq!(app.nodes[match_node_idx].resource_type, "ec2.subnet");
+        assert_eq!(app.nodes[match_node_idx].resource_type, "ec2.vpc");
     }
 
     #[test]

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_all_create.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_all_create.snap
@@ -3,9 +3,9 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
-│    ├── + ec2.route_table rt                                                                                          │
-│    └── + ec2.subnet subnet                                                                                           │
+│+ ec2.route_table rt                                                                                                  │
+│    └── + ec2.vpc vpc                                                                                                 │
+│+ ec2.subnet subnet                                                                                                   │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,9 +30,9 @@ expression: output
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
+│+ ec2.route_table rt                                                                                                  │
 │                                                                                                                      │
-│  cidr_block: "10.0.0.0/16"                                                                                           │
+│  vpc_id: vpc.vpc_id →                                                                                                │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_second_node.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_second_node.snap
@@ -3,9 +3,9 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
-│    ├── + ec2.route_table rt                                                                                          │
-│    └── + ec2.subnet subnet                                                                                           │
+│+ ec2.route_table rt                                                                                                  │
+│    └── + ec2.vpc vpc                                                                                                 │
+│+ ec2.subnet subnet                                                                                                   │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,9 +30,9 @@ expression: output
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│+ ec2.route_table rt                                                                                                  │
+│+ ec2.vpc vpc                                                                                                         │
 │                                                                                                                      │
-│  vpc_id: vpc.vpc_id →                                                                                                │
+│  cidr_block: "10.0.0.0/16"                                                                                           │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_third_node.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_detail_panel_third_node.snap
@@ -3,9 +3,9 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
-│    ├── + ec2.route_table rt                                                                                          │
-│    └── + ec2.subnet subnet                                                                                           │
+│+ ec2.route_table rt                                                                                                  │
+│    └── + ec2.vpc vpc                                                                                                 │
+│+ ec2.subnet subnet                                                                                                   │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_route_table.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_route_table.snap
@@ -3,8 +3,8 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
-│    └── + ec2.route_table rt                                                                                          │
+│+ ec2.route_table rt                                                                                                  │
+│                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_subnet.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_filter_mode_subnet.snap
@@ -3,8 +3,8 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 3 to create, 0 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│+ ec2.vpc vpc                                                                                                         │
-│    └── + ec2.subnet subnet                                                                                           │
+│+ ec2.subnet subnet                                                                                                   │
+│                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_mixed_operations.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_mixed_operations.snap
@@ -3,8 +3,8 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 1 to create, 1 to update, 1 to delete) ──────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
-│    └── + ec2.security_group sg                                                                                       │
+│+ ec2.security_group sg                                                                                               │
+│    └── ~ ec2.vpc vpc                                                                                                 │
 │- ec2.subnet old-subnet                                                                                               │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,10 +30,10 @@ expression: output
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
+│+ ec2.security_group sg                                                                                               │
 │                                                                                                                      │
-│  enable_dns_support: (none) -> true                                                                                  │
-│  # (1 unchanged attribute hidden)                                                                                    │
+│  group_description: "Web security group"                                                                             │
+│  vpc_id: vpc.vpc_id →                                                                                                │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_moved_with_changes.snap
@@ -3,8 +3,8 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 1 to create, 1 to update, 0 to delete) ──────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc new_vpc                                                                                                     │
-│    └── + ec2.subnet (cidr_block: 10.0.1.0/24)                                                                        │
+│+ ec2.subnet (cidr_block: 10.0.1.0/24)                                                                                │
+│    └── ~ ec2.vpc new_vpc                                                                                             │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,10 +30,10 @@ expression: output
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc new_vpc                                                                                                     │
+│+ ec2.subnet (cidr_block: 10.0.1.0/24)                                                                                │
 │                                                                                                                      │
-│  tags: (none) -> {Name: "updated"}                                                                                   │
-│  # (1 unchanged attribute hidden)                                                                                    │
+│  cidr_block: "10.0.1.0/24"                                                                                           │
+│  vpc_id: new_vpc.vpc_id →                                                                                            │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_update_unchanged_count.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_update_unchanged_count.snap
@@ -3,8 +3,8 @@ source: carina-tui/src/tui_snapshot_tests.rs
 expression: output
 ---
 ┌ Plan (Plan: 1 to create, 1 to update, 1 to delete) ──────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
-│    └── + ec2.security_group sg                                                                                       │
+│+ ec2.security_group sg                                                                                               │
+│    └── ~ ec2.vpc vpc                                                                                                 │
 │- ec2.subnet old-subnet                                                                                               │
 │                                                                                                                      │
 │                                                                                                                      │
@@ -30,10 +30,10 @@ expression: output
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│~ ec2.vpc vpc                                                                                                         │
+│+ ec2.security_group sg                                                                                               │
 │                                                                                                                      │
-│  enable_dns_support: (none) -> true                                                                                  │
-│  # (1 unchanged attribute hidden)                                                                                    │
+│  group_description: "Web security group"                                                                             │
+│  vpc_id: vpc.vpc_id →                                                                                                │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -1042,6 +1042,7 @@ mod tests {
 
     #[test]
     fn tree_connector_single_child() {
+        // subnet depends on vpc → subnet is root, vpc is its child
         let mut plan = Plan::new();
         plan.add(Effect::Create(
             Resource::new("ec2.vpc", "my-vpc")
@@ -1058,37 +1059,38 @@ mod tests {
         ));
         let app = App::new(&plan, &std::collections::HashMap::new());
 
-        // Subnet is the only (last) child of VPC
-        let connector = build_tree_connector(1, &app);
+        // vpc (idx 0) is the only child of subnet (idx 1)
+        let connector = build_tree_connector(0, &app);
         assert_eq!(connector, "    └── ");
     }
 
     #[test]
     fn tree_connector_multiple_children() {
+        // instance depends on both subnet_a and subnet_b
         let mut plan = Plan::new();
         plan.add(Effect::Create(
-            Resource::new("ec2.vpc", "my-vpc").with_binding("vpc"),
+            Resource::new("ec2.subnet", "subnet-a").with_binding("subnet_a"),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.subnet", "subnet-a")
-                .with_binding("subnet_a")
-                .with_attribute(
-                    "vpc_id",
-                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-                ),
+            Resource::new("ec2.subnet", "subnet-b").with_binding("subnet_b"),
         ));
         plan.add(Effect::Create(
-            Resource::new("ec2.subnet", "subnet-b")
-                .with_binding("subnet_b")
+            Resource::new("ec2.instance", "my-instance")
+                .with_binding("inst")
                 .with_attribute(
-                    "vpc_id",
-                    Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+                    "subnet_a_id",
+                    Value::resource_ref("subnet_a".to_string(), "id".to_string(), vec![]),
+                )
+                .with_attribute(
+                    "subnet_b_id",
+                    Value::resource_ref("subnet_b".to_string(), "id".to_string(), vec![]),
                 ),
         ));
         let app = App::new(&plan, &std::collections::HashMap::new());
 
-        // First child gets ├─, last child gets └─
-        let children = &app.nodes[0].children;
+        // instance (idx 2) is root with subnet_a and subnet_b as children
+        let inst_idx = 2;
+        let children = &app.nodes[inst_idx].children;
         assert_eq!(children.len(), 2);
         let first_child = children[0];
         let last_child = children[1];


### PR DESCRIPTION
Closes #1676

## Summary

- Flip plan tree so dependencies are shown as children instead of dependents
- Roots are now resources that nothing depends on (outermost consumers)
- Children are the resources a parent depends on (created first)
- Removed the `nested_under_dependent` special case (no longer needed with flipped direction)
- Added 3 unit tests for `build_single_parent_tree` in `carina-core`
- Updated 19 snapshots (CLI + TUI) and 8 unit tests to match new tree direction

## Test plan

- [x] `cargo test` — all workspace tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Reviewed all updated snapshots for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)