### PR TITLE
Align upstream_state syntax with let bindings

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -665,12 +665,12 @@ mod load_upstream_states_tests {
         fs::create_dir_all(&dir_b).unwrap();
         fs::write(
             dir_a.join("main.crn"),
-            r#"upstream_state "b" { source = "../b" }"#,
+            r#"let b = upstream_state { source = "../b" }"#,
         )
         .unwrap();
         fs::write(
             dir_b.join("main.crn"),
-            r#"upstream_state "a" { source = "../a" }"#,
+            r#"let a = upstream_state { source = "../a" }"#,
         )
         .unwrap();
 
@@ -747,7 +747,7 @@ mod run_plan_upstream_state_tests {
         fs::write(
             dir_b.join("main.crn"),
             r#"
-                upstream_state "a" { source = "../a" }
+                let a = upstream_state { source = "../a" }
                 exports { region = a.region }
             "#,
         )

--- a/carina-cli/tests/fixtures/plan_display/deferred_for/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/deferred_for/main.crn
@@ -4,7 +4,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-upstream_state "orgs" {
+let orgs = upstream_state {
   source = "../organizations"
 }
 

--- a/carina-cli/tests/fixtures/plan_display/upstream_state/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state/main.crn
@@ -4,7 +4,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-upstream_state "network" {
+let network = upstream_state {
   source = "./network"
 }
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -3,14 +3,15 @@
 // Entry point
 file = { SOI ~ statement* ~ EOI }
 
-statement = { backend_block | provider_block | arguments_block | attributes_block | exports_block | import_state_block | removed_block | moved_block | require_statement | upstream_state_block | if_expr | for_expr | fn_def | let_binding | module_call | anonymous_resource }
+statement = { backend_block | provider_block | arguments_block | attributes_block | exports_block | import_state_block | removed_block | moved_block | require_statement | if_expr | for_expr | fn_def | let_binding | module_call | anonymous_resource }
 
 // Require statement: require <validate_expr>, "error message"
 require_statement = { "require" ~ validate_expr ~ "," ~ string }
 
-// Upstream state block: upstream_state "<binding>" { source = "<dir>" }
+// Upstream state expression: upstream_state { source = "<dir>" }
 // Declares a read-only reference to another Carina configuration's state.
-upstream_state_block = { "upstream_state" ~ string ~ "{" ~ attribute* ~ "}" }
+// Used as the RHS of a `let` binding: `let orgs = upstream_state { source = "../organizations" }`.
+upstream_state_expr = { "upstream_state" ~ "{" ~ attribute* ~ "}" }
 
 // User-defined function: fn name(params) { body }
 fn_def = { "fn" ~ identifier ~ "(" ~ fn_params? ~ ")" ~ (":" ~ type_expr)? ~ "{" ~ fn_body ~ "}" }
@@ -191,6 +192,7 @@ function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 // Primary value
 primary = {
     read_resource_expr   // Must come before resource_expr for "read aws..." parsing
+  | upstream_state_expr  // Must come before module_call so "upstream_state { ... }" is not parsed as a module call
   | resource_expr
   | import_expr          // Must come before variable_ref since "import" is an identifier
   | for_expr             // Must come before module_call so "for" is not parsed as module name

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -370,7 +370,7 @@ pub struct BackendConfig {
     pub attributes: HashMap<String, Value>,
 }
 
-/// Upstream state reference: `upstream_state "<binding>" { source = "<dir>" }`.
+/// Upstream state reference: `let <binding> = upstream_state { source = "<dir>" }`.
 ///
 /// Declares a read-only reference to another Carina configuration's state.
 /// The `source` path is resolved against the enclosing `.crn` file's
@@ -787,7 +787,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
     let mut export_params = Vec::new();
     let mut backend = None;
     let mut state_blocks = Vec::new();
-    let mut upstream_states = Vec::new();
+    let mut upstream_states: Vec<UpstreamState> = Vec::new();
     let mut requires = Vec::new();
     let mut anon_for_counter = 0usize;
     let mut anon_if_counter = 0usize;
@@ -843,25 +843,6 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                             Rule::require_statement => {
                                 requires.push(parse_require_statement(stmt)?);
                             }
-                            Rule::upstream_state_block => {
-                                let (line, _) = stmt.as_span().start_pos().line_col();
-                                let us = parse_upstream_state_block(stmt)?;
-                                if ctx.upstream_states.contains_key(&us.binding)
-                                    || ctx.variables.contains_key(&us.binding)
-                                    || ctx.resource_bindings.contains_key(&us.binding)
-                                {
-                                    return Err(ParseError::DuplicateBinding {
-                                        name: us.binding,
-                                        line,
-                                    });
-                                }
-                                // Register the binding so `<binding>.<attr>` references
-                                // resolve as ResourceRef rather than being rejected.
-                                let placeholder = Resource::new("_upstream_state", &us.binding);
-                                ctx.set_resource_binding(us.binding.clone(), placeholder);
-                                ctx.upstream_states.insert(us.binding.clone(), us.clone());
-                                upstream_states.push(us);
-                            }
                             Rule::for_expr => {
                                 let iterable_name =
                                     extract_for_iterable_name(&stmt, anon_for_counter);
@@ -913,13 +894,16 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                     ctx.structural_bindings.insert(name.clone());
                                 }
                                 let is_discard = name == "_";
+                                let is_upstream_state = ctx.upstream_states.contains_key(&name);
                                 if !is_discard {
                                     if ctx.variables.contains_key(&name)
                                         || ctx.resource_bindings.contains_key(&name)
                                     {
                                         return Err(ParseError::DuplicateBinding { name, line });
                                     }
-                                    ctx.set_variable(name.clone(), value);
+                                    if !is_upstream_state {
+                                        ctx.set_variable(name.clone(), value);
+                                    }
                                 }
                                 if !expanded_resources.is_empty() {
                                     if !is_discard {
@@ -945,6 +929,11 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                         let placeholder = Resource::new("_module_binding", &name);
                                         ctx.set_resource_binding(name.clone(), placeholder);
                                     }
+                                }
+                                if is_upstream_state && !is_discard {
+                                    let placeholder = Resource::new("_upstream_state", &name);
+                                    ctx.set_resource_binding(name.clone(), placeholder);
+                                    upstream_states.push(ctx.upstream_states[&name].clone());
                                 }
                                 if let Some(import) = maybe_import {
                                     ctx.imported_modules
@@ -1437,7 +1426,7 @@ fn parse_module_call(
     if module_name == "remote_state" {
         return Err(ParseError::InvalidExpression {
             line: span.start_pos().line_col().0,
-            message: "`remote_state` has been replaced by the top-level `upstream_state \"<binding>\" { source = \"...\" }` block".to_string(),
+            message: "`remote_state` has been replaced by `let <binding> = upstream_state { source = \"...\" }`".to_string(),
         });
     }
 
@@ -1514,22 +1503,26 @@ fn parse_let_binding_extended(
     ))
 }
 
-/// Detect if an expression pair's innermost primary is an if/for/read expression.
+/// Detect if an expression pair's innermost primary is an if/for/read/upstream_state expression.
 fn detect_structural_rhs(pair: &pest::iterators::Pair<Rule>) -> bool {
     // Walk into expression -> pipe_expr -> compose_expr -> primary -> inner
     fn find_inner_rule(pair: &pest::iterators::Pair<Rule>) -> Option<Rule> {
         let inner = pair.clone().into_inner().next()?;
         match inner.as_rule() {
-            Rule::if_expr | Rule::for_expr | Rule::read_resource_expr => Some(inner.as_rule()),
+            Rule::if_expr
+            | Rule::for_expr
+            | Rule::read_resource_expr
+            | Rule::upstream_state_expr => Some(inner.as_rule()),
             Rule::pipe_expr | Rule::compose_expr | Rule::coalesce_expr | Rule::expression => {
                 find_inner_rule(&inner)
             }
             Rule::primary => {
                 let primary_inner = inner.into_inner().next()?;
                 match primary_inner.as_rule() {
-                    Rule::if_expr | Rule::for_expr | Rule::read_resource_expr => {
-                        Some(primary_inner.as_rule())
-                    }
+                    Rule::if_expr
+                    | Rule::for_expr
+                    | Rule::read_resource_expr
+                    | Rule::upstream_state_expr => Some(primary_inner.as_rule()),
                     _ => None,
                 }
             }
@@ -1686,6 +1679,19 @@ fn parse_primary_with_resource_or_module(
             let resource = parse_read_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
             Ok((ref_value, vec![resource], vec![], None))
+        }
+        Rule::upstream_state_expr => {
+            let (line, _) = inner.as_span().start_pos().line_col();
+            let us = parse_upstream_state_expr(inner, binding_name)?;
+            if ctx.upstream_states.contains_key(&us.binding) {
+                return Err(ParseError::DuplicateBinding {
+                    name: us.binding,
+                    line,
+                });
+            }
+            ctx.upstream_states.insert(us.binding.clone(), us);
+            let ref_value = Value::String(format!("${{{}}}", binding_name));
+            Ok((ref_value, vec![], vec![], None))
         }
         Rule::resource_expr => {
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
@@ -3144,14 +3150,16 @@ fn parse_backend_block(
     })
 }
 
-/// Parse an `upstream_state "<binding>" { source = "<dir>" }` block.
-fn parse_upstream_state_block(
+/// Parse an `upstream_state { source = "<dir>" }` expression.
+///
+/// The binding name comes from the enclosing `let` binding, so it's passed in
+/// rather than extracted from the expression itself.
+fn parse_upstream_state_expr(
     pair: pest::iterators::Pair<Rule>,
+    binding_name: &str,
 ) -> Result<UpstreamState, ParseError> {
     let (block_line, _) = pair.as_span().start_pos().line_col();
-    let mut inner = pair.into_inner();
-    let binding_pair = next_pair(&mut inner, "binding name", "upstream_state block")?;
-    let binding = extract_string_from_string_pair(binding_pair)?;
+    let inner = pair.into_inner();
 
     let mut source: Option<String> = None;
     for attr_pair in inner {
@@ -3160,10 +3168,18 @@ fn parse_upstream_state_block(
         }
         let (attr_line, _) = attr_pair.as_span().start_pos().line_col();
         let mut attr_inner = attr_pair.into_inner();
-        let key = next_pair(&mut attr_inner, "attribute name", "upstream_state block")?
-            .as_str()
-            .to_string();
-        let value_pair = next_pair(&mut attr_inner, "attribute value", "upstream_state block")?;
+        let key = next_pair(
+            &mut attr_inner,
+            "attribute name",
+            "upstream_state expression",
+        )?
+        .as_str()
+        .to_string();
+        let value_pair = next_pair(
+            &mut attr_inner,
+            "attribute value",
+            "upstream_state expression",
+        )?;
         match key.as_str() {
             "source" => {
                 let value_text = value_pair.as_str().to_string();
@@ -3171,8 +3187,8 @@ fn parse_upstream_state_block(
                     ParseError::InvalidExpression {
                         line: attr_line,
                         message: format!(
-                            "upstream_state \"{}\": 'source' must be a string literal, got: {}",
-                            binding, value_text
+                            "upstream_state '{}': 'source' must be a string literal, got: {}",
+                            binding_name, value_text
                         ),
                     }
                 })?);
@@ -3181,8 +3197,8 @@ fn parse_upstream_state_block(
                 return Err(ParseError::InvalidExpression {
                     line: attr_line,
                     message: format!(
-                        "unknown attribute '{}' in upstream_state \"{}\" block",
-                        other, binding
+                        "unknown attribute '{}' in upstream_state '{}' expression",
+                        other, binding_name
                     ),
                 });
             }
@@ -3192,44 +3208,15 @@ fn parse_upstream_state_block(
     let source = source.ok_or_else(|| ParseError::InvalidExpression {
         line: block_line,
         message: format!(
-            "upstream_state \"{}\" requires a 'source' attribute",
-            binding
+            "upstream_state '{}' requires a 'source' attribute",
+            binding_name
         ),
     })?;
 
     Ok(UpstreamState {
-        binding,
+        binding: binding_name.to_string(),
         source: std::path::PathBuf::from(source),
     })
-}
-
-/// Extract a string value directly from a Rule::string pair
-fn extract_string_from_string_pair(
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<String, ParseError> {
-    // string = single_quoted_string | double_quoted_string
-    let inner_pair = pair.into_inner().next().unwrap();
-
-    if inner_pair.as_rule() == Rule::single_quoted_string {
-        return Ok(inner_pair
-            .into_inner()
-            .next()
-            .map(|p| unescape_single_quoted(p.as_str()))
-            .unwrap_or_default());
-    }
-
-    // Double-quoted string
-    let mut result = String::new();
-    for inner in inner_pair.into_inner() {
-        if inner.as_rule() == Rule::string_part {
-            for part in inner.into_inner() {
-                if part.as_rule() == Rule::string_literal {
-                    result.push_str(part.as_str());
-                }
-            }
-        }
-    }
-    Ok(result)
 }
 
 /// Extract a string value from a pair (expression -> pipe_expr -> primary -> string)
@@ -7899,7 +7886,7 @@ aws.s3.bucket {
     #[test]
     fn parse_top_level_for_uses_last_segment_of_dotted_iterable() {
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../orgs"
             }
             for acct in orgs.accounts {
@@ -9439,7 +9426,7 @@ arguments {
         // After parsing upstream_state, the binding should be registered so that
         // `network.vpc.vpc_id` is parsed as a ResourceRef.
         let input = r#"
-            upstream_state "network" {
+            let network = upstream_state {
                 source = "../network"
             }
 
@@ -10084,7 +10071,7 @@ awscc.ec2.vpc {
         // When a for-expression iterates over an unresolved upstream_state,
         // the warning should mention the upstream directory rather than generic "known after apply".
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10161,7 +10148,7 @@ awscc.ec2.vpc {
         // Initially deferred (no remote values available at parse time).
         // Then expand with remote_bindings and verify concrete resources are created.
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10233,7 +10220,7 @@ awscc.ec2.vpc {
     #[test]
     fn expand_deferred_for_no_remote_data_stays_deferred() {
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10265,7 +10252,7 @@ awscc.ec2.vpc {
         // Map binding `for k, v in orgs.accounts` should expand each entry with
         // both the key and value variables available.
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10321,7 +10308,7 @@ awscc.ec2.vpc {
         // and value variables. Prior to the fix both vars shared the same
         // placeholder, causing the index to receive the item value.
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10375,7 +10362,7 @@ awscc.ec2.vpc {
         // Placeholder substitution must recurse into Value::Interpolation parts,
         // otherwise the rendered resource ships the raw placeholder string.
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10435,7 +10422,7 @@ awscc.ec2.vpc {
         // Simple binding but upstream resolves to a map — mismatch should warn
         // and leave deferred.
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10481,7 +10468,7 @@ awscc.ec2.vpc {
         // Map binding but upstream resolves to a list — mismatch should produce
         // a warning and leave the for-expression deferred (do not silently expand).
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
 
@@ -10540,9 +10527,9 @@ awscc.ec2.vpc {
     }
 
     #[test]
-    fn parses_upstream_state_block_with_source() {
+    fn parses_upstream_state_expr_with_source() {
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../organizations"
             }
         "#;
@@ -10551,6 +10538,23 @@ awscc.ec2.vpc {
         let us = &parsed.upstream_states[0];
         assert_eq!(us.binding, "orgs");
         assert_eq!(us.source, std::path::PathBuf::from("../organizations"));
+    }
+
+    #[test]
+    fn old_top_level_upstream_state_syntax_is_rejected() {
+        // The pre-#1926 form `upstream_state "name" { ... }` was a top-level
+        // statement; with the let-binding form it should no longer parse.
+        let input = r#"
+            upstream_state "orgs" {
+                source = "../organizations"
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "old top-level upstream_state syntax must be rejected, got: {:?}",
+            result.ok().map(|p| p.upstream_states)
+        );
     }
 
     #[test]
@@ -10569,7 +10573,7 @@ awscc.ec2.vpc {
 
     #[test]
     fn upstream_state_missing_source_is_error() {
-        let input = r#"upstream_state "orgs" { }"#;
+        let input = r#"let orgs = upstream_state { }"#;
         let err = parse(input, &ProviderContext::default())
             .expect_err("missing source must be a parse error");
         let msg = err.to_string();
@@ -10581,7 +10585,7 @@ awscc.ec2.vpc {
 
     #[test]
     fn upstream_state_source_must_be_string() {
-        let input = r#"upstream_state "orgs" { source = 42 }"#;
+        let input = r#"let orgs = upstream_state { source = 42 }"#;
         let err = parse(input, &ProviderContext::default())
             .expect_err("non-string source must be a parse error");
         let msg = err.to_string();
@@ -10594,7 +10598,7 @@ awscc.ec2.vpc {
     #[test]
     fn upstream_state_unknown_attribute_is_error() {
         let input = r#"
-            upstream_state "orgs" {
+            let orgs = upstream_state {
                 source = "../foo"
                 backend = "s3"
             }
@@ -10611,8 +10615,8 @@ awscc.ec2.vpc {
     #[test]
     fn upstream_state_duplicate_binding_is_error() {
         let input = r#"
-            upstream_state "orgs" { source = "../a" }
-            upstream_state "orgs" { source = "../b" }
+            let orgs = upstream_state { source = "../a" }
+            let orgs = upstream_state { source = "../b" }
         "#;
         let err = parse(input, &ProviderContext::default())
             .expect_err("duplicate upstream_state binding must be a parse error");

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -191,10 +191,7 @@ impl CompletionProvider {
                 in_args_or_attrs_block = true;
                 resource_type.clear();
                 module_name = None;
-            } else if brace_depth == 0
-                && trimmed.starts_with("upstream_state ")
-                && trimmed.ends_with('{')
-            {
+            } else if brace_depth == 0 && is_let_upstream_state_line(trimmed) {
                 in_upstream_state_block = true;
                 resource_type.clear();
                 module_name = None;
@@ -206,7 +203,6 @@ impl CompletionProvider {
                 && !trimmed.starts_with("arguments ")
                 && !trimmed.starts_with("attributes ")
                 && !trimmed.starts_with("exports ")
-                && !trimmed.starts_with("upstream_state ")
                 && !trimmed.starts_with('#')
             {
                 // This is a module call: "module_name {"
@@ -585,4 +581,27 @@ enum CompletionContext {
         partial_path: String,
     },
     None,
+}
+
+/// Detect a `let <binding> = upstream_state {` opening line, where `<binding>`
+/// is a bare identifier. Used to enter the upstream_state block context.
+fn is_let_upstream_state_line(trimmed: &str) -> bool {
+    let Some(rest) = trimmed.strip_prefix("let ") else {
+        return false;
+    };
+    let Some(eq_pos) = rest.find('=') else {
+        return false;
+    };
+    let binding = rest[..eq_pos].trim();
+    if binding.is_empty() || !binding.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return false;
+    }
+    let after_eq = rest[eq_pos + 1..].trim_start();
+    let Some(rest) = after_eq.strip_prefix("upstream_state") else {
+        return false;
+    };
+    // Must be followed by whitespace or `{` to ensure it's the keyword, not a
+    // longer identifier like `upstream_states`.
+    let next = rest.trim_start();
+    next.starts_with('{') || next.is_empty()
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -835,7 +835,7 @@ fn top_level_completion_suggests_upstream_state() {
 fn upstream_state_block_completes_source_attribute() {
     let provider = test_provider();
     let doc = create_document(
-        r#"upstream_state "orgs" {
+        r#"let orgs = upstream_state {
 
 }"#,
     );

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -149,7 +149,7 @@ impl CompletionProvider {
                 label: "upstream_state".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
                 insert_text: Some(
-                    "upstream_state \"${1:binding}\" {\n    source = \"${2:../other-project}\"\n}"
+                    "let ${1:binding} = upstream_state {\n    source = \"${2:../other-project}\"\n}"
                         .to_string(),
                 ),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -313,6 +313,14 @@ impl SemanticTokensProvider {
                     let read_start = let_start + 4 + read_pos + 2; // position of "read"
                     tokens.push((read_start as u32, 4, 0)); // KEYWORD: read
                 }
+                // Check for "upstream_state" keyword after "let name = upstream_state ..."
+                if let Some(us_pos) = after_let.find("= upstream_state") {
+                    let after_kw = after_let[us_pos + 16..].chars().next();
+                    if after_kw.is_none_or(|c| c.is_whitespace() || c == '{') {
+                        let us_start = let_start + 4 + us_pos + 2; // position of "upstream_state"
+                        tokens.push((us_start as u32, 14, 0)); // KEYWORD: upstream_state
+                    }
+                }
                 // Check for "import" keyword after "let name = import ..."
                 if let Some(import_pos) = after_let.find("= import ") {
                     let import_start = let_start + 4 + import_pos + 2; // position of "import"
@@ -335,8 +343,6 @@ impl SemanticTokensProvider {
                     tokens.push((if_start as u32, 2, 0)); // KEYWORD: if
                 }
             }
-        } else if trimmed.starts_with("upstream_state ") {
-            tokens.push((indent, 14, 0)); // KEYWORD: upstream_state
         } else if trimmed.starts_with("attributes ") || trimmed == "attributes{" {
             tokens.push((indent, 10, 0)); // KEYWORD: attributes
         } else if trimmed.starts_with("exports ") || trimmed == "exports{" {
@@ -394,7 +400,6 @@ impl SemanticTokensProvider {
         if !trimmed.starts_with("provider ")
             && !trimmed.starts_with("backend ")
             && !trimmed.starts_with("let ")
-            && !trimmed.starts_with("upstream_state ")
             && !trimmed.starts_with("attributes ")
             && !trimmed.starts_with("attributes{")
             && !trimmed.starts_with("exports ")
@@ -1324,14 +1329,14 @@ mod tests {
     #[test]
     fn upstream_state_keyword_is_highlighted() {
         let provider = SemanticTokensProvider::new(&[]);
-        let tokens = provider.tokenize_line(r#"upstream_state "orgs" {"#, 0);
-        // "upstream_state" should be KEYWORD at position 0 with length 14
+        let tokens = provider.tokenize_line(r#"let orgs = upstream_state {"#, 0);
+        // "upstream_state" appears at column 11 with length 14
         let keyword_token = tokens
             .iter()
-            .find(|(start, len, typ)| *start == 0 && *len == 14 && *typ == 0);
+            .find(|(start, len, typ)| *start == 11 && *len == 14 && *typ == 0);
         assert!(
             keyword_token.is_some(),
-            "Expected KEYWORD token for 'upstream_state'. Got: {:?}",
+            "Expected KEYWORD token for 'upstream_state' in `let name = upstream_state {{`. Got: {:?}",
             tokens
         );
     }

--- a/docs/src/content/docs/guides/state-management.md
+++ b/docs/src/content/docs/guides/state-management.md
@@ -130,7 +130,7 @@ This removes the resource from Carina's state but leaves the actual cloud resour
 To read outputs from another Carina project's state, use `upstream_state`:
 
 ```crn
-upstream_state "network" {
+let network = upstream_state {
   source = "../network"
 }
 
@@ -144,7 +144,7 @@ awscc.ec2.security_group {
 }
 ```
 
-The `upstream_state` block points at an upstream project's directory. Carina loads that directory's configuration, resolves its backend, reads its state, and exposes the upstream's `exports` through the declared binding. In this example, `network.vpc_id` references the `vpc_id` value published by the `../network` project's `exports` block.
+The `upstream_state` expression points at an upstream project's directory. Carina loads that directory's configuration, resolves its backend, reads its state, and exposes the upstream's `exports` through the `let`-bound name. In this example, `network.vpc_id` references the `vpc_id` value published by the `../network` project's `exports` block.
 
 `source` is required and resolved relative to the enclosing `.crn` file's directory. The upstream directory must contain a valid Carina configuration (a `main.crn` or flat `*.crn` files) with an `exports` block that publishes the values consumers need.
 

--- a/docs/src/content/docs/reference/dsl/expressions.md
+++ b/docs/src/content/docs/reference/dsl/expressions.md
@@ -146,7 +146,7 @@ let vpc = awscc.ec2.vpc {
 let network = import './modules/network'
 ```
 
-Upstream state is declared at the top level with the `upstream_state` block rather than through `let`. See [Upstream State](/reference/dsl/syntax/#upstream-state) for details.
+Upstream state is bound with `let <binding> = upstream_state { source = "..." }`. See [Upstream State](/reference/dsl/syntax/#upstream-state) for details.
 
 Use `let _ =` (the discard pattern) when you need to evaluate an expression but do not need to reference the result. See [Syntax: Discard Pattern](/reference/dsl/syntax/#discard-pattern) for details.
 

--- a/docs/src/content/docs/reference/dsl/syntax.md
+++ b/docs/src/content/docs/reference/dsl/syntax.md
@@ -265,7 +265,7 @@ removed {
 Reference values exported by another Carina project:
 
 ```crn
-upstream_state "network" {
+let network = upstream_state {
   source = "../network"
 }
 


### PR DESCRIPTION
## Summary

Closes #1926.

Change `upstream_state` from a dedicated top-level block with a quoted binding name to a let-bound expression with a bare identifier — consistent with every other named binding in the DSL.

**Before**
```crn
upstream_state "orgs" {
  source = "../organizations"
}
```

**After**
```crn
let orgs = upstream_state {
  source = "../organizations"
}
```

## Changes

- **Grammar (`carina.pest`)**: drop `upstream_state_block` from `statement`; add `upstream_state_expr` to `primary` (before `module_call` so it isn't mis-parsed as one).
- **Parser (`parser/mod.rs`)**: dispatch `upstream_state_expr` inside `parse_primary_with_resource_or_module`, taking the binding name from the enclosing `let`. The let-binding handler detects the construct via `ctx.upstream_states.contains_key(&name)` and registers it as a resource binding (no sentinel string in `Value::String`).
- **LSP**: `semantic_tokens.rs` highlights the `upstream_state` keyword after `let X =` (with a boundary check so identifiers like `upstream_states_xxx` don't false-match); `completion/mod.rs` enters the upstream_state completion context for `let X = upstream_state` lines via the new `is_let_upstream_state_line` helper; `completion/top_level.rs` emits the new template.
- **Fixtures, inline tests, docs**: rewritten to the new syntax (`carina-cli/tests/fixtures/plan_display/{upstream_state,deferred_for}/main.crn`, `carina-cli/src/commands/plan.rs` test fixtures, three docs pages).
- **Regression test**: `old_top_level_upstream_state_syntax_is_rejected` guards against the pre-#1926 form parsing.

## Test plan

- [x] `cargo test -p carina-core` — 1193 passed
- [x] `cargo test -p carina-lsp` — 195 passed
- [x] `cargo test -p carina-cli` — 252 passed (including 25 plan_snapshot)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `make plan-fixtures` runs both `upstream_state` and `deferred_for` fixtures successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)