### PR TITLE
fix: disambiguate upstream warning from local 'known after apply'

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -834,6 +834,7 @@ pub async fn run_apply(
 ) -> Result<(), AppError> {
     let loaded = load_configuration_with_config(path, provider_context)?;
     let mut parsed = loaded.parsed;
+    parsed.print_warnings();
     let backend_file = loaded.backend_file;
 
     let base_dir = get_base_dir(path);

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -333,6 +333,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -108,6 +108,7 @@ pub async fn run_plan(
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
     let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    parsed.print_warnings();
 
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, false)?;

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -39,6 +39,7 @@ pub fn run_validate(
 ) -> Result<(), AppError> {
     let loaded = load_configuration_with_config(path, provider_context)?;
     let mut parsed = loaded.parsed;
+    parsed.print_warnings();
 
     let base_dir = get_base_dir(path);
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -675,6 +675,7 @@ fn test_find_state_bucket_resource_matching_type() {
         remote_states: vec![],
         requires: vec![],
         structural_bindings: HashSet::new(),
+        warnings: vec![],
     };
 
     // Matching resource type
@@ -1960,6 +1961,7 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
         remote_states: vec![],
         requires: vec![],
         structural_bindings: HashSet::new(),
+        warnings: vec![],
     };
 
     // MockProvider returns not_found for both resources (simulates external deletion)

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -52,6 +52,7 @@ pub fn load_configuration_with_config(
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
         let mut merged = empty_parsed();
         let mut unresolved_merged = empty_parsed();
@@ -96,6 +97,7 @@ pub fn load_configuration_with_config(
                     unresolved_merged
                         .structural_bindings
                         .extend(unresolved.structural_bindings);
+                    unresolved_merged.warnings.extend(unresolved.warnings);
 
                     // Merge resolved
                     merged.providers.extend(parsed.providers);
@@ -113,6 +115,7 @@ pub fn load_configuration_with_config(
                     merged
                         .structural_bindings
                         .extend(parsed.structural_bindings);
+                    merged.warnings.extend(parsed.warnings);
                     // Merge backend (only one allowed)
                     if let Some(backend) = parsed.backend {
                         if merged.backend.is_some() {

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -138,6 +138,14 @@ pub fn load_configuration_with_config(
         if !parse_errors.is_empty() {
             return Err(parse_errors.join("\n"));
         }
+
+        // Upgrade cross-file warnings: a for-expression in one file may reference
+        // a remote_state defined in another file.  During per-file parsing the
+        // remote_state is unknown, so the warning falls back to the generic
+        // "(known after apply)".  Now that all files are merged we can detect
+        // these and rewrite to an upstream-aware message.
+        upgrade_cross_file_warnings(&mut merged, &unresolved_merged);
+
         Ok(LoadedConfig {
             parsed: merged,
             unresolved_parsed: unresolved_merged,
@@ -145,6 +153,47 @@ pub fn load_configuration_with_config(
         })
     } else {
         Err(format!("Path not found: {}", path.display()))
+    }
+}
+
+/// Upgrade generic "(known after apply)" warnings to upstream-aware messages
+/// when the binding matches a remote_state found in a different file.
+fn upgrade_cross_file_warnings(merged: &mut ParsedFile, unresolved: &ParsedFile) {
+    let suffix = " is not yet available (known after apply)";
+    for warning in &mut merged.warnings {
+        if !warning.message.ends_with(suffix) {
+            continue;
+        }
+        // Extract binding name: message is "`orgs.accounts` is not yet available ..."
+        let path_str = match warning
+            .message
+            .strip_prefix('`')
+            .and_then(|s| s.split('`').next())
+        {
+            Some(p) => p,
+            None => continue,
+        };
+        let binding_name = match path_str.split('.').next() {
+            Some(b) => b,
+            None => continue,
+        };
+        // Check against merged remote_states (includes all files)
+        let remote_states = merged
+            .remote_states
+            .iter()
+            .chain(unresolved.remote_states.iter());
+        if let Some(rs) = remote_states
+            .into_iter()
+            .find(|r| r.binding == binding_name)
+        {
+            let new_msg = format!(
+                "`{}` is not yet in the upstream state (remote_state '{}' → {}).\n    Apply that directory first, then re-plan.",
+                path_str,
+                binding_name,
+                rs.backend.location(),
+            );
+            warning.message = new_msg;
+        }
     }
 }
 

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -194,6 +194,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         // Read all .crn files in the directory
@@ -225,6 +226,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             merged
                 .structural_bindings
                 .extend(parsed.structural_bindings);
+            merged.warnings.extend(parsed.warnings);
         }
 
         Ok(merged)
@@ -1245,6 +1247,7 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
         remote_states: vec![],
         requires: vec![],
         structural_bindings: HashSet::new(),
+        warnings: vec![],
     };
 
     for entry in entries.flatten() {
@@ -1267,6 +1270,7 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
             merged
                 .structural_bindings
                 .extend(parsed.structural_bindings);
+            merged.warnings.extend(parsed.warnings);
         }
     }
 
@@ -1333,6 +1337,7 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
         remote_states: vec![],
         requires: vec![],
         structural_bindings: HashSet::new(),
+        warnings: vec![],
     };
 
     for entry in entries {
@@ -1360,6 +1365,7 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
             merged
                 .structural_bindings
                 .extend(parsed.structural_bindings);
+            merged.warnings.extend(parsed.warnings);
         }
     }
 
@@ -1424,6 +1430,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 
@@ -1558,6 +1565,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 
@@ -1683,6 +1691,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 
@@ -2031,6 +2040,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 
@@ -2316,6 +2326,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         }
     }
 
@@ -2486,6 +2497,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {
@@ -2549,6 +2561,7 @@ mod tests {
             remote_states: vec![],
             requires: vec![],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {
@@ -2640,6 +2653,7 @@ mod tests {
                 error_message: "cert_arn is required when HTTPS is enabled".to_string(),
             }],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {
@@ -2707,6 +2721,7 @@ mod tests {
                 error_message: "cert is required when HTTPS is enabled".to_string(),
             }],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {
@@ -2771,6 +2786,7 @@ mod tests {
                 error_message: "ALB requires at least two subnets".to_string(),
             }],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {
@@ -2861,6 +2877,7 @@ mod tests {
                 error_message: "min_size must be <= max_size".to_string(),
             }],
             structural_bindings: HashSet::new(),
+            warnings: vec![],
         };
 
         let resolver = {

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -53,6 +53,13 @@ pub enum ParseError {
     UserFunctionError(String),
 }
 
+/// A structured warning emitted during parsing (non-fatal).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParseWarning {
+    pub line: usize,
+    pub message: String,
+}
+
 /// Resource type path for typed references (e.g., aws.vpc, aws.security_group)
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResourceTypePath {
@@ -343,6 +350,16 @@ pub enum RemoteStateBackend {
     },
 }
 
+impl RemoteStateBackend {
+    /// Human-readable location string (file path or S3 URI).
+    pub fn location(&self) -> String {
+        match self {
+            RemoteStateBackend::Local { path } => path.clone(),
+            RemoteStateBackend::S3 { bucket, key, .. } => format!("s3://{}/{}", bucket, key),
+        }
+    }
+}
+
 /// Parse result
 #[derive(Debug, Clone)]
 pub struct ParsedFile {
@@ -372,6 +389,8 @@ pub struct ParsedFile {
     /// Binding names that are structurally required (if/for/read expressions)
     /// and should not trigger unused-binding warnings.
     pub structural_bindings: HashSet<String>,
+    /// Non-fatal warnings collected during parsing.
+    pub warnings: Vec<ParseWarning>,
 }
 
 impl ParsedFile {
@@ -405,6 +424,10 @@ struct ParseContext<'cfg> {
     config: &'cfg ProviderContext,
     /// Binding names from structurally-required expressions (if/for/read)
     structural_bindings: HashSet<String>,
+    /// Remote state bindings (binding_name -> RemoteState)
+    remote_states: HashMap<String, RemoteState>,
+    /// Non-fatal warnings collected during parsing
+    warnings: Vec<ParseWarning>,
 }
 
 impl<'cfg> ParseContext<'cfg> {
@@ -417,6 +440,8 @@ impl<'cfg> ParseContext<'cfg> {
             evaluating_functions: Vec::new(),
             config,
             structural_bindings: HashSet::new(),
+            remote_states: HashMap::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -599,7 +624,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                 let binding_name = format!("_for{}", anon_for_counter);
                                 anon_for_counter += 1;
                                 let (expanded_resources, expanded_module_calls) =
-                                    parse_for_expr(stmt, &ctx, &binding_name)?;
+                                    parse_for_expr(stmt, &mut ctx, &binding_name)?;
                                 resources.extend(expanded_resources);
                                 module_calls.extend(expanded_module_calls);
                             }
@@ -612,7 +637,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                     expanded_module_calls,
                                     _import,
                                     _remote_state,
-                                ) = parse_if_expr(stmt, &ctx, &binding_name)?;
+                                ) = parse_if_expr(stmt, &mut ctx, &binding_name)?;
                                 resources.extend(expanded_resources);
                                 module_calls.extend(expanded_module_calls);
                             }
@@ -646,7 +671,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                     maybe_import,
                                     maybe_remote_state,
                                     is_structural,
-                                ) = parse_let_binding_extended(stmt, &ctx)?;
+                                ) = parse_let_binding_extended(stmt, &mut ctx)?;
                                 if is_structural {
                                     ctx.structural_bindings.insert(name.clone());
                                 }
@@ -696,6 +721,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                         let placeholder = Resource::new("_remote_state", &name);
                                         ctx.set_resource_binding(name.clone(), placeholder);
                                     }
+                                    ctx.remote_states.insert(rs.binding.clone(), rs.clone());
                                     remote_states.push(rs);
                                 }
                             }
@@ -741,6 +767,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         remote_states,
         requires,
         structural_bindings: ctx.structural_bindings,
+        warnings: ctx.warnings,
     })
 }
 
@@ -1217,7 +1244,7 @@ type LetBindingRhs = (
 #[allow(clippy::type_complexity)]
 fn parse_let_binding_extended(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
 ) -> Result<
     (
         String,
@@ -1282,7 +1309,7 @@ fn detect_structural_rhs(pair: &pest::iterators::Pair<Rule>) -> bool {
 /// Parse expression with potential resource, module call, import, or remote_state
 fn parse_expression_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
     binding_name: &str,
 ) -> Result<LetBindingRhs, ParseError> {
     let coalesce = first_inner(pair, "expression", "expression with resource or module")?;
@@ -1292,7 +1319,7 @@ fn parse_expression_with_resource_or_module(
 
 fn parse_pipe_expr_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
     binding_name: &str,
 ) -> Result<LetBindingRhs, ParseError> {
     let mut inner = pair.into_inner();
@@ -1422,7 +1449,7 @@ fn parse_pipe_expr_with_resource_or_module(
 
 fn parse_primary_with_resource_or_module(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
     binding_name: &str,
 ) -> Result<LetBindingRhs, ParseError> {
     let inner = first_inner(pair, "value", "primary expression")?;
@@ -1502,7 +1529,7 @@ enum ForBodyResult {
 /// a binding name like `binding[0]` or `binding["key"]`.
 fn parse_for_expr(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
     binding_name: &str,
 ) -> Result<(Vec<Resource>, Vec<ModuleCall>), ParseError> {
     let for_line = pair.as_span().start_pos().line_col().0;
@@ -1568,11 +1595,25 @@ fn parse_for_expr(
         }
         // Unresolved reference (e.g., missing upstream export) — tolerate with warning
         (_, Value::ResourceRef { path }) => {
-            eprintln!(
-                "  ⚠ for expression at line {}: {} is not yet available (known after apply)",
-                for_line,
-                path.to_dot_string()
-            );
+            let remote_binding = path.binding();
+            let message = if let Some(rs) = ctx.remote_states.get(remote_binding) {
+                format!(
+                    "`{}` is not yet in the upstream state (remote_state '{}' → {}).\n    Apply that directory first, then re-plan.",
+                    path.to_dot_string(),
+                    remote_binding,
+                    rs.backend.location(),
+                )
+            } else {
+                format!(
+                    "`{}` is not yet available (known after apply)",
+                    path.to_dot_string()
+                )
+            };
+            eprintln!("  ⚠ for expression at line {}: {}", for_line, message);
+            ctx.warnings.push(ParseWarning {
+                line: for_line,
+                message,
+            });
             // Return empty — the for body produces zero resources
         }
         _ => {
@@ -1768,7 +1809,7 @@ enum IfBodyResult {
 /// The condition must evaluate to a static Bool value at parse time.
 fn parse_if_expr(
     pair: pest::iterators::Pair<Rule>,
-    ctx: &ParseContext,
+    ctx: &mut ParseContext,
     binding_name: &str,
 ) -> Result<LetBindingRhs, ParseError> {
     let mut inner = pair.into_inner();
@@ -9863,6 +9904,116 @@ awscc.ec2.vpc {
             cidr,
             Some(&Value::String("10.1.0.0/16".to_string())),
             "?? should return left when it's resolved"
+        );
+    }
+
+    #[test]
+    fn for_unresolved_remote_state_local_warning() {
+        // When a for-expression iterates over an unresolved remote_state (local backend),
+        // the warning should mention the upstream directory rather than generic "known after apply".
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for name, account in orgs.accounts {
+                awscc.ec2.vpc {
+                    name = name
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.warnings.len(), 1);
+        let w = &parsed.warnings[0];
+        assert!(
+            w.message.contains("remote_state 'orgs'"),
+            "warning should mention remote_state binding name, got: {}",
+            w.message
+        );
+        assert!(
+            w.message.contains("../organizations/carina.state.json"),
+            "warning should mention the upstream path, got: {}",
+            w.message
+        );
+        assert!(
+            w.message.contains("Apply that directory first"),
+            "warning should suggest applying upstream, got: {}",
+            w.message
+        );
+        // Should NOT contain the ambiguous "known after apply"
+        assert!(
+            !w.message.contains("known after apply"),
+            "warning should NOT use ambiguous 'known after apply', got: {}",
+            w.message
+        );
+    }
+
+    #[test]
+    fn for_unresolved_remote_state_s3_warning() {
+        // When a for-expression iterates over an unresolved remote_state (S3 backend),
+        // the warning should show the S3 path.
+        let input = r#"
+            let orgs = remote_state "s3" {
+                bucket = "carina-rs-state"
+                key = "management/organizations/carina.state.json"
+            }
+
+            for name, account in orgs.accounts {
+                awscc.ec2.vpc {
+                    name = name
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.warnings.len(), 1);
+        let w = &parsed.warnings[0];
+        assert!(
+            w.message
+                .contains("s3://carina-rs-state/management/organizations/carina.state.json"),
+            "warning should show S3 URI, got: {}",
+            w.message
+        );
+        assert!(
+            w.message.contains("remote_state 'orgs'"),
+            "warning should mention binding name, got: {}",
+            w.message
+        );
+    }
+
+    #[test]
+    fn for_unresolved_non_remote_state_warning() {
+        // When a for-expression has an unresolved ref that is NOT a remote_state,
+        // it should use the generic "known after apply" message.
+        let input = r#"
+            let config = awscc.ec2.vpc {
+                name = "base"
+                cidr_block = '10.0.0.0/16'
+            }
+
+            for name, item in config.items {
+                awscc.ec2.subnet {
+                    name = name
+                    cidr_block = '10.0.1.0/24'
+                }
+            }
+        "#;
+
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.warnings.len(), 1);
+        let w = &parsed.warnings[0];
+        assert!(
+            w.message.contains("known after apply"),
+            "non-remote_state unresolved ref should use generic message, got: {}",
+            w.message
+        );
+        assert!(
+            !w.message.contains("remote_state"),
+            "should NOT mention remote_state for local bindings, got: {}",
+            w.message
         );
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -406,6 +406,13 @@ impl ParsedFile {
                 && matches!(r.get_attr(attr_name), Some(Value::String(n)) if n == attr_value)
         })
     }
+
+    /// Print all collected warnings to stderr.
+    pub fn print_warnings(&self) {
+        for w in &self.warnings {
+            eprintln!("  ⚠ for expression at line {}: {}", w.line, w.message);
+        }
+    }
 }
 
 /// Parse context (variable scope)
@@ -1609,7 +1616,6 @@ fn parse_for_expr(
                     path.to_dot_string()
                 )
             };
-            eprintln!("  ⚠ for expression at line {}: {}", for_line, message);
             ctx.warnings.push(ParseWarning {
                 line: for_line,
                 message,

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -522,6 +522,7 @@ mod tests {
             remote_states: Vec::new(),
             requires: Vec::new(),
             structural_bindings: HashSet::new(),
+            warnings: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Closes #1820

## Summary

- When a `for` expression iterates over an unresolved `remote_state` binding, the warning now shows which upstream state file to apply first (with the remote_state binding name and path/S3 URI), instead of the generic "(known after apply)" which misleadingly implies this directory's apply would resolve it.
- Non-remote-state unresolved references retain the existing "(known after apply)" wording.
- Adds `ParseWarning` struct and `warnings` field to `ParsedFile` for structured warning collection.
- Adds `RemoteStateBackend::location()` method for human-readable backend path formatting.

### Before
```
⚠ for expression at line 60: orgs.accounts is not yet available (known after apply)
```

### After (remote_state)
```
⚠ for expression at line 60: `orgs.accounts` is not yet in the upstream state (remote_state 'orgs' → s3://carina-rs-state/management/organizations/carina.state.json).
    Apply that directory first, then re-plan.
```

### After (non-remote_state, unchanged semantics)
```
⚠ for expression at line 42: `config.items` is not yet available (known after apply)
```

## Test plan
- [x] 3 new parser tests: local backend, S3 backend, non-remote-state fallback
- [x] All existing tests pass (1168 carina-core, full workspace green)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)