### PR TITLE
feat: show deferred for-expressions in plan output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,15 +116,19 @@ plan-fixtures:
 	@echo ""
 	@echo "=== remote_state ==="
 	@$(MAKE) plan-remote-state
+	@echo "---"
+	@$(MAKE) plan-deferred-for
 
 plan-remote-state:
 	cd $(FIXTURES)/remote_state && $(CARINA) plan --refresh=false
+plan-deferred-for:
+	cd $(FIXTURES)/deferred_for && $(CARINA) plan --refresh=false
 plan-exports:
 	cd $(FIXTURES)/exports && $(CARINA) plan --refresh=false
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
-        plan-remote-state plan-exports \
+        plan-remote-state plan-deferred-for plan-exports \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1378,6 +1378,7 @@ async fn run_apply_locked(
         Some(ctx.schemas()),
         &moved_origins,
         &resolved_exports,
+        &parsed.deferred_for_expressions,
     );
 
     // Confirmation prompt
@@ -1679,6 +1680,7 @@ async fn run_apply_from_plan_locked(
         &delete_attributes,
         None,
         &HashMap::new(),
+        &[],
         &[],
     );
 

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -334,6 +334,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -285,6 +285,7 @@ pub async fn run_plan(
             Some(wiring.schemas()),
             &ctx.moved_origins,
             &resolved_exports,
+            &parsed.deferred_for_expressions,
         );
     }
 

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -239,14 +239,7 @@ pub fn format_plan(
 /// Format a single deferred for-expression for plan display.
 fn format_deferred_for_expression(deferred: &carina_core::parser::DeferredForExpression) -> String {
     let mut out = String::new();
-    writeln!(
-        out,
-        "  {} {} (line {})",
-        "?".cyan(),
-        deferred.header,
-        deferred.line,
-    )
-    .unwrap();
+    writeln!(out, "  {} {}", "?".cyan(), deferred.header).unwrap();
     writeln!(
         out,
         "      {}",

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -11,6 +11,7 @@ use carina_core::diff_helpers::compute_map_diff;
 #[cfg(test)]
 use carina_core::effect::CascadingUpdate;
 use carina_core::effect::Effect;
+use carina_core::parser::DEFERRED_UPSTREAM_PLACEHOLDER;
 use carina_core::plan::Plan;
 #[cfg(test)]
 use carina_core::plan_tree::shorten_attr_name;
@@ -49,6 +50,33 @@ fn format_compact_name(
     }
 }
 
+/// Format a value in a deferred for-expression template.
+/// Placeholder strings are shown dimmed; resolved values are shown normally.
+fn format_deferred_value(value: &Value) -> String {
+    match value {
+        Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
+            format!("{}", s.dimmed())
+        }
+        Value::String(s) => format!("'{}'", s),
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::ResourceRef { path } => path.to_dot_string().to_string(),
+        Value::List(items) => {
+            let formatted: Vec<String> = items.iter().map(format_deferred_value).collect();
+            format!("[{}]", formatted.join(", "))
+        }
+        Value::Map(map) => {
+            let formatted: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{} = {}", k, format_deferred_value(v)))
+                .collect();
+            format!("{{{}}}", formatted.join(", "))
+        }
+        _ => format!("{}", DEFERRED_UPSTREAM_PLACEHOLDER.dimmed()),
+    }
+}
+
 /// Format an export value for plan display.
 fn format_export_value(value: &Value) -> String {
     match value {
@@ -79,6 +107,7 @@ pub fn print_plan(
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_params: &[carina_core::parser::ExportParameter],
+    deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
 ) {
     print!(
         "{}",
@@ -88,7 +117,8 @@ pub fn print_plan(
             delete_attributes,
             schemas,
             moved_origins,
-            export_params
+            export_params,
+            deferred_for_expressions,
         )
     );
 }
@@ -104,10 +134,11 @@ pub fn format_plan(
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_params: &[carina_core::parser::ExportParameter],
+    deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
 ) -> String {
     let mut out = String::new();
 
-    if plan.is_empty() {
+    if plan.is_empty() && deferred_for_expressions.is_empty() {
         writeln!(
             out,
             "{}",
@@ -132,6 +163,11 @@ pub fn format_plan(
         schemas,
         moved_origins,
     ));
+
+    // Show deferred for-expressions
+    for deferred in deferred_for_expressions {
+        out.push_str(&format_deferred_for_expression(deferred));
+    }
 
     // Show exports if any
     if !export_params.is_empty() {
@@ -188,9 +224,47 @@ pub fn format_plan(
     if summary.moved > 0 {
         parts.push(format!("{} to move", summary.moved.to_string().yellow()));
     }
+    if !deferred_for_expressions.is_empty() {
+        parts.push(format!(
+            "{} deferred",
+            deferred_for_expressions.len().to_string().cyan()
+        ));
+    }
     writeln!(out, "Plan: {}.", parts.join(", ")).unwrap();
     writeln!(out).unwrap();
 
+    out
+}
+
+/// Format a single deferred for-expression for plan display.
+fn format_deferred_for_expression(deferred: &carina_core::parser::DeferredForExpression) -> String {
+    let mut out = String::new();
+    writeln!(
+        out,
+        "  {} {} (line {})",
+        "?".cyan(),
+        deferred.header,
+        deferred.line,
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "      {}",
+        format!(
+            "expands to {} resources (count known after upstream apply)",
+            deferred.resource_type
+        )
+        .dimmed()
+    )
+    .unwrap();
+    // Sort attributes for deterministic output
+    let mut attrs: Vec<_> = deferred.attributes.iter().collect();
+    attrs.sort_by_key(|(k, _)| k.clone());
+    for (key, value) in &attrs {
+        let formatted = format_deferred_value(value);
+        writeln!(out, "      {}: {}", key.dimmed(), formatted).unwrap();
+    }
+    writeln!(out).unwrap();
     out
 }
 
@@ -1670,6 +1744,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &[],
         );
     }
 
@@ -1690,6 +1765,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
             &[],
         );
     }
@@ -2213,6 +2289,7 @@ mod tests {
             None,
             &HashMap::new(),
             &[],
+            &[],
         );
     }
 
@@ -2240,6 +2317,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
             &[],
         );
     }
@@ -2391,6 +2469,7 @@ mod tests {
             &HashMap::new(),
             None,
             &HashMap::new(),
+            &[],
             &[],
         );
     }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -242,6 +242,7 @@ fn snapshot_all_create() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -256,6 +257,7 @@ fn snapshot_no_changes() {
         None,
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -269,6 +271,7 @@ fn snapshot_mixed_operations() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -299,6 +302,7 @@ fn snapshot_delete_orphan() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -312,6 +316,7 @@ fn snapshot_compact() {
         &HashMap::new(),
         None,
         &HashMap::new(),
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -327,6 +332,7 @@ fn snapshot_map_key_diff() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -341,6 +347,7 @@ fn snapshot_enum_display() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -354,6 +361,7 @@ fn snapshot_no_changes_enum() {
         &HashMap::new(),
         None,
         &HashMap::new(),
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -405,6 +413,7 @@ fn snapshot_default_values() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -418,6 +427,7 @@ fn snapshot_read_only_attrs() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -433,6 +443,7 @@ fn snapshot_explicit() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -447,6 +458,7 @@ fn snapshot_default_tags() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -460,6 +472,7 @@ fn snapshot_state_blocks() {
         &HashMap::new(),
         Some(&schemas),
         &HashMap::new(),
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -490,6 +503,7 @@ fn snapshot_secret_values() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
     ));
     insta::assert_snapshot!(output);
 }
@@ -503,6 +517,7 @@ fn snapshot_moved_with_changes() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -531,6 +546,7 @@ fn snapshot_moved_prev_keys() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -565,6 +581,7 @@ fn snapshot_moved_pure() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
+        &[],
         &[],
     ));
     insta::assert_snapshot!(output);
@@ -644,6 +661,7 @@ fn plan_snapshot_remote_state() {
         Some(&schemas),
         &moved_origins,
         &[],
+        &[],
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -681,6 +699,7 @@ fn plan_snapshot_exports() {
         Some(&schemas),
         &moved_origins,
         &exports,
+        &[],
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -695,6 +714,40 @@ fn snapshot_nested_map_diff() {
         Some(&schemas),
         &HashMap::new(),
         &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_deferred_for() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let fixture_path = PathBuf::from(format!(
+        "{}/tests/fixtures/plan_display/deferred_for",
+        manifest_dir
+    ));
+
+    // Parse — the remote_state has no backing file, so the for-expression is deferred
+    let loaded = load_configuration(&fixture_path).unwrap();
+    let mut parsed = loaded.parsed;
+    let base_dir = get_base_dir(&fixture_path);
+    validate_and_resolve(&mut parsed, base_dir, true).unwrap();
+
+    // The plan should be empty (no concrete effects) but deferred_for_expressions non-empty
+    let plan = carina_core::plan::Plan::new();
+    assert!(
+        !parsed.deferred_for_expressions.is_empty(),
+        "expected at least one deferred for-expression"
+    );
+
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        None,
+        &HashMap::new(),
+        &[],
+        &parsed.deferred_for_expressions,
     ));
     insta::assert_snapshot!(output);
 }

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
@@ -1,0 +1,16 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ? for account_id in orgs.accounts (line 13)
+      expands to sso.assignment resources (count known after upstream apply)
+      instance_arn: 'arn:aws:sso:::instance/ssoins-12345'
+      principal_id: 'group-abc-123'
+      principal_type: 'GROUP'
+      target_id: (known after upstream apply)
+      target_type: 'AWS_ACCOUNT'
+
+
+Plan: 0 to add, 0 to change, 0 to destroy, 1 deferred.

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  ? for account_id in orgs.accounts (line 13)
+  ? for account_id in orgs.accounts
       expands to sso.assignment resources (count known after upstream apply)
       instance_arn: 'arn:aws:sso:::instance/ssoins-12345'
       principal_id: 'group-abc-123'

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -676,6 +676,7 @@ fn test_find_state_bucket_resource_matching_type() {
         requires: vec![],
         structural_bindings: HashSet::new(),
         warnings: vec![],
+        deferred_for_expressions: vec![],
     };
 
     // Matching resource type
@@ -1962,6 +1963,7 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
         requires: vec![],
         structural_bindings: HashSet::new(),
         warnings: vec![],
+        deferred_for_expressions: vec![],
     };
 
     // MockProvider returns not_found for both resources (simulates external deletion)

--- a/carina-cli/tests/fixtures/plan_display/deferred_for/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/deferred_for/main.crn
@@ -1,0 +1,21 @@
+# Test deferred for-expression: remote_state iterable not yet available
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let orgs = remote_state {
+  path = '../organizations/carina.state.json'
+}
+
+let sso_instance_arn = 'arn:aws:sso:::instance/ssoins-12345'
+
+for account_id in orgs.accounts {
+  awscc.sso.assignment {
+    instance_arn   = sso_instance_arn
+    principal_id   = 'group-abc-123'
+    principal_type = 'GROUP'
+    target_id      = account_id
+    target_type    = 'AWS_ACCOUNT'
+  }
+}

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -53,6 +53,7 @@ pub fn load_configuration_with_config(
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
         let mut merged = empty_parsed();
         let mut unresolved_merged = empty_parsed();
@@ -98,6 +99,9 @@ pub fn load_configuration_with_config(
                         .structural_bindings
                         .extend(unresolved.structural_bindings);
                     unresolved_merged.warnings.extend(unresolved.warnings);
+                    unresolved_merged
+                        .deferred_for_expressions
+                        .extend(unresolved.deferred_for_expressions);
 
                     // Merge resolved
                     merged.providers.extend(parsed.providers);
@@ -116,6 +120,9 @@ pub fn load_configuration_with_config(
                         .structural_bindings
                         .extend(parsed.structural_bindings);
                     merged.warnings.extend(parsed.warnings);
+                    merged
+                        .deferred_for_expressions
+                        .extend(parsed.deferred_for_expressions);
                     // Merge backend (only one allowed)
                     if let Some(backend) = parsed.backend {
                         if merged.backend.is_some() {

--- a/carina-core/src/module_resolver.rs
+++ b/carina-core/src/module_resolver.rs
@@ -195,6 +195,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         // Read all .crn files in the directory
@@ -227,6 +228,9 @@ impl<'cfg> ModuleResolver<'cfg> {
                 .structural_bindings
                 .extend(parsed.structural_bindings);
             merged.warnings.extend(parsed.warnings);
+            merged
+                .deferred_for_expressions
+                .extend(parsed.deferred_for_expressions);
         }
 
         Ok(merged)
@@ -1248,6 +1252,7 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
         requires: vec![],
         structural_bindings: HashSet::new(),
         warnings: vec![],
+        deferred_for_expressions: vec![],
     };
 
     for entry in entries.flatten() {
@@ -1271,6 +1276,9 @@ pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
                 .structural_bindings
                 .extend(parsed.structural_bindings);
             merged.warnings.extend(parsed.warnings);
+            merged
+                .deferred_for_expressions
+                .extend(parsed.deferred_for_expressions);
         }
     }
 
@@ -1338,6 +1346,7 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
         requires: vec![],
         structural_bindings: HashSet::new(),
         warnings: vec![],
+        deferred_for_expressions: vec![],
     };
 
     for entry in entries {
@@ -1366,6 +1375,9 @@ pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
                 .structural_bindings
                 .extend(parsed.structural_bindings);
             merged.warnings.extend(parsed.warnings);
+            merged
+                .deferred_for_expressions
+                .extend(parsed.deferred_for_expressions);
         }
     }
 
@@ -1431,6 +1443,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 
@@ -1566,6 +1579,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 
@@ -1692,6 +1706,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 
@@ -2041,6 +2056,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 
@@ -2327,6 +2343,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         }
     }
 
@@ -2498,6 +2515,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {
@@ -2562,6 +2580,7 @@ mod tests {
             requires: vec![],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {
@@ -2654,6 +2673,7 @@ mod tests {
             }],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {
@@ -2722,6 +2742,7 @@ mod tests {
             }],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {
@@ -2787,6 +2808,7 @@ mod tests {
             }],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {
@@ -2878,6 +2900,7 @@ mod tests {
             }],
             structural_bindings: HashSet::new(),
             warnings: vec![],
+            deferred_for_expressions: vec![],
         };
 
         let resolver = {

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -60,6 +60,25 @@ pub struct ParseWarning {
     pub message: String,
 }
 
+/// Placeholder text for values that depend on an upstream apply.
+pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
+
+/// A for-expression whose iterable is unresolved (e.g., remote_state not yet available).
+/// Captures the structural shape of the loop body so the plan can show what
+/// resources *would* be created once the iterable becomes available.
+#[derive(Debug, Clone)]
+pub struct DeferredForExpression {
+    /// Source line number of the `for` keyword.
+    pub line: usize,
+    /// The for-expression header, e.g., `for account_id in orgs.accounts`.
+    pub header: String,
+    /// The resource type the loop body would produce (e.g., `sso.assignment`).
+    pub resource_type: String,
+    /// Attribute template: key → value (concrete values are resolved;
+    /// loop-bound variables remain as `ResourceRef` or placeholder strings).
+    pub attributes: Vec<(String, Value)>,
+}
+
 /// Resource type path for typed references (e.g., aws.vpc, aws.security_group)
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResourceTypePath {
@@ -391,6 +410,8 @@ pub struct ParsedFile {
     pub structural_bindings: HashSet<String>,
     /// Non-fatal warnings collected during parsing.
     pub warnings: Vec<ParseWarning>,
+    /// For-expressions whose iterables are unresolved; displayed as deferred in plan.
+    pub deferred_for_expressions: Vec<DeferredForExpression>,
 }
 
 impl ParsedFile {
@@ -435,6 +456,8 @@ struct ParseContext<'cfg> {
     remote_states: HashMap<String, RemoteState>,
     /// Non-fatal warnings collected during parsing
     warnings: Vec<ParseWarning>,
+    /// Deferred for-expressions collected during parsing
+    deferred_for_expressions: Vec<DeferredForExpression>,
 }
 
 impl<'cfg> ParseContext<'cfg> {
@@ -449,6 +472,7 @@ impl<'cfg> ParseContext<'cfg> {
             structural_bindings: HashSet::new(),
             remote_states: HashMap::new(),
             warnings: Vec::new(),
+            deferred_for_expressions: Vec::new(),
         }
     }
 
@@ -775,6 +799,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         requires,
         structural_bindings: ctx.structural_bindings,
         warnings: ctx.warnings,
+        deferred_for_expressions: ctx.deferred_for_expressions,
     })
 }
 
@@ -1620,7 +1645,56 @@ fn parse_for_expr(
                 line: for_line,
                 message,
             });
-            // Return empty — the for body produces zero resources
+
+            // Build the for-expression header string
+            let header = match &binding {
+                ForBinding::Simple(var) => {
+                    format!("for {} in {}", var, path.to_dot_string())
+                }
+                ForBinding::Indexed(idx, val) => {
+                    format!("for ({}, {}) in {}", idx, val, path.to_dot_string())
+                }
+                ForBinding::Map(k, v) => {
+                    format!("for {}, {} in {}", k, v, path.to_dot_string())
+                }
+            };
+
+            // Try to parse the body once with placeholder values for the loop
+            // variable(s) to extract the resource type and attribute template.
+            let mut template_ctx = ctx.clone();
+            let placeholder = || Value::String(DEFERRED_UPSTREAM_PLACEHOLDER.to_string());
+            match &binding {
+                ForBinding::Simple(var) => {
+                    template_ctx.set_variable(var.clone(), placeholder());
+                }
+                ForBinding::Indexed(idx, val) => {
+                    template_ctx.set_variable(idx.clone(), placeholder());
+                    template_ctx.set_variable(val.clone(), placeholder());
+                }
+                ForBinding::Map(k, v) => {
+                    template_ctx.set_variable(k.clone(), placeholder());
+                    template_ctx.set_variable(v.clone(), placeholder());
+                }
+            }
+
+            let address = format!("{}[?]", binding_name);
+            if let Ok(ForBodyResult::Resource(resource)) =
+                parse_for_body(body_pair, &template_ctx, &address)
+            {
+                let attrs: Vec<(String, Value)> = resource
+                    .attributes
+                    .iter()
+                    .filter(|(k, _)| !k.starts_with('_'))
+                    .map(|(k, expr)| (k.clone(), expr.0.clone()))
+                    .collect();
+                ctx.deferred_for_expressions.push(DeferredForExpression {
+                    line: for_line,
+                    header,
+                    resource_type: resource.id.resource_type.clone(),
+                    attributes: attrs,
+                });
+            }
+            // Return empty — the for body produces zero concrete resources
         }
         _ => {
             let iterable_type = match &iterable {

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -523,6 +523,7 @@ mod tests {
             requires: Vec::new(),
             structural_bindings: HashSet::new(),
             warnings: Vec::new(),
+            deferred_for_expressions: Vec::new(),
         }
     }
 


### PR DESCRIPTION
Closes #1821

## Summary

- When a `for` expression's iterable is an unresolved `remote_state` reference, the plan now shows the structural shape of the loop body as a template instead of silently hiding the resources with "0 to add"
- The parser extracts the resource type and attribute template by parsing the body once with placeholder values for loop variables
- Plan summary includes a "N deferred" count so reviewers know resources are pending

### Before
```
Plan: 2 to read, 0 to add, 0 to change, 0 to destroy.
```

### After
```
Execution Plan:

  <= aws.identitystore.user mizzy (data source)
  <= aws.sts.caller_identity caller (data source)
  ? for account_id in orgs.accounts (line 60)
      expands to sso.assignment resources (count known after upstream apply)
      instance_arn: sso.instance_arn
      permission_set_arn: administrator_access.permission_set_arn
      principal_id: admins.group_id
      principal_type: 'awscc.sso.assignment.PrincipalType.GROUP'
      target_id: (known after upstream apply)
      target_type: 'awscc.sso.assignment.TargetType.AWS_ACCOUNT'

Plan: 2 to read, 0 to add, 0 to change, 0 to destroy, 1 deferred.
```

## Implementation

- **`DeferredForExpression`** struct in `carina-core/src/parser`: captures line, header, resource type, and attribute template
- **`DEFERRED_UPSTREAM_PLACEHOLDER`** constant: shared between parser and display to avoid magic strings
- **`format_deferred_for_expression()`** in `display.rs`: renders the template with `?` symbol
- Fixture + snapshot test in `carina-cli/tests/fixtures/plan_display/deferred_for/`

## Test plan
- [x] New snapshot test for deferred for-expression display
- [x] All existing tests pass (1168 carina-core, 215 carina-cli)
- [x] Clippy clean
- [x] Verified with real infrastructure (identity-center directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)