### PR TITLE
Centralize DSL keyword list with drift-detection tests (#1938)

### DIFF
--- a/carina-core/src/keywords.rs
+++ b/carina-core/src/keywords.rs
@@ -1,0 +1,105 @@
+//! Single source of truth for the Carina DSL's reserved keywords.
+//!
+//! The LSP (semantic tokens, completion) and the TextMate grammars each
+//! maintain their own representation; parity tests keep them from drifting
+//! apart.
+
+/// Semantic role of a keyword, aligned with the TextMate scope split used by
+/// `editors/vscode/syntaxes/carina.tmLanguage.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum KeywordKind {
+    /// Binding / function introducer: `let`, `fn`.
+    Storage,
+    /// Top-level / structural block declarations: `provider`, `backend`,
+    /// `upstream_state`, `exports`, `attributes`, `arguments`, `validation`,
+    /// `moved`, `removed`.
+    Declaration,
+    /// Control flow: `for`, `in`, `if`, `else`.
+    Control,
+    /// Prefix / non-block keywords: `import`, `require`, `read`.
+    Other,
+    /// Null literal.
+    NullLiteral,
+}
+
+pub const KEYWORDS: &[(&str, KeywordKind)] = &[
+    ("fn", KeywordKind::Storage),
+    ("let", KeywordKind::Storage),
+    ("arguments", KeywordKind::Declaration),
+    ("attributes", KeywordKind::Declaration),
+    ("backend", KeywordKind::Declaration),
+    ("exports", KeywordKind::Declaration),
+    ("moved", KeywordKind::Declaration),
+    ("provider", KeywordKind::Declaration),
+    ("removed", KeywordKind::Declaration),
+    ("upstream_state", KeywordKind::Declaration),
+    ("validation", KeywordKind::Declaration),
+    ("else", KeywordKind::Control),
+    ("for", KeywordKind::Control),
+    ("if", KeywordKind::Control),
+    ("in", KeywordKind::Control),
+    ("import", KeywordKind::Other),
+    ("read", KeywordKind::Other),
+    ("require", KeywordKind::Other),
+    ("null", KeywordKind::NullLiteral),
+];
+
+/// Keywords filtered by kind.
+pub fn by_kind(kind: KeywordKind) -> impl Iterator<Item = &'static str> {
+    KEYWORDS
+        .iter()
+        .filter(move |(_, k)| *k == kind)
+        .map(|(name, _)| *name)
+}
+
+/// Return true when `word` is a reserved keyword.
+pub fn is_keyword(word: &str) -> bool {
+    KEYWORDS.iter().any(|(name, _)| *name == word)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keywords_are_unique() {
+        let mut names: Vec<&str> = KEYWORDS.iter().map(|(n, _)| *n).collect();
+        names.sort_unstable();
+        let unique: std::collections::HashSet<&str> = names.iter().copied().collect();
+        assert_eq!(
+            names.len(),
+            unique.len(),
+            "Duplicate keyword entry in KEYWORDS"
+        );
+    }
+
+    #[test]
+    fn pest_grammar_contains_every_keyword() {
+        let pest_grammar = include_str!("parser/carina.pest");
+        for (name, _) in KEYWORDS {
+            let literal = format!("\"{}\"", name);
+            assert!(
+                pest_grammar.contains(&literal),
+                "KEYWORDS entry `{}` is not referenced as a string literal in carina.pest. \
+                 Either the pest grammar lost a keyword or KEYWORDS has a stale entry.",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn is_keyword_matches_list() {
+        assert!(is_keyword("let"));
+        assert!(is_keyword("upstream_state"));
+        assert!(!is_keyword("not_a_keyword"));
+        assert!(!is_keyword(""));
+    }
+
+    #[test]
+    fn by_kind_partitions_correctly() {
+        let storage: Vec<&str> = by_kind(KeywordKind::Storage).collect();
+        assert_eq!(storage, vec!["fn", "let"]);
+        let null: Vec<&str> = by_kind(KeywordKind::NullLiteral).collect();
+        assert_eq!(null, vec!["null"]);
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod executor;
 pub mod formatter;
 pub mod heredoc;
 pub mod identifier;
+pub mod keywords;
 pub mod lint;
 pub mod module;
 pub mod module_resolver;

--- a/carina-core/tests/tmlanguage_keyword_parity.rs
+++ b/carina-core/tests/tmlanguage_keyword_parity.rs
@@ -1,0 +1,107 @@
+//! Drift-detection tests: assert that every `KEYWORDS` entry appears in each
+//! `carina.tmLanguage.json` under its expected scope, and that the grammar
+//! lists nothing beyond `KEYWORDS`.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use carina_core::keywords::{KEYWORDS, KeywordKind};
+
+const VSCODE_GRAMMAR: &str = "../editors/vscode/syntaxes/carina.tmLanguage.json";
+const TMBUNDLE_GRAMMAR: &str = "../editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json";
+
+fn kind_for_scope(scope: &str) -> Option<KeywordKind> {
+    match scope {
+        "storage.type.carina" => Some(KeywordKind::Storage),
+        "keyword.declaration.carina" => Some(KeywordKind::Declaration),
+        "keyword.control.carina" => Some(KeywordKind::Control),
+        "keyword.other.carina" => Some(KeywordKind::Other),
+        "constant.language.null.carina" => Some(KeywordKind::NullLiteral),
+        _ => None,
+    }
+}
+
+fn parse_grammar_keywords(path: &str) -> BTreeSet<(KeywordKind, String)> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let full_path = manifest_dir.join(path);
+    let content = fs::read_to_string(&full_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", full_path.display(), e));
+    let json: serde_json::Value =
+        serde_json::from_str(&content).expect("tmLanguage file must be valid JSON");
+
+    let patterns = json
+        .pointer("/repository/keywords/patterns")
+        .and_then(|v| v.as_array())
+        .expect("expected repository.keywords.patterns to be an array");
+
+    let mut pairs = BTreeSet::new();
+    for pattern in patterns {
+        let scope = pattern
+            .get("name")
+            .and_then(|v| v.as_str())
+            .expect("pattern missing `name`");
+        let match_re = pattern
+            .get("match")
+            .and_then(|v| v.as_str())
+            .expect("pattern missing `match`");
+        let kind =
+            kind_for_scope(scope).unwrap_or_else(|| panic!("unknown scope `{scope}` in {path}"));
+        for word in extract_words(match_re) {
+            pairs.insert((kind, word));
+        }
+    }
+    pairs
+}
+
+/// Parse `\b(a|b|c)\b` or `\bword\b` into the alternation members. Panics on
+/// any other shape — this is a linter, so malformed input should fail loudly.
+fn extract_words(regex: &str) -> Vec<String> {
+    let inner = regex
+        .strip_prefix("\\b")
+        .and_then(|s| s.strip_suffix("\\b"))
+        .unwrap_or_else(|| panic!("regex `{regex}` must be bracketed by \\b"));
+    let has_open = inner.starts_with('(');
+    let has_close = inner.ends_with(')');
+    let inner = match (has_open, has_close) {
+        (true, true) => &inner[1..inner.len() - 1],
+        (false, false) => inner,
+        _ => panic!("regex `{regex}` has unbalanced parentheses"),
+    };
+    inner.split('|').map(|s| s.trim().to_string()).collect()
+}
+
+fn expected_pairs() -> BTreeSet<(KeywordKind, String)> {
+    KEYWORDS
+        .iter()
+        .map(|(name, kind)| (*kind, name.to_string()))
+        .collect()
+}
+
+fn assert_grammar_matches(path: &str) {
+    let actual = parse_grammar_keywords(path);
+    let expected = expected_pairs();
+
+    let missing: Vec<_> = expected.difference(&actual).collect();
+    let extra: Vec<_> = actual.difference(&expected).collect();
+
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "TextMate grammar {} drifted from carina_core::keywords::KEYWORDS.\n  \
+         Missing (in KEYWORDS but not in grammar): {:?}\n  \
+         Extra (in grammar but not in KEYWORDS): {:?}",
+        path,
+        missing,
+        extra
+    );
+}
+
+#[test]
+fn vscode_grammar_matches_keywords() {
+    assert_grammar_matches(VSCODE_GRAMMAR);
+}
+
+#[test]
+fn tmbundle_grammar_matches_keywords() {
+    assert_grammar_matches(TMBUNDLE_GRAMMAR);
+}


### PR DESCRIPTION
## Summary

Introduce `carina_core::keywords::KEYWORDS` as a single source of truth for the Carina DSL's 19 reserved keywords, and add parity tests that catch drift between that list, the pest grammar, and the two TextMate grammar files.

Closes #1938

## Scope decision

The original issue listed 4 duplication sites: pest, LSP semantic tokens, LSP completion, and the TextMate grammars. Walking each Rust site showed that `semantic_tokens.rs` has bespoke per-keyword position logic and `top_level.rs` has per-keyword snippet bodies — neither can be mechanically rewired through a flat `&[(&str, KeywordKind)]` list without losing information. So this PR deliberately focuses on **drift detection** (which is what #1934 actually needed) rather than forcing code sharing. The LSP files are untouched.

## What's added

- `carina-core/src/keywords.rs`:
  - `KeywordKind` enum (`Storage`, `Declaration`, `Control`, `Other`, `NullLiteral`) aligned with the TextMate scopes.
  - `KEYWORDS: &[(&str, KeywordKind)]` — 19 entries.
  - Helpers: `is_keyword`, `by_kind`.
- `carina-core/tests/tmlanguage_keyword_parity.rs`:
  - Parses `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json`.
  - Asserts bidirectional parity with `KEYWORDS` grouped by expected scope.
- Unit test in `keywords.rs`:
  - `pest_grammar_contains_every_keyword` asserts each entry is a `"keyword"` literal in `carina.pest`.

## Drift-detection verified

Confirmed with two local experiments that the failures are loud and directional:

- Removing `fn` from the grammar produced:
  `Missing (in KEYWORDS but not in grammar): [(Storage, "fn")]`
- Adding a bogus entry to `KEYWORDS` produced:
  `KEYWORDS entry `nonexistent` is not referenced as a string literal in carina.pest.`

Both reverted cleanly.

## Test plan

- [x] `cargo test -p carina-core` (all pass, includes 4 unit tests + 2 parity tests).
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings`.

