### PR TITLE
Upsert lock entry on cache-hit resolver paths (#2032)

### DIFF
--- a/carina-provider-resolver/src/provider_resolver.rs
+++ b/carina-provider-resolver/src/provider_resolver.rs
@@ -299,6 +299,50 @@ fn extract_tar_gz(archive_path: &Path, dest_dir: &Path) -> Result<PathBuf, Strin
     ))
 }
 
+/// Validate a cached version-mode binary and ensure the lock file records it.
+///
+/// When a previous `carina init` left a binary in `.carina/providers/`, the
+/// next run must still upsert a matching lock entry before the caller saves
+/// the lock. Otherwise an empty in-memory `LockFile` gets written back to
+/// disk and stomps the on-disk record (issue #2032).
+fn verify_or_record_version_cache(
+    binary_path: &Path,
+    source: &str,
+    version: &str,
+    name: &str,
+    lock_file: &mut LockFile,
+) -> Result<(), String> {
+    let actual_hash =
+        sha256_file(binary_path).map_err(|e| format!("Failed to hash binary: {e}"))?;
+    // Preserve any constraint already recorded; the resolver callers
+    // overwrite it afterwards when the `.crn` specifies one.
+    let existing_constraint = match lock_file.find(source, version) {
+        Some(entry) => {
+            if actual_hash != entry.sha256 {
+                return Err(format!(
+                    "SHA256 mismatch for provider '{}' ({}@{}). Expected: {}, got: {}. Re-run `carina init` to re-download.",
+                    name, source, version, entry.sha256, actual_hash
+                ));
+            }
+            match &entry.kind {
+                LockEntryKind::Version { constraint, .. } => constraint.clone(),
+                _ => None,
+            }
+        }
+        None => None,
+    };
+    lock_file.upsert(LockEntry {
+        name: name.to_string(),
+        source: source.to_string(),
+        kind: LockEntryKind::Version {
+            version: version.to_string(),
+            constraint: existing_constraint,
+        },
+        sha256: actual_hash,
+    });
+    Ok(())
+}
+
 /// Resolve a single provider: download if missing, verify if cached.
 ///
 /// Resolution order:
@@ -316,32 +360,14 @@ pub fn resolve_provider(
     // 1. Check local WASM cache first.
     let wasm_path = cache_path_wasm(base_dir, source, version);
     if wasm_path.exists() {
-        if let Some(lock_entry) = lock_file.find(source, version) {
-            let actual_hash =
-                sha256_file(&wasm_path).map_err(|e| format!("Failed to hash WASM binary: {e}"))?;
-            if actual_hash != lock_entry.sha256 {
-                return Err(format!(
-                    "SHA256 mismatch for provider '{}' ({}@{}). Expected: {}, got: {}. Re-run `carina init` to re-download.",
-                    name, source, version, lock_entry.sha256, actual_hash
-                ));
-            }
-        }
+        verify_or_record_version_cache(&wasm_path, source, version, name, lock_file)?;
         return Ok(wasm_path);
     }
 
     // 2. Check native binary cache.
     let binary_path = cache_path(base_dir, source, version);
     if binary_path.exists() {
-        if let Some(lock_entry) = lock_file.find(source, version) {
-            let actual_hash =
-                sha256_file(&binary_path).map_err(|e| format!("Failed to hash binary: {e}"))?;
-            if actual_hash != lock_entry.sha256 {
-                return Err(format!(
-                    "SHA256 mismatch for provider '{}' ({}@{}). Expected: {}, got: {}. Re-run `carina init` to re-download.",
-                    name, source, version, lock_entry.sha256, actual_hash
-                ));
-            }
-        }
+        verify_or_record_version_cache(&binary_path, source, version, name, lock_file)?;
         return Ok(binary_path);
     }
 
@@ -912,6 +938,64 @@ mod tests {
         let mut lock_file = LockFile::default();
         let result = resolve_provider(base, source, version, "awscc", &mut lock_file).unwrap();
         assert_eq!(result, wasm_path);
+    }
+
+    /// Issue #2032: when `resolve_provider` hits the project-local WASM cache,
+    /// it must still upsert a lock entry before returning. Otherwise the caller
+    /// writes an empty `LockFile` back to disk on subsequent `carina init` runs
+    /// and silently wipes the existing entry.
+    #[test]
+    fn resolve_upserts_lock_entry_when_wasm_cache_is_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        let source = "github.com/carina-rs/carina-provider-awscc";
+        let version = "0.1.0";
+
+        let wasm_path = cache_path_wasm(base, source, version);
+        fs::create_dir_all(wasm_path.parent().unwrap()).unwrap();
+        fs::File::create(&wasm_path)
+            .unwrap()
+            .write_all(b"fake wasm content")
+            .unwrap();
+
+        let mut lock_file = LockFile::default();
+        resolve_provider(base, source, version, "awscc", &mut lock_file).unwrap();
+
+        let entry = lock_file
+            .find_by_source(source)
+            .expect("cache-hit path must upsert a lock entry");
+        match &entry.kind {
+            LockEntryKind::Version {
+                version: locked, ..
+            } => assert_eq!(locked, version),
+            other => panic!("expected Version variant, got {other:?}"),
+        }
+        assert!(!entry.sha256.is_empty(), "entry must record a sha256");
+    }
+
+    /// Same guarantee for the native binary cache path.
+    #[test]
+    fn resolve_upserts_lock_entry_when_native_cache_is_hit() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        let source = "github.com/carina-rs/carina-provider-awscc";
+        let version = "0.1.0";
+
+        // Only the native binary exists — no WASM in the cache.
+        let native_path = cache_path(base, source, version);
+        fs::create_dir_all(native_path.parent().unwrap()).unwrap();
+        fs::File::create(&native_path)
+            .unwrap()
+            .write_all(b"fake native binary")
+            .unwrap();
+
+        let mut lock_file = LockFile::default();
+        resolve_provider(base, source, version, "awscc", &mut lock_file).unwrap();
+
+        assert!(
+            lock_file.find_by_source(source).is_some(),
+            "native-cache-hit path must upsert a lock entry"
+        );
     }
 
     /// Round-trip a version-mode entry through TOML. The serialized form carries

--- a/carina-provider-resolver/src/revision_resolver.rs
+++ b/carina-provider-resolver/src/revision_resolver.rs
@@ -373,20 +373,31 @@ pub fn resolve_provider_by_revision(
     // 2. Check cache
     let wasm_path = cache_path_revision(base_dir, source, &sha);
     if wasm_path.exists() {
-        if let Some(lock_entry) = lock_file.find_by_source_and_sha(source, &sha) {
-            let actual_hash = super::provider_resolver::sha256_file(&wasm_path)
-                .map_err(|e| format!("Failed to hash WASM binary: {e}"))?;
-            if actual_hash != lock_entry.sha256 {
-                return Err(format!(
-                    "SHA256 mismatch for provider '{}' ({}@{}). Expected: {}, got: {}. Re-run `carina init` to re-download.",
-                    name,
-                    source,
-                    &sha[..12],
-                    lock_entry.sha256,
-                    actual_hash
-                ));
-            }
+        let actual_hash = super::provider_resolver::sha256_file(&wasm_path)
+            .map_err(|e| format!("Failed to hash WASM binary: {e}"))?;
+        if let Some(lock_entry) = lock_file.find_by_source_and_sha(source, &sha)
+            && actual_hash != lock_entry.sha256
+        {
+            return Err(format!(
+                "SHA256 mismatch for provider '{}' ({}@{}). Expected: {}, got: {}. Re-run `carina init` to re-download.",
+                name,
+                source,
+                &sha[..12],
+                lock_entry.sha256,
+                actual_hash
+            ));
         }
+        // Record the entry so a caller that subsequently writes the lock
+        // doesn't stomp it with an empty in-memory LockFile (issue #2032).
+        lock_file.upsert(super::provider_resolver::LockEntry {
+            name: name.to_string(),
+            source: source.to_string(),
+            kind: super::provider_resolver::LockEntryKind::Revision {
+                revision: revision.to_string(),
+                resolved_sha: sha.clone(),
+            },
+            sha256: actual_hash,
+        });
         return Ok((wasm_path, sha));
     }
 


### PR DESCRIPTION
## Summary

Closes #2032.

When `resolve_provider` or `resolve_provider_by_revision` hit an existing binary in `.carina/providers/`, they returned early **without recording a lock entry**. `resolve_all` then called `lock_file.save` with an in-memory `LockFile` that didn't contain the provider, stomping the on-disk record with `provider = []`.

## Reproduction

\`\`\`console
$ mkdir t && cd t && cat > providers.crn << 'CRN'
provider awscc {
  provider = awscc.Region.ap_northeast_1
  source   = 'github.com/carina-rs/carina-provider-awscc'
  revision = 'main'
}
CRN
$ carina init
$ cat carina-providers.lock  # fine
[[provider]]
mode = "revision"
...

$ carina init
$ cat carina-providers.lock  # wiped
provider = []
\`\`\`

## Fix

- Extract the shared cache-verify-then-upsert logic into `verify_or_record_version_cache`. Called from both WASM (step 1) and native (step 2) cache-hit branches. Preserves any existing constraint so the downstream `*constraint = ...` assignments in `resolve_all` / `resolve_single_config` remain idempotent.
- Add the matching upsert to `revision_resolver.rs::resolve_provider_by_revision` step 2 (local cache). The existing global-cache path (step 2b) already upserts correctly.

## Tests

- `resolve_upserts_lock_entry_when_wasm_cache_is_hit` — lock entry present after cache hit, Version variant, non-empty sha256.
- `resolve_upserts_lock_entry_when_native_cache_is_hit` — same guarantee for the native binary path.
- Revision path's network call on step 1 makes a pure unit test awkward; end-to-end repro against the real awscc provider confirmed the fix.

## Test plan

- [x] `cargo test -p carina-provider-resolver` (46/46 pass)
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] End-to-end repro: `echo 'provider = []' > carina-providers.lock && carina init` now regenerates a well-formed entry instead of leaving the empty form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)