### PR TITLE
feat: LSP Map key completions from typed key schema

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -393,28 +393,37 @@ impl CompletionProvider {
     /// For a single-element path like ["versioning_configuration"], looks up the attribute directly.
     /// For multi-element paths like ["assume_role_policy_document", "statement"],
     /// walks down the struct hierarchy.
+    /// Resolve the AttributeType at the given attr_path within a resource schema.
+    fn resolve_type_for_path<'a>(
+        &self,
+        schema: &'a ResourceSchema,
+        attr_path: &[String],
+    ) -> Option<&'a AttributeType> {
+        if attr_path.is_empty() {
+            return None;
+        }
+
+        let attr_schema = self.find_attr_schema(schema, &attr_path[0])?;
+        let mut current_type = &attr_schema.attr_type;
+
+        for name in &attr_path[1..] {
+            let fields = self.extract_struct_fields(current_type)?;
+            let field = fields
+                .iter()
+                .find(|f| f.name == *name || f.block_name.as_deref() == Some(name))?;
+            current_type = &field.field_type;
+        }
+
+        Some(current_type)
+    }
+
     fn resolve_struct_fields_for_path<'a>(
         &self,
         schema: &'a ResourceSchema,
         attr_path: &[String],
     ) -> Option<&'a Vec<StructField>> {
-        if attr_path.is_empty() {
-            return None;
-        }
-
-        // Find the top-level attribute
-        let attr_schema = self.find_attr_schema(schema, &attr_path[0])?;
-        let mut fields = self.extract_struct_fields(&attr_schema.attr_type)?;
-
-        // Walk down the remaining path
-        for name in &attr_path[1..] {
-            let field = fields
-                .iter()
-                .find(|f| f.name == *name || f.block_name.as_deref() == Some(name))?;
-            fields = self.extract_struct_fields(&field.field_type)?;
-        }
-
-        Some(fields)
+        let attr_type = self.resolve_type_for_path(schema, attr_path)?;
+        self.extract_struct_fields(attr_type)
     }
 
     fn struct_field_completions(
@@ -428,35 +437,78 @@ impl CompletionProvider {
             arguments: None,
         };
 
-        if let Some(schema) = self.schemas.get(resource_type)
-            && let Some(fields) = self.resolve_struct_fields_for_path(schema, attr_path)
-        {
-            fields
-                .iter()
-                .map(|field| {
-                    let required_marker = if field.required { " (required)" } else { "" };
-                    CompletionItem {
-                        label: field.name.clone(),
-                        kind: Some(CompletionItemKind::FIELD),
-                        detail: field
-                            .description
-                            .as_ref()
-                            .map(|d| format!("{}{}", d, required_marker))
-                            .or_else(|| {
-                                if field.required {
-                                    Some("(required)".to_string())
-                                } else {
-                                    None
-                                }
-                            }),
-                        insert_text: Some(format!("{} = ", field.name)),
-                        command: Some(trigger_suggest.clone()),
-                        ..Default::default()
-                    }
-                })
-                .collect()
+        if let Some(schema) = self.schemas.get(resource_type) {
+            // Try struct field completions first
+            if let Some(fields) = self.resolve_struct_fields_for_path(schema, attr_path) {
+                return fields
+                    .iter()
+                    .map(|field| {
+                        let required_marker = if field.required { " (required)" } else { "" };
+                        CompletionItem {
+                            label: field.name.clone(),
+                            kind: Some(CompletionItemKind::FIELD),
+                            detail: field
+                                .description
+                                .as_ref()
+                                .map(|d| format!("{}{}", d, required_marker))
+                                .or_else(|| {
+                                    if field.required {
+                                        Some("(required)".to_string())
+                                    } else {
+                                        None
+                                    }
+                                }),
+                            insert_text: Some(format!("{} = ", field.name)),
+                            command: Some(trigger_suggest.clone()),
+                            ..Default::default()
+                        }
+                    })
+                    .collect();
+            }
+
+            // Try map key completions: if the attribute type at attr_path is a Map
+            // with a StringEnum key, provide key name completions
+            if let Some(key_type) = self.resolve_map_key_type(schema, attr_path) {
+                return self.map_key_completions_from_type(key_type, &trigger_suggest);
+            }
+        }
+
+        vec![]
+    }
+
+    /// Resolve the Map key type for an attribute path.
+    /// Returns the key AttributeType if the attribute at the path is a Map.
+    fn resolve_map_key_type<'a>(
+        &self,
+        schema: &'a ResourceSchema,
+        attr_path: &[String],
+    ) -> Option<&'a AttributeType> {
+        let attr_type = self.resolve_type_for_path(schema, attr_path)?;
+        if let AttributeType::Map { key, .. } = attr_type {
+            Some(key)
         } else {
-            vec![]
+            None
+        }
+    }
+
+    /// Generate completions from a Map key type (e.g., StringEnum values).
+    fn map_key_completions_from_type(
+        &self,
+        key_type: &AttributeType,
+        trigger_suggest: &Command,
+    ) -> Vec<CompletionItem> {
+        match key_type {
+            AttributeType::StringEnum { values, .. } => values
+                .iter()
+                .map(|v| CompletionItem {
+                    label: v.clone(),
+                    kind: Some(CompletionItemKind::ENUM_MEMBER),
+                    insert_text: Some(format!("{} = ", v)),
+                    command: Some(trigger_suggest.clone()),
+                    ..Default::default()
+                })
+                .collect(),
+            _ => vec![],
         }
     }
 

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1156,3 +1156,62 @@ outer =
         labels
     );
 }
+
+#[test]
+fn map_key_completions_from_string_enum_key_type() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // Create a schema with a Map attribute whose key is StringEnum
+    let condition_keys = vec![
+        "string_equals".to_string(),
+        "string_like".to_string(),
+        "arn_like".to_string(),
+    ];
+    let map_type = AttributeType::map_with_key(
+        AttributeType::StringEnum {
+            name: "ConditionOperator".to_string(),
+            values: condition_keys.clone(),
+            namespace: None,
+            to_dsl: None,
+        },
+        AttributeType::map(AttributeType::String),
+    );
+    let schema =
+        ResourceSchema::new("test.resource").attribute(AttributeSchema::new("condition", map_type));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.resource".to_string(), schema);
+
+    let provider = super::super::CompletionProvider::new(Arc::new(schemas), vec![], vec![], vec![]);
+
+    // Simulate being inside `condition = { | }` — attr_path = ["condition"]
+    let completions =
+        provider.struct_field_completions("test.resource", &["condition".to_string()]);
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"string_equals"),
+        "Map key completions should include 'string_equals'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"string_like"),
+        "Map key completions should include 'string_like'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"arn_like"),
+        "Map key completions should include 'arn_like'. Got: {:?}",
+        labels
+    );
+    assert_eq!(labels.len(), 3, "Should have exactly 3 completions");
+
+    // Verify insert_text includes " = " suffix
+    let first = &completions[0];
+    assert!(
+        first.insert_text.as_deref().unwrap_or("").contains(" = "),
+        "Insert text should include ' = '"
+    );
+}


### PR DESCRIPTION
Closes #1758

## Summary

When the cursor is inside a Map block whose key type is `StringEnum`, suggest the enum values as key completions.

```crn
condition = {
  |  # ← suggests: string_equals, string_like, arn_like, ...
}
```

## Changes

- **`resolve_type_for_path()`**: Shared helper extracted from `resolve_struct_fields_for_path()` — walks an attr_path to resolve the terminal `AttributeType`
- **`resolve_map_key_type()`**: Uses `resolve_type_for_path()` to find Map key type
- **`map_key_completions_from_type()`**: Generates completions from StringEnum values
- **`struct_field_completions()`**: Falls back to map key completions when struct fields not found
- Test: `map_key_completions_from_string_enum_key_type`

## Note

Providers need to update their condition field type from `Map(Map(...))` to `map_with_key(StringEnum { ... }, Map(...))` for completions to activate.

## Test plan

- [x] 184 LSP tests pass (1 new)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)