### PR TITLE
fix: install LSP providers in .crn file's directory, not workspace root

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use carina_core::formatter::{self, FormatConfig};
@@ -77,10 +77,13 @@ pub type FactoryBuildResult = (
     HashMap<String, String>, // provider name -> error reason
 );
 
-/// Function type for building provider factories from configs and a base directory.
-/// This callback is provided by main.rs to keep provider-specific wiring out of the library.
-pub type FactoryBuilder =
-    Arc<dyn Fn(&[carina_core::parser::ProviderConfig], &Path) -> FactoryBuildResult + Send + Sync>;
+/// Function type for building provider factories from configs with their source directories.
+/// Each tuple is (source_directory, provider_config). The source directory is where the
+/// `.crn` file defining the provider was found, used for installing providers in the
+/// correct location rather than at the workspace root.
+pub type FactoryBuilder = Arc<
+    dyn Fn(&[(PathBuf, carina_core::parser::ProviderConfig)]) -> FactoryBuildResult + Send + Sync,
+>;
 
 pub struct Backend {
     client: Client,
@@ -162,9 +165,8 @@ impl Backend {
         // Build factories using the injected builder (runs WASM loading)
         let (factories, provider_errors) = tokio::task::spawn_blocking({
             let configs = provider_configs.clone();
-            let dir = workspace_root.clone();
             let builder = Arc::clone(factory_builder);
-            move || builder(&configs, &dir)
+            move || builder(&configs)
         })
         .await
         .unwrap_or_default();

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::PathBuf;
 
 use carina_core::parser::{ProviderConfig, ProviderContext};
 use carina_core::provider::ProviderFactory;
@@ -9,12 +9,13 @@ use carina_lsp::Backend;
 use carina_lsp::backend::FactoryBuildResult;
 
 /// Build provider factories from discovered provider configs.
-/// Returns loaded factories and a map of provider name -> error reason for failures.
-fn build_factories(providers: &[ProviderConfig], base_dir: &Path) -> FactoryBuildResult {
+/// Each entry is (source_directory, provider_config) so providers are installed
+/// in the directory containing the `.crn` file, not at the workspace root.
+fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResult {
     let mut factories: Vec<Box<dyn ProviderFactory>> = Vec::new();
     let mut errors: HashMap<String, String> = HashMap::new();
 
-    for config in providers {
+    for (source_dir, config) in providers {
         let source = match &config.source {
             Some(s) => s,
             None => {
@@ -30,7 +31,7 @@ fn build_factories(providers: &[ProviderConfig], base_dir: &Path) -> FactoryBuil
         let binary_path = if let Some(path) = source.strip_prefix("file://") {
             std::path::PathBuf::from(path)
         } else if source.starts_with("github.com/") {
-            match carina_provider_resolver::resolve_single_config(base_dir, config) {
+            match carina_provider_resolver::resolve_single_config(source_dir, config) {
                 Ok(path) => path,
                 Err(e) => {
                     errors.insert(config.name.clone(), e);

--- a/carina-lsp/src/workspace.rs
+++ b/carina-lsp/src/workspace.rs
@@ -1,17 +1,18 @@
 //! Workspace scanning: discover provider configurations from .crn files.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use carina_core::parser::{self, ProviderConfig, ProviderContext};
 
 /// Discover all provider configurations from .crn files in a workspace directory.
 ///
 /// Recursively scans the directory for files ending in `.crn`,
-/// parses each one, and collects all `provider` blocks. Duplicate provider
-/// names are deduplicated (first occurrence wins). Unreadable or unparseable
-/// files are silently skipped.
-pub fn discover_providers(workspace_root: &Path) -> Vec<ProviderConfig> {
+/// parses each one, and collects all `provider` blocks. Each provider is
+/// returned with the directory containing the `.crn` file it was found in.
+/// Duplicate provider names are deduplicated (first occurrence wins).
+/// Unreadable or unparseable files are silently skipped.
+pub fn discover_providers(workspace_root: &Path) -> Vec<(PathBuf, ProviderConfig)> {
     let mut seen_names = std::collections::HashSet::new();
     let mut providers = Vec::new();
     discover_providers_recursive(workspace_root, &mut seen_names, &mut providers);
@@ -21,7 +22,7 @@ pub fn discover_providers(workspace_root: &Path) -> Vec<ProviderConfig> {
 fn discover_providers_recursive(
     dir: &Path,
     seen_names: &mut std::collections::HashSet<String>,
-    providers: &mut Vec<ProviderConfig>,
+    providers: &mut Vec<(PathBuf, ProviderConfig)>,
 ) {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
@@ -37,9 +38,10 @@ fn discover_providers_recursive(
         {
             let ctx = ProviderContext::default();
             if let Ok(parsed) = parser::parse(&content, &ctx) {
+                let source_dir = path.parent().unwrap_or(dir);
                 for provider in parsed.providers {
                     if seen_names.insert(provider.name.clone()) {
-                        providers.push(provider);
+                        providers.push((source_dir.to_path_buf(), provider));
                     }
                 }
             }
@@ -63,7 +65,8 @@ mod tests {
 
         let providers = discover_providers(dir.path());
         assert_eq!(providers.len(), 1);
-        assert_eq!(providers[0].name, "aws");
+        assert_eq!(providers[0].1.name, "aws");
+        assert_eq!(providers[0].0, dir.path());
     }
 
     #[test]
@@ -82,7 +85,7 @@ mod tests {
 
         let providers = discover_providers(dir.path());
         assert_eq!(providers.len(), 2);
-        let names: Vec<&str> = providers.iter().map(|p| p.name.as_str()).collect();
+        let names: Vec<&str> = providers.iter().map(|p| p.1.name.as_str()).collect();
         assert!(names.contains(&"aws"));
         assert!(names.contains(&"awscc"));
     }
@@ -103,7 +106,7 @@ mod tests {
 
         let providers = discover_providers(dir.path());
         assert_eq!(providers.len(), 1);
-        assert_eq!(providers[0].name, "aws");
+        assert_eq!(providers[0].1.name, "aws");
     }
 
     #[test]
@@ -138,7 +141,7 @@ mod tests {
 
         let providers = discover_providers(dir.path());
         assert_eq!(providers.len(), 1);
-        assert_eq!(providers[0].name, "awscc");
+        assert_eq!(providers[0].1.name, "awscc");
     }
 
     #[test]
@@ -167,12 +170,74 @@ mod tests {
 
         let providers = discover_providers(dir.path());
         assert_eq!(providers.len(), 1);
-        assert_eq!(providers[0].name, "awscc");
+        assert_eq!(providers[0].1.name, "awscc");
+        assert_eq!(providers[0].0, nested);
     }
 
     #[test]
     fn discover_providers_nonexistent_directory() {
         let providers = discover_providers(Path::new("/nonexistent/path"));
         assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn discover_providers_returns_source_directory() {
+        let dir = TempDir::new().unwrap();
+        let sub_a = dir.path().join("env_a");
+        let sub_b = dir.path().join("env_b");
+        fs::create_dir_all(&sub_a).unwrap();
+        fs::create_dir_all(&sub_b).unwrap();
+
+        fs::write(
+            sub_a.join("providers.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            sub_b.join("providers.crn"),
+            "provider awscc {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 2);
+
+        for (source_dir, config) in &providers {
+            match config.name.as_str() {
+                "aws" => assert_eq!(source_dir, &sub_a),
+                "awscc" => assert_eq!(source_dir, &sub_b),
+                other => panic!("unexpected provider: {}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn discover_providers_dedup_preserves_source_directory() {
+        let dir = TempDir::new().unwrap();
+        let sub_a = dir.path().join("env_a");
+        let sub_b = dir.path().join("env_b");
+        fs::create_dir_all(&sub_a).unwrap();
+        fs::create_dir_all(&sub_b).unwrap();
+
+        fs::write(
+            sub_a.join("providers.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            sub_b.join("providers.crn"),
+            "provider aws {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let providers = discover_providers(dir.path());
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].1.name, "aws");
+        // Source directory should be one of the two (readdir order is not guaranteed)
+        assert!(
+            providers[0].0 == sub_a || providers[0].0 == sub_b,
+            "source_dir should be one of the subdirectories, got: {:?}",
+            providers[0].0
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `discover_providers()` now returns `Vec<(PathBuf, ProviderConfig)>` — each provider paired with the directory of the `.crn` file it was found in
- `FactoryBuilder` and `build_factories()` updated to pass the per-provider source directory to `resolve_single_config()` instead of the workspace root
- Providers are now installed (`.carina/`, `carina-providers.lock`) in the correct directory matching `carina init .` behavior

Closes #1698

## Test plan

- [x] Existing workspace discovery tests updated to verify source directories
- [x] New test: `discover_providers_returns_source_directory` — multi-directory layout returns correct per-provider directories
- [x] New test: `discover_providers_dedup_preserves_source_directory` — deduplication keeps a valid source directory
- [x] All 167 carina-lsp tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)