### PR TITLE
feat: add validate-custom-type WIT interface for WASM provider plugins

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod validate;
 
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
 
 use carina_core::module_resolver;
 use carina_core::parser::{BackendConfig, ParsedFile, ProviderContext};
@@ -124,13 +125,20 @@ pub fn validate_and_resolve(
 }
 
 /// Create a `ProviderContext` with custom type validators extracted from
-/// the already-collected schema map.
+/// the already-collected schema map and factory-based validation for WASM providers.
 fn enrich_provider_context(
     schemas: &std::collections::HashMap<String, carina_core::schema::ResourceSchema>,
+    factories: Arc<Vec<Box<dyn carina_core::provider::ProviderFactory>>>,
 ) -> ProviderContext {
     ProviderContext {
         decryptor: None,
         validators: carina_core::provider::collect_custom_type_validators(schemas),
+        custom_type_validator: Some(Box::new(move |type_name: &str, value: &str| {
+            for factory in factories.iter() {
+                factory.validate_custom_type(type_name, value)?;
+            }
+            Ok(())
+        })),
     }
 }
 
@@ -167,7 +175,7 @@ pub fn validate_and_resolve_with_config(
     validate_provider_region_with_ctx(&ctx, parsed)?;
 
     // Enrich provider context with custom type validators from loaded schemas
-    let enriched_context = enrich_provider_context(ctx.schemas());
+    let enriched_context = enrich_provider_context(ctx.schemas(), ctx.factories_arc());
 
     // Validate module call arguments before expansion (needs enriched context for custom type validators)
     validate_module_calls(parsed, base_dir, &enriched_context)?;

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -289,6 +289,7 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
             })
         })),
         validators: std::collections::HashMap::new(),
+        custom_type_validator: None,
     }
 }
 

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 use colored::Colorize;
@@ -43,18 +44,25 @@ pub struct PlanContext {
 /// site (which rebuilds the full schema set every time), create a single
 /// `WiringContext` and pass it through the command execution path.
 pub struct WiringContext {
-    factories: Vec<Box<dyn ProviderFactory>>,
+    factories: Arc<Vec<Box<dyn ProviderFactory>>>,
     schemas: HashMap<String, ResourceSchema>,
 }
 
 impl WiringContext {
     pub fn new(factories: Vec<Box<dyn ProviderFactory>>) -> Self {
         let schemas = provider_mod::collect_schemas(&factories);
-        Self { factories, schemas }
+        Self {
+            factories: Arc::new(factories),
+            schemas,
+        }
     }
 
     pub fn factories(&self) -> &[Box<dyn ProviderFactory>] {
         &self.factories
+    }
+
+    pub fn factories_arc(&self) -> Arc<Vec<Box<dyn ProviderFactory>>> {
+        Arc::clone(&self.factories)
     }
 
     pub fn schemas(&self) -> &HashMap<String, ResourceSchema> {

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -92,6 +92,7 @@ mod tests {
         ProviderContext {
             decryptor: Some(decrypt_fn),
             validators: HashMap::new(),
+            custom_type_validator: None,
         }
     }
 

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -2965,6 +2965,7 @@ mod tests {
         let config = ProviderContext {
             decryptor: None,
             validators,
+            custom_type_validator: None,
         };
 
         let mut module = create_test_module();
@@ -3036,6 +3037,7 @@ mod tests {
         let config = ProviderContext {
             decryptor: None,
             validators,
+            custom_type_validator: None,
         };
 
         let mut module = create_test_module();

--- a/carina-core/src/parser/config.rs
+++ b/carina-core/src/parser/config.rs
@@ -10,6 +10,12 @@ use std::collections::HashMap;
 /// Takes a string value and returns `Ok(())` if valid, or `Err(message)` if invalid.
 pub type ValidatorFn = Box<dyn Fn(&str) -> Result<(), String> + Send + Sync>;
 
+/// Signature for a factory-based custom type validator.
+///
+/// Takes `(type_name, value)` and returns `Ok(())` if valid or unknown,
+/// or `Err(message)` if invalid.
+pub type CustomTypeValidatorFn = Box<dyn Fn(&str, &str) -> Result<(), String> + Send + Sync>;
+
 /// Signature for a decryptor function.
 ///
 /// Takes `(ciphertext, optional_key)` and returns the decrypted plaintext or an error.
@@ -26,6 +32,9 @@ pub struct ProviderContext {
     pub decryptor: Option<DecryptorFn>,
     /// Custom type validators keyed by type name (e.g., "arn", "availability_zone").
     pub validators: HashMap<String, ValidatorFn>,
+    /// Factory-based custom type validator that calls through to provider factories
+    /// (e.g., WASM plugins) for types not covered by `validators`.
+    pub custom_type_validator: Option<CustomTypeValidatorFn>,
 }
 
 impl std::fmt::Debug for ProviderContext {
@@ -33,6 +42,10 @@ impl std::fmt::Debug for ProviderContext {
         f.debug_struct("ProviderContext")
             .field("decryptor", &self.decryptor.as_ref().map(|_| "..."))
             .field("validators", &self.validators.keys().collect::<Vec<_>>())
+            .field(
+                "custom_type_validator",
+                &self.custom_type_validator.as_ref().map(|_| "..."),
+            )
             .finish()
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -2313,9 +2313,13 @@ pub fn validate_custom_type(
         (_, Value::FunctionCall { .. }) => Ok(()), // will be resolved later
         (_, Value::Interpolation(_)) => Ok(()),   // will be resolved later
         (name, Value::String(s)) => {
-            // Check custom validators from config
+            // Check custom validators from config (schema-extracted)
             if let Some(validator) = config.validators.get(name) {
-                validator(s)
+                validator(s)?;
+            }
+            // Fall back to factory-based validator (e.g., WASM providers)
+            if let Some(ref factory_validator) = config.custom_type_validator {
+                factory_validator(name, s)
             } else {
                 Ok(())
             }
@@ -8716,6 +8720,7 @@ aws.s3.bucket {
                 Ok(format!("decrypted:{ciphertext}"))
             })),
             validators: HashMap::new(),
+            custom_type_validator: None,
         };
 
         // decrypt() in resource attributes is resolved during resolve_resource_refs,
@@ -8773,6 +8778,7 @@ aws.s3.bucket {
         let config = ProviderContext {
             decryptor: None,
             validators,
+            custom_type_validator: None,
         };
 
         let result = validate_custom_type(
@@ -8812,6 +8818,7 @@ aws.s3.bucket {
         let config = ProviderContext {
             decryptor: None,
             validators,
+            custom_type_validator: None,
         };
 
         // Test validate_custom_type directly since the grammar may not accept

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -440,6 +440,13 @@ pub trait ProviderFactory: Send + Sync {
     /// using [`provider_config_attribute_types`] before this is called.
     fn validate_config(&self, attributes: &HashMap<String, Value>) -> Result<(), String>;
 
+    /// Validate a value against a provider-defined custom type.
+    /// Returns `Ok(())` if the value is valid or the type is unknown to this provider.
+    /// Returns `Err(message)` if the value is invalid for the given type.
+    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Extract region from config in SDK format (e.g., "ap-northeast-1").
     /// Returns a default region if none is configured.
     fn extract_region(&self, attributes: &HashMap<String, Value>) -> String;

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -416,6 +416,7 @@ mod tests {
         ProviderContext {
             decryptor: None,
             validators,
+            custom_type_validator: None,
         }
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -74,9 +74,16 @@ impl DiagnosticEngine {
         provider_names: Vec<String>,
         factories: Arc<Vec<Box<dyn ProviderFactory>>>,
     ) -> Self {
+        let factories_clone = Arc::clone(&factories);
         let provider_context = carina_core::parser::ProviderContext {
             decryptor: None,
             validators: carina_core::provider::collect_custom_type_validators(&schemas),
+            custom_type_validator: Some(Box::new(move |type_name: &str, value: &str| {
+                for factory in factories_clone.iter() {
+                    factory.validate_custom_type(type_name, value)?;
+                }
+                Ok(())
+            })),
         };
         Self {
             schemas,

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -89,6 +89,7 @@ async fn main() {
         let provider_context = ProviderContext {
             decryptor: None,
             validators: HashMap::new(),
+            custom_type_validator: None,
         };
 
         // Pass factory builder callback — actual WASM loading happens asynchronously

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -23,6 +23,7 @@ impl TestClient {
             let provider_context = ProviderContext {
                 decryptor: None,
                 validators: HashMap::new(),
+                custom_type_validator: None,
             };
             Backend::new(client, provider_context, None)
         });

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -351,6 +351,26 @@ impl WasmBindings {
         }
     }
 
+    async fn call_validate_custom_type(
+        &self,
+        store: &mut Store<HostState>,
+        type_name: &str,
+        value: &str,
+    ) -> wasmtime::Result<Result<(), String>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                b.carina_provider_provider()
+                    .call_validate_custom_type(store, type_name, value)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                b.carina_provider_provider()
+                    .call_validate_custom_type(store, type_name, value)
+                    .await
+            }
+        }
+    }
+
     async fn call_initialize(
         &self,
         store: &mut Store<HostState>,
@@ -1148,6 +1168,20 @@ impl ProviderFactory for WasmProviderFactory {
                     .call_validate_config(store, &wit_attrs)
                     .await
                     .map_err(|e| format!("Failed to call validate_config(): {e}"))?
+            })
+        })
+    }
+
+    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let mut guard = self.init_instance.lock().await;
+                let (ref mut store, ref bindings) = *guard;
+                store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
+                bindings
+                    .call_validate_custom_type(store, type_name, value)
+                    .await
+                    .map_err(|e| format!("Failed to call validate_custom_type(): {e}"))?
             })
         })
     }

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -163,6 +163,13 @@ pub trait CarinaProvider {
         HashMap::new()
     }
 
+    /// Validate a value against a provider-defined custom type.
+    /// Returns `Ok(())` if the value is valid or the type is unknown.
+    /// Returns `Err(message)` if the value is invalid for the given type.
+    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Normalize desired resources (optional).
     fn normalize_desired(&self, resources: Vec<Resource>) -> Vec<Resource> {
         resources

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -351,6 +351,18 @@ macro_rules! export_provider {
                     $crate::CarinaProvider::identity_attributes(&*provider)
                 }
 
+                fn validate_custom_type(
+                    type_name: String,
+                    value: String,
+                ) -> Result<(), String> {
+                    let provider = get_provider().lock().unwrap();
+                    $crate::CarinaProvider::validate_custom_type(
+                        &*provider,
+                        &type_name,
+                        &value,
+                    )
+                }
+
                 fn get_enum_aliases() -> String {
                     let provider = get_provider().lock().unwrap();
                     let aliases = $crate::CarinaProvider::enum_aliases(&*provider);
@@ -687,6 +699,18 @@ macro_rules! export_provider {
                 fn identity_attributes() -> Vec<String> {
                     let provider = get_provider().lock().unwrap();
                     $crate::CarinaProvider::identity_attributes(&*provider)
+                }
+
+                fn validate_custom_type(
+                    type_name: String,
+                    value: String,
+                ) -> Result<(), String> {
+                    let provider = get_provider().lock().unwrap();
+                    $crate::CarinaProvider::validate_custom_type(
+                        &*provider,
+                        &type_name,
+                        &value,
+                    )
                 }
 
                 fn get_enum_aliases() -> String {


### PR DESCRIPTION
Refs #1722

## Summary

- Add `validate-custom-type(type-name, value) -> result<_, string>` to the WIT provider interface
- Add `validate_custom_type` method to `CarinaProvider` trait (SDK) and `ProviderFactory` trait (core) with default `Ok(())`
- Wire WASM host call-through via `WasmProviderFactory`
- Add `custom_type_validator` field to `ProviderContext` as factory-based validation fallback
- CLI and LSP build a closure over `Arc`-shared factories to call through to provider plugins

## Next steps (separate PRs in provider repos)

Provider repos need to implement `validate_custom_type` in their `CarinaProvider` implementations:
- `carina-provider-aws`: delegate to existing validators in `carina-aws-types`
- `carina-provider-awscc`: same pattern

## Test plan

- [x] All existing tests pass (no behavioral change without provider-side implementation)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)