### PR TITLE
feat: add module binding name completion at top level

### DIFF
--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1071,3 +1071,25 @@ fn type_completion_inside_map_shows_basic_types() {
         labels
     );
 }
+
+#[test]
+fn module_binding_completion_at_top_level() {
+    let provider = test_provider();
+    let doc = create_document("let github = import './modules/github-oidc'\n\ng");
+    let position = Position {
+        line: 2,
+        character: 1,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"github"),
+        "Top-level completions should include module binding 'github'. Got: {:?}",
+        labels
+    );
+
+    let github_completion = completions.iter().find(|c| c.label == "github").unwrap();
+    assert_eq!(github_completion.kind, Some(CompletionItemKind::MODULE));
+}

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -154,6 +154,28 @@ impl CompletionProvider {
             },
         ];
 
+        // Generate module binding completions from import statements
+        // e.g., "let github = import '...'" → suggest "github" with call scaffold
+        for line in lines.iter() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("let ")
+                && let Some(eq_pos) = rest.find('=')
+            {
+                let binding = rest[..eq_pos].trim();
+                let after_eq = rest[eq_pos + 1..].trim();
+                if after_eq.starts_with("import ") && !binding.is_empty() && binding != "_" {
+                    completions.push(CompletionItem {
+                        label: binding.to_string(),
+                        kind: Some(CompletionItemKind::MODULE),
+                        insert_text: Some(format!("{} {{\n    ${{1}}\n}}", binding)),
+                        insert_text_format: Some(InsertTextFormat::SNIPPET),
+                        detail: Some("Module call".to_string()),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
         // Generate resource type completions from schemas
         for (resource_type, schema) in self.schemas.iter() {
             let description = schema


### PR DESCRIPTION
## Summary

- Scan `let <name> = import '...'` statements in the document
- Suggest module binding names as top-level completions (MODULE kind)
- Selecting a completion inserts a call block scaffold with cursor inside

This addresses item #1 from #1720. Item #2 (argument completion inside module calls) is already implemented.

refs #1720

## Test plan

- [x] `module_binding_completion_at_top_level` — "github" appears with MODULE kind
- [x] Full workspace tests pass
- [x] Clippy clean
- [x] Simplify: no issues
- [x] Review: 5 rounds, fixed `_` binding exclusion in round 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)