### PR TITLE
Soften upstream_state validate warning to not assert absence

### DIFF
--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -43,7 +43,7 @@ pub fn run_validate(
     let base_dir = get_base_dir(path);
 
     // Surface bad `upstream_state.source` paths before printing warnings —
-    // otherwise the "is not yet in the upstream state" warning implies the
+    // otherwise the "validate does not inspect" warning implies the
     // source is reachable and misdirects the user.
     check_upstream_state_sources(base_dir, &parsed.upstream_states)?;
 

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -216,7 +216,7 @@ fn upgrade_cross_file_warnings(merged: &mut ParsedFile, unresolved: &ParsedFile)
             .find(|u| u.binding == binding_name)
         {
             let new_msg = format!(
-                "`{}` is not yet in the upstream state (upstream_state '{}' → {}).\n    Apply that directory first, then re-plan.",
+                "`{}` depends on upstream_state '{}' ({}), which validate does not inspect.",
                 path_str,
                 binding_name,
                 us.source.display(),
@@ -821,6 +821,77 @@ let orgs = upstream_state {
             result.is_ok(),
             "expected cross-file upstream_state binding in `for` to resolve, got: {:?}",
             result.err()
+        );
+    }
+
+    #[test]
+    fn cross_file_upstream_state_warning_does_not_assert_absence() {
+        // Regression for #1967: when a for-expression references an upstream_state
+        // declared in a different file, the merged warning must describe the
+        // dependency without claiming the key is absent — validate never reads
+        // the upstream state, so it cannot know.
+        let dir = create_temp_dir("cross_file_upstream_warning_wording");
+        fs::write(
+            dir.join("backend.crn"),
+            r#"backend local { path = 'carina.state.json' }
+
+let orgs = upstream_state {
+  source = '../organizations'
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("main.crn"),
+            r#"for name, account_id in orgs.accounts {
+  aws.s3.bucket {
+    name = name
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let result = load_configuration(&dir);
+        let loaded = result.expect("load should succeed");
+        cleanup(&dir);
+
+        let warning = loaded
+            .parsed
+            .warnings
+            .iter()
+            .find(|w| w.message.contains("orgs.accounts"))
+            .expect("expected a warning for orgs.accounts");
+
+        assert!(
+            warning.message.contains("upstream_state 'orgs'"),
+            "warning should name the upstream_state binding, got: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains("../organizations"),
+            "warning should name the upstream source, got: {}",
+            warning.message
+        );
+        assert!(
+            warning.message.contains("validate does not inspect"),
+            "warning should explain that validate does not inspect upstream state, got: {}",
+            warning.message
+        );
+        assert!(
+            !warning.message.contains("not yet in the upstream state"),
+            "warning must not assert the key is absent, got: {}",
+            warning.message
+        );
+        assert!(
+            !warning.message.contains("Apply that directory first"),
+            "warning must not prescribe re-applying upstream, got: {}",
+            warning.message
+        );
+        assert!(
+            !warning.message.contains("known after apply"),
+            "cross-file warning should be upgraded past generic 'known after apply', got: {}",
+            warning.message
         );
     }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1863,12 +1863,12 @@ fn parse_for_expr(
                 collect(result, &mut resources, &mut module_calls);
             }
         }
-        // Unresolved reference (e.g., missing upstream export) — tolerate with warning
+        // Unresolved reference — tolerate with warning; the value resolves at plan time
         (_, Value::ResourceRef { path }) => {
             let remote_binding = path.binding();
             let message = if let Some(us) = ctx.upstream_states.get(remote_binding) {
                 format!(
-                    "`{}` is not yet in the upstream state (upstream_state '{}' → {}).\n    Apply that directory first, then re-plan.",
+                    "`{}` depends on upstream_state '{}' ({}), which validate does not inspect.",
                     path.to_dot_string(),
                     remote_binding,
                     us.source.display(),
@@ -10190,7 +10190,9 @@ awscc.ec2.vpc {
     #[test]
     fn for_unresolved_upstream_state_warning() {
         // When a for-expression iterates over an unresolved upstream_state,
-        // the warning should mention the upstream directory rather than generic "known after apply".
+        // the warning should name the upstream binding and source without
+        // asserting absence or prescribing an action — validate does not
+        // read the upstream state, so it cannot know whether the key exists.
         let input = r#"
             let orgs = upstream_state {
                 source = "../organizations"
@@ -10218,8 +10220,19 @@ awscc.ec2.vpc {
             w.message
         );
         assert!(
-            w.message.contains("Apply that directory first"),
-            "warning should suggest applying upstream, got: {}",
+            w.message.contains("validate does not inspect"),
+            "warning should explain that validate does not inspect upstream state, got: {}",
+            w.message
+        );
+        // Must NOT assert absence — validate never reads the upstream state.
+        assert!(
+            !w.message.contains("not yet in the upstream state"),
+            "warning must not assert the key is absent, got: {}",
+            w.message
+        );
+        assert!(
+            !w.message.contains("Apply that directory first"),
+            "warning must not prescribe re-applying upstream, got: {}",
             w.message
         );
         // Should NOT contain the ambiguous "known after apply"
@@ -10641,7 +10654,7 @@ awscc.ec2.vpc {
                 .warnings
                 .iter()
                 .any(|w| w.message.contains("not yet available")
-                    || w.message.contains("not yet in the upstream state")),
+                    || w.message.contains("validate does not inspect")),
             "parse-time warning should be replaced, got: {:?}",
             parsed.warnings
         );


### PR DESCRIPTION
## Summary

- `carina validate` claimed `` `orgs.accounts` is not yet in the upstream state ... Apply that directory first, then re-plan `` even when the upstream was already applied and did export the key. The message asserted a fact validate never verified — it never reads the upstream state at all.
- Rewrite the warning to describe only what validate actually knows: the reference depends on an upstream_state that validate does not inspect. No absence claim, no re-apply prescription.

New wording:

```
`orgs.accounts` depends on upstream_state 'orgs' (../organizations), which validate does not inspect.
```

Implements Option 2 from the issue (soften the wording). Option 1 (actually read the upstream state from `validate`) overlaps with #1949 and is out of scope here.

Closes #1967

## Test plan

- [x] `cargo test -p carina-core` — 1208 pass, 0 fail
- [x] `cargo test -p carina-cli` — all pass
- [x] `cargo clippy -p carina-core -p carina-cli --all-targets -- -D warnings` — clean
- [x] Updated `for_unresolved_upstream_state_warning` with negative assertions against the old "absence/apply" phrases
- [x] Added `cross_file_upstream_state_warning_does_not_assert_absence` regression test covering the `upgrade_cross_file_warnings` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)