### PR TITLE
docs: rewrite remote_state references to upstream_state

### DIFF
--- a/docs/src/content/docs/guides/state-management.md
+++ b/docs/src/content/docs/guides/state-management.md
@@ -1,6 +1,6 @@
 ---
 title: "State Management"
-description: "Learn how Carina tracks infrastructure state, configure an S3 backend, import existing resources, move and remove state entries, and reference remote state."
+description: "Learn how Carina tracks infrastructure state, configure an S3 backend, import existing resources, move and remove state entries, and reference upstream state."
 ---
 
 Carina uses a state file to track which resources it manages and their current attributes. This guide covers how to configure state storage, manipulate state entries, and share state between projects.
@@ -125,18 +125,18 @@ removed {
 
 This removes the resource from Carina's state but leaves the actual cloud resource untouched. This is useful when transferring ownership of a resource to another tool or project.
 
-## Referencing remote state
+## Referencing upstream state
 
-To read outputs from another Carina project's state, use `remote_state`:
+To read outputs from another Carina project's state, use `upstream_state`:
 
 ```crn
-let network = remote_state {
-  path = 'network.state.json'
+upstream_state "network" {
+  source = "../network"
 }
 
 awscc.ec2.security_group {
   group_description = 'Web security group'
-  vpc_id            = network.vpc.vpc_id
+  vpc_id            = network.vpc_id
 
   tags = {
     Name = 'web-sg'
@@ -144,17 +144,9 @@ awscc.ec2.security_group {
 }
 ```
 
-The `remote_state` block loads another project's state file and makes its resource attributes available through the binding. In this example, `network.vpc.vpc_id` references the `vpc_id` attribute of the `vpc` resource from the network project's state.
+The `upstream_state` block points at an upstream project's directory. Carina loads that directory's configuration, resolves its backend, reads its state, and exposes the upstream's `exports` through the declared binding. In this example, `network.vpc_id` references the `vpc_id` value published by the `../network` project's `exports` block.
 
-You can also specify the backend type explicitly:
-
-```crn
-let network = remote_state 's3' {
-  bucket = 'carina-state'
-  key    = 'network/carina.state.json'
-  region = 'ap-northeast-1'
-}
-```
+`source` is required and resolved relative to the enclosing `.crn` file's directory. The upstream directory must contain a valid Carina configuration (a `main.crn` or flat `*.crn` files) with an `exports` block that publishes the values consumers need.
 
 ## State CLI commands
 

--- a/docs/src/content/docs/reference/dsl/expressions.md
+++ b/docs/src/content/docs/reference/dsl/expressions.md
@@ -144,12 +144,9 @@ let vpc = awscc.ec2.vpc {
 
 # Module import binding
 let network = import './modules/network'
-
-# Remote state binding
-let shared = remote_state {
-  path = 'shared.state.json'
-}
 ```
+
+Upstream state is declared at the top level with the `upstream_state` block rather than through `let`. See [Upstream State](/reference/dsl/syntax/#upstream-state) for details.
 
 Use `let _ =` (the discard pattern) when you need to evaluate an expression but do not need to reference the result. See [Syntax: Discard Pattern](/reference/dsl/syntax/#discard-pattern) for details.
 

--- a/docs/src/content/docs/reference/dsl/syntax.md
+++ b/docs/src/content/docs/reference/dsl/syntax.md
@@ -260,29 +260,21 @@ removed {
 }
 ```
 
-## Remote State
+## Upstream State
 
-Reference resources managed by another Carina project:
+Reference values exported by another Carina project:
 
 ```crn
-let network = remote_state {
-  path = 'network.state.json'
+upstream_state "network" {
+  source = "../network"
 }
 
 awscc.ec2.security_group {
-  vpc_id = network.vpc.vpc_id
+  vpc_id = network.vpc_id
 }
 ```
 
-Remote state with an S3 backend:
-
-```crn
-let network = remote_state 's3' {
-  bucket = 'my-state-bucket'
-  key    = 'network/carina.state.json'
-  region = 'ap-northeast-1'
-}
-```
+`source` is required and points at the upstream project's directory. The path is resolved relative to the enclosing `.crn` file's directory. Carina loads the upstream's configuration, resolves its backend, reads its state, and exposes the values published by its `exports` block through the declared binding.
 
 ## Comments
 


### PR DESCRIPTION
## Summary
- Rewrite `remote_state` references in user-facing documentation to use the new `upstream_state` DSL
- Update `state-management.md` guide, `syntax.md` and `expressions.md` DSL references
- Historical plan/spec files documenting this migration are preserved as-is

## Scope note
The issue's verification grep targets `examples`, `docs`, `README.md`, and `CLAUDE.md`. `examples/`, `README.md`, and `CLAUDE.md` already contained no `remote_state` references. `docs/src/` is now clean. `docs/plans/2026-04-16-upstream-state-dsl.md` and `docs/specs/2026-04-16-upstream-state-dsl-design.md` still mention `remote_state` by design — they are the historical record of this migration itself.

## Test plan
- [x] `cargo test` (full workspace) — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `grep -rn 'remote_state' docs/src README.md CLAUDE.md` — no matches

Closes #1915