### PR TITLE
Fix deferred for-expression: record binding kind and substitute map key var

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -66,6 +66,10 @@ pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
 /// Placeholder reserved for map-binding key variables. Distinct from the
 /// value-var placeholder so expansion can substitute each correctly.
 pub(crate) const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
+/// Placeholder reserved for indexed-binding index variables — distinct from
+/// key and value placeholders so `for (i, x) in list` expansion can
+/// substitute `i` with the integer index.
+pub(crate) const DEFERRED_UPSTREAM_INDEX_PLACEHOLDER: &str = "(known after upstream apply: index)";
 
 /// A for-expression whose iterable is unresolved (e.g., remote_state not yet available).
 /// Captures the structural shape of the loop body so the plan can show what
@@ -489,16 +493,29 @@ impl ParsedFile {
             };
 
             match (&deferred.binding, iterable_value) {
-                // Simple/Indexed bindings expand over lists
-                (ForBinding::Simple(_), Value::List(items))
-                | (ForBinding::Indexed(_, _), Value::List(items)) => {
+                // Simple binding: only the value var is bound
+                (ForBinding::Simple(_), Value::List(items)) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
                         resource.id.name = address.clone();
                         resource.binding = Some(address);
                         for (_k, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, None, item);
+                            substitute_placeholder(&mut expr.0, None, None, item);
+                        }
+                        expanded_resources.push(resource);
+                    }
+                    resolved_indices.push(idx);
+                }
+                // Indexed binding: both index and value vars are bound
+                (ForBinding::Indexed(_, _), Value::List(items)) => {
+                    for (i, item) in items.iter().enumerate() {
+                        let address = format!("{}[{}]", deferred.binding_name, i);
+                        let mut resource = deferred.template_resource.clone();
+                        resource.id.name = address.clone();
+                        resource.binding = Some(address);
+                        for (_k, expr) in resource.attributes.iter_mut() {
+                            substitute_placeholder(&mut expr.0, Some(i as i64), None, item);
                         }
                         expanded_resources.push(resource);
                     }
@@ -515,7 +532,7 @@ impl ParsedFile {
                         resource.id.name = address.clone();
                         resource.binding = Some(address);
                         for (_k, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, Some(key), val);
+                            substitute_placeholder(&mut expr.0, None, Some(key), val);
                         }
                         expanded_resources.push(resource);
                     }
@@ -578,12 +595,14 @@ impl ParsedFile {
 
 /// Substitute deferred-for-expression placeholders in a Value tree.
 ///
-/// Replaces `DEFERRED_UPSTREAM_PLACEHOLDER` with `value`. If `key` is
-/// supplied (map-binding expansion), also replaces
+/// Replaces `DEFERRED_UPSTREAM_PLACEHOLDER` with `value`. If `index` is
+/// supplied (indexed-binding expansion), replaces
+/// `DEFERRED_UPSTREAM_INDEX_PLACEHOLDER` with the integer index. If `key`
+/// is supplied (map-binding expansion), replaces
 /// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string. Recurses into
 /// all compound Value variants so placeholders nested inside
 /// interpolations / function calls / secrets are reached.
-fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
+fn substitute_placeholder(v: &mut Value, index: Option<i64>, key: Option<&str>, value: &Value) {
     match v {
         Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
             *v = value.clone();
@@ -593,30 +612,35 @@ fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
                 *v = Value::String(k.to_string());
             }
         }
+        Value::String(s) if s == DEFERRED_UPSTREAM_INDEX_PLACEHOLDER => {
+            if let Some(i) = index {
+                *v = Value::Int(i);
+            }
+        }
         Value::List(items) => {
             for item in items.iter_mut() {
-                substitute_placeholder(item, key, value);
+                substitute_placeholder(item, index, key, value);
             }
         }
         Value::Map(map) => {
             for val in map.values_mut() {
-                substitute_placeholder(val, key, value);
+                substitute_placeholder(val, index, key, value);
             }
         }
         Value::FunctionCall { args, .. } => {
             for arg in args.iter_mut() {
-                substitute_placeholder(arg, key, value);
+                substitute_placeholder(arg, index, key, value);
             }
         }
         Value::Interpolation(parts) => {
             for part in parts.iter_mut() {
                 if let crate::resource::InterpolationPart::Expr(inner) = part {
-                    substitute_placeholder(inner, key, value);
+                    substitute_placeholder(inner, index, key, value);
                 }
             }
         }
         Value::Secret(inner) => {
-            substitute_placeholder(inner, key, value);
+            substitute_placeholder(inner, index, key, value);
         }
         _ => {}
     }
@@ -1884,7 +1908,10 @@ fn parse_for_expr(
                     template_ctx.set_variable(var.clone(), placeholder());
                 }
                 ForBinding::Indexed(idx, val) => {
-                    template_ctx.set_variable(idx.clone(), placeholder());
+                    template_ctx.set_variable(
+                        idx.clone(),
+                        Value::String(DEFERRED_UPSTREAM_INDEX_PLACEHOLDER.to_string()),
+                    );
                     template_ctx.set_variable(val.clone(), placeholder());
                 }
                 ForBinding::Map(k, v) => {
@@ -10607,6 +10634,60 @@ awscc.ec2.vpc {
         assert_eq!(
             dev.get_attr("target_id"),
             Some(&Value::String("222222222222".to_string()))
+        );
+    }
+
+    #[test]
+    fn expand_deferred_for_indexed_binding_substitutes_index_and_value() {
+        // Indexed binding `for (i, x) in list` must substitute BOTH the index
+        // and value variables. Prior to the fix both vars shared the same
+        // placeholder, causing the index to receive the item value.
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for (i, account_id) in orgs.accounts {
+                awscc.sso.assignment {
+                    target_id = account_id
+                    position = i
+                }
+            }
+        "#;
+
+        let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::List(vec![
+                Value::String("111111111111".to_string()),
+                Value::String("222222222222".to_string()),
+            ]),
+        );
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        parsed.expand_deferred_for_expressions(&remote_bindings);
+
+        assert_eq!(parsed.resources.len(), 2);
+        assert_eq!(
+            parsed.resources[0].get_attr("target_id"),
+            Some(&Value::String("111111111111".to_string()))
+        );
+        assert_eq!(
+            parsed.resources[0].get_attr("position"),
+            Some(&Value::Int(0)),
+            "index should be 0, not the item value"
+        );
+        assert_eq!(
+            parsed.resources[1].get_attr("target_id"),
+            Some(&Value::String("222222222222".to_string()))
+        );
+        assert_eq!(
+            parsed.resources[1].get_attr("position"),
+            Some(&Value::Int(1))
         );
     }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -63,6 +63,9 @@ pub struct ParseWarning {
 
 /// Placeholder text for values that depend on an upstream apply.
 pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
+/// Placeholder reserved for map-binding key variables. Distinct from the
+/// value-var placeholder so expansion can substitute each correctly.
+pub const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
 
 /// A for-expression whose iterable is unresolved (e.g., remote_state not yet available).
 /// Captures the structural shape of the loop body so the plan can show what
@@ -87,8 +90,10 @@ pub struct DeferredForExpression {
     /// The iterable access path segments (e.g., `["orgs", "accounts"]`).
     pub iterable_binding: String,
     pub iterable_attr: String,
-    /// Loop variable name (used for substitution during expansion).
-    pub loop_var: String,
+    /// Binding pattern — records the kind (Simple/Indexed/Map) so the expansion
+    /// can verify the resolved iterable's shape matches and substitute the
+    /// correct variable(s).
+    pub binding: ForBinding,
     /// Template resource for expansion (the for body parsed with placeholders).
     pub template_resource: Resource,
 }
@@ -466,6 +471,7 @@ impl ParsedFile {
     ) {
         let mut expanded_resources = Vec::new();
         let mut resolved_indices = Vec::new();
+        let mut new_warnings: Vec<ParseWarning> = Vec::new();
 
         for (idx, deferred) in self.deferred_for_expressions.iter().enumerate() {
             // Look up the iterable value in remote_bindings
@@ -477,8 +483,10 @@ impl ParsedFile {
                 continue;
             };
 
-            match iterable_value {
-                Value::List(items) => {
+            match (&deferred.binding, iterable_value) {
+                // Simple/Indexed bindings expand over lists
+                (ForBinding::Simple(_), Value::List(items))
+                | (ForBinding::Indexed(_, _), Value::List(items)) => {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
@@ -486,13 +494,14 @@ impl ParsedFile {
                         resource.binding = Some(address);
                         // Substitute the placeholder in all attributes
                         for (_key, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, &deferred.loop_var, item);
+                            substitute_placeholder(&mut expr.0, item);
                         }
                         expanded_resources.push(resource);
                     }
                     resolved_indices.push(idx);
                 }
-                Value::Map(map) => {
+                // Map binding expands over maps, substituting both key and value vars
+                (ForBinding::Map(_, _), Value::Map(map)) => {
                     let mut keys: Vec<&String> = map.keys().collect();
                     keys.sort();
                     for key in keys {
@@ -501,12 +510,34 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.name = address.clone();
                         resource.binding = Some(address);
-                        for (_key, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, &deferred.loop_var, val);
-                        }
+                        substitute_for_map_entry(&mut resource, key, val);
                         expanded_resources.push(resource);
                     }
                     resolved_indices.push(idx);
+                }
+                // Shape mismatch: emit warning and leave deferred
+                (ForBinding::Map(_, _), Value::List(_)) => {
+                    new_warnings.push(ParseWarning {
+                        file: deferred.file.clone(),
+                        line: deferred.line,
+                        message: format!(
+                            "for binding expected map iterable but `{}.{}` resolved to a list. \
+                             Fix either the upstream export shape or the downstream binding.",
+                            deferred.iterable_binding, deferred.iterable_attr,
+                        ),
+                    });
+                }
+                (ForBinding::Simple(_), Value::Map(_))
+                | (ForBinding::Indexed(_, _), Value::Map(_)) => {
+                    new_warnings.push(ParseWarning {
+                        file: deferred.file.clone(),
+                        line: deferred.line,
+                        message: format!(
+                            "for binding expected list iterable but `{}.{}` resolved to a map. \
+                             Fix either the upstream export shape or the downstream binding.",
+                            deferred.iterable_binding, deferred.iterable_attr,
+                        ),
+                    });
                 }
                 _ => {
                     // Iterable is not a list or map — leave deferred
@@ -524,28 +555,59 @@ impl ParsedFile {
         }
 
         self.resources.extend(expanded_resources);
+        self.warnings.extend(new_warnings);
     }
 }
 
 /// Substitute placeholder values in a Value tree.
 /// Replaces `Value::String(DEFERRED_UPSTREAM_PLACEHOLDER)` with the actual value,
 /// matching the loop variable name.
-fn substitute_placeholder(value: &mut Value, _loop_var: &str, replacement: &Value) {
+fn substitute_placeholder(value: &mut Value, replacement: &Value) {
     match value {
         Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
             *value = replacement.clone();
         }
         Value::List(items) => {
             for item in items.iter_mut() {
-                substitute_placeholder(item, _loop_var, replacement);
+                substitute_placeholder(item, replacement);
             }
         }
         Value::Map(map) => {
             for v in map.values_mut() {
-                substitute_placeholder(v, _loop_var, replacement);
+                substitute_placeholder(v, replacement);
             }
         }
         _ => {}
+    }
+}
+
+/// Substitute key and value placeholders for a map-binding entry.
+/// Replaces `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string and
+/// `DEFERRED_UPSTREAM_PLACEHOLDER` with the value.
+fn substitute_for_map_entry(resource: &mut Resource, key: &str, value: &Value) {
+    fn recurse(v: &mut Value, key: &str, replacement: &Value) {
+        match v {
+            Value::String(s) if s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
+                *v = Value::String(key.to_string());
+            }
+            Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
+                *v = replacement.clone();
+            }
+            Value::List(items) => {
+                for item in items.iter_mut() {
+                    recurse(item, key, replacement);
+                }
+            }
+            Value::Map(map) => {
+                for val in map.values_mut() {
+                    recurse(val, key, replacement);
+                }
+            }
+            _ => {}
+        }
+    }
+    for (_, expr) in resource.attributes.iter_mut() {
+        recurse(&mut expr.0, key, value);
     }
 }
 
@@ -1649,7 +1711,8 @@ fn parse_primary_with_resource_or_module(
 }
 
 /// Binding pattern for a for expression
-enum ForBinding {
+#[derive(Debug, Clone)]
+pub enum ForBinding {
     /// Simple: `for x in ...`
     Simple(String),
     /// Indexed: `for (i, x) in ...`
@@ -1814,7 +1877,10 @@ fn parse_for_expr(
                     template_ctx.set_variable(val.clone(), placeholder());
                 }
                 ForBinding::Map(k, v) => {
-                    template_ctx.set_variable(k.clone(), placeholder());
+                    template_ctx.set_variable(
+                        k.clone(),
+                        Value::String(DEFERRED_UPSTREAM_KEY_PLACEHOLDER.to_string()),
+                    );
                     template_ctx.set_variable(v.clone(), placeholder());
                 }
             }
@@ -1829,11 +1895,6 @@ fn parse_for_expr(
                     .filter(|(k, _)| !k.starts_with('_'))
                     .map(|(k, expr)| (k.clone(), expr.0.clone()))
                     .collect();
-                let loop_var = match &binding {
-                    ForBinding::Simple(var) => var.clone(),
-                    ForBinding::Indexed(_, val) => val.clone(),
-                    ForBinding::Map(_, v) => v.clone(),
-                };
                 ctx.deferred_for_expressions.push(DeferredForExpression {
                     file: None,
                     line: for_line,
@@ -1847,7 +1908,7 @@ fn parse_for_expr(
                     binding_name: binding_name.to_string(),
                     iterable_binding: path.binding().to_string(),
                     iterable_attr: path.attribute().to_string(),
-                    loop_var,
+                    binding: binding.clone(),
                     template_resource: *resource,
                 });
             }
@@ -10481,5 +10542,112 @@ awscc.ec2.vpc {
             "should stay deferred when remote data not available"
         );
         assert_eq!(parsed.resources.len(), 0);
+    }
+
+    #[test]
+    fn expand_deferred_for_map_binding_substitutes_key_and_value() {
+        // Map binding `for k, v in orgs.accounts` should expand each entry with
+        // both the key and value variables available.
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for name, account_id in orgs.accounts {
+                awscc.sso.assignment {
+                    target_id = account_id
+                    target_name = name
+                }
+            }
+        "#;
+
+        let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "prod".to_string(),
+            Value::String("111111111111".to_string()),
+        );
+        accounts.insert("dev".to_string(), Value::String("222222222222".to_string()));
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts));
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        parsed.expand_deferred_for_expressions(&remote_bindings);
+
+        assert_eq!(parsed.deferred_for_expressions.len(), 0);
+        assert_eq!(parsed.resources.len(), 2);
+
+        // Verify both key and value are substituted.
+        let mut by_name: HashMap<String, &Resource> = HashMap::new();
+        for r in &parsed.resources {
+            if let Some(Value::String(s)) = r.get_attr("target_name") {
+                by_name.insert(s.clone(), r);
+            }
+        }
+        let prod = by_name.get("prod").expect("prod entry");
+        assert_eq!(
+            prod.get_attr("target_id"),
+            Some(&Value::String("111111111111".to_string()))
+        );
+        let dev = by_name.get("dev").expect("dev entry");
+        assert_eq!(
+            dev.get_attr("target_id"),
+            Some(&Value::String("222222222222".to_string()))
+        );
+    }
+
+    #[test]
+    fn expand_deferred_for_map_binding_with_list_iterable_warns() {
+        // Map binding but upstream resolves to a list — mismatch should produce
+        // a warning and leave the for-expression deferred (do not silently expand).
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for name, account_id in orgs.accounts {
+                awscc.sso.assignment {
+                    target_id = account_id
+                }
+            }
+        "#;
+
+        let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::List(vec![
+                Value::String("111111111111".to_string()),
+                Value::String("222222222222".to_string()),
+            ]),
+        );
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        parsed.expand_deferred_for_expressions(&remote_bindings);
+
+        // Mismatch: should NOT expand silently with numeric indices
+        assert_eq!(
+            parsed.resources.len(),
+            0,
+            "map binding with list iterable should not silently expand"
+        );
+        assert_eq!(
+            parsed.deferred_for_expressions.len(),
+            1,
+            "should remain deferred on shape mismatch"
+        );
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("expected map") || w.message.contains("shape")),
+            "should warn about shape mismatch, got: {:?}",
+            parsed.warnings
+        );
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -570,8 +570,10 @@ fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
         Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
             *v = value.clone();
         }
-        Value::String(s) if key.is_some() && s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
-            *v = Value::String(key.unwrap().to_string());
+        Value::String(s) if s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
+            if let Some(k) = key {
+                *v = Value::String(k.to_string());
+            }
         }
         Value::List(items) => {
             for item in items.iter_mut() {
@@ -10572,6 +10574,52 @@ awscc.ec2.vpc {
         assert_eq!(
             dev.get_attr("target_id"),
             Some(&Value::String("222222222222".to_string()))
+        );
+    }
+
+    #[test]
+    fn expand_deferred_for_simple_binding_with_map_iterable_warns() {
+        // Simple binding but upstream resolves to a map — mismatch should warn
+        // and leave deferred.
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for account_id in orgs.accounts {
+                awscc.sso.assignment {
+                    target_id = account_id
+                }
+            }
+        "#;
+
+        let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "prod".to_string(),
+            Value::String("111111111111".to_string()),
+        );
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts));
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        parsed.expand_deferred_for_expressions(&remote_bindings);
+
+        assert_eq!(
+            parsed.resources.len(),
+            0,
+            "simple binding with map iterable should not silently expand"
+        );
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("expected list")),
+            "should warn about list vs map shape mismatch, got: {:?}",
+            parsed.warnings
         );
     }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -65,7 +65,7 @@ pub struct ParseWarning {
 pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
 /// Placeholder reserved for map-binding key variables. Distinct from the
 /// value-var placeholder so expansion can substitute each correctly.
-pub const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
+pub(crate) const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
 
 /// A for-expression whose iterable is unresolved (e.g., remote_state not yet available).
 /// Captures the structural shape of the loop body so the plan can show what
@@ -492,9 +492,8 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.name = address.clone();
                         resource.binding = Some(address);
-                        // Substitute the placeholder in all attributes
-                        for (_key, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, item);
+                        for (_k, expr) in resource.attributes.iter_mut() {
+                            substitute_placeholder(&mut expr.0, None, item);
                         }
                         expanded_resources.push(resource);
                     }
@@ -510,7 +509,9 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.name = address.clone();
                         resource.binding = Some(address);
-                        substitute_for_map_entry(&mut resource, key, val);
+                        for (_k, expr) in resource.attributes.iter_mut() {
+                            substitute_placeholder(&mut expr.0, Some(key), val);
+                        }
                         expanded_resources.push(resource);
                     }
                     resolved_indices.push(idx);
@@ -559,55 +560,30 @@ impl ParsedFile {
     }
 }
 
-/// Substitute placeholder values in a Value tree.
-/// Replaces `Value::String(DEFERRED_UPSTREAM_PLACEHOLDER)` with the actual value,
-/// matching the loop variable name.
-fn substitute_placeholder(value: &mut Value, replacement: &Value) {
-    match value {
+/// Substitute deferred-for-expression placeholders in a Value tree.
+///
+/// Replaces `DEFERRED_UPSTREAM_PLACEHOLDER` with `value`. If `key` is
+/// supplied (map-binding expansion), also replaces
+/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string.
+fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
+    match v {
         Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
-            *value = replacement.clone();
+            *v = value.clone();
+        }
+        Value::String(s) if key.is_some() && s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
+            *v = Value::String(key.unwrap().to_string());
         }
         Value::List(items) => {
             for item in items.iter_mut() {
-                substitute_placeholder(item, replacement);
+                substitute_placeholder(item, key, value);
             }
         }
         Value::Map(map) => {
-            for v in map.values_mut() {
-                substitute_placeholder(v, replacement);
+            for val in map.values_mut() {
+                substitute_placeholder(val, key, value);
             }
         }
         _ => {}
-    }
-}
-
-/// Substitute key and value placeholders for a map-binding entry.
-/// Replaces `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string and
-/// `DEFERRED_UPSTREAM_PLACEHOLDER` with the value.
-fn substitute_for_map_entry(resource: &mut Resource, key: &str, value: &Value) {
-    fn recurse(v: &mut Value, key: &str, replacement: &Value) {
-        match v {
-            Value::String(s) if s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
-                *v = Value::String(key.to_string());
-            }
-            Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
-                *v = replacement.clone();
-            }
-            Value::List(items) => {
-                for item in items.iter_mut() {
-                    recurse(item, key, replacement);
-                }
-            }
-            Value::Map(map) => {
-                for val in map.values_mut() {
-                    recurse(val, key, replacement);
-                }
-            }
-            _ => {}
-        }
-    }
-    for (_, expr) in resource.attributes.iter_mut() {
-        recurse(&mut expr.0, key, value);
     }
 }
 
@@ -1711,7 +1687,7 @@ fn parse_primary_with_resource_or_module(
 }
 
 /// Binding pattern for a for expression
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ForBinding {
     /// Simple: `for x in ...`
     Simple(String),

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -471,6 +471,11 @@ impl ParsedFile {
     ) {
         let mut expanded_resources = Vec::new();
         let mut resolved_indices = Vec::new();
+        // Indices where the iterable resolved but had the wrong shape. These
+        // entries stay deferred (user must fix), but their parse-time "not yet
+        // available" warning is replaced by the more specific shape-mismatch
+        // warning collected in `new_warnings`.
+        let mut mismatched_indices: Vec<usize> = Vec::new();
         let mut new_warnings: Vec<ParseWarning> = Vec::new();
 
         for (idx, deferred) in self.deferred_for_expressions.iter().enumerate() {
@@ -516,8 +521,10 @@ impl ParsedFile {
                     }
                     resolved_indices.push(idx);
                 }
-                // Shape mismatch: emit warning and leave deferred
+                // Shape mismatch: replace the original "not yet available" warning
+                // with a specific shape-mismatch warning, leave entry deferred.
                 (ForBinding::Map(_, _), Value::List(_)) => {
+                    mismatched_indices.push(idx);
                     new_warnings.push(ParseWarning {
                         file: deferred.file.clone(),
                         line: deferred.line,
@@ -530,6 +537,7 @@ impl ParsedFile {
                 }
                 (ForBinding::Simple(_), Value::Map(_))
                 | (ForBinding::Indexed(_, _), Value::Map(_)) => {
+                    mismatched_indices.push(idx);
                     new_warnings.push(ParseWarning {
                         file: deferred.file.clone(),
                         line: deferred.line,
@@ -544,6 +552,14 @@ impl ParsedFile {
                     // Iterable is not a list or map — leave deferred
                 }
             }
+        }
+
+        // Remove parse-time warnings for mismatched entries (the new
+        // shape-mismatch warning replaces the generic "not yet available" one).
+        for idx in &mismatched_indices {
+            let deferred = &self.deferred_for_expressions[*idx];
+            self.warnings
+                .retain(|w| w.line != deferred.line || w.file != deferred.file);
         }
 
         // Remove resolved deferred entries (reverse order to preserve indices)
@@ -10671,6 +10687,17 @@ awscc.ec2.vpc {
                 .iter()
                 .any(|w| w.message.contains("expected map") || w.message.contains("shape")),
             "should warn about shape mismatch, got: {:?}",
+            parsed.warnings
+        );
+        // The parse-time "not yet available" warning should be replaced by the
+        // more specific shape-mismatch warning (not kept alongside).
+        assert!(
+            !parsed
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("not yet available")
+                    || w.message.contains("not yet in the upstream state")),
+            "parse-time warning should be replaced, got: {:?}",
             parsed.warnings
         );
     }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -580,7 +580,9 @@ impl ParsedFile {
 ///
 /// Replaces `DEFERRED_UPSTREAM_PLACEHOLDER` with `value`. If `key` is
 /// supplied (map-binding expansion), also replaces
-/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string.
+/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string. Recurses into
+/// all compound Value variants so placeholders nested inside
+/// interpolations / function calls / secrets are reached.
 fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
     match v {
         Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
@@ -600,6 +602,21 @@ fn substitute_placeholder(v: &mut Value, key: Option<&str>, value: &Value) {
             for val in map.values_mut() {
                 substitute_placeholder(val, key, value);
             }
+        }
+        Value::FunctionCall { args, .. } => {
+            for arg in args.iter_mut() {
+                substitute_placeholder(arg, key, value);
+            }
+        }
+        Value::Interpolation(parts) => {
+            for part in parts.iter_mut() {
+                if let crate::resource::InterpolationPart::Expr(inner) = part {
+                    substitute_placeholder(inner, key, value);
+                }
+            }
+        }
+        Value::Secret(inner) => {
+            substitute_placeholder(inner, key, value);
         }
         _ => {}
     }
@@ -10590,6 +10607,67 @@ awscc.ec2.vpc {
         assert_eq!(
             dev.get_attr("target_id"),
             Some(&Value::String("222222222222".to_string()))
+        );
+    }
+
+    #[test]
+    fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
+        // The loop var may appear inside a string interpolation like "acct-${id}".
+        // Placeholder substitution must recurse into Value::Interpolation parts,
+        // otherwise the rendered resource ships the raw placeholder string.
+        let input = r#"
+            let orgs = remote_state {
+                path = "../organizations/carina.state.json"
+            }
+
+            for account_id in orgs.accounts {
+                awscc.sso.assignment {
+                    target_id = account_id
+                    label = "acct-${account_id}"
+                }
+            }
+        "#;
+
+        let mut parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.deferred_for_expressions.len(), 1);
+
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert(
+            "accounts".to_string(),
+            Value::List(vec![Value::String("111111111111".to_string())]),
+        );
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        parsed.expand_deferred_for_expressions(&remote_bindings);
+        assert_eq!(parsed.resources.len(), 1);
+
+        // label must have the placeholder substituted in the interpolation.
+        let label = parsed.resources[0].get_attr("label");
+        let rendered = match label {
+            Some(Value::Interpolation(parts)) => {
+                let mut s = String::new();
+                for p in parts {
+                    match p {
+                        crate::resource::InterpolationPart::Literal(lit) => s.push_str(lit),
+                        crate::resource::InterpolationPart::Expr(Value::String(v)) => s.push_str(v),
+                        _ => s.push_str("<expr>"),
+                    }
+                }
+                s
+            }
+            Some(Value::String(s)) => s.clone(),
+            other => panic!("unexpected label shape: {:?}", other),
+        };
+        assert!(
+            rendered.contains("111111111111"),
+            "interpolation should contain substituted account id, got: {}",
+            rendered
+        );
+        assert!(
+            !rendered.contains(DEFERRED_UPSTREAM_PLACEHOLDER),
+            "placeholder must not leak into rendered label, got: {}",
+            rendered
         );
     }
 


### PR DESCRIPTION
## Summary

When a `for` loop over an unresolved `remote_state` value is stored as a `DeferredForExpression` and later expanded, the expansion now:

1. Records the full `ForBinding` (Simple/Indexed/Map) on the deferred entry
2. Verifies the resolved iterable's shape matches the binding kind
   — a map binding with a list iterable (or vice versa) emits a warning and leaves the for-expression deferred instead of silently expanding with wrong addresses
3. For map bindings, substitutes both the key variable and the value variable

## Implementation

- Made `ForBinding` public with `Debug, Clone, PartialEq` derives
- Added `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` sentinel (`pub(crate)`) for map-binding key variables
- Extended `substitute_placeholder` with an optional `key` parameter to handle both placeholders in one function
- Expansion loop now matches on `(ForBinding, Value)` tuples with explicit shape-check arms

## Test plan

- [x] Map binding + map iterable: both key and value are substituted
- [x] Map binding + list iterable: emits warning, leaves deferred
- [x] Simple binding + map iterable: emits warning, leaves deferred
- [x] Existing tests unchanged (simple binding + list, unresolved remote)
- [x] Full carina-core test suite passes (1195 tests)
- [x] `cargo clippy -p carina-core` — no warnings

Closes #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)