### PR TITLE
Fix: validate Map entry types in export ResourceRef check

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -327,6 +327,19 @@ fn collect_ref_type_errors(
                 );
             }
         }
+        (TypeExpr::Map(inner), Value::Map(map)) => {
+            for value in map.values() {
+                collect_ref_type_errors(
+                    inner,
+                    value,
+                    param_name,
+                    binding_map,
+                    schemas,
+                    schema_key_fn,
+                    errors,
+                );
+            }
+        }
         _ => {}
     }
 }
@@ -1884,5 +1897,103 @@ let vpc = awscc.ec2.vpc {
             &TypeExpr::Simple("aws_account_id".to_string()),
             &AttributeType::String,
         ));
+    }
+
+    #[test]
+    fn validate_export_param_ref_types_map_accepts_compatible_types() {
+        use crate::parser::ExportParameter;
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "organizations.account".to_string(),
+            make_schema(
+                "organizations.account",
+                vec![("account_id", AttributeType::String)],
+            ),
+        );
+
+        let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+            .with_binding("registry_prod")
+            .with_attribute("account_id", Value::String("111".to_string()));
+
+        let mut map_value = HashMap::new();
+        map_value.insert(
+            "prod".to_string(),
+            Value::resource_ref(
+                "registry_prod".to_string(),
+                "account_id".to_string(),
+                vec![],
+            ),
+        );
+
+        let exports = vec![ExportParameter {
+            name: "accounts".to_string(),
+            // declared as map(string), and values are String-typed — should pass
+            type_expr: Some(TypeExpr::Map(Box::new(TypeExpr::String))),
+            value: Some(Value::Map(map_value)),
+        }];
+
+        let result = validate_export_param_ref_types(
+            &exports,
+            &[registry_prod],
+            &schemas,
+            &test_schema_key_fn,
+        );
+        assert!(
+            result.is_ok(),
+            "map(string) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_export_param_ref_types_map_rejects_type_mismatch() {
+        use crate::parser::ExportParameter;
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "organizations.account".to_string(),
+            make_schema(
+                "organizations.account",
+                vec![("account_id", AttributeType::String)],
+            ),
+        );
+
+        let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+            .with_binding("registry_prod")
+            .with_attribute("account_id", Value::String("111".to_string()));
+
+        let mut map_value = HashMap::new();
+        map_value.insert(
+            "prod".to_string(),
+            Value::resource_ref(
+                "registry_prod".to_string(),
+                "account_id".to_string(),
+                vec![],
+            ),
+        );
+
+        let exports = vec![ExportParameter {
+            name: "accounts".to_string(),
+            // declared as map(bool) — values should be rejected as they are strings
+            type_expr: Some(TypeExpr::Map(Box::new(TypeExpr::Bool))),
+            value: Some(Value::Map(map_value)),
+        }];
+
+        let result = validate_export_param_ref_types(
+            &exports,
+            &[registry_prod],
+            &schemas,
+            &test_schema_key_fn,
+        );
+        assert!(
+            result.is_err(),
+            "map(bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("accounts") && err.contains("type mismatch"),
+            "error should mention the export name and type mismatch, got: {err}"
+        );
     }
 }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -622,6 +622,17 @@ impl DiagnosticEngine {
                 }
                 None
             }
+            // Map: recurse into values
+            (TypeExpr::Map(inner), Value::Map(map)) => {
+                for (key, val) in map {
+                    if let Some(e) =
+                        self.validate_type_with_ref_awareness(inner, val, sibling_bindings)
+                    {
+                        return Some(format!("Key '{}': {}", key, e));
+                    }
+                }
+                None
+            }
             // ResourceRef: skip (resolved at runtime)
             (_, Value::ResourceRef { .. }) => None,
             // Everything else: normal validation

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1908,6 +1908,50 @@ fn exports_type_warning_multiline_vs_oneline() {
 }
 
 #[test]
+fn exports_map_type_warning_for_cross_file_ref() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+
+    // Schema: registry_prod.account_id is String — incompatible with map(bool)
+    let schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", AttributeType::String));
+    let schemas: HashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
+        .into_iter()
+        .collect();
+    let engine = custom_engine(schemas);
+
+    let doc = create_document(
+        r#"exports {
+  accounts: map(bool) = {
+    prod = registry_prod.account_id
+    dev  = registry_dev.account_id
+  }
+}"#,
+    );
+
+    let mut sibling_bindings = HashMap::new();
+    sibling_bindings.insert(
+        "registry_prod".to_string(),
+        "awscc.organizations.account".to_string(),
+    );
+    sibling_bindings.insert(
+        "registry_dev".to_string(),
+        "awscc.organizations.account".to_string(),
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &sibling_bindings, &HashSet::new());
+
+    let type_warning = diagnostics
+        .iter()
+        .find(|d| d.message.contains("type mismatch") || d.message.contains("expected"));
+    assert!(
+        type_warning.is_some(),
+        "Should warn about map(bool) vs String account_id. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn no_undefined_resource_for_sibling_binding_in_exports() {
     let engine = DiagnosticEngine::new(
         Arc::new(HashMap::new()),


### PR DESCRIPTION
## Summary

- Add `Map(inner)` case to `collect_ref_type_errors` in carina-core, matching the existing `List(inner)` recursion
- Exports declared as `map(T)` with `ResourceRef` values now trigger type mismatch errors when the referenced attribute type is incompatible

Before:
```
exports {
  accounts: map(bool) = {
    prod = registry_prod.account_id  # account_id is String — no warning shown
  }
}
```

After: "export 'accounts': type mismatch for 'registry_prod.account_id': expected map(Bool), got String"

## Test plan

- [x] New test: `validate_export_param_ref_types_map_rejects_type_mismatch`
- [x] New test: `validate_export_param_ref_types_map_accepts_compatible_types`
- [x] Full workspace `cargo test` passes
- [x] `cargo clippy` — no warnings

Closes #1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)