### PR TITLE
Build WASM mock fixture in CI and fix test path lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,13 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
+      # Build the WASM fixture so carina-plugin-host's integration tests run
+      # instead of silently skipping. Without this step a stale or missing
+      # fixture leaves the wasm_integration_test suite as a no-op in CI.
+      - run: cargo build -p carina-provider-mock --target wasm32-wasip2
       - run: cargo test --all-features
 
   binary-build:

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -34,12 +34,25 @@ macro_rules! skip_if_no_wasm {
     };
 }
 
+/// Build a `WasmProviderFactory` using a per-test temporary cache directory.
+///
+/// Tests in this binary run in parallel; if they all shared
+/// `WasmProviderFactory::new()`'s default `~/.carina/cache`, concurrent
+/// precompile runs race on the same `.cwasm` path and one test can observe
+/// a partially-written file (`"failed to load code for …"`). Each test gets
+/// its own cache dir via this helper to eliminate that race.
+async fn load_factory(wasm: &std::path::Path) -> (WasmProviderFactory, tempfile::TempDir) {
+    let cache = tempfile::tempdir().expect("Failed to create cache tempdir");
+    let factory = WasmProviderFactory::from_file_cached(wasm, cache.path())
+        .await
+        .expect("Failed to load WASM provider");
+    (factory, cache)
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_factory() {
     let path = skip_if_no_wasm!();
-    let factory = WasmProviderFactory::new(path)
-        .await
-        .expect("Failed to load WASM provider");
+    let (factory, _cache) = load_factory(&path).await;
 
     assert_eq!(factory.name(), "mock");
     assert_eq!(factory.display_name(), "Mock Provider (Process)");
@@ -52,9 +65,7 @@ async fn test_wasm_mock_provider_factory() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_create_and_read() {
     let path = skip_if_no_wasm!();
-    let factory = WasmProviderFactory::new(path)
-        .await
-        .expect("Failed to load WASM provider");
+    let (factory, _cache) = load_factory(&path).await;
     let provider = factory.create_provider(&HashMap::new()).await;
 
     assert_eq!(provider.name(), "mock");
@@ -111,9 +122,7 @@ async fn test_wasm_mock_provider_create_and_read() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_update_and_delete() {
     let path = skip_if_no_wasm!();
-    let factory = WasmProviderFactory::new(path)
-        .await
-        .expect("Failed to load WASM provider");
+    let (factory, _cache) = load_factory(&path).await;
     let provider = factory.create_provider(&HashMap::new()).await;
 
     let id = ResourceId::with_provider("mock", "test.resource", "updatable");
@@ -180,9 +189,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_normalizer() {
     let path = skip_if_no_wasm!();
-    let factory = WasmProviderFactory::new(path)
-        .await
-        .expect("Failed to load WASM provider");
+    let (factory, _cache) = load_factory(&path).await;
     let normalizer = factory.create_normalizer(&HashMap::new()).await;
 
     // normalize_desired: mock provider returns resources unchanged
@@ -218,9 +225,7 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     // into state plus a sentinel `__mock_read_data_source__` flag. If
     // that flag shows up, the WASM bridge forwarded the call correctly.
     let path = skip_if_no_wasm!();
-    let factory = WasmProviderFactory::new(path)
-        .await
-        .expect("Failed to load WASM provider");
+    let (factory, _cache) = load_factory(&path).await;
     let provider = factory.create_provider(&HashMap::new()).await;
 
     let mut resource = Resource::with_provider("mock", "test.data_source", "example");

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -9,8 +9,14 @@ use carina_plugin_host::WasmProviderFactory;
 
 fn wasm_path() -> Option<PathBuf> {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
-    let path = workspace_root.join("target/wasm32-wasip2/debug/carina_provider_mock.wasm");
-    if path.exists() { Some(path) } else { None }
+    // Cargo uses hyphens in binary names but underscores in library names; check both.
+    for name in &["carina_provider_mock.wasm", "carina-provider-mock.wasm"] {
+        let path = workspace_root.join("target/wasm32-wasip2/debug").join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 macro_rules! skip_if_no_wasm {


### PR DESCRIPTION
## Summary

Fixes #1960. Two bugs were causing all 5 tests in \`carina-plugin-host/tests/wasm_integration_test.rs\` to skip silently in CI (and fail locally with a stale build):

1. **CI never built the WASM fixture.** The \`test\` job just ran \`cargo test --all-features\`, so the integration tests short-circuited via \`skip_if_no_wasm!\`. Regressions (like the recent \`validate-custom-type\` export addition that exposed the stale local fixture in #1960) never surfaced in CI.

2. **Path lookup mismatched \`cargo build\`'s output.** \`wasm_integration_test.rs::wasm_path()\` only looked for \`carina_provider_mock.wasm\` (underscore), but \`cargo build\` emits \`carina-provider-mock.wasm\` (hyphen). Some contributors had a manual underscore→hyphen symlink in their target dir, hiding the issue locally. The sibling \`wasm_precompile_test.rs\` already checked both names; mirror that here.

## Changes

- \`.github/workflows/ci.yml\` — \`test\` job installs \`wasm32-wasip2\` target and builds \`carina-provider-mock\` before \`cargo test\`.
- \`carina-plugin-host/tests/wasm_integration_test.rs\` — \`wasm_path()\` now falls back to both naming conventions.

## Test plan

- [x] \`cargo test --all-features\` — full workspace green, including the 5 previously-skipping wasm integration tests (\`test_wasm_mock_provider_factory\`, \`…_create_and_read\`, \`…_update_and_delete\`, \`…_normalizer\`, \`…_read_data_source_dispatches_override\`)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean (pre-commit hook)
- [x] Verified locally: the integration tests that fail with a stale fixture now pass after rebuilding \`carina-provider-mock --target wasm32-wasip2\` — which is exactly what the new CI step does

Closes #1960