### PR TITLE
Fix deferred for-expression display: full type name and clearer wording

### DIFF
--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -244,7 +244,7 @@ fn format_deferred_for_expression(deferred: &carina_core::parser::DeferredForExp
         out,
         "      {}",
         format!(
-            "expands to {} resources (count known after upstream apply)",
+            "expands to one {} per element (count known after upstream apply)",
             deferred.resource_type
         )
         .dimmed()

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__snapshot_deferred_for.snap
@@ -5,7 +5,7 @@ expression: output
 Execution Plan:
 
   ? for account_id in orgs.accounts
-      expands to sso.assignment resources (count known after upstream apply)
+      expands to one awscc.sso.assignment per element (count known after upstream apply)
       instance_arn: 'arn:aws:sso:::instance/ssoins-12345'
       principal_id: 'group-abc-123'
       principal_type: 'GROUP'

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -77,7 +77,7 @@ pub struct DeferredForExpression {
     pub line: usize,
     /// The for-expression header, e.g., `for account_id in orgs.accounts`.
     pub header: String,
-    /// The resource type the loop body would produce (e.g., `sso.assignment`).
+    /// The provider-qualified resource type the loop body would produce (e.g., `awscc.sso.assignment`).
     pub resource_type: String,
     /// Attribute template: key → value (concrete values are resolved;
     /// loop-bound variables remain as `ResourceRef` or placeholder strings).
@@ -1811,7 +1811,11 @@ fn parse_for_expr(
                     file: None,
                     line: for_line,
                     header,
-                    resource_type: resource.id.resource_type.clone(),
+                    resource_type: if resource.id.provider.is_empty() {
+                        resource.id.resource_type.clone()
+                    } else {
+                        format!("{}.{}", resource.id.provider, resource.id.resource_type)
+                    },
                     attributes: attrs,
                     binding_name: binding_name.to_string(),
                     iterable_binding: path.binding().to_string(),


### PR DESCRIPTION
## Summary

- Use provider-qualified type name (`awscc.sso.assignment` instead of `sso.assignment`)
- Change wording from "expands to ... resources" to "expands to one ... per element"

Before:
```
? for account_id in orgs.accounts
    expands to sso.assignment resources (count known after upstream apply)
```

After:
```
? for account_id in orgs.accounts
    expands to one awscc.sso.assignment per element (count known after upstream apply)
```

## Test plan

- [x] Snapshot test updated and passes
- [x] All carina-cli tests pass
- [x] `cargo clippy` — no warnings

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)