### PR TITLE
Migrate check_unused_bindings to iter_all_resources

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -511,9 +511,11 @@ pub fn validate_export_params(
 /// A binding is unused if its name never appears as a `ResourceRef.binding_name`
 /// in any resource attribute, module call argument, or attribute parameter value.
 pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
-    // Collect all defined binding names (skip discard pattern `_`)
+    // Collect all defined binding names (skip discard pattern `_`).
+    // Walk top-level and for-body resources so bindings declared inside a
+    // `for` template are also tracked.
     let mut defined_bindings: Vec<String> = Vec::new();
-    for resource in &parsed.resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         if let Some(ref binding_name) = resource.binding {
             if binding_name == "_" {
                 continue;
@@ -526,9 +528,11 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
         return Vec::new();
     }
 
-    // Collect all referenced binding names
+    // Collect all referenced binding names. Walk both top-level resources
+    // and for-body template resources so bindings referenced only inside a
+    // `for` loop are counted as used.
     let mut referenced: HashSet<String> = HashSet::new();
-    for resource in &parsed.resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         for (attr_name, value) in &resource.attributes {
             if attr_name.starts_with('_') {
                 continue;

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2674,6 +2674,28 @@ fn for_iterable_multiline_header_still_flagged() {
 }
 
 #[test]
+fn lsp_binding_used_only_in_for_body_is_not_flagged_unused() {
+    let provider = test_engine();
+    let source = r#"
+let vpc = test.r.vpc { name = "v" }
+for _, id in orgs.xs {
+  test.r.res { name = vpc.name }
+}
+"#;
+    let doc = create_document(source);
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    // Match "Unused" (LSP check_unused_bindings) and "unused" (parser warnings)
+    // case-insensitively so the assertion fires whichever path flags `vpc`.
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.to_lowercase().contains("unused") && d.message.contains("vpc")),
+        "vpc used in for body, must not be flagged unused, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn enum_mismatch_inside_for_body_surfaces_as_diagnostic() {
     let provider = test_engine_with_enum_attr();
     let source = r#"


### PR DESCRIPTION
Closes #2054

Refs #2046

Stacked on top of #2063 (Task 7). Set the base branch to `main` once #2063 merges.

## Summary
- `carina_core::validation::check_unused_bindings` now walks resources via `ParsedFile::iter_all_resources()` for both the defined-binding collection and the referenced-binding collection, so bindings referenced only inside a `for` body count as used.
- Adds an LSP regression test that fails on the pre-migration code and passes after.

## Test plan
- [x] New regression test `lsp_binding_used_only_in_for_body_is_not_flagged_unused` fails on unmigrated main, passes here.
- [x] `cargo test -p carina-lsp` — 281 tests pass.
- [x] `cargo test -p carina-core` — 1251+ tests pass.
- [x] `cargo clippy -p carina-lsp -p carina-core --all-targets -- -D warnings` — clean.