### PR TITLE
Fail carina init when a provider block has no source

### DIFF
--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -26,14 +26,18 @@ pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> 
     let loaded = load_configuration_with_config(&path_buf, &provider_context)
         .map_err(|e| format!("Failed to load configuration: {e}"))?;
 
-    let sourced_providers: Vec<_> = loaded
+    let missing_source: Vec<String> = loaded
         .parsed
         .providers
         .iter()
-        .filter(|p| p.source.is_some())
+        .filter(|p| p.source.is_none())
+        .map(|p| crate::commands::missing_provider_source_message(&p.name))
         .collect();
+    if !missing_source.is_empty() {
+        return Err(missing_source.join("\n"));
+    }
 
-    if !sourced_providers.is_empty() {
+    if !loaded.parsed.providers.is_empty() {
         let action = match mode {
             LockMode::Upgrade => "Upgrading",
             LockMode::Locked => "Verifying locked",
@@ -41,7 +45,12 @@ pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> 
         };
         println!(
             "{}",
-            format!("{} {} provider(s)...", action, sourced_providers.len()).cyan()
+            format!(
+                "{} {} provider(s)...",
+                action,
+                loaded.parsed.providers.len()
+            )
+            .cyan()
         );
 
         let resolved =

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -79,6 +79,16 @@ pub fn check_backend_lock(
     }
 }
 
+/// Error message for a provider block that declares no `source` attribute.
+/// Shared between `init` (pre-resolution check) and validation (post-load check)
+/// so both surfaces report the same text.
+pub fn missing_provider_source_message(name: &str) -> String {
+    format!(
+        "Provider '{}' has no source configured. Add `source = 'github.com/...'` to the provider block.",
+        name
+    )
+}
+
 /// Save the backend lock file for the current configuration.
 /// Called after state is successfully written to ensure the lock
 /// exists for future backend-change detection.
@@ -157,10 +167,7 @@ pub fn validate_and_resolve_with_config(
                 if let Some(reason) = load_errors.get(&provider.name) {
                     errors.push(reason.clone());
                 } else if provider.source.is_none() {
-                    errors.push(format!(
-                        "Provider '{}' has no source configured. Add `source = 'github.com/...'` to the provider block.",
-                        provider.name
-                    ));
+                    errors.push(missing_provider_source_message(&provider.name));
                 }
             }
         }

--- a/carina-cli/tests/init_validation.rs
+++ b/carina-cli/tests/init_validation.rs
@@ -1,0 +1,64 @@
+//! Integration tests for `carina init` validation.
+//!
+//! These tests verify that `init` rejects projects whose provider blocks
+//! cannot be resolved (e.g. missing `source`), instead of silently claiming
+//! success.
+
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn carina_init(project_dir: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_carina"))
+        .args(["init", project_dir.to_str().unwrap()])
+        .output()
+        .expect("failed to execute carina init")
+}
+
+#[test]
+fn init_fails_when_provider_has_no_source() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    fs::write(
+        project.join("main.crn"),
+        r#"provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  name = 'test'
+}
+"#,
+    )
+    .unwrap();
+
+    let output = carina_init(project);
+
+    assert!(
+        !output.status.success(),
+        "expected init to fail but it succeeded.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("has no source configured"),
+        "expected error about missing source, got stderr:\n{}",
+        stderr,
+    );
+
+    assert!(
+        !project.join(".carina").exists(),
+        ".carina/ should not be created on failure",
+    );
+    assert!(
+        !project.join("carina-backend.lock").exists(),
+        "carina-backend.lock should not be created on failure",
+    );
+    assert!(
+        !project.join("carina-providers.lock").exists(),
+        "carina-providers.lock should not be created on failure",
+    );
+}


### PR DESCRIPTION
## Summary
- `carina init` used to silently filter out providers missing `source` and report "Initialized successfully." The misconfiguration surfaced only on the next `plan` / `apply`.
- Now `init` checks every provider up front and errors out with the same message the plan path already emits (`Provider '<name>' has no source configured. Add \`source = 'github.com/...'\` to the provider block.`), exiting non-zero.
- The check runs before backend-lock creation, so no `.carina/`, `carina-backend.lock`, or `carina-providers.lock` is written on failure.
- The shared error text is consolidated into `commands::missing_provider_source_message` so `init` and `validate_and_resolve_with_config` stay in sync.

## Test plan
- [x] New `carina-cli/tests/init_validation.rs` runs `carina init` on a source-less `.crn` fixture and asserts non-zero exit, expected error text, and that no artifacts are written.
- [x] `cargo test -p carina-cli` (all passing).
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` clean.
- [x] Manual repro from the issue now fails with the expected message and exit code 1.

Closes #2004

🤖 Generated with [Claude Code](https://claude.com/claude-code)