### PR TITLE
feat(lsp): recognize upstream_state DSL construct

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -59,6 +59,7 @@ impl CompletionProvider {
             CompletionContext::InsideResourceBlock { resource_type } => {
                 self.attribute_completions_for_type(&resource_type)
             }
+            CompletionContext::InsideUpstreamStateBlock => self.upstream_state_block_completions(),
             CompletionContext::InsideModuleCall { module_name } => {
                 self.module_parameter_completions(&module_name, &text, base_path)
             }
@@ -72,7 +73,6 @@ impl CompletionProvider {
                 &text,
                 current_binding.as_deref(),
                 position,
-                base_path,
             ),
             CompletionContext::InsideStructBlock {
                 resource_type,
@@ -146,6 +146,7 @@ impl CompletionProvider {
         let mut module_name: Option<String> = None;
         let mut provider_block_name: Option<String> = None;
         let mut in_args_or_attrs_block = false;
+        let mut in_upstream_state_block = false;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
 
@@ -191,6 +192,13 @@ impl CompletionProvider {
                 resource_type.clear();
                 module_name = None;
             } else if brace_depth == 0
+                && trimmed.starts_with("upstream_state ")
+                && trimmed.ends_with('{')
+            {
+                in_upstream_state_block = true;
+                resource_type.clear();
+                module_name = None;
+            } else if brace_depth == 0
                 && trimmed.ends_with('{')
                 && !trimmed.starts_with("let ")
                 && !self.starts_with_provider_prefix(trimmed)
@@ -198,6 +206,7 @@ impl CompletionProvider {
                 && !trimmed.starts_with("arguments ")
                 && !trimmed.starts_with("attributes ")
                 && !trimmed.starts_with("exports ")
+                && !trimmed.starts_with("upstream_state ")
                 && !trimmed.starts_with('#')
             {
                 // This is a module call: "module_name {"
@@ -238,6 +247,7 @@ impl CompletionProvider {
                         module_name = None;
                         provider_block_name = None;
                         in_args_or_attrs_block = false;
+                        in_upstream_state_block = false;
                         nested_block_names.clear();
                     } else {
                         // Truncate to current depth
@@ -325,6 +335,9 @@ impl CompletionProvider {
 
         // Inside module call block
         if brace_depth > 0 {
+            if in_upstream_state_block {
+                return CompletionContext::InsideUpstreamStateBlock;
+            }
             if let Some(name) = module_name {
                 return CompletionContext::InsideModuleCall { module_name: name };
             }
@@ -543,6 +556,7 @@ enum CompletionContext {
     InsideResourceBlock {
         resource_type: String,
     },
+    InsideUpstreamStateBlock,
     InsideModuleCall {
         module_name: String,
     },

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use super::*;
 use tower_lsp::lsp_types::InsertTextFormat;
 
@@ -809,257 +807,48 @@ awscc.ec2.vpc_gateway_attachment {
     );
 }
 
-/// Helper to create a temporary state file for remote_state completion tests.
-fn create_test_state_file(dir: &std::path::Path, filename: &str) -> std::path::PathBuf {
-    let state_path = dir.join(filename);
-    let state_json = serde_json::json!({
-        "version": 4,
-        "serial": 1,
-        "lineage": "test-lineage",
-        "carina_version": "0.1.0",
-        "resources": [
-            {
-                "resource_type": "ec2.vpc",
-                "name": "main-vpc",
-                "provider": "awscc",
-                "attributes": {
-                    "vpc_id": "vpc-12345",
-                    "cidr_block": "10.0.0.0/16"
-                },
-                "binding": "vpc",
-                "dependency_bindings": []
-            },
-            {
-                "resource_type": "ec2.subnet",
-                "name": "main-subnet",
-                "provider": "awscc",
-                "attributes": {
-                    "subnet_id": "subnet-67890",
-                    "vpc_id": "vpc-12345",
-                    "availability_zone": "ap-northeast-1a"
-                },
-                "binding": "subnet",
-                "dependency_bindings": ["vpc"]
-            }
-        ]
-    });
-    let mut f = std::fs::File::create(&state_path).unwrap();
-    f.write_all(
-        serde_json::to_string_pretty(&state_json)
-            .unwrap()
-            .as_bytes(),
-    )
-    .unwrap();
-    state_path
-}
-
 #[test]
-fn remote_state_first_segment_completes_resource_bindings() {
+fn top_level_completion_suggests_upstream_state() {
     let provider = test_provider();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    create_test_state_file(tmp_dir.path(), "network.state.json");
-
-    let doc = create_document(
-        r#"let network = remote_state {
-    path = "network.state.json"
-}
-
-awscc.ec2.security_group {
-    vpc_id = network.
-}"#,
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: 0,
+        },
+        "",
+        None,
     );
-
-    // Cursor after "network." on line 5 (character 22)
-    let position = Position {
-        line: 5,
-        character: 22,
-    };
-
-    let completions = provider.complete(&doc, position, Some(tmp_dir.path()));
-
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
-
     assert!(
-        labels.contains(&"network.vpc"),
-        "Should suggest 'network.vpc' from remote state. Got: {:?}",
+        labels.contains(&"upstream_state"),
+        "Top-level completions should include 'upstream_state'. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"network.subnet"),
-        "Should suggest 'network.subnet' from remote state. Got: {:?}",
-        labels
-    );
-}
-
-#[test]
-fn remote_state_second_segment_completes_resource_attributes() {
-    let provider = test_provider();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    create_test_state_file(tmp_dir.path(), "network.state.json");
-
-    let doc = create_document(
-        r#"let network = remote_state {
-    path = "network.state.json"
-}
-
-awscc.ec2.security_group {
-    vpc_id = network.vpc.
-}"#,
-    );
-
-    // Cursor after "network.vpc." on line 5 (character 26)
-    let position = Position {
-        line: 5,
-        character: 26,
-    };
-
-    let completions = provider.complete(&doc, position, Some(tmp_dir.path()));
-
-    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
-
-    assert!(
-        labels.contains(&"network.vpc.vpc_id"),
-        "Should suggest 'network.vpc.vpc_id' from remote state. Got: {:?}",
-        labels
-    );
-    assert!(
-        labels.contains(&"network.vpc.cidr_block"),
-        "Should suggest 'network.vpc.cidr_block' from remote state. Got: {:?}",
-        labels
-    );
-    // Should NOT contain subnet attributes
-    assert!(
-        !labels.iter().any(|l| l.contains("subnet_id")),
-        "Should NOT suggest subnet attributes when completing vpc. Got: {:?}",
+        !labels.contains(&"remote_state"),
+        "Top-level completions should not include 'remote_state'. Got: {:?}",
         labels
     );
 }
 
 #[test]
-fn remote_state_missing_file_returns_no_completions() {
+fn upstream_state_block_completes_source_attribute() {
     let provider = test_provider();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    // Do NOT create the state file
-
     let doc = create_document(
-        r#"let network = remote_state {
-    path = "nonexistent.state.json"
-}
+        r#"upstream_state "orgs" {
 
-awscc.ec2.security_group {
-    vpc_id = network.
 }"#,
     );
-
+    // Cursor on the empty line inside the block
     let position = Position {
-        line: 5,
-        character: 22,
+        line: 1,
+        character: 0,
     };
-
-    let completions = provider.complete(&doc, position, Some(tmp_dir.path()));
-
-    assert!(
-        completions.is_empty(),
-        "Should return no completions when state file is missing. Got: {:?}",
-        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn remote_state_first_segment_triggers_suggest() {
-    // After selecting a resource binding (first segment), the LSP should
-    // trigger another completion to show attributes (second segment).
-    let provider = test_provider();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    create_test_state_file(tmp_dir.path(), "network.state.json");
-
-    let doc = create_document(
-        r#"let network = remote_state {
-    path = "network.state.json"
-}
-
-awscc.ec2.security_group {
-    vpc_id = network.
-}"#,
-    );
-
-    let position = Position {
-        line: 5,
-        character: 22,
-    };
-
-    let completions = provider.complete(&doc, position, Some(tmp_dir.path()));
-
-    let vpc_completion = completions
-        .iter()
-        .find(|c| c.label == "network.vpc")
-        .expect("Should have network.vpc completion");
-
-    assert!(
-        vpc_completion.command.is_some(),
-        "First segment completion should trigger suggest command"
-    );
-    assert_eq!(
-        vpc_completion.command.as_ref().unwrap().command,
-        "editor.action.triggerSuggest"
-    );
-}
-
-#[test]
-fn remote_state_no_base_path_returns_relative_no_completions() {
-    // When base_path is None and the state path is relative, no completions.
-    let provider = test_provider();
-
-    let doc = create_document(
-        r#"let network = remote_state {
-    path = "network.state.json"
-}
-
-awscc.ec2.security_group {
-    vpc_id = network.
-}"#,
-    );
-
-    let position = Position {
-        line: 5,
-        character: 22,
-    };
-
     let completions = provider.complete(&doc, position, None);
-
-    assert!(
-        completions.is_empty(),
-        "Should return no completions when base_path is None for relative path"
-    );
-}
-
-#[test]
-fn remote_state_single_line_syntax() {
-    // Single-line remote_state syntax should also work.
-    let provider = test_provider();
-    let tmp_dir = tempfile::tempdir().unwrap();
-    create_test_state_file(tmp_dir.path(), "network.state.json");
-
-    let doc = create_document(
-        r#"let network = remote_state { path = "network.state.json" }
-
-awscc.ec2.security_group {
-    vpc_id = network.
-}"#,
-    );
-
-    let position = Position {
-        line: 3,
-        character: 22,
-    };
-
-    let completions = provider.complete(&doc, position, Some(tmp_dir.path()));
-
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
-
     assert!(
-        labels.contains(&"network.vpc"),
-        "Should suggest 'network.vpc' from single-line remote_state. Got: {:?}",
+        labels.contains(&"source"),
+        "upstream_state block should offer 'source' attribute. Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -94,7 +94,7 @@ impl CompletionProvider {
                 kind: Some(CompletionItemKind::KEYWORD),
                 insert_text: Some("exports {\n    ${1:name}: ${2:type} = ${3:value}\n}".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
-                detail: Some("Publish values for remote_state consumers".to_string()),
+                detail: Some("Publish values for upstream_state consumers".to_string()),
                 ..Default::default()
             },
             CompletionItem {
@@ -146,11 +146,14 @@ impl CompletionProvider {
                 ..Default::default()
             },
             CompletionItem {
-                label: "remote_state".to_string(),
+                label: "upstream_state".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("let ${1:name} = remote_state {\n    path = \"${2:../other-project/carina.state.json}\"\n}".to_string()),
+                insert_text: Some(
+                    "upstream_state \"${1:binding}\" {\n    source = \"${2:../other-project}\"\n}"
+                        .to_string(),
+                ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
-                detail: Some("Reference another project's state".to_string()),
+                detail: Some("Reference another project's exported state".to_string()),
                 ..Default::default()
             },
             CompletionItem {

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1,8 +1,5 @@
 //! Attribute, value, and type-specific completions.
 
-use std::collections::HashMap;
-use std::path::Path;
-
 use tower_lsp::lsp_types::{
     Command, CompletionItem, CompletionItemKind, InsertTextFormat, Position, Range, TextEdit,
 };
@@ -16,21 +13,6 @@ use super::CompletionProvider;
 struct BindingDotContext {
     binding_name: String,
     resource_type: String,
-}
-
-/// Context when the user has typed `remote_binding.` or `remote_binding.resource.` after `=`.
-enum RemoteStateDotContext {
-    /// After `remote_binding.` — complete with resource binding names
-    FirstSegment {
-        binding_name: String,
-        state_path: String,
-    },
-    /// After `remote_binding.resource.` — complete with attribute names
-    SecondSegment {
-        binding_name: String,
-        resource_binding: String,
-        state_path: String,
-    },
 }
 
 fn type_completion_item(label: String, detail: String, range: Range) -> CompletionItem {
@@ -106,7 +88,6 @@ impl CompletionProvider {
         text: &str,
         current_binding: Option<&str>,
         position: Position,
-        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
 
@@ -115,12 +96,6 @@ impl CompletionProvider {
         // from the start of "igw" to the cursor, so accepting a completion like
         // "igw.internet_gateway_id" replaces "igw." instead of being appended.
         let ref_edit_range = self.compute_value_prefix_range(text, position);
-
-        // Check if the user has typed "remote_binding." or "remote_binding.resource."
-        // after "=" — if so, show remote state completions.
-        if let Some(remote_ctx) = self.detect_remote_state_dot_context(text, position) {
-            return self.remote_state_completions(&remote_ctx, ref_edit_range, base_path);
-        }
 
         // Check if the user has typed "binding." after "=" — if so, show only
         // that binding's resource attributes, not built-in functions or generic completions.
@@ -316,276 +291,6 @@ impl CompletionProvider {
         completions
     }
 
-    /// Extract remote_state binding names and their paths from text.
-    /// Parses lines like `let network = remote_state { path = "..." }` or multi-line variants.
-    fn extract_remote_state_bindings(&self, text: &str) -> Vec<(String, String)> {
-        let mut bindings = Vec::new();
-        let mut current_binding: Option<String> = None;
-        let mut in_remote_state_block = false;
-        let mut brace_depth = 0;
-
-        for line in text.lines() {
-            let trimmed = line.trim();
-
-            // Detect "let name = remote_state {"
-            if let Some(rest) = trimmed.strip_prefix("let ")
-                && let Some(eq_pos) = rest.find('=')
-            {
-                let name = rest[..eq_pos].trim();
-                let after_eq = rest[eq_pos + 1..].trim();
-                if let Some(after_rs) = after_eq.strip_prefix("remote_state")
-                    && (after_rs.is_empty()
-                        || after_rs.starts_with(char::is_whitespace)
-                        || after_rs.starts_with('{')
-                        || after_rs.starts_with('"'))
-                {
-                    // Skip optional backend name string (e.g., "s3")
-                    let after_rs = after_rs.trim();
-                    let after_backend = if let Some(stripped) = after_rs.strip_prefix('"') {
-                        // Skip past the closing quote of the backend name
-                        if let Some(end_quote) = stripped.find('"') {
-                            stripped[end_quote + 1..].trim()
-                        } else {
-                            after_rs
-                        }
-                    } else {
-                        after_rs
-                    };
-                    if let Some(after_brace) = after_backend.strip_prefix('{') {
-                        current_binding = Some(name.to_string());
-                        in_remote_state_block = true;
-                        brace_depth = 1;
-
-                        // Check if path is on the same line
-                        let inside_block = after_brace.trim();
-                        if let Some(path) = Self::extract_path_from_line(inside_block) {
-                            bindings.push((name.to_string(), path));
-                            current_binding = None;
-                            in_remote_state_block = false;
-                            brace_depth = 0;
-                        }
-                        continue;
-                    }
-                }
-            }
-
-            if in_remote_state_block {
-                // Track braces
-                for c in trimmed.chars() {
-                    if c == '{' {
-                        brace_depth += 1;
-                    } else if c == '}' {
-                        brace_depth -= 1;
-                        if brace_depth == 0 {
-                            in_remote_state_block = false;
-                            current_binding = None;
-                            break;
-                        }
-                    }
-                }
-
-                // Look for path = "..."
-                if let Some(ref binding_name) = current_binding
-                    && let Some(path) = Self::extract_path_from_line(trimmed)
-                {
-                    bindings.push((binding_name.clone(), path));
-                }
-            }
-        }
-
-        bindings
-    }
-
-    /// Extract path value from a line containing `path = "..."`.
-    fn extract_path_from_line(line: &str) -> Option<String> {
-        let trimmed = line.trim();
-        let rest = trimmed.strip_prefix("path")?.trim();
-        let rest = rest.strip_prefix('=')?.trim();
-        let rest = rest.strip_prefix('"')?;
-        let end = rest.find('"')?;
-        Some(rest[..end].to_string())
-    }
-
-    /// Detect if the user has typed `remote_binding.` or `remote_binding.resource.` after `=`.
-    fn detect_remote_state_dot_context(
-        &self,
-        text: &str,
-        position: Position,
-    ) -> Option<RemoteStateDotContext> {
-        let lines: Vec<&str> = text.lines().collect();
-        let line_idx = position.line as usize;
-        if line_idx >= lines.len() {
-            return None;
-        }
-
-        let col = position.character as usize;
-        let prefix: String = lines[line_idx].chars().take(col).collect();
-
-        // Extract the value part after "="
-        let after_eq = prefix.rsplit('=').next()?.trim();
-
-        // Must contain at least one dot
-        let first_dot = after_eq.find('.')?;
-        let candidate_binding = &after_eq[..first_dot];
-
-        // Validate binding name
-        if candidate_binding.is_empty()
-            || !candidate_binding
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_')
-        {
-            return None;
-        }
-
-        // Check if this binding is a remote_state binding
-        let remote_bindings = self.extract_remote_state_bindings(text);
-        let state_path = remote_bindings
-            .iter()
-            .find(|(name, _)| name == candidate_binding)?
-            .1
-            .clone();
-
-        let after_first_dot = &after_eq[first_dot + 1..];
-
-        // Check for second dot: "remote_binding.resource."
-        if let Some(second_dot) = after_first_dot.find('.') {
-            let resource_binding = &after_first_dot[..second_dot];
-            if !resource_binding.is_empty()
-                && resource_binding
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_')
-            {
-                return Some(RemoteStateDotContext::SecondSegment {
-                    binding_name: candidate_binding.to_string(),
-                    resource_binding: resource_binding.to_string(),
-                    state_path,
-                });
-            }
-        }
-
-        // First dot only: "remote_binding."
-        Some(RemoteStateDotContext::FirstSegment {
-            binding_name: candidate_binding.to_string(),
-            state_path,
-        })
-    }
-
-    /// Load a remote state file and return its resource bindings.
-    /// Returns None if the file cannot be read or parsed.
-    fn load_remote_state_bindings(
-        &self,
-        state_path: &str,
-        base_path: Option<&Path>,
-    ) -> Option<HashMap<String, HashMap<String, String>>> {
-        let path = if Path::new(state_path).is_absolute() {
-            std::path::PathBuf::from(state_path)
-        } else {
-            base_path?.join(state_path)
-        };
-
-        let content = std::fs::read_to_string(&path).ok()?;
-        let state_file = carina_state::check_and_migrate(&content).ok()?;
-
-        // Build a map of binding_name -> { attr_name -> attr_display_value }
-        let mut result = HashMap::new();
-        for rs in &state_file.resources {
-            if let Some(ref binding) = rs.binding {
-                let attrs: HashMap<String, String> = rs
-                    .attributes
-                    .keys()
-                    .map(|k| (k.clone(), format!("{}.{}", rs.resource_type, k)))
-                    .collect();
-                result.insert(binding.clone(), attrs);
-            }
-        }
-
-        Some(result)
-    }
-
-    /// Provide completions for remote state bindings.
-    fn remote_state_completions(
-        &self,
-        ctx: &RemoteStateDotContext,
-        edit_range: Range,
-        base_path: Option<&Path>,
-    ) -> Vec<CompletionItem> {
-        match ctx {
-            RemoteStateDotContext::FirstSegment {
-                binding_name,
-                state_path,
-            } => {
-                let Some(remote_bindings) = self.load_remote_state_bindings(state_path, base_path)
-                else {
-                    return vec![];
-                };
-
-                remote_bindings
-                    .keys()
-                    .map(|resource_binding| {
-                        let full_ref = format!("{}.{}", binding_name, resource_binding);
-                        CompletionItem {
-                            label: full_ref.clone(),
-                            kind: Some(CompletionItemKind::MODULE),
-                            detail: Some(format!(
-                                "Remote state resource binding '{}'",
-                                resource_binding
-                            )),
-                            text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(
-                                TextEdit {
-                                    range: edit_range,
-                                    new_text: full_ref,
-                                },
-                            )),
-                            command: Some(Command {
-                                title: "Trigger Suggest".to_string(),
-                                command: "editor.action.triggerSuggest".to_string(),
-                                arguments: None,
-                            }),
-                            ..Default::default()
-                        }
-                    })
-                    .collect()
-            }
-            RemoteStateDotContext::SecondSegment {
-                binding_name,
-                resource_binding,
-                state_path,
-            } => {
-                let Some(remote_bindings) = self.load_remote_state_bindings(state_path, base_path)
-                else {
-                    return vec![];
-                };
-
-                let Some(attrs) = remote_bindings.get(resource_binding) else {
-                    return vec![];
-                };
-
-                attrs
-                    .keys()
-                    .map(|attr_name| {
-                        let full_ref =
-                            format!("{}.{}.{}", binding_name, resource_binding, attr_name);
-                        CompletionItem {
-                            label: full_ref.clone(),
-                            kind: Some(CompletionItemKind::FIELD),
-                            detail: Some(format!(
-                                "Attribute '{}' from remote resource '{}'",
-                                attr_name, resource_binding
-                            )),
-                            text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(
-                                TextEdit {
-                                    range: edit_range,
-                                    new_text: full_ref,
-                                },
-                            )),
-                            ..Default::default()
-                        }
-                    })
-                    .collect()
-            }
-        }
-    }
-
     /// Compute a text edit range covering the value prefix the user has already typed
     /// after the `=` sign. This allows resource reference completions like `igw.internet_gateway_id`
     /// to replace the already-typed prefix (e.g., `igw.`) instead of being appended after it.
@@ -745,6 +450,17 @@ impl CompletionProvider {
                 ..Default::default()
             },
         ]
+    }
+
+    pub(super) fn upstream_state_block_completions(&self) -> Vec<CompletionItem> {
+        vec![CompletionItem {
+            label: "source".to_string(),
+            kind: Some(CompletionItemKind::PROPERTY),
+            detail: Some("Path to the upstream project directory".to_string()),
+            insert_text: Some("source = \"$0\"".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        }]
     }
 
     pub(super) fn generic_value_completions(&self) -> Vec<CompletionItem> {

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -334,12 +334,9 @@ impl SemanticTokensProvider {
                     let if_start = let_start + 4 + if_pos + 2; // position of "if"
                     tokens.push((if_start as u32, 2, 0)); // KEYWORD: if
                 }
-                // Check for "remote_state" keyword after "let name = remote_state ..."
-                if let Some(rs_pos) = after_let.find("= remote_state ") {
-                    let rs_start = let_start + 4 + rs_pos + 2; // position of "remote_state"
-                    tokens.push((rs_start as u32, 12, 0)); // KEYWORD: remote_state
-                }
             }
+        } else if trimmed.starts_with("upstream_state ") {
+            tokens.push((indent, 14, 0)); // KEYWORD: upstream_state
         } else if trimmed.starts_with("attributes ") || trimmed == "attributes{" {
             tokens.push((indent, 10, 0)); // KEYWORD: attributes
         } else if trimmed.starts_with("exports ") || trimmed == "exports{" {
@@ -397,6 +394,7 @@ impl SemanticTokensProvider {
         if !trimmed.starts_with("provider ")
             && !trimmed.starts_with("backend ")
             && !trimmed.starts_with("let ")
+            && !trimmed.starts_with("upstream_state ")
             && !trimmed.starts_with("attributes ")
             && !trimmed.starts_with("attributes{")
             && !trimmed.starts_with("exports ")
@@ -1319,6 +1317,21 @@ mod tests {
         assert!(
             string_tokens.len() >= 2,
             "Heredoc body and closing marker should be highlighted as STRING. Got: {:?}",
+            tokens
+        );
+    }
+
+    #[test]
+    fn upstream_state_keyword_is_highlighted() {
+        let provider = SemanticTokensProvider::new(&[]);
+        let tokens = provider.tokenize_line(r#"upstream_state "orgs" {"#, 0);
+        // "upstream_state" should be KEYWORD at position 0 with length 14
+        let keyword_token = tokens
+            .iter()
+            .find(|(start, len, typ)| *start == 0 && *len == 14 && *typ == 0);
+        assert!(
+            keyword_token.is_some(),
+            "Expected KEYWORD token for 'upstream_state'. Got: {:?}",
             tokens
         );
     }


### PR DESCRIPTION
## Summary
- Replace `remote_state` with `upstream_state` in LSP completion (top-level keyword + block attributes) and semantic tokens
- Remove ~290 lines of `remote_state` file-loading code that ran disk I/O on every completion request
- Wire `upstream_state` through existing keyword/block detection patterns

## Details
- `top_level.rs`: swap `remote_state` keyword completion for `upstream_state` with new DSL snippet
- `semantic_tokens.rs`: highlight `upstream_state ` at line start (14 chars, KEYWORD); remove the let-RHS `remote_state` branch
- `completion/mod.rs`: add `CompletionContext::InsideUpstreamStateBlock` variant and detect `upstream_state "name" {` blocks
- `completion/values.rs`: add `upstream_state_block_completions()` returning `source` attribute; drop now-unused `base_path` parameter and imports
- Tests: drop 6 `remote_state_*` tests, add 3 new tests covering top-level suggestion, block completion, and semantic highlighting

## Test plan
- [x] `cargo test -p carina-lsp` (195 passed)
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings`
- [x] `cargo build` (full workspace)

Closes #1913