### PR TITLE
Add identity attribute for anonymous resource identifier hashing

### DIFF
--- a/carina-core/src/identifier.rs
+++ b/carina-core/src/identifier.rs
@@ -374,6 +374,7 @@ pub fn compute_anonymous_identifiers(
         };
 
         let create_only_attrs = schema.create_only_attributes();
+        let schema_identity_attrs = schema.identity_attributes();
 
         // Collect identity attribute values (e.g., region) from provider config
         let mut identity_values: BTreeMap<String, String> = BTreeMap::new();
@@ -399,6 +400,16 @@ pub fn compute_anonymous_identifiers(
                 // Use the prefix for hashing to produce a stable identifier
                 hash_values.insert(attr_name, format!("Prefix({:?})", prefix));
             } else if let Some(value) = resource.get_attr(attr_name) {
+                hash_values.insert(attr_name, deterministic_value_string(value));
+            }
+        }
+        // Also include schema-level identity attributes in the hash.
+        // These distinguish resources that share create-only values but differ
+        // in other key attributes (e.g., Route 53 RecordSet `type`).
+        for attr_name in &schema_identity_attrs {
+            if !hash_values.contains_key(attr_name)
+                && let Some(value) = resource.get_attr(attr_name)
+            {
                 hash_values.insert(attr_name, deterministic_value_string(value));
             }
         }
@@ -1281,6 +1292,77 @@ mod tests {
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("collision"));
+    }
+
+    #[test]
+    fn test_identity_attribute_prevents_collision() {
+        // Two anonymous resources of the same type with the same create-only attrs
+        // but different identity attrs should NOT collide.
+        // This simulates route53.record_set where `name` is create-only (same)
+        // but `type` is identity (A vs AAAA).
+        let schema = ResourceSchema::new("awscc.route53.record_set")
+            .attribute(AttributeSchema::new("name", AttributeType::String).create_only())
+            .attribute(AttributeSchema::new("hosted_zone_id", AttributeType::String).create_only())
+            .attribute(AttributeSchema::new("type", AttributeType::String).identity())
+            .attribute(AttributeSchema::new("ttl", AttributeType::String))
+            .attribute(AttributeSchema::new(
+                "resource_records",
+                AttributeType::list(AttributeType::String),
+            ));
+        let schemas: HashMap<String, ResourceSchema> =
+            vec![("awscc.route53.record_set".to_string(), schema)]
+                .into_iter()
+                .collect();
+        let providers = vec![ProviderConfig {
+            name: "awscc".to_string(),
+            attributes: HashMap::new(),
+            default_tags: HashMap::new(),
+            source: None,
+            version: None,
+            revision: None,
+        }];
+        let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+        let mut r1 = Resource::with_provider("awscc", "route53.record_set", "");
+        r1.set_attr(
+            "name".to_string(),
+            Value::String("carina-rs.dev".to_string()),
+        );
+        r1.set_attr(
+            "hosted_zone_id".to_string(),
+            Value::String("Z123".to_string()),
+        );
+        r1.set_attr("type".to_string(), Value::String("A".to_string()));
+
+        let mut r2 = Resource::with_provider("awscc", "route53.record_set", "");
+        r2.set_attr(
+            "name".to_string(),
+            Value::String("carina-rs.dev".to_string()),
+        );
+        r2.set_attr(
+            "hosted_zone_id".to_string(),
+            Value::String("Z123".to_string()),
+        );
+        r2.set_attr("type".to_string(), Value::String("AAAA".to_string()));
+
+        let mut resources = vec![r1, r2];
+        compute_anonymous_identifiers(
+            &mut resources,
+            &providers,
+            &schemas,
+            &schema_key_fn,
+            &identity_fn,
+        )
+        .expect("should not collide when identity attrs differ");
+
+        // Both should have identifiers assigned
+        assert!(!resources[0].id.name.is_empty());
+        assert!(!resources[1].id.name.is_empty());
+        // Identifiers should be different
+        assert_ne!(
+            resources[0].id.name, resources[1].id.name,
+            "different identity attr values should produce different identifiers"
+        );
     }
 
     #[test]

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -664,6 +664,13 @@ pub struct AttributeSchema {
     /// appear in read responses. This is NOT related to sensitive/secret values — it
     /// indicates a CloudFormation `writeOnlyProperties` attribute.
     pub write_only: bool,
+    /// Whether this attribute contributes to anonymous resource identity.
+    /// Identity attributes are included in the hash when computing anonymous resource
+    /// identifiers, alongside create-only attributes. Use this for attributes that
+    /// distinguish resources of the same type that share the same create-only values
+    /// (e.g., Route 53 RecordSet `type` differentiates A vs AAAA records with the
+    /// same name and hosted zone).
+    pub identity: bool,
 }
 
 impl AttributeSchema {
@@ -681,6 +688,7 @@ impl AttributeSchema {
             removable: None,
             block_name: None,
             write_only: false,
+            identity: false,
         }
     }
 
@@ -701,6 +709,11 @@ impl AttributeSchema {
 
     pub fn write_only(mut self) -> Self {
         self.write_only = true;
+        self
+    }
+
+    pub fn identity(mut self) -> Self {
+        self.identity = true;
         self
     }
 
@@ -908,6 +921,15 @@ impl ResourceSchema {
         self.attributes
             .iter()
             .filter(|(_, schema)| schema.create_only)
+            .map(|(name, _)| name.as_str())
+            .collect()
+    }
+
+    /// Returns the names of identity attributes (contribute to anonymous resource hashing)
+    pub fn identity_attributes(&self) -> Vec<&str> {
+        self.attributes
+            .iter()
+            .filter(|(_, schema)| schema.identity)
             .map(|(name, _)| name.as_str())
             .collect()
     }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -798,6 +798,7 @@ let vpc = awscc.ec2.vpc {
                     removable: None,
                     block_name: None,
                     write_only: false,
+                    identity: false,
                 },
             );
         }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -333,6 +333,7 @@ fn proto_attr_schema_to_core(a: &proto::AttributeSchema) -> CoreAttributeSchema 
         removable: a.removable,
         block_name: a.block_name.clone(),
         write_only: a.write_only,
+        identity: a.identity,
     }
 }
 

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -219,6 +219,9 @@ pub struct AttributeSchema {
     /// `None` = auto-detect, `Some(false)` = explicitly non-removable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub removable: Option<bool>,
+    /// Whether this attribute contributes to anonymous resource identity hashing.
+    #[serde(default)]
+    pub identity: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Refs #1768

## Summary

- Add `identity: bool` field to `AttributeSchema` that marks attributes as contributing to anonymous resource identifier hashing
- Identity attributes are included in the hash alongside create-only attributes, preventing collisions when resources of the same type share the same create-only values
- Propagated through protocol types and plugin host WASM conversion
- This is the carina-core infrastructure; the provider-side change to mark `route53.record_set.type` as identity is tracked in carina-rs/carina-provider-awscc#118

## Test plan

- [x] New test `test_identity_attribute_prevents_collision` — two resources with same create-only values but different identity values get different identifiers
- [x] All existing 1868 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)