### PR TITLE
Fix false 'Undefined resource' for cross-file bindings in LSP

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -186,12 +186,22 @@ impl Backend {
 
     /// Scan sibling .crn files for `let binding = provider.service.type {` patterns.
     /// Returns a map of binding_name → "provider.service.type" (schema key).
-    fn scan_sibling_bindings(dir: &Path, current_uri: &Url) -> HashMap<String, String> {
+    /// Scan sibling .crn files for let bindings and references.
+    ///
+    /// Returns:
+    /// - `bindings`: binding_name → resource_type for let bindings in sibling files
+    /// - `referenced`: binding names from the current file that are referenced by sibling files
+    fn scan_sibling_context(
+        dir: &Path,
+        current_uri: &Url,
+        current_bindings: &std::collections::HashSet<String>,
+    ) -> (HashMap<String, String>, std::collections::HashSet<String>) {
         let mut bindings = HashMap::new();
+        let mut referenced = std::collections::HashSet::new();
         let current_path = current_uri.to_file_path().ok();
         let entries = match std::fs::read_dir(dir) {
             Ok(e) => e,
-            Err(_) => return bindings,
+            Err(_) => return (bindings, referenced),
         };
         for entry in entries.flatten() {
             let path = entry.path();
@@ -216,10 +226,21 @@ impl Backend {
                             }
                         }
                     }
+
+                    // Check if this line references any binding from the current file
+                    // Look for "binding_name." patterns after "="
+                    if let Some(eq_pos) = trimmed.find('=') {
+                        let after_eq = trimmed[eq_pos + 1..].trim();
+                        for name in current_bindings.iter() {
+                            if after_eq.starts_with(&format!("{}.", name)) {
+                                referenced.insert(name.clone());
+                            }
+                        }
+                    }
                 }
             }
         }
-        bindings
+        (bindings, referenced)
     }
 
     async fn update_diagnostics(&self, uri: Url) {
@@ -229,10 +250,29 @@ impl Backend {
                 .ok()
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
-            // Scan sibling files for binding→resource_type mapping
-            let sibling_bindings = base_path
+            // Extract current file's bindings for cross-file reference scanning
+            let current_bindings: std::collections::HashSet<String> = {
+                let text = doc.text();
+                let mut bindings = std::collections::HashSet::new();
+                for line in text.lines() {
+                    let trimmed = line.trim();
+                    if let Some(rest) = trimmed.strip_prefix("let ")
+                        && let Some(eq_pos) = rest.find('=')
+                    {
+                        let name = rest[..eq_pos].trim();
+                        if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+                        {
+                            bindings.insert(name.to_string());
+                        }
+                    }
+                }
+                bindings
+            };
+
+            // Scan sibling files for bindings and references to this file's bindings
+            let (sibling_bindings, sibling_referenced) = base_path
                 .as_ref()
-                .map(|dir| Self::scan_sibling_bindings(dir, &uri))
+                .map(|dir| Self::scan_sibling_context(dir, &uri, &current_bindings))
                 .unwrap_or_default();
 
             let providers = self.providers.read().await;
@@ -240,10 +280,12 @@ impl Backend {
                 .as_ref()
                 .map(|p| providers.state_for_path(p))
                 .unwrap_or(&providers.empty);
-            let diagnostics =
-                state
-                    .diagnostic_engine
-                    .analyze(&doc, base_path.as_deref(), &sibling_bindings);
+            let diagnostics = state.diagnostic_engine.analyze(
+                &doc,
+                base_path.as_deref(),
+                &sibling_bindings,
+                &sibling_referenced,
+            );
             drop(providers);
 
             self.client

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -4,7 +4,7 @@ mod validation;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -108,6 +108,7 @@ impl DiagnosticEngine {
         doc: &Document,
         base_path: Option<&Path>,
         sibling_bindings: &HashMap<String, String>,
+        sibling_referenced: &HashSet<String>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
         let text = doc.text();
@@ -604,8 +605,13 @@ impl DiagnosticEngine {
             // Check exports blocks
             diagnostics.extend(self.check_exports_blocks(doc, parsed, None, sibling_bindings));
 
-            // Check for unused let bindings
-            diagnostics.extend(self.check_unused_bindings(doc, parsed));
+            // Check for unused let bindings (exclude bindings referenced by sibling files)
+            let unused_diags = self.check_unused_bindings(doc, parsed);
+            diagnostics.extend(unused_diags.into_iter().filter(|d| {
+                !sibling_referenced
+                    .iter()
+                    .any(|name| d.message.contains(&format!("'{}'", name)))
+            }));
 
             // Check for unknown attributes on resource references (typo detection)
             diagnostics.extend(self.check_resource_ref_attributes(

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -121,7 +121,12 @@ impl DiagnosticEngine {
         }
 
         // Check for undefined resource references in the raw text
-        let undef_diags = self.check_undefined_references(&text, &defined_bindings);
+        // Include sibling file bindings to avoid false positives for cross-file refs
+        let mut all_bindings = defined_bindings.clone();
+        for name in sibling_bindings.keys() {
+            all_bindings.insert(name.clone());
+        }
+        let undef_diags = self.check_undefined_references(&text, &all_bindings);
         diagnostics.extend(undef_diags);
 
         // Semantic analysis on parsed file

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -18,7 +18,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown_field_diag = diagnostics
         .iter()
@@ -48,7 +48,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_mismatch = diagnostics.iter().find(|d| {
         (d.message.contains("Type mismatch") && d.message.contains("Int"))
@@ -80,7 +80,7 @@ ipv4_ipam_pool_id = vpc.vpc_id
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_mismatch = diagnostics
         .iter()
@@ -112,7 +112,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_mismatch = diagnostics
         .iter()
@@ -151,7 +151,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let bad_field_diag = diagnostics
         .iter()
@@ -192,7 +192,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let block_diag = diagnostics
         .iter()
@@ -235,7 +235,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     // Both blocks should get errors
     let block_count = diagnostics
@@ -271,7 +271,7 @@ security_group_ingress = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let lint_diag = diagnostics
         .iter()
@@ -306,7 +306,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let lint_diag = diagnostics
         .iter()
@@ -332,7 +332,7 @@ group_description = "Test security group"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let lint_diag = diagnostics
         .iter()
@@ -356,7 +356,7 @@ region = aws.Region.ap_northeast_1
 aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let data_source_diag = diagnostics
         .iter()
@@ -379,7 +379,7 @@ region = aws.Region.ap_northeast_1
 let identity = read aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let data_source_diag = diagnostics
         .iter()
@@ -404,7 +404,7 @@ name = "my-bucket"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let data_source_diag = diagnostics
         .iter()
@@ -431,8 +431,8 @@ name = "my-bucket"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new());
+    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -461,8 +461,8 @@ cidr_block = "10.0.0.0/16"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new());
+    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -493,8 +493,8 @@ name = "test-bucket"
 }"#,
     );
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new());
+    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -523,7 +523,7 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let dup_diag = diagnostics.iter().find(|d| {
         d.message
             .contains("Duplicate attribute 'internet_gateway_id'")
@@ -556,7 +556,7 @@ let vpc = awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let dup_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Duplicate attribute"));

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1886,3 +1886,43 @@ fn exports_type_warning_multiline_vs_oneline() {
         diag_literal.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn no_undefined_resource_for_sibling_binding_in_exports() {
+    let engine = DiagnosticEngine::new(
+        Arc::new(HashMap::new()),
+        vec!["awscc".to_string()],
+        Arc::new(vec![]),
+    );
+    let doc = create_document(
+        r#"exports {
+  accounts: map(aws_account_id) = {
+    prod = registry_prod.account_id
+    dev = registry_dev.account_id
+  }
+}
+"#,
+    );
+
+    // registry_prod and registry_dev are defined in sibling files
+    let mut sibling_bindings = HashMap::new();
+    sibling_bindings.insert(
+        "registry_prod".to_string(),
+        "awscc.organizations.account".to_string(),
+    );
+    sibling_bindings.insert(
+        "registry_dev".to_string(),
+        "awscc.organizations.account".to_string(),
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &sibling_bindings);
+
+    let undefined = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource"));
+    assert!(
+        undefined.is_none(),
+        "Sibling binding refs should not be flagged as undefined. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -19,7 +19,7 @@ operating_region {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown = diagnostics
         .iter()
@@ -45,7 +45,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown = diagnostics
         .iter()
@@ -70,7 +70,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let mismatch = diagnostics
         .iter()
@@ -97,7 +97,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     // Filter to only struct-related diagnostics (ignore unknown attribute warnings from test schema)
     let struct_diags: Vec<_> = diagnostics
@@ -126,7 +126,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.invalid_value
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let enum_diag = diagnostics
         .iter()
@@ -152,7 +152,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.default
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let enum_diag = diagnostics
         .iter()
@@ -184,7 +184,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let enum_diag = diagnostics
         .iter()
@@ -215,7 +215,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let enum_diag = diagnostics
         .iter()
@@ -247,7 +247,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let port_diag = diagnostics
         .iter()
@@ -289,7 +289,7 @@ protocols = ["tcp", "invalid_protocol"]
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let item_diag = diagnostics
         .iter()
@@ -322,7 +322,7 @@ operating_regions = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let mixed_error = diagnostics.iter().find(|d| {
         d.message.contains("operating_region")
@@ -370,7 +370,7 @@ mode = "invalid_mode"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_error = diagnostics
         .iter()
@@ -416,7 +416,7 @@ mode = "active"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_error = diagnostics
         .iter()
@@ -462,7 +462,7 @@ mode = 42
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_error = diagnostics
         .iter()
@@ -487,7 +487,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let undefined_diag = diagnostics
         .iter()
@@ -516,7 +516,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let undefined_diag = diagnostics
         .iter()
@@ -541,7 +541,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -573,7 +573,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -601,7 +601,7 @@ config = {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown = diagnostics
         .iter()
@@ -652,7 +652,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -684,7 +684,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let undefined_diag = diagnostics
         .iter()
@@ -716,7 +716,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let undefined_diag = diagnostics
         .iter()
@@ -745,7 +745,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -773,7 +773,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -799,7 +799,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function 'not_a_function'"));
@@ -826,7 +826,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function"));
@@ -860,7 +860,7 @@ awscc.ec2.route {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let typo_diag = diagnostics.iter().find(|d| {
         d.message
@@ -891,7 +891,7 @@ awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let ref_diag = diagnostics
         .iter()
@@ -915,7 +915,7 @@ let name = join("-", parts)
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let pipe_diag = diagnostics
         .iter()
@@ -1060,7 +1060,7 @@ let name = parts |> join("-")
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let pipe_diag = diagnostics
         .iter()
@@ -1085,7 +1085,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -1110,7 +1110,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -1135,7 +1135,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -1160,7 +1160,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -1240,7 +1240,7 @@ test.target {
 union_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let union_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1260,7 +1260,7 @@ test.target {
 enum_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let enum_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1280,7 +1280,7 @@ test.target {
 custom_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let custom_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("custom_attr"));
@@ -1300,7 +1300,7 @@ test.target {
 union_attr = src.name
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let string_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("union_attr"));
@@ -1324,7 +1324,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let type_diag = diagnostics
         .iter()
@@ -1369,7 +1369,7 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
         "mock.test.resource {\n  name = 'test'\n  tags = {\n    key = 'Project'\n    value = 'carina'\n  }\n}",
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let tags_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("tags key/value error"));
@@ -1404,7 +1404,7 @@ fn warning_when_provider_loaded_but_schema_missing() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown_type = diagnostics
         .iter()
@@ -1440,7 +1440,7 @@ fn error_when_provider_not_loaded_at_all() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let unknown_type = diagnostics
         .iter()
@@ -1468,7 +1468,7 @@ fn no_undefined_resource_for_namespaced_enum_value() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let undefined = diagnostics
         .iter()
@@ -1535,7 +1535,7 @@ fn map_key_validation_warns_on_invalid_key() {
 }
 "#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let has_key_error = diagnostics
         .iter()
         .any(|d| d.message.contains("Map key") || d.message.contains("unknown_op"));
@@ -1603,7 +1603,7 @@ awscc.sso.assignment {
 target_id = caller.account_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let type_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch"));
@@ -1654,7 +1654,7 @@ fn exports_cross_file_ref_no_false_positive() {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     let false_positive = diagnostics
         .iter()
@@ -1678,8 +1678,18 @@ fn exports_type_warning_survives_formatter_round_trip() {
     let formatted = format(original, &FormatConfig::default()).unwrap();
 
     let engine = test_engine();
-    let before = engine.analyze(&create_document(original), None, &HashMap::new());
-    let after = engine.analyze(&create_document(&formatted), None, &HashMap::new());
+    let before = engine.analyze(
+        &create_document(original),
+        None,
+        &HashMap::new(),
+        &HashSet::new(),
+    );
+    let after = engine.analyze(
+        &create_document(&formatted),
+        None,
+        &HashMap::new(),
+        &HashSet::new(),
+    );
 
     let before_warning = before
         .iter()
@@ -1723,8 +1733,18 @@ exports {
 }"#;
     let formatted = format(original, &FormatConfig::default()).unwrap();
 
-    let before = engine.analyze(&create_document(original), None, &HashMap::new());
-    let after = engine.analyze(&create_document(&formatted), None, &HashMap::new());
+    let before = engine.analyze(
+        &create_document(original),
+        None,
+        &HashMap::new(),
+        &HashSet::new(),
+    );
+    let after = engine.analyze(
+        &create_document(&formatted),
+        None,
+        &HashMap::new(),
+        &HashSet::new(),
+    );
 
     let before_warning = before
         .iter()
@@ -1788,7 +1808,7 @@ exports {
         text: formatted.clone(),
     });
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     let warning = diagnostics
         .iter()
         .find(|d| d.message.contains("export 'values': type mismatch"))
@@ -1820,7 +1840,7 @@ fn exports_type_warning_after_format_with_cross_file_ref() {
   accounts: list(bool) = [registry_prod.account_id, registry_dev.account_id]
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
     // "registry_prod.account_id" is a cross-file ref (dot-notation string).
     // It should NOT produce a false positive (12-digit check etc.).
@@ -1851,7 +1871,7 @@ fn exports_type_warning_for_literal_mismatch() {
   flag: bool = 'hello'
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new());
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
     eprintln!(
         "literal mismatch diagnostics: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -1871,7 +1891,7 @@ fn exports_type_warning_multiline_vs_oneline() {
     let engine = test_engine();
     // Multi-line (before format)
     let doc_multi = create_document("exports {\n  flag: bool = 'hello'\n}");
-    let diag_multi = engine.analyze(&doc_multi, None, &HashMap::new());
+    let diag_multi = engine.analyze(&doc_multi, None, &HashMap::new(), &HashSet::new());
     eprintln!(
         "multi-line: {:?}",
         diag_multi.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -1880,7 +1900,7 @@ fn exports_type_warning_multiline_vs_oneline() {
     // After user types but before format - with wrong type and literal
     let doc_literal =
         create_document("exports {\n  accounts: list(bool) = ['literal1', 'literal2']\n}");
-    let diag_literal = engine.analyze(&doc_literal, None, &HashMap::new());
+    let diag_literal = engine.analyze(&doc_literal, None, &HashMap::new(), &HashSet::new());
     eprintln!(
         "literal list(bool): {:?}",
         diag_literal.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -1915,7 +1935,7 @@ fn no_undefined_resource_for_sibling_binding_in_exports() {
         "awscc.organizations.account".to_string(),
     );
 
-    let diagnostics = engine.analyze(&doc, None, &sibling_bindings);
+    let diagnostics = engine.analyze(&doc, None, &sibling_bindings, &HashSet::new());
 
     let undefined = diagnostics
         .iter()


### PR DESCRIPTION
## Summary

- Include `sibling_bindings` in the undefined-reference check so bindings from sibling `.crn` files are recognized
- Extend sibling scan to detect which current-file bindings are referenced by siblings, suppressing false "Unused let binding" warnings
- Fixes both cross-file diagnostic false positives

## Root Cause

Commit 9bcd27d6 replaced the `dir_parsed`-based approach with `sibling_bindings` but forgot to merge them into the binding set passed to `check_undefined_references()`. Additionally, `check_unused_bindings` only sees the single-file ParsedFile and cannot detect references from sibling files.

## Test plan

- [x] New test: `no_undefined_resource_for_sibling_binding_in_exports`
- [x] All LSP tests pass (195 passed)
- [x] `cargo clippy -p carina-lsp` — no warnings

Closes #1885
Closes #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)