### PR TITLE
validate + LSP: reject undefined upstream_state fields statically (#1990)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,34 @@ plan-exports:
         plan-upstream-state plan-deferred-for plan-exports \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+#
+# `cargo install --force` has a rebuild-avoidance quirk where it can reuse a
+# previously-installed artifact when only a dependency crate changed, leaving
+# ~/.cargo/bin with a stale binary even though `cargo install` exits 0.
+#
+# Always rebuild the release binaries explicitly and copy them into
+# $(INSTALL_DIR). Safe to re-run; cheap when nothing changed.
+#
+# Uses `cargo metadata` to resolve the effective target directory, so this
+# works with both the default `target/` and a custom `target-dir` set in
+# .cargo/config.toml.
+
+INSTALL_DIR ?= $(HOME)/.cargo/bin
+CARGO_TARGET_DIR := $(shell cargo metadata --format-version 1 --no-deps | \
+                            sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+
+install: install-cli install-lsp
+install-cli:
+	cargo build -p carina-cli --release
+	install -m 755 "$(CARGO_TARGET_DIR)/release/carina" "$(INSTALL_DIR)/carina"
+	@echo "Installed $(INSTALL_DIR)/carina"
+install-lsp:
+	cargo build -p carina-lsp --release
+	install -m 755 "$(CARGO_TARGET_DIR)/release/carina-lsp" "$(INSTALL_DIR)/carina-lsp"
+	@echo "Installed $(INSTALL_DIR)/carina-lsp"
+
+.PHONY: install install-cli install-lsp

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1123,10 +1123,6 @@ async fn run_apply_locked(
     // are included in the sorted set used for planning (#1844).
     parsed.expand_deferred_for_expressions(&remote_bindings);
 
-    // Now that the upstream exports are known, any reference to a field that
-    // isn't in them is a typo, not a deferred value.
-    super::plan::validate_upstream_state_field_references(parsed, &remote_bindings)?;
-
     // Print warnings after expansion (resolved ones are removed)
     parsed.print_warnings();
 

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -222,6 +222,31 @@ pub fn validate_and_resolve_with_config(
     // Compute anonymous identifiers
     compute_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, &parsed.providers)?;
 
+    // Reject references to `upstream_state` fields that the upstream's
+    // `exports { }` block does not declare. Gated like the other
+    // validations above so `destroy` / `state` (which pass
+    // `skip_resource_validation = true`) can still run when an upstream
+    // has drifted — those commands are the recovery path for exactly
+    // that situation. No state I/O: we parse the upstream's `.crn`
+    // files directly.
+    if !skip_resource_validation {
+        let (upstream_exports, resolve_errors) =
+            carina_core::upstream_exports::resolve_upstream_exports(
+                base_dir,
+                &parsed.upstream_states,
+                &enriched_context,
+            );
+        let field_errors = carina_core::upstream_exports::check_upstream_state_field_references(
+            parsed,
+            &upstream_exports,
+        );
+        if !resolve_errors.is_empty() || !field_errors.is_empty() {
+            let mut lines: Vec<String> = resolve_errors.iter().map(ToString::to_string).collect();
+            lines.extend(field_errors.iter().map(ToString::to_string));
+            return Err(AppError::Validation(lines.join("\n")));
+        }
+    }
+
     Ok(())
 }
 
@@ -408,6 +433,56 @@ mod tests {
             msg.contains("has no source configured"),
             "Error should tell user to add source. Got: {}",
             msg
+        );
+    }
+
+    #[test]
+    fn upstream_field_check_honors_skip_resource_validation() {
+        // `destroy` and `state` subcommands pass `skip_resource_validation =
+        // true` so they can run on projects whose upstream has drifted.
+        // The static upstream-exports check must respect that gate;
+        // otherwise a broken upstream would block recovery commands.
+        use std::fs;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        fs::write(
+            upstream_dir.join("exports.crn"),
+            "exports { accounts: string = \"x\" }\n",
+        )
+        .unwrap();
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+        fs::write(
+            base.join("main.crn"),
+            r#"let orgs = upstream_state { source = "../organizations" }
+exports {
+    bad: string = orgs.missing
+}
+"#,
+        )
+        .unwrap();
+
+        let loaded = carina_core::config_loader::load_configuration_with_config(
+            &base,
+            &ProviderContext::default(),
+        )
+        .expect("load");
+        let mut parsed = loaded.parsed;
+
+        // With full validation, the typo is rejected.
+        let err = validate_and_resolve_with_config(&mut parsed.clone(), &base, false)
+            .expect_err("full validation must flag the typo");
+        assert!(err.to_string().contains("does not export `missing`"));
+
+        // With skip_resource_validation=true, recovery commands pass
+        // through despite the typo.
+        let result = validate_and_resolve_with_config(&mut parsed, &base, true);
+        assert!(
+            result.is_ok(),
+            "skip_resource_validation=true must bypass upstream field check, got: {:?}",
+            result.err()
         );
     }
 }

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -232,10 +232,6 @@ pub async fn run_plan(
     // Expand deferred for-expressions now that remote values are available
     parsed.expand_deferred_for_expressions(&remote_bindings);
 
-    // Now that the upstream exports are known, any reference to a field that
-    // isn't in them is a typo, not a deferred value.
-    validate_upstream_state_field_references(&parsed, &remote_bindings)?;
-
     // Print warnings after expansion (resolved deferred for-expressions have their warnings removed)
     parsed.print_warnings();
 
@@ -612,89 +608,6 @@ async fn load_upstream_bindings_at(
     Ok(state_file.build_remote_bindings())
 }
 
-/// Reject field references against `upstream_state` bindings whose target is
-/// absent from the upstream's `exports`. The `validate` subcommand can't do
-/// this (no upstream I/O), but once `plan` / `apply` have loaded
-/// `remote_bindings` the check becomes a straightforward map lookup.
-pub(crate) fn validate_upstream_state_field_references(
-    parsed: &carina_core::parser::ParsedFile,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-) -> Result<(), AppError> {
-    let mut errors: Vec<String> = Vec::new();
-
-    for resource in &parsed.resources {
-        for (attr_name, expr) in resource.attributes.iter() {
-            check_ref_against_upstream(
-                expr.as_value(),
-                remote_bindings,
-                &format!("{} attribute `{}`", resource.id, attr_name),
-                &mut errors,
-            );
-        }
-    }
-    for attr in &parsed.attribute_params {
-        if let Some(value) = &attr.value {
-            check_ref_against_upstream(
-                value,
-                remote_bindings,
-                &format!("attributes.{}", attr.name),
-                &mut errors,
-            );
-        }
-    }
-    for export in &parsed.export_params {
-        if let Some(value) = &export.value {
-            check_ref_against_upstream(
-                value,
-                remote_bindings,
-                &format!("exports.{}", export.name),
-                &mut errors,
-            );
-        }
-    }
-    for call in &parsed.module_calls {
-        let caller = call.binding_name.as_deref().unwrap_or(&call.module_name);
-        for (arg_name, v) in call.arguments.iter() {
-            check_ref_against_upstream(
-                v,
-                remote_bindings,
-                &format!("module `{}` argument `{}`", caller, arg_name),
-                &mut errors,
-            );
-        }
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(AppError::Validation(errors.join("\n")))
-    }
-}
-
-fn check_ref_against_upstream(
-    value: &Value,
-    remote_bindings: &HashMap<String, HashMap<String, Value>>,
-    location: &str,
-    errors: &mut Vec<String>,
-) {
-    value.visit_refs(&mut |path| {
-        let binding = path.binding();
-        let field = path.attribute();
-        let Some(exports) = remote_bindings.get(binding) else {
-            return;
-        };
-        if !exports.contains_key(field) {
-            let known: Vec<&str> = exports.keys().map(String::as_str).collect();
-            let suggestion = carina_core::schema::suggest_similar_name(field, &known)
-                .map(|s| format!(" Did you mean `{}`?", s))
-                .unwrap_or_default();
-            errors.push(format!(
-                "{location}: upstream_state `{binding}` does not export `{field}`.{suggestion}"
-            ));
-        }
-    });
-}
-
 #[cfg(test)]
 mod load_upstream_states_tests {
     use super::*;
@@ -817,7 +730,8 @@ mod run_plan_upstream_state_tests {
 
         fs::write(
             dir_a.join("main.crn"),
-            r#"backend local { path = "carina.state.json" }"#,
+            r#"backend local { path = "carina.state.json" }
+exports { region: string = "ap-northeast-1" }"#,
         )
         .unwrap();
 
@@ -945,95 +859,5 @@ mod export_diff_tests {
         assert_eq!(changes[0].name(), "added");
         assert_eq!(changes[1].name(), "modified");
         assert_eq!(changes[2].name(), "removed");
-    }
-}
-
-#[cfg(test)]
-mod upstream_state_field_tests {
-    use super::*;
-    use carina_core::parser::parse;
-
-    fn remote_bindings_with(
-        binding: &str,
-        fields: &[(&str, Value)],
-    ) -> HashMap<String, HashMap<String, Value>> {
-        let inner: HashMap<String, Value> = fields
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), v.clone()))
-            .collect();
-        let mut outer = HashMap::new();
-        outer.insert(binding.to_string(), inner);
-        outer
-    }
-
-    #[test]
-    fn reference_to_missing_upstream_field_is_error() {
-        let src = r#"
-            let orgs = upstream_state { source = "../organizations" }
-            aws.s3_bucket {
-                name = orgs.account
-            }
-        "#;
-        let parsed = parse(src, &ProviderContext::default()).unwrap();
-        let bindings =
-            remote_bindings_with("orgs", &[("accounts", Value::String("a".to_string()))]);
-        let err = validate_upstream_state_field_references(&parsed, &bindings)
-            .expect_err("orgs.account must fail");
-        let msg = err.to_string();
-        assert!(msg.contains("orgs"), "error should name the binding: {msg}");
-        assert!(
-            msg.contains("account"),
-            "error should name the field: {msg}"
-        );
-        assert!(
-            msg.contains("Did you mean `accounts`"),
-            "should suggest `accounts`: {msg}"
-        );
-    }
-
-    #[test]
-    fn reference_to_existing_upstream_field_is_ok() {
-        let src = r#"
-            let orgs = upstream_state { source = "../organizations" }
-            aws.s3_bucket {
-                name = orgs.accounts
-            }
-        "#;
-        let parsed = parse(src, &ProviderContext::default()).unwrap();
-        let bindings =
-            remote_bindings_with("orgs", &[("accounts", Value::String("a".to_string()))]);
-        assert!(validate_upstream_state_field_references(&parsed, &bindings).is_ok());
-    }
-
-    #[test]
-    fn missing_upstream_field_inside_interpolation_is_caught() {
-        let src = r#"
-            let orgs = upstream_state { source = "../organizations" }
-            aws.s3_bucket {
-                name = "prefix-${orgs.account}-suffix"
-            }
-        "#;
-        let parsed = parse(src, &ProviderContext::default()).unwrap();
-        let bindings =
-            remote_bindings_with("orgs", &[("accounts", Value::String("a".to_string()))]);
-        let err = validate_upstream_state_field_references(&parsed, &bindings)
-            .expect_err("missing field inside interpolation must be caught");
-        assert!(err.to_string().contains("`account`"));
-    }
-
-    #[test]
-    fn reference_to_non_upstream_binding_is_not_checked() {
-        // `bucket.id` points at a resource binding, not an upstream_state binding,
-        // so this pass leaves it alone (validate_resource_ref_types handles that case).
-        let src = r#"
-            let bucket = aws.s3_bucket { name = "b" }
-            aws.s3_bucket_policy {
-                name = "p"
-                bucket_name = bucket.id
-            }
-        "#;
-        let parsed = parse(src, &ProviderContext::default()).unwrap();
-        let bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
-        assert!(validate_upstream_state_field_references(&parsed, &bindings).is_ok());
     }
 }

--- a/carina-cli/tests/fixtures/plan_display/upstream_state/network/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state/network/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+exports {
+  vpc: struct = {
+    vpc_id = "vpc-abc123"
+    cidr_block = "10.0.0.0/16"
+  }
+}

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -20,3 +20,4 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tempfile = "3"

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -168,33 +168,6 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
-        // Upgrade cross-file warnings: a for-expression in one file may reference
-        // an upstream_state defined in another file.  During per-file parsing the
-        // upstream_state is unknown, so the warning falls back to the generic
-        // "(known after apply)".  Now that all files are merged we can detect
-        // these and rewrite to an upstream-aware message.
-        upgrade_cross_file_warnings(&mut merged, &unresolved_merged);
-
-        // Emit "validate does not inspect" warnings for simple attribute
-        // references to upstream_state bindings declared in sibling files.
-        // Per-file parsing only sees its own upstream_states; this catches
-        // the cross-file case. Dedupe against warnings already present so
-        // we don't double-count same-file references.
-        let merged_upstream_states: Vec<parser::UpstreamState> = merged
-            .upstream_states
-            .iter()
-            .chain(unresolved_merged.upstream_states.iter())
-            .cloned()
-            .collect();
-        parser::warn_unverified_upstream_state_refs(
-            &merged_upstream_states,
-            &merged.resources,
-            &merged.attribute_params,
-            &merged.module_calls,
-            &merged.export_params,
-            &mut merged.warnings,
-        );
-
         Ok(LoadedConfig {
             parsed: merged,
             unresolved_parsed: unresolved_merged,
@@ -202,47 +175,6 @@ pub fn load_configuration_with_config(
         })
     } else {
         Err(format!("Path not found: {}", path.display()))
-    }
-}
-
-/// Upgrade generic "(known after apply)" warnings to upstream-aware messages
-/// when the binding matches an upstream_state found in a different file.
-fn upgrade_cross_file_warnings(merged: &mut ParsedFile, unresolved: &ParsedFile) {
-    let suffix = " is not yet available (known after apply)";
-    for warning in &mut merged.warnings {
-        if !warning.message.ends_with(suffix) {
-            continue;
-        }
-        // Extract binding name: message is "`orgs.accounts` is not yet available ..."
-        let path_str = match warning
-            .message
-            .strip_prefix('`')
-            .and_then(|s| s.split('`').next())
-        {
-            Some(p) => p,
-            None => continue,
-        };
-        let binding_name = match path_str.split('.').next() {
-            Some(b) => b,
-            None => continue,
-        };
-        // Check against merged upstream_states (includes all files)
-        let upstream_states = merged
-            .upstream_states
-            .iter()
-            .chain(unresolved.upstream_states.iter());
-        if let Some(us) = upstream_states
-            .into_iter()
-            .find(|u| u.binding == binding_name)
-        {
-            let new_msg = format!(
-                "`{}` depends on upstream_state '{}' ({}), which validate does not inspect.",
-                path_str,
-                binding_name,
-                us.source.display(),
-            );
-            warning.message = new_msg;
-        }
     }
 }
 
@@ -256,21 +188,52 @@ fn upgrade_cross_file_warnings(merged: &mut ParsedFile, unresolved: &ParsedFile)
 /// Returns `None` for `export_params` values that are cross-file string
 /// references (e.g. `"registry_prod.account_id"`) resolved to `ResourceRef`.
 pub fn parse_directory(dir: &Path, config: &ProviderContext) -> Result<ParsedFile, String> {
+    parse_directory_with_overrides(dir, config, &HashMap::new())
+}
+
+/// Like [`parse_directory`] but takes an `overrides` map from **file name**
+/// (e.g. `"main.crn"`) to source text. Files present in the map are parsed
+/// from the override text; the rest are read from disk.
+///
+/// LSP uses this to analyze the open document's in-memory buffer alongside
+/// the on-disk siblings, so edits show diagnostics before the user saves.
+pub fn parse_directory_with_overrides(
+    dir: &Path,
+    config: &ProviderContext,
+    overrides: &HashMap<String, String>,
+) -> Result<ParsedFile, String> {
     let dir_buf = dir.to_path_buf();
     let files = find_crn_files_in_dir(&dir_buf)?;
-    if files.is_empty() {
+    let mut paths: Vec<(std::path::PathBuf, String)> = files
+        .into_iter()
+        .filter_map(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str().map(|s| (p.clone(), s.to_string())))
+        })
+        .collect();
+    // Also include overrides whose filename isn't on disk yet (e.g. a new
+    // buffer the user hasn't saved). Keep the list de-duplicated by name.
+    for name in overrides.keys() {
+        if !paths.iter().any(|(_, n)| n == name) {
+            paths.push((dir_buf.join(name), name.clone()));
+        }
+    }
+    if paths.is_empty() {
         return Err(format!("No .crn files found in {}", dir.display()));
     }
 
     let mut merged = ParsedFile::default();
     let mut parse_errors = Vec::new();
 
-    for file in &files {
-        let content = fs::read_to_string(file)
-            .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
+    for (file, name) in &paths {
+        let content = match overrides.get(name) {
+            Some(buffer) => buffer.clone(),
+            None => fs::read_to_string(file)
+                .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?,
+        };
         match parser::parse(&content, config) {
             Ok(mut parsed) => {
-                let file_name = file.file_name().map(|n| n.to_string_lossy().into_owned());
+                let file_name = Some(name.clone());
                 for w in &mut parsed.warnings {
                     w.file = file_name.clone();
                 }
@@ -845,18 +808,21 @@ let orgs = upstream_state {
     }
 
     #[test]
-    fn cross_file_upstream_state_warning_does_not_assert_absence() {
-        // Regression for #1967: when a for-expression references an upstream_state
-        // declared in a different file, the merged warning must describe the
-        // dependency without claiming the key is absent — validate never reads
-        // the upstream state, so it cannot know.
-        let dir = create_temp_dir("cross_file_upstream_warning_wording");
+    fn cross_file_upstream_state_refs_emit_no_soft_warning() {
+        // Field validity is checked statically by the `upstream_exports`
+        // module now. Loader- and parser-level "validate does not inspect"
+        // soft warnings are gone across the board.
+        let dir = create_temp_dir("cross_file_upstream_no_warning");
         fs::write(
             dir.join("backend.crn"),
             r#"backend local { path = 'carina.state.json' }
 
 let orgs = upstream_state {
   source = '../organizations'
+}
+
+let network = upstream_state {
+  source = '../network'
 }
 "#,
         )
@@ -868,73 +834,8 @@ let orgs = upstream_state {
     name = name
   }
 }
-"#,
-        )
-        .unwrap();
 
-        let result = load_configuration(&dir);
-        let loaded = result.expect("load should succeed");
-        cleanup(&dir);
-
-        let warning = loaded
-            .parsed
-            .warnings
-            .iter()
-            .find(|w| w.message.contains("orgs.accounts"))
-            .expect("expected a warning for orgs.accounts");
-
-        assert!(
-            warning.message.contains("upstream_state 'orgs'"),
-            "warning should name the upstream_state binding, got: {}",
-            warning.message
-        );
-        assert!(
-            warning.message.contains("../organizations"),
-            "warning should name the upstream source, got: {}",
-            warning.message
-        );
-        assert!(
-            warning.message.contains("validate does not inspect"),
-            "warning should explain that validate does not inspect upstream state, got: {}",
-            warning.message
-        );
-        assert!(
-            !warning.message.contains("not yet in the upstream state"),
-            "warning must not assert the key is absent, got: {}",
-            warning.message
-        );
-        assert!(
-            !warning.message.contains("Apply that directory first"),
-            "warning must not prescribe re-applying upstream, got: {}",
-            warning.message
-        );
-        assert!(
-            !warning.message.contains("known after apply"),
-            "cross-file warning should be upgraded past generic 'known after apply', got: {}",
-            warning.message
-        );
-    }
-
-    #[test]
-    fn cross_file_simple_ref_to_upstream_state_emits_warning() {
-        // When a resource in one file references an upstream_state declared in
-        // another file via a simple attribute reference, the merged config must
-        // still surface the "validate does not inspect" warning — one warning
-        // per binding.
-        let dir = create_temp_dir("cross_file_simple_ref_upstream");
-        fs::write(
-            dir.join("backend.crn"),
-            r#"backend local { path = 'carina.state.json' }
-
-let network = upstream_state {
-  source = '../network'
-}
-"#,
-        )
-        .unwrap();
-        fs::write(
-            dir.join("main.crn"),
-            r#"awscc.ec2.security_group {
+awscc.ec2.security_group {
   group_description = 'Web SG'
   vpc_id = network.vpc_id
 }
@@ -946,27 +847,16 @@ let network = upstream_state {
         let loaded = result.expect("load should succeed");
         cleanup(&dir);
 
-        let matching: Vec<_> = loaded
+        let upstream_warnings: Vec<_> = loaded
             .parsed
             .warnings
             .iter()
-            .filter(|w| w.message.contains("upstream_state 'network'"))
+            .filter(|w| w.message.contains("upstream_state"))
             .collect();
-        assert_eq!(
-            matching.len(),
-            1,
-            "expected exactly one warning for cross-file simple ref, got: {:?}",
-            loaded.parsed.warnings
-        );
         assert!(
-            matching[0].message.contains("../network"),
-            "warning should name the upstream source, got: {}",
-            matching[0].message
-        );
-        assert!(
-            matching[0].message.contains("validate does not inspect"),
-            "warning should explain validate does not inspect, got: {}",
-            matching[0].message
+            upstream_warnings.is_empty(),
+            "loader should emit no soft upstream_state warnings, got: {:?}",
+            upstream_warnings
         );
     }
 

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod provider;
 pub mod resolver;
 pub mod resource;
 pub mod schema;
+pub mod upstream_exports;
 pub mod utils;
 pub mod validation;
 pub mod value;

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -985,19 +985,6 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         &export_params,
     )?;
 
-    // Fourth pass: emit "validate does not inspect" warnings for simple
-    // attribute references to upstream_state bindings. Dedupe per binding
-    // and skip bindings that already got a for-iterable warning (which
-    // carries richer context about deferred expansion).
-    warn_unverified_upstream_state_refs(
-        &upstream_states,
-        &resources,
-        &attribute_params,
-        &module_calls,
-        &export_params,
-        &mut ctx.warnings,
-    );
-
     Ok(ParsedFile {
         providers,
         resources,
@@ -1938,28 +1925,12 @@ fn parse_for_expr(
                 collect(result, &mut resources, &mut module_calls);
             }
         }
-        // Unresolved reference — tolerate with warning; the value resolves at plan time
+        // Unresolved reference — defer expansion to plan/apply when the
+        // upstream values are loaded. Field validity is checked statically
+        // by `upstream_exports::check_upstream_state_field_references`; for
+        // a valid field the deferral is an implementation detail the user
+        // doesn't need to hear about at validate time.
         (_, Value::ResourceRef { path }) => {
-            let remote_binding = path.binding();
-            let message = if let Some(us) = ctx.upstream_states.get(remote_binding) {
-                format!(
-                    "`{}` depends on upstream_state '{}' ({}), which validate does not inspect.",
-                    path.to_dot_string(),
-                    remote_binding,
-                    us.source.display(),
-                )
-            } else {
-                format!(
-                    "`{}` is not yet available (known after apply)",
-                    path.to_dot_string()
-                )
-            };
-            ctx.warnings.push(ParseWarning {
-                file: None,
-                line: for_line,
-                message,
-            });
-
             // Build the for-expression header string
             let header = match &binding {
                 ForBinding::Simple(var) => {
@@ -4251,131 +4222,6 @@ fn check_undefined_in_value(
         return Err(ParseError::UndefinedIdentifier { name, line: 0 });
     }
     Ok(())
-}
-
-/// Walk a `Value` looking for `Value::String("binding.attr")` forms that
-/// survived cross-file resolution without being converted to `ResourceRef`.
-/// The callback receives the binding name (portion before the first `.`).
-fn visit_string_refs(value: &Value, record: &mut impl FnMut(&str)) {
-    match value {
-        Value::String(s) => {
-            if let Some((binding, rest)) = s.split_once('.')
-                && !rest.is_empty()
-                && is_identifier(binding)
-            {
-                record(binding);
-            }
-        }
-        Value::List(items) => {
-            for item in items {
-                visit_string_refs(item, record);
-            }
-        }
-        Value::Map(map) => {
-            for v in map.values() {
-                visit_string_refs(v, record);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn is_identifier(s: &str) -> bool {
-    let mut chars = s.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => return false,
-    }
-    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
-/// Walk every `Value` collected during parsing and emit a warning for each
-/// `upstream_state` binding that is referenced but not already covered by a
-/// for-iterable warning.
-///
-/// Dedup key is the binding name — many attribute references to the same
-/// upstream_state collapse into a single warning, since the point is to flag
-/// that validate does not inspect that upstream, not to repeat per-reference.
-pub(crate) fn warn_unverified_upstream_state_refs(
-    upstream_states: &[UpstreamState],
-    resources: &[Resource],
-    attribute_params: &[AttributeParameter],
-    module_calls: &[ModuleCall],
-    export_params: &[ExportParameter],
-    warnings: &mut Vec<ParseWarning>,
-) {
-    if upstream_states.is_empty() {
-        return;
-    }
-
-    let by_name: HashMap<&str, &UpstreamState> = upstream_states
-        .iter()
-        .map(|u| (u.binding.as_str(), u))
-        .collect();
-
-    // Bindings that already got a warning (for-iterable or simple-ref from an
-    // earlier pass) — skip them to avoid duplicates.
-    let already_warned: HashSet<String> = warnings
-        .iter()
-        .filter_map(|w| {
-            w.message
-                .split("upstream_state '")
-                .nth(1)
-                .and_then(|s| s.split('\'').next())
-                .map(String::from)
-        })
-        .collect();
-
-    let mut referenced: HashSet<String> = HashSet::new();
-    let mut record = |binding: &str| {
-        if by_name.contains_key(binding) && !already_warned.contains(binding) {
-            referenced.insert(binding.to_string());
-        }
-    };
-    let mut visit = |v: &Value| {
-        v.visit_refs(&mut |path| record(path.binding()));
-        // Cross-file references that never got resolved to ResourceRef remain
-        // as Value::String("binding.attr"). Detect those too so cross-file
-        // attribute refs surface warnings during directory-scope parsing.
-        visit_string_refs(v, &mut record);
-    };
-
-    for r in resources {
-        for expr in r.attributes.values() {
-            visit(expr.as_value());
-        }
-    }
-    for ap in attribute_params {
-        if let Some(v) = &ap.value {
-            visit(v);
-        }
-    }
-    for ep in export_params {
-        if let Some(v) = &ep.value {
-            visit(v);
-        }
-    }
-    for mc in module_calls {
-        for v in mc.arguments.values() {
-            visit(v);
-        }
-    }
-
-    // Emit in a deterministic order (binding name) so output is stable.
-    let mut names: Vec<&String> = referenced.iter().collect();
-    names.sort();
-    for name in names {
-        let us = by_name[name.as_str()];
-        warnings.push(ParseWarning {
-            file: None,
-            line: 0,
-            message: format!(
-                "upstream_state '{}' ({}) is referenced but validate does not inspect it — attribute existence and types are not verified.",
-                name,
-                us.source.display(),
-            ),
-        });
-    }
 }
 
 /// Resolve forward references after the full binding set is known.
@@ -10401,147 +10247,17 @@ awscc.ec2.vpc {
     }
 
     #[test]
-    fn for_unresolved_upstream_state_warning() {
-        // When a for-expression iterates over an unresolved upstream_state,
-        // the warning should name the upstream binding and source without
-        // asserting absence or prescribing an action — validate does not
-        // read the upstream state, so it cannot know whether the key exists.
+    fn upstream_state_refs_emit_no_parser_warnings() {
+        // Field validity against upstream `exports { }` is now checked
+        // statically by the `upstream_exports` module. The parser itself
+        // stays silent about upstream_state references — the old "validate
+        // does not inspect" soft warning is gone.
         let input = r#"
             let orgs = upstream_state {
                 source = "../organizations"
             }
-
-            for name, _ in orgs.accounts {
-                awscc.ec2.vpc {
-                    name = name
-                    cidr_block = '10.0.0.0/16'
-                }
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        let w = parsed
-            .warnings
-            .iter()
-            .find(|w| w.message.contains("upstream_state 'orgs'"))
-            .expect("expected upstream_state warning");
-        assert!(
-            w.message.contains("../organizations"),
-            "warning should mention the upstream source, got: {}",
-            w.message
-        );
-        assert!(
-            w.message.contains("validate does not inspect"),
-            "warning should explain that validate does not inspect upstream state, got: {}",
-            w.message
-        );
-        // Must NOT assert absence — validate never reads the upstream state.
-        assert!(
-            !w.message.contains("not yet in the upstream state"),
-            "warning must not assert the key is absent, got: {}",
-            w.message
-        );
-        assert!(
-            !w.message.contains("Apply that directory first"),
-            "warning must not prescribe re-applying upstream, got: {}",
-            w.message
-        );
-        // Should NOT contain the ambiguous "known after apply"
-        assert!(
-            !w.message.contains("known after apply"),
-            "warning should NOT use ambiguous 'known after apply', got: {}",
-            w.message
-        );
-    }
-
-    #[test]
-    fn simple_ref_to_upstream_state_emits_warning() {
-        // A simple attribute reference to an upstream_state binding (not a
-        // for-iterable) should emit the same "validate does not inspect"
-        // warning — validate never reads the upstream state, so the
-        // referenced attribute's existence and type cannot be verified.
-        let input = r#"
             let network = upstream_state {
                 source = "../network"
-            }
-
-            awscc.ec2.security_group {
-                group_description = "Web SG"
-                vpc_id = network.vpc_id
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(
-            parsed.warnings.len(),
-            1,
-            "expected 1 warning, got: {:?}",
-            parsed.warnings
-        );
-        let w = &parsed.warnings[0];
-        assert!(
-            w.message.contains("upstream_state 'network'"),
-            "warning should mention binding name, got: {}",
-            w.message
-        );
-        assert!(
-            w.message.contains("../network"),
-            "warning should mention upstream source, got: {}",
-            w.message
-        );
-        assert!(
-            w.message.contains("validate does not inspect"),
-            "warning should explain validate does not inspect, got: {}",
-            w.message
-        );
-    }
-
-    #[test]
-    fn multiple_refs_to_same_upstream_state_emit_single_warning() {
-        // Multiple attribute references to the same upstream_state binding
-        // should produce only one warning — the point is to flag that the
-        // upstream is unverified, not to repeat per-attribute.
-        let input = r#"
-            let network = upstream_state {
-                source = "../network"
-            }
-
-            awscc.ec2.security_group {
-                group_description = "Web SG"
-                vpc_id = network.vpc_id
-            }
-
-            awscc.ec2.subnet {
-                vpc_id = network.vpc_id
-                cidr_block = network.subnet_cidr
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(
-            parsed.warnings.len(),
-            1,
-            "expected 1 dedup'd warning, got: {:?}",
-            parsed.warnings
-        );
-        assert!(
-            parsed.warnings[0]
-                .message
-                .contains("upstream_state 'network'"),
-            "warning should name the binding, got: {}",
-            parsed.warnings[0].message
-        );
-    }
-
-    #[test]
-    fn for_iterable_and_simple_ref_on_same_upstream_state_emit_single_warning() {
-        // When a file has both a for-iterable using upstream_state and a
-        // simple attribute ref to the same binding, only the for-iterable
-        // warning should fire — it carries extra context about deferred
-        // expansion and supersedes the attribute-ref warning.
-        let input = r#"
-            let orgs = upstream_state {
-                source = "../organizations"
             }
 
             for name, _ in orgs.accounts {
@@ -10551,118 +10267,30 @@ awscc.ec2.vpc {
                 }
             }
 
-            awscc.iam.role {
-                role_name = orgs.admin_role
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(
-            parsed.warnings.len(),
-            1,
-            "for-iterable warning should suppress the attribute-ref warning, got: {:?}",
-            parsed.warnings
-        );
-    }
-
-    #[test]
-    fn declared_but_unreferenced_upstream_state_emits_no_warning() {
-        // Declaring an upstream_state without referencing any of its attributes
-        // should stay silent — nothing to flag.
-        let input = r#"
-            let network = upstream_state {
-                source = "../network"
-            }
-
-            awscc.ec2.vpc {
-                cidr_block = '10.0.0.0/16'
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(
-            parsed.warnings.len(),
-            0,
-            "unreferenced upstream_state should produce no warning, got: {:?}",
-            parsed.warnings
-        );
-    }
-
-    #[test]
-    fn refs_to_different_upstream_states_emit_separate_warnings() {
-        // Dedup is per-binding: two distinct upstream_state bindings should
-        // each get their own warning.
-        let input = r#"
-            let network = upstream_state {
-                source = "../network"
-            }
-
-            let orgs = upstream_state {
-                source = "../organizations"
-            }
-
             awscc.ec2.security_group {
-                group_description = "sg"
+                group_description = "Web SG"
                 vpc_id = network.vpc_id
-                role_name = orgs.admin_role
             }
         "#;
 
         let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(
-            parsed.warnings.len(),
-            2,
-            "expected one warning per upstream_state binding, got: {:?}",
-            parsed.warnings
-        );
-        let bindings: Vec<String> = parsed
+        let upstream_warnings: Vec<&ParseWarning> = parsed
             .warnings
             .iter()
-            .filter_map(|w| {
-                w.message
-                    .split("upstream_state '")
-                    .nth(1)
-                    .and_then(|s| s.split('\'').next())
-                    .map(String::from)
-            })
+            .filter(|w| w.message.contains("upstream_state"))
             .collect();
         assert!(
-            bindings.contains(&"network".to_string()) && bindings.contains(&"orgs".to_string()),
-            "warnings should cover both bindings, got: {:?}",
+            upstream_warnings.is_empty(),
+            "parser should emit no upstream_state warnings, got: {:?}",
+            upstream_warnings
+        );
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .all(|w| !w.message.contains("known after apply")),
+            "deferred for-iterable must no longer emit 'known after apply', got: {:?}",
             parsed.warnings
-        );
-    }
-
-    #[test]
-    fn for_unresolved_non_upstream_state_warning() {
-        // When a for-expression has an unresolved ref that is NOT an upstream_state,
-        // it should use the generic "known after apply" message.
-        let input = r#"
-            let config = awscc.ec2.vpc {
-                name = "base"
-                cidr_block = '10.0.0.0/16'
-            }
-
-            for name, _ in config.items {
-                awscc.ec2.subnet {
-                    name = name
-                    cidr_block = '10.0.1.0/24'
-                }
-            }
-        "#;
-
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
-        assert_eq!(parsed.warnings.len(), 1);
-        let w = &parsed.warnings[0];
-        assert!(
-            w.message.contains("known after apply"),
-            "non-upstream_state unresolved ref should use generic message, got: {}",
-            w.message
-        );
-        assert!(
-            !w.message.contains("upstream_state"),
-            "should NOT mention upstream_state for local bindings, got: {}",
-            w.message
         );
     }
 

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -1,0 +1,575 @@
+//! Static validation of `upstream_state` field references.
+//!
+//! An `upstream_state { source = "..." }` binding exposes exactly the keys
+//! declared by the upstream project's `exports { }` block. Those keys are
+//! fixed at declaration time and visible by parsing the upstream's `.crn`
+//! files — no state I/O.
+//!
+//! Two public entry points:
+//! - [`resolve_upstream_exports`] parses each upstream's source directory
+//!   and returns the declared key set per binding.
+//! - [`check_upstream_state_field_references`] walks a parsed project and
+//!   returns an error for every reference whose field isn't in the set.
+//!
+//! Both are pure functions so `validate`, LSP diagnostics, and any other
+//! surface can share the same logic without duplicating traversal code.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::config_loader::{find_crn_files_in_dir, parse_directory};
+use crate::parser::{ParsedFile, ProviderContext, UpstreamState};
+use crate::resource::Value;
+use crate::schema::suggest_similar_name;
+
+pub type UpstreamExports = HashMap<String, HashSet<String>>;
+
+/// An `upstream_state` binding whose source directory exists but couldn't
+/// be parsed. Downstream field-reference checks against this binding are
+/// skipped (we don't know what it exports), but the failure itself must be
+/// surfaced — otherwise a broken upstream silently masks downstream typos.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamResolveError {
+    pub binding: String,
+    pub source: std::path::PathBuf,
+    pub reason: String,
+}
+
+impl std::fmt::Display for UpstreamResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "upstream_state `{}`: failed to parse source `{}`: {}",
+            self.binding,
+            self.source.display(),
+            self.reason
+        )
+    }
+}
+
+impl std::error::Error for UpstreamResolveError {}
+
+/// A reference in the downstream project whose field isn't declared by the
+/// upstream's `exports { }` block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamFieldError {
+    /// Where in the downstream project the bad reference appears
+    /// (e.g. `"aws.s3.bucket.main attribute `name`"`).
+    pub location: String,
+    pub binding: String,
+    pub field: String,
+    pub suggestion: Option<String>,
+}
+
+impl UpstreamFieldError {
+    /// Location-free phrasing shared by CLI and LSP — the LSP diagnostic
+    /// range already tells the user *where*, so it only needs *what*.
+    pub fn diagnostic_message(&self) -> String {
+        let suggestion = self
+            .suggestion
+            .as_ref()
+            .map(|s| format!(" Did you mean `{}`?", s))
+            .unwrap_or_default();
+        format!(
+            "upstream_state `{}` does not export `{}`.{}",
+            self.binding, self.field, suggestion
+        )
+    }
+}
+
+impl std::fmt::Display for UpstreamFieldError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.location, self.diagnostic_message())
+    }
+}
+
+impl std::error::Error for UpstreamFieldError {}
+
+/// Statically resolve each `upstream_state` binding's declared exports.
+///
+/// Returns `(exports, resolve_errors)` — a **partial** result so one broken
+/// upstream doesn't suppress checks against the others.
+///
+/// - Present in `exports` (possibly empty set): source exists and parses.
+///   An empty set means "exports nothing", so every downstream reference
+///   against it is invalid.
+/// - Omitted from `exports` and listed in `resolve_errors`: source exists
+///   but fails to parse — callers should surface this error separately.
+/// - Absent from both: source directory is missing. The dedicated
+///   `check_upstream_state_sources` diagnostic already handles that case.
+///
+/// An empty directory (no `.crn` files) is treated as "exports nothing"
+/// rather than a parse failure; the user may be mid-setup.
+pub fn resolve_upstream_exports(
+    base_dir: &Path,
+    upstream_states: &[UpstreamState],
+    config: &ProviderContext,
+) -> (UpstreamExports, Vec<UpstreamResolveError>) {
+    let mut out: UpstreamExports = HashMap::new();
+    let mut errors: Vec<UpstreamResolveError> = Vec::new();
+    for us in upstream_states {
+        let source_abs = base_dir.join(&us.source);
+        if !source_abs.is_dir() {
+            continue;
+        }
+        if matches!(find_crn_files_in_dir(&source_abs), Ok(files) if files.is_empty()) {
+            out.insert(us.binding.clone(), HashSet::new());
+            continue;
+        }
+        match parse_directory(&source_abs, config) {
+            Ok(parsed) => {
+                let keys: HashSet<String> = parsed
+                    .export_params
+                    .iter()
+                    .map(|e| e.name.clone())
+                    .collect();
+                out.insert(us.binding.clone(), keys);
+            }
+            Err(reason) => {
+                errors.push(UpstreamResolveError {
+                    binding: us.binding.clone(),
+                    source: us.source.clone(),
+                    reason,
+                });
+            }
+        }
+    }
+    (out, errors)
+}
+
+/// Walk a parsed project and return an error for every reference whose root
+/// binding is in `exports` but whose field isn't in its declared key set.
+/// Also covers deferred for-iterables (e.g. `for _ in orgs.accounts`), which
+/// parse into `deferred_for_expressions` rather than `Value::ResourceRef`.
+///
+/// Bindings absent from `exports` are skipped — the caller decides what to
+/// do about unresolved upstreams.
+pub fn check_upstream_state_field_references(
+    parsed: &ParsedFile,
+    exports: &UpstreamExports,
+) -> Vec<UpstreamFieldError> {
+    let mut errors: Vec<UpstreamFieldError> = Vec::new();
+
+    // One &str slice per binding so a project with many bad refs doesn't
+    // re-materialize the same Vec for every error.
+    let known_by_binding: HashMap<&str, Vec<&str>> = exports
+        .iter()
+        .map(|(b, keys)| (b.as_str(), keys.iter().map(String::as_str).collect()))
+        .collect();
+
+    // Ref-checking closure lives in its own scope so the `&mut errors`
+    // borrow it holds is released before we push deferred-iterable
+    // errors directly below.
+    {
+        let mut check = |value: &Value, location: &str| {
+            value.visit_refs(&mut |path| {
+                let binding = path.binding();
+                let field = path.attribute();
+                let Some(keys) = exports.get(binding) else {
+                    return;
+                };
+                if keys.contains(field) {
+                    return;
+                }
+                let known = known_by_binding
+                    .get(binding)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                errors.push(UpstreamFieldError {
+                    location: location.to_string(),
+                    binding: binding.to_string(),
+                    field: field.to_string(),
+                    suggestion: suggest_similar_name(field, known),
+                });
+            });
+        };
+
+        for (name, value) in parsed.variables.iter() {
+            check(value, &format!("let {}", name));
+        }
+        for resource in &parsed.resources {
+            for (attr_name, expr) in resource.attributes.iter() {
+                check(
+                    expr.as_value(),
+                    &format!("{} attribute `{}`", resource.id, attr_name),
+                );
+            }
+        }
+        for attr in &parsed.attribute_params {
+            if let Some(value) = &attr.value {
+                check(value, &format!("attributes.{}", attr.name));
+            }
+        }
+        for export in &parsed.export_params {
+            if let Some(value) = &export.value {
+                check(value, &format!("exports.{}", export.name));
+            }
+        }
+        for call in &parsed.module_calls {
+            let caller = call.binding_name.as_deref().unwrap_or(&call.module_name);
+            for (arg_name, v) in call.arguments.iter() {
+                check(v, &format!("module `{}` argument `{}`", caller, arg_name));
+            }
+        }
+        // Deferred for-expression bodies: the body is parked on the
+        // deferred expression until plan-time expansion and isn't reached
+        // by the `resources` walk above.
+        for deferred in &parsed.deferred_for_expressions {
+            for (attr_name, expr) in deferred.template_resource.attributes.iter() {
+                check(
+                    expr.as_value(),
+                    &format!(
+                        "for-body `{}` {} attribute `{}`",
+                        deferred.header, deferred.template_resource.id, attr_name
+                    ),
+                );
+            }
+            for (attr_name, value) in &deferred.attributes {
+                check(
+                    value,
+                    &format!("for-body `{}` attribute `{}`", deferred.header, attr_name),
+                );
+            }
+        }
+    }
+
+    // Deferred for-expression iterables are a direct
+    // (binding, attribute) pair rather than a Value tree, so check them
+    // after the closure block has released its borrow on `errors`.
+    for deferred in &parsed.deferred_for_expressions {
+        let Some(keys) = exports.get(deferred.iterable_binding.as_str()) else {
+            continue;
+        };
+        if keys.contains(&deferred.iterable_attr) {
+            continue;
+        }
+        let known = known_by_binding
+            .get(deferred.iterable_binding.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        errors.push(UpstreamFieldError {
+            location: format!("for-expression `{}`", deferred.header),
+            binding: deferred.iterable_binding.clone(),
+            field: deferred.iterable_attr.clone(),
+            suggestion: suggest_similar_name(&deferred.iterable_attr, known),
+        });
+    }
+
+    // HashMap-backed walks (parsed.variables, resource.attributes,
+    // call.arguments) visit entries in nondeterministic order. Sort the
+    // final error list so CLI output and any snapshot-style assertions
+    // stay stable across runs.
+    errors.sort_by(|a, b| {
+        (a.location.as_str(), a.binding.as_str(), a.field.as_str()).cmp(&(
+            b.location.as_str(),
+            b.binding.as_str(),
+            b.field.as_str(),
+        ))
+    });
+    errors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write_crn(dir: &Path, name: &str, body: &str) {
+        fs::write(dir.join(name), body).unwrap();
+    }
+
+    fn ctx() -> ProviderContext {
+        ProviderContext::default()
+    }
+
+    fn upstream(binding: &str, source: &str) -> UpstreamState {
+        UpstreamState {
+            binding: binding.to_string(),
+            source: PathBuf::from(source),
+        }
+    }
+
+    fn parse_project(source: &str) -> ParsedFile {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("main.crn"), source).unwrap();
+        parse_directory(tmp.path(), &ctx()).expect("parse_directory")
+    }
+
+    fn mk_exports(pairs: &[(&str, &[&str])]) -> UpstreamExports {
+        pairs
+            .iter()
+            .map(|(binding, keys)| {
+                (
+                    binding.to_string(),
+                    keys.iter().map(|s| s.to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn resolve_reads_exports_from_default_exports_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "exports.crn",
+            r#"exports {
+                accounts: string = "x"
+                region: string = "ap-northeast-1"
+            }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let keys = got.get("orgs").expect("resolved");
+        assert!(keys.contains("accounts"));
+        assert!(keys.contains("region"));
+    }
+
+    #[test]
+    fn resolve_reads_exports_from_any_crn_file() {
+        // exports.crn is convention; the block can live in any .crn file.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "main.crn",
+            r#"exports {
+                accounts: string = "x"
+            }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let keys = got.get("orgs").expect("resolved");
+        assert!(keys.contains("accounts"));
+    }
+
+    #[test]
+    fn resolve_skips_missing_source_directory() {
+        // Missing-directory is `check_upstream_state_sources`' job; this
+        // resolver stays quiet about it.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../missing")], &ctx());
+        assert!(got.is_empty());
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn resolve_returns_empty_set_when_source_has_no_exports_block() {
+        // An upstream without `exports { }` exports nothing — valid static
+        // answer. Downstream refs against it will then fail the checker.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "main.crn",
+            r#"backend local { path = "carina.state.json" }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let keys = got.get("orgs").expect("binding should be resolved");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn resolve_treats_empty_directory_as_empty_exports() {
+        // Empty dir (user is mid-setup) — not a parse failure.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty());
+        assert!(got.get("orgs").expect("resolved").is_empty());
+    }
+
+    #[test]
+    fn resolve_reports_parse_errors_for_broken_upstream() {
+        // A readable upstream whose .crn fails to parse must surface as a
+        // resolve error — otherwise downstream typos get silently masked.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(&upstream_dir, "main.crn", "not valid crn syntax {{{");
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(!got.contains_key("orgs"));
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].binding, "orgs");
+        assert!(errs[0].to_string().contains("orgs"));
+        assert!(errs[0].to_string().contains("organizations"));
+    }
+
+    #[test]
+    fn check_rejects_unexported_field_with_suggestion() {
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            exports {
+                bad: string = orgs.account
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert_eq!(errs.len(), 1, "got: {errs:?}");
+        assert_eq!(errs[0].binding, "orgs");
+        assert_eq!(errs[0].field, "account");
+        assert_eq!(errs[0].suggestion.as_deref(), Some("accounts"));
+        assert!(errs[0].to_string().contains("exports.bad"));
+        assert!(
+            errs[0]
+                .diagnostic_message()
+                .contains("Did you mean `accounts`?")
+        );
+    }
+
+    #[test]
+    fn check_accepts_exported_field() {
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            exports {
+                good: string = orgs.accounts
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+        assert!(check_upstream_state_field_references(&parsed, &exports).is_empty());
+    }
+
+    #[test]
+    fn check_rejects_any_field_when_upstream_declares_no_exports() {
+        // Empty key set → every ref is invalid. Provable statically.
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            exports {
+                x: string = orgs.anything
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &[])]);
+
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].field, "anything");
+        assert!(errs[0].suggestion.is_none());
+    }
+
+    #[test]
+    fn check_skips_bindings_without_resolved_exports() {
+        // Binding absent from exports map → checker ignores it.
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+            let other = upstream_state { source = "../other" }
+
+            exports {
+                x: string = other.foo
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+        assert!(check_upstream_state_field_references(&parsed, &exports).is_empty());
+    }
+
+    #[test]
+    fn check_rejects_unexported_field_in_let_binding() {
+        // `let x = orgs.acc` stores the ref in `variables`, not in
+        // `resources` — walker must cover that surface too.
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            let x = orgs.acc
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert_eq!(errs.len(), 1, "got: {errs:?}");
+        assert_eq!(errs[0].field, "acc");
+        assert!(errs[0].location.contains("let"));
+    }
+
+    #[test]
+    fn check_rejects_unexported_field_in_for_expression_body() {
+        // The iterable is valid (`orgs.accounts`) but a ref inside the body
+        // points at a non-exported field. Must still be flagged — body refs
+        // don't reach `parsed.resources` until plan-time expansion.
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            for name, _ in orgs.accounts {
+                awscc.ec2.vpc {
+                    name = name
+                    cidr_block = orgs.NONEXISTENT
+                }
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert!(
+            errs.iter().any(|e| e.field == "NONEXISTENT"),
+            "for-body ref to non-exported field must be flagged, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn check_rejects_unexported_field_in_for_expression_iterable() {
+        // `for name, _ in orgs.account` — issue #1990's canonical repro.
+        let parsed = parse_project(
+            r#"
+            let orgs = upstream_state { source = "../organizations" }
+
+            for name, _ in orgs.account {
+                awscc.ec2.vpc {
+                    name = name
+                    cidr_block = '10.0.0.0/16'
+                }
+            }
+            "#,
+        );
+        let exports = mk_exports(&[("orgs", &["accounts"])]);
+
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].binding, "orgs");
+        assert_eq!(errs[0].field, "account");
+        assert_eq!(errs[0].suggestion.as_deref(), Some("accounts"));
+        assert!(errs[0].location.contains("for"));
+    }
+}

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -264,13 +264,19 @@ impl Backend {
                 .map(|dir| Self::scan_sibling_context(dir, &uri, &current_bindings))
                 .unwrap_or_default();
 
+            let current_file_name: Option<String> = uri
+                .to_file_path()
+                .ok()
+                .and_then(|p| p.file_name().and_then(|n| n.to_str().map(String::from)));
+
             let providers = self.providers.read().await;
             let state = base_path
                 .as_ref()
                 .map(|p| providers.state_for_path(p))
                 .unwrap_or(&providers.empty);
-            let diagnostics = state.diagnostic_engine.analyze(
+            let diagnostics = state.diagnostic_engine.analyze_with_filename(
                 &doc,
+                current_file_name.as_deref(),
                 base_path.as_deref(),
                 &sibling_bindings,
                 &sibling_referenced,

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -24,50 +24,79 @@ fn find_source_value_position(text: &str, expected: &str) -> Option<(u32, u32, u
     let mut in_upstream_state = false;
     let mut brace_depth: u32 = 0;
     for (line_idx, line) in text.lines().enumerate() {
-        let trimmed = line.trim_start();
-        if !in_upstream_state && trimmed.contains("upstream_state") && trimmed.contains('{') {
-            in_upstream_state = true;
-            brace_depth = 1;
-            continue;
-        }
-        if !in_upstream_state {
-            continue;
-        }
+        // On the opening line, scan only the segment after the first `{`
+        // so a single-line form
+        //   `let orgs = upstream_state { source = '...' }`
+        // also has its `source` attribute parsed without a separate line.
+        let (scan_from_byte, is_opening_line) =
+            if !in_upstream_state && line.contains("upstream_state") {
+                match line.find('{') {
+                    Some(idx) => {
+                        in_upstream_state = true;
+                        brace_depth = 1;
+                        (idx + 1, true)
+                    }
+                    None => continue,
+                }
+            } else if in_upstream_state {
+                (0, false)
+            } else {
+                continue;
+            };
+
+        let segment = &line[scan_from_byte..];
+
         // Track nested braces so a struct value inside upstream_state doesn't
-        // prematurely close the block.
-        brace_depth += trimmed.matches('{').count() as u32;
-        brace_depth = brace_depth.saturating_sub(trimmed.matches('}').count() as u32);
-        if brace_depth == 0 {
+        // prematurely close the block. On the opening line we've already
+        // counted the `{` that opened it.
+        brace_depth += segment.matches('{').count() as u32;
+        brace_depth = brace_depth.saturating_sub(segment.matches('}').count() as u32);
+        // Drop out of state mode at end of line, but still look for `source`
+        // on this line first.
+        let should_close = brace_depth == 0;
+
+        // `source` can appear after the opening brace on the same line.
+        let trimmed = segment.trim_start();
+        let found = trimmed.starts_with("source")
+            && trimmed
+                .split_once('=')
+                .map(|(lhs, _)| lhs.trim_end() == "source")
+                .unwrap_or(false);
+
+        if found {
+            // trimmed: "source = '../x' ..."
+            let (_, rhs) = trimmed.split_once('=').unwrap();
+            let after_eq = rhs.trim_start();
+            if let Some(quote) = after_eq.chars().next().filter(|c| *c == '\'' || *c == '"') {
+                let inner = &after_eq[quote.len_utf8()..];
+                if let Some(end_byte) = inner.find(quote)
+                    && &inner[..end_byte] == expected
+                {
+                    // Compute columns: prefix up to start of inner string.
+                    let trimmed_offset = segment.len() - trimmed.len();
+                    let rhs_offset = trimmed.len() - rhs.len();
+                    let after_eq_offset = rhs.len() - after_eq.len();
+                    let value_byte_in_line = scan_from_byte
+                        + trimmed_offset
+                        + rhs_offset
+                        + after_eq_offset
+                        + quote.len_utf8();
+                    let start_col = line[..value_byte_in_line].chars().count() as u32;
+                    let end_col = start_col + inner[..end_byte].chars().count() as u32;
+                    return Some((line_idx as u32, start_col, end_col));
+                }
+            }
+        }
+
+        // Close after processing this line, in case `source = '...'` was on
+        // the same line as the closing `}`.
+        if should_close {
             in_upstream_state = false;
-            continue;
         }
-        if !trimmed.starts_with("source") {
-            continue;
-        }
-        let Some((lhs, rhs)) = trimmed.split_once('=') else {
-            continue;
-        };
-        // Skip `source` followed by non-whitespace (e.g. `source_path`).
-        if !lhs.trim_end().eq("source") {
-            continue;
-        }
-        let after_eq = rhs.trim_start();
-        let Some(quote) = after_eq.chars().next().filter(|c| *c == '\'' || *c == '"') else {
-            continue;
-        };
-        let inner = &after_eq[quote.len_utf8()..];
-        let Some(end_byte) = inner.find(quote) else {
-            continue;
-        };
-        if &inner[..end_byte] != expected {
-            continue;
-        }
-        // Columns are character counts from the start of the line up to the
-        // start of `inner` (i.e. just past the opening quote).
-        let prefix_len = line.len() - after_eq.len() + quote.len_utf8();
-        let start_col = line[..prefix_len].chars().count() as u32;
-        let end_col = start_col + inner[..end_byte].chars().count() as u32;
-        return Some((line_idx as u32, start_col, end_col));
+
+        // Silence unused-variable warnings for is_opening_line (reserved for
+        // potential future multi-block tracking).
+        let _ = is_opening_line;
     }
     None
 }
@@ -252,6 +281,92 @@ impl DiagnosticEngine {
             }
         }
         None
+    }
+
+    /// Reject references like `orgs.account` whose field isn't declared by
+    /// the upstream's `exports { }` block.
+    ///
+    /// Uses a directory-scoped parse that overrides the on-disk copy of
+    /// `current_file_name` with the editor's in-memory buffer, so edits
+    /// produce diagnostics before the user saves. Runs even when the
+    /// single-file parse fails — common when a `for` iterates over a
+    /// binding declared in a sibling file.
+    pub(super) fn check_upstream_state_field_references(
+        &self,
+        doc: &Document,
+        current_file_name: Option<&str>,
+        base_path: &std::path::Path,
+    ) -> Vec<Diagnostic> {
+        let mut overrides: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        if let Some(name) = current_file_name {
+            overrides.insert(name.to_string(), doc.text());
+        }
+        let merged = carina_core::config_loader::parse_directory_with_overrides(
+            base_path,
+            &self.provider_context,
+            &overrides,
+        );
+        let Ok(merged) = merged else {
+            return Vec::new();
+        };
+
+        let (exports, resolve_errors) = carina_core::upstream_exports::resolve_upstream_exports(
+            base_path,
+            &merged.upstream_states,
+            &self.provider_context,
+        );
+
+        let mut diagnostics = Vec::new();
+        let text = doc.text();
+
+        // Broken-upstream diagnostics anchor to the `source = ...` line in
+        // the current document (if this file is the one declaring that
+        // upstream_state); otherwise they belong to the sibling.
+        for err in resolve_errors {
+            let source_str = err.source.to_string_lossy();
+            let Some((line, col, end_col)) = find_source_value_position(&text, &source_str) else {
+                continue;
+            };
+            diagnostics.push(carina_diagnostic(
+                line,
+                col,
+                end_col,
+                DiagnosticSeverity::ERROR,
+                err.to_string(),
+            ));
+        }
+
+        // Multiple `UpstreamFieldError`s can share the same `binding.field`
+        // text (e.g. two `let` bindings that both reference `orgs.bad`).
+        // `find_ref_value_position` returns the first occurrence; tracking
+        // how many times we've already consumed each ref text lets us
+        // anchor later diagnostics at subsequent occurrences instead of
+        // stacking them on the first.
+        let field_errors =
+            carina_core::upstream_exports::check_upstream_state_field_references(&merged, &exports);
+        let mut seen_count: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for err in field_errors {
+            let ref_text = format!("{}.{}", err.binding, err.field);
+            let skip = *seen_count.get(&ref_text).unwrap_or(&0);
+            // Only surface errors whose reference appears in the current
+            // document; sibling-file errors are handled when that file is
+            // analyzed.
+            let Some((line, col)) = self.find_ref_value_position_nth(doc, &ref_text, skip) else {
+                continue;
+            };
+            *seen_count.entry(ref_text.clone()).or_insert(0) += 1;
+            let end_col = col + ref_text.chars().count() as u32;
+            diagnostics.push(carina_diagnostic(
+                line,
+                col,
+                end_col,
+                DiagnosticSeverity::ERROR,
+                err.diagnostic_message(),
+            ));
+        }
+        diagnostics
     }
 
     /// Flag `upstream_state { source = ... }` paths that do not resolve to an
@@ -1175,15 +1290,54 @@ impl DiagnosticEngine {
         });
     }
 
-    /// Find the position of a resource reference value (e.g., "igw.internet_gateway_id") in the document.
+    /// Locate the first occurrence of `ref_text` as a standalone identifier
+    /// chain — so `orgs.acc` won't match inside `orgs.accounts`.
     fn find_ref_value_position(&self, doc: &Document, ref_text: &str) -> Option<(u32, u32)> {
+        self.find_ref_value_position_nth(doc, ref_text, 0)
+    }
+
+    /// Locate the `skip + 1`-th identifier-chain occurrence of `ref_text`
+    /// in the document. Used when the core checker emits multiple errors
+    /// with identical `binding.field` strings so each diagnostic lands on
+    /// its own source site instead of stacking on the first.
+    fn find_ref_value_position_nth(
+        &self,
+        doc: &Document,
+        ref_text: &str,
+        skip: usize,
+    ) -> Option<(u32, u32)> {
+        fn is_ident_cont(c: char) -> bool {
+            c.is_ascii_alphanumeric() || c == '_'
+        }
         let text = doc.text();
+        let mut skipped = 0usize;
         for (line_idx, line) in text.lines().enumerate() {
-            if let Some(byte_pos) = line.find(ref_text) {
-                return Some((
-                    line_idx as u32,
-                    position::byte_offset_to_char_offset(line, byte_pos),
-                ));
+            let mut search_from = 0;
+            while let Some(rel) = line[search_from..].find(ref_text) {
+                let byte_pos = search_from + rel;
+                let before_ok = byte_pos == 0
+                    || line[..byte_pos]
+                        .chars()
+                        .next_back()
+                        .map(|c| !is_ident_cont(c))
+                        .unwrap_or(true);
+                let after_idx = byte_pos + ref_text.len();
+                let after_ok = after_idx >= line.len()
+                    || line[after_idx..]
+                        .chars()
+                        .next()
+                        .map(|c| !is_ident_cont(c))
+                        .unwrap_or(true);
+                if before_ok && after_ok {
+                    if skipped == skip {
+                        return Some((
+                            line_idx as u32,
+                            position::byte_offset_to_char_offset(line, byte_pos),
+                        ));
+                    }
+                    skipped += 1;
+                }
+                search_from = byte_pos + ref_text.len();
             }
         }
         None

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -110,6 +110,21 @@ impl DiagnosticEngine {
         sibling_bindings: &HashMap<String, String>,
         sibling_referenced: &HashSet<String>,
     ) -> Vec<Diagnostic> {
+        self.analyze_with_filename(doc, None, base_path, sibling_bindings, sibling_referenced)
+    }
+
+    /// Like [`analyze`] but lets the caller pass the current document's file
+    /// name (basename, e.g. `"main.crn"`). LSP uses this to feed the open
+    /// buffer into directory-scoped parses that would otherwise only see
+    /// on-disk content — so diagnostics update on keystrokes.
+    pub fn analyze_with_filename(
+        &self,
+        doc: &Document,
+        current_file_name: Option<&str>,
+        base_path: Option<&Path>,
+        sibling_bindings: &HashMap<String, String>,
+        sibling_referenced: &HashSet<String>,
+    ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
         let text = doc.text();
 
@@ -129,6 +144,19 @@ impl DiagnosticEngine {
         }
         let undef_diags = self.check_undefined_references(&text, &all_bindings);
         diagnostics.extend(undef_diags);
+
+        // Upstream_state field-ref check: must run even when the current
+        // document fails to parse on its own (e.g. when the downstream
+        // references a `let` declared in a sibling file). Uses a
+        // directory-scoped parse fed with the current buffer, not just
+        // disk content.
+        if let Some(base) = base_path {
+            diagnostics.extend(self.check_upstream_state_field_references(
+                doc,
+                current_file_name,
+                base,
+            ));
+        }
 
         // Semantic analysis on parsed file
         if let Some(parsed) = doc.parsed() {

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2090,3 +2090,339 @@ fn upstream_state_existing_source_directory_is_ok() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// =====================================================================
+// upstream_state field-reference diagnostics (#1990)
+// =====================================================================
+
+fn set_up_project_with_upstream(
+    main_crn: &str,
+    upstream_exports_crn: Option<&str>,
+) -> (tempfile::TempDir, std::path::PathBuf, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    if let Some(body) = upstream_exports_crn {
+        std::fs::write(upstream.join("exports.crn"), body).unwrap();
+    }
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(base.join("main.crn"), main_crn).unwrap();
+    (tmp, base, "main.crn".to_string())
+}
+
+fn analyze_with_buffer(
+    engine: &DiagnosticEngine,
+    base: &std::path::Path,
+    filename: &str,
+    buffer: &str,
+) -> Vec<tower_lsp::lsp_types::Diagnostic> {
+    let doc = create_document(buffer);
+    engine.analyze_with_filename(
+        &doc,
+        Some(filename),
+        Some(base),
+        &HashMap::new(),
+        &HashSet::new(),
+    )
+}
+
+#[test]
+fn upstream_state_unknown_field_in_for_expression_is_flagged() {
+    // The issue's canonical repro.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+for name, _ in orgs.account {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join(&name)).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, &buffer);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export `account`")),
+        "got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_known_field_passes() {
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+for name, _ in orgs.accounts {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join(&name)).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, &buffer);
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export")),
+        "known field should not be flagged, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_buffer_differs_from_disk_uses_buffer() {
+    // Disk: `orgs.accounts` (correct). Buffer in editor: `orgs.acc` (typo).
+    // Must flag based on the buffer, not disk.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.accounts
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let edited = r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.acc
+"#;
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, edited);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export `acc`")),
+        "buffer typo must be flagged against disk exports, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_buffer_fix_clears_diagnostic() {
+    // Disk: `orgs.account` (typo, would be flagged). Buffer: `orgs.accounts`
+    // (user fixed it). Must NOT flag — reflects the buffer, not disk.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.account
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let fixed = r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.accounts
+"#;
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, fixed);
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export")),
+        "fixed buffer should clear diagnostic even if disk is stale, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_buffer_retypo_reflags() {
+    // Reproduces the user-reported sequence:
+    //   disk typo → fix in buffer → retype typo in buffer.
+    // Diagnostic must reappear on the second typo.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.accounts
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+
+    // Simulate user editing to a new typo.
+    let retypo = r#"let orgs = upstream_state { source = '../organizations' }
+let x = orgs.acc
+"#;
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, retypo);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export `acc`")),
+        "retyped typo must reflag, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_cross_file_declaration_is_checked() {
+    // `let orgs = upstream_state { ... }` lives in `backend.crn`; the
+    // reference lives in `main.crn`. Must still flag.
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        r#"exports { accounts: string = "x" }
+"#,
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        r#"let orgs = upstream_state { source = '../organizations' }
+"#,
+    )
+    .unwrap();
+    let main_src = r#"for name, _ in orgs.account {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#;
+    std::fs::write(base.join("main.crn"), main_src).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main_src);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("does not export `account`")),
+        "cross-file upstream_state ref must be flagged, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_duplicate_bad_refs_anchor_to_distinct_sites() {
+    // Two for-iterables both misspell the same field. Each diagnostic
+    // must anchor to its own source site, not stack on the first.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state {
+    source = '../organizations'
+}
+
+for name, _ in orgs.bad {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+
+for other, _ in orgs.bad {
+    awscc.ec2.subnet {
+        name = other
+        cidr_block = '10.0.1.0/24'
+    }
+}
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join(&name)).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, &buffer);
+
+    let bad_ref_diags: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("does not export `bad`"))
+        .collect();
+    assert_eq!(
+        bad_ref_diags.len(),
+        2,
+        "expected 2 diagnostics for 2 occurrences, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let lines: std::collections::HashSet<u32> =
+        bad_ref_diags.iter().map(|d| d.range.start.line).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "diagnostics should anchor to distinct lines, got lines: {:?}",
+        bad_ref_diags
+            .iter()
+            .map(|d| d.range.start.line)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_single_line_block_source_diagnostic() {
+    // `let orgs = upstream_state { source = '../x' }` on one line.
+    // `find_source_value_position` must still locate the source value.
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(upstream.join("main.crn"), "not valid crn {{{").unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    let src = "let orgs = upstream_state { source = '../organizations' }\n";
+    std::fs::write(base.join("main.crn"), src).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", src);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("failed to parse source")),
+        "single-line upstream_state block must yield resolve-error diagnostic, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_broken_upstream_surfaces_resolve_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(upstream.join("main.crn"), "not valid crn {{{").unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    let src = r#"let orgs = upstream_state {
+    source = '../organizations'
+}
+"#;
+    std::fs::write(base.join("main.crn"), src).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", src);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("failed to parse source")),
+        "broken upstream must produce resolve-error diagnostic, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Parse each `upstream_state { source = "..." }` directory and read its `exports { }` block directly; unknown field references become hard errors at `validate` (and transitively `plan` / `apply`) and editor squiggles in LSP.
- No state I/O: the exports contract is static in the upstream's `.crn`.
- LSP check uses a directory-scoped parse fed with the current editor buffer, so diagnostics update on keystrokes — not only on save.

Closes #1990

## Key changes

- **`carina-core::upstream_exports`** (new): `resolve_upstream_exports` + `check_upstream_state_field_references`.
- **`carina-core::config_loader::parse_directory_with_overrides`** (new): directory parse with per-file source overrides, consumed by LSP to reflect unsaved buffers.
- **`carina-cli` validate**: wired into `validate_and_resolve_with_config`, so `plan` / `apply` inherit the check without duplicated plumbing.
- **`carina-cli` plan / apply**: drop the state-based check added in #1952. The new static check supersedes it; keeping both invited divergence when `.crn` and state disagreed.
- **`carina-lsp`**: new diagnostic (`check_upstream_state_field_references`). Boundary-aware reference location lookup (`orgs.acc` no longer matches inside `orgs.accounts`).
- **Soft warnings removed**: parser's `warn_unverified_upstream_state_refs` and loader's `upgrade_cross_file_warnings`, plus the "known after apply" branch of the for-iterable warning (misleading for validate).

## Why plan/apply touch less now

PR #1952 added a duplicate check in `plan.rs` using `remote_bindings` from state. With the static check, that path was both redundant (same typo caught twice) and capable of producing spurious errors when `.crn` is edited but state hasn't been re-applied. Deleted in this PR.

## Test plan

- [x] `cargo test --workspace` — core 1234, cli 256, lsp 250; 0 regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] New core tests: missing field + suggestion, exports in non-`exports.crn`, missing dir, empty dir, broken upstream, for-iterable typo, let-binding typo, cross-binding skip.
- [x] New LSP tests: unknown field, known field, **buffer differs from disk**, **buffer fix clears diagnostic**, **buffer retypo reflags**, cross-file declaration, broken upstream resolve error.
- [x] E2E with real binary on `validate`.

## Follow-ups (separate issues)

- #1996 — LSP completion: suggest upstream_state exports after `<binding>.`.
- #1998 — `for`-expression iterable: undefined *binding* (not field) not flagged.
- File-and-line info in CLI error messages (will file a separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)