### PR TITLE
Fix: persist export changes when apply has no resource work

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -491,7 +491,7 @@ pub async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), AppErro
 
     // Resolve exports and persist to state
     if !input.export_params.is_empty() {
-        let exports = resolve_exports(input.export_params, input.sorted_resources, &state);
+        let exports = resolve_exports(input.export_params, &state);
         state.exports = exports;
     }
 
@@ -508,7 +508,6 @@ pub async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), AppErro
 /// Resolve export expressions using the binding map built from applied state.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::ExportParameter],
-    _resources: &[Resource],
     state: &StateFile,
 ) -> HashMap<String, serde_json::Value> {
     use carina_core::resource::Value;
@@ -606,21 +605,17 @@ pub(crate) async fn persist_exports_only(
     lock: Option<&LockInfo>,
     state_file: Option<StateFile>,
     export_params: &[carina_core::parser::ExportParameter],
-    sorted_resources: &[Resource],
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
-    let exports = resolve_exports(export_params, sorted_resources, &state);
+    let exports = resolve_exports(export_params, &state);
     state.exports = exports;
     if let Some(lk) = lock {
         save_state_locked(backend, lk, &mut state).await?;
     } else {
         save_state_unlocked(backend, &mut state).await?;
     }
-    println!(
-        "  {} State saved (serial: {}), exports updated.",
-        "✓".green(),
-        state.serial
-    );
+    println!("  {} State saved (serial: {})", "✓".green(), state.serial);
+    println!("  {} Exports updated", "✓".green());
     Ok(())
 }
 
@@ -1362,12 +1357,13 @@ async fn run_apply_locked(
             &sorted_resources,
             &current_states,
         );
+        let empty_exports = HashMap::new();
         let current_exports = state_file
             .as_ref()
-            .map(|s| s.exports.clone())
-            .unwrap_or_default();
+            .map(|s| &s.exports)
+            .unwrap_or(&empty_exports);
         let export_changes =
-            crate::commands::plan::compute_export_diffs(&resolved_exports, &current_exports);
+            crate::commands::plan::compute_export_diffs(&resolved_exports, current_exports);
 
         if export_changes.is_empty() {
             println!("{}", "No changes needed.".green());
@@ -1382,14 +1378,7 @@ async fn run_apply_locked(
             )
             .cyan()
         );
-        persist_exports_only(
-            backend,
-            lock,
-            state_file,
-            &parsed.export_params,
-            &sorted_resources,
-        )
-        .await?;
+        persist_exports_only(backend, lock, state_file, &parsed.export_params).await?;
         return Ok(());
     }
 
@@ -2326,7 +2315,7 @@ mod tests {
             value: Some(Value::String("registry_prod.account_id".to_string())),
         }];
 
-        let exports = resolve_exports(&export_params, &[], &state);
+        let exports = resolve_exports(&export_params, &state);
 
         assert_eq!(
             exports.get("account_id"),

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -596,6 +596,34 @@ pub async fn save_state_unlocked(
     backend.write_state(state).await.map_err(AppError::Backend)
 }
 
+/// Persist export changes when the resource plan is empty.
+///
+/// Used when `plan.is_empty()` short-circuits apply: resources don't need
+/// any work, but exports may have changed. Rebuild the exports from the
+/// current state + desired `export_params` and write the state.
+pub(crate) async fn persist_exports_only(
+    backend: &dyn StateBackend,
+    lock: Option<&LockInfo>,
+    state_file: Option<StateFile>,
+    export_params: &[carina_core::parser::ExportParameter],
+    sorted_resources: &[Resource],
+) -> Result<(), AppError> {
+    let mut state = state_file.unwrap_or_default();
+    let exports = resolve_exports(export_params, sorted_resources, &state);
+    state.exports = exports;
+    if let Some(lk) = lock {
+        save_state_locked(backend, lk, &mut state).await?;
+    } else {
+        save_state_unlocked(backend, &mut state).await?;
+    }
+    println!(
+        "  {} State saved (serial: {}), exports updated.",
+        "✓".green(),
+        state.serial
+    );
+    Ok(())
+}
+
 pub struct ApplyStateSave<'a> {
     pub state_file: Option<StateFile>,
     pub sorted_resources: &'a [Resource],
@@ -1327,7 +1355,41 @@ async fn run_apply_locked(
     }
 
     if plan.is_empty() {
-        println!("{}", "No changes needed.".green());
+        // Even when no resources need changes, exports may have changed.
+        // Persist them before returning so state stays in sync with config.
+        let resolved_exports = crate::commands::plan::resolve_export_values_for_display(
+            &parsed.export_params,
+            &sorted_resources,
+            &current_states,
+        );
+        let current_exports = state_file
+            .as_ref()
+            .map(|s| s.exports.clone())
+            .unwrap_or_default();
+        let export_changes =
+            crate::commands::plan::compute_export_diffs(&resolved_exports, &current_exports);
+
+        if export_changes.is_empty() {
+            println!("{}", "No changes needed.".green());
+            return Ok(());
+        }
+
+        println!(
+            "{}",
+            format!(
+                "Persisting {} export change(s) to state.",
+                export_changes.len()
+            )
+            .cyan()
+        );
+        persist_exports_only(
+            backend,
+            lock,
+            state_file,
+            &parsed.export_params,
+            &sorted_resources,
+        )
+        .await?;
         return Ok(());
     }
 

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -746,7 +746,7 @@ pub(crate) async fn run_state_refresh_locked(
 
     // Re-resolve exports using refreshed state
     if !parsed.export_params.is_empty() {
-        state.exports = crate::commands::apply::resolve_exports(&parsed.export_params, &[], &state);
+        state.exports = crate::commands::apply::resolve_exports(&parsed.export_params, &state);
     }
 
     // Save state (with or without lock validation)

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2687,6 +2687,35 @@ impl StateBackend for CapturingBackend {
 }
 
 #[tokio::test]
+async fn persist_exports_only_clears_state_exports_when_params_empty() {
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    // Pre-existing state with stale exports
+    let mut state_in = StateFile::new();
+    state_in
+        .exports
+        .insert("old".to_string(), serde_json::json!("stale"));
+
+    let result =
+        crate::commands::apply::persist_exports_only(&backend, Some(&lock), Some(state_in), &[])
+            .await;
+
+    assert!(result.is_ok(), "persist_exports_only failed: {:?}", result);
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert!(
+        state.exports.is_empty(),
+        "stale exports should be cleared when export_params is empty, got: {:?}",
+        state.exports
+    );
+}
+
+#[tokio::test]
 async fn persist_exports_only_writes_state_with_new_exports() {
     use carina_core::parser::ExportParameter;
     use carina_core::resource::Value;

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2632,3 +2632,93 @@ fn plan_file_serialization_redacts_secrets() {
     // Non-secret values should still be present
     assert!(json.contains("my-db"));
 }
+
+/// Backend that captures the state written to it.
+struct CapturingBackend {
+    captured: Arc<Mutex<Option<StateFile>>>,
+}
+
+#[async_trait::async_trait]
+impl StateBackend for CapturingBackend {
+    async fn read_state(&self) -> carina_state::BackendResult<Option<StateFile>> {
+        Ok(Some(StateFile::new()))
+    }
+    async fn write_state(&self, state: &StateFile) -> carina_state::BackendResult<()> {
+        *self.captured.lock().unwrap() = Some(state.clone());
+        Ok(())
+    }
+    async fn acquire_lock(&self, operation: &str) -> carina_state::BackendResult<LockInfo> {
+        Ok(LockInfo::new(operation))
+    }
+    async fn release_lock(&self, _lock: &LockInfo) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn renew_lock(&self, lock: &LockInfo) -> carina_state::BackendResult<LockInfo> {
+        Ok(lock.renewed())
+    }
+    async fn write_state_locked(
+        &self,
+        state: &carina_state::StateFile,
+        _lock: &LockInfo,
+    ) -> carina_state::BackendResult<()> {
+        self.write_state(state).await
+    }
+    async fn force_unlock(&self, _lock_id: &str) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn init(&self) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    async fn bucket_exists(&self) -> carina_state::BackendResult<bool> {
+        Ok(true)
+    }
+    async fn create_bucket(&self) -> carina_state::BackendResult<()> {
+        Ok(())
+    }
+    fn resource_type(&self) -> Option<&str> {
+        None
+    }
+    fn provider_name(&self) -> Option<&str> {
+        None
+    }
+    fn resource_definition(&self, _bucket_name: &str) -> Option<String> {
+        None
+    }
+}
+
+#[tokio::test]
+async fn persist_exports_only_writes_state_with_new_exports() {
+    use carina_core::parser::ExportParameter;
+    use carina_core::resource::Value;
+
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    let export_params = vec![ExportParameter {
+        name: "account_id".to_string(),
+        type_expr: None,
+        value: Some(Value::String("123456789012".to_string())),
+    }];
+
+    let result = crate::commands::apply::persist_exports_only(
+        &backend,
+        Some(&lock),
+        Some(StateFile::new()),
+        &export_params,
+        &[],
+    )
+    .await;
+
+    assert!(result.is_ok(), "persist_exports_only failed: {:?}", result);
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert_eq!(state.exports.len(), 1);
+    assert_eq!(
+        state.exports.get("account_id"),
+        Some(&serde_json::json!("123456789012"))
+    );
+}

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2708,7 +2708,6 @@ async fn persist_exports_only_writes_state_with_new_exports() {
         Some(&lock),
         Some(StateFile::new()),
         &export_params,
-        &[],
     )
     .await;
 


### PR DESCRIPTION
## Summary

When `plan.is_empty()`, `carina apply` short-circuited with "No changes needed." and returned without writing the new exports to state. This caused downstream `carina plan` to keep showing the export diff forever.

## Fix

Before the short-circuit:
1. Compute export diffs (same function used for plan display)
2. If export_changes is empty → short-circuit as before ("No changes needed.")
3. If only exports changed → write state with new exports and report the change count

## Scope

This PR fixes the primary `carina apply <dir>` path. The plan-file apply path (`carina apply plan.json`) is unchanged because `PlanFile` doesn't currently carry `export_params`. A follow-up PR can extend `PlanFile` and fix that short-circuit.

## Test plan

- [x] New test `persist_exports_only_writes_state_with_new_exports` using a CapturingBackend
- [x] All carina-cli tests pass (240 passed)
- [x] `cargo clippy` — no warnings

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)