### PR TITLE
LSP completion: suggest upstream_state exports after `<binding>.`

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -52,6 +52,19 @@ impl CompletionProvider {
         base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let text = doc.text();
+
+        // `<binding>.<partial>` where `<binding>` is an `upstream_state` is
+        // matched ahead of the block-context walk: the same prefix would
+        // otherwise be interpreted as `AfterEquals` (dot-after-binding inside
+        // a resource block) or fall through to `TopLevel`, neither of which
+        // knows how to surface upstream exports.
+        if let Some((binding, partial, source)) =
+            detect_upstream_state_dot(&text, position, base_path)
+        {
+            return self
+                .upstream_state_dot_completions(&binding, &partial, &source, position, base_path);
+        }
+
         let context = self.get_completion_context(&text, position);
 
         match context {
@@ -686,6 +699,132 @@ fn extract_for_iterable_partial(prefix: &str) -> Option<String> {
         return None;
     }
     Some(after_in.to_string())
+}
+
+/// If the prefix up to `position` ends with `<binding>.<partial>` where
+/// `<binding>` matches a `let <binding> = upstream_state { ... }` declared
+/// anywhere in `base_path`, return `(binding, partial, source_path)`. The
+/// source is returned alongside so the handler doesn't have to re-scan
+/// sibling files. Bare `<binding>` (no dot yet) is the ForIterable / value
+/// completion surface, not this one.
+fn detect_upstream_state_dot(
+    text: &str,
+    position: Position,
+    base_path: Option<&std::path::Path>,
+) -> Option<(String, String, String)> {
+    let line_idx = position.line as usize;
+    let current_line = text.lines().nth(line_idx)?;
+    let col = position.character as usize;
+    let prefix: String = current_line.chars().take(col).collect();
+    let dot_rel = prefix.rfind('.')?;
+    let before_dot = &prefix[..dot_rel];
+    let after_dot = &prefix[dot_rel + 1..];
+    if !after_dot
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+    let binding_start = before_dot
+        .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let binding = &before_dot[binding_start..];
+    if binding.is_empty()
+        || !binding
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    {
+        return None;
+    }
+    let bindings = collect_upstream_state_bindings(text, base_path);
+    let source = bindings.get(binding)?.clone();
+    Some((binding.to_string(), after_dot.to_string(), source))
+}
+
+/// Return every `let <name> = upstream_state { source = '...' }` declared
+/// in the current buffer or any sibling `.crn` under `base_path`, as a map
+/// from binding name to source path (relative, as written).
+///
+/// Intentionally does a text scan rather than going through `parse_directory`:
+/// completion runs on partial, often syntactically invalid buffers. We only
+/// need binding → source to feed `resolve_upstream_exports`, which then
+/// parses the *upstream* directory (separate from the downstream buffer).
+fn collect_upstream_state_bindings(
+    text: &str,
+    base_path: Option<&std::path::Path>,
+) -> std::collections::HashMap<String, String> {
+    let mut out = std::collections::HashMap::new();
+    scan_upstream_state_let(text, &mut out);
+    let Some(base) = base_path else {
+        return out;
+    };
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn")
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            scan_upstream_state_let(&content, &mut out);
+        }
+    }
+    out
+}
+
+/// Line-by-line state machine that captures `let <name> = upstream_state { ... }`
+/// and the first `source = '...'` inside its body. Handles both the common
+/// multi-line form and the single-line
+/// `let x = upstream_state { source = '...' }`.
+///
+/// A bare `find("let ")` walk would match `let ` embedded in comments or
+/// string literals; requiring `let` at the start of a trimmed line dodges
+/// those false positives.
+fn scan_upstream_state_let(text: &str, out: &mut std::collections::HashMap<String, String>) {
+    let mut pending: Option<String> = None;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if let Some((name, rhs)) = crate::let_parse::parse_let_header(line) {
+            // Any new `let` ends a previous `upstream_state` search window,
+            // preventing a sibling block's `source` from being misattributed.
+            pending = None;
+            let rhs_after = rhs.strip_prefix("upstream_state").map(str::trim_start);
+            if let Some(after_keyword) = rhs_after {
+                if let Some(body) = after_keyword.strip_prefix('{')
+                    && let Some(src) = find_source_in_line(body)
+                {
+                    out.insert(name.to_string(), src);
+                    continue;
+                }
+                pending = Some(name.to_string());
+            }
+            continue;
+        }
+        if let Some(binding) = &pending {
+            if let Some(src) = find_source_in_line(trimmed) {
+                out.insert(binding.clone(), src);
+                pending = None;
+                continue;
+            }
+            if trimmed.starts_with('}') {
+                pending = None;
+            }
+        }
+    }
+}
+
+/// If `segment` (a single line or the tail of one) contains `source = '...'`
+/// or `source = "..."`, return the inner string.
+fn find_source_in_line(segment: &str) -> Option<String> {
+    let trimmed = segment.trim_start();
+    let rest = trimmed.strip_prefix("source")?.trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let quote = rest.chars().next().filter(|c| *c == '\'' || *c == '"')?;
+    let inner = &rest[quote.len_utf8()..];
+    let end = inner.find(quote)?;
+    Some(inner[..end].to_string())
 }
 
 /// If `prefix` ends with `source = '<partial>` or `source = "<partial>`

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1620,3 +1620,182 @@ fn for_iterable_after_dot_does_not_trigger() {
         completions.iter().map(|c| &c.label).collect::<Vec<_>>()
     );
 }
+
+// =====================================================================
+// upstream_state exports completion after `<binding>.` (#1996)
+// =====================================================================
+
+fn set_up_upstream_project(
+    upstream_exports: &str,
+    downstream_main: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(upstream.join("exports.crn"), upstream_exports).unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(base.join("main.crn"), downstream_main).unwrap();
+    (tmp, base)
+}
+
+#[test]
+fn upstream_state_dot_completion_in_for_iterable_lists_exports() {
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(string) = \"x\"\n  region: string = \"ap-northeast-1\"\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    // Cursor right after `orgs.` on line 1.
+    let position = Position {
+        line: 1,
+        character: "for _, id in orgs.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"accounts"),
+        "expected `accounts` in completions, got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"region"),
+        "expected `region` in completions, got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_dot_completion_cross_file_binding() {
+    // `let orgs = ...` declared in a sibling .crn file, referenced from
+    // main.crn. The completion must still find the exports.
+    let provider = test_provider();
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    let main = "for _, id in orgs.\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 0,
+        character: "for _, id in orgs.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+
+    assert!(
+        completions.iter().any(|c| c.label == "accounts"),
+        "expected `accounts` from sibling-declared upstream_state, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_dot_completion_text_edit_replaces_partial() {
+    // `orgs.acc<cursor>` — the TextEdit must replace the `acc` partial so
+    // accepting `accounts` yields `orgs.accounts`, not `orgs.accaccounts`.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.acc\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "for _, id in orgs.acc".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let accounts = completions
+        .iter()
+        .find(|c| c.label == "accounts")
+        .expect("expected `accounts` completion");
+    match accounts.text_edit.as_ref() {
+        Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) => {
+            assert_eq!(edit.new_text, "accounts");
+            assert_eq!(edit.range.start.line, 1);
+            // `for _, id in orgs.` occupies cols 0..18; `acc` starts at col 18
+            assert_eq!(edit.range.start.character, 18);
+            assert_eq!(edit.range.end.character, 21);
+        }
+        other => panic!("expected TextEdit::Edit, got {:?}", other),
+    }
+}
+
+#[test]
+fn upstream_state_dot_completion_missing_source_does_not_crash() {
+    // Source directory doesn't exist — must return no completions, not panic.
+    let provider = test_provider();
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    let main = "let orgs = upstream_state { source = '../does-not-exist' }\nfor _, id in orgs.\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 1,
+        character: "for _, id in orgs.".chars().count() as u32,
+    };
+
+    let _ = provider.complete(&doc, position, Some(&base));
+    // No crash is the entire assertion here.
+}
+
+#[test]
+fn upstream_state_dot_completion_ignores_unrelated_let_source() {
+    // `let orgs = upstream_state { ... }` declares the binding but omits
+    // the source on the opening line. The next `let` declares a sibling
+    // block with its own `source`. The scanner must not misattribute that
+    // sibling's source to `orgs`.
+    let provider = test_provider();
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let other = tmp.path().join("other");
+    std::fs::create_dir(&other).unwrap();
+    std::fs::write(other.join("exports.crn"), "exports {\n}\n").unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    // `orgs` opens without `source` on the opening line (malformed or
+    // mid-edit), then a different `let` with its own source follows.
+    let main = "\
+let orgs = upstream_state {
+}
+let other = upstream_state { source = '../other' }
+for _, id in orgs.
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 3,
+        character: "for _, id in orgs.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+
+    assert!(
+        !completions.iter().any(|c| c.label == "accounts"),
+        "orgs has no source set, must not resolve to other's exports"
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -564,6 +564,62 @@ impl CompletionProvider {
         items
     }
 
+    /// Completions for `<binding>.<partial>` where `<binding>` is an
+    /// `upstream_state`. Lists every key declared in the upstream's
+    /// `exports { }` block, via `resolve_upstream_exports`.
+    pub(super) fn upstream_state_dot_completions(
+        &self,
+        binding: &str,
+        partial: &str,
+        source: &str,
+        position: Position,
+        base_path: Option<&Path>,
+    ) -> Vec<CompletionItem> {
+        let Some(base) = base_path else {
+            return Vec::new();
+        };
+        let upstream = carina_core::parser::UpstreamState {
+            binding: binding.to_string(),
+            source: std::path::PathBuf::from(source),
+        };
+        let (exports, _errors) = carina_core::upstream_exports::resolve_upstream_exports(
+            base,
+            &[upstream],
+            &Default::default(),
+        );
+        let Some(keys) = exports.get(binding) else {
+            return Vec::new();
+        };
+
+        // Replace just `<partial>` (the characters after the dot), so
+        // accepting a suggestion slots into the existing `<binding>.` prefix
+        // instead of duplicating it.
+        let partial_chars = partial.chars().count() as u32;
+        let range = Range {
+            start: Position {
+                line: position.line,
+                character: position.character.saturating_sub(partial_chars),
+            },
+            end: position,
+        };
+
+        let mut items: Vec<CompletionItem> = keys
+            .iter()
+            .map(|key| CompletionItem {
+                label: key.clone(),
+                kind: Some(CompletionItemKind::FIELD),
+                detail: Some(format!("export from upstream_state `{}`", binding)),
+                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: key.clone(),
+                })),
+                ..Default::default()
+            })
+            .collect();
+        items.sort_by(|a, b| a.label.cmp(&b.label));
+        items
+    }
+
     pub(super) fn upstream_state_block_completions(&self) -> Vec<CompletionItem> {
         vec![CompletionItem {
             label: "source".to_string(),


### PR DESCRIPTION
## Summary

- Dot-completion after an `upstream_state` binding (`orgs.`) lists exactly the keys declared in the upstream's `exports { }` block — the same set #1990 validates.
- Detection runs ahead of the usual block-context walk; the cursor commonly sits in a `for _ in <binding>.<partial>` header (no `=` in the prefix) and would otherwise fall through to `TopLevel`.
- Binding→source is recovered by a lightweight text scan (not `parse_directory`) so an in-progress buffer with a trailing `orgs.` (which breaks the parser) still produces candidates.

## Test plan

- [x] `cargo test --workspace` — all green (276 LSP tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] 5 new tests: basic, cross-file binding, partial text-edit replacement, missing source no-crash, sibling-block source misattribution regression

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)