### PR TITLE
Assert tmLanguage grammars stay byte-identical (#1936)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,13 @@ When modifying the DSL or resource schemas, also update the LSP:
   - `checks.rs`: Module loading and additional checks
   - Parser errors are automatically detected via `carina-core::parser`
 
+- **TextMate grammars** (editor syntax highlighting):
+  - `editors/vscode/syntaxes/carina.tmLanguage.json` and
+    `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` must stay
+    **byte-identical**. Edit both files together; the parity test in
+    `carina-core/tests/tmlanguage_keyword_parity.rs` fails the build
+    otherwise.
+
 **Testing**: When bugs are found or issues are pointed out, write test code to capture the fix. This ensures regressions are caught and documents expected behavior.
 
 ### Resource Type Mapping

--- a/carina-core/tests/tmlanguage_keyword_parity.rs
+++ b/carina-core/tests/tmlanguage_keyword_parity.rs
@@ -1,6 +1,9 @@
-//! Drift-detection tests: assert that every `KEYWORDS` entry appears in each
-//! `carina.tmLanguage.json` under its expected scope, and that the grammar
-//! lists nothing beyond `KEYWORDS`.
+//! Drift-detection tests for the two TextMate grammar files.
+//!
+//! - Per-file: every `KEYWORDS` entry appears under its expected scope, and
+//!   nothing extra is listed.
+//! - Cross-file: the vscode and tmbundle grammars are byte-identical, so an
+//!   edit to one without the other is caught immediately.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -104,4 +107,28 @@ fn vscode_grammar_matches_keywords() {
 #[test]
 fn tmbundle_grammar_matches_keywords() {
     assert_grammar_matches(TMBUNDLE_GRAMMAR);
+}
+
+#[test]
+fn vscode_and_tmbundle_grammars_are_byte_identical() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let vscode = fs::read(manifest_dir.join(VSCODE_GRAMMAR))
+        .unwrap_or_else(|e| panic!("failed to read {VSCODE_GRAMMAR}: {e}"));
+    let tmbundle = fs::read(manifest_dir.join(TMBUNDLE_GRAMMAR))
+        .unwrap_or_else(|e| panic!("failed to read {TMBUNDLE_GRAMMAR}: {e}"));
+    if vscode != tmbundle {
+        let first_diff = vscode
+            .iter()
+            .zip(tmbundle.iter())
+            .position(|(a, b)| a != b)
+            .unwrap_or(vscode.len().min(tmbundle.len()));
+        panic!(
+            "`{VSCODE_GRAMMAR}` ({vscode_len} bytes) and `{TMBUNDLE_GRAMMAR}` \
+             ({tmbundle_len} bytes) must stay byte-identical. First difference at \
+             byte offset {first_diff}. Edit both files together; the keyword \
+             parity tests above only inspect the keyword bucket.",
+            vscode_len = vscode.len(),
+            tmbundle_len = tmbundle.len(),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Add a byte-identity assertion between the two tmLanguage grammar files so future drift fails the build. No Makefile, CI job, or symlink added — the check rides on `cargo test -p carina-core` which already runs in CI.

Closes #1936

## What

- New test `vscode_and_tmbundle_grammars_are_byte_identical` in `carina-core/tests/tmlanguage_keyword_parity.rs`.
- Short note in `CLAUDE.md` under *LSP Integration → TextMate grammars* making the contract explicit.

## Why this approach

The issue listed a symlink or a Makefile+CI check as options. Both add infrastructure (symlinks are fragile on Windows; Makefile+CI adds a new job to maintain). A parity test hits the same goal with less: a dedicated file already exists that reads both grammars, so adding one `fs::read` + byte-compare keeps the detection path together.

The existing per-file keyword parity tests (#1938) cover keyword drift. Byte-parity catches everything else — reordered JSON fields, whitespace tweaks, accidental edits in one file only.

## Drift-detection verified

Temporarily appended two newlines to the vscode grammar; the test failed with:

```
`../editors/vscode/syntaxes/carina.tmLanguage.json` (3164 bytes) and
`../editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` (3162 bytes)
must stay byte-identical. First difference at byte offset 3162.
Edit both files together; the keyword parity tests above only inspect
the keyword bucket.
```

Reverted cleanly.

## Test plan

- [x] `cargo test -p carina-core --test tmlanguage_keyword_parity` — 3 passed.
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings`.
