### PR TITLE
Extract parse_let_header helper for LSP let-binding parsing (#1933)

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -211,11 +211,7 @@ impl Backend {
             {
                 for line in content.lines() {
                     let trimmed = line.trim();
-                    if let Some(rest) = trimmed.strip_prefix("let ")
-                        && let Some(eq_pos) = rest.find('=')
-                    {
-                        let binding = rest[..eq_pos].trim();
-                        let after_eq = rest[eq_pos + 1..].trim();
+                    if let Some((binding, after_eq)) = crate::let_parse::parse_let_header(line) {
                         // Strip "read " prefix if present
                         let type_part = after_eq.strip_prefix("read ").unwrap_or(after_eq);
                         // Extract "provider.service.type" before "{"
@@ -255,15 +251,8 @@ impl Backend {
                 let text = doc.text();
                 let mut bindings = std::collections::HashSet::new();
                 for line in text.lines() {
-                    let trimmed = line.trim();
-                    if let Some(rest) = trimmed.strip_prefix("let ")
-                        && let Some(eq_pos) = rest.find('=')
-                    {
-                        let name = rest[..eq_pos].trim();
-                        if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
-                        {
-                            bindings.insert(name.to_string());
-                        }
+                    if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
+                        bindings.insert(name.to_string());
                     }
                 }
                 bindings

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -166,12 +166,8 @@ impl CompletionProvider {
                 resource_type = rt;
                 module_name = None;
                 // Extract binding name from "let binding_name = resource_type {"
-                current_binding = trimmed
-                    .strip_prefix("let ")
-                    .and_then(|rest| rest.find('=').map(|eq| rest[..eq].trim().to_string()))
-                    .filter(|name| {
-                        !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_')
-                    });
+                current_binding =
+                    crate::let_parse::parse_let_header(trimmed).map(|(name, _)| name.to_string());
             } else if brace_depth == 0 && trimmed.starts_with("provider ") && trimmed.ends_with('{')
             {
                 // Detect "provider <name> {"
@@ -602,18 +598,10 @@ enum CompletionContext {
 /// Detect a `let <binding> = upstream_state {` opening line, where `<binding>`
 /// is a bare identifier. Used to enter the upstream_state block context.
 fn is_let_upstream_state_line(trimmed: &str) -> bool {
-    let Some(rest) = trimmed.strip_prefix("let ") else {
+    let Some((_, rhs)) = crate::let_parse::parse_let_header(trimmed) else {
         return false;
     };
-    let Some(eq_pos) = rest.find('=') else {
-        return false;
-    };
-    let binding = rest[..eq_pos].trim();
-    if binding.is_empty() || !binding.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        return false;
-    }
-    let after_eq = rest[eq_pos + 1..].trim_start();
-    let Some(rest) = after_eq.strip_prefix("upstream_state") else {
+    let Some(rest) = rhs.strip_prefix("upstream_state") else {
         return false;
     };
     // Must be followed by whitespace or `{` to ensure it's the keyword, not a

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -186,24 +186,19 @@ impl CompletionProvider {
         // Generate module binding completions from import statements
         // e.g., "let github = import '...'" → suggest "github" with call scaffold
         for line in lines.iter() {
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("let ")
-                && let Some(eq_pos) = rest.find('=')
+            if let Some((binding, after_eq)) = crate::let_parse::parse_let_header(line)
+                && binding != "_"
+                && after_eq.starts_with("import ")
             {
-                let binding = rest[..eq_pos].trim();
-                let after_eq = rest[eq_pos + 1..].trim();
-                if after_eq.starts_with("import ") && !binding.is_empty() && binding != "_" {
-                    // Try to load module and scaffold arguments
-                    let snippet = self.build_module_call_snippet(binding, after_eq, base_path);
-                    completions.push(CompletionItem {
-                        label: binding.to_string(),
-                        kind: Some(CompletionItemKind::MODULE),
-                        insert_text: Some(snippet),
-                        insert_text_format: Some(InsertTextFormat::SNIPPET),
-                        detail: Some("Module call".to_string()),
-                        ..Default::default()
-                    });
-                }
+                let snippet = self.build_module_call_snippet(binding, after_eq, base_path);
+                completions.push(CompletionItem {
+                    label: binding.to_string(),
+                    kind: Some(CompletionItemKind::MODULE),
+                    insert_text: Some(snippet),
+                    insert_text_format: Some(InsertTextFormat::SNIPPET),
+                    detail: Some("Module call".to_string()),
+                    ..Default::default()
+                });
             }
         }
 
@@ -300,26 +295,9 @@ impl CompletionProvider {
     pub(super) fn extract_resource_bindings(&self, text: &str) -> Vec<(String, String)> {
         let mut bindings = Vec::new();
         for line in text.lines() {
-            let trimmed = line.trim();
-            // Parse: let binding_name = <resource_type> {
-            if let Some(rest) = trimmed.strip_prefix("let ")
-                && let Some(eq_pos) = rest.find('=')
-            {
-                let binding_name = rest[..eq_pos].trim();
-                if !binding_name.is_empty()
-                    && binding_name
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_')
-                {
-                    // Extract resource type from the part after "="
-                    let after_eq = rest[eq_pos + 1..].trim();
-                    if let Some(resource_type) = self.extract_resource_type(after_eq) {
-                        bindings.push((binding_name.to_string(), resource_type));
-                    } else {
-                        // Fallback: include binding with empty resource type
-                        bindings.push((binding_name.to_string(), String::new()));
-                    }
-                }
+            if let Some((binding_name, after_eq)) = crate::let_parse::parse_let_header(line) {
+                let resource_type = self.extract_resource_type(after_eq).unwrap_or_default();
+                bindings.push((binding_name.to_string(), resource_type));
             }
         }
         bindings
@@ -390,24 +368,16 @@ impl CompletionProvider {
     /// Find the import path for a given module name from let import bindings
     pub(super) fn find_module_import_path(&self, module_name: &str, text: &str) -> Option<String> {
         for line in text.lines() {
-            let trimmed = line.trim();
-            // Parse: let name = import "path"
-            if let Some(rest) = trimmed.strip_prefix("let ") {
-                let rest = rest.trim_start();
-                if let Some(eq_pos) = rest.find('=') {
-                    let alias = rest[..eq_pos].trim();
-                    let after_eq = rest[eq_pos + 1..].trim();
-                    if let Some(import_rest) = after_eq.strip_prefix("import ") {
-                        let import_rest = import_rest.trim();
-                        if let Some(path_start) = import_rest.find('"')
-                            && let Some(path_end) = import_rest[path_start + 1..].find('"')
-                        {
-                            let path = &import_rest[path_start + 1..path_start + 1 + path_end];
-                            if alias == module_name {
-                                return Some(path.to_string());
-                            }
-                        }
-                    }
+            if let Some((alias, after_eq)) = crate::let_parse::parse_let_header(line)
+                && alias == module_name
+                && let Some(import_rest) = after_eq.strip_prefix("import ")
+            {
+                let import_rest = import_rest.trim();
+                if let Some(path_start) = import_rest.find('"')
+                    && let Some(path_end) = import_rest[path_start + 1..].find('"')
+                {
+                    let path = &import_rest[path_start + 1..path_start + 1 + path_end];
+                    return Some(path.to_string());
                 }
             }
         }
@@ -546,15 +516,7 @@ fn is_after_let_binding(line: &str, prefix_start: usize) -> bool {
         .nth(prefix_start)
         .map(|(i, _)| i)
         .unwrap_or(line.len());
-    let trimmed = line[..byte_end].trim_start();
-    let Some(rest) = trimmed.strip_prefix("let ") else {
-        return false;
-    };
-    let Some(eq_pos) = rest.find('=') else {
-        return false;
-    };
-    let name = rest[..eq_pos].trim();
-    !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    crate::let_parse::parse_let_header(&line[..byte_end]).is_some()
 }
 
 #[cfg(test)]

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -393,18 +393,14 @@ impl DiagnosticEngine {
         binding_name: &str,
     ) -> Option<(u32, u32)> {
         for (line_idx, line) in text.lines().enumerate() {
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("let ")
-                && let Some(eq_pos) = rest.find('=')
+            if let Some((name, _)) = crate::let_parse::parse_let_header(line)
+                && name == binding_name
             {
-                let name = rest[..eq_pos].trim();
-                if name == binding_name {
-                    // Find the column of the binding name in the original line
-                    let let_byte_pos = line.find("let ").unwrap();
-                    let let_char_pos = position::byte_offset_to_char_offset(line, let_byte_pos);
-                    let name_col = let_char_pos + 4; // "let " is 4 chars
-                    return Some((line_idx as u32, name_col));
-                }
+                // Find the column of the binding name in the original line
+                let let_byte_pos = line.find("let ").unwrap();
+                let let_char_pos = position::byte_offset_to_char_offset(line, let_byte_pos);
+                let name_col = let_char_pos + 4; // "let " is 4 chars
+                return Some((line_idx as u32, name_col));
             }
         }
         None
@@ -414,18 +410,8 @@ impl DiagnosticEngine {
     pub(super) fn extract_resource_bindings(&self, text: &str) -> HashSet<String> {
         let mut bindings = HashSet::new();
         for line in text.lines() {
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("let ")
-                && let Some(eq_pos) = rest.find('=')
-            {
-                let binding_name = rest[..eq_pos].trim();
-                if !binding_name.is_empty()
-                    && binding_name
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_')
-                {
-                    bindings.insert(binding_name.to_string());
-                }
+            if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
+                bindings.insert(name.to_string());
             }
         }
         bindings

--- a/carina-lsp/src/let_parse.rs
+++ b/carina-lsp/src/let_parse.rs
@@ -1,0 +1,102 @@
+//! Partial-line parsing of `let <name> = <rhs>` bindings.
+//!
+//! The LSP repeatedly scans lines the user is still typing, so it can't rely on
+//! the pest parser (which rejects incomplete input). This helper is the one
+//! place that knows how to peel a `let` header off such a line.
+
+/// Parse a `let <name> = <rhs>` header from a single line.
+///
+/// Returns `(binding_name, rhs)` on success, where `rhs` is the trimmed text
+/// after the `=`. The binding name must be a non-empty ASCII identifier
+/// (alphanumeric or `_`); otherwise `None` is returned. The ASCII restriction
+/// deliberately matches the pest grammar (`identifier = ASCII_ALPHA ~ ...`) so
+/// the LSP and parser agree on what counts as a valid binding.
+///
+/// Leading whitespace on `line` is ignored, and so is whitespace around the
+/// name and around the `=`. Trailing whitespace on `rhs` is preserved so the
+/// caller can decide whether to trim further.
+pub(crate) fn parse_let_header(line: &str) -> Option<(&str, &str)> {
+    let rest = line.trim_start().strip_prefix("let ")?;
+    let eq_pos = rest.find('=')?;
+    let name = rest[..eq_pos].trim();
+    if name.is_empty() || !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return None;
+    }
+    let rhs = rest[eq_pos + 1..].trim_start();
+    Some((name, rhs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_well_formed_let_binding() {
+        assert_eq!(parse_let_header("let foo = bar"), Some(("foo", "bar")));
+    }
+
+    #[test]
+    fn trims_leading_whitespace() {
+        assert_eq!(parse_let_header("    let foo = bar"), Some(("foo", "bar")));
+        assert_eq!(parse_let_header("\tlet foo = bar"), Some(("foo", "bar")));
+    }
+
+    #[test]
+    fn accepts_identifier_with_digits_and_underscore() {
+        assert_eq!(
+            parse_let_header("let my_var_1 = expr"),
+            Some(("my_var_1", "expr"))
+        );
+    }
+
+    #[test]
+    fn accepts_discard_pattern() {
+        // `_` is a valid binding name at the parse level; callers that want to
+        // exclude the discard pattern must check it themselves.
+        assert_eq!(parse_let_header("let _ = expr"), Some(("_", "expr")));
+    }
+
+    #[test]
+    fn rhs_is_trimmed_at_start_only() {
+        let (name, rhs) = parse_let_header("let x =  \t  value   ").unwrap();
+        assert_eq!(name, "x");
+        assert_eq!(rhs, "value   ");
+    }
+
+    #[test]
+    fn tolerates_no_spaces_around_equals() {
+        assert_eq!(parse_let_header("let x=expr"), Some(("x", "expr")));
+    }
+
+    #[test]
+    fn rejects_without_let_keyword() {
+        assert_eq!(parse_let_header("x = expr"), None);
+        assert_eq!(parse_let_header("letx = expr"), None);
+        assert_eq!(parse_let_header("letter = expr"), None);
+    }
+
+    #[test]
+    fn rejects_without_equals_sign() {
+        assert_eq!(parse_let_header("let foo"), None);
+    }
+
+    #[test]
+    fn rejects_empty_binding_name() {
+        assert_eq!(parse_let_header("let  = expr"), None);
+        assert_eq!(parse_let_header("let = expr"), None);
+    }
+
+    #[test]
+    fn rejects_invalid_identifier_characters() {
+        assert_eq!(parse_let_header("let foo-bar = expr"), None);
+        assert_eq!(parse_let_header("let foo.bar = expr"), None);
+        assert_eq!(parse_let_header("let foo bar = expr"), None);
+    }
+
+    #[test]
+    fn allows_empty_rhs() {
+        // Common when user has typed `let name = ` and is waiting for completion.
+        assert_eq!(parse_let_header("let x = "), Some(("x", "")));
+        assert_eq!(parse_let_header("let x ="), Some(("x", "")));
+    }
+}

--- a/carina-lsp/src/lib.rs
+++ b/carina-lsp/src/lib.rs
@@ -3,6 +3,7 @@ pub mod completion;
 pub mod diagnostics;
 pub mod document;
 pub mod hover;
+pub(crate) mod let_parse;
 pub mod position;
 pub mod semantic_tokens;
 pub mod workspace;


### PR DESCRIPTION
## Summary

Pure refactor. The LSP scans lines the user is still typing, so it can't use the pest parser. That led to 10 copies of the same `let <name> = <rhs>` header parsing across `completion/`, `diagnostics/`, and `backend.rs`. Consolidate them into `carina_lsp::let_parse::parse_let_header`.

Closes #1933

## Helper

```rust
pub(crate) fn parse_let_header(line: &str) -> Option<(&str, &str)>;
```

Returns `(binding_name, rhs)` on success. Leading whitespace on the line, around the name, and around the `=` is ignored. Trailing whitespace on `rhs` is preserved so callers decide whether to trim further.

The binding name is restricted to ASCII alphanumerics and `_`, matching the pest grammar (`identifier = ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")*`). Previously a few call sites used `chars().all(is_alphanumeric)` which accepted Unicode alphanumerics — a subtle LSP/parser divergence this refactor resolves.

## Migrated sites (10)

| File | Function / block |
|---|---|
| `carina-lsp/src/diagnostics/checks.rs` | `find_let_binding_position`, `extract_resource_bindings` |
| `carina-lsp/src/completion/mod.rs` | `current_binding` extraction in `get_completion_context`, `is_let_upstream_state_line` |
| `carina-lsp/src/completion/top_level.rs` | module import completion loop, `extract_resource_bindings`, `find_module_import_path`, `is_after_let_binding` |
| `carina-lsp/src/backend.rs` | cross-file binding scan, current-file binding extraction |

Net: **-71 source lines**.

## Test plan

- [x] 11 focused unit tests for `parse_let_header` (happy path, whitespace variants, discard pattern, every rejection path).
- [x] `cargo test -p carina-lsp` — 219 passed (208 pre-existing + 11 new).
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings`.
