### PR TITLE
docs: set custom domain carina-rs.dev on GitHub Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,3 +36,4 @@ jobs:
           publish_branch: main
           publish_dir: ./docs/dist
           personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          cname: carina-rs.dev


### PR DESCRIPTION
## Summary

Adds `cname: carina-rs.dev` to the `peaceiris/actions-gh-pages@v4` step in the Deploy Docs workflow so every deploy writes a `CNAME` file containing the domain and keeps the GitHub Pages custom-domain setting intact.

## Context

Route 53 hosted zone and apex A/AAAA records for `carina-rs.dev` are already in place via [carina-rs/infra#5](https://github.com/carina-rs/infra/pull/5) and [#6](https://github.com/carina-rs/infra/pull/6). Registrar NS is updated. The remaining step is GitHub Pages: it needs the domain configured on the served branch, which the deploy action overwrites every run, so this has to live in the action invocation rather than as a standalone commit to `carina-rs.github.io`.

## Test plan

- [ ] Merge → `Deploy Docs` runs → `carina-rs.github.io` `main` branch has a top-level `CNAME` file with `carina-rs.dev`
- [ ] `gh api repos/carina-rs/carina-rs.github.io/pages` reports `cname: "carina-rs.dev"`
- [ ] https://carina-rs.dev serves the docs (after DNS + GitHub verification propagate)
- [ ] HTTPS gets enabled (may require manual toggle in repo Settings → Pages once the domain is verified)