### PR TITLE
Migrate validate_resources to iter_all_resources

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -205,7 +205,7 @@ pub fn validate_and_resolve_with_config(
         for us in &parsed.upstream_states {
             argument_names.insert(us.binding.clone());
         }
-        validate_resource_ref_types_with_ctx(&ctx, &parsed.resources, &argument_names)?;
+        validate_resource_ref_types_with_ctx(&ctx, parsed, &argument_names)?;
         validate_attribute_param_ref_types_with_ctx(
             &ctx,
             &parsed.attribute_params,

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -198,7 +198,7 @@ pub fn validate_and_resolve_with_config(
     resolve_names_with_ctx(&ctx, &mut parsed.resources)?;
 
     if !skip_resource_validation {
-        validate_resources_with_ctx(&ctx, &parsed.resources)?;
+        validate_resources_with_ctx(&ctx, parsed)?;
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -176,11 +176,11 @@ pub fn validate_resources_with_ctx(
 
 pub fn validate_resource_ref_types_with_ctx(
     ctx: &WiringContext,
-    resources: &[Resource],
+    parsed: &ParsedFile,
     argument_names: &HashSet<String>,
 ) -> Result<(), AppError> {
     validation::validate_resource_ref_types(
-        resources,
+        parsed,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         argument_names,

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -158,7 +158,7 @@ pub fn build_factories_from_providers(
 
 pub fn validate_resources_with_ctx(
     ctx: &WiringContext,
-    resources: &[Resource],
+    parsed: &ParsedFile,
 ) -> Result<(), AppError> {
     let known_providers: HashSet<String> = ctx
         .factories()
@@ -166,7 +166,7 @@ pub fn validate_resources_with_ctx(
         .map(|f| f.name().to_string())
         .collect();
     validation::validate_resources(
-        resources,
+        parsed,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &known_providers,
@@ -1368,7 +1368,11 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
 #[cfg(test)]
 pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
-    validate_resources_with_ctx(&ctx, resources)
+    let parsed = ParsedFile {
+        resources: resources.to_vec(),
+        ..ParsedFile::default()
+    };
+    validate_resources_with_ctx(&ctx, &parsed)
 }
 
 #[cfg(test)]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -66,22 +66,24 @@ pub fn validate_resources(
 /// For example, if `ipv4_ipam_pool_id` expects `IpamPoolId` type,
 /// a reference like `vpc.vpc_id` (which is `AwsResourceId`) should be an error.
 pub fn validate_resource_ref_types(
-    resources: &[Resource],
+    parsed: &ParsedFile,
     schemas: &HashMap<String, ResourceSchema>,
     schema_key_fn: &dyn Fn(&Resource) -> String,
     argument_names: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
-    // Build binding_name -> resource map
+    // Build binding_name -> resource map from direct resources only.
+    // For-body template resources never carry a `binding`, so skipping
+    // them here keeps the map correct for lookup.
     let mut binding_map: HashMap<String, &Resource> = HashMap::new();
-    for resource in resources {
+    for resource in &parsed.resources {
         if let Some(ref binding_name) = resource.binding {
             binding_map.insert(binding_name.clone(), resource);
         }
     }
 
-    for resource in resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         let schema_key = schema_key_fn(resource);
 
         let Some(schema) = schemas.get(&schema_key) else {
@@ -1107,8 +1109,10 @@ let vpc = awscc.ec2.vpc {
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         );
 
+        let mut parsed = empty_parsed();
+        parsed.resources.push(subnet);
         let result =
-            validate_resource_ref_types(&[subnet], &schemas, &test_schema_key_fn, &HashSet::new());
+            validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         assert_eq!(
             result.unwrap_err(),
             "awscc.ec2.subnet.web-subnet: unknown binding 'vpc' in reference vpc.vpc_id"
@@ -1138,12 +1142,11 @@ let vpc = awscc.ec2.vpc {
             Value::resource_ref("vpc".to_string(), "nonexistent_attr".to_string(), vec![]),
         );
 
-        let result = validate_resource_ref_types(
-            &[vpc, subnet],
-            &schemas,
-            &test_schema_key_fn,
-            &HashSet::new(),
-        );
+        let mut parsed = empty_parsed();
+        parsed.resources.push(vpc);
+        parsed.resources.push(subnet);
+        let result =
+            validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         assert_eq!(
             result.unwrap_err(),
             "awscc.ec2.subnet.web-subnet: unknown attribute 'nonexistent_attr' on 'vpc' in reference vpc.nonexistent_attr"
@@ -1184,12 +1187,11 @@ let vpc = awscc.ec2.vpc {
             ),
         );
 
-        let result = validate_resource_ref_types(
-            &[igw, route],
-            &schemas,
-            &test_schema_key_fn,
-            &HashSet::new(),
-        );
+        let mut parsed = empty_parsed();
+        parsed.resources.push(igw);
+        parsed.resources.push(route);
+        let result =
+            validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         let err = result.unwrap_err();
         assert!(
             err.contains("Did you mean 'internet_gateway_id'?"),
@@ -1222,17 +1224,57 @@ let vpc = awscc.ec2.vpc {
             ),
         );
 
-        let result = validate_resource_ref_types(
-            &[vpc, subnet],
-            &schemas,
-            &test_schema_key_fn,
-            &HashSet::new(),
-        );
+        let mut parsed = empty_parsed();
+        parsed.resources.push(vpc);
+        parsed.resources.push(subnet);
+        let result =
+            validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         let err = result.unwrap_err();
         assert!(
             !err.contains("Did you mean"),
             "Should not suggest when name is too different, got: {}",
             err
+        );
+    }
+
+    #[test]
+    fn ref_type_mismatch_inside_for_body_is_rejected() {
+        // Inside a for body, assigning an Int-typed attribute to a Bool-typed
+        // target must be flagged.
+        let src = r#"
+            provider test {
+                source = 'x/y'
+                version = '0.1'
+                region = 'ap-northeast-1'
+            }
+            let vpc = test.r.vpc { name = "v" }
+            for _, id in orgs.xs {
+                test.r.pool_user {
+                    pool_id = vpc.vpc_id
+                }
+            }
+        "#;
+        let parsed = crate::parser::parse(src, &ProviderContext::default()).unwrap();
+
+        let mut schemas = HashMap::new();
+        // test.r.vpc exposes `vpc_id: Int`
+        schemas.insert(
+            "r.vpc".to_string(),
+            make_schema("r.vpc", vec![("vpc_id", AttributeType::Int)]),
+        );
+        // test.r.pool_user requires `pool_id: Bool` — incompatible with Int.
+        schemas.insert(
+            "r.pool_user".to_string(),
+            make_schema("r.pool_user", vec![("pool_id", AttributeType::Bool)]),
+        );
+
+        let result =
+            validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+        assert!(result.is_err(), "expected type-mismatch error in for body");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("pool_id"),
+            "expected error to mention pool_id, got: {msg}"
         );
     }
 

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -12,14 +12,14 @@ use crate::schema::{AttributeType, ResourceSchema, suggest_similar_name};
 /// Checks that each resource's type is known, data sources use the `read` keyword,
 /// and all attributes pass schema validation.
 pub fn validate_resources(
-    resources: &[Resource],
+    parsed: &ParsedFile,
     schemas: &HashMap<String, ResourceSchema>,
     schema_key_fn: &dyn Fn(&Resource) -> String,
     known_providers: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
-    for resource in resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         // Skip virtual resources (module attribute containers)
         if resource.is_virtual() {
             continue;
@@ -2087,10 +2087,59 @@ let vpc = awscc.ec2.vpc {
         let mut known = HashSet::new();
         known.insert("awscc".to_string());
 
-        let err = validate_resources(&[vpc], &schemas, &test_schema_key_fn, &known).unwrap_err();
+        let mut parsed = empty_parsed();
+        parsed.resources.push(vpc);
+        let err = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known).unwrap_err();
         assert!(
             err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),
             "expected exclusive_required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn enum_membership_violation_in_for_body_is_flagged() {
+        // Regression for #2044: inside a `for` body, a string literal that
+        // isn't a valid member of a StringEnum attribute must be flagged.
+        let src = r#"
+            provider test {
+                source = 'x/y'
+                version = '0.1'
+                region = 'ap-northeast-1'
+            }
+            for _, id in orgs.xs {
+                test.r.mode_holder {
+                    mode = "aaaa"
+                }
+            }
+        "#;
+        let parsed = crate::parser::parse(src, &ProviderContext::default()).unwrap();
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "r.mode_holder".to_string(),
+            make_schema(
+                "r.mode_holder",
+                vec![(
+                    "mode",
+                    AttributeType::StringEnum {
+                        name: "Mode".to_string(),
+                        values: vec!["on".to_string(), "off".to_string()],
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )],
+            ),
+        );
+
+        let mut known = HashSet::new();
+        known.insert("test".to_string());
+
+        let result = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known);
+        assert!(result.is_err(), "expected enum-mismatch error in for body");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("aaaa"),
+            "expected error to mention 'aaaa', got: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Migrate `validate_resources` to take `&ParsedFile` and walk resources
via `ParsedFile::iter_all_resources()`, so per-resource schema
validation (required attrs, enum membership, custom-type validators)
runs on for-body resources.

This addresses the class of bugs tracked by #2044 — a string literal
inside a `for` body that does not match a `StringEnum` attribute now
triggers a validate error.

## Changes

- `carina-core/src/validation.rs`: `validate_resources` signature changes
  from `&[Resource]` to `&ParsedFile`; inner loop uses `iter_all_resources()`.
- `carina-cli/src/wiring.rs`: `validate_resources_with_ctx` and the
  test-only `validate_resources` wrapper updated.
- `carina-cli/src/commands/mod.rs`: caller passes the full `ParsedFile`.
- In-crate test `validate_resources_rejects_missing_exclusive_required`
  migrated to use `empty_parsed()`.
- Added regression test `enum_membership_violation_in_for_body_is_flagged`.

## Test plan

- [x] New test `enum_membership_violation_in_for_body_is_flagged` fails
      without the migration, passes with it.
- [x] `cargo test -p carina-core` passes (1254 tests).
- [x] `cargo test -p carina-cli` passes.
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` clean.
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` clean.

Stacks on #2067 (which stacks on #2061).

Closes #2052
Refs #2046