### PR TITLE
feat: add exports keyword to LSP

### DIFF
--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -90,6 +90,14 @@ impl CompletionProvider {
                 ..Default::default()
             },
             CompletionItem {
+                label: "exports".to_string(),
+                kind: Some(CompletionItemKind::KEYWORD),
+                insert_text: Some("exports {\n    ${1:name}: ${2:type} = ${3:value}\n}".to_string()),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                detail: Some("Publish values for remote_state consumers".to_string()),
+                ..Default::default()
+            },
+            CompletionItem {
                 label: "fn".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
                 insert_text: Some("fn ${1:name}(${2:params}) {\n    ${3:body}\n}".to_string()),

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -342,6 +342,8 @@ impl SemanticTokensProvider {
             }
         } else if trimmed.starts_with("attributes ") || trimmed == "attributes{" {
             tokens.push((indent, 10, 0)); // KEYWORD: attributes
+        } else if trimmed.starts_with("exports ") || trimmed == "exports{" {
+            tokens.push((indent, 7, 0)); // KEYWORD: exports
         } else if trimmed.starts_with("arguments ") || trimmed == "arguments{" {
             tokens.push((indent, 9, 0)); // KEYWORD: arguments
         } else if trimmed.starts_with("import ") || trimmed == "import{" {
@@ -397,6 +399,8 @@ impl SemanticTokensProvider {
             && !trimmed.starts_with("let ")
             && !trimmed.starts_with("attributes ")
             && !trimmed.starts_with("attributes{")
+            && !trimmed.starts_with("exports ")
+            && !trimmed.starts_with("exports{")
             && !trimmed.starts_with("arguments ")
             && !trimmed.starts_with("arguments{")
             && !trimmed.starts_with("import ")


### PR DESCRIPTION
Closes #1803
Closes #1797

## Summary

- Semantic tokens: highlight `exports` keyword
- Completion: add `exports { }` snippet
- Guard: exclude `exports` from property highlighting

This completes the exports feature (#1797). All 5 tasks done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)