### PR TITLE
feat: LSP uses installed providers only, no auto-download

### DIFF
--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -31,7 +31,9 @@ fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResul
         let binary_path = if let Some(path) = source.strip_prefix("file://") {
             std::path::PathBuf::from(path)
         } else if source.starts_with("github.com/") {
-            match carina_provider_resolver::resolve_single_config(source_dir, config) {
+            // LSP uses find_installed_provider (no download) instead of
+            // resolve_single_config to avoid filesystem side effects.
+            match carina_provider_resolver::find_installed_provider(source_dir, config) {
                 Ok(path) => path,
                 Err(e) => {
                     errors.insert(config.name.clone(), e);

--- a/carina-provider-resolver/src/provider_resolver.rs
+++ b/carina-provider-resolver/src/provider_resolver.rs
@@ -446,6 +446,74 @@ pub fn resolve_single_config(base_dir: &Path, config: &ProviderConfig) -> Result
     Ok(binary_path)
 }
 
+/// Find an already-installed provider without downloading.
+///
+/// Checks local project cache, global plugin cache, and lock file entries.
+/// Returns the path to the WASM binary if found, or an error suggesting
+/// `carina init` if not installed.
+///
+/// This is used by the LSP to avoid filesystem side effects from the editor.
+pub fn find_installed_provider(
+    base_dir: &Path,
+    config: &ProviderConfig,
+) -> Result<PathBuf, String> {
+    let source = config
+        .source
+        .as_deref()
+        .ok_or_else(|| format!("Provider '{}' has no source", config.name))?;
+
+    let lock_path = base_dir.join("carina-providers.lock");
+    let lock_file = LockFile::load(&lock_path).unwrap_or_default();
+
+    // Check revision-based cache
+    if let Some(revision) = &config.revision {
+        if let Some(lock_entry) = lock_file.find_by_source(source)
+            && let Some(ref sha) = lock_entry.resolved_sha
+        {
+            let wasm_path = crate::revision_resolver::cache_path_revision(base_dir, source, sha);
+            if wasm_path.exists() {
+                return Ok(wasm_path);
+            }
+            // Check global cache
+            if let Some(global_path) =
+                crate::revision_resolver::global_cache_path_revision(source, sha)
+                && global_path.exists()
+            {
+                return Ok(global_path);
+            }
+        }
+        return Err(format!(
+            "not installed. Run `carina init` in {} to install (revision: {})",
+            base_dir.display(),
+            revision
+        ));
+    }
+
+    // Check version-based cache
+    if let Some(lock_entry) = lock_file.find_by_source(source) {
+        let version = &lock_entry.version;
+        let wasm_path = cache_path_wasm(base_dir, source, version);
+        if wasm_path.exists() {
+            return Ok(wasm_path);
+        }
+        let binary_path = cache_path(base_dir, source, version);
+        if binary_path.exists() {
+            return Ok(binary_path);
+        }
+        // Check global cache
+        if let Some(global_wasm) = global_cache_path_wasm(source, version)
+            && global_wasm.exists()
+        {
+            return Ok(global_wasm);
+        }
+    }
+
+    Err(format!(
+        "not installed. Run `carina init` in {}",
+        base_dir.display()
+    ))
+}
+
 /// Returns true if the given path points to a WASM provider binary.
 pub fn is_wasm_provider(path: &Path) -> bool {
     path.extension().is_some_and(|ext| ext == "wasm")

--- a/carina-provider-resolver/src/revision_resolver.rs
+++ b/carina-provider-resolver/src/revision_resolver.rs
@@ -330,7 +330,7 @@ pub fn cache_path_revision(base_dir: &Path, source: &str, sha: &str) -> PathBuf 
         .join(format!("{repo}.wasm"))
 }
 
-fn global_cache_path_revision(source: &str, sha: &str) -> Option<PathBuf> {
+pub(crate) fn global_cache_path_revision(source: &str, sha: &str) -> Option<PathBuf> {
     let repo = source.split('/').next_back().unwrap_or("provider");
     let sha_prefix = &sha[..sha.len().min(12)];
     super::provider_resolver::global_cache_dir().map(|dir| {


### PR DESCRIPTION
## Summary

- Add `find_installed_provider()` to carina-provider-resolver — checks local project cache and global plugin cache without downloading
- LSP's `build_factories` uses `find_installed_provider` instead of `resolve_single_config`
- Missing providers show "not installed. Run \`carina init\` in <dir>" as a diagnostic
- No filesystem side effects from opening files in the editor

Closes #1730

## Test plan

- [x] All 37 carina-provider-resolver tests pass
- [x] All 180 LSP tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)