### PR TITLE
Extract shared type-compatibility check into AttributeType

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -487,6 +487,29 @@ impl AttributeType {
     pub fn is_string_based_custom(&self) -> bool {
         matches!(self, AttributeType::Custom { base, .. } if matches!(**base, AttributeType::String))
     }
+
+    /// Check if two attribute types are compatible for ResourceRef assignment.
+    ///
+    /// Compatibility rules:
+    /// - Union type accepts any member type name
+    /// - Same type name is always compatible
+    /// - Either side being `String` is compatible (String is the base for Custom types)
+    /// - Both sides being String-based Custom types are compatible
+    pub fn is_compatible_with(&self, other: &AttributeType) -> bool {
+        let self_name = self.type_name();
+        let other_name = other.type_name();
+
+        if self.accepts_type_name(&other_name) || other.accepts_type_name(&self_name) {
+            return true;
+        }
+        if self_name == "String" || other_name == "String" {
+            return true;
+        }
+        if self.is_string_based_custom() && other.is_string_based_custom() {
+            return true;
+        }
+        false
+    }
 }
 
 impl fmt::Display for AttributeType {
@@ -3219,5 +3242,56 @@ mod tests {
         attrs.insert("_binding".to_string(), Value::String("b".to_string()));
 
         assert!(schema.validate(&attrs).is_ok());
+    }
+
+    fn make_custom(name: &str, base: AttributeType) -> AttributeType {
+        AttributeType::Custom {
+            name: name.to_string(),
+            base: Box::new(base),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+        }
+    }
+
+    #[test]
+    fn is_compatible_with_same_type() {
+        assert!(AttributeType::String.is_compatible_with(&AttributeType::String));
+        assert!(AttributeType::Int.is_compatible_with(&AttributeType::Int));
+    }
+
+    #[test]
+    fn is_compatible_with_different_base_types() {
+        assert!(!AttributeType::Bool.is_compatible_with(&AttributeType::Int));
+        assert!(!AttributeType::Int.is_compatible_with(&AttributeType::Bool));
+    }
+
+    #[test]
+    fn is_compatible_with_string_and_custom() {
+        let custom = make_custom("VpcId", AttributeType::String);
+        assert!(AttributeType::String.is_compatible_with(&custom));
+        assert!(custom.is_compatible_with(&AttributeType::String));
+    }
+
+    #[test]
+    fn is_compatible_with_two_string_based_customs() {
+        let vpc_id = make_custom("VpcId", AttributeType::String);
+        let subnet_id = make_custom("SubnetId", AttributeType::String);
+        assert!(vpc_id.is_compatible_with(&subnet_id));
+    }
+
+    #[test]
+    fn is_compatible_with_union_accepts_member() {
+        let vpc_id = make_custom("VpcId", AttributeType::String);
+        let union = AttributeType::Union(vec![vpc_id, AttributeType::String]);
+        let other_vpc_id = make_custom("VpcId", AttributeType::String);
+        assert!(union.is_compatible_with(&other_vpc_id));
+    }
+
+    #[test]
+    fn is_compatible_with_int_custom_rejects_string_custom() {
+        let int_custom = make_custom("Port", AttributeType::Int);
+        let string_custom = make_custom("VpcId", AttributeType::String);
+        assert!(!int_custom.is_compatible_with(&string_custom));
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -137,21 +137,9 @@ pub fn validate_resource_ref_types(
             };
             let ref_type_name = ref_attr_schema.attr_type.type_name();
 
-            // Type compatibility check:
-            // - Union type accepts any member type name -> OK
-            // - Same type -> OK
-            // - Either is "String" -> OK (String is the base type for Custom types)
-            // - Both are String-based Custom types -> OK (different length/pattern constraints
-            //   for the same logical identifier, or semantic type assigned to generic pattern)
-            // - Different Custom types -> Error
-            if attr_schema.attr_type.accepts_type_name(&ref_type_name) {
-                continue;
-            }
-            if expected_type_name == "String" || ref_type_name == "String" {
-                continue;
-            }
-            if attr_schema.attr_type.is_string_based_custom()
-                && ref_attr_schema.attr_type.is_string_based_custom()
+            if attr_schema
+                .attr_type
+                .is_compatible_with(&ref_attr_schema.attr_type)
             {
                 continue;
             }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -757,21 +757,14 @@ fn check_resource_ref_type_mismatch(
 ) -> Option<String> {
     let ref_schema = binding_schema_map.get(ref_binding)?;
     let ref_attr_schema = ref_schema.attributes.get(ref_attr)?;
-    let ref_type_name = ref_attr_schema.attr_type.type_name();
 
-    let expected_type_name = expected_type.type_name();
-    if expected_type.accepts_type_name(&ref_type_name)
-        || expected_type_name == "String"
-        || ref_type_name == "String"
-        || (expected_type.is_string_based_custom()
-            && ref_attr_schema.attr_type.is_string_based_custom())
-    {
+    if expected_type.is_compatible_with(&ref_attr_schema.attr_type) {
         None
     } else {
         Some(format!(
             "Type mismatch: expected {}, got {} (from {}.{})",
             expected_type.type_name(),
-            ref_type_name,
+            ref_attr_schema.attr_type.type_name(),
             ref_binding,
             ref_attr
         ))


### PR DESCRIPTION
## Summary

- Add `AttributeType::is_compatible_with()` method in carina-core
- Replace duplicated type-compat logic in CLI (`validation.rs`) and LSP (`diagnostics/mod.rs`)
- Eliminates drift risk that caused #1822

## Test plan

- [x] 6 new unit tests for `is_compatible_with` (same type, different types, String+Custom, two Custom, Union, Int-Custom vs String-Custom)
- [x] Full workspace `cargo test` passes
- [x] `cargo clippy` — no warnings

Closes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)