### PR TITLE
Document precompile() mmap-safety invariant and add guard test

### DIFF
--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -975,6 +975,25 @@ impl WasmProviderFactory {
     }
 
     /// Precompile a .wasm file and save the result to a .cwasm file.
+    ///
+    /// **Mmap safety invariant:** `from_precompiled` loads `.cwasm` via
+    /// `Component::deserialize_file`, which keeps the file memory-mapped for
+    /// the lifetime of the returned `Component`. Any in-place mutation of
+    /// `cwasm_path` — including `std::fs::write(cwasm_path, …)` or
+    /// `OpenOptions::truncate(true)` — while a previous `Component` is still
+    /// alive pulls backing pages out from under the mmap region; subsequent
+    /// access then traps as `SIGBUS` on Linux (macOS is more lenient, so a
+    /// bug slipping through on macOS still blows up in CI).
+    ///
+    /// To honor the invariant, this function writes to a sibling temp file
+    /// and then `rename()`s it onto `cwasm_path`. Rename creates a new inode
+    /// while keeping the old one alive until its last mapping closes, so any
+    /// previously-loaded factories remain valid. Do not "simplify" this to
+    /// a direct `std::fs::write(cwasm_path, …)`.
+    ///
+    /// The tempfile path includes the current process ID so that multiple
+    /// processes racing to precompile the same component don't clobber each
+    /// other's in-progress writes.
     pub fn precompile(wasm_path: &Path, cwasm_path: &Path) -> Result<(), String> {
         let config = build_engine_config();
         let engine = Engine::new(&config).map_err(|e| format!("Engine error: {e}"))?;
@@ -984,8 +1003,8 @@ impl WasmProviderFactory {
             .map_err(|e| format!("Precompile error: {e}"))?;
         if let Some(parent) = cwasm_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("Mkdir error: {e}"))?;
-            // Write to a temp file and atomically rename to avoid race conditions
-            // when multiple processes precompile the same component concurrently.
+            // Tempfile + atomic rename; preserves any live mmap held by a
+            // previously-loaded Component (see doc comment above for why).
             let tmp_path = parent.join(format!(
                 ".{}.tmp.{}",
                 cwasm_path

--- a/carina-plugin-host/tests/wasm_precompile_test.rs
+++ b/carina-plugin-host/tests/wasm_precompile_test.rs
@@ -200,3 +200,38 @@ async fn test_new_uses_default_cache() {
         "Cache file should not be rewritten on second call"
     );
 }
+
+/// Regression guard for #1978. `Component::deserialize_file` mmap's the
+/// `.cwasm`. If `precompile` ever starts writing the target path in place
+/// (instead of write-tempfile + atomic rename), a second precompile run on
+/// the same path while an earlier factory's mmap is still live will trap
+/// as SIGBUS on Linux — the same failure mode that broke #1976's test.
+///
+/// This test loads a factory, keeps it alive, overwrites the cache via the
+/// public `precompile` API, loads a second factory from the same path, and
+/// then lets both drop. If the invariant holds the whole sequence is a
+/// no-op from the user's perspective; if someone breaks it, the Linux CI
+/// runner crashes here.
+#[tokio::test(flavor = "multi_thread")]
+async fn precompile_preserves_prior_factory_mmap() {
+    let wasm = skip_if_no_wasm!();
+    let cache_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let cwasm_path = cache_dir.path().join("carina_provider_mock.cwasm");
+
+    WasmProviderFactory::precompile(&wasm, &cwasm_path).expect("initial precompile should succeed");
+    let factory1 = WasmProviderFactory::from_precompiled(&cwasm_path)
+        .await
+        .expect("first from_precompiled should succeed");
+
+    // Overwrite the cache file via the public API while `factory1` still
+    // holds its mmap. A `precompile` implementation that writes in place
+    // would pull backing pages out from under `factory1`'s Component.
+    WasmProviderFactory::precompile(&wasm, &cwasm_path).expect("second precompile should succeed");
+
+    let factory2 = WasmProviderFactory::from_precompiled(&cwasm_path)
+        .await
+        .expect("second from_precompiled should succeed");
+
+    assert_eq!(factory1.name(), "mock");
+    assert_eq!(factory2.name(), "mock");
+}


### PR DESCRIPTION
## Summary

Follow-up guardrail for #1976. \`from_precompiled\` loads \`.cwasm\` through \`Component::deserialize_file\`, which keeps the file memory-mapped for the lifetime of the returned \`Component\`. An in-place mutation of the same \`cwasm_path\` while a previously-loaded \`Component\` is still alive pulls backing pages out from under the mmap region; subsequent access traps as \`SIGBUS\` on Linux. That exact failure mode broke the \`wasm_precompile_test\` stale-cache recovery test under #1976.

\`precompile\` already avoids the footgun by writing a sibling tempfile and \`rename\`-ing onto \`cwasm_path\` — because rename creates a new inode, any previously-loaded factory's mmap stays valid until its last reference drops. The original comment only mentioned the cross-process race, so a future "simplify" pass could easily flatten this to \`std::fs::write(cwasm_path, …)\` and reintroduce the latent bug.

This PR:

- Expands the doc comment on \`precompile\` to spell out the mmap-safety invariant (including the \`OpenOptions::truncate(true)\` variant of the same footgun), and adds a pointer from the inline comment.
- Adds a regression test (\`precompile_preserves_prior_factory_mmap\`) that exercises the invariant end-to-end through the public API: load a factory, keep it alive, \`precompile\` the same path again, load a second factory, drop both. If anyone breaks \`precompile\`'s atomicity, this test crashes on the Linux CI runner.

## Test plan

- [x] \`cargo test -p carina-plugin-host --test wasm_precompile_test\` — 7/7 green including the new guard
- [x] \`cargo clippy --all-targets -- -D warnings\` clean

Closes #1978