### PR TITLE
Fix duplicate `let` in LSP snippet completion (#1930)

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1060,3 +1060,124 @@ fn union_struct_field_completions() {
         labels
     );
 }
+
+#[test]
+fn upstream_state_snippet_on_fresh_line_includes_let() {
+    let provider = test_provider();
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: 0,
+        },
+        "",
+        None,
+    );
+    let item = find_completion(&completions, "upstream_state");
+    let snippet = item.insert_text.as_deref().unwrap_or("");
+    assert!(
+        snippet.starts_with("let "),
+        "On fresh line upstream_state should still insert full 'let ... = upstream_state {{...}}'. Got: {:?}",
+        snippet
+    );
+}
+
+#[test]
+fn upstream_state_snippet_after_let_binding_omits_let() {
+    // Bug #1930: typing `let orgs = u` then picking `upstream_state` produced
+    // `let orgs = let binding = upstream_state {...}`. The snippet must drop
+    // its leading `let ${1:binding} = ` when the line already has `let <name> =`.
+    let provider = test_provider();
+    let text = "let orgs = u";
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: text.len() as u32,
+        },
+        text,
+        None,
+    );
+    let item = find_completion(&completions, "upstream_state");
+    let snippet = item.insert_text.as_deref().unwrap_or("");
+    assert!(
+        !snippet.contains("let "),
+        "After existing `let <name> =`, upstream_state snippet must not re-emit `let `. Got: {:?}",
+        snippet
+    );
+    assert!(
+        snippet.starts_with("upstream_state"),
+        "Snippet should start directly with `upstream_state`. Got: {:?}",
+        snippet
+    );
+}
+
+#[test]
+fn read_snippet_after_let_binding_omits_let() {
+    let provider = test_provider();
+    let text = "let b = r";
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: text.len() as u32,
+        },
+        text,
+        None,
+    );
+    let item = find_completion(&completions, "read");
+    let snippet = item.insert_text.as_deref().unwrap_or("");
+    assert!(
+        !snippet.contains("let "),
+        "After existing `let <name> =`, read snippet must not re-emit `let `. Got: {:?}",
+        snippet
+    );
+    assert!(
+        snippet.starts_with("read "),
+        "Snippet should start directly with `read `. Got: {:?}",
+        snippet
+    );
+}
+
+#[test]
+fn let_import_snippet_after_let_binding_omits_let() {
+    let provider = test_provider();
+    let text = "let m = i";
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: text.len() as u32,
+        },
+        text,
+        None,
+    );
+    let item = find_completion(&completions, "let import");
+    let snippet = item.insert_text.as_deref().unwrap_or("");
+    assert!(
+        !snippet.contains("let "),
+        "After existing `let <name> =`, `let import` snippet must not re-emit `let `. Got: {:?}",
+        snippet
+    );
+    assert!(
+        snippet.starts_with("import "),
+        "Snippet should start directly with `import `. Got: {:?}",
+        snippet
+    );
+}
+
+#[test]
+fn read_snippet_on_fresh_line_includes_let() {
+    let provider = test_provider();
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: 0,
+        },
+        "",
+        None,
+    );
+    let item = find_completion(&completions, "read");
+    let snippet = item.insert_text.as_deref().unwrap_or("");
+    assert!(
+        snippet.starts_with("let "),
+        "On fresh line read snippet should still include `let ... = read ...`. Got: {:?}",
+        snippet
+    );
+}

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -13,6 +13,16 @@ pub(super) fn create_document(content: &str) -> Document {
     Document::new(content.to_string(), Arc::new(ProviderContext::default()))
 }
 
+pub(super) fn find_completion<'a>(
+    completions: &'a [CompletionItem],
+    label: &str,
+) -> &'a CompletionItem {
+    completions
+        .iter()
+        .find(|c| c.label == label)
+        .unwrap_or_else(|| panic!("completion '{}' not found", label))
+}
+
 pub(super) fn test_provider() -> CompletionProvider {
     let factories: Vec<Box<dyn ProviderFactory>> = vec![];
     let schemas = Arc::new(carina_core::provider::collect_schemas(&factories));

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -48,6 +48,26 @@ impl CompletionProvider {
             end: position,
         };
 
+        // Avoid emitting a duplicate `let` when the line already has `let <name> =`.
+        let after_let_binding =
+            line_idx < lines.len() && is_after_let_binding(lines[line_idx], prefix_start as usize);
+
+        let read_snippet = if after_let_binding {
+            "read ${1:aws.s3.bucket} {\n    name = \"${2:existing-resource}\"\n}"
+        } else {
+            "let ${1:name} = read ${2:aws.s3.bucket} {\n    name = \"${3:existing-resource}\"\n}"
+        };
+        let let_import_snippet = if after_let_binding {
+            "import \"${1:./modules/name}\""
+        } else {
+            "let ${1:module_name} = import \"${2:./modules/name}\""
+        };
+        let upstream_state_snippet = if after_let_binding {
+            "upstream_state {\n    source = \"${1:../other-project}\"\n}"
+        } else {
+            "let ${1:binding} = upstream_state {\n    source = \"${2:../other-project}\"\n}"
+        };
+
         let mut completions = vec![
             CompletionItem {
                 label: "provider".to_string(),
@@ -68,7 +88,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "read".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("let ${1:name} = read ${2:aws.s3.bucket} {\n    name = \"${3:existing-resource}\"\n}".to_string()),
+                insert_text: Some(read_snippet.to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Read existing resource (data source)".to_string()),
                 ..Default::default()
@@ -108,7 +128,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "let import".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("let ${1:module_name} = import \"${2:./modules/name}\"".to_string()),
+                insert_text: Some(let_import_snippet.to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Import a module".to_string()),
                 ..Default::default()
@@ -148,10 +168,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "upstream_state".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some(
-                    "let ${1:binding} = upstream_state {\n    source = \"${2:../other-project}\"\n}"
-                        .to_string(),
-                ),
+                insert_text: Some(upstream_state_snippet.to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Reference another project's exported state".to_string()),
                 ..Default::default()
@@ -518,5 +535,43 @@ impl CompletionProvider {
 
         completions.sort_by(|a, b| a.label.cmp(&b.label));
         completions
+    }
+}
+
+/// Return true when `line[..prefix_start]` already forms a `let <name> =` binding header.
+/// `prefix_start` is a char offset, converted to a byte offset for slicing.
+fn is_after_let_binding(line: &str, prefix_start: usize) -> bool {
+    let byte_end = line
+        .char_indices()
+        .nth(prefix_start)
+        .map(|(i, _)| i)
+        .unwrap_or(line.len());
+    let trimmed = line[..byte_end].trim_start();
+    let Some(rest) = trimmed.strip_prefix("let ") else {
+        return false;
+    };
+    let Some(eq_pos) = rest.find('=') else {
+        return false;
+    };
+    let name = rest[..eq_pos].trim();
+    !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+#[cfg(test)]
+mod helper_tests {
+    use super::is_after_let_binding;
+
+    #[test]
+    fn detects_after_let_binding() {
+        assert!(is_after_let_binding("let orgs = u", 11));
+        assert!(is_after_let_binding("let orgs =u", 10));
+        assert!(is_after_let_binding("  let x = ", 10));
+    }
+
+    #[test]
+    fn rejects_plain_top_level() {
+        assert!(!is_after_let_binding("u", 1));
+        assert!(!is_after_let_binding("let ", 4));
+        assert!(!is_after_let_binding("let orgs", 8));
     }
 }


### PR DESCRIPTION
## Summary

- Fix LSP bug where snippet completions for `upstream_state`, `read`, and `let import` duplicated `let` when the user had already typed `let <name> = `.
- Detect the `let <name> =` prefix on the current line and strip the leading `let ${1:...} = ` from the inserted snippet, renumbering tab stops.
- Add unit tests covering both fresh-line and after-let-binding contexts.

Closes #1930

## Reproduction before the fix

Typing `let orgs = u` and accepting the `upstream_state` completion produced:

```
let orgs = let binding = upstream_state {
    source = "../other-project"
}
```

After the fix, it inserts `upstream_state { source = "..." }` directly after the existing `let orgs = `.

## Notes

The same `let <name> = <rhs>` partial-line parsing logic is duplicated across several LSP code paths. Refactor to a shared helper is tracked separately in #1933 to keep this PR scoped to the bug fix.

## Test plan

- [x] `cargo test -p carina-lsp` (202 passed)
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings`
