### PR TITLE
docs: restore left padding on table first column

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -107,6 +107,11 @@ table thead th {
   background-color: var(--sl-color-accent-low);
   color: var(--sl-color-white);
 }
+
+/* Restore left padding on first column (Starlight zeroes it by default) */
+.sl-markdown-content :is(th:first-child, td:first-child):not(:where(.not-content *)) {
+  padding-inline-start: 1rem;
+}
 table tbody tr:nth-child(even) {
   background-color: var(--sl-color-gray-6);
 }


### PR DESCRIPTION
## Summary
- Starlight's default zeroes `padding-inline-start` on `th:first-child` / `td:first-child`, which caused the Field column header (with its accent background) and striped rows to look cramped against the left edge in provider reference tables (e.g. `aws.route53.record_set` → `AliasTarget`).
- Restores `padding-inline-start: 1rem` so the first column visually matches the rest.

## Test plan
- [x] Verified locally via `npm run dev` on `/reference/providers/aws/route53/record_set/#AliasTarget`

🤖 Generated with [Claude Code](https://claude.com/claude-code)