### PR TITLE
feat: support struct field completions inside Union types

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -368,6 +368,9 @@ impl CompletionProvider {
                 AttributeType::Struct { fields, .. } => Some(fields),
                 _ => None,
             },
+            AttributeType::Union(members) => {
+                members.iter().find_map(|m| self.extract_struct_fields(m))
+            }
             _ => None,
         }
     }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1215,3 +1215,59 @@ fn map_key_completions_from_string_enum_key_type() {
         "Insert text should include ' = '"
     );
 }
+
+#[test]
+fn union_struct_field_completions() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // principal: Union([Struct { fields: [service, aws, federated] }, String])
+    let principal_type = AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "Principal".to_string(),
+            fields: vec![
+                StructField::new("service", AttributeType::String),
+                StructField::new("aws", AttributeType::String),
+                StructField::new("federated", AttributeType::String),
+            ],
+        },
+        AttributeType::String,
+    ]);
+
+    let statement_type = AttributeType::Struct {
+        name: "Statement".to_string(),
+        fields: vec![StructField::new("principal", principal_type)],
+    };
+
+    let schema = ResourceSchema::new("test.resource")
+        .attribute(AttributeSchema::new("statement", statement_type));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.resource".to_string(), schema);
+
+    let provider = super::super::CompletionProvider::new(Arc::new(schemas), vec![], vec![], vec![]);
+
+    // Inside principal = { | } — attr_path = ["statement", "principal"]
+    let completions = provider.struct_field_completions(
+        "test.resource",
+        &["statement".to_string(), "principal".to_string()],
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"federated"),
+        "Union(Struct) should suggest 'federated'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"service"),
+        "Union(Struct) should suggest 'service'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"aws"),
+        "Union(Struct) should suggest 'aws'. Got: {:?}",
+        labels
+    );
+}


### PR DESCRIPTION
## Summary

`extract_struct_fields` now looks inside `Union` members for a `Struct` variant. This enables completions for fields like `federated`, `service`, `aws` inside `principal = { | }` where `principal` is typed as `Union([Struct { fields }, String])`.

## Changes

- `extract_struct_fields`: add `Union(members)` arm that recursively searches for a Struct
- Test: `union_struct_field_completions`

## Test plan

- [x] 185 LSP tests pass (1 new)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)