### PR TITLE
fix: LSP state_for_path skipped the config directory itself

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -103,11 +103,22 @@ impl ProviderStates {
     /// 2. If not found, check if the file's directory is imported by a caller
     ///    and use the caller's ProviderState
     fn state_for_path(&self, file_path: &Path) -> &ProviderState {
-        // First: walk up to find a config directory
+        self.state_for_path_with_info(file_path).0
+    }
+
+    fn state_for_path_with_info(&self, file_path: &Path) -> (&ProviderState, Option<PathBuf>) {
+        // First: walk up to find a config directory (try both raw and canonical)
         let mut dir = file_path.parent();
         while let Some(d) = dir {
             if let Some(state) = self.by_dir.get(d) {
-                return state;
+                return (state, Some(d.to_path_buf()));
+            }
+            // Try canonical path in case the by_dir key is different
+            if let Ok(canonical) = d.canonicalize()
+                && canonical != d
+                && let Some(state) = self.by_dir.get(&canonical)
+            {
+                return (state, Some(canonical));
             }
             dir = d.parent();
         }
@@ -117,18 +128,17 @@ impl ProviderStates {
         let canonical = file_dir.canonicalize().unwrap_or(file_dir.to_path_buf());
         if let Some(callers) = self.import_map.get(&canonical) {
             for caller_dir in callers {
-                // Walk up from caller to find its config directory
                 let mut dir = Some(caller_dir.as_path());
                 while let Some(d) = dir {
                     if let Some(state) = self.by_dir.get(d) {
-                        return state;
+                        return (state, Some(d.to_path_buf()));
                     }
                     dir = d.parent();
                 }
             }
         }
 
-        &self.empty
+        (&self.empty, None)
     }
 }
 
@@ -186,10 +196,19 @@ impl Backend {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
             let providers = self.providers.read().await;
-            let state = base_path
+            let (state, matched_dir) = base_path
                 .as_ref()
-                .map(|p| providers.state_for_path(p))
-                .unwrap_or(&providers.empty);
+                .map(|p| {
+                    let (s, d) = providers.state_for_path_with_info(p);
+                    (s, d)
+                })
+                .unwrap_or((&providers.empty, None));
+            log::debug!(
+                "Diagnostics for {}: matched config dir = {:?}, provider_names = {:?}",
+                uri,
+                matched_dir,
+                state.diagnostic_engine.provider_names(),
+            );
             let diagnostics = state.diagnostic_engine.analyze(&doc, base_path.as_deref());
             drop(providers);
 

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -103,50 +103,38 @@ impl ProviderStates {
     /// 2. If not found, check if the file's directory is imported by a caller
     ///    and use the caller's ProviderState
     fn state_for_path(&self, file_path: &Path) -> &ProviderState {
-        self.state_for_path_with_info(file_path).0
-    }
-
-    fn state_for_path_with_info(&self, file_path: &Path) -> (&ProviderState, Option<PathBuf>) {
-        log::debug!(
-            "state_for_path: looking up file_path={}, by_dir keys={:?}",
-            file_path.display(),
-            self.by_dir
-                .keys()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-        );
-        // First: walk up to find a config directory (try both raw and canonical)
-        let mut dir = file_path.parent();
+        // Start from file_path itself (which is the file's parent directory),
+        // not file_path.parent() — the config dir might be the directory itself.
+        let mut dir = Some(file_path);
         while let Some(d) = dir {
             if let Some(state) = self.by_dir.get(d) {
-                return (state, Some(d.to_path_buf()));
+                return state;
             }
             // Try canonical path in case the by_dir key is different
             if let Ok(canonical) = d.canonicalize()
                 && canonical != d
                 && let Some(state) = self.by_dir.get(&canonical)
             {
-                return (state, Some(canonical));
+                return state;
             }
             dir = d.parent();
         }
 
-        // Second: check import map for module files
-        let file_dir = file_path.parent().unwrap_or(file_path);
-        let canonical = file_dir.canonicalize().unwrap_or(file_dir.to_path_buf());
+        // Check import map for module files
+        let canonical = file_path.canonicalize().unwrap_or(file_path.to_path_buf());
         if let Some(callers) = self.import_map.get(&canonical) {
             for caller_dir in callers {
                 let mut dir = Some(caller_dir.as_path());
                 while let Some(d) = dir {
                     if let Some(state) = self.by_dir.get(d) {
-                        return (state, Some(d.to_path_buf()));
+                        return state;
                     }
                     dir = d.parent();
                 }
             }
         }
 
-        (&self.empty, None)
+        &self.empty
     }
 }
 
@@ -204,19 +192,10 @@ impl Backend {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
             let providers = self.providers.read().await;
-            let (state, matched_dir) = base_path
+            let state = base_path
                 .as_ref()
-                .map(|p| {
-                    let (s, d) = providers.state_for_path_with_info(p);
-                    (s, d)
-                })
-                .unwrap_or((&providers.empty, None));
-            log::debug!(
-                "Diagnostics for {}: matched config dir = {:?}, provider_names = {:?}",
-                uri,
-                matched_dir,
-                state.diagnostic_engine.provider_names(),
-            );
+                .map(|p| providers.state_for_path(p))
+                .unwrap_or(&providers.empty);
             let diagnostics = state.diagnostic_engine.analyze(&doc, base_path.as_deref());
             drop(providers);
 
@@ -291,18 +270,13 @@ impl Backend {
 
         states.import_map = import_map;
         let dir_count = states.by_dir.len();
-        let dir_keys: Vec<String> = states
-            .by_dir
-            .keys()
-            .map(|p| p.display().to_string())
-            .collect();
         *self.providers.write().await = states;
         self.client
             .log_message(
                 MessageType::INFO,
                 format!(
-                    "Loaded providers for {} directory(s), {} resource type schema(s) total. Dirs: {:?}",
-                    dir_count, total_schemas, dir_keys
+                    "Loaded providers for {} directory(s), {} resource type schema(s) total",
+                    dir_count, total_schemas
                 ),
             )
             .await;

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -107,6 +107,14 @@ impl ProviderStates {
     }
 
     fn state_for_path_with_info(&self, file_path: &Path) -> (&ProviderState, Option<PathBuf>) {
+        log::debug!(
+            "state_for_path: looking up file_path={}, by_dir keys={:?}",
+            file_path.display(),
+            self.by_dir
+                .keys()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+        );
         // First: walk up to find a config directory (try both raw and canonical)
         let mut dir = file_path.parent();
         while let Some(d) = dir {
@@ -283,14 +291,18 @@ impl Backend {
 
         states.import_map = import_map;
         let dir_count = states.by_dir.len();
+        let dir_keys: Vec<String> = states
+            .by_dir
+            .keys()
+            .map(|p| p.display().to_string())
+            .collect();
         *self.providers.write().await = states;
-
         self.client
             .log_message(
                 MessageType::INFO,
                 format!(
-                    "Loaded providers for {} directory(s), {} resource type schema(s) total",
-                    dir_count, total_schemas
+                    "Loaded providers for {} directory(s), {} resource type schema(s) total. Dirs: {:?}",
+                    dir_count, total_schemas, dir_keys
                 ),
             )
             .await;

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -84,6 +84,10 @@ impl DiagnosticEngine {
         self.schemas.len()
     }
 
+    pub fn provider_names(&self) -> &[String] {
+        &self.provider_names
+    }
+
     pub fn with_provider_errors(mut self, errors: HashMap<String, String>) -> Self {
         self.provider_errors = errors;
         self

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -84,10 +84,6 @@ impl DiagnosticEngine {
         self.schemas.len()
     }
 
-    pub fn provider_names(&self) -> &[String] {
-        &self.provider_names
-    }
-
     pub fn with_provider_errors(mut self, errors: HashMap<String, String>) -> Self {
         self.provider_errors = errors;
         self

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1449,3 +1449,31 @@ fn error_when_provider_not_loaded_at_all() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn no_undefined_resource_for_namespaced_enum_value() {
+    // provider_names includes "awscc", so awscc.xxx.yyy.EnumType.VALUE
+    // should NOT be flagged as "Undefined resource"
+    let engine = DiagnosticEngine::new(
+        Arc::new(HashMap::new()),
+        vec!["awscc".to_string()],
+        Arc::new(vec![]),
+    );
+    let doc = create_document(
+        r#"awscc.organizations.organization {
+  feature_set = awscc.organizations.organization.FeatureSet.ALL
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let undefined = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource"));
+    assert!(
+        undefined.is_none(),
+        "Namespaced enum value should not be flagged as undefined resource. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

`state_for_path` received the file's parent directory (e.g., `/aws/management/organizations`)
but started walking from `file_path.parent()` (e.g., `/aws/management`), completely skipping
the directory itself. This caused all `by_dir` lookups to miss, resulting in empty
`provider_names` and false "Undefined resource" errors.

Fix: start the walk from `file_path` itself (which is already the directory), not its parent.

Closes #1718

## Root cause

Introduced in #1713 (per-directory schema scoping). The `state_for_path` function assumed
`file_path` was a file, but it actually receives the file's parent directory from
`uri.to_file_path().parent()` in `update_diagnostics`.

## Test plan

- [x] All 176 LSP tests pass
- [x] Clippy clean
- [x] Verified via debug logging that config dir now matches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)