### PR TITLE
module_resolver: reject single-file modules, require directory paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,9 +225,13 @@ Enum values use namespaced identifiers like `aws.s3.VersioningStatus.Enabled`.
 
 ### Module Loading
 
-Directory-based modules (e.g., `modules/web_tier/`) require special handling:
-- CLI: `load_module()` checks `is_dir()` and merges all `.crn` files in the directory uniformly (no file name is privileged; `main.crn` is a peer of `arguments.crn`, `exports.crn`, etc.)
-- LSP: Module loading in `diagnostics/checks.rs` handles directory modules for proper validation
+Modules are directory-scoped. An import target must be a directory containing
+one or more `.crn` files; single-file modules are rejected with
+`ModuleError::NotADirectory`. Inside a module directory all `.crn` files are
+merged uniformly — no file name (including `main.crn`) is privileged.
+
+- CLI: `load_module()` / `ModuleResolver::load_module` require a directory path.
+- LSP: Module loading in `diagnostics/checks.rs` handles directory modules for proper validation.
 
 ## Git Workflow
 

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -119,7 +119,12 @@ impl<'cfg> ModuleResolver<'cfg> {
     pub fn load_module(&mut self, path: &str) -> Result<ParsedFile, ModuleError> {
         let full_path = self.resolve_path(path);
 
-        if !full_path.is_dir() {
+        // Distinguish "file exists but isn't a directory" from
+        // "path doesn't exist / permission denied": only the former is the
+        // single-file-module contract violation. Otherwise let canonicalize()
+        // surface the underlying IO error (NotFound, PermissionDenied, ...).
+        let metadata = full_path.metadata()?;
+        if !metadata.is_dir() {
             return Err(ModuleError::NotADirectory {
                 path: path.to_string(),
             });
@@ -1808,8 +1813,9 @@ mod tests {
 
     #[test]
     fn test_load_module_missing_path_cleans_resolving_set() {
-        // Nonexistent import path => NotADirectory. The resolving set must be
-        // cleaned up so a retry does not masquerade as a circular import.
+        // Nonexistent import path => descriptive IO error (NotFound), not the
+        // single-file-module contract error. The resolving set must be cleaned
+        // up so a retry does not masquerade as a circular import.
         let tmp_dir = std::env::temp_dir().join("carina_test_missing_path_cleanup");
         let _ = fs::create_dir_all(&tmp_dir);
 
@@ -1819,16 +1825,16 @@ mod tests {
             .load_module("nonexistent")
             .expect_err("expected error");
         assert!(
-            matches!(&err, ModuleError::NotADirectory { .. }),
-            "expected NotADirectory on first attempt, got: {err:?}"
+            matches!(&err, ModuleError::Io(_)),
+            "expected Io error for a nonexistent path, got: {err:?}"
         );
 
         let err = resolver
             .load_module("nonexistent")
             .expect_err("expected error");
         assert!(
-            matches!(&err, ModuleError::NotADirectory { .. }),
-            "expected NotADirectory on second attempt, not CircularImport, got: {err:?}"
+            matches!(&err, ModuleError::Io(_)),
+            "expected Io error on second attempt, not CircularImport, got: {err:?}"
         );
 
         let _ = fs::remove_dir_all(&tmp_dir);

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -71,6 +71,11 @@ pub enum ModuleError {
 
     #[error("Require constraint failed in module '{module}': {message}")]
     RequireConstraintFailed { module: String, message: String },
+
+    #[error(
+        "Module path '{path}' must be a directory. Single-file modules are not supported; put the module's .crn files in a directory and import the directory."
+    )]
+    NotADirectory { path: String },
 }
 
 /// Context for module resolution
@@ -106,19 +111,21 @@ impl<'cfg> ModuleResolver<'cfg> {
         }
     }
 
-    /// Load and cache a module from a file or directory path
+    /// Load and cache a module from a directory path.
+    ///
+    /// Modules are directory-scoped: a module is a directory containing one or
+    /// more `.crn` files. Single-file modules are not supported — pass the
+    /// module's directory, not an individual `.crn` file.
     pub fn load_module(&mut self, path: &str) -> Result<ParsedFile, ModuleError> {
         let full_path = self.resolve_path(path);
 
-        // Canonicalize for consistent cycle detection and caching.
-        // For directories, canonicalize directly. For files, try with .crn extension.
-        let canonical = if full_path.exists() {
-            full_path.canonicalize()?
-        } else if full_path.with_extension("crn").exists() {
-            full_path.with_extension("crn").canonicalize()?
-        } else {
-            full_path.clone()
-        };
+        if !full_path.is_dir() {
+            return Err(ModuleError::NotADirectory {
+                path: path.to_string(),
+            });
+        }
+
+        let canonical = full_path.canonicalize()?;
 
         // Check for circular import
         if self.resolving.contains(&canonical) {
@@ -133,17 +140,7 @@ impl<'cfg> ModuleResolver<'cfg> {
         // Mark as resolving
         self.resolving.insert(canonical.clone());
 
-        // Load module: directory or single file
-        let load_result = if full_path.is_dir() {
-            self.load_directory_module(&full_path)
-        } else {
-            fs::read_to_string(&full_path)
-                .map_err(ModuleError::from)
-                .and_then(|content| {
-                    crate::parser::parse(&content, self.config).map_err(ModuleError::from)
-                })
-        };
-        let mut parsed = match load_result {
+        let mut parsed = match self.load_directory_module(&full_path) {
             Ok(parsed) => parsed,
             Err(e) => {
                 self.resolving.remove(&canonical);
@@ -164,13 +161,8 @@ impl<'cfg> ModuleResolver<'cfg> {
         }
 
         // Recursively resolve nested module imports within this module.
-        // The module's base directory is used for resolving its relative imports.
-        let module_base_dir = if full_path.is_dir() {
-            full_path.clone()
-        } else {
-            full_path.parent().unwrap_or(&full_path).to_path_buf()
-        };
-        if let Err(e) = self.resolve_nested_modules(&mut parsed, &module_base_dir) {
+        // The module's directory is used for resolving its relative imports.
+        if let Err(e) = self.resolve_nested_modules(&mut parsed, &full_path) {
             self.resolving.remove(&canonical);
             return Err(e);
         }
@@ -657,21 +649,18 @@ pub fn get_parsed_file(path: &Path) -> Result<ParsedFile, ModuleError> {
     Ok(parsed)
 }
 
-/// Load a module from a file or directory path.
+/// Load a module from a directory path.
 ///
-/// For directories, merges all `.crn` files uniformly. No file name
-/// (including `main.crn`) is privileged: definitions in sibling files
-/// are preserved alongside `main.crn`.
+/// Modules are directory-scoped: all `.crn` files in the directory are merged
+/// uniformly, with no file name (including `main.crn`) treated as privileged.
 ///
-/// Returns `None` if the path cannot be read/parsed, or if the directory
+/// Returns `None` if `path` is not a directory, cannot be read/parsed, or
 /// contains no module definitions (no inputs or outputs).
 pub fn load_module(path: &Path) -> Option<ParsedFile> {
-    if path.is_dir() {
-        load_directory_module(path)
-    } else {
-        let content = fs::read_to_string(path).ok()?;
-        crate::parser::parse(&content, &ProviderContext::default()).ok()
+    if !path.is_dir() {
+        return None;
     }
+    load_directory_module(path)
 }
 
 /// Check that a module argument value matches the declared type.
@@ -1818,27 +1807,28 @@ mod tests {
     }
 
     #[test]
-    fn test_load_module_io_error_cleans_resolving_set() {
-        let tmp_dir = std::env::temp_dir().join("carina_test_io_error_cleanup");
+    fn test_load_module_missing_path_cleans_resolving_set() {
+        // Nonexistent import path => NotADirectory. The resolving set must be
+        // cleaned up so a retry does not masquerade as a circular import.
+        let tmp_dir = std::env::temp_dir().join("carina_test_missing_path_cleanup");
         let _ = fs::create_dir_all(&tmp_dir);
 
         let mut resolver = ModuleResolver::new(&tmp_dir);
 
-        // First attempt: load a non-existent file -> IO error
-        let result = resolver.load_module("nonexistent");
-        assert!(result.is_err());
+        let err = resolver
+            .load_module("nonexistent")
+            .expect_err("expected error");
         assert!(
-            matches!(&result.unwrap_err(), ModuleError::Io(_)),
-            "expected IO error on first attempt"
+            matches!(&err, ModuleError::NotADirectory { .. }),
+            "expected NotADirectory on first attempt, got: {err:?}"
         );
 
-        // Second attempt: should get the same IO error, not a circular import error.
-        // Before the fix, the path stayed in `resolving` and this would return CircularImport.
-        let result = resolver.load_module("nonexistent");
-        assert!(result.is_err());
+        let err = resolver
+            .load_module("nonexistent")
+            .expect_err("expected error");
         assert!(
-            matches!(&result.unwrap_err(), ModuleError::Io(_)),
-            "expected IO error on second attempt, not CircularImport"
+            matches!(&err, ModuleError::NotADirectory { .. }),
+            "expected NotADirectory on second attempt, not CircularImport, got: {err:?}"
         );
 
         let _ = fs::remove_dir_all(&tmp_dir);
@@ -1846,15 +1836,20 @@ mod tests {
 
     #[test]
     fn test_load_module_parse_error_cleans_resolving_set() {
-        let tmp_dir = std::env::temp_dir().join("carina_test_parse_error_cleanup");
-        let _ = fs::create_dir_all(&tmp_dir);
-        let bad_file = tmp_dir.join("bad_module.crn");
-        fs::write(&bad_file, "this is not valid carina syntax {{{{").unwrap();
+        let tmp_root = std::env::temp_dir().join("carina_test_parse_error_cleanup");
+        let _ = fs::remove_dir_all(&tmp_root);
+        let bad_module_dir = tmp_root.join("bad_module");
+        fs::create_dir_all(&bad_module_dir).unwrap();
+        fs::write(
+            bad_module_dir.join("main.crn"),
+            "this is not valid carina syntax {{{{",
+        )
+        .unwrap();
 
-        let mut resolver = ModuleResolver::new(&tmp_dir);
+        let mut resolver = ModuleResolver::new(&tmp_root);
 
-        // First attempt: parse error (use .crn extension since load_module reads full_path directly)
-        let result = resolver.load_module("bad_module.crn");
+        // First attempt: parse error on a directory module with a bad .crn file.
+        let result = resolver.load_module("bad_module");
         assert!(
             result.is_err(),
             "expected error but got: {:?}",
@@ -1867,7 +1862,8 @@ mod tests {
         );
 
         // Second attempt: should still get parse error, not circular import
-        let result = resolver.load_module("bad_module.crn");
+        // (the resolving set must have been cleaned up).
+        let result = resolver.load_module("bad_module");
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1875,7 +1871,29 @@ mod tests {
             "expected Parse error on second attempt, not CircularImport, got: {err:?}"
         );
 
-        let _ = fs::remove_dir_all(&tmp_dir);
+        let _ = fs::remove_dir_all(&tmp_root);
+    }
+
+    #[test]
+    fn test_load_module_rejects_file_path() {
+        // Issue #1997: Modules must be directories. A single `.crn` file as a
+        // module target should be rejected with NotADirectory instead of being
+        // parsed as a one-file module.
+        let tmp_root = std::env::temp_dir().join("carina_test_module_rejects_file");
+        let _ = fs::remove_dir_all(&tmp_root);
+        fs::create_dir_all(&tmp_root).unwrap();
+        fs::write(tmp_root.join("single.crn"), "arguments {\n  x: string\n}\n").unwrap();
+
+        let mut resolver = ModuleResolver::new(&tmp_root);
+        let err = resolver
+            .load_module("single.crn")
+            .expect_err("a single .crn file must not be loadable as a module");
+        assert!(
+            matches!(&err, ModuleError::NotADirectory { .. }),
+            "expected NotADirectory, got {err:?}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp_root);
     }
 
     /// Helper to create a module with a validated port argument

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1290,7 +1290,10 @@ fn for_loop_discard_not_suggested() {
 }
 
 #[test]
-fn import_path_completion_lists_directories_and_crn_files() {
+fn import_path_completion_lists_directories_only() {
+    // Modules are directory-scoped (issue #1997). Stray `.crn` files next to
+    // module directories must NOT be suggested as import targets — the
+    // resolver would reject them with NotADirectory.
     let tmp = tempfile::tempdir().unwrap();
     let modules_dir = tmp.path().join("modules");
     std::fs::create_dir_all(&modules_dir).unwrap();
@@ -1312,13 +1315,13 @@ fn import_path_completion_lists_directories_and_crn_files() {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"web"),
-        "Should suggest 'web' (.crn file without extension). Got: {:?}",
+        labels.contains(&"shared/"),
+        "Should suggest 'shared/' directory. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"shared/"),
-        "Should suggest 'shared/' directory. Got: {:?}",
+        !labels.contains(&"web"),
+        "Must NOT suggest 'web' for a standalone .crn file. Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -184,60 +184,6 @@ web_tier {
 }
 
 #[test]
-fn module_parameter_completion_with_single_file_module() {
-    use std::fs;
-    use tempfile::tempdir;
-
-    let provider = test_provider();
-
-    // Create a temporary directory structure
-    let temp_dir = tempdir().expect("Failed to create temp dir");
-    let base_path = temp_dir.path();
-
-    // Create module directory
-    let module_dir = base_path.join("modules");
-    fs::create_dir_all(&module_dir).expect("Failed to create module dir");
-
-    // Create single file module
-    let module_content = r#"
-arguments {
-name: string
-count: int = 1
-}
-"#;
-    fs::write(module_dir.join("simple.crn"), module_content).expect("Failed to write module file");
-
-    // Create main file that imports the module
-    let main_content = r#"let simple = import "./modules/simple.crn"
-
-simple {
-n
-}"#;
-    let doc = create_document(main_content);
-
-    // Cursor inside the module call block (line 3, after "n")
-    let position = Position {
-        line: 3,
-        character: 5,
-    };
-
-    let completions = provider.complete(&doc, position, Some(base_path));
-
-    // Should have module parameter completions
-    let name_completion = completions.iter().find(|c| c.label == "name");
-    assert!(
-        name_completion.is_some(),
-        "Should have name parameter completion"
-    );
-
-    let count_completion = completions.iter().find(|c| c.label == "count");
-    assert!(
-        count_completion.is_some(),
-        "Should have count parameter completion"
-    );
-}
-
-#[test]
 #[ignore = "requires provider schemas"]
 fn instance_tenancy_completion_for_aws_vpc() {
     let provider = test_provider();

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -475,30 +475,20 @@ impl CompletionProvider {
             }
 
             let path = entry.path();
-            if path.is_dir() {
-                // Directory: suggest as path component
-                if name.starts_with(name_prefix) {
-                    completions.push(CompletionItem {
-                        label: format!("{}/", name),
-                        kind: Some(CompletionItemKind::FOLDER),
-                        insert_text: Some(format!("{}/", name)),
-                        detail: Some("Directory".to_string()),
-                        command: Some(Command {
-                            title: "Trigger Suggest".to_string(),
-                            command: "editor.action.triggerSuggest".to_string(),
-                            arguments: None,
-                        }),
-                        ..Default::default()
-                    });
-                }
-            } else if name.ends_with(".crn") && name.starts_with(name_prefix) {
-                // .crn file: suggest without extension
-                let stem = name.strip_suffix(".crn").unwrap_or(&name);
+            // Modules are directory-scoped, so only directories are valid
+            // import targets; .crn files on their own are rejected by the
+            // resolver (ModuleError::NotADirectory).
+            if path.is_dir() && name.starts_with(name_prefix) {
                 completions.push(CompletionItem {
-                    label: stem.to_string(),
-                    kind: Some(CompletionItemKind::FILE),
-                    insert_text: Some(stem.to_string()),
-                    detail: Some("Carina module".to_string()),
+                    label: format!("{}/", name),
+                    kind: Some(CompletionItemKind::FOLDER),
+                    insert_text: Some(format!("{}/", name)),
+                    detail: Some("Module directory".to_string()),
+                    command: Some(Command {
+                        title: "Trigger Suggest".to_string(),
+                        command: "editor.action.triggerSuggest".to_string(),
+                        arguments: None,
+                    }),
                     ..Default::default()
                 });
             }

--- a/docs/src/content/docs/reference/dsl/modules.md
+++ b/docs/src/content/docs/reference/dsl/modules.md
@@ -7,10 +7,10 @@ Modules are reusable units of Carina configuration. A module defines a set of re
 
 ## Module Structure
 
-A module is a `.crn` file (or a directory containing `main.crn`) that declares `arguments` and `attributes` blocks.
+A module is a directory containing one or more `.crn` files that together declare `arguments` and `attributes` blocks. Carina merges every `.crn` file in the directory as peers; there is no privileged filename like `main.crn`.
 
 ```crn
-# modules/network/main.crn
+# modules/network/main.crn  (any filename works — main.crn is just convention)
 
 arguments {
   cidr_block : string
@@ -168,19 +168,31 @@ awscc.ec2.security_group {
 
 ## Directory Modules
 
-A module can be either:
+A module is always a **directory** containing one or more `.crn` files. Every
+`.crn` file in that directory is merged into a single module — no file name
+(including `main.crn`) is treated as privileged, so definitions can be split
+across `arguments.crn`, `exports.crn`, `resources.crn`, etc. as naturally as
+you like.
 
-- **A single file**: `import "./modules/network.crn"` (the `.crn` extension can be omitted)
-- **A directory**: `import "./modules/network"` which loads `./modules/network/main.crn`
+```
+modules/network/
+  main.crn        # optional; just one of the module's .crn files
+  arguments.crn   # merged in as peers
+  exports.crn
+```
 
-Directory modules are useful when a module needs helper files or becomes complex enough to warrant its own directory.
+Single-file imports (`import "./modules/network.crn"`) are **not supported**:
+the loader returns `NotADirectory` for any path that is not a directory.
+If your module is currently a single `.crn` file, move it into a directory of
+its own.
 
 ## Module Resolution
 
-Import paths are resolved relative to the file containing the `import` statement:
+Import paths are resolved relative to the file containing the `import`
+statement and must point at a directory:
 
 ```crn
-# From project/main.crn, imports project/modules/network/main.crn
+# From project/main.crn, imports every .crn file under project/modules/network/
 let network = import './modules/network'
 
 # Relative path from current file


### PR DESCRIPTION
## Summary

Modules are directory-scoped in Carina, but the loader still quietly accepted single-file targets: `ModuleResolver::load_module` would fall back to parsing an individual `.crn` file (even auto-appending the extension), and the free function `load_module` parsed any file path. This PR eliminates that last single-file escape hatch as part of #1997 ("eliminate single-file assumptions in directory-scoped parsing" — the overall intent of which is to route everything through directory-scoped parsing rather than accommodating per-file code paths).

- Add `ModuleError::NotADirectory { path }` and return it whenever an import target is not a directory.
- Remove the `full_path.with_extension("crn")` auto-completion in the resolver — modules are directories, so there is no extension to infer.
- Simplify the recursive-resolution base directory: it is always the module directory itself, no `parent()` fallback.
- Replace the IO-error resolving-set-cleanup test with an equivalent `NotADirectory`-cleanup test, and rewrite the parse-error-cleanup test to use a directory module containing a bad `.crn`. Same intent (resolving set is cleaned up on failure), matched to the new contract.
- Add `test_load_module_rejects_file_path` to pin the new behavior.
- Remove the now-duplicate `module_parameter_completion_with_single_file_module` LSP test; the pre-existing directory-module test covers the same surface.
- Update `CLAUDE.md`'s Module Loading section to describe the rule.

## Test plan

- [x] `cargo test -p carina-core` — full pass (1238 tests)
- [x] `cargo test --workspace` — full pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] pre-commit (fmt + clippy) pass

Refs #1997