### PR TITLE
refactor: rename remote_state leftovers in resolver to upstream_state

### DIFF
--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -17,8 +17,8 @@ use crate::resource::{Expr, InterpolationPart, Resource, ResourceId, State, Valu
 /// metadata on each resource. This preserves dependency information that would
 /// otherwise be lost when ResourceRef values are replaced with plain strings.
 ///
-/// `remote_bindings` provides external bindings from remote state data sources.
-/// Each entry maps a remote_state binding name to a map of resource binding names
+/// `remote_bindings` provides external bindings from upstream state data sources.
+/// Each entry maps an upstream_state binding name to a map of resource binding names
 /// to their attributes. For example, `network -> { vpc -> { vpc_id -> "vpc-123" } }`.
 pub fn resolve_refs_with_state(
     resources: &mut [Resource],
@@ -27,7 +27,7 @@ pub fn resolve_refs_with_state(
     resolve_refs_with_state_and_remote(resources, current_states, &HashMap::new())
 }
 
-/// Resolve all ResourceRef values in resources using current state and remote state bindings.
+/// Resolve all ResourceRef values in resources using current state and upstream state bindings.
 pub fn resolve_refs_with_state_and_remote(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
@@ -67,8 +67,8 @@ pub fn resolve_refs_with_state_and_remote(
         }
     }
 
-    // Inject remote state bindings.
-    // Each remote_state binding (e.g., "network") maps to a Map value containing
+    // Inject upstream state bindings.
+    // Each upstream_state binding (e.g., "network") maps to a Map value containing
     // resource bindings as nested maps (e.g., { "vpc" -> Map { "vpc_id" -> "vpc-123" } }).
     for (remote_binding, remote_attrs) in remote_bindings {
         binding_map.insert(remote_binding.clone(), remote_attrs.clone());
@@ -641,9 +641,9 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_remote_state_binding() {
-        // Simulate a resource that references a remote_state binding:
-        // network.vpc.vpc_id where network is a remote_state
+    fn test_resolve_upstream_state_binding() {
+        // Simulate a resource that references an upstream_state binding:
+        // network.vpc.vpc_id where network is an upstream_state
         let mut resources = vec![make_resource(
             "web-sg",
             None,
@@ -682,8 +682,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_remote_state_unresolved_keeps_ref() {
-        // If the remote state doesn't have the referenced resource, the ref stays as-is
+    fn test_resolve_upstream_state_unresolved_keeps_ref() {
+        // If the upstream state doesn't have the referenced resource, the ref stays as-is
         let mut resources = vec![make_resource(
             "web-sg",
             None,


### PR DESCRIPTION
Closes #1912

Part of the `upstream_state` DSL migration (task-6/9). See PR #1906 for the broader plan.

## Summary
- Rename `remote_state`/`RemoteState` mentions in `carina-core/src/resolver.rs` (doc comments, inline comments, and 2 test function names) to `upstream_state`/`UpstreamState`.
- The `remote_bindings: &HashMap<...>` parameter name is intentionally preserved per the issue — it is the resolved value map, not a DSL keyword.

## Scope notes
- The issue lists four files; only `resolver.rs` had remaining occurrences. `config_loader.rs`, `validation.rs`, and `module_resolver/mod.rs` were already clean from prior tasks.
- Parser hits in `parser/mod.rs` (deprecation error + its test) are intentional and out of scope.

## Verification
- `cargo check -p carina-core` clean
- `cargo test -p carina-core` clean — 1192 passed, 0 failed (renamed tests `test_resolve_upstream_state_binding` / `test_resolve_upstream_state_unresolved_keeps_ref` pass)
- `cargo clippy -p carina-core --all-targets -- -D warnings` clean
- `grep -rn 'remote_state\|RemoteState' carina-core/src` returns only the intentional parser deprecation message + its test

## Test plan
- [x] cargo check / test / clippy on carina-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)