### PR TITLE
ci: trigger docs deploy when workflow file itself changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Closes #1779

## Summary

Add `.github/workflows/docs.yml` to the `paths` filter so changes to the workflow file trigger a docs deploy.

Audited `ci.yml` and `release.yml` — neither uses `paths` filters, so no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)