### PR TITLE
feat: scope LSP provider schemas per-directory

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use carina_core::formatter::{self, FormatConfig};
@@ -70,11 +70,40 @@ impl ProviderState {
             hover_provider: HoverProvider::new(schemas, region_completions),
         }
     }
-}
 
-impl ProviderState {
     fn schema_count(&self) -> usize {
         self.diagnostic_engine.schema_count()
+    }
+}
+
+/// Per-directory provider states keyed by configuration directory.
+struct ProviderStates {
+    /// Directory → ProviderState. Each directory with provider declarations
+    /// gets its own state with its own schemas.
+    by_dir: HashMap<PathBuf, ProviderState>,
+    /// Fallback state for files that don't belong to any config directory.
+    empty: ProviderState,
+}
+
+impl ProviderStates {
+    fn new() -> Self {
+        Self {
+            by_dir: HashMap::new(),
+            empty: ProviderState::new(vec![], HashMap::new()),
+        }
+    }
+
+    /// Find the ProviderState for a given file path by walking up the
+    /// directory tree to find the nearest config directory.
+    fn state_for_path(&self, file_path: &Path) -> &ProviderState {
+        let mut dir = file_path.parent();
+        while let Some(d) = dir {
+            if let Some(state) = self.by_dir.get(d) {
+                return state;
+            }
+            dir = d.parent();
+        }
+        &self.empty
     }
 }
 
@@ -95,7 +124,7 @@ pub type FactoryBuilder = Arc<
 pub struct Backend {
     client: Client,
     documents: DashMap<Url, Document>,
-    providers: tokio::sync::RwLock<ProviderState>,
+    providers: tokio::sync::RwLock<ProviderStates>,
     provider_context: Arc<ProviderContext>,
     workspace_root: tokio::sync::OnceCell<Option<PathBuf>>,
     factory_builder: Option<FactoryBuilder>,
@@ -108,13 +137,11 @@ impl Backend {
         factory_builder: Option<FactoryBuilder>,
     ) -> Self {
         let provider_context = Arc::new(provider_context);
-        // Start with empty schemas — they will be loaded asynchronously after initialize
-        let state = ProviderState::new(vec![], HashMap::new());
 
         Self {
             client,
             documents: DashMap::new(),
-            providers: tokio::sync::RwLock::new(state),
+            providers: tokio::sync::RwLock::new(ProviderStates::new()),
             provider_context,
             workspace_root: tokio::sync::OnceCell::new(),
             factory_builder,
@@ -134,9 +161,11 @@ impl Backend {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
             let providers = self.providers.read().await;
-            let diagnostics = providers
-                .diagnostic_engine
-                .analyze(&doc, base_path.as_deref());
+            let state = base_path
+                .as_ref()
+                .map(|p| providers.state_for_path(p))
+                .unwrap_or(&providers.empty);
+            let diagnostics = state.diagnostic_engine.analyze(&doc, base_path.as_deref());
             drop(providers);
 
             self.client
@@ -157,10 +186,9 @@ impl Backend {
             None => return,
         };
 
-        let provider_configs = workspace::discover_providers(&workspace_root);
-        if provider_configs.is_empty() {
-            // Clear schemas when no providers are configured
-            *self.providers.write().await = ProviderState::new(vec![], HashMap::new());
+        let dir_providers = workspace::discover_providers_by_dir(&workspace_root);
+        if dir_providers.is_empty() {
+            *self.providers.write().await = ProviderStates::new();
             let uris: Vec<Url> = self.documents.iter().map(|r| r.key().clone()).collect();
             for uri in uris {
                 self.update_diagnostics(uri).await;
@@ -168,40 +196,52 @@ impl Backend {
             return;
         }
 
-        // Build factories using the injected builder (runs WASM loading)
-        let (factories, provider_errors) = tokio::task::spawn_blocking({
-            let configs = provider_configs.clone();
-            let builder = Arc::clone(factory_builder);
-            move || builder(&configs)
-        })
-        .await
-        .unwrap_or_default();
+        // Build factories per directory. Each directory gets its own set of
+        // provider factories loaded from its own provider configs.
+        // WASM loading is cached on disk, so repeated loads are fast.
+        let mut states = ProviderStates::new();
+        let mut total_schemas = 0;
 
-        if !provider_errors.is_empty() {
-            for (name, reason) in &provider_errors {
+        for (dir, configs) in &dir_providers {
+            let dir_configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)> =
+                configs.iter().map(|c| (dir.clone(), c.clone())).collect();
+
+            let (dir_factories, dir_errors) = tokio::task::spawn_blocking({
+                let configs = dir_configs;
+                let builder = Arc::clone(factory_builder);
+                move || builder(&configs)
+            })
+            .await
+            .unwrap_or_default();
+
+            for (name, reason) in &dir_errors {
                 self.client
                     .log_message(
                         MessageType::WARNING,
-                        format!("Provider '{}' not loaded: {}", name, reason),
+                        format!(
+                            "Provider '{}' not loaded in {}: {}",
+                            name,
+                            dir.display(),
+                            reason
+                        ),
                     )
                     .await;
             }
+
+            let state = ProviderState::new(dir_factories, dir_errors);
+            total_schemas += state.schema_count();
+            states.by_dir.insert(dir.clone(), state);
         }
 
-        let factory_count = factories.len();
-        let new_state = ProviderState::new(factories, provider_errors);
-        *self.providers.write().await = new_state;
+        let dir_count = states.by_dir.len();
+        *self.providers.write().await = states;
 
-        let schema_count = {
-            let providers = self.providers.read().await;
-            providers.schema_count()
-        };
         self.client
             .log_message(
                 MessageType::INFO,
                 format!(
-                    "Loaded {} provider(s), {} resource type schema(s)",
-                    factory_count, schema_count
+                    "Loaded providers for {} directory(s), {} resource type schema(s) total",
+                    dir_count, total_schemas
                 ),
             )
             .await;
@@ -336,8 +376,12 @@ impl LanguageServer for Backend {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
             let providers = self.providers.read().await;
+            let state = base_path
+                .as_ref()
+                .map(|p| providers.state_for_path(p))
+                .unwrap_or(&providers.empty);
             let completions =
-                providers
+                state
                     .completion_provider
                     .complete(&doc, position, base_path.as_deref());
             return Ok(Some(CompletionResponse::Array(completions)));
@@ -355,7 +399,11 @@ impl LanguageServer for Backend {
                 .ok()
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
             let providers = self.providers.read().await;
-            return Ok(providers.hover_provider.hover_with_base_path(
+            let state = base_path
+                .as_ref()
+                .map(|p| providers.state_for_path(p))
+                .unwrap_or(&providers.empty);
+            return Ok(state.hover_provider.hover_with_base_path(
                 &doc,
                 position,
                 base_path.as_deref(),
@@ -371,8 +419,16 @@ impl LanguageServer for Backend {
         let uri = &params.text_document.uri;
 
         if let Some(doc) = self.documents.get(uri) {
+            let base_path = uri
+                .to_file_path()
+                .ok()
+                .and_then(|p| p.parent().map(|p| p.to_path_buf()));
             let providers = self.providers.read().await;
-            let tokens = providers.semantic_tokens_provider.tokenize(&doc.text());
+            let state = base_path
+                .as_ref()
+                .map(|p| providers.state_for_path(p))
+                .unwrap_or(&providers.empty);
+            let tokens = state.semantic_tokens_provider.tokenize(&doc.text());
             return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
                 result_id: None,
                 data: tokens,

--- a/carina-lsp/src/workspace.rs
+++ b/carina-lsp/src/workspace.rs
@@ -1,5 +1,6 @@
 //! Workspace scanning: discover provider configurations from .crn files.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -42,6 +43,49 @@ fn discover_providers_recursive(
                 for provider in parsed.providers {
                     if seen_names.insert(provider.name.clone()) {
                         providers.push((source_dir.to_path_buf(), provider));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Discover provider configurations grouped by directory.
+///
+/// Unlike `discover_providers` which deduplicates globally, this groups
+/// providers by their source directory. Each directory is an independent
+/// Carina configuration with its own set of providers.
+/// Within a single directory, duplicate provider names are deduplicated.
+pub fn discover_providers_by_dir(workspace_root: &Path) -> HashMap<PathBuf, Vec<ProviderConfig>> {
+    let mut result: HashMap<PathBuf, Vec<ProviderConfig>> = HashMap::new();
+    discover_by_dir_recursive(workspace_root, &mut result);
+    result
+}
+
+fn discover_by_dir_recursive(dir: &Path, result: &mut HashMap<PathBuf, Vec<ProviderConfig>>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            discover_by_dir_recursive(&path, result);
+        } else if path.extension().is_some_and(|ext| ext == "crn")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            let ctx = ProviderContext::default();
+            if let Ok(parsed) = parser::parse(&content, &ctx)
+                && !parsed.providers.is_empty()
+            {
+                let source_dir = path.parent().unwrap_or(dir).to_path_buf();
+                let dir_providers = result.entry(source_dir).or_default();
+                let seen: std::collections::HashSet<String> =
+                    dir_providers.iter().map(|p| p.name.clone()).collect();
+                for provider in parsed.providers {
+                    if !seen.contains(&provider.name) {
+                        dir_providers.push(provider);
                     }
                 }
             }
@@ -239,5 +283,86 @@ mod tests {
             "source_dir should be one of the subdirectories, got: {:?}",
             providers[0].0
         );
+    }
+
+    #[test]
+    fn discover_by_dir_groups_by_directory() {
+        let dir = TempDir::new().unwrap();
+        let env_a = dir.path().join("env_a");
+        let env_b = dir.path().join("env_b");
+        fs::create_dir_all(&env_a).unwrap();
+        fs::create_dir_all(&env_b).unwrap();
+
+        fs::write(
+            env_a.join("providers.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            env_b.join("providers.crn"),
+            "provider awscc {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let by_dir = discover_providers_by_dir(dir.path());
+        assert_eq!(by_dir.len(), 2);
+        assert_eq!(by_dir[&env_a].len(), 1);
+        assert_eq!(by_dir[&env_a][0].name, "aws");
+        assert_eq!(by_dir[&env_b].len(), 1);
+        assert_eq!(by_dir[&env_b][0].name, "awscc");
+    }
+
+    #[test]
+    fn discover_by_dir_same_provider_in_different_dirs_not_deduplicated() {
+        let dir = TempDir::new().unwrap();
+        let env_a = dir.path().join("env_a");
+        let env_b = dir.path().join("env_b");
+        fs::create_dir_all(&env_a).unwrap();
+        fs::create_dir_all(&env_b).unwrap();
+
+        // Same provider name in two directories — both should appear
+        fs::write(
+            env_a.join("providers.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            env_b.join("providers.crn"),
+            "provider aws {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let by_dir = discover_providers_by_dir(dir.path());
+        assert_eq!(by_dir.len(), 2);
+        assert!(by_dir.contains_key(&env_a));
+        assert!(by_dir.contains_key(&env_b));
+    }
+
+    #[test]
+    fn discover_by_dir_deduplicates_within_same_directory() {
+        let dir = TempDir::new().unwrap();
+        // Two files in the same directory both declare provider aws
+        fs::write(
+            dir.path().join("a.crn"),
+            "provider aws {\n  region = 'us-east-1'\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.crn"),
+            "provider aws {\n  region = 'ap-northeast-1'\n}\n",
+        )
+        .unwrap();
+
+        let by_dir = discover_providers_by_dir(dir.path());
+        assert_eq!(by_dir.len(), 1);
+        assert_eq!(by_dir[dir.path()].len(), 1);
+        assert_eq!(by_dir[dir.path()][0].name, "aws");
+    }
+
+    #[test]
+    fn discover_by_dir_empty_workspace() {
+        let dir = TempDir::new().unwrap();
+        let by_dir = discover_providers_by_dir(dir.path());
+        assert!(by_dir.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Each directory in a Carina workspace is an independent configuration. The LSP now
maintains per-directory `ProviderState` instead of one global set.

- `discover_providers_by_dir()` groups providers by directory (no cross-directory dedup)
- `ProviderStates` struct holds `HashMap<PathBuf, ProviderState>` + empty fallback
- `state_for_path()` walks up from file to nearest config directory
- All LSP handlers (diagnostics, completion, hover, semantic tokens) use per-directory state
- Factory building happens per directory (WASM disk cache keeps it fast)

Closes #1713

## Test plan

- [x] `discover_by_dir_groups_by_directory` — different dirs get separate entries
- [x] `discover_by_dir_same_provider_in_different_dirs_not_deduplicated` — same name in different dirs kept
- [x] `discover_by_dir_deduplicates_within_same_directory` — within-dir dedup works
- [x] `discover_by_dir_empty_workspace` — empty workspace returns empty map
- [x] All 173 LSP tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)