### PR TITLE
config_loader: stamp warnings with full source path, not bare filename

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -65,13 +65,17 @@ pub fn load_configuration_with_config(
                 .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
             match parser::parse(&content, config) {
                 Ok(mut parsed) => {
-                    // Stamp source file name onto warnings and deferred for-expressions
-                    let file_name = file.file_name().map(|n| n.to_string_lossy().into_owned());
+                    // Stamp the full source path onto warnings and deferred
+                    // for-expressions. Bare filenames are ambiguous when a
+                    // project spans multiple `.crn` files (and identically
+                    // named files in sibling directories), and they break
+                    // editor jump-to-location.
+                    let file_path = Some(file.display().to_string());
                     for w in &mut parsed.warnings {
-                        w.file = file_name.clone();
+                        w.file = file_path.clone();
                     }
                     for d in &mut parsed.deferred_for_expressions {
-                        d.file = file_name.clone();
+                        d.file = file_path.clone();
                     }
 
                     let unresolved = parsed.clone();
@@ -233,12 +237,12 @@ pub fn parse_directory_with_overrides(
         };
         match parser::parse(&content, config) {
             Ok(mut parsed) => {
-                let file_name = Some(name.clone());
+                let file_path = Some(file.display().to_string());
                 for w in &mut parsed.warnings {
-                    w.file = file_name.clone();
+                    w.file = file_path.clone();
                 }
                 for d in &mut parsed.deferred_for_expressions {
-                    d.file = file_name.clone();
+                    d.file = file_path.clone();
                 }
                 merge_parsed_file(&mut merged, parsed);
             }
@@ -717,6 +721,47 @@ mod tests {
             ),
             Ok(_) => panic!("expected error for file path"),
         }
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn load_configuration_stamps_full_path_on_warnings() {
+        // Issue #1997: warnings and deferred for-expressions must carry a full
+        // source path, not a bare filename. Bare filenames are ambiguous when a
+        // project spans multiple .crn files and break editor jump-to-location.
+        let dir = create_temp_dir("load_warning_full_path");
+        // A for-loop with an unused binding generates a ParseWarning.
+        let crn_path = dir.join("main.crn");
+        fs::write(
+            &crn_path,
+            r#"provider aws {
+    region = aws.Region.ap_northeast_1
+}
+
+let empty_list = []
+let _ = for unused_var in empty_list {
+    aws.ec2.vpc {
+        cidr_block = "10.0.0.0/16"
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let config = load_configuration(&dir).unwrap();
+        assert!(
+            !config.parsed.warnings.is_empty(),
+            "fixture must produce at least one ParseWarning"
+        );
+        let stamped = config.parsed.warnings[0]
+            .file
+            .as_ref()
+            .expect("warning must have a file path stamped");
+        assert_eq!(
+            stamped,
+            &crn_path.display().to_string(),
+            "warning.file must carry the full source path, not a bare filename",
+        );
         cleanup(&dir);
     }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -61,6 +61,9 @@ pub enum ParseError {
 /// A structured warning emitted during parsing (non-fatal).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseWarning {
+    /// Full source path of the file this warning originated from
+    /// (stamped by `config_loader` after parsing). `None` at parse time;
+    /// always `Some` once the warning reaches CLI/LSP callers.
     pub file: Option<String>,
     pub line: usize,
     pub message: String,
@@ -83,7 +86,8 @@ pub(crate) const DEFERRED_UPSTREAM_INDEX_PLACEHOLDER: &str = "(known after upstr
 /// is loaded from upstream_state.
 #[derive(Debug, Clone)]
 pub struct DeferredForExpression {
-    /// Source file name (stamped by config_loader after parsing).
+    /// Full source path of the file this deferred expression originated
+    /// from (stamped by `config_loader` after parsing).
     pub file: Option<String>,
     /// Source line number of the `for` keyword.
     pub line: usize,


### PR DESCRIPTION
## Summary

`ParseWarning::file` and `DeferredForExpression::file` were stamped with `file.file_name()` — a bare filename (e.g. `main.crn`). In a directory-scoped project that spans multiple `.crn` files (or when module directories at different paths happen to contain same-named files), a bare filename is ambiguous and breaks editor jump-to-location. Part of #1997 ("eliminate single-file assumptions in directory-scoped parsing").

- Both `load_configuration_with_config` and `parse_directory_with_overrides` now stamp the full source path (`file.display().to_string()`).
- Updated the doc-comments on `ParseWarning::file` and `DeferredForExpression::file` to reflect the contract.
- The `w.file == deferred.file` equality checks inside `parser::expand_*` compare the stamped value against itself, so changing both stamp sites in lockstep preserves the invariant.
- Added `load_configuration_stamps_full_path_on_warnings` to pin the new behavior: an unused-for-binding warning must carry the full path of the originating `.crn`.

## Test plan

- [x] `cargo test -p carina-core` — 1239 tests pass (including the new one)
- [x] `cargo test --workspace` — full pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] pre-commit (fmt + clippy) pass

Refs #1997