### PR TITLE
Flag undefined for-iterable bindings in LSP

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -168,8 +168,13 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
-        if let Err(e) = parser::check_deferred_for_iterables(&merged) {
-            return Err(e.to_string());
+        let iterable_errors = parser::check_deferred_for_iterables(&merged);
+        if !iterable_errors.is_empty() {
+            return Err(iterable_errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"));
         }
 
         Ok(LoadedConfig {
@@ -261,12 +266,10 @@ pub fn parse_directory_with_overrides(
         return Err(e.to_string());
     }
 
-    // Per-file parse deliberately skips this check: the iterable may reference
-    // an `upstream_state` or `let` declared in a sibling file.
-    if let Err(e) = parser::check_deferred_for_iterables(&merged) {
-        return Err(e.to_string());
-    }
-
+    // Deferred-for-iterable validation is left to callers. LSP needs the
+    // ParsedFile even when an iterable names an undefined binding, so it
+    // can surface the error as a diagnostic; CLI entry points run
+    // `check_deferred_for_iterables` themselves.
     Ok(merged)
 }
 
@@ -906,7 +909,7 @@ awscc.ec2.security_group {
     }
 
     #[test]
-    fn parse_directory_rejects_undefined_iterable_even_after_merge() {
+    fn parse_directory_leaves_undefined_iterable_for_caller_to_check() {
         let dir = create_temp_dir("undefined_for_iterable");
         fs::write(
             dir.join("main.crn"),
@@ -921,7 +924,34 @@ awscc.ec2.security_group {
 
         let result = parse_directory(&dir, &ProviderContext::default());
         cleanup(&dir);
-        let err = result.expect_err("undefined iterable should still error after merge");
+        let parsed = result.expect("parse_directory should not fail on undefined iterable");
+        let errs = parser::check_deferred_for_iterables(&parsed);
+        assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
+        match &errs[0] {
+            parser::ParseError::UndefinedIdentifier { name, .. } => {
+                assert_eq!(name, "does_not_exist");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        // `load_configuration_with_config` still fails fast for CLI callers.
+        let dir2 = create_temp_dir("undefined_for_iterable_cli");
+        fs::write(
+            dir2.join("main.crn"),
+            r#"for name, account_id in does_not_exist.accounts {
+  aws.s3.bucket {
+    name = name
+  }
+}
+"#,
+        )
+        .unwrap();
+        let cli_result = load_configuration_with_config(&dir2, &ProviderContext::default());
+        cleanup(&dir2);
+        let err = match cli_result {
+            Ok(_) => panic!("CLI load path should fail on undefined iterable"),
+            Err(e) => e,
+        };
         assert!(
             err.contains("Undefined identifier `does_not_exist`"),
             "unexpected error: {err}"

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -4429,7 +4429,7 @@ pub fn resolve_resource_refs_with_config(
 /// This must run on a fully merged `ParsedFile` (directory-wide), not on a
 /// single-file parse — iterables commonly reference `upstream_state` or `let`
 /// bindings declared in sibling files that only become visible after merging.
-pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Result<(), ParseError> {
+pub fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
     let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
     known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref()));
     known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
@@ -4445,15 +4445,15 @@ pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Result<(), Pa
     known.extend(parsed.variables.keys().map(String::as_str));
     known.extend(parsed.structural_bindings.iter().map(String::as_str));
 
-    for deferred in &parsed.deferred_for_expressions {
-        if !known.contains(deferred.iterable_binding.as_str()) {
-            return Err(ParseError::UndefinedIdentifier {
-                name: deferred.iterable_binding.clone(),
-                line: deferred.line,
-            });
-        }
-    }
-    Ok(())
+    parsed
+        .deferred_for_expressions
+        .iter()
+        .filter(|d| !known.contains(d.iterable_binding.as_str()))
+        .map(|d| ParseError::UndefinedIdentifier {
+            name: d.iterable_binding.clone(),
+            line: d.line,
+        })
+        .collect()
 }
 
 fn resolve_value_with_config(
@@ -10814,9 +10814,9 @@ awscc.ec2.vpc {
         // per-file parsing.
         let parsed = parse(input, &ProviderContext::default())
             .expect("single-file parse must not reject cross-file iterables");
-        let err = check_deferred_for_iterables(&parsed)
-            .expect_err("undefined `orgs` must be a hard error");
-        match err {
+        let errs = check_deferred_for_iterables(&parsed);
+        assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
+        match &errs[0] {
             ParseError::UndefinedIdentifier { name, .. } => {
                 assert_eq!(name, "orgs");
             }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -4429,7 +4429,7 @@ pub fn resolve_resource_refs_with_config(
 /// This must run on a fully merged `ParsedFile` (directory-wide), not on a
 /// single-file parse — iterables commonly reference `upstream_state` or `let`
 /// bindings declared in sibling files that only become visible after merging.
-pub fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
+pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
     let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
     known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref()));
     known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -101,6 +101,49 @@ fn find_source_value_position(text: &str, expected: &str) -> Option<(u32, u32, u
     None
 }
 
+/// On the known `line_one_based` of a `for <pat> in <binding>.<attr>` header,
+/// find the character columns spanning `<binding>`. `DeferredForExpression`
+/// already carries the line; this narrows the scan to that one line.
+fn find_for_iterable_binding_column(
+    text: &str,
+    line_one_based: usize,
+    binding: &str,
+) -> Option<(u32, u32)> {
+    let line = text.lines().nth(line_one_based.saturating_sub(1))?;
+    let in_byte = line.find(" in ")?;
+    let after_in = &line[in_byte + 4..];
+    let after_in_trimmed = after_in.trim_start();
+    let ident_end = after_in_trimmed
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(after_in_trimmed.len());
+    if &after_in_trimmed[..ident_end] != binding {
+        return None;
+    }
+    let byte_in_line = in_byte + 4 + (after_in.len() - after_in_trimmed.len());
+    let start_col = line[..byte_in_line].chars().count() as u32;
+    let end_col = start_col + binding.chars().count() as u32;
+    Some((start_col, end_col))
+}
+
+/// Whether `deferred` was parsed from the editor's current document.
+/// `DeferredForExpression.file` is stamped with the full source path, so we
+/// compare by basename to the LSP-supplied `current_file_name`.
+fn deferred_in_current_file(
+    deferred: &carina_core::parser::DeferredForExpression,
+    current_file_name: Option<&str>,
+) -> bool {
+    let Some(current) = current_file_name else {
+        return false;
+    };
+    let Some(file) = deferred.file.as_deref() else {
+        return false;
+    };
+    std::path::Path::new(file)
+        .file_name()
+        .and_then(|n| n.to_str())
+        == Some(current)
+}
+
 /// Check if a string looks like an unresolved cross-file reference ("binding.attribute").
 fn is_dot_notation_ref(s: &str) -> bool {
     let parts: Vec<&str> = s.split('.').collect();
@@ -283,34 +326,38 @@ impl DiagnosticEngine {
         None
     }
 
-    /// Reject references like `orgs.account` whose field isn't declared by
-    /// the upstream's `exports { }` block.
-    ///
-    /// Uses a directory-scoped parse that overrides the on-disk copy of
-    /// `current_file_name` with the editor's in-memory buffer, so edits
-    /// produce diagnostics before the user saves. Runs even when the
-    /// single-file parse fails — common when a `for` iterates over a
-    /// binding declared in a sibling file.
-    pub(super) fn check_upstream_state_field_references(
+    /// Run a directory-scoped parse with the current editor buffer substituted
+    /// for its on-disk copy, so diagnostics that need cross-file context
+    /// (upstream-state exports, for-iterable bindings) update on keystrokes.
+    pub(super) fn parse_merged_with_buffer(
         &self,
         doc: &Document,
         current_file_name: Option<&str>,
         base_path: &std::path::Path,
-    ) -> Vec<Diagnostic> {
-        let mut overrides: std::collections::HashMap<String, String> =
-            std::collections::HashMap::new();
+    ) -> Option<ParsedFile> {
+        let mut overrides: HashMap<String, String> = HashMap::new();
         if let Some(name) = current_file_name {
             overrides.insert(name.to_string(), doc.text());
         }
-        let merged = carina_core::config_loader::parse_directory_with_overrides(
+        carina_core::config_loader::parse_directory_with_overrides(
             base_path,
             &self.provider_context,
             &overrides,
-        );
-        let Ok(merged) = merged else {
-            return Vec::new();
-        };
+        )
+        .ok()
+    }
 
+    /// Reject references like `orgs.account` whose field isn't declared by
+    /// the upstream's `exports { }` block.
+    ///
+    /// Runs even when the single-file parse fails — common when a `for`
+    /// iterates over a binding declared in a sibling file.
+    pub(super) fn check_upstream_state_field_references(
+        &self,
+        doc: &Document,
+        merged: &ParsedFile,
+        base_path: &std::path::Path,
+    ) -> Vec<Diagnostic> {
         let (exports, resolve_errors) = carina_core::upstream_exports::resolve_upstream_exports(
             base_path,
             &merged.upstream_states,
@@ -344,7 +391,7 @@ impl DiagnosticEngine {
         // anchor later diagnostics at subsequent occurrences instead of
         // stacking them on the first.
         let field_errors =
-            carina_core::upstream_exports::check_upstream_state_field_references(&merged, &exports);
+            carina_core::upstream_exports::check_upstream_state_field_references(merged, &exports);
         let mut seen_count: std::collections::HashMap<String, usize> =
             std::collections::HashMap::new();
         for err in field_errors {
@@ -369,6 +416,51 @@ impl DiagnosticEngine {
         diagnostics
     }
 
+    /// Flag `for _ in <name>.<attr>` whose root binding `<name>` is not
+    /// declared anywhere in the directory-scoped parse.
+    ///
+    /// The same typo outside a `for` is rejected at single-file parse time,
+    /// but for-iterables are deferred until directory merge (they may name a
+    /// sibling `upstream_state` or `let`), so this check has to run on the
+    /// merged buffer+disk parse too.
+    pub(super) fn check_for_iterable_bindings(
+        &self,
+        doc: &Document,
+        merged: &ParsedFile,
+        current_file_name: Option<&str>,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        let text = doc.text();
+        for err in carina_core::parser::check_deferred_for_iterables(merged) {
+            let carina_core::parser::ParseError::UndefinedIdentifier { name, line } = &err else {
+                continue;
+            };
+            // Surface only errors whose `for` header lives in the current
+            // document; sibling-file typos are reported when that file is
+            // analyzed. Matching by (name, line) uniquely identifies the
+            // deferred expression that produced the error.
+            let Some(deferred) = merged.deferred_for_expressions.iter().find(|d| {
+                d.iterable_binding == *name
+                    && d.line == *line
+                    && deferred_in_current_file(d, current_file_name)
+            }) else {
+                continue;
+            };
+            let Some((col, end_col)) = find_for_iterable_binding_column(&text, deferred.line, name)
+            else {
+                continue;
+            };
+            diagnostics.push(carina_diagnostic(
+                (deferred.line.saturating_sub(1)) as u32,
+                col,
+                end_col,
+                DiagnosticSeverity::ERROR,
+                err.to_string(),
+            ));
+        }
+        diagnostics
+    }
+
     /// Flag `upstream_state { source = ... }` paths that do not resolve to an
     /// existing directory relative to the project's base path.
     ///
@@ -380,8 +472,8 @@ impl DiagnosticEngine {
     /// Scope: **directory existence only.** Parsing the upstream's `.crn`
     /// files (across every sibling file in the upstream directory) and
     /// checking references against its declared exports is the job of
-    /// [`Self::check_upstream_state_field_references`], which runs a full
-    /// directory-scoped parse via `parse_directory_with_overrides`.
+    /// [`Self::check_upstream_state_field_references`], which consumes the
+    /// merged directory parse from [`Self::parse_merged_with_buffer`].
     pub(super) fn check_upstream_state_sources(
         &self,
         doc: &Document,

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -125,6 +125,27 @@ fn find_for_iterable_binding_column(
     Some((start_col, end_col))
 }
 
+/// Binding names declared anywhere in the merged parse — the same set
+/// `carina_core::parser::check_deferred_for_iterables` uses to decide whether
+/// a for-iterable's root is in scope.
+fn collect_known_bindings(merged: &ParsedFile) -> HashSet<&str> {
+    let mut known: HashSet<&str> = HashSet::new();
+    known.extend(merged.resources.iter().filter_map(|r| r.binding.as_deref()));
+    known.extend(merged.arguments.iter().map(|a| a.name.as_str()));
+    known.extend(
+        merged
+            .module_calls
+            .iter()
+            .filter_map(|c| c.binding_name.as_deref()),
+    );
+    known.extend(merged.upstream_states.iter().map(|u| u.binding.as_str()));
+    known.extend(merged.imports.iter().map(|i| i.alias.as_str()));
+    known.extend(merged.user_functions.keys().map(String::as_str));
+    known.extend(merged.variables.keys().map(String::as_str));
+    known.extend(merged.structural_bindings.iter().map(String::as_str));
+    known
+}
+
 /// Whether `deferred` was parsed from the editor's current document.
 /// `DeferredForExpression.file` is stamped with the full source path, so we
 /// compare by basename to the LSP-supplied `current_file_name`.
@@ -429,33 +450,45 @@ impl DiagnosticEngine {
         merged: &ParsedFile,
         current_file_name: Option<&str>,
     ) -> Vec<Diagnostic> {
-        let mut diagnostics = Vec::new();
+        let known = collect_known_bindings(merged);
         let text = doc.text();
-        for err in carina_core::parser::check_deferred_for_iterables(merged) {
-            let carina_core::parser::ParseError::UndefinedIdentifier { name, line } = &err else {
+        let mut diagnostics = Vec::new();
+        // Iterating the deferred list directly (rather than the error list
+        // from `check_deferred_for_iterables`) keeps a 1:1 mapping between
+        // deferred expressions and diagnostics; two sibling files with
+        // `for _ in <same>.attr` on the same line would otherwise collide on
+        // the error's `(name, line)` key.
+        for deferred in &merged.deferred_for_expressions {
+            if !deferred_in_current_file(deferred, current_file_name) {
                 continue;
-            };
-            // Surface only errors whose `for` header lives in the current
-            // document; sibling-file typos are reported when that file is
-            // analyzed. Matching by (name, line) uniquely identifies the
-            // deferred expression that produced the error.
-            let Some(deferred) = merged.deferred_for_expressions.iter().find(|d| {
-                d.iterable_binding == *name
-                    && d.line == *line
-                    && deferred_in_current_file(d, current_file_name)
-            }) else {
+            }
+            if known.contains(deferred.iterable_binding.as_str()) {
                 continue;
-            };
-            let Some((col, end_col)) = find_for_iterable_binding_column(&text, deferred.line, name)
-            else {
-                continue;
-            };
+            }
+            let line_zero_based = deferred.line.saturating_sub(1) as u32;
+            let (col, end_col) =
+                find_for_iterable_binding_column(&text, deferred.line, &deferred.iterable_binding)
+                    .unwrap_or_else(|| {
+                        // Multi-line `for` headers put the iterable on a later line;
+                        // anchor the squiggle at the `for` keyword line so the user
+                        // still sees the error.
+                        let line_chars = text
+                            .lines()
+                            .nth(deferred.line.saturating_sub(1))
+                            .map(|l| l.chars().count() as u32)
+                            .unwrap_or(0);
+                        (0, line_chars)
+                    });
             diagnostics.push(carina_diagnostic(
-                (deferred.line.saturating_sub(1)) as u32,
+                line_zero_based,
                 col,
                 end_col,
                 DiagnosticSeverity::ERROR,
-                err.to_string(),
+                carina_core::parser::ParseError::UndefinedIdentifier {
+                    name: deferred.iterable_binding.clone(),
+                    line: deferred.line,
+                }
+                .to_string(),
             ));
         }
         diagnostics

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -147,17 +147,15 @@ impl DiagnosticEngine {
             self.check_undefined_references(&text, &all_bindings, &declared_providers);
         diagnostics.extend(undef_diags);
 
-        // Upstream_state field-ref check: must run even when the current
-        // document fails to parse on its own (e.g. when the downstream
-        // references a `let` declared in a sibling file). Uses a
-        // directory-scoped parse fed with the current buffer, not just
-        // disk content.
-        if let Some(base) = base_path {
-            diagnostics.extend(self.check_upstream_state_field_references(
-                doc,
-                current_file_name,
-                base,
-            ));
+        // Checks that need cross-file context share one directory-scoped parse
+        // (buffer substituted for its on-disk copy). Both must run even when
+        // the current document fails to parse on its own — a `for` or `let`
+        // commonly references a binding declared in a sibling file.
+        if let Some(base) = base_path
+            && let Some(merged) = self.parse_merged_with_buffer(doc, current_file_name, base)
+        {
+            diagnostics.extend(self.check_upstream_state_field_references(doc, &merged, base));
+            diagnostics.extend(self.check_for_iterable_bindings(doc, &merged, current_file_name));
         }
 
         // Semantic analysis on parsed file

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2502,3 +2502,112 @@ fn upstream_state_broken_upstream_surfaces_resolve_error() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// =====================================================================
+// for-expression iterable: undefined binding (#1998)
+// =====================================================================
+
+#[test]
+fn for_iterable_undefined_binding_is_flagged() {
+    // `org` is a typo for `orgs` — the binding doesn't exist. LSP must
+    // flag it, the same way `let x = org.accounts` outside a `for` does.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+for name, _ in org.accounts {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join(&name)).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, &buffer);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Undefined identifier `org`")),
+        "got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_iterable_defined_binding_passes() {
+    // `orgs` is correct — no undefined-identifier diagnostic.
+    let (_tmp, base, name) = set_up_project_with_upstream(
+        r#"let orgs = upstream_state { source = '../organizations' }
+for name, _ in orgs.accounts {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#,
+        Some(
+            r#"exports { accounts: string = "x" }
+"#,
+        ),
+    );
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join(&name)).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, &name, &buffer);
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.contains("Undefined identifier")),
+        "correctly-named binding should not flag, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_iterable_undefined_binding_cross_file_is_flagged() {
+    // `orgs` is declared in sibling file, but main.crn typos it as `org`.
+    // The directory-scoped merge must still catch it.
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        r#"exports { accounts: string = "x" }
+"#,
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("upstream.crn"),
+        r#"let orgs = upstream_state { source = '../organizations' }
+"#,
+    )
+    .unwrap();
+    let main = r#"for name, _ in org.accounts {
+    awscc.ec2.vpc {
+        name = name
+        cidr_block = '10.0.0.0/16'
+    }
+}
+"#;
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Undefined identifier `org`")),
+        "cross-file typo must be flagged after directory merge, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2611,3 +2611,64 @@ fn for_iterable_undefined_binding_cross_file_is_flagged() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn for_iterable_undefined_binding_not_duplicated_across_siblings() {
+    // Two sibling files with `for _ in <same_undefined>.<attr>` on the same
+    // 1-based line must produce exactly one diagnostic in the currently
+    // edited file — not one per deferred in the merged parse.
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("project");
+    std::fs::create_dir(&base).unwrap();
+    let main = r#"for name, _ in missing.accounts {
+    awscc.ec2.vpc { name = name cidr_block = '10.0.0.0/16' }
+}
+"#;
+    let sibling = r#"for name, _ in missing.accounts {
+    awscc.ec2.vpc { name = name cidr_block = '10.0.0.0/16' }
+}
+"#;
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    std::fs::write(base.join("sibling.crn"), sibling).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Undefined identifier `missing`"))
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "expected one diagnostic in main.crn, got {}: {:?}",
+        hits.len(),
+        hits.iter()
+            .map(|d| (&d.range, &d.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_iterable_multiline_header_still_flagged() {
+    // Pest's `WHITESPACE` includes NEWLINE, so `for _ in\n    bad.attr {`
+    // parses. `deferred.line` points at the `for` keyword's line, which
+    // doesn't contain the iterable token — the diagnostic must still surface
+    // (anchored at the `for` line) rather than be silently dropped.
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("project");
+    std::fs::create_dir(&base).unwrap();
+    let main = "for name, _ in\n    missing.accounts {\n    awscc.ec2.vpc { name = name cidr_block = '10.0.0.0/16' }\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Undefined identifier `missing`")),
+        "multi-line for header must still flag the undefined iterable, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- `for _ in <binding>.<attr>` whose root binding is undeclared was already rejected by `carina validate`/`plan`/`apply`, but the LSP silently accepted it — no squiggle in the editor.
- The check (`check_deferred_for_iterables`) already existed, but lived inside `parse_directory_with_overrides`. When it fired, the whole `ParsedFile` was dropped and LSP had nothing to surface.
- Split the check out so LSP can call it on the merged parse and emit a diagnostic pointing at the iterable's root identifier. CLI entry points keep fail-fast semantics.

## Test plan

- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New LSP tests cover: undefined binding flagged, correct binding passes, cross-file case flagged
- [x] Manual repro (`carina validate`) still exits 1 with the same message

Closes #1998

🤖 Generated with [Claude Code](https://claude.com/claude-code)