### PR TITLE
fix: type completions inside list()/map() in arguments blocks

### DIFF
--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -990,3 +990,51 @@ versioning_configuration {
         labels
     );
 }
+
+#[test]
+fn type_completion_inside_list_shows_basic_types() {
+    let provider = test_provider();
+    let doc = create_document("arguments {\nitems: list(s");
+    let position = Position {
+        line: 1,
+        character: 13,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"string"),
+        "Type completions inside list() should include 'string'. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"list("),
+        "Type completions inside list() should NOT include 'list('. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn type_completion_inside_map_shows_basic_types() {
+    let provider = test_provider();
+    let doc = create_document("arguments {\ndata: map(");
+    let position = Position {
+        line: 1,
+        character: 11,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"string"),
+        "Type completions inside map() should include 'string'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"int"),
+        "Type completions inside map() should include 'int'. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -880,18 +880,24 @@ impl CompletionProvider {
         let line_idx = position.line as usize;
         let col = position.character as usize;
 
-        let type_start = if line_idx < lines.len() {
+        let (type_start, inside_generic) = if line_idx < lines.len() {
             let prefix: String = lines[line_idx].chars().take(col).collect();
-            // Find the colon and position right after it (plus any whitespace)
+            // Check if cursor is inside list() or map() — find last open paren after colon
             if let Some(colon_pos) = prefix.rfind(':') {
                 let after_colon = &prefix[colon_pos + 1..];
-                let whitespace_len = after_colon.len() - after_colon.trim_start().len();
-                (colon_pos + 1 + whitespace_len) as u32
+                if let Some(paren_pos) = after_colon.rfind('(') {
+                    // Inside list() or map(): start after the open paren
+                    let abs_paren = colon_pos + 1 + paren_pos + 1;
+                    (abs_paren as u32, true)
+                } else {
+                    let whitespace_len = after_colon.len() - after_colon.trim_start().len();
+                    ((colon_pos + 1 + whitespace_len) as u32, false)
+                }
             } else {
-                position.character
+                (position.character, false)
             }
         } else {
-            position.character
+            (position.character, false)
         };
 
         let replacement_range = Range {
@@ -914,15 +920,20 @@ impl CompletionProvider {
             type_completion_item(name.to_string(), detail.to_string(), replacement_range)
         });
 
-        // Generic type constructors
-        let generic = [
-            ("list(", "List type constructor"),
-            ("map(", "Map type constructor"),
-        ]
-        .iter()
-        .map(|(name, detail)| {
-            type_completion_item(name.to_string(), detail.to_string(), replacement_range)
-        });
+        // Generic type constructors (skip when already inside list()/map())
+        let generic: Vec<CompletionItem> = if inside_generic {
+            vec![]
+        } else {
+            [
+                ("list(", "List type constructor"),
+                ("map(", "Map type constructor"),
+            ]
+            .iter()
+            .map(|(name, detail)| {
+                type_completion_item(name.to_string(), detail.to_string(), replacement_range)
+            })
+            .collect()
+        };
 
         // Custom types from provider validators
         let custom = self.custom_type_names.iter().map(move |name| {


### PR DESCRIPTION
## Summary

- Fix replacement range for type completions inside `list()`/`map()` to start after `(` not `:`
- Exclude `list(` and `map(` from completions when already inside a generic type constructor

Closes #1702

## Test plan

- [x] `type_completion_inside_list_shows_basic_types` — `string` appears, `list(` does not
- [x] `type_completion_inside_map_shows_basic_types` — `string` and `int` appear
- [x] All 178 LSP tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)