### PR TITLE
LSP completion: offer bindings at `for ... in <HERE>`

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -95,7 +95,7 @@ impl CompletionProvider {
                 self.upstream_state_source_completions(&partial_path, position, base_path)
             }
             CompletionContext::ForIterable { partial } => {
-                self.for_iterable_completions(&text, position, &partial)
+                self.for_iterable_completions(&text, position, &partial, base_path)
             }
             CompletionContext::None => vec![],
         }

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -667,11 +667,15 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
 /// which is a separate completion context (see #1996).
 fn extract_for_iterable_partial(prefix: &str) -> Option<String> {
     let rest = prefix.trim_start().strip_prefix("for ")?;
-    // A real `in` token is surrounded by whitespace on both sides — so a
-    // pattern like `information` or `in_place` can't masquerade as the
-    // keyword. `match_indices(" in ")` guarantees both boundaries at once.
-    let in_rel = rest.match_indices(" in ").next().map(|(i, _)| i)?;
-    let after_in = rest[in_rel + 4..].trim_start();
+    // A real `in` token has whitespace on the left (so `information` can't
+    // masquerade) and either whitespace or end-of-prefix on the right (so
+    // the moment the cursor lands just past `in` — with no trailing space
+    // yet — still fires).
+    let after_in = rest.match_indices(" in").find_map(|(idx, _)| {
+        let after = &rest[idx + 3..];
+        let right_ok = after.is_empty() || after.starts_with(|c: char| c.is_whitespace());
+        right_ok.then_some(after.trim_start())
+    })?;
     // Anything non-identifier (`.`, `[`, whitespace, `{`, etc.) means the
     // user has moved past the root-binding position — into field access,
     // indexing, or the loop body — all of which are other contexts.

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -94,6 +94,9 @@ impl CompletionProvider {
             CompletionContext::InsideUpstreamStateSource { partial_path } => {
                 self.upstream_state_source_completions(&partial_path, position, base_path)
             }
+            CompletionContext::ForIterable { partial } => {
+                self.for_iterable_completions(&text, position, &partial)
+            }
             CompletionContext::None => vec![],
         }
     }
@@ -109,6 +112,13 @@ impl CompletionProvider {
         let current_line = lines[line_idx];
         let col = position.character as usize;
         let prefix: String = current_line.chars().take(col).collect();
+
+        // `for <pat> in <HERE>`: offer in-scope bindings. Detected before the
+        // block-context walk because a `for` header sits at brace_depth 0 and
+        // would otherwise fall through to `TopLevel`.
+        if let Some(partial) = extract_for_iterable_partial(&prefix) {
+            return CompletionContext::ForIterable { partial };
+        }
 
         // Check if we're typing after "<provider>.Region." or "<provider>.Region"
         for provider_name in &self.provider_names {
@@ -625,6 +635,13 @@ enum CompletionContext {
     InsideUpstreamStateSource {
         partial_path: String,
     },
+    /// Cursor is at the iterable position of a `for ... in <HERE>` header
+    /// (after the `in` keyword, before any `.` field access). The partial is
+    /// whatever the user has typed so far, used by the handler to compute
+    /// the replace range.
+    ForIterable {
+        partial: String,
+    },
     None,
 }
 
@@ -641,6 +658,30 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
     // longer identifier like `upstream_states`.
     let next = rest.trim_start();
     next.starts_with('{') || next.is_empty()
+}
+
+/// If the cursor sits at the iterable position of a `for <pat> in <partial>`
+/// header — i.e. after the `in` keyword and inside (possibly empty) identifier
+/// characters — return the partial identifier typed so far. A `.` in the
+/// partial means the user has moved past the root binding into field access,
+/// which is a separate completion context (see #1996).
+fn extract_for_iterable_partial(prefix: &str) -> Option<String> {
+    let rest = prefix.trim_start().strip_prefix("for ")?;
+    // A real `in` token is surrounded by whitespace on both sides — so a
+    // pattern like `information` or `in_place` can't masquerade as the
+    // keyword. `match_indices(" in ")` guarantees both boundaries at once.
+    let in_rel = rest.match_indices(" in ").next().map(|(i, _)| i)?;
+    let after_in = rest[in_rel + 4..].trim_start();
+    // Anything non-identifier (`.`, `[`, whitespace, `{`, etc.) means the
+    // user has moved past the root-binding position — into field access,
+    // indexing, or the loop body — all of which are other contexts.
+    if !after_in
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+    Some(after_in.to_string())
 }
 
 /// If `prefix` ends with `source = '<partial>` or `source = "<partial>`

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1469,3 +1469,99 @@ fn upstream_state_source_text_edit_range_covers_typed_partial() {
     assert_eq!(edit.range.end.line, 1);
     assert_eq!(edit.range.end.character, 19);
 }
+
+// =====================================================================
+// for-iterable binding completion (#2037)
+// =====================================================================
+
+#[test]
+fn for_iterable_position_suggests_let_binding() {
+    // `for _ in <HERE>`: the in-scope `let` binding should appear.
+    let provider = test_provider();
+    let source = "let orgs = upstream_state { source = '../organizations' }\nfor name, _ in o";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        completions.iter().any(|c| c.label == "orgs"),
+        "expected `orgs` in completions, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_iterable_position_suggests_module_call_binding() {
+    // A module call binding (`let x = mymod { ... }`) must also appear.
+    let provider = test_provider();
+    let source = "\
+import './mods' as mymod
+let inst = mymod { foo = 1 }
+for name, _ in i";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 2,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        completions.iter().any(|c| c.label == "inst"),
+        "expected `inst` in completions, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_binding_declaration_position_does_not_suggest_bindings() {
+    // `for <HERE>, _ in orgs.accounts`: cursor is on the loop-variable
+    // declaration (before `in`), not on the iterable. Existing bindings
+    // must not appear — only the iterable position triggers ForIterable.
+    let provider = test_provider();
+    // Cursor after `for ` on line 1; the `, _ in orgs.accounts {` tail is
+    // already on the line, so the full line is a valid-looking for-header.
+    let source = "let orgs = upstream_state { source = '../organizations' }\nfor , _ in orgs.accounts {\n}\n";
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: 4, // cursor sits right after "for "
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        !completions.iter().any(|c| c.label == "orgs"),
+        "binding-declaration position must not offer existing bindings, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_iterable_after_dot_does_not_trigger() {
+    // `for _ in orgs.<HERE>` is field-access, handled by dot completion
+    // (#1996) — the ForIterable context must not fire once a `.` appears
+    // in the iterable partial.
+    let provider = test_provider();
+    let source = "let orgs = upstream_state { source = '../organizations' }\nfor name, _ in orgs.";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        !completions.iter().any(|c| c.label == "orgs"),
+        "after-dot position must not echo the binding back, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1544,6 +1544,30 @@ fn for_binding_declaration_position_does_not_suggest_bindings() {
 }
 
 #[test]
+fn for_iterable_fires_immediately_after_in_without_trailing_space() {
+    // User types `for name, _ in` and invokes completion before adding a
+    // space — the cursor is right after the `n` of `in` and the rest of
+    // the line is empty. Must still offer bindings so the popup shows
+    // up without forcing the user to press space first.
+    let provider = test_provider();
+    let source = "let orgs = upstream_state { source = '../organizations' }\nfor name, _ in";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        completions.iter().any(|c| c.label == "orgs"),
+        "expected `orgs` even with no space after `in`, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn for_iterable_after_dot_does_not_trigger() {
     // `for _ in orgs.<HERE>` is field-access, handled by dot completion
     // (#1996) — the ForIterable context must not fire once a `.` appears

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1544,6 +1544,37 @@ fn for_binding_declaration_position_does_not_suggest_bindings() {
 }
 
 #[test]
+fn for_iterable_offers_binding_declared_in_sibling_file() {
+    // `let orgs = upstream_state { ... }` commonly lives in a sibling
+    // `backend.crn` while the `for _ in orgs.accounts` sits in `main.crn`.
+    // Completion must surface bindings from the whole directory, not just
+    // the current buffer.
+    let provider = test_provider();
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    let main = "for _, account_id in or";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 0,
+        character: main.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(base));
+
+    assert!(
+        completions.iter().any(|c| c.label == "orgs"),
+        "expected `orgs` from sibling backend.crn, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn for_iterable_fires_immediately_after_in_without_trailing_space() {
     // User types `for name, _ in` and invokes completion before adding a
     // space — the cursor is right after the `n` of `in` and the rest of

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -288,19 +288,31 @@ impl CompletionProvider {
         params
     }
 
+    /// Extract every `let <name> = <rhs>` from `text`.
+    ///
+    /// Returns `Vec<(name, rhs)>` where `rhs` is the trimmed text after `=`
+    /// (e.g. `awscc.ec2.vpc { ... }`, `upstream_state { ... }`, `import '...'`).
+    /// Callers classify the rhs themselves — `extract_resource_bindings` maps
+    /// it to a schema key, the for-iterable handler keys it into a detail
+    /// label, etc.
+    pub(super) fn extract_let_bindings(text: &str) -> Vec<(String, String)> {
+        text.lines()
+            .filter_map(|line| {
+                crate::let_parse::parse_let_header(line)
+                    .map(|(name, rhs)| (name.to_string(), rhs.to_string()))
+            })
+            .collect()
+    }
+
     /// Extract resource binding names and their resource types from text
     /// (variables defined with `let binding_name = awscc.ec2.vpc {`)
     /// Returns Vec<(binding_name, resource_type)> where resource_type is the schema key
     /// (e.g., "awscc.ec2.vpc")
     pub(super) fn extract_resource_bindings(&self, text: &str) -> Vec<(String, String)> {
-        let mut bindings = Vec::new();
-        for line in text.lines() {
-            if let Some((binding_name, after_eq)) = crate::let_parse::parse_let_header(line) {
-                let resource_type = self.extract_resource_type(after_eq).unwrap_or_default();
-                bindings.push((binding_name.to_string(), resource_type));
-            }
-        }
-        bindings
+        Self::extract_let_bindings(text)
+            .into_iter()
+            .map(|(name, rhs)| (name, self.extract_resource_type(&rhs).unwrap_or_default()))
+            .collect()
     }
 
     pub(super) fn module_parameter_completions(

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -474,6 +474,63 @@ impl CompletionProvider {
         ]
     }
 
+    /// Completions for `for <pat> in <HERE>` — every binding that
+    /// `check_deferred_for_iterables` treats as in-scope: `let`,
+    /// `upstream_state`, module calls, imports, and argument parameters.
+    pub(super) fn for_iterable_completions(
+        &self,
+        text: &str,
+        position: Position,
+        partial: &str,
+    ) -> Vec<CompletionItem> {
+        let partial_chars = partial.chars().count() as u32;
+        let range = Range {
+            start: Position {
+                line: position.line,
+                character: position.character.saturating_sub(partial_chars),
+            },
+            end: position,
+        };
+
+        let mut items = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let push = |items: &mut Vec<CompletionItem>,
+                    seen: &mut std::collections::HashSet<String>,
+                    name: String,
+                    detail: &str| {
+            if !seen.insert(name.clone()) {
+                return;
+            }
+            items.push(CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                detail: Some(detail.to_string()),
+                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: name,
+                })),
+                ..Default::default()
+            });
+        };
+
+        for (name, rhs) in Self::extract_let_bindings(text) {
+            let detail = if rhs.starts_with("upstream_state") {
+                "upstream_state binding"
+            } else if rhs.starts_with("import ") {
+                "module import"
+            } else {
+                "binding"
+            };
+            push(&mut items, &mut seen, name, detail);
+        }
+
+        for (name, _) in self.extract_argument_parameters(text) {
+            push(&mut items, &mut seen, name, "argument");
+        }
+
+        items
+    }
+
     pub(super) fn upstream_state_block_completions(&self) -> Vec<CompletionItem> {
         vec![CompletionItem {
             label: "source".to_string(),

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -22,6 +22,31 @@ struct BindingDotContext {
     resource_type: String,
 }
 
+/// Concatenate every `.crn` file in `base_path` into one string. The
+/// current-file buffer is scanned separately by the caller (it might
+/// contain unsaved edits that differ from disk), so returning disk
+/// content for the whole directory is fine — duplicates are deduped
+/// by the completion handler's `seen` set.
+fn read_sibling_crn(base_path: Option<&Path>) -> String {
+    let Some(base) = base_path else {
+        return String::new();
+    };
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return String::new();
+    };
+    let mut out = String::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn")
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            out.push_str(&content);
+            out.push('\n');
+        }
+    }
+    out
+}
+
 fn type_completion_item(label: String, detail: String, range: Range) -> CompletionItem {
     CompletionItem {
         label: label.clone(),
@@ -477,11 +502,17 @@ impl CompletionProvider {
     /// Completions for `for <pat> in <HERE>` — every binding that
     /// `check_deferred_for_iterables` treats as in-scope: `let`,
     /// `upstream_state`, module calls, imports, and argument parameters.
+    ///
+    /// Bindings commonly live in sibling `.crn` files (a typical pattern
+    /// is `let orgs = upstream_state { ... }` in `backend.crn` iterated
+    /// from `main.crn`), so we read every `.crn` in `base_path`, not just
+    /// the current buffer.
     pub(super) fn for_iterable_completions(
         &self,
         text: &str,
         position: Position,
         partial: &str,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let partial_chars = partial.chars().count() as u32;
         let range = Range {
@@ -513,19 +544,21 @@ impl CompletionProvider {
             });
         };
 
-        for (name, rhs) in Self::extract_let_bindings(text) {
-            let detail = if rhs.starts_with("upstream_state") {
-                "upstream_state binding"
-            } else if rhs.starts_with("import ") {
-                "module import"
-            } else {
-                "binding"
-            };
-            push(&mut items, &mut seen, name, detail);
-        }
-
-        for (name, _) in self.extract_argument_parameters(text) {
-            push(&mut items, &mut seen, name, "argument");
+        let sibling_text = read_sibling_crn(base_path);
+        for source in [text, sibling_text.as_str()] {
+            for (name, rhs) in Self::extract_let_bindings(source) {
+                let detail = if rhs.starts_with("upstream_state") {
+                    "upstream_state binding"
+                } else if rhs.starts_with("import ") {
+                    "module import"
+                } else {
+                    "binding"
+                };
+                push(&mut items, &mut seen, name, detail);
+            }
+            for (name, _) in self.extract_argument_parameters(source) {
+                push(&mut items, &mut seen, name, "argument");
+            }
         }
 
         items


### PR DESCRIPTION
## Summary

- The iterable position of a `for` expression didn't offer completion candidates. Users had to remember the exact binding name; typos were only caught after the fact by #1998's diagnostic.
- Detect `for <pat> in <partial>` via a whitespace-bounded `in` token, then surface every `let` binding (resources, `upstream_state`, module calls, `let import`) and `arguments` parameter.
- Doesn't trigger at the loop-variable declaration (`for <HERE>, _ in ...`) or after a dot (`for _ in orgs.<HERE>` — field completion is #1996).

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] 4 new LSP completion tests

Closes #2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)