### PR TITLE
feat: LSP completions and diagnostics for exports type annotations

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -182,7 +182,9 @@ impl CompletionProvider {
                     module_name = None;
                 }
             } else if brace_depth == 0
-                && (trimmed.starts_with("arguments") || trimmed.starts_with("attributes"))
+                && (trimmed.starts_with("arguments")
+                    || trimmed.starts_with("attributes")
+                    || trimmed.starts_with("exports"))
                 && trimmed.ends_with('{')
             {
                 in_args_or_attrs_block = true;
@@ -195,6 +197,7 @@ impl CompletionProvider {
                 && !trimmed.starts_with("provider ")
                 && !trimmed.starts_with("arguments ")
                 && !trimmed.starts_with("attributes ")
+                && !trimmed.starts_with("exports ")
                 && !trimmed.starts_with('#')
             {
                 // This is a module call: "module_name {"

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -636,6 +636,64 @@ impl DiagnosticEngine {
         None
     }
 
+    /// Validate export parameter values against their type annotations.
+    pub(super) fn check_exports_blocks(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        for param in &parsed.export_params {
+            if let (Some(type_expr), Some(value)) = (&param.type_expr, &param.value)
+                && let Some(type_error) = self.validate_attributes_type(type_expr, value)
+                && let Some((line, col)) = self.find_exports_param_position(doc, &param.name)
+            {
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    col + param.name.len() as u32,
+                    DiagnosticSeverity::WARNING,
+                    type_error,
+                ));
+            }
+        }
+
+        diagnostics
+    }
+
+    /// Find the position of an exports parameter name in the document.
+    fn find_exports_param_position(&self, doc: &Document, param_name: &str) -> Option<(u32, u32)> {
+        let text = doc.text();
+        let mut in_exports_block = false;
+
+        for (line_idx, line) in text.lines().enumerate() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("exports") && trimmed.contains('{') {
+                in_exports_block = true;
+                continue;
+            }
+
+            if in_exports_block {
+                if trimmed == "}" {
+                    in_exports_block = false;
+                    continue;
+                }
+
+                if trimmed.starts_with(param_name)
+                    && trimmed[param_name.len()..]
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c == ':' || c == ' ')
+                {
+                    return Some((line_idx as u32, position::leading_whitespace_chars(line)));
+                }
+            }
+        }
+        None
+    }
+
     /// Check for undefined resource references in attribute values
     pub(super) fn check_undefined_references(
         &self,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -590,6 +590,9 @@ impl DiagnosticEngine {
             // Check attributes blocks
             diagnostics.extend(self.check_attributes_blocks(doc, parsed));
 
+            // Check exports blocks
+            diagnostics.extend(self.check_exports_blocks(doc, parsed));
+
             // Check for unused let bindings
             diagnostics.extend(self.check_unused_bindings(doc, parsed));
 


### PR DESCRIPTION
## Summary

- Add type completions for `exports { }` blocks — provider-defined types like `aws_account_id` now appear after `:`, matching `arguments`/`attributes` behavior
- Add LSP diagnostics for export type validation — invalid values get real-time warnings in the editor
- Prevent `exports {` from being misidentified as a module call in completion context

## Changes

- `carina-lsp/src/completion/mod.rs`: Add `exports` to block detection for type position completions
- `carina-lsp/src/diagnostics/checks.rs`: Add `check_exports_blocks()` and `find_exports_param_position()`
- `carina-lsp/src/diagnostics/mod.rs`: Wire up exports diagnostics

## Test plan

- [x] All existing tests pass (1909 tests)
- [x] Clippy clean

Closes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)