### PR TITLE
docs: update code examples to use single quotes and equals syntax

### DIFF
--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -2,29 +2,29 @@
 const PAGE_TITLE_ID = '_top';
 
 const codeHtml = `<span class="kw">provider</span> <span class="id">aws</span> {
-  <span class="attr">region:</span> <span class="enum">aws.Region.ap_northeast_1</span>
+  <span class="attr">region =</span> <span class="enum">aws.Region.ap_northeast_1</span>
 }
 
 <span class="kw">let</span> <span class="id">vpc</span> = <span class="type">awscc.ec2.vpc</span> {
-  <span class="attr">cidr_block:</span> <span class="str">"10.0.0.0/16"</span>
-  <span class="attr">enable_dns_support:</span> <span class="bool">true</span>
+  <span class="attr">cidr_block =</span> <span class="str">'10.0.0.0/16'</span>
+  <span class="attr">enable_dns_support =</span> <span class="bool">true</span>
 }
 
 <span class="type">awscc.ec2.subnet</span> {
-  <span class="attr">vpc_id:</span> <span class="id">vpc</span>.vpc_id
-  <span class="attr">cidr_block:</span> <span class="str">"10.0.1.0/24"</span>
+  <span class="attr">vpc_id =</span> <span class="id">vpc</span>.vpc_id
+  <span class="attr">cidr_block =</span> <span class="str">'10.0.1.0/24'</span>
 }`;
 
-const planHtml = `<span class="prompt">$</span> carina plan main.crn
+const planHtml = `<span class="prompt">$</span> carina plan .
 <span class="muted">Planning...</span>
 
 <span class="add">+</span> <span class="id">awscc.ec2.vpc</span>
-  <span class="attr">cidr_block:</span> <span class="str">"10.0.0.0/16"</span>
+  <span class="attr">cidr_block:</span> <span class="str">'10.0.0.0/16'</span>
   <span class="attr">enable_dns_support:</span> <span class="bool">true</span>
 
 <span class="add">+</span> <span class="id">awscc.ec2.subnet</span>
   <span class="attr">vpc_id:</span> <span class="id">vpc</span>.vpc_id
-  <span class="attr">cidr_block:</span> <span class="str">"10.0.1.0/24"</span>
+  <span class="attr">cidr_block:</span> <span class="str">'10.0.1.0/24'</span>
 
 <span class="plan-summary">Plan: 2 to create, 0 to update, 0 to delete.</span>`;
 ---

--- a/docs/src/content/docs/reference/cli/state.md
+++ b/docs/src/content/docs/reference/cli/state.md
@@ -43,7 +43,7 @@ Output groups attributes under each resource:
 ```
 # aws.s3.bucket (my_bucket)
   bucket = "my-bucket-name"
-  versioning_status = "Enabled"
+  versioning_status = aws.s3.bucket.VersioningStatus.Enabled
 ```
 
 #### Flags

--- a/docs/src/content/docs/reference/providers/aws/index.md
+++ b/docs/src/content/docs/reference/providers/aws/index.md
@@ -18,10 +18,10 @@ Resources are defined using the `aws.<resource_type>` syntax:
 
 ```crn
 let vpc = aws.ec2_vpc {
-  name       = "my-vpc"
-  cidr_block = "10.0.0.0/16"
+  name       = 'my-vpc'
+  cidr_block = '10.0.0.0/16'
   tags = {
-    Environment = "production"
+    Environment = 'production'
   }
 }
 ```
@@ -30,10 +30,10 @@ Named resources (using `let`) can be referenced by other resources:
 
 ```crn
 let subnet = aws.ec2_subnet {
-  name              = "my-subnet"
+  name              = 'my-subnet'
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 ```
 

--- a/docs/src/content/docs/reference/providers/awscc/index.md
+++ b/docs/src/content/docs/reference/providers/awscc/index.md
@@ -18,10 +18,10 @@ Resources are defined using the `awscc.<service>.<resource_type>` syntax:
 
 ```crn
 let vpc = awscc.ec2.vpc {
-  name       = "my-vpc"
-  cidr_block = "10.0.0.0/16"
+  name       = 'my-vpc'
+  cidr_block = '10.0.0.0/16'
   tags = {
-    Environment = "production"
+    Environment = 'production'
   }
 }
 ```
@@ -30,10 +30,10 @@ Named resources (using `let`) can be referenced by other resources:
 
 ```crn
 let subnet = awscc.ec2.subnet {
-  name              = "my-subnet"
+  name              = 'my-subnet'
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 ```
 


### PR DESCRIPTION
Closes #1780

## Summary

- Hero.astro (homepage): colon syntax → equals, double → single quotes, `main.crn` → `.`
- aws/index.md, awscc/index.md: double → single quotes in .crn examples
- cli/state.md: `"Enabled"` → `aws.s3.bucket.VersioningStatus.Enabled`

## Test plan

- [x] Docs-only changes — no Rust code affected
- [x] Verified only .crn code examples changed, not prose or schema notation

🤖 Generated with [Claude Code](https://claude.com/claude-code)