### PR TITLE
fix: detect cross-file binding refs in exports via dot-notation scan

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -9806,6 +9806,47 @@ awscc.ec2.subnet {
     }
 
     #[test]
+    fn exports_cross_file_binding_detection() {
+        // Simulate cross-file: exports.crn parsed WITHOUT the let binding
+        let exports_input = r#"
+exports {
+  vpc_id = vpc.vpc_id
+}
+"#;
+        let exports_parsed = parse(exports_input, &ProviderContext::default()).unwrap();
+        eprintln!("export_params: {:?}", exports_parsed.export_params);
+        assert_eq!(exports_parsed.export_params.len(), 1);
+        // Check if the value is a ResourceRef
+        let value = exports_parsed.export_params[0].value.as_ref().unwrap();
+        eprintln!("value: {:?}", value);
+        let is_ref = matches!(value, Value::ResourceRef { .. });
+        eprintln!("is_ref: {}", is_ref);
+
+        // Now simulate merged ParsedFile with binding from main.crn
+        let main_input = r#"
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = '10.0.0.0/16'
+}
+"#;
+        let main_parsed = parse(main_input, &ProviderContext::default()).unwrap();
+
+        // Merge like config_loader does
+        let mut merged = main_parsed;
+        merged.export_params.extend(exports_parsed.export_params);
+
+        let unused = crate::validation::check_unused_bindings(&merged);
+        assert!(
+            unused.is_empty(),
+            "vpc should not be unused when referenced from exports in a separate file, got: {:?}",
+            unused
+        );
+    }
+
+    #[test]
     fn coalesce_operator_returns_left_when_resolved() {
         let input = r#"
 provider awscc {

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -378,6 +378,15 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
     for export_param in &parsed.export_params {
         if let Some(value) = &export_param.value {
             collect_resource_refs(value, &mut referenced);
+            // Cross-file: when exports.crn is parsed without the binding context,
+            // "vpc.vpc_id" becomes String("vpc.vpc_id") instead of ResourceRef.
+            // Extract the binding name from such dot-notation strings.
+            collect_dot_notation_refs(value, &mut referenced);
+        }
+    }
+    for attr_param in &parsed.attribute_params {
+        if let Some(value) = &attr_param.value {
+            collect_dot_notation_refs(value, &mut referenced);
         }
     }
 
@@ -407,6 +416,37 @@ fn collect_resource_refs(value: &Value, refs: &mut HashSet<String>) {
         Value::Map(map) => {
             for v in map.values() {
                 collect_resource_refs(v, refs);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract binding names from dot-notation string values (e.g., "vpc.vpc_id" → "vpc").
+///
+/// When files are parsed independently, cross-file references like `vpc.vpc_id`
+/// become `String("vpc.vpc_id")` instead of `ResourceRef`. This function extracts
+/// the first component as a potential binding name.
+fn collect_dot_notation_refs(value: &Value, refs: &mut HashSet<String>) {
+    match value {
+        Value::String(s) if s.contains('.') && !s.contains(' ') && !s.starts_with('/') => {
+            if let Some(binding) = s.split('.').next()
+                && !binding.is_empty()
+                && binding
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                refs.insert(binding.to_string());
+            }
+        }
+        Value::List(items) => {
+            for item in items {
+                collect_dot_notation_refs(item, refs);
+            }
+        }
+        Value::Map(map) => {
+            for v in map.values() {
+                collect_dot_notation_refs(v, refs);
             }
         }
         _ => {}


### PR DESCRIPTION
Closes #1814

## Summary

When `exports.crn` is parsed without the binding context from `main.crn`, `vpc.vpc_id` becomes `String("vpc.vpc_id")` instead of `ResourceRef`. Add `collect_dot_notation_refs()` to extract the first component of dot-notation strings as potential binding names.

## Test plan

- [x] `exports_cross_file_binding_detection` — new test
- [x] `cargo test -p carina-core` — 1165 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)