### PR TITLE
for-binding: support `_` discard and warn on unused loop vars

### DIFF
--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -216,11 +216,14 @@ for_expr = {
     "for" ~ for_binding ~ "in" ~ for_iterable ~ "{" ~ for_body ~ "}"
 }
 
-// For binding: simple (x), indexed ((i, x)), or map (k, v)
+// For binding: simple (x), indexed ((i, x)), or map (k, v).
+// `_` is accepted in any position as a discard pattern (same semantics as
+// `let _ = ...`): the binding is not registered and is exempt from the
+// unused-binding warning.
 for_binding = { for_indexed_binding | for_map_binding | for_simple_binding }
-for_simple_binding = { identifier }
-for_indexed_binding = { "(" ~ identifier ~ "," ~ identifier ~ ")" }
-for_map_binding = { identifier ~ "," ~ identifier }
+for_simple_binding = { discard_pattern | identifier }
+for_indexed_binding = { "(" ~ (discard_pattern | identifier) ~ "," ~ (discard_pattern | identifier) ~ ")" }
+for_map_binding = { (discard_pattern | identifier) ~ "," ~ (discard_pattern | identifier) }
 
 // For iterable: restricted to simple expressions to avoid ambiguity with body block
 for_iterable = { function_call | list | variable_ref | "(" ~ expression ~ ")" }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1768,6 +1768,42 @@ pub enum ForBinding {
     Map(String, String),
 }
 
+impl ForBinding {
+    /// Every binding name introduced by this pattern, in declaration order.
+    pub fn names(&self) -> Vec<&str> {
+        match self {
+            ForBinding::Simple(a) => vec![a.as_str()],
+            ForBinding::Indexed(a, b) | ForBinding::Map(a, b) => vec![a.as_str(), b.as_str()],
+        }
+    }
+}
+
+/// Whether `name` appears in `text` as a whole identifier (not a substring
+/// of a longer identifier). An identifier is bounded by anything that is
+/// not ASCII alphanumeric or `_`.
+fn identifier_appears_in(text: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = text.as_bytes();
+    let name_bytes = name.as_bytes();
+    let is_id_char = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+
+    let mut i = 0;
+    while i + name_bytes.len() <= bytes.len() {
+        if &bytes[i..i + name_bytes.len()] == name_bytes {
+            let before_ok = i == 0 || !is_id_char(bytes[i - 1]);
+            let after_idx = i + name_bytes.len();
+            let after_ok = after_idx == bytes.len() || !is_id_char(bytes[after_idx]);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Result of parsing a for expression body: either a resource or a module call
 enum ForBodyResult {
     Resource(Box<Resource>),
@@ -1829,6 +1865,25 @@ fn parse_for_expr(
     // Parse the body (we'll re-parse it for each iteration)
     let body_pair = next_pair(&mut inner, "body", "for expression")?;
 
+    // Warn on loop variables never referenced in the body. `_` is a discard
+    // marker and is skipped. The check is a scan over the body's raw text
+    // for the binding name as a whole identifier — good enough because the
+    // grammar already guarantees identifiers appear at token boundaries.
+    let body_text = body_pair.as_str();
+    for var in binding.names() {
+        if var == "_" || identifier_appears_in(body_text, var) {
+            continue;
+        }
+        ctx.warnings.push(ParseWarning {
+            file: None,
+            line: for_line,
+            message: format!(
+                "for-loop binding '{}' is unused. Rename to '_' to suppress this warning.",
+                var
+            ),
+        });
+    }
+
     let mut resources = Vec::new();
     let mut module_calls = Vec::new();
 
@@ -1841,13 +1896,20 @@ fn parse_for_expr(
         }
     };
 
+    // Helper: only register non-discard bindings so `_` is never addressable.
+    let bind = |c: &mut ParseContext, name: &str, v: Value| {
+        if name != "_" {
+            c.set_variable(name.to_string(), v);
+        }
+    };
+
     // Expand based on iterable type
     match (&binding, &iterable) {
         (ForBinding::Simple(var), Value::List(items)) => {
             for (i, item) in items.iter().enumerate() {
                 let address = format!("{}[{}]", binding_name, i);
                 let mut iter_ctx = ctx.clone();
-                iter_ctx.set_variable(var.clone(), item.clone());
+                bind(&mut iter_ctx, var, item.clone());
                 let result = parse_for_body(body_pair.clone(), &iter_ctx, &address)?;
                 collect(result, &mut resources, &mut module_calls);
             }
@@ -1856,8 +1918,8 @@ fn parse_for_expr(
             for (i, item) in items.iter().enumerate() {
                 let address = format!("{}[{}]", binding_name, i);
                 let mut iter_ctx = ctx.clone();
-                iter_ctx.set_variable(idx_var.clone(), Value::Int(i as i64));
-                iter_ctx.set_variable(val_var.clone(), item.clone());
+                bind(&mut iter_ctx, idx_var, Value::Int(i as i64));
+                bind(&mut iter_ctx, val_var, item.clone());
                 let result = parse_for_body(body_pair.clone(), &iter_ctx, &address)?;
                 collect(result, &mut resources, &mut module_calls);
             }
@@ -1870,8 +1932,8 @@ fn parse_for_expr(
                 let val = &map[key];
                 let address = format!("{}[\"{}\"]", binding_name, key);
                 let mut iter_ctx = ctx.clone();
-                iter_ctx.set_variable(key_var.clone(), Value::String(key.clone()));
-                iter_ctx.set_variable(val_var.clone(), val.clone());
+                bind(&mut iter_ctx, key_var, Value::String(key.clone()));
+                bind(&mut iter_ctx, val_var, val.clone());
                 let result = parse_for_body(body_pair.clone(), &iter_ctx, &address)?;
                 collect(result, &mut resources, &mut module_calls);
             }
@@ -1915,23 +1977,30 @@ fn parse_for_expr(
             // variable(s) to extract the resource type and attribute template.
             let mut template_ctx = ctx.clone();
             let placeholder = || Value::String(DEFERRED_UPSTREAM_PLACEHOLDER.to_string());
+            let bind = |c: &mut ParseContext, name: &str, v: Value| {
+                if name != "_" {
+                    c.set_variable(name.to_string(), v);
+                }
+            };
             match &binding {
                 ForBinding::Simple(var) => {
-                    template_ctx.set_variable(var.clone(), placeholder());
+                    bind(&mut template_ctx, var, placeholder());
                 }
                 ForBinding::Indexed(idx, val) => {
-                    template_ctx.set_variable(
-                        idx.clone(),
+                    bind(
+                        &mut template_ctx,
+                        idx,
                         Value::String(DEFERRED_UPSTREAM_INDEX_PLACEHOLDER.to_string()),
                     );
-                    template_ctx.set_variable(val.clone(), placeholder());
+                    bind(&mut template_ctx, val, placeholder());
                 }
                 ForBinding::Map(k, v) => {
-                    template_ctx.set_variable(
-                        k.clone(),
+                    bind(
+                        &mut template_ctx,
+                        k,
                         Value::String(DEFERRED_UPSTREAM_KEY_PLACEHOLDER.to_string()),
                     );
-                    template_ctx.set_variable(v.clone(), placeholder());
+                    bind(&mut template_ctx, v, placeholder());
                 }
             }
 
@@ -2001,7 +2070,13 @@ fn parse_for_expr(
     Ok((resources, module_calls))
 }
 
-/// Parse a for binding pattern
+/// Parse a for binding pattern.
+///
+/// Each position accepts either an `identifier` or a `discard_pattern`
+/// (`_`). The text of the matched pair — either the identifier name or
+/// the literal `_` — is stored as the binding name. A `_` marker is not
+/// added to the parse-time scope and is exempt from the unused-binding
+/// warning; downstream code checks for `name == "_"` to enforce that.
 fn parse_for_binding(pair: pest::iterators::Pair<Rule>) -> Result<ForBinding, ParseError> {
     let inner = first_inner(pair, "binding pattern", "for binding")?;
     match inner.as_rule() {
@@ -10336,7 +10411,7 @@ awscc.ec2.vpc {
                 source = "../organizations"
             }
 
-            for name, account in orgs.accounts {
+            for name, _ in orgs.accounts {
                 awscc.ec2.vpc {
                     name = name
                     cidr_block = '10.0.0.0/16'
@@ -10345,13 +10420,11 @@ awscc.ec2.vpc {
         "#;
 
         let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(parsed.warnings.len(), 1);
-        let w = &parsed.warnings[0];
-        assert!(
-            w.message.contains("upstream_state 'orgs'"),
-            "warning should mention upstream_state binding name, got: {}",
-            w.message
-        );
+        let w = parsed
+            .warnings
+            .iter()
+            .find(|w| w.message.contains("upstream_state 'orgs'"))
+            .expect("expected upstream_state warning");
         assert!(
             w.message.contains("../organizations"),
             "warning should mention the upstream source, got: {}",
@@ -10471,7 +10544,7 @@ awscc.ec2.vpc {
                 source = "../organizations"
             }
 
-            for name, account in orgs.accounts {
+            for name, _ in orgs.accounts {
                 awscc.ec2.vpc {
                     name = name
                     cidr_block = '10.0.0.0/16'
@@ -10570,7 +10643,7 @@ awscc.ec2.vpc {
                 cidr_block = '10.0.0.0/16'
             }
 
-            for name, item in config.items {
+            for name, _ in config.items {
                 awscc.ec2.subnet {
                     name = name
                     cidr_block = '10.0.1.0/24'
@@ -11148,6 +11221,198 @@ awscc.ec2.vpc {
             result.is_ok(),
             "Reference to declared binding's attribute must parse: {:?}",
             result.err()
+        );
+    }
+
+    #[test]
+    fn for_discard_pattern_simple_parses() {
+        // `for _ in xs` should parse — the loop variable is intentionally unused.
+        let input = r#"
+            for _ in [1, 2, 3] {
+                awscc.ec2.vpc {
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_ok(),
+            "discard in simple for-binding must parse: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn for_discard_pattern_map_key_parses() {
+        // `for _, v in m` — discard the map key, use only the value.
+        let input = r#"
+            let things = { a = 1, b = 2 }
+            for _, value in things {
+                awscc.ec2.vpc {
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_ok(),
+            "discard in map-form key position must parse: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn for_discard_pattern_map_value_parses() {
+        let input = r#"
+            let things = { a = 1, b = 2 }
+            for key, _ in things {
+                awscc.ec2.vpc {
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_ok(),
+            "discard in map-form value position must parse: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn for_discard_pattern_indexed_parses() {
+        let input = r#"
+            for (_, item) in [1, 2, 3] {
+                awscc.ec2.vpc {
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_ok(),
+            "discard in indexed-form must parse: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn for_discard_pattern_cannot_be_referenced() {
+        // Using `_` on the RHS should error — it's not a binding, it's a
+        // discard marker. This mirrors `let _ = expr`.
+        let input = r#"
+            for _, v in { a = 1 } {
+                awscc.ec2.vpc {
+                    name = _
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "referencing a discard binding should error, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn for_unused_binding_warns_simple() {
+        // Simple-form loop variable never referenced inside the body — warn.
+        let input = r#"
+            for item in [1, 2, 3] {
+                awscc.ec2.vpc {
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        let unused: Vec<_> = parsed
+            .warnings
+            .iter()
+            .filter(|w| w.message.contains("unused") && w.message.contains("item"))
+            .collect();
+        assert_eq!(
+            unused.len(),
+            1,
+            "expected one unused-for-binding warning, got: {:?}",
+            parsed.warnings
+        );
+    }
+
+    #[test]
+    fn for_used_binding_no_warning() {
+        // Binding is referenced in body — no warning.
+        let input = r#"
+            for item in [1, 2, 3] {
+                awscc.ec2.vpc {
+                    name = item
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert!(
+            !parsed
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("unused") && w.message.contains("item")),
+            "expected no unused warning when binding is used, got: {:?}",
+            parsed.warnings
+        );
+    }
+
+    #[test]
+    fn for_unused_map_key_warns_only_key() {
+        // Only the map key is unused — warn for key, not value.
+        let input = r#"
+            let things = { a = 1, b = 2 }
+            for name, account_id in things {
+                awscc.ec2.vpc {
+                    cidr_block = account_id
+                }
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        let unused: Vec<_> = parsed
+            .warnings
+            .iter()
+            .filter(|w| w.message.contains("unused"))
+            .collect();
+        assert_eq!(
+            unused.len(),
+            1,
+            "expected one warning for unused key, got: {:?}",
+            parsed.warnings
+        );
+        assert!(
+            unused[0].message.contains("name"),
+            "expected warning to mention 'name', got: {}",
+            unused[0].message
+        );
+        assert!(
+            !unused[0].message.contains("account_id"),
+            "warning should not mention used binding, got: {}",
+            unused[0].message
+        );
+    }
+
+    #[test]
+    fn for_discard_binding_no_unused_warning() {
+        // `_` discard should suppress the unused-warning check.
+        let input = r#"
+            let things = { a = 1, b = 2 }
+            for _, account_id in things {
+                awscc.ec2.vpc {
+                    cidr_block = account_id
+                }
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        assert!(
+            !parsed.warnings.iter().any(|w| w.message.contains("unused")),
+            "discard binding should suppress unused warning, got: {:?}",
+            parsed.warnings
         );
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
 use crate::document::Document;
 use crate::position;
-use carina_core::parser::ParseError;
+use carina_core::parser::{ParseError, ParsedFile};
 use carina_core::provider::ProviderFactory;
 use carina_core::resource::Value;
 use carina_core::schema::ResourceSchema;
@@ -614,6 +614,12 @@ impl DiagnosticEngine {
                     .any(|name| d.message.contains(&format!("'{}'", name)))
             }));
 
+            // Surface unused-for-binding warnings (recorded in parsed.warnings by
+            // the parser) as LSP diagnostics. Other ParseWarnings (e.g. the
+            // upstream_state "validate does not inspect" note) are informational
+            // context meant for CLI output only and are not elevated here.
+            diagnostics.extend(self.check_unused_for_bindings(doc, parsed));
+
             // Check for unknown attributes on resource references (typo detection)
             diagnostics.extend(self.check_resource_ref_attributes(
                 doc,
@@ -685,6 +691,34 @@ impl DiagnosticEngine {
                         "Consider using pipe form for '{}': data |> {}(...)",
                         pw.name, pw.name
                     ),
+                ))
+            })
+            .collect()
+    }
+
+    /// Elevate "for-loop binding '<name>' is unused" parse warnings to LSP
+    /// diagnostics. Other ParseWarnings are intentionally not surfaced here:
+    /// informational notes (e.g. upstream_state "validate does not inspect")
+    /// belong on the CLI, not as editor squiggles.
+    fn check_unused_for_bindings(&self, doc: &Document, parsed: &ParsedFile) -> Vec<Diagnostic> {
+        let prefix = "for-loop binding '";
+        let text = doc.text();
+        parsed
+            .warnings
+            .iter()
+            .filter_map(|w| {
+                let rest = w.message.strip_prefix(prefix)?;
+                let name = rest.split('\'').next()?;
+                let line_idx = w.line.checked_sub(1)?;
+                let line_text = text.lines().nth(line_idx)?;
+                let byte_pos = line_text.find(name)?;
+                let col = position::byte_offset_to_char_offset(line_text, byte_pos);
+                Some(carina_diagnostic(
+                    line_idx as u32,
+                    col,
+                    col + name.chars().count() as u32,
+                    DiagnosticSeverity::WARNING,
+                    w.message.clone(),
                 ))
             })
             .collect()

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -627,3 +627,89 @@ fn carina_diagnostic_helper_with_multiline_range() {
     assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
     assert_eq!(diag.source, Some("carina".to_string()));
 }
+
+#[test]
+fn unused_for_binding_emits_lsp_diagnostic() {
+    // A for-loop binding never referenced in the body should surface as an
+    // LSP diagnostic — not only a CLI warning — so editor users see it too.
+    let engine = test_engine();
+    let doc = create_document(
+        r#"let things = { a = 1, b = 2 }
+
+for name, account_id in things {
+  awscc.ec2.vpc {
+    cidr_block = account_id
+  }
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+
+    let unused = diagnostics
+        .iter()
+        .find(|d| d.message.contains("for-loop binding 'name'"));
+    assert!(
+        unused.is_some(),
+        "expected LSP diagnostic for unused for-loop binding 'name', got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let d = unused.unwrap();
+    assert_eq!(d.source, Some("carina".to_string()));
+    // Diagnostic should sit on the `for` line (1-indexed line 3 in source = 0-indexed 2)
+    assert_eq!(d.range.start.line, 2);
+}
+
+#[test]
+fn used_for_binding_no_lsp_diagnostic() {
+    let engine = test_engine();
+    let doc = create_document(
+        r#"let things = { a = 1, b = 2 }
+
+for key, value in things {
+  awscc.ec2.vpc {
+    name = key
+    cidr_block = value
+  }
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("for-loop binding")),
+        "used for-loop bindings should not produce diagnostics, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_warning_not_in_lsp() {
+    // upstream_state "validate does not inspect" is a CLI-time informational
+    // note, not an editor-surface problem. Do NOT emit as LSP diagnostic.
+    let engine = test_engine();
+    let doc = create_document(
+        r#"let network = upstream_state {
+  source = "../network"
+}
+
+awscc.ec2.security_group {
+  group_description = "Web SG"
+  vpc_id = network.vpc_id
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("validate does not inspect")),
+        "upstream_state informational warning must stay CLI-only, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Two gaps in `for` binding syntax that `let` already handles, plus the LSP surface:

1. **Discard `_`**: not accepted anywhere in a `for` binding (simple, indexed, or map form). Now allowed in every position with `let _ = ...` semantics — the name is not added to scope and cannot be referenced from the body.
2. **Unused-binding warning**: loop variables never referenced inside the body are now flagged. `_` and `_`-only patterns suppress the warning.
3. **LSP parity**: the unused-binding warning is also emitted as an LSP diagnostic so editor users see it, not just CLI users. Other ParseWarnings (the upstream_state "validate does not inspect" note from #1984) are intentionally kept CLI-only — they're informational context, not code problems that deserve editor squiggles.

Closes #1969

## Scope

- `carina-core/src/parser/carina.pest`: `discard_pattern | identifier` in all three `for_*_binding` rules.
- `carina-core/src/parser/mod.rs`:
  - `ForBinding::names()` helper.
  - `identifier_appears_in` does a word-boundary scan of the body's raw text.
  - `parse_for_expr` emits one warning per unused non-discard loop variable.
  - `set_variable` is skipped for `_` so referencing it from the body errors as "expected primary".
- `carina-lsp/src/diagnostics/mod.rs`: new `check_unused_for_bindings` lifts the for-unused `ParseWarning` into a LSP `Diagnostic` pointing at the name's position on the `for` line.

## Out of scope

`_name`-style "intentionally unused" prefix (Rust convention). The identifier grammar starts with `ASCII_ALPHA`; accepting a leading underscore would cascade through many rules. Issue marks it optional.

## Test plan

- [x] `cargo test --workspace` — all pass (1229 core + 229 LSP, 10 new total)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Reproducer: `for name, account_id in things { cidr_block = account_id }` warns only on `name` (CLI and LSP); rewriting to `for _, account_id in things { ... }` silences it; `for _, v in m { cidr_block = _ }` errors at parse time.
- [x] New parser tests: `_` in simple/indexed/map-key/map-value positions; `_` cannot be referenced; unused simple binding warns; used binding does not warn; unused map key warns while used value stays silent; `_` suppresses the warning.
- [x] New LSP tests: unused for-binding surfaces as a Diagnostic; used binding does not; upstream_state informational warning does NOT appear in LSP (stays CLI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)