### PR TITLE
Flag missing upstream_state source paths as LSP diagnostics

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -13,6 +13,65 @@ use carina_core::schema::{ResourceSchema, suggest_similar_name};
 
 use super::{DiagnosticEngine, carina_diagnostic};
 
+/// Locate the `source = '<expected>'` or `source = "<expected>"` line inside
+/// an `upstream_state { ... }` block whose value equals `expected`. Returns
+/// `(line, start_col, end_col)` in character columns, positioned over the
+/// inner value (quotes excluded).
+///
+/// Restricting to `upstream_state` blocks avoids false matches against
+/// `provider` / `module` blocks that also take a `source` attribute.
+fn find_source_value_position(text: &str, expected: &str) -> Option<(u32, u32, u32)> {
+    let mut in_upstream_state = false;
+    let mut brace_depth: u32 = 0;
+    for (line_idx, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if !in_upstream_state && trimmed.contains("upstream_state") && trimmed.contains('{') {
+            in_upstream_state = true;
+            brace_depth = 1;
+            continue;
+        }
+        if !in_upstream_state {
+            continue;
+        }
+        // Track nested braces so a struct value inside upstream_state doesn't
+        // prematurely close the block.
+        brace_depth += trimmed.matches('{').count() as u32;
+        brace_depth = brace_depth.saturating_sub(trimmed.matches('}').count() as u32);
+        if brace_depth == 0 {
+            in_upstream_state = false;
+            continue;
+        }
+        if !trimmed.starts_with("source") {
+            continue;
+        }
+        let Some((lhs, rhs)) = trimmed.split_once('=') else {
+            continue;
+        };
+        // Skip `source` followed by non-whitespace (e.g. `source_path`).
+        if !lhs.trim_end().eq("source") {
+            continue;
+        }
+        let after_eq = rhs.trim_start();
+        let Some(quote) = after_eq.chars().next().filter(|c| *c == '\'' || *c == '"') else {
+            continue;
+        };
+        let inner = &after_eq[quote.len_utf8()..];
+        let Some(end_byte) = inner.find(quote) else {
+            continue;
+        };
+        if &inner[..end_byte] != expected {
+            continue;
+        }
+        // Columns are character counts from the start of the line up to the
+        // start of `inner` (i.e. just past the opening quote).
+        let prefix_len = line.len() - after_eq.len() + quote.len_utf8();
+        let start_col = line[..prefix_len].chars().count() as u32;
+        let end_col = start_col + inner[..end_byte].chars().count() as u32;
+        return Some((line_idx as u32, start_col, end_col));
+    }
+    None
+}
+
 /// Check if a string looks like an unresolved cross-file reference ("binding.attribute").
 fn is_dot_notation_ref(s: &str) -> bool {
     let parts: Vec<&str> = s.split('.').collect();
@@ -193,6 +252,45 @@ impl DiagnosticEngine {
             }
         }
         None
+    }
+
+    /// Flag `upstream_state { source = ... }` paths that do not resolve to an
+    /// existing directory relative to the project's base path.
+    ///
+    /// Mirrors the CLI-side check in `carina-cli::commands::validate` so editors
+    /// surface typo'd source paths as squiggles instead of waiting until the
+    /// user runs `carina validate` or `carina plan`. Cheap by design — no
+    /// canonicalize, no remote state reads.
+    pub(super) fn check_upstream_state_sources(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+        base_path: &std::path::Path,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let text = doc.text();
+
+        for us in &parsed.upstream_states {
+            if base_path.join(&us.source).is_dir() {
+                continue;
+            }
+            let source_str = us.source.to_string_lossy();
+            let Some((line, col, end_col)) = find_source_value_position(&text, &source_str) else {
+                continue;
+            };
+            diagnostics.push(carina_diagnostic(
+                line,
+                col,
+                end_col,
+                DiagnosticSeverity::ERROR,
+                format!(
+                    "upstream_state '{}': source '{}' does not exist",
+                    us.binding, source_str
+                ),
+            ));
+        }
+
+        diagnostics
     }
 
     /// Check module calls against imported module definitions

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -144,6 +144,7 @@ impl DiagnosticEngine {
             // Check module calls
             if let Some(base) = base_path {
                 diagnostics.extend(self.check_module_calls(doc, parsed, base));
+                diagnostics.extend(self.check_upstream_state_sources(doc, parsed, base));
             }
             // Build binding_name -> (provider, resource_type) map for ResourceRef type checking
             let mut binding_schema_map: HashMap<String, ResourceSchema> = HashMap::new();

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1990,3 +1990,103 @@ fn no_undefined_resource_for_sibling_binding_in_exports() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn upstream_state_missing_source_directory_is_flagged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+
+    let engine = test_engine();
+    let doc = create_document(
+        r#"let orgs = upstream_state {
+    source = '../nonexistent'
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("upstream_state 'orgs'"));
+    assert!(
+        diag.is_some(),
+        "Expected a diagnostic for missing upstream_state source. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let diag = diag.unwrap();
+    assert!(
+        diag.message.contains("../nonexistent") && diag.message.contains("does not exist"),
+        "unexpected message: {}",
+        diag.message
+    );
+    // Range should point at the source value on line 1 (0-based).
+    assert_eq!(
+        diag.range.start.line, 1,
+        "diagnostic should point at the `source = ...` line"
+    );
+}
+
+#[test]
+fn upstream_state_source_check_ignores_same_source_in_provider_block() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+
+    let engine = test_engine();
+    // A `provider` block with the same `source = '...'` string as the
+    // `upstream_state` block. The diagnostic must land on the upstream_state
+    // line (line 5 here, 0-based 4), not the provider line.
+    let doc = create_document(
+        r#"provider aws {
+    source = '../nonexistent'
+    region = 'ap-northeast-1'
+}
+let orgs = upstream_state {
+    source = '../nonexistent'
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("upstream_state 'orgs'"));
+    assert!(
+        diag.is_some(),
+        "expected diagnostic for upstream_state source. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        diag.unwrap().range.start.line,
+        5,
+        "diagnostic must point at the upstream_state source line, not the provider's"
+    );
+}
+
+#[test]
+fn upstream_state_existing_source_directory_is_ok() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("project");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::create_dir(tmp.path().join("upstream")).unwrap();
+
+    let engine = test_engine();
+    let doc = create_document(
+        r#"let orgs = upstream_state {
+    source = '../upstream'
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("upstream_state"));
+    assert!(
+        diag.is_none(),
+        "Existing source should not trigger diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Extends #1962's CLI-side \`upstream_state.source\` existence check to the LSP. Typo'd / missing source paths now show up as editor squiggles instead of being surfaced only when the user eventually runs \`carina validate\` from a shell.

- Adds \`check_upstream_state_sources\` to \`carina-lsp/src/diagnostics/checks.rs\` and wires it into \`DiagnosticEngine::analyze()\`.
- Emits \`DiagnosticSeverity::ERROR\` with the same wording as the CLI: \`upstream_state '{binding}': source '{path}' does not exist\`.
- The scanner that positions the squiggle is scoped to \`upstream_state { ... }\` blocks by brace-depth tracking, so \`source = '...'\` attributes in \`provider\` / \`module\` blocks aren't misidentified when they share the same path string.
- Column math uses char counts (not bytes), so indentation / comments with non-ASCII don't shift the range.

## Test plan

- [x] \`cargo test -p carina-lsp\` — 223 passed, including:
  - \`upstream_state_missing_source_directory_is_flagged\` — positive
  - \`upstream_state_existing_source_directory_is_ok\` — negative
  - \`upstream_state_source_check_ignores_same_source_in_provider_block\` — regression for the provider-block-aliasing edge case found during review
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean

Closes #1963