### PR TITLE
feat: show structured diff for nested map changes in plan output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ plan-compact:
 	cd $(FIXTURES)/compact && $(CARINA) plan --refresh=false --detail none
 plan-map-diff:
 	cd $(FIXTURES)/map_key_diff && $(CARINA) plan --refresh=false
+plan-nested-map-diff:
+	cd $(FIXTURES)/nested_map_diff && $(CARINA) plan --refresh=false
 plan-enum-display:
 	cd $(FIXTURES)/enum_display && $(CARINA) plan --refresh=false
 plan-no-changes-enum:
@@ -69,6 +71,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== map_key_diff ==="
 	@$(MAKE) plan-map-diff
+	@echo ""
+	@echo "=== nested_map_diff ==="
+	@$(MAKE) plan-nested-map-diff
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -1033,6 +1033,16 @@ fn render_map_diff_entries(out: &mut String, entries: &[MapDiffEntryIR], attr_pr
                 let nested_prefix = format!("{}    ", attr_prefix);
                 render_map_diff_entries(out, entries, &nested_prefix);
             }
+            MapDiffEntryIR::NestedListOfMapsDiff {
+                key,
+                modified,
+                added,
+                removed,
+            } => {
+                writeln!(out, "{}    {}:", attr_prefix, key).unwrap();
+                let nested_prefix = format!("{}    ", attr_prefix);
+                render_list_of_maps_diff(out, &[], modified, added, removed, &nested_prefix);
+            }
         }
     }
 }

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -1060,15 +1060,48 @@ fn render_list_of_maps_diff(
         writeln!(out, "{}    {}", attr_prefix, item).unwrap();
     }
     for item in modified {
-        let rendered_fields = render_modified_fields(&item.fields);
-        writeln!(
-            out,
-            "{}  {} {{{}}}",
-            attr_prefix,
-            "~".yellow().bold(),
-            rendered_fields
-        )
-        .unwrap();
+        let has_nested = item
+            .fields
+            .iter()
+            .any(|f| matches!(f, ListOfMapsDiffField::NestedMapChanged { .. }));
+        if has_nested {
+            writeln!(out, "{}  {} {{", attr_prefix, "~".yellow().bold()).unwrap();
+            for field in &item.fields {
+                match field {
+                    ListOfMapsDiffField::Unchanged { key, value } => {
+                        writeln!(out, "{}      {}: {}", attr_prefix, key, value).unwrap();
+                    }
+                    ListOfMapsDiffField::Changed { key, old, new } => {
+                        writeln!(
+                            out,
+                            "{}    {} {}: {} → {}",
+                            attr_prefix,
+                            "~".yellow(),
+                            key,
+                            old.red().strikethrough(),
+                            new.green()
+                        )
+                        .unwrap();
+                    }
+                    ListOfMapsDiffField::NestedMapChanged { key, entries } => {
+                        writeln!(out, "{}      {}:", attr_prefix, key).unwrap();
+                        let nested_prefix = format!("{}      ", attr_prefix);
+                        render_map_diff_entries(out, entries, &nested_prefix);
+                    }
+                }
+            }
+            writeln!(out, "{}    }}", attr_prefix).unwrap();
+        } else {
+            let rendered_fields = render_modified_fields(&item.fields);
+            writeln!(
+                out,
+                "{}  {} {{{}}}",
+                attr_prefix,
+                "~".yellow().bold(),
+                rendered_fields
+            )
+            .unwrap();
+        }
     }
     for item in added {
         writeln!(out, "{}  {} {}", attr_prefix, "+".green().bold(), item).unwrap();
@@ -1100,6 +1133,9 @@ fn render_modified_fields(fields: &[ListOfMapsDiffField]) -> String {
                     old.red().strikethrough(),
                     new.green()
                 ));
+            }
+            ListOfMapsDiffField::NestedMapChanged { key, .. } => {
+                result_parts.push(format!("{}: (nested changes)", key));
             }
         }
     }

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -1028,6 +1028,11 @@ fn render_map_diff_entries(out: &mut String, entries: &[MapDiffEntryIR], attr_pr
                 )
                 .unwrap();
             }
+            MapDiffEntryIR::NestedMapDiff { key, entries } => {
+                writeln!(out, "{}    {}:", attr_prefix, key).unwrap();
+                let nested_prefix = format!("{}    ", attr_prefix);
+                render_map_diff_entries(out, entries, &nested_prefix);
+            }
         }
     }
 }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -629,3 +629,16 @@ fn plan_snapshot_remote_state() {
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
+
+#[test]
+fn snapshot_nested_map_diff() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("nested_map_diff");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+    ));
+    insta::assert_snapshot!(output);
+}

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_nested_map_diff.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_nested_map_diff.snap
@@ -1,0 +1,18 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.ec2.vpc vpc
+      config:
+          settings:
+            ~ mode: "basic" → "advanced"
+            ~ timeout: "30" → "60"
+      # (1 unchanged attribute hidden)
+        │
+        └─ + awscc.ec2.subnet 
+              cidr_block: "10.0.1.0/24"
+              vpc_id: "vpc-0123456789abcdef0"
+
+Plan: 1 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
@@ -1,0 +1,31 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-nested-map-diff",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.vpc",
+      "name": "vpc",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0123456789abcdef0",
+        "config": {
+          "settings": {
+            "mode": "basic",
+            "timeout": "30"
+          }
+        }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block", "config"],
+      "binding": "vpc",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/nested_map_diff/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/nested_map_diff/main.crn
@@ -1,0 +1,20 @@
+# Nested map diff: keys changed inside a nested map structure
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = '10.0.0.0/16'
+  config = {
+    settings = {
+      mode = 'advanced'
+      timeout = '60'
+    }
+  }
+}
+
+awscc.ec2.subnet {
+  vpc_id     = vpc.vpc_id
+  cidr_block = '10.0.1.0/24'
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -144,6 +144,12 @@ pub enum MapDiffEntryIR {
         old: String,
         new: String,
     },
+    /// Nested map diff: when both old and new values are maps,
+    /// recursively compute key-level diffs instead of showing as one-liner.
+    NestedMapDiff {
+        key: String,
+        entries: Vec<MapDiffEntryIR>,
+    },
 }
 
 /// A modified item in a list-of-maps diff
@@ -679,11 +685,20 @@ fn compute_map_diff_entries(old_value: Option<&Value>, new_value: &Value) -> Vec
     for item in diff.iter_by_key() {
         match item {
             crate::diff_helpers::MapDiffItem::Changed(e) => {
-                entries.push(MapDiffEntryIR::Changed {
-                    key: e.key.clone(),
-                    old: format_value_with_key(&e.old_value, Some(&e.key)),
-                    new: format_value_with_key(&e.new_value, Some(&e.key)),
-                });
+                // If both old and new are maps, recursively diff
+                if matches!(&e.old_value, Value::Map(_)) && matches!(&e.new_value, Value::Map(_)) {
+                    let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value);
+                    entries.push(MapDiffEntryIR::NestedMapDiff {
+                        key: e.key.clone(),
+                        entries: nested,
+                    });
+                } else {
+                    entries.push(MapDiffEntryIR::Changed {
+                        key: e.key.clone(),
+                        old: format_value_with_key(&e.old_value, Some(&e.key)),
+                        new: format_value_with_key(&e.new_value, Some(&e.key)),
+                    });
+                }
             }
             crate::diff_helpers::MapDiffItem::Added(e) => {
                 entries.push(MapDiffEntryIR::Added {

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -178,6 +178,11 @@ pub enum ListOfMapsDiffField {
         old: String,
         new: String,
     },
+    /// Field value is a nested map that changed — show recursive key-level diffs
+    NestedMapChanged {
+        key: String,
+        entries: Vec<MapDiffEntryIR>,
+    },
 }
 
 /// A cascading update entry
@@ -865,14 +870,25 @@ fn compute_list_of_maps_diff_parts(
                         .map(|ov| ov.semantically_equal(&new_map[*k]))
                         .unwrap_or(false);
                     if !field_same {
-                        let old_v = old_map
-                            .get(*k)
-                            .map(format_value)
-                            .unwrap_or_else(|| "(none)".to_string());
-                        ListOfMapsDiffField::Changed {
-                            key: k.to_string(),
-                            old: old_v,
-                            new: new_v,
+                        let old_val = old_map.get(*k);
+                        // If both old and new are maps, show recursive diff
+                        if matches!(old_val, Some(Value::Map(_)))
+                            && matches!(&new_map[*k], Value::Map(_))
+                        {
+                            let nested = compute_map_diff_entries(old_val, &new_map[*k]);
+                            ListOfMapsDiffField::NestedMapChanged {
+                                key: k.to_string(),
+                                entries: nested,
+                            }
+                        } else {
+                            let old_v = old_val
+                                .map(format_value)
+                                .unwrap_or_else(|| "(none)".to_string());
+                            ListOfMapsDiffField::Changed {
+                                key: k.to_string(),
+                                old: old_v,
+                                new: new_v,
+                            }
                         }
                     } else {
                         ListOfMapsDiffField::Unchanged {

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -150,6 +150,14 @@ pub enum MapDiffEntryIR {
         key: String,
         entries: Vec<MapDiffEntryIR>,
     },
+    /// Nested list-of-maps diff: when both old and new values are lists of maps,
+    /// show per-item field-level diffs instead of one-liner.
+    NestedListOfMapsDiff {
+        key: String,
+        modified: Vec<ListOfMapsDiffModified>,
+        added: Vec<String>,
+        removed: Vec<String>,
+    },
 }
 
 /// A modified item in a list-of-maps diff
@@ -691,6 +699,16 @@ fn compute_map_diff_entries(old_value: Option<&Value>, new_value: &Value) -> Vec
                     entries.push(MapDiffEntryIR::NestedMapDiff {
                         key: e.key.clone(),
                         entries: nested,
+                    });
+                } else if is_list_of_maps(&e.new_value) {
+                    // List-of-maps: compute per-item field-level diffs
+                    let (_, modified, added, removed) =
+                        compute_list_of_maps_diff_parts(Some(&e.old_value), &e.new_value);
+                    entries.push(MapDiffEntryIR::NestedListOfMapsDiff {
+                        key: e.key.clone(),
+                        modified,
+                        added,
+                        removed,
                     });
                 } else {
                     entries.push(MapDiffEntryIR::Changed {

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -694,6 +694,20 @@ fn render_map_diff_entries(lines: &mut Vec<Line>, entries: &[MapDiffEntryIR]) {
                     ),
                 ]));
             }
+            MapDiffEntryIR::NestedMapDiff { key, entries } => {
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::raw(format!("{}:", key)),
+                ]));
+                // Indent nested entries
+                let mut nested_lines = Vec::new();
+                render_map_diff_entries(&mut nested_lines, entries);
+                for line in nested_lines {
+                    let mut indented_spans = vec![Span::raw("    ")];
+                    indented_spans.extend(line.spans);
+                    lines.push(Line::from(indented_spans));
+                }
+            }
         }
     }
 }

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -699,9 +699,30 @@ fn render_map_diff_entries(lines: &mut Vec<Line>, entries: &[MapDiffEntryIR]) {
                     Span::raw("      "),
                     Span::raw(format!("{}:", key)),
                 ]));
-                // Indent nested entries
                 let mut nested_lines = Vec::new();
                 render_map_diff_entries(&mut nested_lines, entries);
+                for line in nested_lines {
+                    let mut indented_spans = vec![Span::raw("    ")];
+                    indented_spans.extend(line.spans);
+                    lines.push(Line::from(indented_spans));
+                }
+            }
+            MapDiffEntryIR::NestedListOfMapsDiff {
+                key,
+                modified,
+                added,
+                removed,
+            } => {
+                let mut nested_lines = Vec::new();
+                render_list_of_maps_diff(
+                    &mut nested_lines,
+                    key,
+                    &[],
+                    modified,
+                    added,
+                    removed,
+                    false,
+                );
                 for line in nested_lines {
                     let mut indented_spans = vec![Span::raw("    ")];
                     indented_spans.extend(line.spans);

--- a/carina-tui/src/ui.rs
+++ b/carina-tui/src/ui.rs
@@ -775,6 +775,18 @@ fn render_list_of_maps_diff(
                     spans.push(Span::raw(" -> "));
                     spans.push(Span::styled(new.clone(), Style::default().fg(Color::Green)));
                 }
+                ListOfMapsDiffField::NestedMapChanged { key, entries } => {
+                    // Flush current spans as a line, then render nested entries
+                    spans.push(Span::raw(format!("{}: ", key)));
+                    lines.push(Line::from(std::mem::take(&mut spans)));
+                    let mut nested_lines = Vec::new();
+                    render_map_diff_entries(&mut nested_lines, entries);
+                    for line in nested_lines {
+                        let mut indented = vec![Span::raw("      ")];
+                        indented.extend(line.spans);
+                        lines.push(Line::from(indented));
+                    }
+                }
             }
         }
         spans.push(Span::raw("}"));


### PR DESCRIPTION
Closes #1751

## Summary

When a nested map attribute changes, show per-key diffs with indentation instead of the full before → after value on one line.

**Before:**
```
~ config: {settings: {mode: "basic", timeout: "30"}} → {settings: {mode: "advanced", timeout: "60"}}
```

**After:**
```
config:
    settings:
      ~ mode: "basic" → "advanced"
      ~ timeout: "30" → "60"
```

## Changes

- Add `NestedMapDiff` variant to `MapDiffEntryIR` for recursive map diffing
- `compute_map_diff_entries`: when both old and new values are Maps, recursively compute key-level diffs
- CLI `render_map_diff_entries`: render nested diffs with additional indentation
- TUI `render_map_diff_entries`: same for terminal UI
- New fixture `nested_map_diff` with snapshot test

## Test plan

- [x] New snapshot test `snapshot_nested_map_diff` showing structured output
- [x] All 22 existing snapshot tests pass unchanged
- [x] `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)