### PR TITLE
Show export value changes in plan output

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -543,7 +543,7 @@ pub(crate) fn resolve_exports(
 }
 
 /// Convert a DSL Value to a serde_json::Value for state persistence.
-fn dsl_value_to_json(value: &carina_core::resource::Value) -> Option<serde_json::Value> {
+pub(crate) fn dsl_value_to_json(value: &carina_core::resource::Value) -> Option<serde_json::Value> {
     use carina_core::resource::Value;
     match value {
         Value::String(s) => Some(serde_json::Value::String(s.clone())),
@@ -1356,13 +1356,19 @@ async fn run_apply_locked(
         &sorted_resources,
         &current_states,
     );
+    let current_exports = state_file
+        .as_ref()
+        .map(|s| s.exports.clone())
+        .unwrap_or_default();
+    let export_changes =
+        crate::commands::plan::compute_export_diffs(&resolved_exports, &current_exports);
     print_plan(
         &plan,
         DetailLevel::Full,
         &delete_attributes,
         Some(ctx.schemas()),
         &moved_origins,
-        &resolved_exports,
+        &export_changes,
         &parsed.deferred_for_expressions,
     );
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -283,13 +283,18 @@ pub async fn run_plan(
             &ctx.sorted_resources,
             &ctx.current_states,
         );
+        let current_exports = state_file
+            .as_ref()
+            .map(|s| s.exports.clone())
+            .unwrap_or_default();
+        let export_changes = compute_export_diffs(&resolved_exports, &current_exports);
         print_plan(
             &ctx.plan,
             detail,
             &delete_attributes,
             Some(wiring.schemas()),
             &ctx.moved_origins,
-            &resolved_exports,
+            &export_changes,
             &parsed.deferred_for_expressions,
         );
     }
@@ -408,6 +413,86 @@ pub(crate) fn resolve_export_value(
     }
 }
 
+/// Represents a change to an export value between current state and desired.
+pub enum ExportChange {
+    Added {
+        name: String,
+        type_expr: Option<carina_core::parser::TypeExpr>,
+        new_value: Value,
+    },
+    Modified {
+        name: String,
+        type_expr: Option<carina_core::parser::TypeExpr>,
+        old_json: serde_json::Value,
+        new_value: Value,
+    },
+    Removed {
+        name: String,
+        old_json: serde_json::Value,
+    },
+}
+
+impl ExportChange {
+    pub fn name(&self) -> &str {
+        match self {
+            ExportChange::Added { name, .. }
+            | ExportChange::Modified { name, .. }
+            | ExportChange::Removed { name, .. } => name,
+        }
+    }
+}
+
+/// Compute the set of export changes by comparing desired (resolved) exports
+/// against current state-recorded exports.
+///
+/// `resolved_params` contains the desired export values resolved against
+/// current resource states. `current_exports` is the JSON-serialized map
+/// from `StateFile.exports`.
+pub fn compute_export_diffs(
+    resolved_params: &[carina_core::parser::ExportParameter],
+    current_exports: &HashMap<String, serde_json::Value>,
+) -> Vec<ExportChange> {
+    let mut changes = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for param in resolved_params {
+        seen.insert(param.name.clone());
+        let Some(ref value) = param.value else {
+            continue;
+        };
+        let new_json = crate::commands::apply::dsl_value_to_json(value);
+        match (current_exports.get(&param.name), new_json) {
+            (None, _) => changes.push(ExportChange::Added {
+                name: param.name.clone(),
+                type_expr: param.type_expr.clone(),
+                new_value: value.clone(),
+            }),
+            (Some(old), Some(new)) if old == &new => {
+                // unchanged — skip
+            }
+            (Some(old), _) => changes.push(ExportChange::Modified {
+                name: param.name.clone(),
+                type_expr: param.type_expr.clone(),
+                old_json: old.clone(),
+                new_value: value.clone(),
+            }),
+        }
+    }
+
+    // Removed: exports in state but not in desired params
+    for (name, old) in current_exports {
+        if !seen.contains(name) {
+            changes.push(ExportChange::Removed {
+                name: name.clone(),
+                old_json: old.clone(),
+            });
+        }
+    }
+
+    changes.sort_by(|a, b| a.name().cmp(b.name()));
+    changes
+}
+
 pub(crate) async fn load_remote_states(
     remote_states: &[RemoteState],
     base_dir: &Path,
@@ -509,4 +594,72 @@ async fn load_remote_state_s3(
             bucket, key, binding, e
         ))
     })
+}
+
+#[cfg(test)]
+mod export_diff_tests {
+    use super::*;
+    use carina_core::parser::ExportParameter;
+
+    fn param(name: &str, value: Value) -> ExportParameter {
+        ExportParameter {
+            name: name.to_string(),
+            type_expr: None,
+            value: Some(value),
+        }
+    }
+
+    #[test]
+    fn compute_export_diffs_added_when_state_empty() {
+        let params = vec![param("count", Value::Int(42))];
+        let current = HashMap::new();
+        let changes = compute_export_diffs(&params, &current);
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(changes[0], ExportChange::Added { .. }));
+    }
+
+    #[test]
+    fn compute_export_diffs_modified_when_value_differs() {
+        let params = vec![param("count", Value::Int(42))];
+        let mut current = HashMap::new();
+        current.insert("count".to_string(), serde_json::json!(7));
+        let changes = compute_export_diffs(&params, &current);
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(changes[0], ExportChange::Modified { .. }));
+    }
+
+    #[test]
+    fn compute_export_diffs_unchanged_when_value_matches() {
+        let params = vec![param("count", Value::Int(42))];
+        let mut current = HashMap::new();
+        current.insert("count".to_string(), serde_json::json!(42));
+        let changes = compute_export_diffs(&params, &current);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn compute_export_diffs_removed_when_param_missing() {
+        let params = vec![];
+        let mut current = HashMap::new();
+        current.insert("stale".to_string(), serde_json::json!("old"));
+        let changes = compute_export_diffs(&params, &current);
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(changes[0], ExportChange::Removed { .. }));
+    }
+
+    #[test]
+    fn compute_export_diffs_mixed_sorted_by_name() {
+        let params = vec![
+            param("added", Value::Int(1)),
+            param("modified", Value::Int(2)),
+        ];
+        let mut current = HashMap::new();
+        current.insert("modified".to_string(), serde_json::json!(99));
+        current.insert("removed".to_string(), serde_json::json!("old"));
+        let changes = compute_export_diffs(&params, &current);
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].name(), "added");
+        assert_eq!(changes[1].name(), "modified");
+        assert_eq!(changes[2].name(), "removed");
+    }
 }

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -100,13 +100,94 @@ fn format_export_value(value: &Value) -> String {
     }
 }
 
+/// Format a `serde_json::Value` for export display (old values stored in state).
+fn format_json_export_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => format!("'{}'", s),
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Array(items) => {
+            let formatted: Vec<String> = items.iter().map(format_json_export_value).collect();
+            format!("[{}]", formatted.join(", "))
+        }
+        serde_json::Value::Object(map) => {
+            let formatted: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{} = {}", k, format_json_export_value(v)))
+                .collect();
+            format!("{{{}}}", formatted.join(", "))
+        }
+    }
+}
+
+/// Format a single export change entry (add/modify/remove) as a displayable line.
+fn format_export_change(change: &crate::commands::plan::ExportChange) -> String {
+    use crate::commands::plan::ExportChange;
+    let mut out = String::new();
+    match change {
+        ExportChange::Added {
+            name,
+            type_expr,
+            new_value,
+        } => {
+            let type_str = type_expr
+                .as_ref()
+                .map(|t| format!(": {}", t))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "  {} {}{} = {}",
+                "+".green(),
+                name,
+                type_str.dimmed(),
+                format_export_value(new_value)
+            )
+            .unwrap();
+        }
+        ExportChange::Modified {
+            name,
+            type_expr,
+            old_json,
+            new_value,
+        } => {
+            let type_str = type_expr
+                .as_ref()
+                .map(|t| format!(": {}", t))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "  {} {}{} = {} {} {}",
+                "~".yellow(),
+                name,
+                type_str.dimmed(),
+                format_json_export_value(old_json),
+                "→".dimmed(),
+                format_export_value(new_value)
+            )
+            .unwrap();
+        }
+        ExportChange::Removed { name, old_json } => {
+            writeln!(
+                out,
+                "  {} {} = {}",
+                "-".red(),
+                name,
+                format_json_export_value(old_json)
+            )
+            .unwrap();
+        }
+    }
+    out
+}
+
 pub fn print_plan(
     plan: &Plan,
     detail: DetailLevel,
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
-    export_params: &[carina_core::parser::ExportParameter],
+    export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
 ) {
     print!(
@@ -117,7 +198,7 @@ pub fn print_plan(
             delete_attributes,
             schemas,
             moved_origins,
-            export_params,
+            export_changes,
             deferred_for_expressions,
         )
     );
@@ -133,12 +214,12 @@ pub fn format_plan(
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
     schemas: Option<&HashMap<String, ResourceSchema>>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
-    export_params: &[carina_core::parser::ExportParameter],
+    export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
 ) -> String {
     let mut out = String::new();
 
-    if plan.is_empty() && deferred_for_expressions.is_empty() {
+    if plan.is_empty() && deferred_for_expressions.is_empty() && export_changes.is_empty() {
         writeln!(
             out,
             "{}",
@@ -169,31 +250,13 @@ pub fn format_plan(
         out.push_str(&format_deferred_for_expression(deferred));
     }
 
-    // Show exports if any
-    if !export_params.is_empty() {
+    // Show export changes if any
+    if !export_changes.is_empty() {
         writeln!(out).unwrap();
         writeln!(out, "{}", "Exports:".cyan().bold()).unwrap();
         writeln!(out).unwrap();
-        for param in export_params {
-            let type_str = param
-                .type_expr
-                .as_ref()
-                .map(|t| format!(": {}", t))
-                .unwrap_or_default();
-            let value_str = param
-                .value
-                .as_ref()
-                .map(format_export_value)
-                .unwrap_or_else(|| "(unknown)".to_string());
-            writeln!(
-                out,
-                "  {} {}{} = {}",
-                "+".green(),
-                param.name,
-                type_str.dimmed(),
-                value_str
-            )
-            .unwrap();
+        for change in export_changes {
+            out.push_str(&format_export_change(change));
         }
     }
 
@@ -228,6 +291,12 @@ pub fn format_plan(
         parts.push(format!(
             "{} deferred",
             deferred_for_expressions.len().to_string().cyan()
+        ));
+    }
+    if !export_changes.is_empty() {
+        parts.push(format!(
+            "{} export change(s)",
+            export_changes.len().to_string().cyan()
         ));
     }
     writeln!(out, "Plan: {}.", parts.join(", ")).unwrap();

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -666,28 +666,21 @@ fn plan_snapshot_remote_state() {
 
 #[test]
 fn plan_snapshot_exports() {
-    use carina_core::parser::{ExportParameter, TypeExpr};
+    use crate::commands::plan::ExportChange;
+    use carina_core::parser::TypeExpr;
     use carina_core::resource::Value;
 
     let (plan, schemas, moved_origins) = build_plan_from_fixture("exports");
-    let exports = vec![
-        ExportParameter {
+    let export_changes = vec![
+        ExportChange::Added {
             name: "vpc_id".to_string(),
             type_expr: Some(TypeExpr::String),
-            value: Some(Value::resource_ref(
-                "vpc".to_string(),
-                "vpc_id".to_string(),
-                vec![],
-            )),
+            new_value: Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         },
-        ExportParameter {
+        ExportChange::Added {
             name: "cidr".to_string(),
             type_expr: None,
-            value: Some(Value::resource_ref(
-                "vpc".to_string(),
-                "cidr_block".to_string(),
-                vec![],
-            )),
+            new_value: Value::resource_ref("vpc".to_string(), "cidr_block".to_string(), vec![]),
         },
     ];
     let output = format_plan(
@@ -696,7 +689,43 @@ fn plan_snapshot_exports() {
         &HashMap::new(),
         Some(&schemas),
         &moved_origins,
-        &exports,
+        &export_changes,
+        &[],
+    );
+    insta::assert_snapshot!(strip_ansi(&output));
+}
+
+#[test]
+fn plan_snapshot_export_changes_mixed() {
+    use crate::commands::plan::ExportChange;
+    use carina_core::parser::TypeExpr;
+    use carina_core::resource::Value;
+
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("no_changes");
+    let export_changes = vec![
+        ExportChange::Added {
+            name: "new_export".to_string(),
+            type_expr: Some(TypeExpr::String),
+            new_value: Value::String("hello".to_string()),
+        },
+        ExportChange::Modified {
+            name: "changed".to_string(),
+            type_expr: Some(TypeExpr::Int),
+            old_json: serde_json::json!(42),
+            new_value: Value::Int(100),
+        },
+        ExportChange::Removed {
+            name: "obsolete".to_string(),
+            old_json: serde_json::json!("gone"),
+        },
+    ];
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &export_changes,
         &[],
     );
     insta::assert_snapshot!(strip_ansi(&output));

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
@@ -1,0 +1,20 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: strip_ansi(&output)
+---
+Execution Plan:
+
+  + awscc.ec2.subnet 
+      cidr_block: "10.0.1.0/24"
+      tags:
+        Name: "test-subnet"
+      vpc_id: "vpc-0123456789abcdef0"
+  - awscc.ec2.subnet ec2_subnet_aac7c86b
+
+Exports:
+
+  + new_export: string = 'hello'
+  ~ changed: int = 42 → 100
+  - obsolete = 'gone'
+
+Plan: 1 to add, 0 to change, 1 to destroy, 3 export change(s).

--- a/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_exports.snap
+++ b/carina-cli/src/snapshots/carina__plan_snapshot_tests__plan_snapshot_exports.snap
@@ -12,4 +12,4 @@ Exports:
   + vpc_id: string = vpc.vpc_id
   + cidr = vpc.cidr_block
 
-Plan: 1 to add, 0 to change, 0 to destroy.
+Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).


### PR DESCRIPTION
## Summary

- Compute diff between current state-recorded exports and desired exports
- Display added/modified/removed entries in the plan output
- Previously all exports were rendered as "+" regardless of actual change state

Before:
```
Exports:
  + accounts: map(aws_account_id) = {prod = "111", dev = "222"}
```

After (shown only when changed):
```
Exports:
  + new_export: string = 'hello'
  ~ changed: int = 42 → 100
  - obsolete = 'gone'
Plan: ..., 3 export change(s).
```

## Implementation

- `ExportChange` enum in plan.rs: `Added { name, type, new_value }`, `Modified { name, type, old_json, new_value }`, `Removed { name, old_json }`
- `compute_export_diffs()` compares desired resolved export values (as DSL Value) against state-stored JSON
- `print_plan`/`format_plan` take `export_changes: &[ExportChange]` (replacing `export_params`)
- Plan summary shows total change count

## Test plan

- [x] 5 unit tests for `compute_export_diffs` (added/modified/unchanged/removed/mixed sorting)
- [x] Snapshot test for mixed export changes display
- [x] Existing exports snapshot updated (summary includes export change count)
- [x] Full carina-cli test suite passes (239 tests)
- [x] `cargo clippy -p carina-cli` — no warnings

Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)