### PR TITLE
Suggest sibling carina projects for upstream_state source (#1932)

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -91,6 +91,9 @@ impl CompletionProvider {
             CompletionContext::InsideImportPath { partial_path } => {
                 self.import_path_completions(&partial_path, base_path)
             }
+            CompletionContext::InsideUpstreamStateSource { partial_path } => {
+                self.upstream_state_source_completions(&partial_path, base_path)
+            }
             CompletionContext::None => vec![],
         }
     }
@@ -311,6 +314,16 @@ impl CompletionProvider {
             }
             return CompletionContext::InsideProviderBlock {
                 provider_name: pname.clone(),
+            };
+        }
+
+        // Check if cursor is inside `source = '...'` within an upstream_state block
+        if in_upstream_state_block
+            && brace_depth > 0
+            && let Some(partial) = extract_upstream_source_partial(&prefix)
+        {
+            return CompletionContext::InsideUpstreamStateSource {
+                partial_path: partial,
             };
         }
 
@@ -580,6 +593,9 @@ enum CompletionContext {
     InsideImportPath {
         partial_path: String,
     },
+    InsideUpstreamStateSource {
+        partial_path: String,
+    },
     None,
 }
 
@@ -604,4 +620,17 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
     // longer identifier like `upstream_states`.
     let next = rest.trim_start();
     next.starts_with('{') || next.is_empty()
+}
+
+/// If `prefix` ends with `source = '<partial>` (unclosed single quote), return
+/// `<partial>`. Otherwise return `None`.
+fn extract_upstream_source_partial(prefix: &str) -> Option<String> {
+    let trimmed = prefix.trim_start();
+    let rest = trimmed.strip_prefix("source")?;
+    let rest = rest.trim_start().strip_prefix('=')?.trim_start();
+    let rest = rest.strip_prefix('\'')?;
+    if rest.contains('\'') {
+        return None;
+    }
+    Some(rest.to_string())
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1199,3 +1199,122 @@ fn arn_completion_uses_single_quotes() {
     let provider = test_provider();
     assert_all_wrapped(&provider.arn_completions(), '\'', "ARN");
 }
+
+#[test]
+fn upstream_state_source_suggests_sibling_carina_projects() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    // Layout:
+    //   root/envs/prod/     (current file here)   <- base_path
+    //   root/envs/staging/  has a .crn  -> should be suggested as '../staging'
+    //   root/envs/prod/sub/ has no .crn -> excluded (not a carina project)
+    //   root/modules/web/   has a .crn  -> should be suggested as '../../modules/web'
+    //   root/unrelated/     has no .crn -> excluded
+    fs::create_dir_all(root.join("envs/prod")).unwrap();
+    fs::create_dir_all(root.join("envs/staging")).unwrap();
+    fs::create_dir_all(root.join("envs/prod/sub")).unwrap();
+    fs::create_dir_all(root.join("modules/web")).unwrap();
+    fs::create_dir_all(root.join("unrelated")).unwrap();
+    fs::write(root.join("envs/prod/main.crn"), "").unwrap();
+    fs::write(root.join("envs/staging/main.crn"), "").unwrap();
+    fs::write(root.join("modules/web/main.crn"), "").unwrap();
+
+    let provider = test_provider();
+    let source = "let orgs = upstream_state {\n    source = '";
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: 14,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"'../staging'"),
+        "Expected sibling '../staging' suggestion. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"'../../modules/web'"),
+        "Expected uncle '../../modules/web' suggestion. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("unrelated")),
+        "Should skip directories without .crn files. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("'../prod'")),
+        "Should not suggest the current project itself. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_source_outside_block_produces_nothing() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("envs/prod")).unwrap();
+    fs::create_dir_all(root.join("envs/staging")).unwrap();
+    fs::write(root.join("envs/staging/main.crn"), "").unwrap();
+
+    let provider = test_provider();
+    // source attribute at top level (not inside upstream_state) should not trigger
+    // this new completion.
+    let doc = create_document("source = '");
+    let position = Position {
+        line: 0,
+        character: 10,
+    };
+    let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.iter().any(|l| l == &"'../staging'"),
+        "Outside upstream_state block, source = '...' should not trigger this completion. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_source_matches_partial_prefix() {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("envs/prod")).unwrap();
+    fs::create_dir_all(root.join("envs/staging")).unwrap();
+    fs::create_dir_all(root.join("envs/orgs")).unwrap();
+    fs::write(root.join("envs/staging/main.crn"), "").unwrap();
+    fs::write(root.join("envs/orgs/main.crn"), "").unwrap();
+
+    let provider = test_provider();
+    let source = "let orgs = upstream_state {\n    source = '../or";
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: 19,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"'../orgs'"),
+        "Should match sibling starting with 'or'. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"'../staging'"),
+        "Should not include sibling that doesn't match the typed prefix. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1,5 +1,7 @@
 //! Attribute, value, and type-specific completions.
 
+use std::path::Path;
+
 use tower_lsp::lsp_types::{
     Command, CompletionItem, CompletionItemKind, InsertTextFormat, Position, Range, TextEdit,
 };
@@ -8,6 +10,11 @@ use carina_core::builtins;
 use carina_core::schema::AttributeType;
 
 use super::CompletionProvider;
+
+/// How far up the directory tree to walk when suggesting upstream_state sources.
+const UPSTREAM_SOURCE_MAX_UP: usize = 6;
+/// Safety cap on the number of suggestions returned.
+const UPSTREAM_SOURCE_MAX_ITEMS: usize = 100;
 
 /// Context when the user has typed `binding_name.` after `=`.
 struct BindingDotContext {
@@ -463,6 +470,57 @@ impl CompletionProvider {
         }]
     }
 
+    /// Suggest sibling (and uncle/grand-uncle) directories that look like carina
+    /// projects, for use as the `source` attribute of an `upstream_state` block.
+    pub(super) fn upstream_state_source_completions(
+        &self,
+        partial_path: &str,
+        base_path: Option<&Path>,
+    ) -> Vec<CompletionItem> {
+        let Some(base) = base_path else {
+            return vec![];
+        };
+        let base_abs = canonical_or_self(base);
+
+        // Skip the directory that is the current project itself; everything else
+        // we emit at most once, preferring the nearest ancestor encoding.
+        let mut seen_targets: std::collections::HashSet<std::path::PathBuf> =
+            std::collections::HashSet::new();
+        seen_targets.insert(base_abs.clone());
+        let mut suggestions: Vec<String> = Vec::new();
+
+        let mut current = base_abs;
+        for depth in 1..=UPSTREAM_SOURCE_MAX_UP {
+            let Some(parent) = current.parent().map(Path::to_path_buf) else {
+                break;
+            };
+            find_carina_projects_under(&parent, depth, &mut seen_targets, &mut suggestions);
+            if suggestions.len() >= UPSTREAM_SOURCE_MAX_ITEMS {
+                suggestions.truncate(UPSTREAM_SOURCE_MAX_ITEMS);
+                break;
+            }
+            current = parent;
+        }
+
+        // Truncated by ancestor discovery order (nearest first), then sorted for display.
+        suggestions.sort();
+
+        suggestions
+            .into_iter()
+            .filter(|p| partial_path.is_empty() || p.starts_with(partial_path))
+            .map(|p| {
+                let quoted = format!("'{}'", p);
+                CompletionItem {
+                    label: quoted.clone(),
+                    kind: Some(CompletionItemKind::FOLDER),
+                    detail: Some("Carina project".to_string()),
+                    insert_text: Some(quoted),
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
     pub(super) fn generic_value_completions(&self) -> Vec<CompletionItem> {
         let mut completions = vec![
             CompletionItem {
@@ -777,4 +835,86 @@ impl CompletionProvider {
                 .collect(),
         }
     }
+}
+
+/// Scan `ancestor` for directories that look like carina projects.
+///
+/// At `up_depth == 1` (the direct parent of `base`), only the immediate
+/// children are considered. From `up_depth >= 2` the scan also descends one
+/// more level, so patterns like `../../modules/web` are reachable even when
+/// the `modules` dir itself is not a project. The descent is deliberately
+/// capped at grandchildren to keep the search bounded at every ancestor.
+///
+/// `seen` holds the canonical paths already emitted at a nearer ancestor (and
+/// the base itself); entries already in `seen` are skipped so a sibling never
+/// reappears via a longer ancestor route.
+fn find_carina_projects_under(
+    ancestor: &Path,
+    up_depth: usize,
+    seen: &mut std::collections::HashSet<std::path::PathBuf>,
+    out: &mut Vec<String>,
+) {
+    let Ok(entries) = std::fs::read_dir(ancestor) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let child = entry.path();
+        let Some(child_name) = visible_dir_name(&child) else {
+            continue;
+        };
+        let child_abs = canonical_or_self(&child);
+        if dir_has_crn_file(&child) {
+            if seen.insert(child_abs) {
+                out.push(join_relative(up_depth, &[&child_name]));
+            }
+            continue;
+        }
+        if up_depth < 2 {
+            continue;
+        }
+        let Ok(grandchildren) = std::fs::read_dir(&child) else {
+            continue;
+        };
+        for grand in grandchildren.flatten() {
+            let grand_path = grand.path();
+            let Some(grand_name) = visible_dir_name(&grand_path) else {
+                continue;
+            };
+            let grand_abs = canonical_or_self(&grand_path);
+            if dir_has_crn_file(&grand_path) && seen.insert(grand_abs) {
+                out.push(join_relative(up_depth, &[&child_name, &grand_name]));
+            }
+        }
+    }
+}
+
+/// `Some(name)` if `path` is a directory with a non-hidden name, else `None`.
+fn visible_dir_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    if name.starts_with('.') || !path.is_dir() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+fn canonical_or_self(p: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+fn dir_has_crn_file(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries
+        .flatten()
+        .any(|e| e.path().extension().is_some_and(|ext| ext == "crn"))
+}
+
+fn join_relative(up_depth: usize, parts: &[&str]) -> String {
+    let mut s = String::new();
+    for _ in 0..up_depth {
+        s.push_str("../");
+    }
+    s.push_str(&parts.join("/"));
+    s
 }


### PR DESCRIPTION
## Summary

Inside `upstream_state { source = '...' }`, the LSP now suggests nearby directories that look like carina projects. This turns typing an upstream state reference from a manual path entry into an autocomplete flow.

Closes #1932

## How it works

- Context detector in `completion/mod.rs` spots the cursor being inside an unclosed `source = '...'` literal within an `upstream_state` block and routes to a new `InsideUpstreamStateSource { partial_path }` context.
- `upstream_state_source_completions` in `completion/values.rs` walks from the current file's directory up to 6 ancestor levels. At each level it scans immediate children, and — from the second ancestor onward — one additional grandchild level. A directory is considered a project when it contains at least one `.crn` file.
- Results are deduplicated by canonical path so the same target never appears via both a sibling route (`'../staging'`) and a longer ancestor route (`'../../envs/staging'`). Nearest ancestor wins.
- Results are capped at 100 and filtered by whatever prefix the user has already typed.
- All labels/insert_text are single-quoted, matching the DSL convention established in #1931.

## Scope decisions

Per conversation with @mizzy:

- ✅ Walk up the tree (not just siblings) so `terraform/envs/service/prod` → `terraform/modules/xxx` is reachable.
- ✅ Project detection = "has any `.crn` file" (simple, cheap).
- ❌ `exports`-block filtering (nice-to-have in the issue) — deferred.
- ❌ Sharing an `extract_unclosed_quoted_arg` helper with `InsideImportPath`: the two detectors differ in where the keyword appears, whether `=` is required, and which quote styles are accepted. Factoring was considered but would have made the abstraction noisier than the two bespoke bodies.

## Test plan

- [x] Red → green TDD with three tests covering: sibling + uncle discovery with mixed project/non-project dirs, rejection outside the block, prefix filtering.
- [x] `cargo test -p carina-lsp` (208 passed).
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings`.
