### PR TITLE
Migrate LSP unused-binding check to for-body (task-8/13)

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -513,9 +513,11 @@ pub fn validate_export_params(
 /// A binding is unused if its name never appears as a `ResourceRef.binding_name`
 /// in any resource attribute, module call argument, or attribute parameter value.
 pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
-    // Collect all defined binding names (skip discard pattern `_`)
+    // Collect all defined binding names (skip discard pattern `_`).
+    // Walk top-level and for-body resources so bindings declared inside a
+    // `for` template are also tracked.
     let mut defined_bindings: Vec<String> = Vec::new();
-    for resource in &parsed.resources {
+    for (_ctx, resource) in parsed.iter_all_resources() {
         if let Some(ref binding_name) = resource.binding {
             if binding_name == "_" {
                 continue;
@@ -528,7 +530,9 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
         return Vec::new();
     }
 
-    // Collect all referenced binding names
+    // Collect all referenced binding names. Walk both top-level resources
+    // and for-body template resources so bindings referenced only inside a
+    // `for` loop are counted as used.
     let mut referenced: HashSet<String> = HashSet::new();
     for (_ctx, resource) in parsed.iter_all_resources() {
         for (attr_name, value) in &resource.attributes {

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2674,6 +2674,28 @@ fn for_iterable_multiline_header_still_flagged() {
 }
 
 #[test]
+fn lsp_binding_used_only_in_for_body_is_not_flagged_unused() {
+    let provider = test_engine();
+    let source = r#"
+let vpc = test.r.vpc { name = "v" }
+for _, id in orgs.xs {
+  test.r.res { name = vpc.name }
+}
+"#;
+    let doc = create_document(source);
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    // Match "Unused" (LSP check_unused_bindings) and "unused" (parser warnings)
+    // case-insensitively so the assertion fires whichever path flags `vpc`.
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message.to_lowercase().contains("unused") && d.message.contains("vpc")),
+        "vpc used in for body, must not be flagged unused, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn enum_mismatch_inside_for_body_surfaces_as_diagnostic() {
     let provider = test_engine_with_enum_attr();
     let source = r#"


### PR DESCRIPTION
Task 8/13 of the unified resource walk. LSP unused-binding warning now
sees for-body refs.

## Summary
- Added regression test `lsp_binding_used_only_in_for_body_is_not_flagged_unused`
  verifying a binding used only inside a `for` template is not flagged unused.
- Extended `carina_core::validation::check_unused_bindings` to also walk
  for-body resources when collecting **defined** bindings (Task 4 only
  touched the *referenced* side). Without this, a binding declared inside
  a for-body template would be invisible to the collector entirely.

## Test plan
- [x] New `lsp_binding_used_only_in_for_body_is_not_flagged_unused` passes
- [x] `cargo test -p carina-core` (1256 pass)
- [x] `cargo test -p carina-lsp` (281 pass)
- [x] `cargo clippy -p carina-core -p carina-lsp --all-targets -- -D warnings` clean

Closes #2054
Refs #2046

(Supersedes #2066 — original was auto-closed when parent branch was deleted on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)