### PR TITLE
plan-display: add multi-file exports fixture and snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,13 @@ plan-deferred-for:
 	$(PLAN_FIXTURE) deferred_for
 plan-exports:
 	$(PLAN_FIXTURE) exports
+plan-exports-multifile:
+	$(PLAN_FIXTURE) exports_multifile
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
-        plan-upstream-state plan-deferred-for plan-exports \
+        plan-upstream-state plan-deferred-for plan-exports plan-exports-multifile \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -33,6 +33,7 @@ pub struct FixturePlan {
     pub schemas: HashMap<String, ResourceSchema>,
     pub moved_origins: HashMap<ResourceId, ResourceId>,
     pub deferred_for_expressions: Vec<carina_core::parser::DeferredForExpression>,
+    pub export_params: Vec<carina_core::parser::ExportParameter>,
 }
 
 /// Build a plan from a fixture directory name (e.g. "all_create"). Resolves
@@ -203,6 +204,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         schemas: wiring.schemas().clone(),
         moved_origins,
         deferred_for_expressions: parsed.deferred_for_expressions,
+        export_params: parsed.export_params,
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -514,32 +514,32 @@ fn plan_snapshot_exports() {
 /// Verifies that a project whose provider/resource/exports blocks are
 /// spread across sibling .crn files produces the same plan as the
 /// single-file `exports` fixture. Guards against regressions where
-/// directory-scoped parsing drops definitions in sibling files.
+/// directory-scoped parsing drops definitions in sibling files: the
+/// `export_changes` fed to `format_plan` are derived from the loaded
+/// `parsed.export_params`, so a dropped `exports.crn` would make the
+/// Exports section disappear from the snapshot.
 #[test]
 fn plan_snapshot_exports_multifile() {
-    use crate::commands::plan::ExportChange;
-    use carina_core::parser::TypeExpr;
-    use carina_core::resource::Value;
+    use crate::commands::plan::compute_export_diffs;
 
-    let (plan, schemas, moved_origins) = build_plan_from_fixture("exports_multifile");
-    let export_changes = vec![
-        ExportChange::Added {
-            name: "vpc_id".to_string(),
-            type_expr: Some(TypeExpr::String),
-            new_value: Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
-        },
-        ExportChange::Added {
-            name: "cidr".to_string(),
-            type_expr: None,
-            new_value: Value::resource_ref("vpc".to_string(), "cidr_block".to_string(), vec![]),
-        },
-    ];
+    let fp = build_plan_from_fixture_name("exports_multifile");
+
+    // Assert the multi-file load actually picked up exports.crn before
+    // rendering, so the snapshot claim is backed by parsed state.
+    let exported_names: Vec<&str> = fp.export_params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        exported_names,
+        vec!["vpc_id", "cidr"],
+        "exports.crn definitions must be merged when loading a multi-file project"
+    );
+
+    let export_changes = compute_export_diffs(&fp.export_params, &HashMap::new());
     let output = format_plan(
-        &plan,
+        &fp.plan,
         DetailLevel::Full,
         &HashMap::new(),
-        Some(&schemas),
-        &moved_origins,
+        Some(&fp.schemas),
+        &fp.moved_origins,
         &export_changes,
         &[],
     );

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -511,6 +511,41 @@ fn plan_snapshot_exports() {
     insta::assert_snapshot!(strip_ansi(&output));
 }
 
+/// Verifies that a project whose provider/resource/exports blocks are
+/// spread across sibling .crn files produces the same plan as the
+/// single-file `exports` fixture. Guards against regressions where
+/// directory-scoped parsing drops definitions in sibling files.
+#[test]
+fn plan_snapshot_exports_multifile() {
+    use crate::commands::plan::ExportChange;
+    use carina_core::parser::TypeExpr;
+    use carina_core::resource::Value;
+
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("exports_multifile");
+    let export_changes = vec![
+        ExportChange::Added {
+            name: "vpc_id".to_string(),
+            type_expr: Some(TypeExpr::String),
+            new_value: Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
+        },
+        ExportChange::Added {
+            name: "cidr".to_string(),
+            type_expr: None,
+            new_value: Value::resource_ref("vpc".to_string(), "cidr_block".to_string(), vec![]),
+        },
+    ];
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &export_changes,
+        &[],
+    );
+    insta::assert_snapshot!(strip_ansi(&output));
+}
+
 #[test]
 fn plan_snapshot_export_changes_mixed() {
     use crate::commands::plan::ExportChange;

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
@@ -9,7 +9,7 @@ Execution Plan:
 
 Exports:
 
-  + vpc_id: string = vpc.vpc_id
   + cidr = vpc.cidr_block
+  + vpc_id: string = vpc.vpc_id
 
 Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
@@ -1,0 +1,15 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: strip_ansi(&output)
+---
+Execution Plan:
+
+  + awscc.ec2.vpc vpc
+      cidr_block: "10.0.0.0/16"
+
+Exports:
+
+  + vpc_id: string = vpc.vpc_id
+  + cidr = vpc.cidr_block
+
+Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile/exports.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile/exports.crn
@@ -1,0 +1,4 @@
+exports {
+  vpc_id: string = vpc.vpc_id
+  cidr = vpc.cidr_block
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile/main.crn
@@ -1,0 +1,3 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}

--- a/carina-cli/tests/fixtures/plan_display/exports_multifile/resources.crn
+++ b/carina-cli/tests/fixtures/plan_display/exports_multifile/resources.crn
@@ -1,0 +1,3 @@
+let vpc = awscc.ec2.vpc {
+  cidr_block = '10.0.0.0/16'
+}


### PR DESCRIPTION
## Summary

Fixtures under `plan_display/` were almost entirely single-file (`main.crn` only), giving no end-to-end coverage that a project split across sibling `.crn` files produces the same plan. After #2002 made directory modules merge every `.crn` uniformly, this was the missing regression guard (sub-item of #1997).

- Add `exports_multifile/` fixture that spreads `provider` / resource / `exports` blocks across `main.crn`, `resources.crn`, and `exports.crn`.
- Add a snapshot test that derives `export_changes` from the parsed state (not a hardcoded vector), so a dropped `exports.crn` would blank the Exports section of the snapshot.
- Expose `export_params` on `FixturePlan` to make that derivation possible.
- Add a `plan-exports-multifile` Makefile target so CI's `Check Plan Fixtures` step (which requires one target per fixture dir) keeps passing.

## Test plan

- [x] `cargo test -p carina-cli plan_snapshot` — new test + existing snapshots pass
- [x] `cargo test --workspace` — full pass
- [x] `bash scripts/check-plan-fixtures.sh` — OK
- [x] Asserted `parsed.export_params` order (`["vpc_id", "cidr"]`) before rendering, so the snapshot is backed by real loaded data

Refs #1997