### PR TITLE
fix: allow cross-schema assignment between String-based Custom types

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -480,6 +480,13 @@ impl AttributeType {
             _ => self.type_name() == name,
         }
     }
+
+    /// Check if this type is a String-based Custom type.
+    /// Used for cross-schema type compatibility: all String-based Custom types
+    /// are considered compatible with each other.
+    pub fn is_string_based_custom(&self) -> bool {
+        matches!(self, AttributeType::Custom { base, .. } if matches!(**base, AttributeType::String))
+    }
 }
 
 impl fmt::Display for AttributeType {

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -141,11 +141,18 @@ pub fn validate_resource_ref_types(
             // - Union type accepts any member type name -> OK
             // - Same type -> OK
             // - Either is "String" -> OK (String is the base type for Custom types)
+            // - Both are String-based Custom types -> OK (different length/pattern constraints
+            //   for the same logical identifier, or semantic type assigned to generic pattern)
             // - Different Custom types -> Error
             if attr_schema.attr_type.accepts_type_name(&ref_type_name) {
                 continue;
             }
             if expected_type_name == "String" || ref_type_name == "String" {
+                continue;
+            }
+            if attr_schema.attr_type.is_string_based_custom()
+                && ref_attr_schema.attr_type.is_string_based_custom()
+            {
                 continue;
             }
 


### PR DESCRIPTION
Closes #1794
Closes #1795

## Summary

Custom types with `String` base are now considered type-compatible for cross-schema reference assignment. This fixes three type mismatch errors in the identity-center plan:

- `identity_store_id` (len: 1..=64 vs 1..=36) — different length bounds for the same identifier
- `target_id` (AwsAccountId vs String(pattern)) — semantic type to generic sink
- `principal_id` was fixed separately in awscc#129 (codegen bug)

## Test plan

- [x] `cargo test -p carina-core` — 1159 tests pass
- [x] `cargo clippy -p carina-core -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)