### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "carina-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "carina-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "futures",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "carina-lsp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
  "carina-plugin-host",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "carina-plugin-host"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
  "carina-provider-protocol",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "carina-plugin-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-mock"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
  "carina-plugin-sdk",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-resolver"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
  "dirs",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "carina-state"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "carina-tui"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 repository = "https://github.com/carina-rs/carina"
 homepage = "https://github.com/carina-rs/carina"

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-plugin-host"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 

--- a/carina-plugin-sdk/Cargo.toml
+++ b/carina-plugin-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-plugin-sdk"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
## Summary
- Bump all crate versions from 0.3.0 to 0.4.0 (workspace, carina-plugin-host, carina-plugin-sdk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)