### PR TITLE
fix: sort resources after expanding deferred for-expressions in apply

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1079,9 +1079,6 @@ async fn run_apply_locked(
     }
     apply_name_overrides(&mut parsed.resources, &state_file);
 
-    // Sort resources by dependencies
-    let sorted_resources = sort_resources_by_dependencies(&parsed.resources)?;
-
     // Select appropriate Provider based on configuration
     let provider = get_provider_with_ctx(ctx, parsed, base_dir).await;
 
@@ -1089,11 +1086,16 @@ async fn run_apply_locked(
     // reference `remote_state` blocks can be resolved during refresh (#1683).
     let remote_bindings = super::plan::load_remote_states(&parsed.remote_states, base_dir).await?;
 
-    // Expand deferred for-expressions now that remote values are available
+    // Expand deferred for-expressions now that remote values are available.
+    // Must happen BEFORE sort_resources_by_dependencies so expanded resources
+    // are included in the sorted set used for planning (#1844).
     parsed.expand_deferred_for_expressions(&remote_bindings);
 
     // Print warnings after expansion (resolved ones are removed)
     parsed.print_warnings();
+
+    // Sort resources by dependencies (after expansion so expanded resources are included)
+    let sorted_resources = sort_resources_by_dependencies(&parsed.resources)?;
 
     // Build state-file-derived maps up front so anonymous → let-bound
     // rename transfer (#1685) can run between refresh phases 1 and 2.


### PR DESCRIPTION
Closes #1844

## Summary

One-line fix: move `sort_resources_by_dependencies` to after `expand_deferred_for_expressions` in the apply path, matching the plan command's order.

### Root cause
```
apply.rs (before):  sort → expand → plan  (expanded resources not in sorted set)
plan.rs:            expand → sort → plan  (correct)
```

### Fix
```
apply.rs (after):   expand → sort → plan  (matches plan.rs)
```

## Test plan
- [x] All 216 CLI tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)