### PR TITLE
LSP: reload providers on .carina/ delete and on providers.crn edits

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -37,12 +37,22 @@ struct ProviderState {
     completion_provider: CompletionProvider,
     hover_provider: HoverProvider,
     semantic_tokens_provider: SemanticTokensProvider,
+    /// Configs and their source directory, retained so a background poller can
+    /// re-probe provider installation without re-scanning the workspace.
+    configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)>,
+    /// Snapshot of which providers resolved to an installed local binary when
+    /// this state was built. Compared against a fresh probe to detect
+    /// `.carina/` deletions the editor's file watcher did not report
+    /// (issue #2023 follow-up: VS Code excludes dot-prefixed directories
+    /// from its watcher by default).
+    install_fingerprint: Vec<(String, bool)>,
 }
 
 impl ProviderState {
     fn new(
         factories: Vec<Box<dyn ProviderFactory>>,
         provider_errors: HashMap<String, String>,
+        configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)>,
     ) -> Self {
         let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
@@ -53,6 +63,7 @@ impl ProviderState {
         // Extract custom type names from provider schemas for completion
         let custom_type_names = provider_mod::collect_custom_type_names(&schemas);
         let factories_arc = Arc::new(factories);
+        let install_fingerprint = probe_install_fingerprint(&configs);
         Self {
             diagnostic_engine: DiagnosticEngine::new(
                 Arc::clone(&schemas),
@@ -68,13 +79,41 @@ impl ProviderState {
             ),
             semantic_tokens_provider: SemanticTokensProvider::new(&region_completions),
             hover_provider: HoverProvider::new(schemas, region_completions),
+            configs,
+            install_fingerprint,
         }
     }
 
     fn schema_count(&self) -> usize {
         self.diagnostic_engine.schema_count()
     }
+
+    /// True when a fresh probe of the configured providers no longer matches
+    /// the fingerprint captured at build time.
+    fn is_stale(&self) -> bool {
+        probe_install_fingerprint(&self.configs) != self.install_fingerprint
+    }
 }
+
+/// Compute `(provider_name, is_installed)` pairs for a list of configs.
+/// Ordered to match the input so equality comparisons are stable.
+fn probe_install_fingerprint(
+    configs: &[(PathBuf, carina_core::parser::ProviderConfig)],
+) -> Vec<(String, bool)> {
+    configs
+        .iter()
+        .map(|(dir, cfg)| {
+            let installed = carina_provider_resolver::find_installed_provider(dir, cfg).is_ok();
+            (cfg.name.clone(), installed)
+        })
+        .collect()
+}
+
+/// How often the background poller checks for `.carina/` drift. Short enough
+/// that deleting the install feels interactive (~seconds), long enough that
+/// the poll cost — one `fs::metadata` per configured provider — is
+/// negligible.
+const PROVIDER_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Per-directory provider states keyed by configuration directory.
 struct ProviderStates {
@@ -93,7 +132,7 @@ impl ProviderStates {
         Self {
             by_dir: HashMap::new(),
             import_map: HashMap::new(),
-            empty: ProviderState::new(vec![], HashMap::new()),
+            empty: ProviderState::new(vec![], HashMap::new(), vec![]),
         }
     }
 
@@ -154,11 +193,14 @@ pub type FactoryBuilder = Arc<
 
 pub struct Backend {
     client: Client,
-    documents: DashMap<Url, Document>,
-    providers: tokio::sync::RwLock<ProviderStates>,
+    documents: Arc<DashMap<Url, Document>>,
+    providers: Arc<tokio::sync::RwLock<ProviderStates>>,
     provider_context: Arc<ProviderContext>,
-    workspace_root: tokio::sync::OnceCell<Option<PathBuf>>,
+    workspace_root: Arc<tokio::sync::OnceCell<Option<PathBuf>>>,
     factory_builder: Option<FactoryBuilder>,
+    /// Set once `initialized` spawns the background `.carina/` drift poller,
+    /// to keep it from double-spawning on clients that re-send `initialized`.
+    poller_spawned: std::sync::atomic::AtomicBool,
 }
 
 impl Backend {
@@ -171,11 +213,12 @@ impl Backend {
 
         Self {
             client,
-            documents: DashMap::new(),
-            providers: tokio::sync::RwLock::new(ProviderStates::new()),
+            documents: Arc::new(DashMap::new()),
+            providers: Arc::new(tokio::sync::RwLock::new(ProviderStates::new())),
             provider_context,
-            workspace_root: tokio::sync::OnceCell::new(),
+            workspace_root: Arc::new(tokio::sync::OnceCell::new()),
             factory_builder,
+            poller_spawned: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -254,136 +297,63 @@ impl Backend {
     }
 
     async fn update_diagnostics(&self, uri: Url) {
-        if let Some(doc) = self.documents.get(&uri) {
-            let base_path = uri
-                .to_file_path()
-                .ok()
-                .and_then(|p| p.parent().map(|p| p.to_path_buf()));
+        publish_diagnostics_for(&self.client, &self.documents, &self.providers, uri).await;
+    }
 
-            // Extract current file's bindings for cross-file reference scanning
-            let current_bindings: std::collections::HashSet<String> = {
-                let text = doc.text();
-                let mut bindings = std::collections::HashSet::new();
-                for line in text.lines() {
-                    if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
-                        bindings.insert(name.to_string());
-                    }
-                }
-                bindings
-            };
-
-            // Scan sibling files for bindings and references to this file's bindings
-            let (sibling_bindings, sibling_referenced) = base_path
-                .as_ref()
-                .map(|dir| Self::scan_sibling_context(dir, &uri, &current_bindings))
-                .unwrap_or_default();
-
-            let current_file_name: Option<String> = uri
-                .to_file_path()
-                .ok()
-                .and_then(|p| p.file_name().and_then(|n| n.to_str().map(String::from)));
-
-            let providers = self.providers.read().await;
-            let state = base_path
-                .as_ref()
-                .map(|p| providers.state_for_path(p))
-                .unwrap_or(&providers.empty);
-            let diagnostics = state.diagnostic_engine.analyze_with_filename(
-                &doc,
-                current_file_name.as_deref(),
-                base_path.as_deref(),
-                &sibling_bindings,
-                &sibling_referenced,
-            );
-            drop(providers);
-
-            self.client
-                .publish_diagnostics(uri, diagnostics, None)
-                .await;
+    /// Spawn a background task that polls the on-disk install state for
+    /// every loaded provider and triggers a reload when it diverges from the
+    /// snapshot the LSP built from. This closes the gap that
+    /// `workspace/didChangeWatchedFiles` leaves when the client excludes
+    /// dot-prefixed directories like `.carina/` from its file watcher (the
+    /// default in VS Code): deleting `.carina/` fires no event, so the
+    /// factory stays live and the `not installed` diagnostic never returns.
+    ///
+    /// Called once from `initialized`. Subsequent calls are no-ops.
+    fn spawn_provider_drift_poller(&self) {
+        use std::sync::atomic::Ordering;
+        if self.poller_spawned.swap(true, Ordering::AcqRel) {
+            return;
         }
+        let providers = Arc::clone(&self.providers);
+        let documents = Arc::clone(&self.documents);
+        let workspace_root = Arc::clone(&self.workspace_root);
+        let factory_builder = self.factory_builder.as_ref().map(Arc::clone);
+        let client = self.client.clone();
+
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(PROVIDER_POLL_INTERVAL);
+            // Skip the initial tick — `initialize` already loaded schemas.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let any_stale = {
+                    let guard = providers.read().await;
+                    guard.by_dir.values().any(|s| s.is_stale())
+                };
+                if any_stale {
+                    load_schemas_impl(
+                        &client,
+                        workspace_root.as_ref(),
+                        factory_builder.as_ref(),
+                        providers.as_ref(),
+                        documents.as_ref(),
+                    )
+                    .await;
+                }
+            }
+        });
     }
 
     /// Load or reload provider schemas from workspace .crn files.
     async fn load_schemas(&self) {
-        let workspace_root = match self.workspace_root() {
-            Some(root) => root.clone(),
-            None => return,
-        };
-
-        let factory_builder = match &self.factory_builder {
-            Some(builder) => builder,
-            None => return,
-        };
-
-        let dir_providers = workspace::discover_providers_by_dir(&workspace_root);
-        let import_map = workspace::discover_import_map(&workspace_root);
-
-        if dir_providers.is_empty() {
-            let mut states = ProviderStates::new();
-            states.import_map = import_map;
-            *self.providers.write().await = states;
-            let uris: Vec<Url> = self.documents.iter().map(|r| r.key().clone()).collect();
-            for uri in uris {
-                self.update_diagnostics(uri).await;
-            }
-            return;
-        }
-
-        // Build factories per directory. Each directory gets its own set of
-        // provider factories loaded from its own provider configs.
-        // WASM loading is cached on disk, so repeated loads are fast.
-        let mut states = ProviderStates::new();
-        let mut total_schemas = 0;
-
-        for (dir, configs) in &dir_providers {
-            let dir_configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)> =
-                configs.iter().map(|c| (dir.clone(), c.clone())).collect();
-
-            let (dir_factories, dir_errors) = tokio::task::spawn_blocking({
-                let configs = dir_configs;
-                let builder = Arc::clone(factory_builder);
-                move || builder(&configs)
-            })
-            .await
-            .unwrap_or_default();
-
-            for (name, reason) in &dir_errors {
-                self.client
-                    .log_message(
-                        MessageType::WARNING,
-                        format!(
-                            "Provider '{}' not loaded in {}: {}",
-                            name,
-                            dir.display(),
-                            reason
-                        ),
-                    )
-                    .await;
-            }
-
-            let state = ProviderState::new(dir_factories, dir_errors);
-            total_schemas += state.schema_count();
-            states.by_dir.insert(dir.clone(), state);
-        }
-
-        states.import_map = import_map;
-        let dir_count = states.by_dir.len();
-        *self.providers.write().await = states;
-        self.client
-            .log_message(
-                MessageType::INFO,
-                format!(
-                    "Loaded providers for {} directory(s), {} resource type schema(s) total",
-                    dir_count, total_schemas
-                ),
-            )
-            .await;
-
-        // Re-run diagnostics on all open documents with new schemas
-        let uris: Vec<Url> = self.documents.iter().map(|r| r.key().clone()).collect();
-        for uri in uris {
-            self.update_diagnostics(uri).await;
-        }
+        load_schemas_impl(
+            &self.client,
+            self.workspace_root.as_ref(),
+            self.factory_builder.as_ref(),
+            self.providers.as_ref(),
+            self.documents.as_ref(),
+        )
+        .await;
     }
 }
 
@@ -471,6 +441,10 @@ impl LanguageServer for Backend {
 
         // Load provider schemas asynchronously (doesn't block the event loop)
         self.load_schemas().await;
+
+        // Start polling for `.carina/` drift so a user deleting it mid-session
+        // is noticed without any editor interaction.
+        self.spawn_provider_drift_poller();
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -625,6 +599,146 @@ impl LanguageServer for Backend {
     }
 }
 
+/// Publish diagnostics for a single document. Free function so both the
+/// `Backend` methods and the provider-drift poller can call it without going
+/// through `&self`.
+async fn publish_diagnostics_for(
+    client: &Client,
+    documents: &DashMap<Url, Document>,
+    providers: &tokio::sync::RwLock<ProviderStates>,
+    uri: Url,
+) {
+    let Some(doc) = documents.get(&uri) else {
+        return;
+    };
+    let base_path = uri
+        .to_file_path()
+        .ok()
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()));
+
+    let current_bindings: std::collections::HashSet<String> = {
+        let text = doc.text();
+        let mut bindings = std::collections::HashSet::new();
+        for line in text.lines() {
+            if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
+                bindings.insert(name.to_string());
+            }
+        }
+        bindings
+    };
+
+    let (sibling_bindings, sibling_referenced) = base_path
+        .as_ref()
+        .map(|dir| Backend::scan_sibling_context(dir, &uri, &current_bindings))
+        .unwrap_or_default();
+
+    let current_file_name: Option<String> = uri
+        .to_file_path()
+        .ok()
+        .and_then(|p| p.file_name().and_then(|n| n.to_str().map(String::from)));
+
+    let guard = providers.read().await;
+    let state = base_path
+        .as_ref()
+        .map(|p| guard.state_for_path(p))
+        .unwrap_or(&guard.empty);
+    let diagnostics = state.diagnostic_engine.analyze_with_filename(
+        &doc,
+        current_file_name.as_deref(),
+        base_path.as_deref(),
+        &sibling_bindings,
+        &sibling_referenced,
+    );
+    drop(guard);
+
+    client.publish_diagnostics(uri, diagnostics, None).await;
+}
+
+/// Workspace-wide schema load/reload. Free function so the drift poller can
+/// invoke it without holding `&Backend`.
+async fn load_schemas_impl(
+    client: &Client,
+    workspace_root: &tokio::sync::OnceCell<Option<PathBuf>>,
+    factory_builder: Option<&FactoryBuilder>,
+    providers: &tokio::sync::RwLock<ProviderStates>,
+    documents: &DashMap<Url, Document>,
+) {
+    let Some(Some(root)) = workspace_root.get() else {
+        return;
+    };
+    let workspace_root = root.clone();
+
+    let Some(factory_builder) = factory_builder else {
+        return;
+    };
+
+    let dir_providers = workspace::discover_providers_by_dir(&workspace_root);
+    let import_map = workspace::discover_import_map(&workspace_root);
+
+    if dir_providers.is_empty() {
+        let mut states = ProviderStates::new();
+        states.import_map = import_map;
+        *providers.write().await = states;
+        let uris: Vec<Url> = documents.iter().map(|r| r.key().clone()).collect();
+        for uri in uris {
+            publish_diagnostics_for(client, documents, providers, uri).await;
+        }
+        return;
+    }
+
+    let mut states = ProviderStates::new();
+    let mut total_schemas = 0;
+
+    for (dir, configs) in &dir_providers {
+        let dir_configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)> =
+            configs.iter().map(|c| (dir.clone(), c.clone())).collect();
+
+        let (dir_factories, dir_errors) = tokio::task::spawn_blocking({
+            let configs = dir_configs.clone();
+            let builder = Arc::clone(factory_builder);
+            move || builder(&configs)
+        })
+        .await
+        .unwrap_or_default();
+
+        for (name, reason) in &dir_errors {
+            client
+                .log_message(
+                    MessageType::WARNING,
+                    format!(
+                        "Provider '{}' not loaded in {}: {}",
+                        name,
+                        dir.display(),
+                        reason
+                    ),
+                )
+                .await;
+        }
+
+        let state = ProviderState::new(dir_factories, dir_errors, dir_configs);
+        total_schemas += state.schema_count();
+        states.by_dir.insert(dir.clone(), state);
+    }
+
+    states.import_map = import_map;
+    let dir_count = states.by_dir.len();
+    *providers.write().await = states;
+    client
+        .log_message(
+            MessageType::INFO,
+            format!(
+                "Loaded providers for {} directory(s), {} resource type schema(s) total",
+                dir_count, total_schemas
+            ),
+        )
+        .await;
+
+    let uris: Vec<Url> = documents.iter().map(|r| r.key().clone()).collect();
+    for uri in uris {
+        publish_diagnostics_for(client, documents, providers, uri).await;
+    }
+}
+
 /// Decide whether a batch of watched-file events requires rebuilding provider
 /// factories. Split out so it can be unit tested without an LSP client.
 fn should_reload_providers(changes: &[FileEvent]) -> bool {
@@ -738,5 +852,76 @@ mod tests {
                 "{name} should not trigger reload"
             );
         }
+    }
+
+    /// The background drift poller relies on this flipping when `.carina/`
+    /// is deleted out from under the LSP. Tests the invariant directly:
+    /// build a `file://` install, probe (installed), delete it, probe again
+    /// (not installed). If these two results are equal the poller will never
+    /// fire and a VS Code user deleting `.carina/` mid-session will keep
+    /// seeing stale diagnostics until they save a `.crn`.
+    #[test]
+    fn install_fingerprint_flips_when_local_wasm_is_deleted() {
+        use carina_core::parser::ProviderConfig;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+
+        let source_wasm = base.join("carina-provider-foo.wasm");
+        std::fs::write(&source_wasm, b"fake").unwrap();
+        let install_dir = base
+            .join(".carina")
+            .join("providers")
+            .join("file")
+            .join("carina-provider-foo");
+        std::fs::create_dir_all(&install_dir).unwrap();
+        let installed = install_dir.join("carina-provider-foo.wasm");
+        std::fs::write(&installed, b"fake").unwrap();
+
+        let config = ProviderConfig {
+            name: "foo".into(),
+            source: Some(format!("file://{}", source_wasm.display())),
+            version: None,
+            revision: None,
+            attributes: std::collections::HashMap::new(),
+            default_tags: std::collections::HashMap::new(),
+        };
+        let configs = vec![(base.to_path_buf(), config)];
+
+        let before = probe_install_fingerprint(&configs);
+        assert_eq!(
+            before,
+            vec![("foo".to_string(), true)],
+            "initial probe should see the installed binary"
+        );
+
+        std::fs::remove_file(&installed).unwrap();
+        let after = probe_install_fingerprint(&configs);
+        assert_eq!(
+            after,
+            vec![("foo".to_string(), false)],
+            "probe after delete must flip to false"
+        );
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn install_fingerprint_stable_when_nothing_changes() {
+        use carina_core::parser::ProviderConfig;
+        let tmp = tempfile::tempdir().unwrap();
+        let config = ProviderConfig {
+            name: "missing".into(),
+            source: None,
+            version: None,
+            revision: None,
+            attributes: std::collections::HashMap::new(),
+            default_tags: std::collections::HashMap::new(),
+        };
+        let configs = vec![(tmp.path().to_path_buf(), config)];
+        assert_eq!(
+            probe_install_fingerprint(&configs),
+            probe_install_fingerprint(&configs),
+            "two back-to-back probes with no fs change must agree"
+        );
     }
 }

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -634,42 +634,15 @@ fn should_reload_providers(changes: &[FileEvent]) -> bool {
 fn should_reload_for_event(event: &FileEvent) -> bool {
     let uri = event.uri.as_str();
 
-    // A provider binary or its lock file changing — including deletion, so the
-    // LSP notices `.carina/` being wiped — is always a reload trigger.
-    if uri.ends_with(".wasm") || uri.ends_with("carina-providers.lock") {
-        return true;
-    }
-
-    // `.crn` saves are cheap per-file but full-workspace reload is not, so
-    // only trigger when the file currently has a `provider` block — or the
-    // file was deleted (the block is gone, but a state that depended on it
-    // may still be loaded).
-    if uri.ends_with(".crn") {
-        if event.typ == FileChangeType::DELETED {
-            return true;
-        }
-        if let Ok(path) = event.uri.to_file_path()
-            && let Ok(content) = std::fs::read_to_string(&path)
-        {
-            return content_declares_provider(&content);
-        }
-    }
-
-    false
-}
-
-/// Cheap textual scan for a `provider NAME {` block. Good enough to gate a
-/// workspace-wide schema reload; false positives (a literal `provider` token
-/// inside a comment or string) are tolerable because the worst case is an
-/// extra reload, not a wrong answer.
-fn content_declares_provider(content: &str) -> bool {
-    content.lines().any(|line| {
-        let trimmed = line.trim_start();
-        let Some(rest) = trimmed.strip_prefix("provider") else {
-            return false;
-        };
-        matches!(rest.chars().next(), Some(c) if c.is_ascii_whitespace())
-    })
+    // A provider binary, its lock file, or any `.crn` file changing — create,
+    // change, or delete — triggers a reload. Gating `.crn` changes on "file
+    // currently declares a provider block" misses the removal case: editing a
+    // file to delete its `provider NAME {}` block silently keeps the stale
+    // factory live, because the post-save content no longer matches.
+    // `didChangeWatchedFiles` fires on save / delete (not on `did_change`
+    // keystrokes), so an unconditional reload cost is bounded and matches the
+    // existing wasm / lock-file behavior.
+    uri.ends_with(".wasm") || uri.ends_with("carina-providers.lock") || uri.ends_with(".crn")
 }
 
 #[cfg(test)]
@@ -716,40 +689,39 @@ mod tests {
     }
 
     #[test]
-    fn reload_when_crn_file_declares_provider() {
+    fn reload_for_any_crn_change_including_removed_provider_block() {
+        // Covers three scenarios in one:
+        // - .crn that declares a provider block (adding `source = ...`)
+        // - .crn whose previously-declared provider block was deleted on save
+        //   (reviewer-spotted regression: gating on current content misses it)
+        // - .crn that never declared a provider (`main.crn` edits).
+        // All three must reload: we can't reliably detect the middle case
+        // from the post-save content alone, and the reload cost is bounded
+        // since `didChangeWatchedFiles` fires on save, not per-keystroke.
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("providers.crn");
-        std::fs::write(
-            &path,
-            "provider awscc {\n  source = 'github.com/carina-rs/carina-provider-awscc'\n}\n",
-        )
-        .unwrap();
-
-        assert!(should_reload_providers(&[file_event(
-            &path,
-            FileChangeType::CHANGED
-        )]));
+        for (name, content) in [
+            (
+                "with_block.crn",
+                "provider awscc {\n  source = 'github.com/carina-rs/carina-provider-awscc'\n}\n",
+            ),
+            ("block_removed.crn", "# provider block removed\n"),
+            ("main.crn", "awscc.s3.bucket { bucket_name = 'ex' }\n"),
+        ] {
+            let path = tmp.path().join(name);
+            std::fs::write(&path, content).unwrap();
+            for typ in [FileChangeType::CREATED, FileChangeType::CHANGED] {
+                assert!(
+                    should_reload_providers(&[file_event(&path, typ)]),
+                    "{name} {typ:?} must trigger reload"
+                );
+            }
+        }
     }
 
     #[test]
-    fn no_reload_when_crn_file_has_no_provider_block() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("main.crn");
-        std::fs::write(&path, "awscc.s3.bucket {\n  bucket_name = 'example'\n}\n").unwrap();
-
-        assert!(!should_reload_providers(&[file_event(
-            &path,
-            FileChangeType::CHANGED
-        )]));
-    }
-
-    #[test]
-    fn reload_when_crn_file_is_deleted_even_without_content() {
+    fn reload_when_crn_file_is_deleted() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("gone.crn");
-        // Deliberately do NOT create the file — a delete event has no content
-        // to inspect, but the previously-loaded provider state may still be
-        // live, so we reload unconditionally.
         assert!(should_reload_providers(&[file_event(
             &path,
             FileChangeType::DELETED
@@ -757,19 +729,14 @@ mod tests {
     }
 
     #[test]
-    fn content_declares_provider_recognizes_leading_whitespace() {
-        assert!(content_declares_provider("provider awscc {"));
-        assert!(content_declares_provider("  provider aws {"));
-        assert!(content_declares_provider("\tprovider awscc {"));
-    }
-
-    #[test]
-    fn content_declares_provider_rejects_non_provider_lines() {
-        assert!(!content_declares_provider(
-            "providers.crn is the convention"
-        ));
-        assert!(!content_declares_provider("provider_name = 'awscc'"));
-        assert!(!content_declares_provider("# nothing here"));
-        assert!(!content_declares_provider("awscc.s3.bucket { }"));
+    fn no_reload_for_unrelated_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        for name in ["README.md", "Cargo.toml", "notes.txt"] {
+            let path = tmp.path().join(name);
+            assert!(
+                !should_reload_providers(&[file_event(&path, FileChangeType::CHANGED)]),
+                "{name} should not trigger reload"
+            );
+        }
     }
 }

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -450,13 +450,13 @@ impl LanguageServer for Backend {
                             glob_pattern: GlobPattern::String(
                                 "**/.carina/providers/**/*.wasm".to_string(),
                             ),
-                            kind: Some(WatchKind::Create | WatchKind::Change),
+                            kind: Some(WatchKind::all()),
                         },
                         FileSystemWatcher {
                             glob_pattern: GlobPattern::String(
                                 "**/carina-providers.lock".to_string(),
                             ),
-                            kind: Some(WatchKind::Create | WatchKind::Change),
+                            kind: Some(WatchKind::all()),
                         },
                     ],
                 })
@@ -508,15 +508,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        // Only reload schemas when provider binaries or lock files change.
-        // .crn file saves should NOT trigger schema reload — it blocks the
-        // providers write lock and makes completions/diagnostics unresponsive.
-        let should_reload = params.changes.iter().any(|c| {
-            let uri = c.uri.as_str();
-            uri.ends_with(".wasm") || uri.ends_with("carina-providers.lock")
-        });
-
-        if should_reload {
+        if should_reload_providers(&params.changes) {
             self.load_schemas().await;
         }
     }
@@ -630,5 +622,154 @@ impl LanguageServer for Backend {
             }
         }
         Ok(None)
+    }
+}
+
+/// Decide whether a batch of watched-file events requires rebuilding provider
+/// factories. Split out so it can be unit tested without an LSP client.
+fn should_reload_providers(changes: &[FileEvent]) -> bool {
+    changes.iter().any(should_reload_for_event)
+}
+
+fn should_reload_for_event(event: &FileEvent) -> bool {
+    let uri = event.uri.as_str();
+
+    // A provider binary or its lock file changing — including deletion, so the
+    // LSP notices `.carina/` being wiped — is always a reload trigger.
+    if uri.ends_with(".wasm") || uri.ends_with("carina-providers.lock") {
+        return true;
+    }
+
+    // `.crn` saves are cheap per-file but full-workspace reload is not, so
+    // only trigger when the file currently has a `provider` block — or the
+    // file was deleted (the block is gone, but a state that depended on it
+    // may still be loaded).
+    if uri.ends_with(".crn") {
+        if event.typ == FileChangeType::DELETED {
+            return true;
+        }
+        if let Ok(path) = event.uri.to_file_path()
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            return content_declares_provider(&content);
+        }
+    }
+
+    false
+}
+
+/// Cheap textual scan for a `provider NAME {` block. Good enough to gate a
+/// workspace-wide schema reload; false positives (a literal `provider` token
+/// inside a comment or string) are tolerable because the worst case is an
+/// extra reload, not a wrong answer.
+fn content_declares_provider(content: &str) -> bool {
+    content.lines().any(|line| {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix("provider") else {
+            return false;
+        };
+        matches!(rest.chars().next(), Some(c) if c.is_ascii_whitespace())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file_event(path: &std::path::Path, typ: FileChangeType) -> FileEvent {
+        FileEvent {
+            uri: Url::from_file_path(path).unwrap(),
+            typ,
+        }
+    }
+
+    #[test]
+    fn reload_for_wasm_change_including_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wasm = tmp.path().join("awscc.wasm");
+        for typ in [
+            FileChangeType::CREATED,
+            FileChangeType::CHANGED,
+            FileChangeType::DELETED,
+        ] {
+            assert!(
+                should_reload_providers(&[file_event(&wasm, typ)]),
+                "wasm {typ:?} must trigger reload"
+            );
+        }
+    }
+
+    #[test]
+    fn reload_for_lock_file_change_including_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = tmp.path().join("carina-providers.lock");
+        for typ in [
+            FileChangeType::CREATED,
+            FileChangeType::CHANGED,
+            FileChangeType::DELETED,
+        ] {
+            assert!(
+                should_reload_providers(&[file_event(&lock, typ)]),
+                "lock {typ:?} must trigger reload"
+            );
+        }
+    }
+
+    #[test]
+    fn reload_when_crn_file_declares_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("providers.crn");
+        std::fs::write(
+            &path,
+            "provider awscc {\n  source = 'github.com/carina-rs/carina-provider-awscc'\n}\n",
+        )
+        .unwrap();
+
+        assert!(should_reload_providers(&[file_event(
+            &path,
+            FileChangeType::CHANGED
+        )]));
+    }
+
+    #[test]
+    fn no_reload_when_crn_file_has_no_provider_block() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("main.crn");
+        std::fs::write(&path, "awscc.s3.bucket {\n  bucket_name = 'example'\n}\n").unwrap();
+
+        assert!(!should_reload_providers(&[file_event(
+            &path,
+            FileChangeType::CHANGED
+        )]));
+    }
+
+    #[test]
+    fn reload_when_crn_file_is_deleted_even_without_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("gone.crn");
+        // Deliberately do NOT create the file — a delete event has no content
+        // to inspect, but the previously-loaded provider state may still be
+        // live, so we reload unconditionally.
+        assert!(should_reload_providers(&[file_event(
+            &path,
+            FileChangeType::DELETED
+        )]));
+    }
+
+    #[test]
+    fn content_declares_provider_recognizes_leading_whitespace() {
+        assert!(content_declares_provider("provider awscc {"));
+        assert!(content_declares_provider("  provider aws {"));
+        assert!(content_declares_provider("\tprovider awscc {"));
+    }
+
+    #[test]
+    fn content_declares_provider_rejects_non_provider_lines() {
+        assert!(!content_declares_provider(
+            "providers.crn is the convention"
+        ));
+        assert!(!content_declares_provider("provider_name = 'awscc'"));
+        assert!(!content_declares_provider("# nothing here"));
+        assert!(!content_declares_provider("awscc.s3.bucket { }"));
     }
 }

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -57,6 +57,7 @@ impl ProviderState {
         provider_errors: HashMap<String, String>,
         configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)>,
         prober: Option<ProviderInstallProber>,
+        install_fingerprint: Vec<(String, bool)>,
     ) -> Self {
         let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
@@ -67,7 +68,6 @@ impl ProviderState {
         // Extract custom type names from provider schemas for completion
         let custom_type_names = provider_mod::collect_custom_type_names(&schemas);
         let factories_arc = Arc::new(factories);
-        let install_fingerprint = probe_install_fingerprint(prober.as_ref(), &configs);
         Self {
             diagnostic_engine: DiagnosticEngine::new(
                 Arc::clone(&schemas),
@@ -149,7 +149,7 @@ impl ProviderStates {
         Self {
             by_dir: HashMap::new(),
             import_map: HashMap::new(),
-            empty: ProviderState::new(vec![], HashMap::new(), vec![], None),
+            empty: ProviderState::new(vec![], HashMap::new(), vec![], None, vec![]),
         }
     }
 
@@ -194,10 +194,16 @@ impl ProviderStates {
     }
 }
 
-/// Result of building provider factories: loaded factories + per-provider error messages.
+/// Result of building provider factories: loaded factories, per-provider
+/// error messages, and the `(name, is_installed)` observations the builder
+/// made. The fingerprint is returned here (rather than recomputed) so the
+/// stored factories and the drift-poll baseline describe the exact same
+/// filesystem snapshot — any later divergence is a real change, not a
+/// TOCTOU artifact or a file://-vs-`.carina/` mismatch.
 pub type FactoryBuildResult = (
     Vec<Box<dyn ProviderFactory>>,
     HashMap<String, String>, // provider name -> error reason
+    Vec<(String, bool)>,     // install fingerprint
 );
 
 /// Function type for building provider factories from configs with their source directories.
@@ -728,7 +734,7 @@ async fn load_schemas_impl(
         let dir_configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)> =
             configs.iter().map(|c| (dir.clone(), c.clone())).collect();
 
-        let (dir_factories, dir_errors) = tokio::task::spawn_blocking({
+        let (dir_factories, dir_errors, dir_fingerprint) = tokio::task::spawn_blocking({
             let configs = dir_configs.clone();
             let builder = Arc::clone(factory_builder);
             move || builder(&configs)
@@ -755,6 +761,7 @@ async fn load_schemas_impl(
             dir_errors,
             dir_configs,
             install_prober.cloned(),
+            dir_fingerprint,
         );
         total_schemas += state.schema_count();
         states.by_dir.insert(dir.clone(), state);

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -40,6 +40,9 @@ struct ProviderState {
     /// Configs and their source directory, retained so a background poller can
     /// re-probe provider installation without re-scanning the workspace.
     configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)>,
+    /// Injected install prober. Kept here so `is_stale()` can recompute the
+    /// fingerprint with the same function that built the snapshot.
+    prober: Option<ProviderInstallProber>,
     /// Snapshot of which providers resolved to an installed local binary when
     /// this state was built. Compared against a fresh probe to detect
     /// `.carina/` deletions the editor's file watcher did not report
@@ -53,6 +56,7 @@ impl ProviderState {
         factories: Vec<Box<dyn ProviderFactory>>,
         provider_errors: HashMap<String, String>,
         configs: Vec<(PathBuf, carina_core::parser::ProviderConfig)>,
+        prober: Option<ProviderInstallProber>,
     ) -> Self {
         let schemas = Arc::new(provider_mod::collect_schemas(&factories));
         let provider_names: Vec<String> = factories.iter().map(|f| f.name().to_string()).collect();
@@ -63,7 +67,7 @@ impl ProviderState {
         // Extract custom type names from provider schemas for completion
         let custom_type_names = provider_mod::collect_custom_type_names(&schemas);
         let factories_arc = Arc::new(factories);
-        let install_fingerprint = probe_install_fingerprint(&configs);
+        let install_fingerprint = probe_install_fingerprint(prober.as_ref(), &configs);
         Self {
             diagnostic_engine: DiagnosticEngine::new(
                 Arc::clone(&schemas),
@@ -80,6 +84,7 @@ impl ProviderState {
             semantic_tokens_provider: SemanticTokensProvider::new(&region_completions),
             hover_provider: HoverProvider::new(schemas, region_completions),
             configs,
+            prober,
             install_fingerprint,
         }
     }
@@ -91,21 +96,33 @@ impl ProviderState {
     /// True when a fresh probe of the configured providers no longer matches
     /// the fingerprint captured at build time.
     fn is_stale(&self) -> bool {
-        probe_install_fingerprint(&self.configs) != self.install_fingerprint
+        probe_install_fingerprint(self.prober.as_ref(), &self.configs) != self.install_fingerprint
     }
 }
+
+/// Checks whether a single provider config resolves to an installed local
+/// binary. Injected from `main.rs` so provider-resolver calls stay out of
+/// the provider-agnostic `carina-lsp` library code.
+pub type ProviderInstallProber =
+    Arc<dyn Fn(&Path, &carina_core::parser::ProviderConfig) -> bool + Send + Sync>;
 
 /// Compute `(provider_name, is_installed)` pairs for a list of configs.
 /// Ordered to match the input so equality comparisons are stable.
 fn probe_install_fingerprint(
+    prober: Option<&ProviderInstallProber>,
     configs: &[(PathBuf, carina_core::parser::ProviderConfig)],
 ) -> Vec<(String, bool)> {
+    let Some(prober) = prober else {
+        // Without a prober we can't tell, so claim every provider is still
+        // installed — the poller falls back to a never-stale snapshot.
+        return configs
+            .iter()
+            .map(|(_, cfg)| (cfg.name.clone(), true))
+            .collect();
+    };
     configs
         .iter()
-        .map(|(dir, cfg)| {
-            let installed = carina_provider_resolver::find_installed_provider(dir, cfg).is_ok();
-            (cfg.name.clone(), installed)
-        })
+        .map(|(dir, cfg)| (cfg.name.clone(), prober(dir, cfg)))
         .collect()
 }
 
@@ -132,7 +149,7 @@ impl ProviderStates {
         Self {
             by_dir: HashMap::new(),
             import_map: HashMap::new(),
-            empty: ProviderState::new(vec![], HashMap::new(), vec![]),
+            empty: ProviderState::new(vec![], HashMap::new(), vec![], None),
         }
     }
 
@@ -198,6 +215,7 @@ pub struct Backend {
     provider_context: Arc<ProviderContext>,
     workspace_root: Arc<tokio::sync::OnceCell<Option<PathBuf>>>,
     factory_builder: Option<FactoryBuilder>,
+    install_prober: Option<ProviderInstallProber>,
     /// Set once `initialized` spawns the background `.carina/` drift poller,
     /// to keep it from double-spawning on clients that re-send `initialized`.
     poller_spawned: std::sync::atomic::AtomicBool,
@@ -209,6 +227,18 @@ impl Backend {
         provider_context: ProviderContext,
         factory_builder: Option<FactoryBuilder>,
     ) -> Self {
+        Self::with_install_prober(client, provider_context, factory_builder, None)
+    }
+
+    /// Construct a backend with a custom install prober. `main.rs` uses this
+    /// to inject a `carina_provider_resolver::find_installed_provider`-based
+    /// prober without pulling the resolver into the library crate.
+    pub fn with_install_prober(
+        client: Client,
+        provider_context: ProviderContext,
+        factory_builder: Option<FactoryBuilder>,
+        install_prober: Option<ProviderInstallProber>,
+    ) -> Self {
         let provider_context = Arc::new(provider_context);
 
         Self {
@@ -218,6 +248,7 @@ impl Backend {
             provider_context,
             workspace_root: Arc::new(tokio::sync::OnceCell::new()),
             factory_builder,
+            install_prober,
             poller_spawned: std::sync::atomic::AtomicBool::new(false),
         }
     }
@@ -318,6 +349,7 @@ impl Backend {
         let documents = Arc::clone(&self.documents);
         let workspace_root = Arc::clone(&self.workspace_root);
         let factory_builder = self.factory_builder.as_ref().map(Arc::clone);
+        let install_prober = self.install_prober.as_ref().map(Arc::clone);
         let client = self.client.clone();
 
         tokio::spawn(async move {
@@ -335,6 +367,7 @@ impl Backend {
                         &client,
                         workspace_root.as_ref(),
                         factory_builder.as_ref(),
+                        install_prober.as_ref(),
                         providers.as_ref(),
                         documents.as_ref(),
                     )
@@ -350,6 +383,7 @@ impl Backend {
             &self.client,
             self.workspace_root.as_ref(),
             self.factory_builder.as_ref(),
+            self.install_prober.as_ref(),
             self.providers.as_ref(),
             self.documents.as_ref(),
         )
@@ -660,6 +694,7 @@ async fn load_schemas_impl(
     client: &Client,
     workspace_root: &tokio::sync::OnceCell<Option<PathBuf>>,
     factory_builder: Option<&FactoryBuilder>,
+    install_prober: Option<&ProviderInstallProber>,
     providers: &tokio::sync::RwLock<ProviderStates>,
     documents: &DashMap<Url, Document>,
 ) {
@@ -715,7 +750,12 @@ async fn load_schemas_impl(
                 .await;
         }
 
-        let state = ProviderState::new(dir_factories, dir_errors, dir_configs);
+        let state = ProviderState::new(
+            dir_factories,
+            dir_errors,
+            dir_configs,
+            install_prober.cloned(),
+        );
         total_schemas += state.schema_count();
         states.by_dir.insert(dir.clone(), state);
     }
@@ -854,41 +894,54 @@ mod tests {
         }
     }
 
+    /// Stub prober for tests: reports a provider as installed iff the
+    /// attribute `_installed_at` points at an existing file. Lets us
+    /// exercise the fingerprint logic without pulling the resolver crate.
+    fn test_prober() -> ProviderInstallProber {
+        Arc::new(|_dir, cfg| {
+            cfg.attributes
+                .get("_installed_at")
+                .and_then(|v| match v {
+                    carina_core::resource::Value::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+                .map(|p| std::path::Path::new(p).exists())
+                .unwrap_or(false)
+        })
+    }
+
     /// The background drift poller relies on this flipping when `.carina/`
     /// is deleted out from under the LSP. Tests the invariant directly:
-    /// build a `file://` install, probe (installed), delete it, probe again
-    /// (not installed). If these two results are equal the poller will never
+    /// build an install, probe (installed), delete it, probe again (not
+    /// installed). If these two results are equal the poller will never
     /// fire and a VS Code user deleting `.carina/` mid-session will keep
     /// seeing stale diagnostics until they save a `.crn`.
     #[test]
     fn install_fingerprint_flips_when_local_wasm_is_deleted() {
         use carina_core::parser::ProviderConfig;
+        use carina_core::resource::Value;
 
         let tmp = tempfile::tempdir().unwrap();
-        let base = tmp.path();
-
-        let source_wasm = base.join("carina-provider-foo.wasm");
-        std::fs::write(&source_wasm, b"fake").unwrap();
-        let install_dir = base
-            .join(".carina")
-            .join("providers")
-            .join("file")
-            .join("carina-provider-foo");
-        std::fs::create_dir_all(&install_dir).unwrap();
-        let installed = install_dir.join("carina-provider-foo.wasm");
+        let installed = tmp.path().join("carina-provider-foo.wasm");
         std::fs::write(&installed, b"fake").unwrap();
 
+        let mut attributes = std::collections::HashMap::new();
+        attributes.insert(
+            "_installed_at".to_string(),
+            Value::String(installed.display().to_string()),
+        );
         let config = ProviderConfig {
             name: "foo".into(),
-            source: Some(format!("file://{}", source_wasm.display())),
+            source: Some("github.com/carina-rs/stub".into()),
             version: None,
             revision: None,
-            attributes: std::collections::HashMap::new(),
+            attributes,
             default_tags: std::collections::HashMap::new(),
         };
-        let configs = vec![(base.to_path_buf(), config)];
+        let configs = vec![(tmp.path().to_path_buf(), config)];
+        let prober = test_prober();
 
-        let before = probe_install_fingerprint(&configs);
+        let before = probe_install_fingerprint(Some(&prober), &configs);
         assert_eq!(
             before,
             vec![("foo".to_string(), true)],
@@ -896,7 +949,7 @@ mod tests {
         );
 
         std::fs::remove_file(&installed).unwrap();
-        let after = probe_install_fingerprint(&configs);
+        let after = probe_install_fingerprint(Some(&prober), &configs);
         assert_eq!(
             after,
             vec![("foo".to_string(), false)],
@@ -918,9 +971,10 @@ mod tests {
             default_tags: std::collections::HashMap::new(),
         };
         let configs = vec![(tmp.path().to_path_buf(), config)];
+        let prober = test_prober();
         assert_eq!(
-            probe_install_fingerprint(&configs),
-            probe_install_fingerprint(&configs),
+            probe_install_fingerprint(Some(&prober), &configs),
+            probe_install_fingerprint(Some(&prober), &configs),
             "two back-to-back probes with no fs change must agree"
         );
     }

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -97,7 +97,21 @@ async fn main() {
         let factory_builder: carina_lsp::backend::FactoryBuilder =
             std::sync::Arc::new(build_factories);
 
-        Backend::new(client, provider_context, Some(factory_builder))
+        // Provider install prober: used by the drift poller to notice when
+        // `<project>/.carina/` is deleted mid-session. Injected here so
+        // provider-resolver calls stay out of the library crate (enforced
+        // by `scripts/check-provider-boundaries.sh`).
+        let install_prober: carina_lsp::backend::ProviderInstallProber =
+            std::sync::Arc::new(|dir, cfg| {
+                carina_provider_resolver::find_installed_provider(dir, cfg).is_ok()
+            });
+
+        Backend::with_install_prober(
+            client,
+            provider_context,
+            Some(factory_builder),
+            Some(install_prober),
+        )
     });
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use carina_core::parser::{ProviderConfig, ProviderContext};
 use carina_core::provider::ProviderFactory;
@@ -8,12 +8,40 @@ use tower_lsp::{LspService, Server};
 use carina_lsp::Backend;
 use carina_lsp::backend::FactoryBuildResult;
 
+/// Resolve the on-disk path the LSP would load for `config`, if any. `None`
+/// means the provider is not currently installed for the LSP's purposes.
+///
+/// Shared by `build_factories` (at load time) and the drift-poll prober (at
+/// poll time) so both sides agree on what "installed" means. In particular:
+/// for `file://` sources, "installed" is the source file itself existing and
+/// being a WASM component — not whether a copy landed in `.carina/…/file/`.
+/// That matters because `build_factories` loads the direct path, so the
+/// drift poll must observe that same path to detect its deletion.
+fn resolve_install(source_dir: &Path, config: &ProviderConfig) -> Option<PathBuf> {
+    let source = config.source.as_deref()?;
+    let binary_path = if let Some(path) = source.strip_prefix("file://") {
+        PathBuf::from(path)
+    } else if source.starts_with("github.com/") {
+        carina_provider_resolver::find_installed_provider(source_dir, config).ok()?
+    } else {
+        return None;
+    };
+    if !carina_provider_resolver::is_wasm_provider(&binary_path) {
+        return None;
+    }
+    if !binary_path.exists() {
+        return None;
+    }
+    Some(binary_path)
+}
+
 /// Build provider factories from discovered provider configs.
 /// Each entry is (source_directory, provider_config) so providers are installed
 /// in the directory containing the `.crn` file, not at the workspace root.
 fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResult {
     let mut factories: Vec<Box<dyn ProviderFactory>> = Vec::new();
     let mut errors: HashMap<String, String> = HashMap::new();
+    let mut fingerprint: Vec<(String, bool)> = Vec::with_capacity(providers.len());
 
     for (source_dir, config) in providers {
         let source = match &config.source {
@@ -24,37 +52,43 @@ fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResul
                     "no source configured. Add `source = 'github.com/...'` to the provider block."
                         .to_string(),
                 );
+                fingerprint.push((config.name.clone(), false));
                 continue;
             }
         };
 
-        let binary_path = if let Some(path) = source.strip_prefix("file://") {
-            std::path::PathBuf::from(path)
-        } else if source.starts_with("github.com/") {
-            // LSP uses find_installed_provider (no download) instead of
-            // resolve_single_config to avoid filesystem side effects.
-            match carina_provider_resolver::find_installed_provider(source_dir, config) {
-                Ok(path) => path,
-                Err(e) => {
-                    errors.insert(config.name.clone(), e);
-                    continue;
+        let binary_path = match resolve_install(source_dir, config) {
+            Some(path) => path,
+            None => {
+                // Build the same error wording the previous code path produced,
+                // so surfaced diagnostics match what users saw before.
+                if source.starts_with("file://") {
+                    let stripped = source.strip_prefix("file://").unwrap_or(source);
+                    let p = PathBuf::from(stripped);
+                    if !p.exists() {
+                        errors.insert(config.name.clone(), format!("file not found: {}", stripped));
+                    } else if !carina_provider_resolver::is_wasm_provider(&p) {
+                        errors.insert(
+                            config.name.clone(),
+                            format!("not a WASM component: {}", p.display()),
+                        );
+                    }
+                } else if source.starts_with("github.com/") {
+                    if let Err(e) =
+                        carina_provider_resolver::find_installed_provider(source_dir, config)
+                    {
+                        errors.insert(config.name.clone(), e);
+                    }
+                } else {
+                    errors.insert(
+                        config.name.clone(),
+                        format!("unsupported source format: {}", source),
+                    );
                 }
+                fingerprint.push((config.name.clone(), false));
+                continue;
             }
-        } else {
-            errors.insert(
-                config.name.clone(),
-                format!("unsupported source format: {}", source),
-            );
-            continue;
         };
-
-        if !carina_provider_resolver::is_wasm_provider(&binary_path) {
-            errors.insert(
-                config.name.clone(),
-                format!("not a WASM component: {}", binary_path.display()),
-            );
-            continue;
-        }
 
         match tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(
@@ -68,14 +102,19 @@ fn build_factories(providers: &[(PathBuf, ProviderConfig)]) -> FactoryBuildResul
                     binary_path.display()
                 );
                 factories.push(Box::new(factory));
+                fingerprint.push((config.name.clone(), true));
             }
             Err(e) => {
                 errors.insert(config.name.clone(), format!("failed to load WASM: {}", e));
+                // Factory failed to load even though the path resolved; treat
+                // as "not installed" from the LSP's perspective so the next
+                // poll can notice if the user replaces the WASM.
+                fingerprint.push((config.name.clone(), false));
             }
         }
     }
 
-    (factories, errors)
+    (factories, errors, fingerprint)
 }
 
 #[tokio::main]
@@ -98,13 +137,12 @@ async fn main() {
             std::sync::Arc::new(build_factories);
 
         // Provider install prober: used by the drift poller to notice when
-        // `<project>/.carina/` is deleted mid-session. Injected here so
-        // provider-resolver calls stay out of the library crate (enforced
-        // by `scripts/check-provider-boundaries.sh`).
+        // `<project>/.carina/` is deleted mid-session. Shares `resolve_install`
+        // with `build_factories` so "installed" means the same thing to both —
+        // the snapshot captured at build time and the drift-poll observation
+        // describe the same filesystem state.
         let install_prober: carina_lsp::backend::ProviderInstallProber =
-            std::sync::Arc::new(|dir, cfg| {
-                carina_provider_resolver::find_installed_provider(dir, cfg).is_ok()
-            });
+            std::sync::Arc::new(|dir, cfg| resolve_install(dir, cfg).is_some());
 
         Backend::with_install_prober(
             client,


### PR DESCRIPTION
## Summary

`carina-lsp/src/backend.rs` missed two classes of file-system changes:

1. **`.crn` file changes were ignored** by `did_change_watched_files`. Editing `providers.crn` (e.g. adding or removing a `source = '...'` line) left the LSP's provider-error set frozen at the startup snapshot, so the diagnostic stayed on the pre-edit wording until the user reloaded the server manually.
2. **`.wasm` and `carina-providers.lock` watchers registered `Create | Change` only — not `Delete`.** Deleting `<project>/.carina/` after a successful install produced no event the LSP could react to, so the previously-loaded factory kept answering schema questions and the `Provider 'X' is not loaded: not installed …` diagnostic never came back.

Both match the lifecycle gap #2018 fixed on the CLI side — the LSP was the only surface still lying about project readiness.

## Change

- Extend the `.wasm` and `carina-providers.lock` `FileSystemWatcher`s to `WatchKind::all()` so Delete events arrive.
- Extract the reload decision into `should_reload_providers(&[FileEvent]) -> bool` with a `content_declares_provider(&str) -> bool` helper so the filter is unit-testable.
- Reload rules:
  - Any change (incl. Delete) to `*.wasm` or `carina-providers.lock` → reload.
  - A `.crn` save whose content contains a `provider NAME {` line → reload.
  - A `.crn` delete → reload unconditionally (content is unavailable but prior state may still depend on the file).
  - Other `.crn` edits → no reload (preserves the original safeguard against keystroke-level reload storms).
- `didChangeWatchedFiles` only fires on filesystem events (save / delete), not on `did_change` text edits, so keystroke traffic is unaffected.

## Caveats

Depends on the LSP client supporting `workspace/didChangeWatchedFiles` and honoring the registered patterns. VS Code and `nvim-lspconfig` do. Clients that don't will still need a manual reload.

## Test plan

- [x] `cargo test -p carina-lsp` — 260 pass (up from 253; added 7)
- [x] New tests in `backend::tests`:
  - `reload_for_wasm_change_including_delete` (Create/Change/Delete)
  - `reload_for_lock_file_change_including_delete` (Create/Change/Delete)
  - `reload_when_crn_file_declares_provider`
  - `no_reload_when_crn_file_has_no_provider_block`
  - `reload_when_crn_file_is_deleted_even_without_content`
  - `content_declares_provider_recognizes_leading_whitespace`
  - `content_declares_provider_rejects_non_provider_lines` (false-positive guards for `providers.crn is ...`, `provider_name = ...`, comments, other resource blocks)
- [x] `cargo clippy -p carina-lsp --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #2023