### PR TITLE
LSP: clarify scan_sibling_context's one-directory-level scope

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -184,13 +184,27 @@ impl Backend {
         self.workspace_root.get().and_then(|opt| opt.as_ref())
     }
 
-    /// Scan sibling .crn files for `let binding = provider.service.type {` patterns.
-    /// Returns a map of binding_name → "provider.service.type" (schema key).
-    /// Scan sibling .crn files for let bindings and references.
+    /// Scan sibling `.crn` files in the same directory for `let` bindings
+    /// and references to the current file's bindings.
     ///
-    /// Returns:
-    /// - `bindings`: binding_name → resource_type for let bindings in sibling files
-    /// - `referenced`: binding names from the current file that are referenced by sibling files
+    /// ## Scope
+    ///
+    /// Intentionally **one directory level only** (the parent directory of
+    /// the file being edited). Carina is directory-scoped — each directory
+    /// is its own parse unit. Files in nested subdirectories are separate
+    /// modules or upstream projects with their own binding scopes, so they
+    /// must not leak bindings into this cross-file reference check.
+    /// Dedicated diagnostics
+    /// ([`crate::diagnostics::checks::DiagnosticEngine::check_upstream_state_field_references`])
+    /// handle references that do cross a directory boundary (upstream
+    /// state exports, module call arguments) via
+    /// `parse_directory_with_overrides`.
+    ///
+    /// ## Returns
+    /// - `bindings`: binding_name → resource_type for `let` bindings in the
+    ///   current file's sibling `.crn`s.
+    /// - `referenced`: binding names from the current file that appear to be
+    ///   referenced by those siblings.
     fn scan_sibling_context(
         dir: &Path,
         current_uri: &Url,


### PR DESCRIPTION
## Summary

`scan_sibling_context`'s doc-comment had a duplicated opening line and said nothing about *why* only one directory level is scanned. Issue #1997 flagged this as a gap ("cross-directory configurations aren't fully considered"), but on closer reading the one-level scope is the right answer for directory-scoped Carina, not a bug:

- Each directory is its own parse unit.
- Files in nested subdirectories are separate modules or upstream projects with their own binding scopes.
- Cross-directory semantics that *do* matter (upstream exports, module calls) already live in `check_upstream_state_field_references`, which runs a full directory-scoped parse via `parse_directory_with_overrides`.

## Changes

- Rewrite the `scan_sibling_context` doc-comment to state the scope plainly, explain that it's intentional (not a TODO), and point at the diagnostic that handles the cross-directory cases.
- No behavior change.

## Test plan

- [x] `cargo test --workspace` — full pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] pre-commit (fmt + clippy) pass

Refs #1997