### PR TITLE
Fix multi-line validation errors missing Error: prefix

### DIFF
--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -349,7 +349,7 @@ async fn main() {
                 }
             }
             Err(e) => {
-                eprintln!("{} {}", "Error:".red().bold(), e);
+                eprint!("{}", format_error_lines(&e.to_string()));
                 std::process::exit(1);
             }
         }
@@ -468,11 +468,18 @@ async fn main() {
                 std::process::exit(130);
             }
             _ => {
-                eprintln!("{} {}", "Error:".red().bold(), e);
+                eprint!("{}", format_error_lines(&e.to_string()));
                 std::process::exit(1);
             }
         }
     }
+}
+
+fn format_error_lines(msg: &str) -> String {
+    let prefix = "Error:".red().bold().to_string();
+    msg.lines()
+        .map(|line| format!("{} {}\n", prefix, line))
+        .collect()
 }
 
 #[cfg(test)]
@@ -485,3 +492,22 @@ mod module_list_tests;
 mod plan_snapshot_tests;
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod error_format_tests {
+    use super::*;
+
+    #[test]
+    fn single_line_error_has_prefix() {
+        colored::control::set_override(false);
+        let result = format_error_lines("something went wrong");
+        assert_eq!(result, "Error: something went wrong\n");
+    }
+
+    #[test]
+    fn multi_line_error_each_line_has_prefix() {
+        colored::control::set_override(false);
+        let result = format_error_lines("first error\nsecond error");
+        assert_eq!(result, "Error: first error\nError: second error\n");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `format_error_lines()` helper that prefixes every line with `Error:` (red, bold)
- Apply to both error exit paths in `main.rs` (plan early-exit and general catch-all)
- Before: only the first line of a multi-line error got the prefix
- After: each line is clearly identified as a separate error

## Test plan

- [x] Unit tests for single-line and multi-line error formatting
- [x] `cargo test -p carina-cli` — 234 passed
- [x] `cargo clippy -p carina-cli` — no warnings

Closes #1877

🤖 Generated with [Claude Code](https://claude.com/claude-code)