### PR TITLE
Migrate detail_rows value_references_binding to Value::visit_refs

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -938,12 +938,13 @@ fn is_both_maps(old_value: Option<&Value>, new_value: &Value) -> bool {
 
 /// Check whether a Value references the given binding name.
 fn value_references_binding(value: &Value, binding: &str) -> bool {
-    match value {
-        Value::ResourceRef { path } => path.binding() == binding,
-        Value::List(items) => items.iter().any(|v| value_references_binding(v, binding)),
-        Value::Map(map) => map.values().any(|v| value_references_binding(v, binding)),
-        _ => false,
-    }
+    let mut found = false;
+    value.visit_refs(&mut |path| {
+        if path.binding() == binding {
+            found = true;
+        }
+    });
+    found
 }
 
 #[cfg(test)]
@@ -1164,5 +1165,45 @@ mod tests {
         let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
         assert_eq!(rows.len(), 1);
         assert!(matches!(&rows[0], DetailRow::ReplaceChanged { key, .. } if key == "cidr_block"));
+    }
+
+    /// The pre-#1971 hand-rolled walker only descended into `List` and `Map`,
+    /// so a ResourceRef nested inside `Interpolation` / `FunctionCall` /
+    /// `Secret` / `Closure` would fail to mark the attribute as referencing
+    /// the binding. Guard against regressing that after migrating to
+    /// `Value::visit_refs`.
+    #[test]
+    fn value_references_binding_covers_non_container_variants() {
+        use crate::resource::InterpolationPart;
+
+        let refs_vpc = Value::resource_ref("vpc", "id", vec![]);
+
+        let interpolation = Value::Interpolation(vec![
+            InterpolationPart::Literal("vpc-".to_string()),
+            InterpolationPart::Expr(refs_vpc.clone()),
+        ]);
+        assert!(value_references_binding(&interpolation, "vpc"));
+
+        let function_call = Value::FunctionCall {
+            name: "join".to_string(),
+            args: vec![Value::String(",".to_string()), refs_vpc.clone()],
+        };
+        assert!(value_references_binding(&function_call, "vpc"));
+
+        let secret = Value::Secret(Box::new(refs_vpc.clone()));
+        assert!(value_references_binding(&secret, "vpc"));
+
+        let closure = Value::Closure {
+            name: "map".to_string(),
+            captured_args: vec![refs_vpc],
+            remaining_arity: 1,
+        };
+        assert!(value_references_binding(&closure, "vpc"));
+
+        // Still false when the binding is genuinely absent.
+        assert!(!value_references_binding(
+            &Value::String("plain".to_string()),
+            "vpc"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1957. Replaces the hand-rolled \`value_references_binding\` walker in \`carina-core/src/detail_rows.rs\` with \`Value::visit_refs\`, completing the visitor migration tracked in #1957's review.

The old walker only descended through \`List\` and \`Map\`, so a \`ResourceRef\` nested inside \`Interpolation\`, \`FunctionCall\`, \`Secret\`, or \`Closure\` was silently ignored — meaning \`build_detail_rows\` could miss cascading-update attributes whose value references the replaced binding from inside any of those variants. Migrating to \`visit_refs\` picks up that coverage for free.

Adds a direct regression test for the four previously-missed variants.

## Scope note

The issue described a second, "byte-identical" copy in \`carina-cli/src/display.rs\`. On inspection it turned out to be \`#[cfg(test)]\` test scaffolding (only used by another \`#[cfg(test)]\` function, \`format_cascading_update_diff\`), not production code — so it does not share the coverage gap. Left alone to keep this PR focused on the production walker; can be cleaned up separately if desired.

## Test plan

- [x] \`cargo test\` full workspace green
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] New \`value_references_binding_covers_non_container_variants\` test exercises Interpolation / FunctionCall / Secret / Closure
- [x] Existing detail_rows tests still pass, confirming semantic parity for \`ResourceRef\` / \`List\` / \`Map\`

Closes #1971