### PR TITLE
fix: re-resolve exports during state refresh

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -506,7 +506,7 @@ pub async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), AppErro
 }
 
 /// Resolve export expressions using the binding map built from applied state.
-fn resolve_exports(
+pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::ExportParameter],
     _resources: &[Resource],
     state: &StateFile,

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -744,6 +744,11 @@ pub(crate) async fn run_state_refresh_locked(
         )?;
     }
 
+    // Re-resolve exports using refreshed state
+    if !parsed.export_params.is_empty() {
+        state.exports = crate::commands::apply::resolve_exports(&parsed.export_params, &[], &state);
+    }
+
     // Save state (with or without lock validation)
     if let Some(lock) = lock {
         crate::commands::apply::save_state_locked(backend, lock, &mut state).await?;


### PR DESCRIPTION
## Summary

- State refresh (`carina state refresh`) now re-resolves export expressions after refreshing resource attributes
- Previously, exports remained stale because `resolve_exports()` was only called in the normal apply path
- Made `resolve_exports()` `pub(crate)` so the state module can reuse it

## Test plan

- [x] All existing tests pass (231 + 1 test suites)
- [x] Clippy clean
- [x] The fix is a 5-line change in a well-tested code path

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)