### PR TITLE
LSP: resolve enclosing resource_type inside for-loop bodies

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -152,6 +152,12 @@ impl CompletionProvider {
         let mut in_upstream_state_block = false;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
+        // Depth-of-for-bodies currently open. A `for ... { <body> }` stacks a
+        // resource_block-free brace level that should be transparent when we
+        // look for enclosing resource types, so a resource declaration at
+        // `brace_depth == for_body_depth` is still a top-level declaration
+        // relative to any enclosing resource.
+        let mut for_body_depth: i32 = 0;
 
         for (i, line) in lines.iter().enumerate() {
             if i > line_idx {
@@ -159,9 +165,17 @@ impl CompletionProvider {
             }
             let trimmed = line.trim();
 
+            // A `for ... in ... {` header opens a pure control-flow brace level,
+            // not a resource block. Track it so resource-type detection below
+            // can see through it.
+            let is_for_header = trimmed.starts_with("for ") && trimmed.ends_with('{');
+
             // Look for resource type declaration: "aws.ec2.vpc {" or "let x = aws.ec2.vpc {"
+            // Accept at depth == 0 (top level) or at depth == for_body_depth
+            // (directly inside a `for` body, which is semantically top-level
+            // for the purpose of resolving the enclosing resource type).
             if let Some(rt) = self.extract_resource_type(line)
-                && brace_depth == 0
+                && brace_depth == for_body_depth
             {
                 resource_type = rt;
                 module_name = None;
@@ -231,10 +245,22 @@ impl CompletionProvider {
                 }
             }
 
+            // Track for-body opens so the opening `{` increments both
+            // brace_depth and for_body_depth. The matching `}` drops
+            // for_body_depth alongside brace_depth.
+            let mut for_brace_pending = is_for_header;
+
             for c in line.chars() {
                 if c == '{' {
                     brace_depth += 1;
+                    if for_brace_pending {
+                        for_body_depth += 1;
+                        for_brace_pending = false;
+                    }
                 } else if c == '}' {
+                    if brace_depth == for_body_depth && for_body_depth > 0 {
+                        for_body_depth -= 1;
+                    }
                     brace_depth -= 1;
                     if brace_depth == 0 {
                         resource_type.clear();
@@ -244,6 +270,13 @@ impl CompletionProvider {
                         in_args_or_attrs_block = false;
                         in_upstream_state_block = false;
                         nested_block_names.clear();
+                    } else if brace_depth == for_body_depth {
+                        // Closed the resource/module block that was inside the
+                        // current for body — forget its type so the next
+                        // resource at this level is detected fresh.
+                        resource_type.clear();
+                        current_binding = None;
+                        module_name = None;
                     } else {
                         // Truncate to current depth
                         let depth_index = (brace_depth - 1) as usize;

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1129,6 +1129,91 @@ fn module_call_scaffolding_includes_arguments() {
 }
 
 #[test]
+fn string_enum_completion_inside_for_loop_body() {
+    // Regression for #1974: inside a `for` body, the enclosing resource_type
+    // must still be detected so StringEnum completions fire. Previously the
+    // for's opening `{` tripped the context detector into brace_depth >= 1
+    // before the resource block's `{`, and `extract_resource_type` was only
+    // consulted at brace_depth == 0 — so the resource schema was missed,
+    // falling through to `generic_value_completions` (regions, true/false).
+    let provider = test_provider_with_enum_and_regions();
+    let doc = create_document(
+        r#"let items = [1, 2]
+for item in items {
+  awscc.s3.bucket {
+    versioning_status =
+  }
+}
+"#,
+    );
+    // Cursor after `    versioning_status = ` on line 3 (0-indexed)
+    let position = Position {
+        line: 3,
+        character: 25,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"Enabled"),
+        "StringEnum 'Enabled' must still be offered inside a for body. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"Suspended"),
+        "StringEnum 'Suspended' must still be offered inside a for body. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.iter().any(|l| l.starts_with("aws.Region.")),
+        "Region values must not pollute StringEnum completions inside for body. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"true") && !labels.contains(&"false"),
+        "Boolean values must not pollute StringEnum completions. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn string_enum_completion_inside_nested_for_loop_body() {
+    // Two stacked `for` bodies still have to see through to the resource
+    // type inside. Regression safety net for the for_body_depth tracker.
+    let provider = test_provider_with_enum_and_regions();
+    let doc = create_document(
+        r#"for a in [1] {
+  for b in [2] {
+    awscc.s3.bucket {
+      versioning_status =
+    }
+  }
+}
+"#,
+    );
+    // Cursor on line 3 after `      versioning_status = `
+    let position = Position {
+        line: 3,
+        character: 27,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"Enabled"),
+        "Enum candidate must reach nested for body. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.iter().any(|l| l.starts_with("aws.Region.")),
+        "No region pollution in nested for body. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
 fn for_loop_binding_suggested_in_body_value_position() {
     let provider = test_provider_single_attr();
     let doc =

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -142,6 +142,40 @@ pub(super) fn test_provider_single_attr() -> CompletionProvider {
     CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![])
 }
 
+/// Like `test_provider_with_nameless_enum` but with a non-empty
+/// `region_completions_data`, so tests can detect region pollution in
+/// type-incompatible completion paths (see #1974).
+pub(super) fn test_provider_with_enum_and_regions() -> CompletionProvider {
+    let status_enum = AttributeType::StringEnum {
+        name: "VersioningStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Suspended".to_string()],
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("awscc.s3.bucket")
+        .attribute(AttributeSchema::new("versioning_status", status_enum));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.s3.bucket".to_string(), schema);
+
+    let region_completions: Vec<CompletionValue> = vec![
+        CompletionValue {
+            value: "aws.Region.ap_northeast_1".to_string(),
+            description: "Asia Pacific (Tokyo)".to_string(),
+        },
+        CompletionValue {
+            value: "aws.Region.us_east_1".to_string(),
+            description: "US East (N. Virginia)".to_string(),
+        },
+    ];
+
+    CompletionProvider::new(
+        Arc::new(schemas),
+        vec!["awscc".to_string(), "aws".to_string()],
+        region_completions,
+        vec![],
+    )
+}
+
 /// Provider with StringEnum that has name but no namespace (simulates WASM provider).
 pub(super) fn test_provider_with_nameless_enum() -> CompletionProvider {
     // Top-level attribute with StringEnum (no namespace)


### PR DESCRIPTION
## Summary

Inside a \`for\` body, LSP value completion was falling back to \`generic_value_completions\` and dumping every region and \`true\`/\`false\` onto the candidate list — even for attributes with tight types like \`StringEnum\`. Root cause: \`get_completion_context\` only looked for a resource declaration when \`brace_depth == 0\`, but \`for ... in ... {\` opens a brace before any resource block, so declarations inside the body were invisible and the schema lookup missed.

Track \`for_body_depth\` alongside \`brace_depth\`. Accept a resource declaration at \`brace_depth == for_body_depth\` — a for body is pure control flow and should be transparent for resolving the enclosing resource.

Refs #1974 (umbrella). This fixes the most frequently reported symptom; the wider matrix (generic fallback hygiene, String/Int/List/Map audits, schema-key normalization) remains for follow-up.

## Behavior change

- \`for item in items { awscc.s3.bucket { versioning_status = ▉ } }\` now offers \`Enabled\`, \`Suspended\`, with no \`aws.Region.*\` / \`true\` / \`false\` pollution.
- Nested \`for\`s handled: \`for a in [..] { for b in [..] { awscc.x.y { attr = ▉ } } }\` still resolves the resource type.

## Test plan

- [x] New: \`string_enum_completion_inside_for_loop_body\` pins the repro.
- [x] New: \`string_enum_completion_inside_nested_for_loop_body\` covers nested for.
- [x] Existing \`for_loop_binding_*\` completion tests still pass (no regression in the #1987 path).
- [x] \`cargo test --workspace\` all pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)