### PR TITLE
ci: upload carina linux-x86_64 binary as artifact on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
+
+  binary-build:
+    name: Binary Build (linux-x86_64)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: binary
+      - run: cargo build --release --bin carina
+      - uses: actions/upload-artifact@v4
+        with:
+          name: carina-linux-x86_64
+          path: target/release/carina
+          retention-days: 30


### PR DESCRIPTION
## Summary

Adds a `binary-build` job to CI that compiles `carina` in release mode on every push to `main` and uploads the binary as the `carina-linux-x86_64` artifact (30-day retention).

## Why

Downstream repos that use carina in their own CI (e.g., [carina-rs/infra](https://github.com/carina-rs/infra)) currently install carina via `cargo install --git ... carina-cli`, which compiles the whole workspace from scratch. With wasmtime and other heavy deps, that's ~16 minutes per CI run on a fresh runner.

GitHub Actions cache is branch-scoped: a cache populated by a PR run isn't visible to the post-merge `main` run. So consumers pay the full build cost twice per PR.

By publishing a pre-built binary as a CI artifact, consumers can `gh run download` the latest successful main build in a few seconds instead.

## How consumers will use it

```yaml
- name: Install carina
  env:
    GH_TOKEN: ${{ github.token }}
  run: |
    run_id=$(gh run list \
      --repo carina-rs/carina \
      --workflow CI \
      --branch main \
      --status success \
      --limit 1 \
      --json databaseId --jq '.[0].databaseId')
    gh run download "$run_id" \
      --repo carina-rs/carina \
      --name carina-linux-x86_64 \
      --dir /tmp/carina
    sudo install -m755 /tmp/carina/carina /usr/local/bin/carina
    carina --version
```

## Notes

- `if: github.event_name == 'push'` skips the binary build on PRs — PR runs already exercise compile via `check`/`test`/`clippy`. Saves runner time.
- Uses `Swatinem/rust-cache` with a dedicated `shared-key: binary` so the release build cache is separate from the debug builds in other jobs (debug and release artifacts have different fingerprints).
- 30-day retention should be plenty given the assumed cadence of main commits. Consumers always pull the *latest* successful run, not a fixed one.