### PR TITLE
Migrate LSP diagnostics to iter_all_resources

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -839,9 +839,10 @@ impl DiagnosticEngine {
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
-        // Collect defined binding names from parsed resources
+        // Collect defined binding names from parsed resources, including
+        // bindings declared inside for-body templates.
         let mut defined_bindings: HashSet<String> = HashSet::new();
-        for resource in &parsed.resources {
+        for (_ctx, resource) in parsed.iter_all_resources() {
             if let Some(ref binding_name) = resource.binding {
                 defined_bindings.insert(binding_name.clone());
             }
@@ -1343,7 +1344,7 @@ impl DiagnosticEngine {
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
-        for resource in &parsed.resources {
+        for (_ctx, resource) in parsed.iter_all_resources() {
             for value in resource.attributes.values() {
                 self.collect_unknown_function_diagnostics(doc, value, &mut diagnostics);
             }
@@ -1427,7 +1428,7 @@ impl DiagnosticEngine {
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
-        for resource in &parsed.resources {
+        for (_ctx, resource) in parsed.iter_all_resources() {
             for (attr_name, attr_value) in &resource.attributes {
                 if attr_name.starts_with('_') {
                     continue;

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -174,9 +174,11 @@ impl DiagnosticEngine {
                 diagnostics.extend(self.check_module_calls(doc, parsed, base));
                 diagnostics.extend(self.check_upstream_state_sources(doc, parsed, base));
             }
-            // Build binding_name -> (provider, resource_type) map for ResourceRef type checking
+            // Build binding_name -> (provider, resource_type) map for ResourceRef type checking.
+            // Walk both top-level resources and for-body template resources so
+            // for-body refs can be type-checked against their referenced binding.
             let mut binding_schema_map: HashMap<String, ResourceSchema> = HashMap::new();
-            for res in &parsed.resources {
+            for (_ctx, res) in parsed.iter_all_resources() {
                 if let Some(ref binding_name) = res.binding {
                     let full_type = format!("{}.{}", res.id.provider, res.id.resource_type);
                     if let Some(s) = self.schemas.get(&full_type).cloned() {
@@ -185,8 +187,9 @@ impl DiagnosticEngine {
                 }
             }
 
-            // Check resource types
-            for resource in &parsed.resources {
+            // Check resource types — include for-body template resources so
+            // attribute/type/enum validation fires inside `for` loops too.
+            for (_ctx, resource) in parsed.iter_all_resources() {
                 let provider = &resource.id.provider;
                 let full_resource_type = format!("{}.{}", provider, resource.id.resource_type);
 

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2672,3 +2672,22 @@ fn for_iterable_multiline_header_still_flagged() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn enum_mismatch_inside_for_body_surfaces_as_diagnostic() {
+    let provider = test_engine_with_enum_attr();
+    let source = r#"
+for _, id in orgs.xs {
+  test.r.mode_holder {
+    mode = "aaaa"
+  }
+}
+"#;
+    let doc = create_document(source);
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    assert!(
+        diagnostics.iter().any(|d| d.message.contains("aaaa")),
+        "expected enum-mismatch diagnostic inside for body, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -59,6 +59,29 @@ pub(super) fn test_engine_with_nested_structs() -> DiagnosticEngine {
     )
 }
 
+pub(super) fn test_engine_with_enum_attr() -> DiagnosticEngine {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let mode_enum = AttributeType::StringEnum {
+        name: "Mode".to_string(),
+        values: vec!["fast".to_string(), "slow".to_string()],
+        namespace: None,
+        to_dsl: None,
+    };
+
+    let schema = ResourceSchema::new("test.r.mode_holder")
+        .attribute(AttributeSchema::new("mode", mode_enum));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.r.mode_holder".to_string(), schema);
+
+    DiagnosticEngine::new(
+        Arc::new(schemas),
+        vec!["test".to_string()],
+        Arc::new(vec![]),
+    )
+}
+
 pub(super) fn test_engine_with_block_name_nested() -> DiagnosticEngine {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 


### PR DESCRIPTION
Closes #2053

Refs #2046

## Summary
- Route the main attribute/type/enum validation loop in `DiagnosticEngine::analyze_with_filename` through `ParsedFile::iter_all_resources()` so resources declared inside a `for` body are validated just like top-level resources.
- Apply the same substitution to the auxiliary LSP checks in `checks.rs`: `check_attributes_blocks` binding collection, `check_unknown_functions`, and `check_resource_ref_attributes`.
- The loop variable `_ctx` is unused for now — LSP squiggle positions are resolved textually, so the `ResourceContext::Deferred` header string is not needed here.

## Test plan
- [x] New regression test `enum_mismatch_inside_for_body_surfaces_as_diagnostic` fails on main and passes after the migration.
- [x] `cargo test -p carina-lsp` — 280 tests pass.
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings` — clean.