### PR TITLE
Migrate validate_resources to iter_all_resources (task-6/13)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -198,7 +198,7 @@ pub fn validate_and_resolve_with_config(
     resolve_names_with_ctx(&ctx, &mut parsed.resources)?;
 
     if !skip_resource_validation {
-        validate_resources_with_ctx(&ctx, &parsed.resources)?;
+        validate_resources_with_ctx(&ctx, parsed)?;
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -158,7 +158,7 @@ pub fn build_factories_from_providers(
 
 pub fn validate_resources_with_ctx(
     ctx: &WiringContext,
-    resources: &[Resource],
+    parsed: &ParsedFile,
 ) -> Result<(), AppError> {
     let known_providers: HashSet<String> = ctx
         .factories()
@@ -166,7 +166,7 @@ pub fn validate_resources_with_ctx(
         .map(|f| f.name().to_string())
         .collect();
     validation::validate_resources(
-        resources,
+        parsed,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &known_providers,
@@ -1368,7 +1368,11 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
 #[cfg(test)]
 pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
     let ctx = WiringContext::new(vec![]);
-    validate_resources_with_ctx(&ctx, resources)
+    let parsed = ParsedFile {
+        resources: resources.to_vec(),
+        ..ParsedFile::default()
+    };
+    validate_resources_with_ctx(&ctx, &parsed)
 }
 
 #[cfg(test)]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -12,14 +12,14 @@ use crate::schema::{AttributeType, ResourceSchema, suggest_similar_name};
 /// Checks that each resource's type is known, data sources use the `read` keyword,
 /// and all attributes pass schema validation.
 pub fn validate_resources(
-    resources: &[Resource],
+    parsed: &ParsedFile,
     schemas: &HashMap<String, ResourceSchema>,
     schema_key_fn: &dyn Fn(&Resource) -> String,
     known_providers: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
-    for resource in resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         // Skip virtual resources (module attribute containers)
         if resource.is_virtual() {
             continue;
@@ -2087,10 +2087,59 @@ let vpc = awscc.ec2.vpc {
         let mut known = HashSet::new();
         known.insert("awscc".to_string());
 
-        let err = validate_resources(&[vpc], &schemas, &test_schema_key_fn, &known).unwrap_err();
+        let mut parsed = empty_parsed();
+        parsed.resources.push(vpc);
+        let err = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known).unwrap_err();
         assert!(
             err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),
             "expected exclusive_required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn enum_membership_violation_in_for_body_is_flagged() {
+        // Regression for #2044: inside a `for` body, a string literal that
+        // isn't a valid member of a StringEnum attribute must be flagged.
+        let src = r#"
+            provider test {
+                source = 'x/y'
+                version = '0.1'
+                region = 'ap-northeast-1'
+            }
+            for _, id in orgs.xs {
+                test.r.mode_holder {
+                    mode = "aaaa"
+                }
+            }
+        "#;
+        let parsed = crate::parser::parse(src, &ProviderContext::default()).unwrap();
+
+        let mut schemas = HashMap::new();
+        schemas.insert(
+            "r.mode_holder".to_string(),
+            make_schema(
+                "r.mode_holder",
+                vec![(
+                    "mode",
+                    AttributeType::StringEnum {
+                        name: "Mode".to_string(),
+                        values: vec!["on".to_string(), "off".to_string()],
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )],
+            ),
+        );
+
+        let mut known = HashSet::new();
+        known.insert("test".to_string());
+
+        let result = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known);
+        assert!(result.is_err(), "expected enum-mismatch error in for body");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("aaaa"),
+            "expected error to mention 'aaaa', got: {err}"
         );
     }
 }


### PR DESCRIPTION
Task 6/13 of the unified resource walk. Per-resource schema validation
(required attrs, enum membership, custom-type validators) now runs on
for-body resources. Covers #2044 directly.

## Summary
- `validate_resources(&[Resource], ...)` → `validate_resources(&ParsedFile, ...)`; loop uses `iter_all_resources()`.
- Updated `carina-cli/src/wiring.rs::validate_resources_with_ctx`, its test wrapper, and `carina-cli/src/commands/mod.rs` caller.
- Updated in-crate test call site.

## Test plan
- [x] New `enum_membership_violation_in_for_body_is_flagged` passes (covers #2044)
- [x] `cargo test -p carina-core` (1256 pass)
- [x] `cargo test -p carina-cli` (all pass)
- [x] `cargo clippy -p carina-core -p carina-cli --all-targets -- -D warnings` clean

Closes #2052
Refs #2046, #2044

(Supersedes #2068 — original was auto-closed when parent branch was deleted on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)