### PR TITLE
feat: scaffold module call with argument tab stops

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -55,7 +55,7 @@ impl CompletionProvider {
         let context = self.get_completion_context(&text, position);
 
         match context {
-            CompletionContext::TopLevel => self.top_level_completions(position, &text),
+            CompletionContext::TopLevel => self.top_level_completions(position, &text, base_path),
             CompletionContext::InsideResourceBlock { resource_type } => {
                 self.attribute_completions_for_type(&resource_type)
             }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1095,6 +1095,38 @@ fn module_binding_completion_at_top_level() {
 }
 
 #[test]
+fn module_call_scaffolding_includes_arguments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let module_dir = tmp.path().join("modules").join("web");
+    std::fs::create_dir_all(&module_dir).unwrap();
+    std::fs::write(
+        module_dir.join("main.crn"),
+        "arguments {\n  name: string\n  port: int\n}\n",
+    )
+    .unwrap();
+
+    let provider = test_provider();
+    let doc = create_document("let web = import './modules/web'\n\nw");
+    let position = Position {
+        line: 2,
+        character: 1,
+    };
+
+    let completions = provider.complete(&doc, position, Some(tmp.path()));
+    let web_completion = completions
+        .iter()
+        .find(|c| c.label == "web")
+        .expect("Should have 'web' completion");
+
+    let snippet = web_completion.insert_text.as_deref().unwrap();
+    assert!(
+        snippet.contains("name") && snippet.contains("port"),
+        "Scaffold should include all arguments. Got:\n{}",
+        snippet
+    );
+}
+
+#[test]
 fn import_path_completion_lists_directories_and_crn_files() {
     let tmp = tempfile::tempdir().unwrap();
     let modules_dir = tmp.path().join("modules");

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -15,6 +15,7 @@ impl CompletionProvider {
         &self,
         position: Position,
         text: &str,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         // Calculate the range for resource type replacements
         // Find where the current word/prefix starts on this line
@@ -164,10 +165,12 @@ impl CompletionProvider {
                 let binding = rest[..eq_pos].trim();
                 let after_eq = rest[eq_pos + 1..].trim();
                 if after_eq.starts_with("import ") && !binding.is_empty() && binding != "_" {
+                    // Try to load module and scaffold arguments
+                    let snippet = self.build_module_call_snippet(binding, after_eq, base_path);
                     completions.push(CompletionItem {
                         label: binding.to_string(),
                         kind: Some(CompletionItemKind::MODULE),
-                        insert_text: Some(format!("{} {{\n    ${{1}}\n}}", binding)),
+                        insert_text: Some(snippet),
                         insert_text_format: Some(InsertTextFormat::SNIPPET),
                         detail: Some("Module call".to_string()),
                         ..Default::default()
@@ -381,6 +384,54 @@ impl CompletionProvider {
             }
         }
         None
+    }
+
+    /// Build a snippet for a module call with argument placeholders.
+    ///
+    /// If the module can be loaded, generates a snippet with all arguments
+    /// as tab stops. Falls back to a simple `name { ${1} }` if loading fails.
+    fn build_module_call_snippet(
+        &self,
+        binding: &str,
+        after_eq: &str,
+        base_path: Option<&Path>,
+    ) -> String {
+        // Extract import path from "import 'path'" or "import \"path\""
+        let import_path = after_eq
+            .strip_prefix("import ")
+            .and_then(|s| {
+                s.trim()
+                    .strip_prefix('\'')
+                    .and_then(|s| s.strip_suffix('\''))
+            })
+            .or_else(|| {
+                after_eq
+                    .strip_prefix("import ")
+                    .and_then(|s| s.trim().strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+            });
+
+        if let Some(path) = import_path
+            && let Some(base) = base_path
+            && let Some(parsed) = carina_core::module_resolver::load_module(&base.join(path))
+            && !parsed.arguments.is_empty()
+        {
+            let mut snippet = format!("{} {{\n", binding);
+            let max_len = parsed
+                .arguments
+                .iter()
+                .map(|a| a.name.len())
+                .max()
+                .unwrap_or(0);
+            for (i, arg) in parsed.arguments.iter().enumerate() {
+                let padding = " ".repeat(max_len - arg.name.len());
+                snippet.push_str(&format!("  {}{} = ${{{}}}\n", arg.name, padding, i + 1));
+            }
+            snippet.push('}');
+            return snippet;
+        }
+
+        // Fallback: simple scaffold
+        format!("{} {{\n  ${{1}}\n}}", binding)
     }
 
     /// Generate import path completions from filesystem.


### PR DESCRIPTION
## Summary

- `build_module_call_snippet` loads the module file and generates a snippet with all arguments as tab stops
- Arguments are aligned by name length for readability
- Falls back to simple `name { ${1} }` if module cannot be loaded
- `top_level_completions` now receives `base_path` for filesystem access

This is the final item (#3) from #1720. All four items are now complete:
1. ✅ Module binding completion (#1741)
2. ✅ Module argument completion (pre-existing)
3. ✅ Call scaffolding (this PR)
4. ✅ Import path completion (#1742)

Closes #1720

## Test plan

- [x] `module_call_scaffolding_includes_arguments` — scaffold includes name and port arguments
- [x] `module_binding_completion_at_top_level` — existing test still passes (fallback)
- [x] All 183 LSP tests pass
- [x] Clippy clean
- [x] Simplify: no issues
- [x] Review: 5 rounds, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)