### PR TITLE
Highlight awscc.* resource types in TextMate grammar (#1937)

### DIFF
--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -53,7 +53,7 @@
       "patterns": [
         {
           "name": "support.class.carina",
-          "match": "(aws|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
+          "match": "(aws|awscc|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
         }
       ]
     },

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -53,7 +53,7 @@
       "patterns": [
         {
           "name": "support.class.carina",
-          "match": "(aws|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
+          "match": "(aws|awscc|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Add `awscc` to the `resource-types` alternation so `awscc.ec2.vpc`, `awscc.s3.bucket`, etc. are highlighted as `support.class.carina` just like their `aws.*` counterparts. `awscc` is an actively maintained provider in the carina-rs org and appears throughout example `.crn` files.

Applied to both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json`; byte-parity test in `carina-core/tests/tmlanguage_keyword_parity.rs` verifies the two files stay identical.

Closes #1937

## Why not a generic pattern

Issue #1937 floated `[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*` as a future-proof alternative. TextMate runs regex without grammar context, so a dotted expression like `foo.bar.baz` appearing anywhere in user code would get `support.class` highlighting. Kept the explicit alternation and deferred genericization unless/until a new provider actually lands.

## Test plan

- [x] `cargo test -p carina-core --test tmlanguage_keyword_parity` — 3 passed (byte-identity + both keyword parity checks).
- [x] Manual diff confirms the two grammar files are still byte-identical.
