### PR TITLE
refactor: require carina init, remove auto-download from plan/apply

### DIFF
--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -96,16 +96,11 @@ pub fn build_factories_from_providers(
             None => continue,
         };
 
-        let binary_path = if let Some(path) = source.strip_prefix("file://") {
-            std::path::PathBuf::from(path)
-        } else if source.starts_with("github.com/") {
-            match carina_provider_resolver::resolve_single_config(base_dir, config) {
+        let binary_path = if source.starts_with("file://") || source.starts_with("github.com/") {
+            match carina_provider_resolver::find_installed_provider(base_dir, config) {
                 Ok(path) => path,
                 Err(e) => {
-                    let reason = format!(
-                        "Failed to resolve provider '{}' from '{}': {}",
-                        config.name, source, e
-                    );
+                    let reason = format!("Provider '{}' {}", config.name, e);
                     eprintln!("{}", reason.red());
                     load_errors.insert(config.name.clone(), reason);
                     continue;
@@ -650,10 +645,9 @@ async fn load_source_provider(
     config: &ProviderConfig,
     base_dir: &Path,
 ) -> Result<(Box<dyn ProviderFactory>, Box<dyn Provider>, String), String> {
-    let binary_path = if let Some(path) = source.strip_prefix("file://") {
-        std::path::PathBuf::from(path)
-    } else if source.starts_with("github.com/") {
-        carina_provider_resolver::resolve_single_config(base_dir, config)?
+    let binary_path = if source.starts_with("file://") || source.starts_with("github.com/") {
+        carina_provider_resolver::find_installed_provider(base_dir, config)
+            .map_err(|e| format!("Provider '{}' {}", config.name, e))?
     } else {
         return Err(format!(
             "Unsupported source format: {source}. Use file:// for local binaries or github.com/owner/repo for remote."

--- a/carina-provider-resolver/src/provider_resolver.rs
+++ b/carina-provider-resolver/src/provider_resolver.rs
@@ -462,6 +462,32 @@ pub fn find_installed_provider(
         .as_deref()
         .ok_or_else(|| format!("Provider '{}' has no source", config.name))?;
 
+    // For file:// sources, look in .carina/providers/file/
+    if let Some(file_path) = source.strip_prefix("file://") {
+        let src = std::path::Path::new(file_path);
+        let file_name = src
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("provider");
+        let dest = base_dir
+            .join(".carina")
+            .join("providers")
+            .join("file")
+            .join(file_name)
+            .join(
+                src.file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("provider.wasm"),
+            );
+        if dest.exists() {
+            return Ok(dest);
+        }
+        return Err(format!(
+            "not installed. Run `carina init` in {}",
+            base_dir.display()
+        ));
+    }
+
     let lock_path = base_dir.join("carina-providers.lock");
     let lock_file = LockFile::load(&lock_path).unwrap_or_default();
 


### PR DESCRIPTION
Closes #1777

## Summary

- Replace `resolve_single_config()` with `find_installed_provider()` in wiring.rs (2 sites)
- `find_installed_provider()` now handles `file://` sources by looking in `.carina/providers/file/`
- Both `file://` and `github.com` sources require `carina init` before plan/apply/destroy
- No network calls during plan/apply — only during init

## Test plan

- [x] `cargo test -p carina-provider-resolver -p carina-cli` — 253 tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)