### PR TITLE
feat: show exports in plan output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,12 @@ plan-fixtures:
 
 plan-remote-state:
 	cd $(FIXTURES)/remote_state && $(CARINA) plan --refresh=false
+plan-exports:
+	cd $(FIXTURES)/exports && $(CARINA) plan --refresh=false
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
-        plan-remote-state \
+        plan-remote-state plan-exports \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1371,6 +1371,7 @@ async fn run_apply_locked(
         &delete_attributes,
         Some(ctx.schemas()),
         &moved_origins,
+        &parsed.export_params,
     );
 
     // Confirmation prompt
@@ -1672,6 +1673,7 @@ async fn run_apply_from_plan_locked(
         &delete_attributes,
         None,
         &HashMap::new(),
+        &[],
     );
 
     // Confirmation prompt

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -277,6 +277,7 @@ pub async fn run_plan(
             &delete_attributes,
             Some(wiring.schemas()),
             &ctx.moved_origins,
+            &parsed.export_params,
         );
     }
 

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -49,16 +49,47 @@ fn format_compact_name(
     }
 }
 
+/// Format an export value for plan display.
+fn format_export_value(value: &Value) -> String {
+    match value {
+        Value::String(s) => format!("'{}'", s),
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::ResourceRef { path } => path.to_dot_string().to_string(),
+        Value::List(items) => {
+            let formatted: Vec<String> = items.iter().map(format_export_value).collect();
+            format!("[{}]", formatted.join(", "))
+        }
+        Value::Map(map) => {
+            let formatted: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{} = {}", k, format_export_value(v)))
+                .collect();
+            format!("{{{}}}", formatted.join(", "))
+        }
+        _ => "(known after apply)".to_string(),
+    }
+}
+
 pub fn print_plan(
     plan: &Plan,
     detail: DetailLevel,
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
+    export_params: &[carina_core::parser::ExportParameter],
 ) {
     print!(
         "{}",
-        format_plan(plan, detail, delete_attributes, schemas, moved_origins)
+        format_plan(
+            plan,
+            detail,
+            delete_attributes,
+            schemas,
+            moved_origins,
+            export_params
+        )
     );
 }
 
@@ -72,6 +103,7 @@ pub fn format_plan(
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
+    export_params: &[carina_core::parser::ExportParameter],
 ) -> String {
     let mut out = String::new();
 
@@ -100,6 +132,34 @@ pub fn format_plan(
         schemas,
         moved_origins,
     ));
+
+    // Show exports if any
+    if !export_params.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "{}", "Exports:".cyan().bold()).unwrap();
+        writeln!(out).unwrap();
+        for param in export_params {
+            let type_str = param
+                .type_expr
+                .as_ref()
+                .map(|t| format!(": {}", t))
+                .unwrap_or_default();
+            let value_str = param
+                .value
+                .as_ref()
+                .map(format_export_value)
+                .unwrap_or_else(|| "(unknown)".to_string());
+            writeln!(
+                out,
+                "  {} {}{} = {}",
+                "+".green(),
+                param.name,
+                type_str.dimmed(),
+                value_str
+            )
+            .unwrap();
+        }
+    }
 
     writeln!(out).unwrap();
     let summary = plan.summary();
@@ -1609,6 +1669,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
         );
     }
 
@@ -1629,6 +1690,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
         );
     }
 
@@ -2150,6 +2212,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
         );
     }
 
@@ -2177,6 +2240,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
         );
     }
 
@@ -2327,6 +2391,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
         );
     }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -241,6 +241,7 @@ fn snapshot_all_create() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -254,6 +255,7 @@ fn snapshot_no_changes() {
         &HashMap::new(),
         None,
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -267,6 +269,7 @@ fn snapshot_mixed_operations() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -295,6 +298,7 @@ fn snapshot_delete_orphan() {
         &delete_attributes,
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -308,6 +312,7 @@ fn snapshot_compact() {
         &HashMap::new(),
         None,
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -321,6 +326,7 @@ fn snapshot_map_key_diff() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -334,6 +340,7 @@ fn snapshot_enum_display() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -347,6 +354,7 @@ fn snapshot_no_changes_enum() {
         &HashMap::new(),
         None,
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -396,6 +404,7 @@ fn snapshot_default_values() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -409,6 +418,7 @@ fn snapshot_read_only_attrs() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -422,6 +432,7 @@ fn snapshot_explicit() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -435,6 +446,7 @@ fn snapshot_default_tags() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -448,6 +460,7 @@ fn snapshot_state_blocks() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -476,6 +489,7 @@ fn snapshot_secret_values() {
         &delete_attributes,
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -489,6 +503,7 @@ fn snapshot_moved_with_changes() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -516,6 +531,7 @@ fn snapshot_moved_prev_keys() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -549,6 +565,7 @@ fn snapshot_moved_pure() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -626,6 +643,44 @@ fn plan_snapshot_remote_state() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
+    );
+    insta::assert_snapshot!(strip_ansi(&output));
+}
+
+#[test]
+fn plan_snapshot_exports() {
+    use carina_core::parser::{ExportParameter, TypeExpr};
+    use carina_core::resource::Value;
+
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("exports");
+    let exports = vec![
+        ExportParameter {
+            name: "vpc_id".to_string(),
+            type_expr: Some(TypeExpr::String),
+            value: Some(Value::resource_ref(
+                "vpc".to_string(),
+                "vpc_id".to_string(),
+                vec![],
+            )),
+        },
+        ExportParameter {
+            name: "cidr".to_string(),
+            type_expr: None,
+            value: Some(Value::resource_ref(
+                "vpc".to_string(),
+                "cidr_block".to_string(),
+                vec![],
+            )),
+        },
+    ];
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &exports,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -639,6 +694,7 @@ fn snapshot_nested_map_diff() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
     ));
     insta::assert_snapshot!(output);
 }

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_exports.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_exports.snap
@@ -1,0 +1,15 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: strip_ansi(&output)
+---
+Execution Plan:
+
+  + awscc.ec2.vpc vpc
+      cidr_block: "10.0.0.0/16"
+
+Exports:
+
+  + vpc_id: string = vpc.vpc_id
+  + cidr = vpc.cidr_block
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/exports/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports/main.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+exports {
+  vpc_id: string = vpc.vpc_id
+  cidr = vpc.cidr_block
+}


### PR DESCRIPTION
Closes #1809

## Summary

Display `exports { }` values in the plan output after the execution plan tree. Each export shows name, optional type annotation, and value expression.

## Test plan

- [x] `cargo test -p carina-cli` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)