### PR TITLE
core: declarative exclusive_required for WASM-safe schema constraints

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -836,6 +836,11 @@ pub struct ResourceSchema {
     /// Per-resource operational config (timeouts, retries).
     /// When None, provider defaults are used.
     pub operation_config: Option<OperationConfig>,
+    /// Declarative "exactly one of" groups. Each inner vec is a group of
+    /// attribute names where exactly one must be specified. Unlike `validator`
+    /// (a function pointer), this is plain data and survives the WASM plugin
+    /// boundary.
+    pub exclusive_required: Vec<Vec<String>>,
 }
 
 impl ResourceSchema {
@@ -849,6 +854,7 @@ impl ResourceSchema {
             name_attribute: None,
             force_replace: false,
             operation_config: None,
+            exclusive_required: Vec::new(),
         }
     }
 
@@ -864,6 +870,20 @@ impl ResourceSchema {
 
     pub fn with_validator(mut self, validator: ResourceValidator) -> Self {
         self.validator = Some(validator);
+        self
+    }
+
+    /// Declare that exactly one of the given attributes must be specified.
+    ///
+    /// Equivalent to a CloudFormation `oneOf` of required properties. Stored
+    /// as data (not a closure) so the constraint survives serialization —
+    /// in particular, crossing the WASM plugin boundary.
+    ///
+    /// Multiple calls append additional groups; each group is evaluated
+    /// independently by `validate()`.
+    pub fn exclusive_required(mut self, fields: &[&str]) -> Self {
+        self.exclusive_required
+            .push(fields.iter().map(|s| s.to_string()).collect());
         self
     }
 
@@ -1014,6 +1034,14 @@ impl ResourceSchema {
                     name: name.clone(),
                     suggestion,
                 });
+            }
+        }
+
+        // Evaluate declarative exclusive-required groups (WASM-safe).
+        for group in &self.exclusive_required {
+            let refs: Vec<&str> = group.iter().map(|s| s.as_str()).collect();
+            if let Err(mut e) = validators::validate_exclusive_required(attributes, &refs) {
+                errors.append(&mut e);
             }
         }
 
@@ -2431,6 +2459,85 @@ mod tests {
         );
         let result = schema.validate(&attrs4);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn exclusive_required_declarative() {
+        // Same semantics as the closure-based form above, but declared as data
+        // so it can cross the WASM plugin boundary.
+        let schema = ResourceSchema::new("vpc")
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+            .attribute(AttributeSchema::new(
+                "ipv4_ipam_pool_id",
+                AttributeType::String,
+            ))
+            .exclusive_required(&["cidr_block", "ipv4_ipam_pool_id"]);
+
+        // Valid: exactly one present
+        let mut one = HashMap::new();
+        one.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        assert!(schema.validate(&one).is_ok());
+
+        // Invalid: neither present
+        let empty = HashMap::new();
+        let err = schema.validate(&empty).unwrap_err();
+        assert!(
+            err.iter().any(|e| e
+                .to_string()
+                .contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified")),
+            "missing expected error, got: {:?}",
+            err
+        );
+
+        // Invalid: both present
+        let mut both = HashMap::new();
+        both.insert(
+            "cidr_block".to_string(),
+            Value::String("10.0.0.0/16".to_string()),
+        );
+        both.insert(
+            "ipv4_ipam_pool_id".to_string(),
+            Value::String("pool-1".to_string()),
+        );
+        let err = schema.validate(&both).unwrap_err();
+        assert!(
+            err.iter().any(|e| e
+                .to_string()
+                .contains("Only one of [cidr_block, ipv4_ipam_pool_id] can be specified")),
+            "missing expected error, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn exclusive_required_multiple_groups() {
+        let schema = ResourceSchema::new("multi")
+            .attribute(AttributeSchema::new("a", AttributeType::String))
+            .attribute(AttributeSchema::new("b", AttributeType::String))
+            .attribute(AttributeSchema::new("x", AttributeType::String))
+            .attribute(AttributeSchema::new("y", AttributeType::String))
+            .exclusive_required(&["a", "b"])
+            .exclusive_required(&["x", "y"]);
+
+        // Neither group satisfied → two errors
+        let err = schema.validate(&HashMap::new()).unwrap_err();
+        assert_eq!(
+            err.iter()
+                .filter(|e| e.to_string().contains("Exactly one of"))
+                .count(),
+            2,
+            "expected two missing-group errors, got: {:?}",
+            err
+        );
+
+        // Satisfy both groups
+        let mut ok = HashMap::new();
+        ok.insert("a".to_string(), Value::String("1".to_string()));
+        ok.insert("x".to_string(), Value::String("1".to_string()));
+        assert!(schema.validate(&ok).is_ok());
     }
 
     #[test]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -1060,6 +1060,7 @@ let vpc = awscc.ec2.vpc {
             name_attribute: None,
             force_replace: false,
             operation_config: None,
+            exclusive_required: Vec::new(),
         }
     }
 
@@ -1994,6 +1995,35 @@ let vpc = awscc.ec2.vpc {
         assert!(
             err.contains("accounts") && err.contains("type mismatch"),
             "error should mention the export name and type mismatch, got: {err}"
+        );
+    }
+
+    /// `validate_resources` must reject a resource whose schema declares an
+    /// `exclusive_required` group that is not satisfied — mirrors
+    /// `awscc.ec2.vpc {}` with no cidr_block / ipam pool.
+    #[test]
+    fn validate_resources_rejects_missing_exclusive_required() {
+        let schema = make_schema(
+            "ec2.vpc",
+            vec![
+                ("cidr_block", AttributeType::String),
+                ("ipv4_ipam_pool_id", AttributeType::String),
+            ],
+        )
+        .exclusive_required(&["cidr_block", "ipv4_ipam_pool_id"]);
+
+        let mut schemas = HashMap::new();
+        schemas.insert("ec2.vpc".to_string(), schema);
+
+        let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc");
+
+        let mut known = HashSet::new();
+        known.insert("awscc".to_string());
+
+        let err = validate_resources(&[vpc], &schemas, &test_schema_key_fn, &known).unwrap_err();
+        assert!(
+            err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),
+            "expected exclusive_required error, got: {err}"
         );
     }
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -278,6 +278,7 @@ fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
                 create_max_retries: c.create_max_retries,
             }
         }),
+        exclusive_required: s.exclusive_required.clone(),
     }
 }
 
@@ -878,6 +879,7 @@ mod tests {
             force_replace: false,
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
+            exclusive_required: vec![],
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         assert!(core_schema.validator.is_some());
@@ -894,9 +896,72 @@ mod tests {
             force_replace: false,
             operation_config: None,
             validators: vec![],
+            exclusive_required: vec![],
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         assert!(core_schema.validator.is_none());
+    }
+
+    #[test]
+    fn test_exclusive_required_roundtrips_through_proto() {
+        // Declarative exclusive_required must survive the proto boundary so
+        // WASM providers can express `oneOf` constraints as data.
+        let proto_schema = proto::ResourceSchema {
+            resource_type: "awscc.ec2.vpc".to_string(),
+            attributes: HashMap::new(),
+            description: None,
+            data_source: false,
+            name_attribute: None,
+            force_replace: false,
+            operation_config: None,
+            validators: vec![],
+            exclusive_required: vec![vec![
+                "cidr_block".to_string(),
+                "ipv4_ipam_pool_id".to_string(),
+            ]],
+        };
+        let core_schema = proto_schema_to_core(&proto_schema);
+        assert_eq!(
+            core_schema.exclusive_required,
+            vec![vec![
+                "cidr_block".to_string(),
+                "ipv4_ipam_pool_id".to_string(),
+            ]]
+        );
+
+        // And the resulting core schema rejects empty attributes.
+        let err = core_schema.validate(&HashMap::new()).unwrap_err();
+        assert!(
+            err.iter().any(|e| e
+                .to_string()
+                .contains("Exactly one of [cidr_block, ipv4_ipam_pool_id]")),
+            "expected missing-group error, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_exclusive_required_survives_json_roundtrip() {
+        // The plugin host receives schemas as JSON. Confirm the new field
+        // is preserved through full JSON round-trip (guest -> host).
+        let proto_schema = proto::ResourceSchema {
+            resource_type: "awscc.ec2.vpc".to_string(),
+            attributes: HashMap::new(),
+            description: None,
+            data_source: false,
+            name_attribute: None,
+            force_replace: false,
+            operation_config: None,
+            validators: vec![],
+            exclusive_required: vec![vec!["a".to_string(), "b".to_string()]],
+        };
+        let json = serde_json::to_string(&vec![proto_schema]).unwrap();
+        let schemas = json_to_schemas(&json);
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(
+            schemas[0].exclusive_required,
+            vec![vec!["a".to_string(), "b".to_string()]]
+        );
     }
 
     #[test]
@@ -910,6 +975,7 @@ mod tests {
             force_replace: false,
             operation_config: None,
             validators: vec![proto::ValidatorType::TagsKeyValueCheck],
+            exclusive_required: vec![],
         };
         let core_schema = proto_schema_to_core(&proto_schema);
         let validator = core_schema.validator.unwrap();

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -180,6 +180,11 @@ pub struct ResourceSchema {
     pub operation_config: Option<OperationConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub validators: Vec<ValidatorType>,
+    /// Declarative "exactly one of" groups. Each inner vec is a group of
+    /// attribute names where exactly one must be specified. Survives
+    /// serialization across the WASM plugin boundary.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclusive_required: Vec<Vec<String>>,
 }
 
 /// Per-resource operational configuration for timeouts and retries.


### PR DESCRIPTION
refs #2025

## Summary

- Add `ResourceSchema.exclusive_required: Vec<Vec<String>>` — a data-driven "exactly one of" group that survives serialization. Evaluated in `validate()` via the existing `validators::validate_exclusive_required` helper.
- Mirror the field through `proto::ResourceSchema` and `proto_schema_to_core` so it round-trips across the WASM plugin boundary.

## Why

Function-pointer validators (`with_validator(|attrs| ...)`) are dropped when schemas cross the WASM boundary — `carina-plugin-host/src/wasm_convert.rs` has no way to reconstruct arbitrary closures. This is why `awscc.ec2.vpc {}` currently passes `validate`/`plan` despite the schema declaring a `oneOf(cidr_block, ipv4_ipam_pool_id)` constraint: the closure is lost in transit.

Expressing the constraint as data fixes the WASM-boundary issue and keeps error messages identical to the closure form (both paths call the same `validate_exclusive_required` helper).

## Scope

- Core groundwork only. No user-visible behavior change for awscc in this PR — awscc still emits `.with_validator(...)`.
- The awscc codegen change (emit `.exclusive_required(&[...])` instead of `.with_validator(...)`) lands in a follow-up PR in `carina-provider-awscc` and will finally close #2025.
- LSP needs no change: `carina-lsp/src/diagnostics/mod.rs:563` already calls `schema.validate()` and surfaces `ResourceValidationFailed`.

## Test plan

- [x] `cargo test -p carina-core exclusive_required` — 3 new tests (declarative, multiple groups, `validate_resources` integration)
- [x] `cargo test -p carina-plugin-host exclusive` — 2 new tests (proto→core round-trip, full JSON round-trip)
- [x] `cargo test` (full workspace) — all 2000+ tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)