### PR TITLE
revert: undo ineffective export display resolution (#1824, #1825)

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1365,18 +1365,13 @@ async fn run_apply_locked(
         .map(|(from, to)| (to.clone(), from.clone()))
         .collect();
 
-    let resolved_exports = crate::commands::plan::resolve_export_values_for_display(
-        &parsed.export_params,
-        &sorted_resources,
-        &current_states,
-    );
     print_plan(
         &plan,
         DetailLevel::Full,
         &delete_attributes,
         Some(ctx.schemas()),
         &moved_origins,
-        &resolved_exports,
+        &parsed.export_params,
     );
 
     // Confirmation prompt

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -271,19 +271,13 @@ pub async fn run_plan(
         carina_tui::run(&ctx.plan, wiring.schemas())
             .map_err(|e| AppError::Config(format!("TUI error: {}", e)))?;
     } else {
-        // Resolve export values for display
-        let resolved_exports = resolve_export_values_for_display(
-            &parsed.export_params,
-            &ctx.sorted_resources,
-            &ctx.current_states,
-        );
         print_plan(
             &ctx.plan,
             detail,
             &delete_attributes,
             Some(wiring.schemas()),
             &ctx.moved_origins,
-            &resolved_exports,
+            &parsed.export_params,
         );
     }
 
@@ -320,49 +314,6 @@ pub async fn run_plan(
 /// map of resource bindings to their attributes. The result maps each remote_state
 /// binding name to a `HashMap<String, Value>` where keys are resource binding names
 /// and values are `Value::Map` of that resource's attributes.
-/// Resolve export value expressions for plan display.
-pub(crate) fn resolve_export_values_for_display(
-    export_params: &[carina_core::parser::ExportParameter],
-    resources: &[Resource],
-    current_states: &HashMap<ResourceId, State>,
-) -> Vec<carina_core::parser::ExportParameter> {
-    use carina_core::resolver::resolve_ref_value;
-
-    // Build binding map from resources + current state
-    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
-    for resource in resources {
-        if let Some(ref binding_name) = resource.binding {
-            let mut attrs: HashMap<String, Value> =
-                carina_core::resource::Expr::resolve_map(&resource.attributes);
-            if let Some(state) = current_states.get(&resource.id)
-                && state.exists
-            {
-                for (k, v) in &state.attributes {
-                    if !attrs.contains_key(k) {
-                        attrs.insert(k.clone(), v.clone());
-                    }
-                }
-            }
-            binding_map.insert(binding_name.clone(), attrs);
-        }
-    }
-
-    export_params
-        .iter()
-        .map(|param| {
-            let resolved_value = param
-                .value
-                .as_ref()
-                .map(|v| resolve_ref_value(v, &binding_map).unwrap_or_else(|_| v.clone()));
-            carina_core::parser::ExportParameter {
-                name: param.name.clone(),
-                type_expr: param.type_expr.clone(),
-                value: resolved_value,
-            }
-        })
-        .collect()
-}
-
 pub(crate) async fn load_remote_states(
     remote_states: &[RemoteState],
     base_dir: &Path,

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -326,6 +326,8 @@ pub(crate) fn resolve_export_values_for_display(
     resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
 ) -> Vec<carina_core::parser::ExportParameter> {
+    use carina_core::resolver::resolve_ref_value;
+
     // Build binding map from resources + current state
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for resource in resources {
@@ -351,7 +353,7 @@ pub(crate) fn resolve_export_values_for_display(
             let resolved_value = param
                 .value
                 .as_ref()
-                .map(|v| resolve_export_value(v, &binding_map));
+                .map(|v| resolve_ref_value(v, &binding_map).unwrap_or_else(|_| v.clone()));
             carina_core::parser::ExportParameter {
                 name: param.name.clone(),
                 type_expr: param.type_expr.clone(),
@@ -359,46 +361,6 @@ pub(crate) fn resolve_export_values_for_display(
             }
         })
         .collect()
-}
-
-/// Resolve a single export value, handling both ResourceRef and dot-notation strings.
-fn resolve_export_value(
-    value: &Value,
-    binding_map: &HashMap<String, HashMap<String, Value>>,
-) -> Value {
-    use carina_core::resolver::resolve_ref_value;
-
-    match value {
-        Value::ResourceRef { .. } => {
-            resolve_ref_value(value, binding_map).unwrap_or_else(|_| value.clone())
-        }
-        // Cross-file: "binding.attr" parsed as String instead of ResourceRef
-        Value::String(s) if s.contains('.') && !s.contains(' ') => {
-            let parts: Vec<&str> = s.splitn(2, '.').collect();
-            if parts.len() == 2
-                && let Some(attrs) = binding_map.get(parts[0])
-                && let Some(resolved) = attrs.get(parts[1])
-            {
-                return resolved.clone();
-            }
-            value.clone()
-        }
-        Value::List(items) => {
-            let resolved: Vec<Value> = items
-                .iter()
-                .map(|item| resolve_export_value(item, binding_map))
-                .collect();
-            Value::List(resolved)
-        }
-        Value::Map(map) => {
-            let resolved: HashMap<String, Value> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), resolve_export_value(v, binding_map)))
-                .collect();
-            Value::Map(resolved)
-        }
-        _ => value.clone(),
-    }
 }
 
 pub(crate) async fn load_remote_states(


### PR DESCRIPTION
Reverts #1824 and #1825.

These PRs attempted to resolve export values for plan display but didn't work in practice — the cross-file parsing issue means values are strings, not ResourceRefs, and the resolution logic was wrong.