### PR TITLE
Add ParsedFile::iter_all_resources() + ResourceContext enum (task-1/13)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -111,6 +111,19 @@ pub struct DeferredForExpression {
     pub template_resource: Resource,
 }
 
+/// Origin of a resource yielded by [`ParsedFile::iter_all_resources`].
+///
+/// `Direct` means the resource was declared at top-level and its iterable
+/// (if any) resolved at parse time. `Deferred` means the resource is the
+/// template body of a `for` expression whose iterable resolves later;
+/// consumers that care about loop-variable placeholders need the
+/// `DeferredForExpression` reference to filter them out.
+#[derive(Debug, Clone, Copy)]
+pub enum ResourceContext<'a> {
+    Direct,
+    Deferred(&'a DeferredForExpression),
+}
+
 /// Resource type path for typed references (e.g., aws.vpc, aws.security_group)
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResourceTypePath {
@@ -439,6 +452,26 @@ pub struct ParsedFile {
 }
 
 impl ParsedFile {
+    /// Iterate every resource reachable from the parsed file — both
+    /// top-level `resources` and the `template_resource` of each deferred
+    /// for-expression — tagged with its origin context.
+    ///
+    /// Per-attribute checkers (type, enum, required, ref validity, etc.)
+    /// should prefer this over `self.resources.iter()` so they stay in sync
+    /// with for-body code. See
+    /// `docs/specs/2026-04-19-unify-resource-walk-design.md` for the
+    /// rationale.
+    pub fn iter_all_resources(&self) -> impl Iterator<Item = (ResourceContext<'_>, &Resource)> {
+        self.resources
+            .iter()
+            .map(|r| (ResourceContext::Direct, r))
+            .chain(
+                self.deferred_for_expressions
+                    .iter()
+                    .map(|d| (ResourceContext::Deferred(d), &d.template_resource)),
+            )
+    }
+
     /// Find a resource by resource type and name attribute value
     pub fn find_resource_by_attr(
         &self,
@@ -4552,6 +4585,37 @@ pub fn parse_and_resolve(input: &str) -> Result<ParsedFile, ParseError> {
 mod tests {
     use super::*;
     use crate::resource::InterpolationPart;
+
+    #[test]
+    fn iter_all_resources_yields_direct_then_deferred() {
+        let src = r#"
+            provider test {
+                source = 'x/y'
+                version = '0.1'
+                region = 'ap-northeast-1'
+            }
+            test.r.res {
+                name = "direct"
+            }
+            for _, id in orgs.accounts {
+                test.r.res {
+                    name = id
+                }
+            }
+        "#;
+        let parsed = parse(src, &ProviderContext::default()).unwrap();
+
+        let items: Vec<_> = parsed.iter_all_resources().collect();
+        assert_eq!(items.len(), 2, "expected one direct + one deferred");
+
+        assert!(matches!(items[0].0, ResourceContext::Direct));
+        assert_eq!(
+            items[0].1.get_attr("name"),
+            Some(&Value::String("direct".to_string()))
+        );
+
+        assert!(matches!(items[1].0, ResourceContext::Deferred(_)));
+    }
 
     #[test]
     fn parse_provider_block() {


### PR DESCRIPTION
Task 1/13 of the unified resource walk. See
[docs/plans/2026-04-19-unify-resource-walk.md](https://github.com/carina-rs/carina/blob/main/docs/plans/2026-04-19-unify-resource-walk.md)
Task 1/13 for the full spec.

## Summary
- Add `ResourceContext<'a>` enum (`Direct` / `Deferred(&DeferredForExpression)`)
  in `carina-core/src/parser/mod.rs`.
- Add `ParsedFile::iter_all_resources()` returning
  `(ResourceContext, &Resource)` pairs — direct resources first, then
  the `template_resource` of each deferred for-expression.
- No caller migration yet; later tasks migrate validation /
  upstream_exports / LSP checkers to this API.

## Test plan
- [x] `cargo test -p carina-core iter_all_resources_yields_direct_then_deferred` (new test, passes)
- [x] `cargo test -p carina-core` — 1251 tests pass
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` — clean

Refs #2046
Closes #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)