### PR TITLE
fix: use current file's ParsedFile for diagnostics, not dir_parsed

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -637,10 +637,14 @@ impl DiagnosticEngine {
     }
 
     /// Validate export parameter values against their type annotations.
+    ///
+    /// `all_resources` provides cross-file resources for schema-level ref type
+    /// checking. If None, falls back to the current file's resources.
     pub(super) fn check_exports_blocks(
         &self,
         doc: &Document,
         parsed: &ParsedFile,
+        all_resources: Option<&[Resource]>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
@@ -660,10 +664,11 @@ impl DiagnosticEngine {
         }
 
         // Schema-level ref type checking for ResourceRef values in exports
+        let resources = all_resources.unwrap_or(&parsed.resources);
         let schema_key_fn = |r: &Resource| format!("{}.{}", r.id.provider, r.id.resource_type);
         if let Err(ref_errors) = carina_core::validation::validate_export_param_ref_types(
             &parsed.export_params,
-            &parsed.resources,
+            resources,
             &self.schemas,
             &schema_key_fn,
         ) {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -121,14 +121,24 @@ impl DiagnosticEngine {
         }
 
         // Check for undefined resource references in the raw text
-        diagnostics.extend(self.check_undefined_references(&text, &defined_bindings));
+        // Use dir_parsed bindings to avoid false positives for cross-file refs
+        let all_bindings = if let Some(dp) = dir_parsed {
+            let mut b = defined_bindings.clone();
+            for r in &dp.resources {
+                if let Some(ref name) = r.binding {
+                    b.insert(name.clone());
+                }
+            }
+            b
+        } else {
+            defined_bindings.clone()
+        };
+        diagnostics.extend(self.check_undefined_references(&text, &all_bindings));
 
-        // Use directory-scoped ParsedFile if available, fall back to single-file parse.
-        // Directory-scoped parsing has all cross-file bindings resolved.
-        let parsed_ref = dir_parsed.or(doc.parsed());
-
-        // Semantic analysis on parsed file
-        if let Some(parsed) = parsed_ref {
+        // Use current file's ParsedFile for diagnostics (not dir_parsed) so
+        // checks only process items from this file. dir_parsed is used only
+        // for cross-file context (bindings, ref type checking).
+        if let Some(parsed) = doc.parsed() {
             // Check provider in module
             diagnostics.extend(self.check_provider_in_module(doc, parsed));
 
@@ -599,8 +609,9 @@ impl DiagnosticEngine {
             // Check attributes blocks
             diagnostics.extend(self.check_attributes_blocks(doc, parsed));
 
-            // Check exports blocks
-            diagnostics.extend(self.check_exports_blocks(doc, parsed));
+            // Check exports blocks — use dir_parsed resources for cross-file ref type checking
+            let all_resources = dir_parsed.map(|dp| &dp.resources[..]);
+            diagnostics.extend(self.check_exports_blocks(doc, parsed, all_resources));
 
             // Check for unused let bindings
             diagnostics.extend(self.check_unused_bindings(doc, parsed));


### PR DESCRIPTION
## Summary

The LSP was using the directory-scoped `ParsedFile` for all diagnostic checks, causing items from sibling files to be processed and producing side effects. Now uses `doc.parsed()` (current file only) for diagnostics, with `dir_parsed` providing only:

- Binding names for undefined-reference checks (avoids false positives for bindings defined in sibling files)
- All resources for export ref type checking (schema lookup needs cross-file bindings)

## Test plan

- [x] All tests pass (1909 tests)
- [x] Clippy clean

Closes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)