### PR TITLE
feat: add Custom type to WASM provider protocol

### DIFF
--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -366,6 +366,17 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
         proto::AttributeType::Union { members } => {
             CoreAttributeType::Union(members.iter().map(proto_attr_type_to_core).collect())
         }
+        proto::AttributeType::Custom {
+            name,
+            base,
+            namespace,
+        } => CoreAttributeType::Custom {
+            name: name.clone(),
+            base: Box::new(proto_attr_type_to_core(base)),
+            validate: |_| Ok(()), // Validation is handled via ProviderContext.validators
+            namespace: namespace.clone(),
+            to_dsl: None,
+        },
     }
 }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -260,6 +260,17 @@ pub enum AttributeType {
     Union {
         members: Vec<AttributeType>,
     },
+    /// Custom type with a name and base type. The validation function is
+    /// resolved on the host side; the protocol only carries the type name
+    /// and underlying base type.
+    #[serde(rename = "custom")]
+    Custom {
+        name: String,
+        base: Box<AttributeType>,
+        /// Optional namespace for enum-style validation
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Add `Custom { name, base, namespace }` variant to `carina-provider-protocol::AttributeType`
- Add Custom → CoreAttributeType::Custom conversion in `wasm_convert.rs`
- Enables `collect_custom_type_names()` to discover provider-defined types from WASM providers

Provider crates (aws/awscc) need a follow-up change to serialize their Custom types through this new variant.

refs #1728

## Test plan

- [x] All provider-protocol tests pass (14)
- [x] All plugin-host tests pass (49 + 1 + 5 + 6)
- [x] Full workspace tests pass
- [x] Clippy clean
- [x] Simplify: no issues
- [x] Review: 5 rounds, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)