### PR TITLE
feat: validate upstream_state source attribute

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -3166,7 +3166,16 @@ fn parse_upstream_state_block(
         let value_pair = next_pair(&mut attr_inner, "attribute value", "upstream_state block")?;
         match key.as_str() {
             "source" => {
-                source = Some(extract_string_from_pair(value_pair)?);
+                let value_text = value_pair.as_str().to_string();
+                source = Some(extract_string_from_pair(value_pair).map_err(|_| {
+                    ParseError::InvalidExpression {
+                        line: attr_line,
+                        message: format!(
+                            "upstream_state \"{}\": 'source' must be a string literal, got: {}",
+                            binding, value_text
+                        ),
+                    }
+                })?);
             }
             other => {
                 return Err(ParseError::InvalidExpression {
@@ -10555,6 +10564,47 @@ awscc.ec2.vpc {
         assert!(
             msg.contains("remote_state") && msg.contains("upstream_state"),
             "error should guide users to upstream_state, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn upstream_state_missing_source_is_error() {
+        let input = r#"upstream_state "orgs" { }"#;
+        let err = parse(input, &ProviderContext::default())
+            .expect_err("missing source must be a parse error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("upstream_state") && msg.contains("source") && msg.contains("orgs"),
+            "error should mention upstream_state, binding, and source: {msg}",
+        );
+    }
+
+    #[test]
+    fn upstream_state_source_must_be_string() {
+        let input = r#"upstream_state "orgs" { source = 42 }"#;
+        let err = parse(input, &ProviderContext::default())
+            .expect_err("non-string source must be a parse error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("source") && msg.contains("orgs"),
+            "error should mention source and binding: {msg}",
+        );
+    }
+
+    #[test]
+    fn upstream_state_unknown_attribute_is_error() {
+        let input = r#"
+            upstream_state "orgs" {
+                source = "../foo"
+                backend = "s3"
+            }
+        "#;
+        let err = parse(input, &ProviderContext::default())
+            .expect_err("unknown attribute must be a parse error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("backend") && msg.contains("orgs"),
+            "error should mention the unknown attribute and binding: {msg}",
         );
     }
 }


### PR DESCRIPTION
Closes #1908

## Summary
Tighten the error message when `upstream_state "<name>" { source = ... }` has a non-string `source`. The underlying `extract_string_from_pair` returns a generic `"expected a string literal"` with `line: 0` and no context; replace it with a message that names the binding and shows the offending token.

Adds three parser tests covering the `source` attribute validation required by task-2/9:
- `upstream_state_missing_source_is_error`
- `upstream_state_source_must_be_string`
- `upstream_state_unknown_attribute_is_error`

The missing/unknown paths were already producing useful errors from task-1/9 — this change hardens the wrong-type path and locks the behavior in with tests.

## Error message examples

| Input | Error |
|-------|-------|
| `upstream_state "orgs" { }` | `upstream_state "orgs" requires a 'source' attribute` |
| `upstream_state "orgs" { source = 42 }` | `upstream_state "orgs": 'source' must be a string literal, got: 42` |
| `upstream_state "orgs" { source = "../foo" backend = "s3" }` | `unknown attribute 'backend' in upstream_state "orgs" block` |

## Test plan
- [x] `cargo test -p carina-core upstream_state_` — 7 passed
- [x] `cargo test -p carina-core` — 1191 passed, 0 failed
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` — clean

## Reference
- Plan: `docs/plans/2026-04-16-upstream-state-dsl.md` Task 2
- Previous task: #1907 (merged in #1916)

🤖 Generated with [Claude Code](https://claude.com/claude-code)