### PR TITLE
editors: split TextMate grammar keyword scopes (#1934)

### DIFF
--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -28,8 +28,24 @@
     "keywords": {
       "patterns": [
         {
+          "name": "storage.type.carina",
+          "match": "\\b(let|fn)\\b"
+        },
+        {
+          "name": "keyword.declaration.carina",
+          "match": "\\b(provider|backend|upstream_state|exports|attributes|arguments|validation|moved|removed)\\b"
+        },
+        {
           "name": "keyword.control.carina",
-          "match": "\\b(provider|let)\\b"
+          "match": "\\b(for|in|if|else)\\b"
+        },
+        {
+          "name": "keyword.other.carina",
+          "match": "\\b(import|require|read)\\b"
+        },
+        {
+          "name": "constant.language.null.carina",
+          "match": "\\bnull\\b"
         }
       ]
     },

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -28,8 +28,24 @@
     "keywords": {
       "patterns": [
         {
+          "name": "storage.type.carina",
+          "match": "\\b(let|fn)\\b"
+        },
+        {
+          "name": "keyword.declaration.carina",
+          "match": "\\b(provider|backend|upstream_state|exports|attributes|arguments|validation|moved|removed)\\b"
+        },
+        {
           "name": "keyword.control.carina",
-          "match": "\\b(provider|let)\\b"
+          "match": "\\b(for|in|if|else)\\b"
+        },
+        {
+          "name": "keyword.other.carina",
+          "match": "\\b(import|require|read)\\b"
+        },
+        {
+          "name": "constant.language.null.carina",
+          "match": "\\bnull\\b"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Split the TextMate grammar's single `keyword.control.carina` bucket into 5 scopes mirroring each keyword's semantic role.
- Add 17 missing keywords (`fn`, `import`, `require`, `backend`, `upstream_state`, `exports`, `attributes`, `arguments`, `validation`, `for`, `in`, `if`, `else`, `read`, `moved`, `removed`, `null`).
- Apply the same change identically to `editors/vscode/syntaxes/` and `editors/carina.tmbundle/Syntaxes/`.

Closes #1934

## Scope mapping

| Keyword | Scope |
|---|---|
| `let`, `fn` | `storage.type.carina` |
| `provider`, `backend`, `upstream_state`, `exports`, `attributes`, `arguments`, `validation`, `moved`, `removed` | `keyword.declaration.carina` |
| `for`, `in`, `if`, `else` | `keyword.control.carina` |
| `import`, `require`, `read` | `keyword.other.carina` |
| `null` | `constant.language.null.carina` |

Themes that distinguish declarations from control flow (most of them) now render the DSL more naturally without user config, and users who dislike the default `let` coloring can override just `storage.type.carina`.

## Follow-ups (filed separately)

- #1936 — sync mechanism for the two tmLanguage files (currently hand-edited twice).
- #1937 — `resource-types` regex misses `awscc`.
- #1938 — single source of truth for the DSL keyword list across pest grammar / LSP / TextMate.

## Test plan

- [x] `python3 -c 'import json; json.load(...)'` on both files — valid JSON.
- [x] `cargo build --workspace` — no Rust side-effects.
- [ ] Manual smoke test: open a `.crn` file in VSCode (with the local extension) and confirm each keyword bucket picks up a different color under the default theme.
