### PR TITLE
fix: resolve cross-file export references in CLI path

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -155,6 +155,15 @@ pub fn load_configuration_with_config(
             return Err(parse_errors.join("\n"));
         }
 
+        // Resolve cross-file forward references on the merged result.
+        // Per-file resolve_resource_refs_with_config (line 78) only sees
+        // bindings within each file; cross-file dot-notation strings in
+        // export_params (e.g., "registry_prod.account_id") remain as
+        // Value::String. This second pass converts them to ResourceRef.
+        if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
+            return Err(e.to_string());
+        }
+
         // Upgrade cross-file warnings: a for-expression in one file may reference
         // a remote_state defined in another file.  During per-file parsing the
         // remote_state is unknown, so the warning falls back to the generic


### PR DESCRIPTION
## Summary

Add a second `resolve_resource_refs_with_config` pass on the merged ParsedFile in `load_configuration_with_config`, so cross-file dot-notation strings in export_params (e.g., `"registry_prod.account_id"` where `registry_prod` is in a sibling file) are resolved to ResourceRef before type validation runs.

The LSP path (`parse_directory`) already did this; the CLI path was missing it.

## Test plan

- [x] All tests pass (1909 tests)
- [x] Clippy clean

Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)