### PR TITLE
Add Value::visit_refs and migrate two walkers

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -677,55 +677,22 @@ fn check_ref_against_upstream(
     location: &str,
     errors: &mut Vec<String>,
 ) {
-    match value {
-        Value::ResourceRef { path } => {
-            let binding = path.binding();
-            let field = path.attribute();
-            let Some(exports) = remote_bindings.get(binding) else {
-                return;
-            };
-            if !exports.contains_key(field) {
-                let known: Vec<&str> = exports.keys().map(String::as_str).collect();
-                let suggestion = carina_core::schema::suggest_similar_name(field, &known)
-                    .map(|s| format!(" Did you mean `{}`?", s))
-                    .unwrap_or_default();
-                errors.push(format!(
-                    "{location}: upstream_state `{binding}` does not export `{field}`.{suggestion}"
-                ));
-            }
+    value.visit_refs(&mut |path| {
+        let binding = path.binding();
+        let field = path.attribute();
+        let Some(exports) = remote_bindings.get(binding) else {
+            return;
+        };
+        if !exports.contains_key(field) {
+            let known: Vec<&str> = exports.keys().map(String::as_str).collect();
+            let suggestion = carina_core::schema::suggest_similar_name(field, &known)
+                .map(|s| format!(" Did you mean `{}`?", s))
+                .unwrap_or_default();
+            errors.push(format!(
+                "{location}: upstream_state `{binding}` does not export `{field}`.{suggestion}"
+            ));
         }
-        Value::List(items) => {
-            for v in items {
-                check_ref_against_upstream(v, remote_bindings, location, errors);
-            }
-        }
-        Value::Map(map) => {
-            for v in map.values() {
-                check_ref_against_upstream(v, remote_bindings, location, errors);
-            }
-        }
-        Value::Interpolation(parts) => {
-            for part in parts {
-                if let carina_core::resource::InterpolationPart::Expr(v) = part {
-                    check_ref_against_upstream(v, remote_bindings, location, errors);
-                }
-            }
-        }
-        Value::FunctionCall { args, .. } => {
-            for arg in args {
-                check_ref_against_upstream(arg, remote_bindings, location, errors);
-            }
-        }
-        Value::Secret(inner) => {
-            check_ref_against_upstream(inner, remote_bindings, location, errors);
-        }
-        Value::Closure { captured_args, .. } => {
-            for arg in captured_args {
-                check_ref_against_upstream(arg, remote_bindings, location, errors);
-            }
-        }
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
-    }
+    });
 }
 
 #[cfg(test)]

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -4153,54 +4153,21 @@ fn check_undefined_in_value(
     known: &std::collections::HashSet<&str>,
     value: &Value,
 ) -> Result<(), ParseError> {
-    match value {
-        Value::ResourceRef { path } => {
-            let root = path.binding();
-            let root_ident = root.split(['[', ']']).next().unwrap_or(root);
-            if !known.contains(root_ident) {
-                return Err(ParseError::UndefinedIdentifier {
-                    name: root_ident.to_string(),
-                    line: 0,
-                });
-            }
-            Ok(())
+    let mut undefined: Option<String> = None;
+    value.visit_refs(&mut |path| {
+        if undefined.is_some() {
+            return;
         }
-        Value::List(items) => {
-            for v in items {
-                check_undefined_in_value(known, v)?;
-            }
-            Ok(())
+        let root = path.binding();
+        let root_ident = root.split(['[', ']']).next().unwrap_or(root);
+        if !known.contains(root_ident) {
+            undefined = Some(root_ident.to_string());
         }
-        Value::Map(map) => {
-            for v in map.values() {
-                check_undefined_in_value(known, v)?;
-            }
-            Ok(())
-        }
-        Value::Interpolation(parts) => {
-            for part in parts {
-                if let crate::resource::InterpolationPart::Expr(v) = part {
-                    check_undefined_in_value(known, v)?;
-                }
-            }
-            Ok(())
-        }
-        Value::FunctionCall { args, .. } => {
-            for arg in args {
-                check_undefined_in_value(known, arg)?;
-            }
-            Ok(())
-        }
-        Value::Secret(inner) => check_undefined_in_value(known, inner),
-        Value::Closure { captured_args, .. } => {
-            for arg in captured_args {
-                check_undefined_in_value(known, arg)?;
-            }
-            Ok(())
-        }
-        // Leaves: exhaustive on purpose so a new Value variant forces a review here.
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => Ok(()),
+    });
+    if let Some(name) = undefined {
+        return Err(ParseError::UndefinedIdentifier { name, line: 0 });
     }
+    Ok(())
 }
 
 /// Resolve forward references after the full binding set is known.

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -283,6 +283,42 @@ impl Value {
             _ => None,
         }
     }
+
+    /// Recursively walk this value, invoking `f` on each `ResourceRef`'s `AccessPath`.
+    pub fn visit_refs(&self, f: &mut impl FnMut(&AccessPath)) {
+        match self {
+            Value::ResourceRef { path } => f(path),
+            Value::List(items) => {
+                for v in items {
+                    v.visit_refs(f);
+                }
+            }
+            Value::Map(map) => {
+                for v in map.values() {
+                    v.visit_refs(f);
+                }
+            }
+            Value::Interpolation(parts) => {
+                for part in parts {
+                    if let InterpolationPart::Expr(v) = part {
+                        v.visit_refs(f);
+                    }
+                }
+            }
+            Value::FunctionCall { args, .. } => {
+                for arg in args {
+                    arg.visit_refs(f);
+                }
+            }
+            Value::Secret(inner) => inner.visit_refs(f),
+            Value::Closure { captured_args, .. } => {
+                for arg in captured_args {
+                    arg.visit_refs(f);
+                }
+            }
+            Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
+        }
+    }
 }
 
 impl Expr {
@@ -1744,5 +1780,52 @@ mod tests {
             remaining_arity: 1,
         };
         assert!(contains_resource_ref(&closure));
+    }
+
+    #[test]
+    fn visit_refs_collects_from_all_nested_variants() {
+        let value = Value::List(vec![
+            Value::resource_ref("a", "id", vec![]),
+            Value::Map(HashMap::from([(
+                "k".to_string(),
+                Value::resource_ref("b", "id", vec![]),
+            )])),
+            Value::Interpolation(vec![
+                InterpolationPart::Literal("x".to_string()),
+                InterpolationPart::Expr(Value::resource_ref("c", "id", vec![])),
+            ]),
+            Value::FunctionCall {
+                name: "join".to_string(),
+                args: vec![Value::resource_ref("d", "id", vec![])],
+            },
+            Value::Secret(Box::new(Value::resource_ref("e", "id", vec![]))),
+            Value::Closure {
+                name: "fn".to_string(),
+                captured_args: vec![Value::resource_ref("f", "id", vec![])],
+                remaining_arity: 1,
+            },
+            Value::String("plain".to_string()),
+        ]);
+
+        let mut collected: Vec<String> = Vec::new();
+        value.visit_refs(&mut |path| {
+            collected.push(path.binding().to_string());
+        });
+        collected.sort();
+        assert_eq!(collected, vec!["a", "b", "c", "d", "e", "f"]);
+    }
+
+    #[test]
+    fn visit_refs_on_leaf_variants_calls_nothing() {
+        for v in [
+            Value::String("s".into()),
+            Value::Int(1),
+            Value::Float(1.0),
+            Value::Bool(true),
+        ] {
+            let mut count = 0;
+            v.visit_refs(&mut |_| count += 1);
+            assert_eq!(count, 0);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `Value::visit_refs(&mut impl FnMut(&AccessPath))` to `carina-core/src/resource.rs` — a shared recursive visitor that invokes the callback on each `ResourceRef` encountered during traversal of `List` / `Map` / `Interpolation` / `FunctionCall` / `Secret` / `Closure`.
- Migrate `check_undefined_in_value` (`carina-core/src/parser/mod.rs`) and `check_ref_against_upstream` (`carina-cli/src/commands/plan.rs`) to call `visit_refs` with a domain-specific closure instead of re-implementing the traversal.
- Pure refactor; existing parser and plan tests pin behavior parity.

## Scope notes

- In-place rewriters (`resolve_forward_ref_in_value`, `substitute_fn_params`, `substitute_placeholder`) are out of scope per the issue — they would need a separate `visit_refs_mut` API.
- Other inspection-only walkers (`contains_resource_ref`, `collect_dependencies`, `collect_ref_attr_diagnostics`) deferred to #1957 to keep 1 PR = 1 topic.

## Test plan

- [x] `cargo test -p carina-core` (1203 passed)
- [x] `cargo test` full workspace (all green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] New unit tests: `visit_refs_collects_from_all_nested_variants`, `visit_refs_on_leaf_variants_calls_nothing`

Closes #1951