### PR TITLE
fix: resolve cross-file export expressions before persisting to state

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -531,18 +531,11 @@ fn resolve_exports(
     let mut exports = HashMap::new();
     for param in export_params {
         if let Some(ref value) = param.value {
-            match carina_core::resolver::resolve_ref_value(value, &binding_map) {
-                Ok(resolved) => {
-                    if let Some(json) = dsl_value_to_json(&resolved) {
-                        exports.insert(param.name.clone(), json);
-                    }
-                }
-                Err(e) => {
-                    eprintln!(
-                        "  Warning: failed to resolve export '{}': {}",
-                        param.name, e
-                    );
-                }
+            // Resolve both ResourceRef and cross-file dot-notation strings
+            // (e.g., "registry_prod.account_id" parsed from a different .crn file).
+            let resolved = crate::commands::plan::resolve_export_value(value, &binding_map);
+            if let Some(json) = dsl_value_to_json(&resolved) {
+                exports.insert(param.name.clone(), json);
             }
         }
     }
@@ -2232,5 +2225,54 @@ mod tests {
     fn format_duration_zero() {
         let d = Duration::from_secs(0);
         assert_eq!(format_duration(d), "0.0s");
+    }
+
+    #[test]
+    fn resolve_exports_resolves_cross_file_dot_notation_strings() {
+        use carina_core::parser::ExportParameter;
+        use carina_core::resource::Value;
+        use carina_state::StateFile;
+
+        // Build a state file with a resource that has a binding and attributes
+        let state = {
+            let json = serde_json::json!({
+                "version": 5,
+                "serial": 1,
+                "lineage": "test",
+                "carina_version": "0.4.0",
+                "resources": [
+                    {
+                        "resource_type": "organizations.account",
+                        "name": "registry-prod",
+                        "identifier": "459524413166",
+                        "provider": "awscc",
+                        "binding": "registry_prod",
+                        "attributes": {
+                            "account_id": "459524413166",
+                            "account_name": "registry-prod"
+                        }
+                    }
+                ]
+            });
+            serde_json::from_value::<StateFile>(json).unwrap()
+        };
+
+        // Export param references registry_prod.account_id as a dot-notation string
+        // (this is how cross-file references are parsed: exports.crn doesn't see
+        // the let binding in main.crn, so the parser emits a plain string)
+        let export_params = vec![ExportParameter {
+            name: "account_id".to_string(),
+            type_expr: None,
+            value: Some(Value::String("registry_prod.account_id".to_string())),
+        }];
+
+        let exports = resolve_exports(&export_params, &[], &state);
+
+        assert_eq!(
+            exports.get("account_id"),
+            Some(&serde_json::Value::String("459524413166".to_string())),
+            "resolve_exports should resolve dot-notation strings to actual values. Got: {:?}",
+            exports
+        );
     }
 }

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -364,7 +364,7 @@ pub(crate) fn resolve_export_values_for_display(
 }
 
 /// Resolve a single export value, handling both ResourceRef and dot-notation strings.
-fn resolve_export_value(
+pub(crate) fn resolve_export_value(
     value: &Value,
     binding_map: &HashMap<String, HashMap<String, Value>>,
 ) -> Value {


### PR DESCRIPTION
Closes #1835

## Summary

The apply path's `resolve_exports` used `resolve_ref_value()` which only handles `ResourceRef` values. Cross-file export expressions (dot-notation strings like `"registry_prod.account_id"` parsed from a different `.crn` file) were persisted as literal strings into `state.exports` instead of resolved values.

Now reuses `resolve_export_value()` from the plan display path (shared single source of truth) which handles both `ResourceRef` and dot-notation strings.

### Before (state.exports)
```json
"exports": { "accounts": ["registry_prod.account_id", "registry_dev.account_id"] }
```

### After (state.exports)
```json
"exports": { "accounts": ["459524413166", "151116838382"] }
```

## Test plan
- [x] New test: `resolve_exports_resolves_cross_file_dot_notation_strings`
- [x] All 216 CLI tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)