### PR TITLE
Migrate check_unused_bindings to iter_all_resources

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -528,7 +528,7 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
 
     // Collect all referenced binding names
     let mut referenced: HashSet<String> = HashSet::new();
-    for resource in &parsed.resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         for (attr_name, value) in &resource.attributes {
             if attr_name.starts_with('_') {
                 continue;
@@ -1025,6 +1025,31 @@ let vpc = awscc.ec2.vpc {
             unused,
             vec!["vpc"],
             "genuinely unused binding should still be warned"
+        );
+    }
+
+    #[test]
+    fn binding_used_inside_for_body_is_not_flagged_as_unused() {
+        use crate::parser::parse;
+
+        let src = r#"
+            provider test {
+                source = 'x/y'
+                version = '0.1'
+                region = 'ap-northeast-1'
+            }
+            let vpc = test.r.res { name = "v" }
+            for _, id in orgs.accounts {
+                test.r.res {
+                    name = vpc.name
+                }
+            }
+        "#;
+        let parsed = parse(src, &crate::parser::ProviderContext::default()).unwrap();
+        let unused = check_unused_bindings(&parsed);
+        assert!(
+            !unused.iter().any(|b| b == "vpc"),
+            "`vpc` is referenced inside the for body, got: {unused:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

A `let` binding referenced only from within a `for` body was
incorrectly flagged as unused because the walk inspected only
`parsed.resources` and skipped deferred for-bodies. This PR drives
the reference collection from `ParsedFile::iter_all_resources()`
so refs inside for bodies count toward "used".

## Changes

- `carina-core/src/validation.rs`: `check_unused_bindings` now iterates
  resources via `parsed.iter_all_resources()` when collecting referenced
  binding names.
- Added regression test `binding_used_inside_for_body_is_not_flagged_as_unused`.

## Test plan

- [x] New test `binding_used_inside_for_body_is_not_flagged_as_unused` passes
- [x] Existing `validation::tests` (64 tests) pass
- [x] `cargo test -p carina-core` passes (1252 tests)
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` clean

Closes #2050
Refs #2046