### PR TITLE
fix: align LSP type-compat check with CLI (#1795 parity)

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -750,7 +750,13 @@ fn check_resource_ref_type_mismatch(
     let ref_attr_schema = ref_schema.attributes.get(ref_attr)?;
     let ref_type_name = ref_attr_schema.attr_type.type_name();
 
-    if expected_type.accepts_type_name(&ref_type_name) || ref_type_name == "String" {
+    let expected_type_name = expected_type.type_name();
+    if expected_type.accepts_type_name(&ref_type_name)
+        || expected_type_name == "String"
+        || ref_type_name == "String"
+        || (expected_type.is_string_based_custom()
+            && ref_attr_schema.attr_type.is_string_based_custom())
+    {
         None
     } else {
         Some(format!(

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1543,3 +1543,71 @@ fn map_key_validation_warns_on_invalid_key() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn string_based_custom_types_are_compatible() {
+    // Regression test for #1822: when both the source and sink are String-based
+    // Custom types (e.g., AwsAccountId → TargetId), the LSP should not flag a
+    // type mismatch, matching the CLI's behavior (#1795).
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    fn validate_account_id(v: &carina_core::resource::Value) -> Result<(), String> {
+        match v {
+            carina_core::resource::Value::String(s) if s.len() == 12 => Ok(()),
+            _ => Err("expected 12-digit account ID".to_string()),
+        }
+    }
+
+    fn validate_target_id(v: &carina_core::resource::Value) -> Result<(), String> {
+        match v {
+            carina_core::resource::Value::String(_) => Ok(()),
+            _ => Err("expected string".to_string()),
+        }
+    }
+
+    // Source resource: has an AwsAccountId attribute
+    let source_schema = ResourceSchema::new("sts.caller_identity").attribute(AttributeSchema::new(
+        "account_id",
+        AttributeType::Custom {
+            name: "AwsAccountId".to_string(),
+            base: Box::new(AttributeType::String),
+            validate: validate_account_id,
+            namespace: Some("aws".to_string()),
+            to_dsl: None,
+        },
+    ));
+
+    // Target resource: has a TargetId attribute (also String-based Custom)
+    let target_schema = ResourceSchema::new("sso.assignment").attribute(AttributeSchema::new(
+        "target_id",
+        AttributeType::Custom {
+            name: "TargetId".to_string(),
+            base: Box::new(AttributeType::String),
+            validate: validate_target_id,
+            namespace: Some("awscc".to_string()),
+            to_dsl: None,
+        },
+    ));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("aws.sts.caller_identity".to_string(), source_schema);
+    schemas.insert("awscc.sso.assignment".to_string(), target_schema);
+    let engine = custom_engine(schemas);
+
+    let doc = create_document(
+        r#"let caller = read aws.sts.caller_identity {}
+
+awscc.sso.assignment {
+target_id = caller.account_id
+}"#,
+    );
+    let diagnostics = engine.analyze(&doc, None);
+    let type_mismatch = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Type mismatch"));
+    assert!(
+        type_mismatch.is_none(),
+        "String-based Custom types should be compatible (AwsAccountId → TargetId). Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Closes #1822

## Summary

- The LSP's `check_resource_ref_type_mismatch` was missing the `is_string_based_custom()` compatibility check that #1795 added to the CLI's `validate_resource_ref_types`
- Also added the missing `expected_type_name == "String"` check (left side of the OR in the CLI)
- Editor no longer shows red squiggles on assignments like `target_id = caller.account_id` where both types are String-based Custom types

## Changes

- `carina-lsp/src/diagnostics/mod.rs`: Added `is_string_based_custom()` check and `expected_type_name == "String"` check to `check_resource_ref_type_mismatch`
- `carina-lsp/src/diagnostics/tests/extended.rs`: Added regression test `string_based_custom_types_are_compatible`

## Test plan
- [x] New test: `AwsAccountId` → `TargetId` no longer produces type mismatch
- [x] All 187 LSP tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)