### PR TITLE
fix: distinguish missing schema from unknown resource type in LSP

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -72,6 +72,12 @@ impl ProviderState {
     }
 }
 
+impl ProviderState {
+    fn schema_count(&self) -> usize {
+        self.diagnostic_engine.schema_count()
+    }
+}
+
 /// Result of building provider factories: loaded factories + per-provider error messages.
 pub type FactoryBuildResult = (
     Vec<Box<dyn ProviderFactory>>,
@@ -186,10 +192,17 @@ impl Backend {
         let new_state = ProviderState::new(factories, provider_errors);
         *self.providers.write().await = new_state;
 
+        let schema_count = {
+            let providers = self.providers.read().await;
+            providers.schema_count()
+        };
         self.client
             .log_message(
                 MessageType::INFO,
-                format!("Loaded {} provider schema(s)", factory_count),
+                format!(
+                    "Loaded {} provider(s), {} resource type schema(s)",
+                    factory_count, schema_count
+                ),
             )
             .await;
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -80,6 +80,10 @@ impl DiagnosticEngine {
         }
     }
 
+    pub fn schema_count(&self) -> usize {
+        self.schemas.len()
+    }
+
     pub fn with_provider_errors(mut self, errors: HashMap<String, String>) -> Self {
         self.provider_errors = errors;
         self
@@ -126,22 +130,21 @@ impl DiagnosticEngine {
                 }
             }
 
-            // Files without provider declarations (modules) inherit providers from
-            // callers, so skip "Unknown resource type" errors — the schemas may not
-            // be available but that's expected.
-            let has_providers = !parsed.providers.is_empty();
-
             // Check resource types
             for resource in &parsed.resources {
                 let provider = &resource.id.provider;
                 let full_resource_type = format!("{}.{}", provider, resource.id.resource_type);
 
-                if !self.schemas.contains_key(&full_resource_type) && has_providers {
-                    // If the provider failed to load, show INFO with the reason
+                if !self.schemas.contains_key(&full_resource_type) {
+                    let provider_loaded = self.provider_names.contains(&provider.to_string());
+
                     if let Some(reason) = self.provider_errors.get(provider) {
-                        if let Some((line, col)) =
-                            self.find_resource_position(doc, &resource.id.resource_type)
-                        {
+                        // Provider failed to load
+                        if let Some((line, col)) = self.find_resource_type_position(
+                            doc,
+                            provider,
+                            &resource.id.resource_type,
+                        ) {
                             let end_col = col
                                 + resource.id.resource_type.len() as u32
                                 + provider.len() as u32
@@ -154,23 +157,50 @@ impl DiagnosticEngine {
                                 format!("Provider '{}' is not loaded: {}", provider, reason),
                             ));
                         }
-                    } else if let Some((line, col)) =
-                        self.find_resource_position(doc, &resource.id.resource_type)
-                    {
-                        let end_col = col
-                            + resource.id.resource_type.len() as u32
-                            + provider.len() as u32
-                            + 1; // "provider." prefix
-                        diagnostics.push(carina_diagnostic(
-                            line,
-                            col,
-                            end_col,
-                            DiagnosticSeverity::ERROR,
-                            format!(
-                                "Unknown resource type: {}.{}",
-                                provider, resource.id.resource_type
-                            ),
-                        ));
+                    } else if !provider_loaded {
+                        // Provider not loaded at all
+                        if let Some((line, col)) = self.find_resource_type_position(
+                            doc,
+                            provider,
+                            &resource.id.resource_type,
+                        ) {
+                            let end_col = col
+                                + resource.id.resource_type.len() as u32
+                                + provider.len() as u32
+                                + 1;
+                            diagnostics.push(carina_diagnostic(
+                                line,
+                                col,
+                                end_col,
+                                DiagnosticSeverity::ERROR,
+                                format!(
+                                    "Unknown resource type: {}.{}",
+                                    provider, resource.id.resource_type
+                                ),
+                            ));
+                        }
+                    } else {
+                        // Provider loaded but no schema for this resource type
+                        if let Some((line, col)) = self.find_resource_type_position(
+                            doc,
+                            provider,
+                            &resource.id.resource_type,
+                        ) {
+                            let end_col = col
+                                + resource.id.resource_type.len() as u32
+                                + provider.len() as u32
+                                + 1;
+                            diagnostics.push(carina_diagnostic(
+                                line,
+                                col,
+                                end_col,
+                                DiagnosticSeverity::WARNING,
+                                format!(
+                                    "No schema for {}.{} — attribute validation skipped",
+                                    provider, resource.id.resource_type
+                                ),
+                            ));
+                        }
                     }
                 }
 
@@ -180,8 +210,11 @@ impl DiagnosticEngine {
                     // Check data source without `read` keyword
                     if schema.data_source
                         && !resource.is_data_source()
-                        && let Some((line, col)) =
-                            self.find_resource_position(doc, &resource.id.resource_type)
+                        && let Some((line, col)) = self.find_resource_type_position(
+                            doc,
+                            provider,
+                            &resource.id.resource_type,
+                        )
                     {
                         let end_col = col
                             + resource.id.resource_type.len() as u32
@@ -498,7 +531,11 @@ impl DiagnosticEngine {
                                     None
                                 };
                             let position = position.or_else(|| {
-                                self.find_resource_position(doc, &resource.id.resource_type)
+                                self.find_resource_type_position(
+                                    doc,
+                                    provider,
+                                    &resource.id.resource_type,
+                                )
                             });
                             if let Some((line, col)) = position {
                                 diagnostics.push(carina_diagnostic_range(
@@ -646,18 +683,21 @@ impl DiagnosticEngine {
             .collect()
     }
 
-    fn find_resource_position(&self, doc: &Document, resource_type: &str) -> Option<(u32, u32)> {
+    fn find_resource_type_position(
+        &self,
+        doc: &Document,
+        provider: &str,
+        resource_type: &str,
+    ) -> Option<(u32, u32)> {
         let text = doc.text();
+        let pattern = format!("{}.{}", provider, resource_type);
 
         for (line_idx, line) in text.lines().enumerate() {
-            for provider_name in &self.provider_names {
-                let pattern = format!("{}.{}", provider_name, resource_type);
-                if let Some(byte_pos) = line.find(pattern.as_str()) {
-                    return Some((
-                        line_idx as u32,
-                        position::byte_offset_to_char_offset(line, byte_pos),
-                    ));
-                }
+            if let Some(byte_pos) = line.find(pattern.as_str()) {
+                return Some((
+                    line_idx as u32,
+                    position::byte_offset_to_char_offset(line, byte_pos),
+                ));
             }
         }
         None

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -126,12 +126,17 @@ impl DiagnosticEngine {
                 }
             }
 
+            // Files without provider declarations (modules) inherit providers from
+            // callers, so skip "Unknown resource type" errors — the schemas may not
+            // be available but that's expected.
+            let has_providers = !parsed.providers.is_empty();
+
             // Check resource types
             for resource in &parsed.resources {
                 let provider = &resource.id.provider;
                 let full_resource_type = format!("{}.{}", provider, resource.id.resource_type);
 
-                if !self.schemas.contains_key(&full_resource_type) {
+                if !self.schemas.contains_key(&full_resource_type) && has_providers {
                     // If the provider failed to load, show INFO with the reason
                     if let Some(reason) = self.provider_errors.get(provider) {
                         if let Some((line, col)) =

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1385,3 +1385,69 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
         diag.range.start.line
     );
 }
+
+#[test]
+fn module_file_no_unknown_resource_type_error() {
+    // Module files have arguments but no provider declarations.
+    // They should not get "Unknown resource type" errors even when the
+    // provider is known to the LSP (schemas loaded from workspace).
+    let engine = DiagnosticEngine::new(
+        Arc::new(HashMap::new()),
+        vec!["awscc".to_string()], // provider known but no schemas for iam.role
+        Arc::new(vec![]),
+    );
+    let doc = create_document(
+        r#"arguments {
+  github_repo: string
+  role_name: string
+}
+
+let role = awscc.iam.role {
+  role_name = role_name
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let unknown_type = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown resource type"));
+    assert!(
+        unknown_type.is_none(),
+        "Module file (no provider declarations) should not show 'Unknown resource type'. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn file_with_provider_still_shows_unknown_resource_type() {
+    // Files WITH provider declarations should still show "Unknown resource type"
+    // for types not in loaded schemas.
+    let engine = DiagnosticEngine::new(
+        Arc::new(HashMap::new()),
+        vec!["awscc".to_string()],
+        Arc::new(vec![]),
+    );
+    let doc = create_document(
+        r#"provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.role {
+  role_name = 'test'
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let unknown_type = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown resource type"));
+    assert!(
+        unknown_type.is_some(),
+        "File with provider declarations should still show 'Unknown resource type' for unloaded schemas. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1387,23 +1387,17 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
 }
 
 #[test]
-fn module_file_no_unknown_resource_type_error() {
-    // Module files have arguments but no provider declarations.
-    // They should not get "Unknown resource type" errors even when the
-    // provider is known to the LSP (schemas loaded from workspace).
+fn warning_when_provider_loaded_but_schema_missing() {
+    // Provider is loaded but doesn't have a schema for this resource type.
+    // Should show WARNING (not ERROR), not "Unknown resource type".
     let engine = DiagnosticEngine::new(
         Arc::new(HashMap::new()),
-        vec!["awscc".to_string()], // provider known but no schemas for iam.role
+        vec!["awscc".to_string()],
         Arc::new(vec![]),
     );
     let doc = create_document(
-        r#"arguments {
-  github_repo: string
-  role_name: string
-}
-
-let role = awscc.iam.role {
-  role_name = role_name
+        r#"awscc.iam.role {
+  role_name = 'test'
 }
 "#,
     );
@@ -1415,26 +1409,30 @@ let role = awscc.iam.role {
         .find(|d| d.message.contains("Unknown resource type"));
     assert!(
         unknown_type.is_none(),
-        "Module file (no provider declarations) should not show 'Unknown resource type'. Got: {:?}",
+        "Loaded provider should not show 'Unknown resource type'. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    let no_schema = diagnostics
+        .iter()
+        .find(|d| d.message.contains("No schema for"));
+    assert!(
+        no_schema.is_some(),
+        "Should show 'No schema' warning. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        no_schema.unwrap().severity,
+        Some(DiagnosticSeverity::WARNING)
     );
 }
 
 #[test]
-fn file_with_provider_still_shows_unknown_resource_type() {
-    // Files WITH provider declarations should still show "Unknown resource type"
-    // for types not in loaded schemas.
-    let engine = DiagnosticEngine::new(
-        Arc::new(HashMap::new()),
-        vec!["awscc".to_string()],
-        Arc::new(vec![]),
-    );
+fn error_when_provider_not_loaded_at_all() {
+    // Provider completely unknown — not in provider_names, not in errors.
+    let engine = DiagnosticEngine::new(Arc::new(HashMap::new()), vec![], Arc::new(vec![]));
     let doc = create_document(
-        r#"provider awscc {
-  region = awscc.Region.ap_northeast_1
-}
-
-awscc.iam.role {
+        r#"awscc.iam.role {
   role_name = 'test'
 }
 "#,
@@ -1447,7 +1445,7 @@ awscc.iam.role {
         .find(|d| d.message.contains("Unknown resource type"));
     assert!(
         unknown_type.is_some(),
-        "File with provider declarations should still show 'Unknown resource type' for unloaded schemas. Got: {:?}",
+        "Unknown provider should show 'Unknown resource type'. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Summary

- Provider loaded but no schema for a resource type → WARNING: "No schema for X — attribute validation skipped"
- Provider not loaded at all → ERROR: "Unknown resource type" (unchanged)
- Provider load error → INFO: "Provider not loaded" (unchanged)
- Log resource type schema count on startup
- Remove `find_resource_position` dependency on `provider_names` list

Closes #1706

## Test plan

- [x] `warning_when_provider_loaded_but_schema_missing` — WARNING shown, not ERROR
- [x] `error_when_provider_not_loaded_at_all` — ERROR preserved for unknown providers
- [x] All 169 LSP tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)