### PR TITLE
LSP: name the 'provider not downloaded' case explicitly

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -213,7 +213,8 @@ impl DiagnosticEngine {
                             ));
                         }
                     } else if !provider_loaded {
-                        // Provider not loaded at all
+                        // Provider not downloaded: point at `carina init`,
+                        // not a generic "unknown" message that reads as a typo.
                         if let Some((line, col)) = self.find_resource_type_position(
                             doc,
                             provider,
@@ -229,8 +230,8 @@ impl DiagnosticEngine {
                                 end_col,
                                 DiagnosticSeverity::ERROR,
                                 format!(
-                                    "Unknown resource type: {}.{}",
-                                    provider, resource.id.resource_type
+                                    "Provider '{}' is not downloaded. Run `carina init` to fetch it.",
+                                    provider
                                 ),
                             ));
                         }

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1432,6 +1432,9 @@ fn warning_when_provider_loaded_but_schema_missing() {
 #[test]
 fn error_when_provider_not_loaded_at_all() {
     // Provider completely unknown — not in provider_names, not in errors.
+    // Message should point at the missing download, not a generic "Unknown
+    // resource type" (which misleads the user into searching for typos in a
+    // name that is actually correct — see issue #2005).
     let engine = DiagnosticEngine::new(Arc::new(HashMap::new()), vec![], Arc::new(vec![]));
     let doc = create_document(
         r#"awscc.iam.role {
@@ -1442,12 +1445,27 @@ fn error_when_provider_not_loaded_at_all() {
 
     let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
 
-    let unknown_type = diagnostics
-        .iter()
-        .find(|d| d.message.contains("Unknown resource type"));
+    let not_downloaded = diagnostics.iter().find(|d| {
+        d.message.contains("Provider 'awscc' is not downloaded")
+            && d.message.contains("carina init")
+    });
     assert!(
-        unknown_type.is_some(),
-        "Unknown provider should show 'Unknown resource type'. Got: {:?}",
+        not_downloaded.is_some(),
+        "Provider-not-downloaded case should say so explicitly, not 'Unknown resource type'. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        not_downloaded.unwrap().severity,
+        Some(DiagnosticSeverity::ERROR)
+    );
+
+    // And the old generic message should no longer fire for this case.
+    let generic_unknown = diagnostics
+        .iter()
+        .find(|d| d.message == "Unknown resource type: awscc.iam.role");
+    assert!(
+        generic_unknown.is_none(),
+        "Should not emit generic 'Unknown resource type' when the provider itself is not downloaded. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Summary

- `carina-lsp` diagnostics for unknown resource types collapsed two distinct failure modes — "provider not downloaded" and "provider loaded, resource type unknown" — into the same `"Unknown resource type: …"` wording. Users had no signal that `carina init` was the fix and would chase typos in names that were actually correct.
- Split the `!provider_loaded` branch's message to `"Provider '<name>' is not downloaded. Run \`carina init\` to fetch it."` (severity unchanged at ERROR). The other two branches (provider load error, provider loaded but schema missing) are untouched.

## Out of scope (per issue)

- CodeAction wiring for `carina init` (workspace/executeCommand) — follow-up.
- "did you mean?" suggestions for typo'd resource types — follow-up.
- Mirroring the rewording in the `validate` / `plan` CLI diagnostics (`carina-core/src/validation.rs`) — separate audit.

## Test plan

- [x] `cargo test -p carina-lsp` — 251 pass, 0 fail
- [x] Updated `error_when_provider_not_loaded_at_all` to assert the new wording **and** that the old generic wording no longer fires for this case (regression guard)
- [x] `warning_when_provider_loaded_but_schema_missing` still passes — confirms the two branches remain distinguishable
- [x] `cargo clippy -p carina-lsp --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #2005