### PR TITLE
fix: walk exports block expressions in unused binding check

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -375,6 +375,11 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
             collect_resource_refs(value, &mut referenced);
         }
     }
+    for export_param in &parsed.export_params {
+        if let Some(value) = &export_param.value {
+            collect_resource_refs(value, &mut referenced);
+        }
+    }
 
     // Return unused binding names, skipping structurally-required bindings
     // (if/for/read expressions) and for-generated indexed bindings (e.g., vpcs[0])
@@ -635,6 +640,29 @@ mod tests {
             });
 
         assert!(check_unused_bindings(&parsed).is_empty());
+    }
+
+    #[test]
+    fn binding_referenced_in_exports_not_warned() {
+        let mut parsed = empty_parsed();
+
+        let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
+        parsed.resources.push(vpc);
+
+        parsed.export_params.push(crate::parser::ExportParameter {
+            name: "vpc_id".to_string(),
+            type_expr: Some(TypeExpr::String),
+            value: Some(Value::resource_ref(
+                "vpc".to_string(),
+                "vpc_id".to_string(),
+                vec![],
+            )),
+        });
+
+        assert!(
+            check_unused_bindings(&parsed).is_empty(),
+            "binding referenced in exports should not be warned"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1808

## Summary

Walk `export_params` expressions in `check_unused_bindings()` to collect referenced binding names. Same pattern as existing `attribute_params` handling.

## Test plan

- [x] `test_binding_referenced_in_exports_not_warned` — new test
- [x] `cargo test -p carina-core` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)