### PR TITLE
Drop factory before mutating cwasm in stale-cache recovery test

### DIFF
--- a/carina-plugin-host/tests/wasm_precompile_test.rs
+++ b/carina-plugin-host/tests/wasm_precompile_test.rs
@@ -108,13 +108,21 @@ async fn test_from_file_cached_recovers_from_stale_cache() {
         .expect("initial from_file_cached should succeed");
     assert_eq!(factory.name(), "mock");
 
-    // Find the .cwasm file and corrupt it
+    // Find the .cwasm file before dropping the factory (path only, no access).
     let cwasm_path = std::fs::read_dir(cache_dir.path())
         .expect("read_dir")
         .filter_map(|e| e.ok())
         .find(|e| e.path().extension().is_some_and(|ext| ext == "cwasm"))
         .expect("should find .cwasm file")
         .path();
+
+    // Drop the factory — and therefore its mmap of this file — before
+    // overwriting. On Linux, mutating a file while a file-backed mmap of it
+    // is live results in SIGBUS on any later access to the now-invalid
+    // pages; macOS is more lenient, which is why this test slipped through
+    // locally.
+    drop(factory);
+
     std::fs::write(&cwasm_path, b"not a valid cwasm file")
         .expect("Failed to write stale cache file");
 


### PR DESCRIPTION
## Summary

Fixes #1976: \`test_from_file_cached_recovers_from_stale_cache\` crashed with \`SIGBUS\` on the ubuntu-latest CI runner once the WASM fixture actually reached it (exposed by #1960 / PR #1975).

### Root cause

The test flow is:

1. \`from_file_cached\` compiles, writes the \`.cwasm\`, and loads it via wasmtime's \`Component::deserialize_file\` — which **mmaps** the cwasm.
2. The test overwrites the file with garbage via \`std::fs::write\`.
3. A second \`from_file_cached\` call is expected to detect the corrupt cache, recompile, and succeed.

Between (1) and (2) the first \`WasmProviderFactory\` was still alive (its binding is shadowed only after the second call completes), so its file-backed mmap was still mapped when \`fs::write\` truncated+replaced the file. On Linux that leaves the mapped region without backing pages; any subsequent access traps as \`SIGBUS\`. macOS's VM handles the same pattern more gracefully, which is why the test had been passing locally.

### Fix

Explicitly \`drop(factory)\` before overwriting the \`.cwasm\`. The test still exercises cache-invalidation recovery — the second call observes an invalid cache and recompiles — but no longer relies on any live mmap of the old contents.

### Verification

The fix was validated by pushing iterative debug CI jobs that isolated the SIGBUS to this single test on Linux and then confirmed the patched test passes on the same runner. Those debug jobs are not part of the final commit.

Related: #1978 tracks a structural guardrail around \`new_with_cache_dir\`'s retry path so the same mmap-vs-mutation pattern cannot be reintroduced in production code.

## Test plan

- [x] \`cargo test -p carina-plugin-host --test wasm_precompile_test\` — 6/6 green locally
- [x] CI \`Test\` job green (the regular CI path still skips wasm integration tests by design — #1975 is the PR that turns that on permanently)

Closes #1976