### PR TITLE
Migrate remaining inspection walkers to Value::visit_refs

### DIFF
--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -34,38 +34,9 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
 
 /// Recursively collect resource reference dependencies from a value
 fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
-    match value {
-        Value::ResourceRef { path } => {
-            deps.insert(path.binding().to_string());
-        }
-        Value::List(items) => {
-            for item in items {
-                collect_dependencies(item, deps);
-            }
-        }
-        Value::Map(map) => {
-            for v in map.values() {
-                collect_dependencies(v, deps);
-            }
-        }
-        Value::Interpolation(parts) => {
-            use crate::resource::InterpolationPart;
-            for part in parts {
-                if let InterpolationPart::Expr(v) = part {
-                    collect_dependencies(v, deps);
-                }
-            }
-        }
-        Value::FunctionCall { args, .. } => {
-            for arg in args {
-                collect_dependencies(arg, deps);
-            }
-        }
-        Value::Secret(inner) => {
-            collect_dependencies(inner, deps);
-        }
-        _ => {}
-    }
+    value.visit_refs(&mut |path| {
+        deps.insert(path.binding().to_string());
+    });
 }
 
 /// Sort resources topologically based on dependencies.
@@ -316,6 +287,31 @@ mod tests {
         assert!(deps.contains("b"));
         assert!(deps.contains("c"));
         assert_eq!(deps.len(), 2);
+    }
+
+    /// Regression: a ResourceRef inside a `Closure`'s captured args must show
+    /// up as a dependency. The prior hand-rolled walk had no `Closure` arm
+    /// and silently dropped these refs, which in turn let the topological
+    /// sort place the dependent resource before its upstream.
+    #[test]
+    fn collect_dependencies_finds_refs_inside_closure() {
+        let mut resource = Resource::new("test", "a");
+        resource.binding = Some("a".to_string());
+        resource.set_attr(
+            "fn".to_string(),
+            Value::Closure {
+                name: "map".to_string(),
+                captured_args: vec![Value::resource_ref("upstream", "id", vec![])],
+                remaining_arity: 1,
+            },
+        );
+
+        let deps = get_resource_dependencies(&resource);
+        assert!(
+            deps.contains("upstream"),
+            "Expected deps to include 'upstream' from Closure captured_args. Got: {:?}",
+            deps
+        );
     }
 
     /// Regression test for #1078: when resolve_refs_with_state partially resolves

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -6,7 +6,9 @@
 use std::collections::HashMap;
 
 use crate::deps::get_resource_dependencies;
-use crate::resource::{Expr, InterpolationPart, Resource, ResourceId, State, Value};
+use crate::resource::{
+    Expr, InterpolationPart, Resource, ResourceId, State, Value, contains_resource_ref,
+};
 
 /// Resolve all ResourceRef values in resources using current state.
 ///
@@ -218,23 +220,6 @@ pub fn resolve_ref_value(
             })
         }
         _ => Ok(value.clone()),
-    }
-}
-
-/// Check if a Value contains any ResourceRef (possibly nested)
-fn contains_resource_ref(value: &Value) -> bool {
-    match value {
-        Value::ResourceRef { .. } => true,
-        Value::List(items) => items.iter().any(contains_resource_ref),
-        Value::Map(map) => map.values().any(contains_resource_ref),
-        Value::Interpolation(parts) => parts.iter().any(|p| match p {
-            InterpolationPart::Expr(v) => contains_resource_ref(v),
-            _ => false,
-        }),
-        Value::FunctionCall { args, .. } => args.iter().any(contains_resource_ref),
-        Value::Secret(inner) => contains_resource_ref(inner),
-        Value::Closure { captured_args, .. } => captured_args.iter().any(contains_resource_ref),
-        _ => false,
     }
 }
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -393,19 +393,9 @@ impl std::ops::DerefMut for Expr {
 
 /// Check if a Value contains any ResourceRef (possibly nested)
 pub fn contains_resource_ref(value: &Value) -> bool {
-    match value {
-        Value::ResourceRef { .. } => true,
-        Value::List(items) => items.iter().any(contains_resource_ref),
-        Value::Map(map) => map.values().any(contains_resource_ref),
-        Value::Interpolation(parts) => parts.iter().any(|p| match p {
-            InterpolationPart::Expr(v) => contains_resource_ref(v),
-            _ => false,
-        }),
-        Value::FunctionCall { args, .. } => args.iter().any(contains_resource_ref),
-        Value::Secret(inner) => contains_resource_ref(inner),
-        Value::Closure { captured_args, .. } => captured_args.iter().any(contains_resource_ref),
-        _ => false,
-    }
+    let mut found = false;
+    value.visit_refs(&mut |_| found = true);
+    found
 }
 
 impl Value {

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1142,68 +1142,37 @@ impl DiagnosticEngine {
         binding_schema_map: &HashMap<String, ResourceSchema>,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
-        match value {
-            Value::ResourceRef { path } => {
-                let binding_name = path.binding();
-                let attribute_name = path.attribute();
-                let Some(ref_schema) = binding_schema_map.get(binding_name) else {
-                    return;
-                };
-                if ref_schema.attributes.contains_key(attribute_name) {
-                    return;
-                }
-                // Attribute not found - build "did you mean" suggestion
-                let known_attrs: Vec<&str> =
-                    ref_schema.attributes.keys().map(|s| s.as_str()).collect();
-                let suggestion = suggest_similar_name(attribute_name, &known_attrs)
-                    .map(|s| format!(" Did you mean '{}'?", s))
-                    .unwrap_or_default();
+        value.visit_refs(&mut |path| {
+            let binding_name = path.binding();
+            let attribute_name = path.attribute();
+            let Some(ref_schema) = binding_schema_map.get(binding_name) else {
+                return;
+            };
+            if ref_schema.attributes.contains_key(attribute_name) {
+                return;
+            }
+            // Attribute not found - build "did you mean" suggestion
+            let known_attrs: Vec<&str> = ref_schema.attributes.keys().map(|s| s.as_str()).collect();
+            let suggestion = suggest_similar_name(attribute_name, &known_attrs)
+                .map(|s| format!(" Did you mean '{}'?", s))
+                .unwrap_or_default();
 
-                let ref_text = format!("{}.{}", binding_name, attribute_name);
-                if let Some((line, col)) = self.find_ref_value_position(doc, &ref_text) {
-                    // Highlight just the attribute part (after the dot)
-                    let attr_col = col + binding_name.len() as u32 + 1; // +1 for the dot
-                    diagnostics.push(carina_diagnostic(
-                        line,
-                        attr_col,
-                        attr_col + attribute_name.len() as u32,
-                        DiagnosticSeverity::WARNING,
-                        format!(
-                            "Unknown attribute '{}' on '{}' (type '{}'){}",
-                            attribute_name, binding_name, ref_schema.resource_type, suggestion,
-                        ),
-                    ));
-                }
+            let ref_text = format!("{}.{}", binding_name, attribute_name);
+            if let Some((line, col)) = self.find_ref_value_position(doc, &ref_text) {
+                // Highlight just the attribute part (after the dot)
+                let attr_col = col + binding_name.len() as u32 + 1; // +1 for the dot
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    attr_col,
+                    attr_col + attribute_name.len() as u32,
+                    DiagnosticSeverity::WARNING,
+                    format!(
+                        "Unknown attribute '{}' on '{}' (type '{}'){}",
+                        attribute_name, binding_name, ref_schema.resource_type, suggestion,
+                    ),
+                ));
             }
-            Value::List(items) => {
-                for item in items {
-                    self.collect_ref_attr_diagnostics(doc, item, binding_schema_map, diagnostics);
-                }
-            }
-            Value::Map(map) => {
-                for v in map.values() {
-                    self.collect_ref_attr_diagnostics(doc, v, binding_schema_map, diagnostics);
-                }
-            }
-            Value::Interpolation(parts) => {
-                for part in parts {
-                    if let carina_core::resource::InterpolationPart::Expr(expr) = part {
-                        self.collect_ref_attr_diagnostics(
-                            doc,
-                            expr,
-                            binding_schema_map,
-                            diagnostics,
-                        );
-                    }
-                }
-            }
-            Value::FunctionCall { args, .. } => {
-                for arg in args {
-                    self.collect_ref_attr_diagnostics(doc, arg, binding_schema_map, diagnostics);
-                }
-            }
-            _ => {}
-        }
+        });
     }
 
     /// Find the position of a resource reference value (e.g., "igw.internet_gateway_id") in the document.


### PR DESCRIPTION
## Summary

Follow-up to #1951, completing the visitor migration for the four inspection-only \`Value\` walkers flagged during that PR's review:

1. \`carina-core/src/resource.rs::contains_resource_ref\`
2. \`carina-core/src/resolver.rs::contains_resource_ref\` — byte-identical duplicate, deleted in favour of importing the public one from \`resource\`
3. \`carina-core/src/deps.rs::collect_dependencies\` — also closes a latent gap: the old walk had no \`Closure\` arm and silently dropped refs nested in captured args
4. \`carina-lsp/src/diagnostics/checks.rs::collect_ref_attr_diagnostics\` — also extends diagnostic coverage to refs inside \`FunctionCall\`, \`Secret\`, and \`Closure\` variants

Net −60 lines. Adds a regression test for the \`Closure\` dependency case (\`collect_dependencies_finds_refs_inside_closure\`).

## Out of scope

- Parser-side rewriters (\`substitute_fn_params\`, \`substitute_placeholder\`, \`resolve_forward_ref_in_value\`) still walk manually — they rewrite \`Value\` in place and need a separate \`visit_refs_mut\` API.
- Simplify review found two more inspection walkers (\`value_references_binding\` in \`detail_rows.rs\` and \`display.rs\`) that would benefit from the same treatment. Tracked as #1971 to keep this PR focused on the four listed in #1957.

## Test plan

- [x] \`cargo test\` — full workspace green (carina-core 1206, carina-lsp 226, carina-cli 259, and others)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] New regression test \`collect_dependencies_finds_refs_inside_closure\` verifies the fixed \`Closure\` gap

Closes #1957