### PR TITLE
fix(docs): prevent LinkCard hover text from vanishing in light theme

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -32,6 +32,7 @@
   --sl-color-gray-4: hsl(217, 19%, 35%);
   --sl-color-gray-5: hsl(217, 33%, 17%);
   --sl-color-gray-6: hsl(222, 47%, 11%);
+  --sl-color-gray-7: hsl(222, 47%, 11%);
   --sl-color-black: hsl(229, 84%, 5%);
   --sl-color-accent-low: hsl(32, 60%, 15%);
   --sl-color-accent: hsl(43, 96%, 56%);


### PR DESCRIPTION
## Summary

- On the docs landing page, hovering the **Providers** LinkCards made the title text invisible for visitors whose browser resolved to the light theme.
- Root cause: Starlight's `LinkCard` sets the hover background to `var(--sl-color-gray-7, var(--sl-color-gray-6))`. Starlight only defines `--sl-color-gray-7` under `:root[data-theme='light']` (≈ `hsl(224, 19%, 97%)`, nearly white). `docs/src/styles/custom.css` overrides the light-theme grayscale with dark values but missed gray-7, so the hover background landed near white under the white title.
- Fix: override `--sl-color-gray-7` to match gray-6 in the light-theme block so behavior is consistent with dark mode (where gray-7 is undefined and the fallback to gray-6 already applies).

## Test plan

- [ ] Load `/` with system appearance set to **Light** and hover the Provider cards — title stays white on the dark gray-6 background.
- [ ] Load `/` with system appearance set to **Dark** — hover still falls back to gray-6, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)