### PR TITLE
fix: validate module attribute params before module expansion

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -22,7 +22,8 @@ use carina_state::backend::BackendConfig as StateBackendConfig;
 use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, compute_anonymous_identifiers_with_ctx,
-    resolve_names_with_ctx, validate_attribute_param_ref_types_with_ctx, validate_module_calls,
+    resolve_names_with_ctx, validate_attribute_param_ref_types_with_ctx,
+    validate_module_attribute_param_types, validate_module_calls,
     validate_provider_region_with_ctx, validate_resource_ref_types_with_ctx,
     validate_resources_with_ctx,
 };
@@ -180,6 +181,11 @@ pub fn validate_and_resolve_with_config(
 
     // Validate module call arguments before expansion (needs enriched context for custom type validators)
     validate_module_calls(parsed, base_dir, &enriched_context)?;
+
+    // Validate module attribute parameter ref types before expansion
+    if !skip_resource_validation {
+        validate_module_attribute_param_types(&ctx, parsed, base_dir)?;
+    }
 
     // Resolve module imports and expand module calls
     module_resolver::resolve_modules_with_config(parsed, base_dir, &enriched_context)

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -546,6 +546,30 @@ pub fn validate_module_calls(
         .map_err(AppError::Validation)
 }
 
+pub fn validate_module_attribute_param_types(
+    ctx: &WiringContext,
+    parsed: &ParsedFile,
+    base_dir: &Path,
+) -> Result<(), AppError> {
+    for import in &parsed.imports {
+        let module_path = base_dir.join(&import.path);
+        let Some(module_parsed) = module_resolver::load_module(&module_path) else {
+            continue;
+        };
+        if module_parsed.attribute_params.is_empty() {
+            continue;
+        }
+        validation::validate_attribute_param_ref_types(
+            &module_parsed.attribute_params,
+            &module_parsed.resources,
+            ctx.schemas(),
+            &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
+        )
+        .map_err(AppError::Validation)?;
+    }
+    Ok(())
+}
+
 pub async fn get_provider_with_ctx(
     ctx: &WiringContext,
     parsed: &ParsedFile,


### PR DESCRIPTION
Refs #1749

## Problem

PR #1753 validated `parsed.attribute_params` after module expansion, but module attribute_params are consumed during expansion (converted to virtual resources, losing type information). The validation was checking an empty list.

## Fix

Add `validate_module_attribute_param_types` that loads each imported module before expansion and validates its `attribute_params` against the module's own resources and provider schemas. Runs alongside `validate_module_calls` before `resolve_modules_with_config`.

## Test plan

- [x] All tests pass (except pre-existing WASM mock test failure unrelated to this change)
- [x] `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)