### PR TITLE
design: exports block for remote_state output

### DIFF
--- a/docs/specs/2026-04-14-exports-design.md
+++ b/docs/specs/2026-04-14-exports-design.md
@@ -1,0 +1,110 @@
+# Exports: Published Output Surface for Remote State
+
+## Goal
+
+Add `exports { }` block to publish named values from a directory for `remote_state` consumers. Only exports are visible — internal `let` bindings are not exposed.
+
+## Keyword
+
+`exports` — distinct from `attributes` (module virtual resource interface).
+
+## Syntax
+
+```crn
+exports {
+  account_id: string = registry_prod.account_id
+  vpc_id: string = vpc.vpc_id
+}
+```
+
+Same syntax as `attributes { }` — name, optional type annotation, value expression.
+
+## Design
+
+### 1. Parser
+
+Add `exports_block` to pest grammar and `ExportParameter` struct:
+
+```rust
+pub struct ExportParameter {
+    pub name: String,
+    pub type_expr: Option<TypeExpr>,
+    pub value: Option<Value>,
+}
+```
+
+`ParsedFile.export_params: Vec<ExportParameter>`
+
+### 2. State Format
+
+Add `exports` field to `StateFile`:
+
+```rust
+pub struct StateFile {
+    pub version: u32,              // 4 → 5
+    pub serial: u64,
+    pub lineage: String,
+    pub carina_version: String,
+    pub resources: Vec<ResourceState>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub exports: HashMap<String, serde_json::Value>,
+}
+```
+
+State version bump: 4 → 5. Migration: v4 state reads as v5 with empty exports.
+
+### 3. Apply
+
+After all resources are applied and state is built:
+
+1. Resolve export value expressions using binding map (same as ResourceRef resolution)
+2. Convert resolved `Value` to `serde_json::Value`
+3. Store in `state_file.exports`
+4. Persist to backend
+
+### 4. Remote State
+
+`build_remote_bindings()` returns only exports:
+
+```rust
+pub fn build_remote_bindings(&self) -> HashMap<String, Value> {
+    self.exports
+        .iter()
+        .map(|(k, v)| (k.clone(), json_to_value(v)))
+        .collect()
+}
+```
+
+No exports → empty map → consumer sees nothing. No fallback to `let` bindings.
+
+### 5. LSP
+
+- Semantic tokens: highlight `exports` keyword
+- Completion: suggest `exports` at top level
+- Diagnostics: validate export references
+
+### 6. Validation
+
+- Export names must be unique
+- Export value expressions must reference valid bindings
+- Type annotations (when present) checked against resolved values
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `carina-core/src/parser/carina.pest` | Add `exports_block` rule |
+| `carina-core/src/parser/mod.rs` | Parse `exports`, add `ExportParameter`, `ParsedFile.export_params` |
+| `carina-state/src/state.rs` | Add `exports` to `StateFile`, bump version |
+| `carina-cli/src/commands/apply.rs` | Resolve exports after apply, persist to state |
+| `carina-cli/src/commands/plan.rs` | Pass exports to plan context for display |
+| `carina-core/src/resolver.rs` | Resolve export value expressions |
+| `carina-lsp/src/semantic_tokens.rs` | Highlight `exports` keyword |
+| `carina-lsp/src/completion/top_level.rs` | Suggest `exports` |
+
+## Edge Cases
+
+- Multiple `exports { }` blocks in same directory: merge (like `attributes`)
+- Export referencing another export: not supported (exports reference resource bindings only)
+- Export referencing anonymous resource: allowed if the anonymous resource has the referenced attribute
+- No exports block: remote_state returns empty map

--- a/docs/specs/2026-04-14-exports-plan.md
+++ b/docs/specs/2026-04-14-exports-plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Exports
+
+## Task 1/5: Parser — add exports block
+
+**Files:** `carina-core/src/parser/carina.pest`, `carina-core/src/parser/mod.rs`
+
+**Changes:**
+- Add `exports_block` grammar rule (mirror `attributes_block`)
+- Add `ExportParameter` struct
+- Add `ParsedFile.export_params: Vec<ExportParameter>`
+- Parse `exports { name: type = expr }` blocks
+- Merge across files in directory-based modules
+
+**Tests:** Parser tests for exports block, single and multiple params, type annotations
+
+## Task 2/5: State format — add exports field
+
+**Files:** `carina-state/src/state.rs`
+
+**Changes:**
+- Add `exports: HashMap<String, serde_json::Value>` to `StateFile`
+- Bump `CURRENT_VERSION` to 5
+- Handle v4 → v5 migration (empty exports)
+- Update `build_remote_bindings()` to return only exports
+
+**Tests:** State roundtrip with exports, migration from v4, empty exports
+
+## Task 3/5: Apply — resolve and persist exports
+
+**Files:** `carina-cli/src/commands/apply.rs`, `carina-core/src/resolver.rs`
+
+**Changes:**
+- After apply, resolve export value expressions using binding map
+- Convert resolved Values to JSON
+- Store in `state_file.exports` before saving
+- Handle exports in plan-file apply path too
+
+**Tests:** Integration test: apply with exports, verify state contains them
+
+## Task 4/5: Remote state — read exports
+
+**Files:** `carina-cli/src/commands/plan.rs`
+
+**Changes:**
+- `load_remote_state_*` functions use `build_remote_bindings()` which now returns exports
+- Verify consumer can reference `remote.export_name`
+- Remove old binding-based exposure
+
+**Tests:** End-to-end: directory A exports, directory B reads via remote_state
+
+## Task 5/5: LSP — exports keyword support
+
+**Files:** `carina-lsp/src/semantic_tokens.rs`, `carina-lsp/src/completion/top_level.rs`
+
+**Changes:**
+- Highlight `exports` keyword in semantic tokens
+- Add `exports` to top-level completions
+- Diagnostics for export references
+
+**Tests:** LSP tests for highlighting and completion


### PR DESCRIPTION
Refs #1797

Design and plan for `exports { }` block — publishes named values from a directory for `remote_state` consumers.

- New `exports` keyword (distinct from `attributes`)
- `StateFile.exports` field (version 5)
- Apply resolves export expressions, persists to state
- `build_remote_bindings()` returns only exports (no fallback)
- 5 implementation tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)