### PR TITLE
Use explicit TextEdit for upstream_state source completion

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -92,7 +92,7 @@ impl CompletionProvider {
                 self.import_path_completions(&partial_path, base_path)
             }
             CompletionContext::InsideUpstreamStateSource { partial_path } => {
-                self.upstream_state_source_completions(&partial_path, base_path)
+                self.upstream_state_source_completions(&partial_path, position, base_path)
             }
             CompletionContext::None => vec![],
         }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1,5 +1,5 @@
 use super::*;
-use tower_lsp::lsp_types::InsertTextFormat;
+use tower_lsp::lsp_types::{InsertTextFormat, TextEdit};
 
 #[test]
 #[ignore = "requires provider schemas"]
@@ -1403,7 +1403,10 @@ fn upstream_state_source_suggestions_work_with_double_quotes() {
     );
 }
 
-fn assert_staging_insert_text_is_bare(source: &str) {
+/// Run the completion provider on `source` (a 2-line snippet whose second
+/// line contains `source = ...<cursor>`), find the `../staging` suggestion,
+/// and return its `TextEdit`.
+fn staging_text_edit(source: &str) -> TextEdit {
     use std::fs;
     use tempfile::tempdir;
 
@@ -1416,38 +1419,53 @@ fn assert_staging_insert_text_is_bare(source: &str) {
 
     let provider = test_provider();
     let doc = create_document(source);
+    // Place the cursor at the end of the second line (where the user just typed).
+    let last_line = source.lines().next_back().unwrap_or("");
     let position = Position {
         line: 1,
-        character: 14,
+        character: last_line.chars().count() as u32,
     };
 
     let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
     let staging = completions
         .iter()
         .find(|c| c.label.contains("../staging"))
-        .expect("expected a staging suggestion");
+        .unwrap_or_else(|| panic!("expected a staging suggestion for source {source:?}"));
 
-    let insert_text = staging
-        .insert_text
-        .as_deref()
-        .expect("staging suggestion must have insert_text");
-    assert_eq!(
-        insert_text, "../staging",
-        "insert_text must be the bare path, not wrapped in quotes (source: {source:?})"
-    );
+    match staging.text_edit.as_ref() {
+        Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) => edit.clone(),
+        other => panic!("expected text_edit::Edit, got {other:?}"),
+    }
 }
 
 #[test]
-fn upstream_state_source_insert_text_has_no_surrounding_quotes_single() {
+fn upstream_state_source_text_edit_inserts_bare_path_single_quote() {
     // #1956: the completion triggers with the cursor already inside an open
-    // quote, so `insert_text` must be the bare path — otherwise accepting a
-    // suggestion produces nested quotes like `'../'../staging''`.
-    assert_staging_insert_text_is_bare("let orgs = upstream_state {\n    source = '");
+    // quote, so the inserted text must be the bare path — otherwise accepting
+    // a suggestion produces nested quotes like `'../'../staging''`.
+    let edit = staging_text_edit("let orgs = upstream_state {\n    source = '");
+    assert_eq!(edit.new_text, "../staging");
 }
 
 #[test]
-fn upstream_state_source_insert_text_has_no_surrounding_quotes_double() {
-    // Same invariant for `source = "..."`, since both quote styles share the
-    // same completion path.
-    assert_staging_insert_text_is_bare("let orgs = upstream_state {\n    source = \"");
+fn upstream_state_source_text_edit_inserts_bare_path_double_quote() {
+    let edit = staging_text_edit("let orgs = upstream_state {\n    source = \"");
+    assert_eq!(edit.new_text, "../staging");
+}
+
+#[test]
+fn upstream_state_source_text_edit_range_covers_typed_partial() {
+    // #1956: when the user has typed a partial path (`../st`), the text edit
+    // must replace the whole partial, not just the trailing word. A plain
+    // `insert_text` would let the client infer the range via word boundaries
+    // and split on `/`/`.`, yielding `../../staging` instead of `../staging`.
+    let source = "let orgs = upstream_state {\n    source = '../st";
+    let edit = staging_text_edit(source);
+    assert_eq!(edit.new_text, "../staging");
+    // `    source = '` occupies cols 0..14, so the partial `../st` starts at
+    // col 14 and ends at the cursor at col 19.
+    assert_eq!(edit.range.start.line, 1);
+    assert_eq!(edit.range.start.character, 14);
+    assert_eq!(edit.range.end.line, 1);
+    assert_eq!(edit.range.end.character, 19);
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1402,3 +1402,52 @@ fn upstream_state_source_suggestions_work_with_double_quotes() {
         labels
     );
 }
+
+fn assert_staging_insert_text_is_bare(source: &str) {
+    use std::fs;
+    use tempfile::tempdir;
+
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("envs/prod")).unwrap();
+    fs::create_dir_all(root.join("envs/staging")).unwrap();
+    fs::write(root.join("envs/prod/main.crn"), "").unwrap();
+    fs::write(root.join("envs/staging/main.crn"), "").unwrap();
+
+    let provider = test_provider();
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: 14,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&root.join("envs/prod")));
+    let staging = completions
+        .iter()
+        .find(|c| c.label.contains("../staging"))
+        .expect("expected a staging suggestion");
+
+    let insert_text = staging
+        .insert_text
+        .as_deref()
+        .expect("staging suggestion must have insert_text");
+    assert_eq!(
+        insert_text, "../staging",
+        "insert_text must be the bare path, not wrapped in quotes (source: {source:?})"
+    );
+}
+
+#[test]
+fn upstream_state_source_insert_text_has_no_surrounding_quotes_single() {
+    // #1956: the completion triggers with the cursor already inside an open
+    // quote, so `insert_text` must be the bare path — otherwise accepting a
+    // suggestion produces nested quotes like `'../'../staging''`.
+    assert_staging_insert_text_is_bare("let orgs = upstream_state {\n    source = '");
+}
+
+#[test]
+fn upstream_state_source_insert_text_has_no_surrounding_quotes_double() {
+    // Same invariant for `source = "..."`, since both quote styles share the
+    // same completion path.
+    assert_staging_insert_text_is_bare("let orgs = upstream_state {\n    source = \"");
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -475,6 +475,7 @@ impl CompletionProvider {
     pub(super) fn upstream_state_source_completions(
         &self,
         partial_path: &str,
+        position: Position,
         base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let Some(base) = base_path else {
@@ -505,20 +506,34 @@ impl CompletionProvider {
         // Truncated by ancestor discovery order (nearest first), then sorted for display.
         suggestions.sort();
 
+        // Replace the typed partial (from just after the opening quote to the
+        // cursor) with the full suggestion. A plain `insert_text` would leave
+        // the client to infer the replacement range via word boundaries, which
+        // splits on `/` and `.` and produces `../../foo` when the user typed
+        // `../or` — an explicit TextEdit avoids that.
+        let partial_chars = partial_path.chars().count() as u32;
+        let range = Range {
+            start: Position {
+                line: position.line,
+                character: position.character.saturating_sub(partial_chars),
+            },
+            end: position,
+        };
+
         suggestions
             .into_iter()
             .filter(|p| partial_path.is_empty() || p.starts_with(partial_path))
             .map(|p| CompletionItem {
-                // Completion fires with the cursor already inside an open
-                // quote (see `extract_upstream_source_partial`), so the
-                // insert text must be the bare path — wrapping it in quotes
-                // would produce nested-quoted output like `'../'../foo''`.
-                // The label keeps quotes for display consistency with how
-                // the value appears in the source.
+                // Label keeps quotes so the popup reads like the source form;
+                // the TextEdit inserts the bare path, since the cursor is
+                // already inside an open quote.
                 label: format!("'{}'", p),
                 kind: Some(CompletionItemKind::FOLDER),
                 detail: Some("Carina project".to_string()),
-                insert_text: Some(p),
+                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: p,
+                })),
                 ..Default::default()
             })
             .collect()

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -508,15 +508,18 @@ impl CompletionProvider {
         suggestions
             .into_iter()
             .filter(|p| partial_path.is_empty() || p.starts_with(partial_path))
-            .map(|p| {
-                let quoted = format!("'{}'", p);
-                CompletionItem {
-                    label: quoted.clone(),
-                    kind: Some(CompletionItemKind::FOLDER),
-                    detail: Some("Carina project".to_string()),
-                    insert_text: Some(quoted),
-                    ..Default::default()
-                }
+            .map(|p| CompletionItem {
+                // Completion fires with the cursor already inside an open
+                // quote (see `extract_upstream_source_partial`), so the
+                // insert text must be the bare path — wrapping it in quotes
+                // would produce nested-quoted output like `'../'../foo''`.
+                // The label keeps quotes for display consistency with how
+                // the value appears in the source.
+                label: format!("'{}'", p),
+                kind: Some(CompletionItemKind::FOLDER),
+                detail: Some("Carina project".to_string()),
+                insert_text: Some(p),
+                ..Default::default()
             })
             .collect()
     }


### PR DESCRIPTION
## Summary

Fixes #1956 for all cursor positions inside the quoted value, not just right after the opening quote.

The original attempt (Option 1: bare \`insert_text\`) handled the nested-quote case but regressed when the user had typed a partial path like \`source = '../or\`. Accepting \`../organizations\` then produced \`'../../organizations'\` because the client infers the replacement range via word boundaries (splitting on \`/\` and \`.\`) and only replaced \`or\`, leaving the original \`../\` behind.

This PR switches to Option 2 from the issue: each completion item carries an explicit \`TextEdit\` whose range covers the full typed partial — from just after the opening quote through the cursor position. The client replaces exactly that range with the full path, independent of any word-boundary heuristics.

## Changes

- \`carina-lsp/src/completion/mod.rs\`: thread \`position\` into \`upstream_state_source_completions\`.
- \`carina-lsp/src/completion/values.rs\`: emit \`text_edit\` (range = partial span, new_text = bare path). Label stays quoted for display.

## Test plan

- [x] \`cargo test -p carina-lsp\` — 226 passed, including:
  - \`upstream_state_source_text_edit_inserts_bare_path_single_quote\`
  - \`upstream_state_source_text_edit_inserts_bare_path_double_quote\`
  - \`upstream_state_source_text_edit_range_covers_typed_partial\` — regression for the \`../or\` → \`../../organizations\` case
  - existing \`upstream_state_source_*\` tests still green
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean

Closes #1956