### PR TITLE
LSP completion: silence exports value position until type-aware filtering lands

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -172,6 +172,7 @@ impl CompletionProvider {
         let mut module_name: Option<String> = None;
         let mut provider_block_name: Option<String> = None;
         let mut in_args_or_attrs_block = false;
+        let mut in_exports_block = false;
         let mut in_upstream_state_block = false;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
@@ -225,6 +226,9 @@ impl CompletionProvider {
                 && trimmed.ends_with('{')
             {
                 in_args_or_attrs_block = true;
+                if trimmed.starts_with("exports") {
+                    in_exports_block = true;
+                }
                 resource_type.clear();
                 module_name = None;
             } else if brace_depth == 0 && is_let_upstream_state_line(trimmed) {
@@ -291,6 +295,7 @@ impl CompletionProvider {
                         module_name = None;
                         provider_block_name = None;
                         in_args_or_attrs_block = false;
+                        in_exports_block = false;
                         in_upstream_state_block = false;
                         nested_block_names.clear();
                     } else if brace_depth == for_body_depth {
@@ -384,6 +389,16 @@ impl CompletionProvider {
             let after_eq = prefix.split('=').next_back().unwrap_or("").trim();
             // Don't show completions if user is typing a string literal (except just starting)
             if !after_eq.starts_with('"') || after_eq == "\"" {
+                // Exports-block values are type-annotated (e.g.
+                // `accounts: map(aws_account_id) = ...`); until the
+                // completion engine can read that annotation and filter
+                // by it, returning nothing beats the old behavior of
+                // dumping every built-in function and region into the
+                // popup (#1993). Matches the "prefer empty to generic"
+                // stance established by #1974.
+                if in_exports_block {
+                    return CompletionContext::None;
+                }
                 // Extract attribute name from current line
                 let attr_name = self.extract_attr_name(&prefix);
                 return CompletionContext::AfterEquals {

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1799,3 +1799,87 @@ for _, id in orgs.
         "orgs has no source set, must not resolve to other's exports"
     );
 }
+
+// =====================================================================
+// exports block: type-aware value-position completion (#1993)
+// =====================================================================
+
+#[test]
+fn exports_value_position_excludes_builtin_functions() {
+    // `exports { accounts: map(string) = { k = <HERE> } }` must not suggest
+    // built-in functions like `replace` — they don't produce a string the
+    // map entry could use without an extra call site, and offering every
+    // function clutters the popup.
+    let provider = test_provider();
+    let source = "\
+exports {
+  accounts: map(string) = {
+    k = re
+  }
+}
+";
+    let doc = create_document(source);
+    let position = Position {
+        line: 2,
+        character: "    k = re".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        !completions.iter().any(|c| c.label == "replace"),
+        "`replace` must not appear at exports value position, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn exports_top_level_value_excludes_builtin_functions() {
+    // `exports { id: string = <HERE> }` — directly at the top-level of the
+    // exports block, not nested in a map.
+    let provider = test_provider();
+    let source = "\
+exports {
+  id: string = re
+}
+";
+    let doc = create_document(source);
+    let position = Position {
+        line: 1,
+        character: "  id: string = re".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+
+    assert!(
+        !completions.iter().any(|c| c.label == "replace"),
+        "`replace` must not appear at exports value position, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn exports_value_position_returns_none_context() {
+    // Stronger guarantee than "no `replace` / no `.Region.`": the context
+    // itself must be `None`, so no handler fires and no generic candidate
+    // set can leak through — regardless of which providers are registered.
+    let provider = test_provider();
+    for source in [
+        "exports {\n  id: string = re\n}\n",
+        "exports {\n  accounts: map(string) = {\n    k = re\n  }\n}\n",
+    ] {
+        let last_line = source.lines().find(|l| l.contains(" = ")).unwrap();
+        let line_idx = source.lines().position(|l| l == last_line).unwrap() as u32;
+        let position = Position {
+            line: line_idx,
+            character: last_line.chars().count() as u32,
+        };
+        let context = provider.get_completion_context(source, position);
+        assert!(
+            matches!(context, CompletionContext::None),
+            "expected None, got {:?} for source:\n{}",
+            context,
+            source
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Inside `exports { key: type = <HERE> }` the completion was falling through to `AfterEquals` with an empty resource type, which ended up surfacing every built-in function (`replace`, `concat`, `join`, …) and — with real providers registered — every `<provider>.Region.*` value. None of those match the declared export type.
- Track the exports block separately from arguments/attributes in the context scan, and short-circuit the `=` branch to `None` when the cursor is inside one.
- Type-aware filtering (only surfacing candidates whose type matches the annotation) is the longer-running task tracked by #2041 / #1992; returning nothing beats the current noise, matching the \"prefer empty to generic\" stance from #1974.

## Test plan

- [x] `cargo test --workspace` — all green (279 LSP tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] 3 new tests: top-level exports value position (no `replace`), nested map value position (no `replace`), context-level `None` assertion that's robust against provider setup

Closes #1993

🤖 Generated with [Claude Code](https://claude.com/claude-code)