### PR TITLE
LSP: treat declared providers as namespaces in undefined-ref check

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -636,6 +636,35 @@ impl DiagnosticEngine {
         bindings
     }
 
+    /// Extract provider names declared with `provider NAME {` in the current
+    /// document text. Used to treat an unresolved `NAME.` prefix as a provider
+    /// namespace rather than an undefined `let` binding when the provider is
+    /// declared but not yet downloaded (issue #2019).
+    pub(super) fn extract_declared_provider_names(&self, text: &str) -> HashSet<String> {
+        let mut names = HashSet::new();
+        for line in text.lines() {
+            let trimmed = line.trim_start();
+            let Some(rest) = trimmed.strip_prefix("provider") else {
+                continue;
+            };
+            let Some(rest) = rest.strip_prefix(|c: char| c.is_ascii_whitespace()) else {
+                continue;
+            };
+            let name_end = rest
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(rest.len());
+            if name_end == 0 {
+                continue;
+            }
+            let name = &rest[..name_end];
+            let after_name = rest[name_end..].trim_start();
+            if after_name.starts_with('{') {
+                names.insert(name.to_string());
+            }
+        }
+        names
+    }
+
     /// Check attributes blocks for type mismatches and undefined binding references.
     pub(super) fn check_attributes_blocks(
         &self,
@@ -1066,6 +1095,7 @@ impl DiagnosticEngine {
         &self,
         text: &str,
         defined_bindings: &HashSet<String>,
+        declared_providers: &HashSet<String>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
@@ -1082,11 +1112,18 @@ impl DiagnosticEngine {
                     continue;
                 }
 
-                // Skip if it starts with a provider prefix (enum values like aws.Region.xxx)
+                // Skip if it starts with a provider prefix. Include providers
+                // declared in the current document (issue #2019) so that an
+                // enum reference like `awscc.Region.ap_northeast_1` is not
+                // flagged as an undefined `let` binding when the provider is
+                // declared but not yet downloaded.
                 let is_provider_prefix = self
                     .provider_names
                     .iter()
-                    .any(|name| after_eq_trimmed.starts_with(&format!("{}.", name)));
+                    .any(|name| after_eq_trimmed.starts_with(&format!("{}.", name)))
+                    || declared_providers
+                        .iter()
+                        .any(|name| after_eq_trimmed.starts_with(&format!("{}.", name)));
                 if is_provider_prefix {
                     continue;
                 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -142,7 +142,9 @@ impl DiagnosticEngine {
         for name in sibling_bindings.keys() {
             all_bindings.insert(name.clone());
         }
-        let undef_diags = self.check_undefined_references(&text, &all_bindings);
+        let declared_providers = self.extract_declared_provider_names(&text);
+        let undef_diags =
+            self.check_undefined_references(&text, &all_bindings, &declared_providers);
         diagnostics.extend(undef_diags);
 
         // Upstream_state field-ref check: must run even when the current

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1499,6 +1499,64 @@ fn no_undefined_resource_for_namespaced_enum_value() {
 }
 
 #[test]
+fn no_undefined_resource_for_declared_but_uninstalled_provider() {
+    // Regression for #2019: when a provider is declared (`provider awscc { ... }`)
+    // in the current document but hasn't been downloaded (installed provider_names
+    // is empty), the provider-namespaced enum reference on its right-hand side
+    // used to be flagged as `Undefined resource: 'awscc'. Define it with 'let
+    // awscc = aws...'` — which is both wrong (awscc is a namespace, not a let
+    // binding) and actively misleading (following the fix breaks valid DSL).
+    let engine = DiagnosticEngine::new(
+        Arc::new(HashMap::new()),
+        vec![], // nothing installed — simulates missing .carina/
+        Arc::new(vec![]),
+    );
+    let doc = create_document(
+        r#"provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+
+    let undefined = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource"));
+    assert!(
+        undefined.is_none(),
+        "Declared-but-uninstalled provider name must not be flagged as 'Undefined resource'. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn undefined_resource_still_fires_when_identifier_is_not_a_declared_provider() {
+    // Regression guard for #2019: the fix must not swallow legitimate undefined-
+    // binding diagnostics. When the root identifier is not a declared provider
+    // and not a defined binding, the existing "Undefined resource" message
+    // should still fire.
+    let engine = DiagnosticEngine::new(Arc::new(HashMap::new()), vec![], Arc::new(vec![]));
+    let doc = create_document(
+        r#"provider awscc {
+  region = totally_unknown.some_attr
+}
+"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+
+    let undefined = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource: 'totally_unknown'"));
+    assert!(
+        undefined.is_some(),
+        "A genuinely unknown identifier should still produce the 'Undefined resource' diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn map_key_validation_warns_on_invalid_key() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 


### PR DESCRIPTION
## Summary

- In `carina-lsp/src/diagnostics/checks.rs`, `check_undefined_references` was skipping the `NAME.` provider-namespace prefix only when `NAME` was an **installed** provider. When a `provider NAME { ... }` block existed in the document but the provider had not yet been downloaded (`.carina/` missing), expressions like `region = NAME.Region.ap_northeast_1` on the right-hand side of `=` fell through to the undefined-binding path and produced `"Undefined resource: 'NAME'. Define it with 'let NAME = aws...'"` — an actively wrong suggestion that turns valid DSL into invalid DSL.
- Added `extract_declared_provider_names` (textual scan for `provider NAME {`) and passed the result into `check_undefined_references`. The provider-prefix skip now considers installed providers OR providers declared in the current document.

## Root cause note

The issue hypothesized the bug lived in `carina-core::check_undefined_bindings`. In practice that function never gets this input — provider-block attributes aren't fed to it, and the repro case CLI-errors earlier via provider resolution. The actual offender is the LSP's raw-text scan in `check_undefined_references`. Fix is LSP-local.

## Out of scope (per issue)

- New diagnostic variant `"Provider 'X' is declared but not downloaded"` and a `carina init` CodeAction — the primary harm (misleading fix) is removed by suppressing the wrong diagnostic; positive "run init" messaging can layer on top later.
- CLI-side parity with `validate` / `plan` — see #2018.

## Test plan

- [x] `cargo test -p carina-lsp` — 253 pass, 0 fail (up from 251; added 2 tests)
- [x] New test `no_undefined_resource_for_declared_but_uninstalled_provider` reproduces the issue exactly (fails before the fix, passes after)
- [x] New test `undefined_resource_still_fires_when_identifier_is_not_a_declared_provider` guards against accidentally swallowing legitimate undefined-binding diagnostics
- [x] `cargo clippy -p carina-lsp --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #2019