### PR TITLE
fix: make apply confirmation prompt interruptible by Ctrl+C

### DIFF
--- a/carina-cli/Cargo.toml
+++ b/carina-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1"
 similar = "2"
 thiserror = "2"
 futures = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "io-std", "io-util"] }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1436,10 +1436,11 @@ async fn run_apply_locked(
         print!("\n  Enter a value: ");
         std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
 
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| e.to_string())?;
+        let stdin = tokio::io::BufReader::new(tokio::io::stdin());
+        let interrupt = async {
+            let _ = tokio::signal::ctrl_c().await;
+        };
+        let input = crate::signal::read_line_with_interrupt(stdin, interrupt).await?;
 
         if input.trim() != "yes" {
             println!();
@@ -1739,10 +1740,11 @@ async fn run_apply_from_plan_locked(
         print!("\n  Enter a value: ");
         std::io::Write::flush(&mut std::io::stdout()).map_err(|e| e.to_string())?;
 
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|e| e.to_string())?;
+        let stdin = tokio::io::BufReader::new(tokio::io::stdin());
+        let interrupt = async {
+            let _ = tokio::signal::ctrl_c().await;
+        };
+        let input = crate::signal::read_line_with_interrupt(stdin, interrupt).await?;
 
         if input.trim() != "yes" {
             println!();

--- a/carina-cli/src/signal.rs
+++ b/carina-cli/src/signal.rs
@@ -7,6 +7,7 @@
 use std::future::Future;
 
 use colored::Colorize;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 
 use crate::error::AppError;
 
@@ -47,6 +48,76 @@ where
             });
 
             Err(AppError::Interrupted)
+        }
+    }
+}
+
+/// Read a single line from `reader`, cancellable by `interrupt`.
+///
+/// Returns the line with any trailing `\n` or `\r\n` stripped, or
+/// `Err(AppError::Interrupted)` if `interrupt` fires first.
+pub async fn read_line_with_interrupt<R, F>(reader: R, interrupt: F) -> Result<String, AppError>
+where
+    R: AsyncBufRead + Unpin,
+    F: Future<Output = ()>,
+{
+    tokio::pin!(reader);
+    let mut buf = String::new();
+    tokio::select! {
+        result = reader.read_line(&mut buf) => {
+            result.map_err(|e| AppError::Config(e.to_string()))?;
+            if buf.ends_with('\n') {
+                buf.pop();
+                if buf.ends_with('\r') {
+                    buf.pop();
+                }
+            }
+            Ok(buf)
+        }
+        _ = interrupt => Err(AppError::Interrupted),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_line_returns_input_before_interrupt() {
+        let input = &b"yes\n"[..];
+        let interrupt = std::future::pending::<()>();
+        let line = read_line_with_interrupt(input, interrupt).await.unwrap();
+        assert_eq!(line, "yes");
+    }
+
+    #[tokio::test]
+    async fn read_line_strips_crlf() {
+        let input = &b"no\r\n"[..];
+        let interrupt = std::future::pending::<()>();
+        let line = read_line_with_interrupt(input, interrupt).await.unwrap();
+        assert_eq!(line, "no");
+    }
+
+    #[tokio::test]
+    async fn read_line_returns_interrupted_when_signal_fires_first() {
+        // Simulates a user who hasn't pressed Enter at the confirmation prompt.
+        let reader = tokio::io::BufReader::new(NeverReady);
+        let interrupt = async {};
+        let err = read_line_with_interrupt(reader, interrupt)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Interrupted));
+    }
+
+    struct NeverReady;
+
+    impl tokio::io::AsyncRead for NeverReady {
+        fn poll_read(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Pending
         }
     }
 }


### PR DESCRIPTION
## Summary

- `carina apply` の確認プロンプトで Ctrl+C が効かない問題を修正
- 同期 `std::io::stdin().read_line()` を `tokio::io::stdin()` + 割り込み対応の非同期 read に置き換え
- `carina-cli/src/signal.rs` に `read_line_with_interrupt` ヘルパーを追加（reader と interrupt future を受け取る汎用実装でユニットテスト可能）

## Root Cause

同期 read_line が tokio worker をブロックし、外側の `run_with_ctrl_c` の `tokio::select!` が発火できなかった。非同期 read に切り替えることで await で譲れるようになり、Ctrl+C が `AppError::Interrupted` として伝播し `exit(130)` に至る。

## Test plan

- [x] `cargo test -p carina-cli signal::` — 3 件の新規テストが pass（入力取得 / CRLF 剥がし / 割り込み）
- [x] `cargo test -p carina-cli` — 既存 244 件 pass
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings`
- [x] `cargo fmt --check`

Closes #1895