### PR TITLE
Defer cross-file for-iterable validation until post-merge

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -164,6 +164,10 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
+        if let Err(e) = parser::check_deferred_for_iterables(&merged) {
+            return Err(e.to_string());
+        }
+
         // Upgrade cross-file warnings: a for-expression in one file may reference
         // an upstream_state defined in another file.  During per-file parsing the
         // upstream_state is unknown, so the warning falls back to the generic
@@ -267,6 +271,12 @@ pub fn parse_directory(dir: &Path, config: &ProviderContext) -> Result<ParsedFil
 
     // Resolve cross-file references on the merged result
     if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
+        return Err(e.to_string());
+    }
+
+    // Per-file parse deliberately skips this check: the iterable may reference
+    // an `upstream_state` or `let` declared in a sibling file.
+    if let Err(e) = parser::check_deferred_for_iterables(&merged) {
         return Err(e.to_string());
     }
 
@@ -779,5 +789,61 @@ mod tests {
             Ok(_) => panic!("expected error for multiple backends"),
         }
         cleanup(&dir);
+    }
+
+    #[test]
+    fn parse_directory_accepts_cross_file_upstream_state_in_for_expression() {
+        let dir = create_temp_dir("cross_file_upstream_for");
+        fs::write(
+            dir.join("backend.crn"),
+            r#"backend local { path = 'carina.state.json' }
+
+let orgs = upstream_state {
+  source = '../organizations'
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("main.crn"),
+            r#"for name, account_id in orgs.accounts {
+  aws.s3.bucket {
+    name = name
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let result = parse_directory(&dir, &ProviderContext::default());
+        cleanup(&dir);
+        assert!(
+            result.is_ok(),
+            "expected cross-file upstream_state binding in `for` to resolve, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn parse_directory_rejects_undefined_iterable_even_after_merge() {
+        let dir = create_temp_dir("undefined_for_iterable");
+        fs::write(
+            dir.join("main.crn"),
+            r#"for name, account_id in does_not_exist.accounts {
+  aws.s3.bucket {
+    name = name
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let result = parse_directory(&dir, &ProviderContext::default());
+        cleanup(&dir);
+        let err = result.expect_err("undefined iterable should still error after merge");
+        assert!(
+            err.contains("Undefined identifier `does_not_exist`"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -983,7 +983,6 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         &attribute_params,
         &module_calls,
         &export_params,
-        &ctx.deferred_for_expressions,
     )?;
 
     Ok(ParsedFile {
@@ -4110,13 +4109,17 @@ fn collect_known_bindings<'ctx>(
 }
 
 /// Reject references whose root identifier is not declared anywhere in scope.
+///
+/// Note: deferred for-expression iterables are not checked here. They may name
+/// bindings declared in sibling files (e.g. an `upstream_state` in `backend.crn`
+/// iterated from `main.crn`) that only become visible after directory-wide
+/// merging. That check runs in `check_deferred_for_iterables` instead.
 fn check_undefined_bindings(
     known: &std::collections::HashSet<&str>,
     resources: &[Resource],
     attribute_params: &[AttributeParameter],
     module_calls: &[ModuleCall],
     export_params: &[ExportParameter],
-    deferred_for_expressions: &[DeferredForExpression],
 ) -> Result<(), ParseError> {
     for resource in resources {
         for expr in resource.attributes.values() {
@@ -4136,14 +4139,6 @@ fn check_undefined_bindings(
     for export in export_params {
         if let Some(value) = &export.value {
             check_undefined_in_value(known, value)?;
-        }
-    }
-    for deferred in deferred_for_expressions {
-        if !known.contains(deferred.iterable_binding.as_str()) {
-            return Err(ParseError::UndefinedIdentifier {
-                name: deferred.iterable_binding.clone(),
-                line: deferred.line,
-            });
         }
     }
     Ok(())
@@ -4353,6 +4348,38 @@ pub fn resolve_resource_refs_with_config(
         }
     }
 
+    Ok(())
+}
+
+/// Verify that every deferred for-expression iterable names a declared binding.
+///
+/// This must run on a fully merged `ParsedFile` (directory-wide), not on a
+/// single-file parse — iterables commonly reference `upstream_state` or `let`
+/// bindings declared in sibling files that only become visible after merging.
+pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Result<(), ParseError> {
+    let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref()));
+    known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
+    known.extend(
+        parsed
+            .module_calls
+            .iter()
+            .filter_map(|c| c.binding_name.as_deref()),
+    );
+    known.extend(parsed.upstream_states.iter().map(|u| u.binding.as_str()));
+    known.extend(parsed.imports.iter().map(|i| i.alias.as_str()));
+    known.extend(parsed.user_functions.keys().map(String::as_str));
+    known.extend(parsed.variables.keys().map(String::as_str));
+    known.extend(parsed.structural_bindings.iter().map(String::as_str));
+
+    for deferred in &parsed.deferred_for_expressions {
+        if !known.contains(deferred.iterable_binding.as_str()) {
+            return Err(ParseError::UndefinedIdentifier {
+                name: deferred.iterable_binding.clone(),
+                line: deferred.line,
+            });
+        }
+    }
     Ok(())
 }
 
@@ -10736,7 +10763,13 @@ awscc.ec2.vpc {
                 }
             }
         "#;
-        let err = parse(input, &ProviderContext::default())
+        // Iterable-binding validation runs in `check_deferred_for_iterables`
+        // on the merged directory-level `ParsedFile`, so that cross-file
+        // `upstream_state` bindings in sibling files aren't rejected during
+        // per-file parsing.
+        let parsed = parse(input, &ProviderContext::default())
+            .expect("single-file parse must not reject cross-file iterables");
+        let err = check_deferred_for_iterables(&parsed)
             .expect_err("undefined `orgs` must be a hard error");
         match err {
             ParseError::UndefinedIdentifier { name, .. } => {


### PR DESCRIPTION
## Summary

Fixes the misleading `Undefined identifier 'orgs'` error reported in #1955. The check that rejected unknown deferred-for-expression iterables ran inside single-file `parser::parse`, which doesn't know about bindings declared in sibling `.crn` files. That caused `validate` to fail on any project where a `for ... in upstream.accounts` iterates a binding declared in `backend.crn`.

Normal `ResourceRef` values already use a two-pass pattern: unresolved `binding.attr` survives single-file parse as `Value::String`, then `resolve_resource_refs_with_config` resolves them against the merged `ParsedFile`. Deferred for-expressions now follow the same model:

- `check_undefined_bindings` no longer validates deferred-for iterables.
- A new `check_deferred_for_iterables(&ParsedFile)` runs after directory-wide merge in both `parse_directory` and `load_configuration_with_config`. It builds the `known` set from every binding source on the merged file.

## Behavior changes

Given `backend.crn` with `let orgs = upstream_state { source = '../organizations' }` and `main.crn` with `for name, account_id in orgs.accounts { ... }`:

- **`validate`** now succeeds with the existing `"(known after apply)"` warning (previously produced the misleading undefined-identifier error).
- **`plan`** with a bad `source` now surfaces `upstream_state 'orgs': cannot resolve source '../management': No such file or directory` — the accurate error from `load_upstream_states`, matching the Suggested Behavior in #1955.
- **Genuinely undefined iterables** (e.g. `for x in does_not_exist.items`) still error with `Undefined identifier`, just at the merged-directory level rather than per-file. Regression covered by `parse_directory_rejects_undefined_iterable_even_after_merge`.

## Test plan

- [x] `cargo test -p carina-core` — 1205 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual repro in `carina-rs/infra/aws/management/identity-center`:
  - correct `source` → validate passes with warning, plan proceeds
  - bad `source` → validate still passes with warning; plan errors with the accurate path-not-found message
- [x] New tests cover both cross-file acceptance and post-merge undefined rejection
- [x] Existing `undefined_identifier_in_for_iterable_is_error` updated to exercise the new post-merge path

Closes #1955