### PR TITLE
feat: make remote_state "s3" region optional

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -329,7 +329,7 @@ pub(crate) async fn load_remote_states(
                 bucket,
                 key,
                 region,
-            } => load_remote_state_s3(bucket, key, region, &rs.binding).await?,
+            } => load_remote_state_s3(bucket, key, region.as_deref(), &rs.binding).await?,
         };
 
         let bindings = state_file.build_remote_bindings();
@@ -374,17 +374,16 @@ fn load_remote_state_local(
 async fn load_remote_state_s3(
     bucket: &str,
     key: &str,
-    region: &str,
+    region: Option<&str>,
     binding: &str,
 ) -> Result<StateFile, AppError> {
-    use carina_core::utils::convert_region_value;
-
-    let aws_region = convert_region_value(region);
-
-    let aws_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-        .region(aws_config::Region::new(aws_region))
-        .load()
-        .await;
+    let mut config_builder = aws_config::defaults(aws_config::BehaviorVersion::latest());
+    if let Some(region) = region {
+        use carina_core::utils::convert_region_value;
+        let aws_region = convert_region_value(region);
+        config_builder = config_builder.region(aws_config::Region::new(aws_region));
+    }
+    let aws_config = config_builder.load().await;
 
     let client = aws_sdk_s3::Client::new(&aws_config);
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -339,7 +339,7 @@ pub enum RemoteStateBackend {
     S3 {
         bucket: String,
         key: String,
-        region: String,
+        region: Option<String>,
     },
 }
 
@@ -2839,7 +2839,7 @@ fn parse_remote_state_block(
             RemoteStateBackend::Local { path }
         }
         Some("s3") => {
-            // S3 backend: requires "bucket", "key", "region"
+            // S3 backend: requires "bucket", "key"; "region" is optional
             let valid_keys: &[&str] = &["bucket", "key", "region"];
             for key in attrs.keys() {
                 if !valid_keys.contains(&key.as_str()) {
@@ -2864,12 +2864,7 @@ fn parse_remote_state_block(
                     line: 0,
                     message: "remote_state \"s3\" block requires a 'key' attribute".to_string(),
                 })?;
-            let region = attrs
-                .remove("region")
-                .ok_or_else(|| ParseError::InvalidExpression {
-                    line: 0,
-                    message: "remote_state \"s3\" block requires a 'region' attribute".to_string(),
-                })?;
+            let region = attrs.remove("region");
             RemoteStateBackend::S3 {
                 bucket,
                 key,
@@ -9147,7 +9142,7 @@ arguments {
             } => {
                 assert_eq!(bucket, "carina-state");
                 assert_eq!(key, "network/carina.state.json");
-                assert_eq!(region, "ap-northeast-1");
+                assert_eq!(region, &Some("ap-northeast-1".to_string()));
             }
             other => panic!("Expected S3 backend, got: {:?}", other),
         }
@@ -9221,7 +9216,7 @@ arguments {
     }
 
     #[test]
-    fn parse_remote_state_s3_missing_region() {
+    fn parse_remote_state_s3_region_optional() {
         let input = r#"
             let network = remote_state "s3" {
                 bucket = "carina-state"
@@ -9229,14 +9224,14 @@ arguments {
             }
         "#;
 
-        let result = parse(input, &ProviderContext::default());
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("region"),
-            "Error should mention 'region', got: {}",
-            err
-        );
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.remote_states.len(), 1);
+        match &parsed.remote_states[0].backend {
+            RemoteStateBackend::S3 { region, .. } => {
+                assert!(region.is_none(), "region should be None when omitted");
+            }
+            _ => panic!("Expected S3 backend"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1812

## Summary

Make `region` optional in `remote_state "s3" { }` — resolved from ambient AWS config when omitted, consistent with `backend s3`.

## Test plan

- [x] `cargo test -p carina-core` — 1164 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Updated test: region omitted → `None`, region present → `Some("ap-northeast-1")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)