### PR TITLE
upstream_state: pin multi-file upstream resolution + clarify LSP check scope

### DIFF
--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -394,6 +394,49 @@ mod tests {
     }
 
     #[test]
+    fn resolve_merges_exports_across_multiple_crn_files_in_upstream() {
+        // Issue #1997: when the upstream project is multi-file, the resolver
+        // must merge every .crn file's exports — not just read one privileged
+        // file. A downstream that references a field declared in a sibling
+        // of the upstream's exports file must still validate.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        // Two sibling files each contributing their own exports block.
+        write_crn(
+            &upstream_dir,
+            "accounts.crn",
+            r#"exports {
+                accounts: string = "x"
+            }"#,
+        );
+        write_crn(
+            &upstream_dir,
+            "region.crn",
+            r#"exports {
+                region: string = "ap-northeast-1"
+            }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let keys = got.get("orgs").expect("resolved");
+        assert!(
+            keys.contains("accounts"),
+            "export from accounts.crn must be merged, got {:?}",
+            keys
+        );
+        assert!(
+            keys.contains("region"),
+            "export from region.crn must be merged, got {:?}",
+            keys
+        );
+    }
+
+    #[test]
     fn resolve_skips_missing_source_directory() {
         // Missing-directory is `check_upstream_state_sources`' job; this
         // resolver stays quiet about it.

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -376,6 +376,12 @@ impl DiagnosticEngine {
     /// surface typo'd source paths as squiggles instead of waiting until the
     /// user runs `carina validate` or `carina plan`. Cheap by design — no
     /// canonicalize, no remote state reads.
+    ///
+    /// Scope: **directory existence only.** Parsing the upstream's `.crn`
+    /// files (across every sibling file in the upstream directory) and
+    /// checking references against its declared exports is the job of
+    /// [`Self::check_upstream_state_field_references`], which runs a full
+    /// directory-scoped parse via `parse_directory_with_overrides`.
     pub(super) fn check_upstream_state_sources(
         &self,
         doc: &Document,


### PR DESCRIPTION
## Summary

Two related clarifications for the #1997 item that claimed LSP "doesn't descend into multi-file target modules" for upstream state. The descent already exists — it just lives in `check_upstream_state_field_references` (which runs a full directory-scoped parse) rather than in `check_upstream_state_sources` (which is deliberately a shallow directory-existence check). This PR pins the invariant with a test and makes the split of responsibility explicit in doc-comments.

## Changes

- Add `resolve_merges_exports_across_multiple_crn_files_in_upstream` to `upstream_exports`. The existing tests covered a single `.crn` containing the `exports` block; this one splits exports across sibling files and asserts the resolver merges them. Works today by virtue of the shared `parse_directory` path — having the invariant explicit in a test prevents a future privileged-file refactor from silently re-introducing the single-file assumption.
- Expand the doc-comment on LSP `check_upstream_state_sources` to call out that the check is deliberately shallow (directory existence only), and point at `check_upstream_state_field_references` as the function that does the directory-scoped parse of every sibling `.crn`.

No behavior change — both `resolve_upstream_exports` and `check_upstream_state_field_references` were already multi-file-aware.

## Test plan

- [x] `cargo test -p carina-core resolve_merges_exports_across_multiple` — new test passes
- [x] `cargo test --workspace` — full pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] pre-commit (fmt + clippy) pass

Refs #1997