### PR TITLE
feat: add import path completion with filesystem listing

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -88,6 +88,9 @@ impl CompletionProvider {
                 self.region_completions_for_provider(&provider_name)
             }
             CompletionContext::InTypePosition => self.ref_type_completions(position, &text),
+            CompletionContext::InsideImportPath { partial_path } => {
+                self.import_path_completions(&partial_path, base_path)
+            }
             CompletionContext::None => vec![],
         }
     }
@@ -111,6 +114,22 @@ impl CompletionProvider {
             if prefix.contains(&dot_pattern) || prefix.ends_with(&end_pattern) {
                 return CompletionContext::AfterProviderRegion {
                     provider_name: provider_name.clone(),
+                };
+            }
+        }
+
+        // Check if cursor is inside an import path string
+        // e.g., let x = import './modules/|'
+        if let Some(import_pos) = prefix.find("import ") {
+            let after_import = &prefix[import_pos + 7..];
+            let trimmed = after_import.trim_start();
+            if (trimmed.starts_with('\'') || trimmed.starts_with('"'))
+                && !trimmed[1..].contains(trimmed.chars().next().unwrap())
+            {
+                // Inside an unclosed quote after "import"
+                let partial_path = &trimmed[1..]; // strip opening quote
+                return CompletionContext::InsideImportPath {
+                    partial_path: partial_path.to_string(),
                 };
             }
         }
@@ -490,5 +509,8 @@ enum CompletionContext {
         provider_name: String,
     },
     InTypePosition,
+    InsideImportPath {
+        partial_path: String,
+    },
     None,
 }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1093,3 +1093,37 @@ fn module_binding_completion_at_top_level() {
     let github_completion = completions.iter().find(|c| c.label == "github").unwrap();
     assert_eq!(github_completion.kind, Some(CompletionItemKind::MODULE));
 }
+
+#[test]
+fn import_path_completion_lists_directories_and_crn_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let modules_dir = tmp.path().join("modules");
+    std::fs::create_dir_all(&modules_dir).unwrap();
+    std::fs::write(
+        modules_dir.join("web.crn"),
+        "arguments {\n  name: string\n}\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(modules_dir.join("shared")).unwrap();
+
+    let provider = test_provider();
+    let doc = create_document("let web = import './modules/");
+    let position = Position {
+        line: 0,
+        character: 28,
+    };
+
+    let completions = provider.complete(&doc, position, Some(tmp.path()));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"web"),
+        "Should suggest 'web' (.crn file without extension). Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"shared/"),
+        "Should suggest 'shared/' directory. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -382,4 +382,79 @@ impl CompletionProvider {
         }
         None
     }
+
+    /// Generate import path completions from filesystem.
+    ///
+    /// Lists directories and `.crn` files relative to the base_path,
+    /// using the partial_path to determine which directory to list.
+    pub(super) fn import_path_completions(
+        &self,
+        partial_path: &str,
+        base_path: Option<&Path>,
+    ) -> Vec<CompletionItem> {
+        let base = match base_path {
+            Some(b) => b,
+            None => return vec![],
+        };
+
+        // Split partial_path into directory prefix and filename prefix
+        let (dir_part, name_prefix) = if let Some(last_slash) = partial_path.rfind('/') {
+            (
+                &partial_path[..=last_slash],
+                &partial_path[last_slash + 1..],
+            )
+        } else {
+            ("", partial_path)
+        };
+
+        let search_dir = base.join(dir_part);
+        let entries = match std::fs::read_dir(&search_dir) {
+            Ok(entries) => entries,
+            Err(_) => return vec![],
+        };
+
+        let mut completions = Vec::new();
+
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let name = file_name.to_string_lossy();
+
+            // Skip hidden files/dirs
+            if name.starts_with('.') {
+                continue;
+            }
+
+            let path = entry.path();
+            if path.is_dir() {
+                // Directory: suggest as path component
+                if name.starts_with(name_prefix) {
+                    completions.push(CompletionItem {
+                        label: format!("{}/", name),
+                        kind: Some(CompletionItemKind::FOLDER),
+                        insert_text: Some(format!("{}/", name)),
+                        detail: Some("Directory".to_string()),
+                        command: Some(Command {
+                            title: "Trigger Suggest".to_string(),
+                            command: "editor.action.triggerSuggest".to_string(),
+                            arguments: None,
+                        }),
+                        ..Default::default()
+                    });
+                }
+            } else if name.ends_with(".crn") && name.starts_with(name_prefix) {
+                // .crn file: suggest without extension
+                let stem = name.strip_suffix(".crn").unwrap_or(&name);
+                completions.push(CompletionItem {
+                    label: stem.to_string(),
+                    kind: Some(CompletionItemKind::FILE),
+                    insert_text: Some(stem.to_string()),
+                    detail: Some("Carina module".to_string()),
+                    ..Default::default()
+                });
+            }
+        }
+
+        completions.sort_by(|a, b| a.label.cmp(&b.label));
+        completions
+    }
 }


### PR DESCRIPTION
## Summary

- Detect `InsideImportPath` context when cursor is in an import string
- List directories (with `/` suffix) and `.crn` files (without extension) as completions
- Directories trigger follow-up completion via `triggerSuggest` command
- Hidden files excluded

This addresses item #4 from #1720.

refs #1720

## Test plan

- [x] `import_path_completion_lists_directories_and_crn_files` — directories and .crn files listed
- [x] Full workspace tests pass (all crates)
- [x] Clippy clean
- [x] Simplify: no issues
- [x] Review: 5 rounds, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)