### PR TITLE
Use single quotes in LSP string-value completions (#1931)

### DIFF
--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -993,7 +993,9 @@ versioning_status =
     );
     // Should NOT have quoted string format
     assert!(
-        !completions.iter().any(|c| c.label == "\"Enabled\""),
+        !completions
+            .iter()
+            .any(|c| c.label == "\"Enabled\"" || c.label == "'Enabled'"),
         "Should not show quoted string format"
     );
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -177,12 +177,12 @@ fn list_string_enum_completions() {
 
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
-        labels.contains(&"\"tcp\""),
+        labels.contains(&"'tcp'"),
         "Should offer tcp as completion for List(StringEnum). Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"\"udp\""),
+        labels.contains(&"'udp'"),
         "Should offer udp as completion for List(StringEnum). Got: {:?}",
         labels
     );
@@ -229,12 +229,12 @@ fn union_completions_include_member_types() {
 
     // Should have StringEnum completions
     assert!(
-        labels.contains(&"\"active\""),
+        labels.contains(&"'active'"),
         "Should offer 'active' from StringEnum member. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"\"passive\""),
+        labels.contains(&"'passive'"),
         "Should offer 'passive' from StringEnum member. Got: {:?}",
         labels
     );
@@ -1180,4 +1180,22 @@ fn read_snippet_on_fresh_line_includes_let() {
         "On fresh line read snippet should still include `let ... = read ...`. Got: {:?}",
         snippet
     );
+}
+
+#[test]
+fn ipv4_cidr_completions_use_single_quotes() {
+    let provider = test_provider();
+    assert_all_wrapped(&provider.cidr_completions(), '\'', "CIDR");
+}
+
+#[test]
+fn ipv6_cidr_completions_use_single_quotes() {
+    let provider = test_provider();
+    assert_all_wrapped(&provider.ipv6_cidr_completions(), '\'', "IPv6 CIDR");
+}
+
+#[test]
+fn arn_completion_uses_single_quotes() {
+    let provider = test_provider();
+    assert_all_wrapped(&provider.arn_completions(), '\'', "ARN");
 }

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -23,6 +23,24 @@ pub(super) fn find_completion<'a>(
         .unwrap_or_else(|| panic!("completion '{}' not found", label))
 }
 
+/// Assert that every item's label and insert_text are wrapped with `quote`.
+pub(super) fn assert_all_wrapped(items: &[CompletionItem], quote: char, kind: &str) {
+    assert!(!items.is_empty(), "Expected at least one {kind} completion");
+    for item in items {
+        assert!(
+            item.label.starts_with(quote) && item.label.ends_with(quote),
+            "{kind} completion label must be wrapped with `{quote}`. Got: {:?}",
+            item.label
+        );
+        let text = item.insert_text.as_deref().unwrap_or("");
+        assert!(
+            text.starts_with(quote) && text.ends_with(quote),
+            "{kind} completion insert_text must be wrapped with `{quote}`. Got: {:?}",
+            text
+        );
+    }
+}
+
 pub(super) fn test_provider() -> CompletionProvider {
     let factories: Vec<Box<dyn ProviderFactory>> = vec![];
     let schemas = Arc::new(carina_core::provider::collect_schemas(&factories));

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -543,10 +543,10 @@ impl CompletionProvider {
         cidrs
             .into_iter()
             .map(|(cidr, description)| CompletionItem {
-                label: format!("\"{}\"", cidr),
+                label: format!("'{}'", cidr),
                 kind: Some(CompletionItemKind::VALUE),
                 detail: Some(description.to_string()),
-                insert_text: Some(format!("\"{}\"", cidr)),
+                insert_text: Some(format!("'{}'", cidr)),
                 ..Default::default()
             })
             .collect()
@@ -564,10 +564,10 @@ impl CompletionProvider {
         cidrs
             .into_iter()
             .map(|(cidr, description)| CompletionItem {
-                label: format!("\"{}\"", cidr),
+                label: format!("'{}'", cidr),
                 kind: Some(CompletionItemKind::VALUE),
                 detail: Some(description.to_string()),
-                insert_text: Some(format!("\"{}\"", cidr)),
+                insert_text: Some(format!("'{}'", cidr)),
                 ..Default::default()
             })
             .collect()
@@ -575,10 +575,10 @@ impl CompletionProvider {
 
     pub(super) fn arn_completions(&self) -> Vec<CompletionItem> {
         vec![CompletionItem {
-            label: "\"arn:aws:...\"".to_string(),
+            label: "'arn:aws:...'".to_string(),
             kind: Some(CompletionItemKind::VALUE),
             insert_text: Some(
-                "\"arn:aws:${1:service}:${2:region}:${3:account}:${4:resource}\"".to_string(),
+                "'arn:aws:${1:service}:${2:region}:${3:account}:${4:resource}'".to_string(),
             ),
             insert_text_format: Some(InsertTextFormat::SNIPPET),
             detail: Some("ARN format: arn:partition:service:region:account:resource".to_string()),
@@ -769,9 +769,9 @@ impl CompletionProvider {
             None => values
                 .iter()
                 .map(|value| CompletionItem {
-                    label: format!("\"{}\"", value),
+                    label: format!("'{}'", value),
                     kind: Some(CompletionItemKind::ENUM_MEMBER),
-                    insert_text: Some(format!("\"{}\"", value)),
+                    insert_text: Some(format!("'{}'", value)),
                     ..Default::default()
                 })
                 .collect(),


### PR DESCRIPTION
## Summary

- Switch LSP string-value completions from double quotes to single quotes to match the DSL convention.
- Four `format!("\"{}\"", ...)` call sites + one string-literal snippet in `carina-lsp/src/completion/values.rs` now emit `'...'` instead of `"..."`.
- Update three existing tests that were snapshotting the old format; add three new tests via a shared `assert_all_wrapped` helper.

Closes #1931

## Changes

| Producer | Before | After |
|---|---|---|
| `cidr_completions` | `"10.0.0.0/16"` | `'10.0.0.0/16'` |
| `ipv6_cidr_completions` | `"::/0"` | `'::/0'` |
| `arn_completions` | `"arn:aws:..."` + snippet | `'arn:aws:...'` + snippet |
| `string_enum_completions` (no-namespace branch) | `"tcp"` | `'tcp'` |

## Out of scope

The issue explicitly scopes to `format!("\"{}\"", ...)` patterns. The attribute-snippet templates elsewhere in the file (e.g. `source = "$0"` at lines ~430, 438, 448, 460) are structurally different and were not changed. If those should also be converted, they can be handled in a follow-up PR.

## Test plan

- [x] `cargo test -p carina-lsp` — 205 passed.
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings`.
