### PR TITLE
Fix LSP confusing map/list type annotations with function calls

### DIFF
--- a/carina-core/src/lint.rs
+++ b/carina-core/src/lint.rs
@@ -110,6 +110,14 @@ pub fn find_pipe_preferred_direct_calls(source: &str) -> Vec<PipePreferredWarnin
                     continue;
                 }
 
+                // Skip if this is a type annotation position: `name: map(...)`
+                // A ':' followed only by whitespace before the function name means
+                // we're in a type position, not a function call.
+                let before_trimmed = before.trim_end();
+                if before_trimmed.ends_with(':') {
+                    continue;
+                }
+
                 warnings.push(PipePreferredWarning {
                     name: func_name.to_string(),
                     line: line_idx + 1,
@@ -753,6 +761,33 @@ let e = replace("old", "new", str)
             results.is_empty(),
             "Should not match when function name is part of a longer identifier"
         );
+    }
+
+    #[test]
+    fn test_pipe_preferred_type_annotation_no_warning() {
+        // `map(aws_account_id)` in a type position is a type annotation, not a
+        // function call. Should not trigger pipe-form warning.
+        let source = r#"exports {
+  accounts: map(aws_account_id) = {
+    prod = x.y
+  }
+}"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        assert!(
+            results.is_empty(),
+            "map() in type annotation position should not trigger pipe warning. Got: {:?}",
+            results
+        );
+    }
+
+    #[test]
+    fn test_pipe_preferred_type_annotation_list_no_warning() {
+        let source = r#"attributes {
+  items: list(string) = ["a", "b"]
+}"#;
+        let results = find_pipe_preferred_direct_calls(source);
+        // `list` is not in PIPE_PREFERRED_FUNCTIONS, but ensure no regression
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -149,8 +149,11 @@ impl HoverProvider {
             }
         }
 
-        // Check for built-in function hover
-        if let Some(hover) = self.builtin_function_hover(&word) {
+        // Check for built-in function hover, but skip when the word is a type
+        // constructor (`map`, `list`) appearing in a type annotation position.
+        if !is_in_type_annotation_position(doc, position, &word)
+            && let Some(hover) = self.builtin_function_hover(&word)
+        {
             return Some(hover);
         }
 
@@ -650,6 +653,40 @@ impl HoverProvider {
     }
 }
 
+/// Determine whether a word at `position` is in a type annotation position.
+///
+/// Returns true for `map` / `list` appearing immediately after `:` on the
+/// same line, e.g., `accounts: map(...)` or `items: list(...)`.
+/// In these cases the word is a type constructor, not a function call,
+/// and builtin-function hover should be suppressed.
+fn is_in_type_annotation_position(doc: &Document, position: Position, word: &str) -> bool {
+    if word != "map" && word != "list" {
+        return false;
+    }
+    let line_str = match doc.line_at(position.line) {
+        Some(l) => l,
+        None => return false,
+    };
+    let col = position.character as usize;
+    let chars: Vec<char> = line_str.chars().collect();
+    if col > chars.len() {
+        return false;
+    }
+    // Walk back from the cursor to find the start of the word
+    let mut start = col;
+    while start > 0 {
+        let prev = chars[start - 1];
+        if prev.is_alphanumeric() || prev == '_' {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+    // Check what's before the word (trimmed of whitespace)
+    let before: String = chars[..start].iter().collect();
+    before.trim_end().ends_with(':')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1096,6 +1133,39 @@ awscc.ec2.vpc_gateway_attachment {
             content.contains("string"),
             "Should show type, got:\n{}",
             content
+        );
+    }
+
+    #[test]
+    fn test_no_builtin_hover_for_map_in_type_annotation() {
+        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        // Line 1 (0-indexed): "  accounts: map(aws_account_id) = {"
+        // Position on "map" → should NOT show function hover
+        let doc = Document::new(
+            "exports {\n  accounts: map(aws_account_id) = {}\n}".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
+        // Column 14 is inside "map" on line 1
+        let hover = provider.hover(&doc, Position::new(1, 14));
+        assert!(
+            hover.is_none(),
+            "map() in type annotation should not trigger builtin function hover, got: {:?}",
+            hover
+        );
+    }
+
+    #[test]
+    fn test_builtin_hover_for_map_in_function_call() {
+        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        // Normal function call (no preceding ':') — should show hover
+        let doc = Document::new(
+            "let x = map(\".id\", items)".to_string(),
+            Arc::new(ProviderContext::default()),
+        );
+        let hover = provider.hover(&doc, Position::new(0, 10));
+        assert!(
+            hover.is_some(),
+            "map() in function call position should show builtin function hover"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `carina-core/src/lint.rs`: Skip pipe-form warning when `map(` is preceded by `:` (type annotation position)
- `carina-lsp/src/hover.rs`: Suppress builtin function hover for `map`/`list` in type annotation position

Before:
```
exports {
  accounts: map(aws_account_id) = { ... }
}
```
- Hover on `map` → showed `map(accessor: string, collection: list | map) -> list | map`
- Warning: "Consider using pipe form for 'map': data |> map(...)"

After: `map` in this position is recognized as a type constructor. No spurious hover/warning.

## Test plan

- [x] Unit test: pipe warning skipped for `map` in type annotation
- [x] Unit test: pipe warning skipped for `list` in type annotation
- [x] Unit test: hover suppressed for `map` in `name: map(...)` position
- [x] Unit test: hover still works for `map` in function call position
- [x] Full workspace `cargo test` passes
- [x] `cargo clippy` — no warnings

Closes #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)