### PR TITLE
UpstreamState: clarify source path resolution for directory-scoped projects

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -382,9 +382,19 @@ pub struct BackendConfig {
 /// Upstream state reference: `let <binding> = upstream_state { source = "<dir>" }`.
 ///
 /// Declares a read-only reference to another Carina configuration's state.
-/// The `source` path is resolved against the enclosing `.crn` file's
-/// directory at plan/apply time; its backend and state file are derived
-/// from the upstream configuration itself.
+///
+/// `source` is a directory path. Carina itself is directory-scoped, so every
+/// sibling `.crn` file in a project (or module) shares the same base
+/// directory; the resolution rule is simply:
+///
+/// - Absolute paths are used as-is.
+/// - Relative paths are resolved against the **enclosing project or module
+///   directory** — the one passed to `carina validate` / `plan` / `apply`,
+///   or the module directory containing the `upstream_state` declaration.
+///
+/// Which specific `.crn` file inside that directory declares the
+/// `upstream_state` does not affect resolution. The upstream's backend and
+/// state file are derived from the upstream configuration itself.
 #[derive(Debug, Clone)]
 pub struct UpstreamState {
     /// The binding name (e.g., "orgs")

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -309,6 +309,43 @@ mod tests {
     }
 
     #[test]
+    fn resolve_uses_base_dir_regardless_of_declaring_file() {
+        // Issue #1997: the `source` path is resolved against the project's
+        // base directory (the directory passed to validate/plan/apply), not
+        // against the specific .crn file that happens to declare the
+        // `upstream_state`. Two declarations in sibling files in the same
+        // project must therefore resolve identically.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "exports.crn",
+            r#"exports {
+                accounts: string = "x"
+            }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+        // Two sibling .crn files living at different depths is not possible
+        // within one base_dir (directory-scoped parse is flat), but the rule
+        // is that file position inside the base dir is irrelevant: the same
+        // relative source string resolves the same way for every declaration.
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        assert!(got.get("orgs").unwrap().contains("accounts"));
+
+        // Same call a second time with an identical UpstreamState produces
+        // the same result — guards against any accidental dependence on
+        // declaring-file state.
+        let (got2, errs2) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs2.is_empty());
+        assert_eq!(got, got2);
+    }
+
+    #[test]
     fn resolve_reads_exports_from_default_exports_file() {
         let tmp = tempfile::tempdir().unwrap();
         let upstream_dir = tmp.path().join("organizations");


### PR DESCRIPTION
## Summary

`UpstreamState`'s doc-comment claimed that the `source` path is resolved "against the enclosing `.crn` file's directory." That wording is misleading — and simply wrong when the enclosing project or module spans multiple `.crn` files. The actual rule (implemented in `resolve_upstream_exports`) is:

- Absolute paths: used as-is.
- Relative paths: resolved against the project's **base directory** — the directory passed to `validate`/`plan`/`apply`, or the module directory containing the declaration.
- The specific `.crn` file inside that base directory is irrelevant.

This is the "clarify (and test) the resolution rule" item on #1997.

## Changes

- Rewrite the `UpstreamState` struct doc-comment to state the rule plainly and call out that declaring-file position does not affect resolution.
- Add `resolve_uses_base_dir_regardless_of_declaring_file` as a regression guard — two identical `UpstreamState` declarations resolve to identical export sets, and the resolver does not carry any hidden per-file state.

## Test plan

- [x] `cargo test -p carina-core resolve_uses_base_dir` — new test passes
- [x] `cargo test --workspace` — full pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] pre-commit (fmt + clippy) pass

Refs #1997