### PR TITLE
feat: include file name in parse warnings

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -65,6 +65,15 @@ pub fn load_configuration_with_config(
                 .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
             match parser::parse(&content, config) {
                 Ok(mut parsed) => {
+                    // Stamp source file name onto warnings and deferred for-expressions
+                    let file_name = file.file_name().map(|n| n.to_string_lossy().into_owned());
+                    for w in &mut parsed.warnings {
+                        w.file = file_name.clone();
+                    }
+                    for d in &mut parsed.deferred_for_expressions {
+                        d.file = file_name.clone();
+                    }
+
                     let unresolved = parsed.clone();
                     if let Err(e) = parser::resolve_resource_refs_with_config(&mut parsed, config) {
                         parse_errors.push(format!("{}: {}", file.display(), e));

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -56,6 +56,7 @@ pub enum ParseError {
 /// A structured warning emitted during parsing (non-fatal).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseWarning {
+    pub file: Option<String>,
     pub line: usize,
     pub message: String,
 }
@@ -68,6 +69,8 @@ pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
 /// resources *would* be created once the iterable becomes available.
 #[derive(Debug, Clone)]
 pub struct DeferredForExpression {
+    /// Source file name (stamped by config_loader after parsing).
+    pub file: Option<String>,
     /// Source line number of the `for` keyword.
     pub line: usize,
     /// The for-expression header, e.g., `for account_id in orgs.accounts`.
@@ -431,7 +434,11 @@ impl ParsedFile {
     /// Print all collected warnings to stderr.
     pub fn print_warnings(&self) {
         for w in &self.warnings {
-            eprintln!("  ⚠ for expression at line {}: {}", w.line, w.message);
+            let location = match &w.file {
+                Some(f) => format!("{}:{}", f, w.line),
+                None => format!("line {}", w.line),
+            };
+            eprintln!("  ⚠ {}: {}", location, w.message);
         }
     }
 }
@@ -1642,6 +1649,7 @@ fn parse_for_expr(
                 )
             };
             ctx.warnings.push(ParseWarning {
+                file: None,
                 line: for_line,
                 message,
             });
@@ -1688,6 +1696,7 @@ fn parse_for_expr(
                     .map(|(k, expr)| (k.clone(), expr.0.clone()))
                     .collect();
                 ctx.deferred_for_expressions.push(DeferredForExpression {
+                    file: None,
                     line: for_line,
                     header,
                     resource_type: resource.id.resource_type.clone(),


### PR DESCRIPTION
Closes #1829

## Summary

- `ParseWarning` and `DeferredForExpression` now have a `file: Option<String>` field
- `config_loader.rs` stamps the file name after parsing each `.crn` file
- `print_warnings()` shows `main.crn:60:` instead of `for expression at line 60:`

### Before
```
⚠ for expression at line 60: `orgs.accounts` is not yet in the upstream state ...
```

### After
```
⚠ main.crn:60: `orgs.accounts` is not yet in the upstream state ...
```

## Test plan
- [x] All existing tests pass
- [x] Clippy clean
- [x] Verified with real infrastructure (identity-center: `main.crn:60:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)