### PR TITLE
test: cover upstream_state duplicate binding detection

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -10607,4 +10607,20 @@ awscc.ec2.vpc {
             "error should mention the unknown attribute and binding: {msg}",
         );
     }
+
+    #[test]
+    fn upstream_state_duplicate_binding_is_error() {
+        let input = r#"
+            upstream_state "orgs" { source = "../a" }
+            upstream_state "orgs" { source = "../b" }
+        "#;
+        let err = parse(input, &ProviderContext::default())
+            .expect_err("duplicate upstream_state binding must be a parse error");
+        match &err {
+            ParseError::DuplicateBinding { name, .. } => {
+                assert_eq!(name, "orgs");
+            }
+            other => panic!("Expected DuplicateBinding error, got: {other}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `upstream_state_duplicate_binding_is_error` parser test to lock in the invariant that two `upstream_state` blocks sharing a binding name fail parsing.
- The detection itself already lives inline in the parser driver where `upstream_state_block` is handled (`ctx.upstream_states.contains_key` → `ParseError::DuplicateBinding`), so this change is test-only.
- Part of the `upstream_state` DSL migration (plan Task 3/9, see PR #1906).

## Test plan
- [x] `cargo test -p carina-core upstream_state_duplicate_binding_is_error`
- [x] `cargo test -p carina-core` (1192 passed)
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings`

Closes #1909

🤖 Generated with [Claude Code](https://claude.com/claude-code)