### PR TITLE
feat: resolve module providers from callers via import map

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -81,6 +81,9 @@ struct ProviderStates {
     /// Directory → ProviderState. Each directory with provider declarations
     /// gets its own state with its own schemas.
     by_dir: HashMap<PathBuf, ProviderState>,
+    /// Reverse import map: module directory → list of caller directories.
+    /// Used to resolve providers for module files that don't declare their own.
+    import_map: HashMap<PathBuf, Vec<PathBuf>>,
     /// Fallback state for files that don't belong to any config directory.
     empty: ProviderState,
 }
@@ -89,13 +92,18 @@ impl ProviderStates {
     fn new() -> Self {
         Self {
             by_dir: HashMap::new(),
+            import_map: HashMap::new(),
             empty: ProviderState::new(vec![], HashMap::new()),
         }
     }
 
-    /// Find the ProviderState for a given file path by walking up the
-    /// directory tree to find the nearest config directory.
+    /// Find the ProviderState for a given file path.
+    ///
+    /// 1. Walk up the directory tree to find the nearest config directory
+    /// 2. If not found, check if the file's directory is imported by a caller
+    ///    and use the caller's ProviderState
     fn state_for_path(&self, file_path: &Path) -> &ProviderState {
+        // First: walk up to find a config directory
         let mut dir = file_path.parent();
         while let Some(d) = dir {
             if let Some(state) = self.by_dir.get(d) {
@@ -103,6 +111,23 @@ impl ProviderStates {
             }
             dir = d.parent();
         }
+
+        // Second: check import map for module files
+        let file_dir = file_path.parent().unwrap_or(file_path);
+        let canonical = file_dir.canonicalize().unwrap_or(file_dir.to_path_buf());
+        if let Some(callers) = self.import_map.get(&canonical) {
+            for caller_dir in callers {
+                // Walk up from caller to find its config directory
+                let mut dir = Some(caller_dir.as_path());
+                while let Some(d) = dir {
+                    if let Some(state) = self.by_dir.get(d) {
+                        return state;
+                    }
+                    dir = d.parent();
+                }
+            }
+        }
+
         &self.empty
     }
 }
@@ -187,8 +212,12 @@ impl Backend {
         };
 
         let dir_providers = workspace::discover_providers_by_dir(&workspace_root);
+        let import_map = workspace::discover_import_map(&workspace_root);
+
         if dir_providers.is_empty() {
-            *self.providers.write().await = ProviderStates::new();
+            let mut states = ProviderStates::new();
+            states.import_map = import_map;
+            *self.providers.write().await = states;
             let uris: Vec<Url> = self.documents.iter().map(|r| r.key().clone()).collect();
             for uri in uris {
                 self.update_diagnostics(uri).await;
@@ -233,6 +262,7 @@ impl Backend {
             states.by_dir.insert(dir.clone(), state);
         }
 
+        states.import_map = import_map;
         let dir_count = states.by_dir.len();
         *self.providers.write().await = states;
 

--- a/carina-lsp/src/workspace.rs
+++ b/carina-lsp/src/workspace.rs
@@ -93,6 +93,63 @@ fn discover_by_dir_recursive(dir: &Path, result: &mut HashMap<PathBuf, Vec<Provi
     }
 }
 
+/// Build a reverse import map: module directory → set of caller directories.
+///
+/// Scans all `.crn` files in the workspace for `import` statements, resolves
+/// the relative paths to absolute module directories, and maps each module
+/// to the directories that import it. This allows module files to inherit
+/// their callers' provider schemas.
+pub fn discover_import_map(workspace_root: &Path) -> HashMap<PathBuf, Vec<PathBuf>> {
+    let mut result: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+    discover_imports_recursive(workspace_root, &mut result);
+    result
+}
+
+fn discover_imports_recursive(dir: &Path, result: &mut HashMap<PathBuf, Vec<PathBuf>>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            discover_imports_recursive(&path, result);
+        } else if path.extension().is_some_and(|ext| ext == "crn")
+            && let Ok(content) = fs::read_to_string(&path)
+        {
+            let ctx = ProviderContext::default();
+            if let Ok(parsed) = parser::parse(&content, &ctx) {
+                let caller_dir = path.parent().unwrap_or(dir);
+                for import in &parsed.imports {
+                    let module_path = caller_dir.join(&import.path);
+                    // Resolve to canonical directory (strip .crn extension, handle dirs)
+                    let module_dir = if module_path.is_dir() {
+                        module_path
+                    } else if module_path.extension().is_some_and(|ext| ext == "crn") {
+                        module_path.parent().unwrap_or(&module_path).to_path_buf()
+                    } else {
+                        // Try with .crn extension
+                        let with_ext = module_path.with_extension("crn");
+                        if with_ext.exists() {
+                            with_ext.parent().unwrap_or(&module_path).to_path_buf()
+                        } else {
+                            // Might be a directory module
+                            module_path
+                        }
+                    };
+                    // Canonicalize to resolve .. and symlinks
+                    let module_dir = module_dir.canonicalize().unwrap_or(module_dir);
+                    let caller_dir = caller_dir
+                        .canonicalize()
+                        .unwrap_or(caller_dir.to_path_buf());
+                    result.entry(module_dir).or_default().push(caller_dir);
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,5 +421,47 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let by_dir = discover_providers_by_dir(dir.path());
         assert!(by_dir.is_empty());
+    }
+
+    #[test]
+    fn discover_import_map_finds_module_callers() {
+        let dir = TempDir::new().unwrap();
+        let caller = dir.path().join("aws").join("github-oidc");
+        let module = dir.path().join("modules").join("github-oidc");
+        fs::create_dir_all(&caller).unwrap();
+        fs::create_dir_all(&module).unwrap();
+
+        // Caller imports the module
+        fs::write(
+            caller.join("main.crn"),
+            "let github = import '../../modules/github-oidc'\n",
+        )
+        .unwrap();
+        // Module has arguments (no provider)
+        fs::write(module.join("main.crn"), "arguments {\n  repo: string\n}\n").unwrap();
+
+        let import_map = discover_import_map(dir.path());
+
+        let module_canonical = module.canonicalize().unwrap();
+        assert!(
+            import_map.contains_key(&module_canonical),
+            "import_map should contain module dir. Keys: {:?}",
+            import_map.keys().collect::<Vec<_>>()
+        );
+
+        let callers = &import_map[&module_canonical];
+        let caller_canonical = caller.canonicalize().unwrap();
+        assert!(
+            callers.contains(&caller_canonical),
+            "callers should contain the caller dir. Got: {:?}",
+            callers
+        );
+    }
+
+    #[test]
+    fn discover_import_map_empty_workspace() {
+        let dir = TempDir::new().unwrap();
+        let import_map = discover_import_map(dir.path());
+        assert!(import_map.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `discover_import_map()` scans workspace for import statements and builds reverse map (module dir → caller dirs)
- `ProviderStates.state_for_path()` now checks the import map when a file's directory has no providers
- Module files inherit their caller's provider schemas for diagnostics, completion, and hover

Closes #1714

## Test plan

- [x] `discover_import_map_finds_module_callers` — import map correctly maps module to caller
- [x] `discover_import_map_empty_workspace` — empty workspace returns empty map
- [x] All 175 LSP tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)