### PR TITLE
Use single quotes in top-level LSP snippets

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -610,15 +610,63 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
     next.starts_with('{') || next.is_empty()
 }
 
-/// If `prefix` ends with `source = '<partial>` (unclosed single quote), return
-/// `<partial>`. Otherwise return `None`.
+/// If `prefix` ends with `source = '<partial>` or `source = "<partial>`
+/// (unclosed quote of either kind), return `<partial>`. Otherwise return
+/// `None`.
 fn extract_upstream_source_partial(prefix: &str) -> Option<String> {
     let trimmed = prefix.trim_start();
     let rest = trimmed.strip_prefix("source")?;
     let rest = rest.trim_start().strip_prefix('=')?.trim_start();
-    let rest = rest.strip_prefix('\'')?;
-    if rest.contains('\'') {
+    let (quote, rest) = if let Some(r) = rest.strip_prefix('\'') {
+        ('\'', r)
+    } else {
+        ('"', rest.strip_prefix('"')?)
+    };
+    if rest.contains(quote) {
         return None;
     }
     Some(rest.to_string())
+}
+
+#[cfg(test)]
+mod helper_tests {
+    use super::extract_upstream_source_partial;
+
+    #[test]
+    fn single_quote_unclosed_returns_partial() {
+        assert_eq!(
+            extract_upstream_source_partial("source = '"),
+            Some(String::new())
+        );
+        assert_eq!(
+            extract_upstream_source_partial("source = '../ot"),
+            Some("../ot".to_string())
+        );
+    }
+
+    #[test]
+    fn double_quote_unclosed_returns_partial() {
+        assert_eq!(
+            extract_upstream_source_partial("source = \""),
+            Some(String::new())
+        );
+        assert_eq!(
+            extract_upstream_source_partial("source = \"../ot"),
+            Some("../ot".to_string())
+        );
+    }
+
+    #[test]
+    fn closed_quotes_return_none() {
+        assert_eq!(extract_upstream_source_partial("source = '../x'"), None);
+        assert_eq!(extract_upstream_source_partial("source = \"../x\""), None);
+    }
+
+    #[test]
+    fn missing_pieces_return_none() {
+        assert_eq!(extract_upstream_source_partial(""), None);
+        assert_eq!(extract_upstream_source_partial("source"), None);
+        assert_eq!(extract_upstream_source_partial("source ="), None);
+        assert_eq!(extract_upstream_source_partial("source = ../x"), None);
+    }
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1318,3 +1318,87 @@ fn upstream_state_source_matches_partial_prefix() {
         labels
     );
 }
+
+// Regression tests for #1947: top-level snippets must use single quotes.
+// The old snippets used double quotes, which meant the upstream_state
+// directory completion path (which only looks for `source = '...'`) never
+// fired on a freshly inserted snippet.
+
+fn top_level_snippet(text: &str, label: &str) -> String {
+    let provider = test_provider();
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: text.len() as u32,
+        },
+        text,
+        None,
+    );
+    find_completion(&completions, label)
+        .insert_text
+        .clone()
+        .unwrap_or_default()
+}
+
+#[test]
+fn top_level_snippets_use_single_quotes() {
+    let cases = [
+        ("", "upstream_state"),
+        ("let orgs = u", "upstream_state"),
+        ("", "let import"),
+        ("let m = i", "let import"),
+        ("", "import"),
+        ("", "removed"),
+        ("", "moved"),
+    ];
+    for (context, label) in cases {
+        let snippet = top_level_snippet(context, label);
+        assert!(
+            !snippet.contains('"'),
+            "{label} snippet (context={context:?}) must not contain double quotes. Got: {snippet:?}"
+        );
+    }
+}
+
+#[test]
+fn upstream_state_snippet_quotes_source_value() {
+    for context in ["", "let orgs = u"] {
+        let snippet = top_level_snippet(context, "upstream_state");
+        assert!(
+            snippet.contains("source = '"),
+            "upstream_state snippet (context={context:?}) must wrap `source` value in single quotes. Got: {snippet:?}"
+        );
+    }
+}
+
+#[test]
+fn upstream_state_source_suggestions_work_with_double_quotes() {
+    // #1947 (2): existing files may contain `source = "..."`. The directory
+    // completion should fire regardless of quote style.
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("envs/prod")).unwrap();
+    fs::create_dir_all(root.join("envs/staging")).unwrap();
+    fs::write(root.join("envs/prod/main.crn"), "").unwrap();
+    fs::write(root.join("envs/staging/main.crn"), "").unwrap();
+
+    let provider = test_provider();
+    let source = "let orgs = upstream_state {\n    source = \"";
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: 14,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"'../staging'"),
+        "Double-quoted source = \"... should still offer directory suggestions. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -58,14 +58,14 @@ impl CompletionProvider {
             "let ${1:name} = read ${2:aws.s3.bucket} {\n    name = \"${3:existing-resource}\"\n}"
         };
         let let_import_snippet = if after_let_binding {
-            "import \"${1:./modules/name}\""
+            "import '${1:./modules/name}'"
         } else {
-            "let ${1:module_name} = import \"${2:./modules/name}\""
+            "let ${1:module_name} = import '${2:./modules/name}'"
         };
         let upstream_state_snippet = if after_let_binding {
-            "upstream_state {\n    source = \"${1:../other-project}\"\n}"
+            "upstream_state {\n    source = '${1:../other-project}'\n}"
         } else {
-            "let ${1:binding} = upstream_state {\n    source = \"${2:../other-project}\"\n}"
+            "let ${1:binding} = upstream_state {\n    source = '${2:../other-project}'\n}"
         };
 
         let mut completions = vec![
@@ -136,7 +136,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "import".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("import {\n    to = ${1:awscc.ec2.vpc} \"${2:name}\"\n    id = \"${3:resource-id}\"\n}".to_string()),
+                insert_text: Some("import {\n    to = ${1:awscc.ec2.vpc} '${2:name}'\n    id = '${3:resource-id}'\n}".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Import existing resource into state".to_string()),
                 ..Default::default()
@@ -144,7 +144,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "removed".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("removed {\n    from = ${1:awscc.ec2.vpc} \"${2:name}\"\n}".to_string()),
+                insert_text: Some("removed {\n    from = ${1:awscc.ec2.vpc} '${2:name}'\n}".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Remove resource from state without destroying".to_string()),
                 ..Default::default()
@@ -152,7 +152,7 @@ impl CompletionProvider {
             CompletionItem {
                 label: "moved".to_string(),
                 kind: Some(CompletionItemKind::KEYWORD),
-                insert_text: Some("moved {\n    from = ${1:awscc.ec2.vpc} \"${2:old-name}\"\n    to   = ${3:awscc.ec2.vpc} \"${4:new-name}\"\n}".to_string()),
+                insert_text: Some("moved {\n    from = ${1:awscc.ec2.vpc} '${2:old-name}'\n    to   = ${3:awscc.ec2.vpc} '${4:new-name}'\n}".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Move/rename resource in state".to_string()),
                 ..Default::default()
@@ -373,8 +373,9 @@ impl CompletionProvider {
                 && let Some(import_rest) = after_eq.strip_prefix("import ")
             {
                 let import_rest = import_rest.trim();
-                if let Some(path_start) = import_rest.find('"')
-                    && let Some(path_end) = import_rest[path_start + 1..].find('"')
+                if let Some(path_start) = import_rest.find(['"', '\''])
+                    && let Some(quote) = import_rest[path_start..].chars().next()
+                    && let Some(path_end) = import_rest[path_start + 1..].find(quote)
                 {
                     let path = &import_rest[path_start + 1..path_start + 1 + path_end];
                     return Some(path.to_string());


### PR DESCRIPTION
## Summary

Two related regressions from #1931 / #1932 in the LSP top-level snippet code:

1. The single-quote migration for string completions only landed in `completion/values.rs`. The top-level snippets (`upstream_state`, `let import`, `import`, `removed`, `moved`) still inserted `\"...\"`, so the DSL's preferred quote style wasn't applied.
2. Because those snippets were double-quoted, the `upstream_state` source directory completion from #1932 — which only fires after `source = '` — never activated when the user accepted the just-inserted snippet.

## Changes

- **Snippets**: convert the 5 top-level snippets in `completion/top_level.rs` from `\"...\"` to `'...'`.
- **`extract_upstream_source_partial` (`completion/mod.rs`)**: accept either `'` or `"` as the opening quote so existing files with double-quoted `source = \"...\"` still get directory suggestions.
- **`find_module_import_path` (`completion/top_level.rs`)**: same dual-quote acceptance for `let import` path resolution (needed now that `let import` snippets use `'`).

## Test plan

- [x] `cargo test -p carina-lsp` — 230 passed
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings` — clean
- [x] Added unit tests for `extract_upstream_source_partial` covering `'`, `"`, closed, and missing-pieces cases
- [x] Added regression tests asserting all 5 top-level snippets contain no `\"`
- [x] Added integration test that `source = \"<cursor>` inside an `upstream_state` block still yields sibling carina project suggestions

Closes #1947