### PR TITLE
feat: directory-scoped parsing for LSP diagnostics

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -213,6 +213,83 @@ fn upgrade_cross_file_warnings(merged: &mut ParsedFile, unresolved: &ParsedFile)
     }
 }
 
+/// Parse all `.crn` files in a directory and return a merged `ParsedFile`.
+///
+/// This is the canonical directory-scope parse: each file is parsed
+/// individually, results are merged, and cross-file references are
+/// resolved against the combined binding map. Both CLI and LSP should
+/// use this to ensure consistent results.
+///
+/// Returns `None` for `export_params` values that are cross-file string
+/// references (e.g. `"registry_prod.account_id"`) resolved to `ResourceRef`.
+pub fn parse_directory(dir: &Path, config: &ProviderContext) -> Result<ParsedFile, String> {
+    let dir_buf = dir.to_path_buf();
+    let files = find_crn_files_in_dir(&dir_buf)?;
+    if files.is_empty() {
+        return Err(format!("No .crn files found in {}", dir.display()));
+    }
+
+    let mut merged = ParsedFile::default();
+    let mut parse_errors = Vec::new();
+
+    for file in &files {
+        let content = fs::read_to_string(file)
+            .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
+        match parser::parse(&content, config) {
+            Ok(mut parsed) => {
+                let file_name = file.file_name().map(|n| n.to_string_lossy().into_owned());
+                for w in &mut parsed.warnings {
+                    w.file = file_name.clone();
+                }
+                for d in &mut parsed.deferred_for_expressions {
+                    d.file = file_name.clone();
+                }
+                merge_parsed_file(&mut merged, parsed);
+            }
+            Err(e) => {
+                parse_errors.push(format!("{}: {}", file.display(), e));
+            }
+        }
+    }
+
+    if !parse_errors.is_empty() {
+        return Err(parse_errors.join("\n"));
+    }
+
+    // Resolve cross-file references on the merged result
+    if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
+        return Err(e.to_string());
+    }
+
+    Ok(merged)
+}
+
+/// Merge fields from `source` into `target`.
+fn merge_parsed_file(target: &mut ParsedFile, source: ParsedFile) {
+    target.providers.extend(source.providers);
+    target.resources.extend(source.resources);
+    target.variables.extend(source.variables);
+    target.imports.extend(source.imports);
+    target.module_calls.extend(source.module_calls);
+    target.arguments.extend(source.arguments);
+    target.attribute_params.extend(source.attribute_params);
+    target.export_params.extend(source.export_params);
+    target.state_blocks.extend(source.state_blocks);
+    target.user_functions.extend(source.user_functions);
+    target.remote_states.extend(source.remote_states);
+    target.requires.extend(source.requires);
+    target
+        .structural_bindings
+        .extend(source.structural_bindings);
+    target.warnings.extend(source.warnings);
+    target
+        .deferred_for_expressions
+        .extend(source.deferred_for_expressions);
+    if let Some(backend) = source.backend {
+        target.backend = Some(backend);
+    }
+}
+
 /// Get base directory for module resolution.
 ///
 /// Since paths are now always directories, this returns the path as-is.

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -394,7 +394,7 @@ impl RemoteStateBackend {
 }
 
 /// Parse result
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ParsedFile {
     pub providers: Vec<ProviderConfig>,
     pub resources: Vec<Resource>,

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -191,12 +191,20 @@ impl Backend {
                 .ok()
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
+            // Parse all .crn files in the directory for cross-file reference resolution
+            let dir_parsed = base_path.as_ref().and_then(|dir| {
+                carina_core::config_loader::parse_directory(dir, &self.provider_context).ok()
+            });
+
             let providers = self.providers.read().await;
             let state = base_path
                 .as_ref()
                 .map(|p| providers.state_for_path(p))
                 .unwrap_or(&providers.empty);
-            let diagnostics = state.diagnostic_engine.analyze(&doc, base_path.as_deref());
+            let diagnostics =
+                state
+                    .diagnostic_engine
+                    .analyze(&doc, base_path.as_deref(), dir_parsed.as_ref());
             drop(providers);
 
             self.client

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use crate::document::Document;
 use crate::position;
-use carina_core::parser::ParseError;
+use carina_core::parser::{ParseError, ParsedFile};
 use carina_core::provider::ProviderFactory;
 use carina_core::resource::Value;
 use carina_core::schema::ResourceSchema;
@@ -103,7 +103,12 @@ impl DiagnosticEngine {
         self
     }
 
-    pub fn analyze(&self, doc: &Document, base_path: Option<&Path>) -> Vec<Diagnostic> {
+    pub fn analyze(
+        &self,
+        doc: &Document,
+        base_path: Option<&Path>,
+        dir_parsed: Option<&ParsedFile>,
+    ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
         let text = doc.text();
 
@@ -118,8 +123,12 @@ impl DiagnosticEngine {
         // Check for undefined resource references in the raw text
         diagnostics.extend(self.check_undefined_references(&text, &defined_bindings));
 
+        // Use directory-scoped ParsedFile if available, fall back to single-file parse.
+        // Directory-scoped parsing has all cross-file bindings resolved.
+        let parsed_ref = dir_parsed.or(doc.parsed());
+
         // Semantic analysis on parsed file
-        if let Some(parsed) = doc.parsed() {
+        if let Some(parsed) = parsed_ref {
             // Check provider in module
             diagnostics.extend(self.check_provider_in_module(doc, parsed));
 

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -18,7 +18,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown_field_diag = diagnostics
         .iter()
@@ -48,7 +48,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_mismatch = diagnostics.iter().find(|d| {
         (d.message.contains("Type mismatch") && d.message.contains("Int"))
@@ -80,7 +80,7 @@ ipv4_ipam_pool_id = vpc.vpc_id
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_mismatch = diagnostics
         .iter()
@@ -112,7 +112,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_mismatch = diagnostics
         .iter()
@@ -151,7 +151,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let bad_field_diag = diagnostics
         .iter()
@@ -192,7 +192,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let block_diag = diagnostics
         .iter()
@@ -235,7 +235,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     // Both blocks should get errors
     let block_count = diagnostics
@@ -271,7 +271,7 @@ security_group_ingress = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -306,7 +306,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -332,7 +332,7 @@ group_description = "Test security group"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -356,7 +356,7 @@ region = aws.Region.ap_northeast_1
 aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -379,7 +379,7 @@ region = aws.Region.ap_northeast_1
 let identity = read aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -404,7 +404,7 @@ name = "my-bucket"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -431,8 +431,8 @@ name = "my-bucket"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None);
-    let diags_reversed = engine_rev.analyze(&doc, None);
+    let diags_normal = engine.analyze(&doc, None, None);
+    let diags_reversed = engine_rev.analyze(&doc, None, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -461,8 +461,8 @@ cidr_block = "10.0.0.0/16"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None);
-    let diags_reversed = engine_rev.analyze(&doc, None);
+    let diags_normal = engine.analyze(&doc, None, None);
+    let diags_reversed = engine_rev.analyze(&doc, None, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -493,8 +493,8 @@ name = "test-bucket"
 }"#,
     );
 
-    let diags_normal = engine.analyze(&doc, None);
-    let diags_reversed = engine_rev.analyze(&doc, None);
+    let diags_normal = engine.analyze(&doc, None, None);
+    let diags_reversed = engine_rev.analyze(&doc, None, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -523,7 +523,7 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let dup_diag = diagnostics.iter().find(|d| {
         d.message
             .contains("Duplicate attribute 'internet_gateway_id'")
@@ -556,7 +556,7 @@ let vpc = awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let dup_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Duplicate attribute"));

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -17,7 +17,7 @@ operating_region {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown = diagnostics
         .iter()
@@ -43,7 +43,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown = diagnostics
         .iter()
@@ -68,7 +68,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let mismatch = diagnostics
         .iter()
@@ -95,7 +95,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     // Filter to only struct-related diagnostics (ignore unknown attribute warnings from test schema)
     let struct_diags: Vec<_> = diagnostics
@@ -124,7 +124,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.invalid_value
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -150,7 +150,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.default
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -182,7 +182,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -213,7 +213,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -245,7 +245,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let port_diag = diagnostics
         .iter()
@@ -287,7 +287,7 @@ protocols = ["tcp", "invalid_protocol"]
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let item_diag = diagnostics
         .iter()
@@ -320,7 +320,7 @@ operating_regions = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let mixed_error = diagnostics.iter().find(|d| {
         d.message.contains("operating_region")
@@ -368,7 +368,7 @@ mode = "invalid_mode"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_error = diagnostics
         .iter()
@@ -414,7 +414,7 @@ mode = "active"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_error = diagnostics
         .iter()
@@ -460,7 +460,7 @@ mode = 42
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_error = diagnostics
         .iter()
@@ -485,7 +485,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -514,7 +514,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -539,7 +539,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -571,7 +571,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -599,7 +599,7 @@ config = {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown = diagnostics
         .iter()
@@ -650,7 +650,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -682,7 +682,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -714,7 +714,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -743,7 +743,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -771,7 +771,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -797,7 +797,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function 'not_a_function'"));
@@ -824,7 +824,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function"));
@@ -858,7 +858,7 @@ awscc.ec2.route {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let typo_diag = diagnostics.iter().find(|d| {
         d.message
@@ -889,7 +889,7 @@ awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let ref_diag = diagnostics
         .iter()
@@ -913,7 +913,7 @@ let name = join("-", parts)
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let pipe_diag = diagnostics
         .iter()
@@ -1058,7 +1058,7 @@ let name = parts |> join("-")
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let pipe_diag = diagnostics
         .iter()
@@ -1083,7 +1083,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1108,7 +1108,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1133,7 +1133,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1158,7 +1158,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1238,7 +1238,7 @@ test.target {
 union_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let union_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1258,7 +1258,7 @@ test.target {
 enum_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let enum_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1278,7 +1278,7 @@ test.target {
 custom_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let custom_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("custom_attr"));
@@ -1298,7 +1298,7 @@ test.target {
 union_attr = src.name
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let string_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("union_attr"));
@@ -1322,7 +1322,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1367,7 +1367,7 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
         "mock.test.resource {\n  name = 'test'\n  tags = {\n    key = 'Project'\n    value = 'carina'\n  }\n}",
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let tags_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("tags key/value error"));
@@ -1402,7 +1402,7 @@ fn warning_when_provider_loaded_but_schema_missing() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown_type = diagnostics
         .iter()
@@ -1438,7 +1438,7 @@ fn error_when_provider_not_loaded_at_all() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let unknown_type = diagnostics
         .iter()
@@ -1466,7 +1466,7 @@ fn no_undefined_resource_for_namespaced_enum_value() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
 
     let undefined = diagnostics
         .iter()
@@ -1533,7 +1533,7 @@ fn map_key_validation_warns_on_invalid_key() {
 }
 "#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let has_key_error = diagnostics
         .iter()
         .any(|d| d.message.contains("Map key") || d.message.contains("unknown_op"));
@@ -1601,7 +1601,7 @@ awscc.sso.assignment {
 target_id = caller.account_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None);
+    let diagnostics = engine.analyze(&doc, None, None);
     let type_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch"));


### PR DESCRIPTION
## Summary

- Add `parse_directory()` to `carina-core::config_loader` — parses all `.crn` files in a directory, merges results, and resolves cross-file references
- LSP's `update_diagnostics()` now uses directory-scoped parsing, eliminating false positives from single-file parsing
- Add `Default` derive for `ParsedFile` and extract `merge_parsed_file()` helper

## Problem fixed

Opening `exports.crn` in the LSP produced false type errors like "must be exactly 12 characters" for `registry_prod.account_id` because the binding `registry_prod` was defined in sibling `main.crn`. With single-file parsing, the binding wasn't resolved and remained as a literal string, failing the `aws_account_id` validator.

## Test plan

- [x] All tests pass (1909 tests)
- [x] Clippy clean

Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)