### PR TITLE
refactor: create backend lock in init, remove from apply/destroy

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -991,9 +991,6 @@ pub async fn run_apply(
         op_result?;
     }
 
-    // Create backend lock after state is successfully written
-    crate::commands::ensure_backend_lock(base_dir, parsed.backend.as_ref())?;
-
     Ok(())
 }
 
@@ -1453,7 +1450,6 @@ pub async fn run_apply_from_plan(
 
     let source_path = std::path::PathBuf::from(&plan_file.source_path);
     let base_dir = get_base_dir(&source_path);
-    let backend_config_for_lock = plan_file.backend_config.clone();
     let op_result = crate::signal::run_with_ctrl_c(run_apply_from_plan_locked(
         plan_file,
         auto_approve,
@@ -1478,9 +1474,6 @@ pub async fn run_apply_from_plan(
     } else {
         op_result?;
     }
-
-    // Create backend lock after state is successfully written
-    crate::commands::ensure_backend_lock(base_dir, backend_config_for_lock.as_ref())?;
 
     Ok(())
 }

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -118,9 +118,6 @@ pub async fn run_destroy(
         op_result?;
     }
 
-    // Create backend lock after state is successfully written
-    crate::commands::ensure_backend_lock(base_dir, parsed.backend.as_ref())?;
-
     Ok(())
 }
 

--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -22,31 +22,31 @@ pub fn run_init(path: &Path, upgrade: bool) -> Result<(), String> {
         .filter(|p| p.source.as_ref().is_some_and(|s| !s.starts_with("file://")))
         .collect();
 
-    if github_providers.is_empty() {
+    if !github_providers.is_empty() {
+        let action = if upgrade { "Upgrading" } else { "Resolving" };
         println!(
             "{}",
-            "No providers with remote source found. Nothing to do.".cyan()
+            format!("{} {} provider(s)...", action, github_providers.len()).cyan()
         );
-        return Ok(());
+
+        let resolved =
+            carina_provider_resolver::resolve_all(base_dir, &loaded.parsed.providers, upgrade)?;
+
+        println!(
+            "{}",
+            format!(
+                "{} provider(s) installed in .carina/providers/",
+                resolved.len()
+            )
+            .green()
+        );
     }
 
-    let action = if upgrade { "Upgrading" } else { "Resolving" };
-    println!(
-        "{}",
-        format!("{} {} provider(s)...", action, github_providers.len()).cyan()
-    );
+    // Create backend lock so apply/destroy can detect backend config changes
+    crate::commands::ensure_backend_lock(base_dir, loaded.parsed.backend.as_ref())
+        .map_err(|e| format!("Failed to create backend lock: {e}"))?;
 
-    let resolved =
-        carina_provider_resolver::resolve_all(base_dir, &loaded.parsed.providers, upgrade)?;
-
-    println!(
-        "{}",
-        format!(
-            "Done. {} provider(s) installed in .carina/providers/",
-            resolved.len()
-        )
-        .green()
-    );
+    println!("{}", "Initialized successfully.".green());
 
     Ok(())
 }

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -32,17 +32,11 @@ use crate::wiring::{
 /// changed since the last run, by comparing against `carina-backend.lock`
 /// under `base_dir`.
 ///
-/// - If no lock exists yet, the current config is written as the new lock.
+/// - If no lock exists, returns an error asking user to run `carina init`.
 /// - If the lock matches, nothing happens.
 /// - If the lock differs and `reconfigure` is `false`, returns an error
 ///   explaining the change and asking the user to re-run with `--reconfigure`.
 /// - If `reconfigure` is `true`, overwrites the lock with the new config.
-///
-/// When no `backend` block is configured, the implicit local backend is
-/// still recorded in the lock. This makes it possible to detect the
-/// local → remote transition (user adds a backend block after having
-/// run carina against local state) — otherwise the lock would be silently
-/// created with the new remote config and the local state abandoned.
 pub fn check_backend_lock(
     base_dir: &Path,
     backend_config: Option<&BackendConfig>,
@@ -77,9 +71,10 @@ pub fn check_backend_lock(
             }
         }
         Some(_) => Ok(()),
-        // No lock file yet — don't create one here. The lock is created
-        // when state is first written (apply/destroy), not on plan/validate.
-        None => Ok(()),
+        // No lock file — user must run `carina init` first
+        None => Err(AppError::Config(
+            "Backend lock file not found. Run 'carina init' to initialize the project.".to_string(),
+        )),
     }
 }
 
@@ -234,13 +229,12 @@ mod tests {
     }
 
     #[test]
-    fn check_backend_lock_does_not_create_lock_on_first_run() {
+    fn check_backend_lock_errors_when_lock_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let config = s3_backend_config("my-bucket", "us-east-1");
-        let result = check_backend_lock(tmp.path(), Some(&config), false);
-        assert!(result.is_ok());
-        // Lock should NOT be created by check — only by ensure_backend_lock
-        assert!(!tmp.path().join("carina-backend.lock").exists());
+        let err = check_backend_lock(tmp.path(), Some(&config), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("carina init"));
     }
 
     #[test]
@@ -289,11 +283,11 @@ mod tests {
     }
 
     #[test]
-    fn check_backend_lock_no_lock_no_backend_does_not_create_file() {
+    fn check_backend_lock_errors_when_lock_missing_no_backend() {
         let tmp = tempfile::tempdir().unwrap();
-        let result = check_backend_lock(tmp.path(), None, false);
-        assert!(result.is_ok());
-        assert!(!tmp.path().join("carina-backend.lock").exists());
+        let err = check_backend_lock(tmp.path(), None, false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("carina init"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1775

## Summary

- Move `ensure_backend_lock()` from apply (2 sites) and destroy (1 site) into `carina init`
- `check_backend_lock()` now errors when lock is missing: "Run 'carina init'"
- Removed unused `backend_config_for_lock` variable from apply

## Test plan

- [x] `cargo test -p carina-cli -- backend_lock` — 9 tests pass
- [x] `cargo clippy -p carina-cli -- -D warnings` — clean
- [x] Tests updated: missing lock now expected to error

🤖 Generated with [Claude Code](https://claude.com/claude-code)