### PR TITLE
Annotate direct parsed.resources consumers with // allow markers (task-9/13)

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -146,7 +146,7 @@ async fn run_destroy_locked(
 
     // Collect all resources (managed + orphans) before sorting.
     // We use the unsorted list for state reads, then sort once at the end.
-    let mut all_resources: Vec<Resource> = parsed.resources.clone();
+    let mut all_resources: Vec<Resource> = parsed.resources.clone(); // allow: direct — plan-time reconciliation
 
     if !refresh {
         eprintln!(

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -144,7 +144,8 @@ pub async fn run_plan(
             let backend_resource_type = backend
                 .resource_type()
                 .ok_or("Backend does not specify a resource type")?;
-            let has_bucket_resource = parsed.resources.iter().any(|r| {
+            #[rustfmt::skip]
+            let has_bucket_resource = parsed.resources.iter().any(|r| { // allow: direct — plan-time reconciliation
                 r.id.resource_type == backend_resource_type
                     && r.attributes
                         .get("bucket")

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -101,8 +101,8 @@ pub fn run_validate(
         }
         let output = ValidateOutput {
             status: "ok",
-            resource_count: parsed.resources.len(),
-            resources: parsed.resources.iter().map(|r| r.id.to_string()).collect(),
+            resource_count: parsed.resources.len(), // allow: direct — display/reporting
+            resources: parsed.resources.iter().map(|r| r.id.to_string()).collect(), // allow: direct — display/reporting
             warnings,
         };
         println!(
@@ -117,7 +117,7 @@ pub fn run_validate(
         "{}",
         format!(
             "✓ {} resources validated successfully.",
-            parsed.resources.len()
+            parsed.resources.len() // allow: direct — display/reporting
         )
         .green()
         .bold()

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -252,7 +252,7 @@ impl<'cfg> ModuleResolver<'cfg> {
                 .unwrap_or_else(|| call.module_name.clone());
 
             match self.expand_module_call(call, &instance_prefix) {
-                Ok(expanded) => parsed.resources.extend(expanded),
+                Ok(expanded) => parsed.resources.extend(expanded), // allow: direct — module expansion, handled separately
                 Err(e) => {
                     self.base_dir = original_base_dir;
                     self.imported_modules = original_imported;
@@ -595,7 +595,7 @@ pub fn resolve_modules_with_config(
             .unwrap_or_else(|| call.module_name.clone());
 
         let expanded = resolver.expand_module_call(call, &instance_prefix)?;
-        parsed.resources.extend(expanded);
+        parsed.resources.extend(expanded); // allow: direct — module expansion, handled separately
     }
 
     Ok(())

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -4464,7 +4464,7 @@ pub fn resolve_resource_refs_with_config(
 /// bindings declared in sibling files that only become visible after merging.
 pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
     let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref()));
+    known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref())); // allow: direct — parser-internal, pre-expansion
     known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
     known.extend(
         parsed
@@ -6805,7 +6805,7 @@ aws.s3.bucket {
         assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
 
         let parsed = result.unwrap();
-        assert_eq!(parsed.resources.len(), 2);
+        assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
         assert_eq!(parsed.arguments.len(), 3);
     }
 
@@ -9482,7 +9482,7 @@ aws.s3.bucket {
         "#;
         let mut parsed = parse(input, &config).unwrap();
         resolve_resource_refs_with_config(&mut parsed, &config).unwrap();
-        assert_eq!(parsed.resources.len(), 1);
+        assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
         let secret_val = parsed.resources[0].get_attr("secret").unwrap();
         assert_eq!(*secret_val, Value::String("decrypted:AQICAHh".to_string()));
     }
@@ -10393,7 +10393,7 @@ awscc.ec2.vpc {
 
         let mut parsed = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(parsed.deferred_for_expressions.len(), 1);
-        assert_eq!(parsed.resources.len(), 0, "no resources before expansion");
+        assert_eq!(parsed.resources.len(), 0, "no resources before expansion"); // allow: direct — fixture test inspection
 
         // Simulate loading upstream_state with actual values
         let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
@@ -10424,7 +10424,7 @@ awscc.ec2.vpc {
         );
         // Two concrete resources should be generated
         assert_eq!(
-            parsed.resources.len(),
+            parsed.resources.len(), // allow: direct — fixture test inspection
             2,
             "should have 2 expanded resources"
         );
@@ -10474,7 +10474,7 @@ awscc.ec2.vpc {
             1,
             "should stay deferred when remote data not available"
         );
-        assert_eq!(parsed.resources.len(), 0);
+        assert_eq!(parsed.resources.len(), 0); // allow: direct — fixture test inspection
     }
 
     #[test]
@@ -10511,7 +10511,7 @@ awscc.ec2.vpc {
         parsed.expand_deferred_for_expressions(&remote_bindings);
 
         assert_eq!(parsed.deferred_for_expressions.len(), 0);
-        assert_eq!(parsed.resources.len(), 2);
+        assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
 
         // Verify both key and value are substituted.
         let mut by_name: HashMap<String, &Resource> = HashMap::new();
@@ -10566,7 +10566,7 @@ awscc.ec2.vpc {
 
         parsed.expand_deferred_for_expressions(&remote_bindings);
 
-        assert_eq!(parsed.resources.len(), 2);
+        assert_eq!(parsed.resources.len(), 2); // allow: direct — fixture test inspection
         assert_eq!(
             parsed.resources[0].get_attr("target_id"),
             Some(&Value::String("111111111111".to_string()))
@@ -10616,7 +10616,7 @@ awscc.ec2.vpc {
         remote_bindings.insert("orgs".to_string(), orgs_attrs);
 
         parsed.expand_deferred_for_expressions(&remote_bindings);
-        assert_eq!(parsed.resources.len(), 1);
+        assert_eq!(parsed.resources.len(), 1); // allow: direct — fixture test inspection
 
         // label must have the placeholder substituted in the interpolation.
         let label = parsed.resources[0].get_attr("label");
@@ -10678,7 +10678,7 @@ awscc.ec2.vpc {
         parsed.expand_deferred_for_expressions(&remote_bindings);
 
         assert_eq!(
-            parsed.resources.len(),
+            parsed.resources.len(), // allow: direct — fixture test inspection
             0,
             "simple binding with map iterable should not silently expand"
         );
@@ -10726,7 +10726,7 @@ awscc.ec2.vpc {
 
         // Mismatch: should NOT expand silently with numeric indices
         assert_eq!(
-            parsed.resources.len(),
+            parsed.resources.len(), // allow: direct — fixture test inspection
             0,
             "map binding with list iterable should not silently expand"
         );

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -739,14 +739,14 @@ mod tests {
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc")
             .with_binding("vpc")
             .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         // Resource that references the binding
         let subnet = Resource::with_provider("awscc", "ec2.subnet", "web-subnet").with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         );
-        parsed.resources.push(subnet);
+        parsed.resources.push(subnet); // allow: direct — fixture test inspection
 
         assert!(check_unused_bindings(&parsed).is_empty());
     }
@@ -758,7 +758,7 @@ mod tests {
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc")
             .with_binding("vpc")
             .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string()));
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         let unused = check_unused_bindings(&parsed);
         assert_eq!(unused, vec!["vpc"]);
@@ -771,7 +771,7 @@ mod tests {
         // Anonymous resource (no _binding attribute)
         let bucket = Resource::with_provider("awscc", "s3.bucket", "my-bucket")
             .with_attribute("bucket_name", Value::String("my-bucket".to_string()));
-        parsed.resources.push(bucket);
+        parsed.resources.push(bucket); // allow: direct — fixture test inspection
 
         assert!(check_unused_bindings(&parsed).is_empty());
     }
@@ -781,7 +781,7 @@ mod tests {
         let mut parsed = empty_parsed();
 
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         // Reference inside a Map inside a List
         let mut map = HashMap::new();
@@ -791,7 +791,7 @@ mod tests {
         );
         let sg = Resource::with_provider("awscc", "ec2.security_group", "web-sg")
             .with_attribute("tags", Value::List(vec![Value::Map(map)]));
-        parsed.resources.push(sg);
+        parsed.resources.push(sg); // allow: direct — fixture test inspection
 
         assert!(check_unused_bindings(&parsed).is_empty());
     }
@@ -801,7 +801,7 @@ mod tests {
         let mut parsed = empty_parsed();
 
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         let mut args = HashMap::new();
         args.insert(
@@ -822,18 +822,18 @@ mod tests {
         let mut parsed = empty_parsed();
 
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         let sg =
             Resource::with_provider("awscc", "ec2.security_group", "web-sg").with_binding("web_sg");
-        parsed.resources.push(sg);
+        parsed.resources.push(sg); // allow: direct — fixture test inspection
 
         // Only vpc is referenced
         let subnet = Resource::with_provider("awscc", "ec2.subnet", "web-subnet").with_attribute(
             "vpc_id",
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         );
-        parsed.resources.push(subnet);
+        parsed.resources.push(subnet); // allow: direct — fixture test inspection
 
         let unused = check_unused_bindings(&parsed);
         assert_eq!(unused, vec!["web_sg"]);
@@ -844,7 +844,7 @@ mod tests {
         let mut parsed = empty_parsed();
 
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         parsed
             .attribute_params
@@ -866,7 +866,7 @@ mod tests {
         let mut parsed = empty_parsed();
 
         let vpc = Resource::with_provider("awscc", "ec2.vpc", "main-vpc").with_binding("vpc");
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
 
         parsed.export_params.push(crate::parser::ExportParameter {
             name: "vpc_id".to_string(),
@@ -1114,7 +1114,7 @@ let vpc = awscc.ec2.vpc {
         );
 
         let mut parsed = empty_parsed();
-        parsed.resources.push(subnet);
+        parsed.resources.push(subnet); // allow: direct — fixture test inspection
         let result =
             validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         assert_eq!(
@@ -1147,8 +1147,8 @@ let vpc = awscc.ec2.vpc {
         );
 
         let mut parsed = empty_parsed();
-        parsed.resources.push(vpc);
-        parsed.resources.push(subnet);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
+        parsed.resources.push(subnet); // allow: direct — fixture test inspection
         let result =
             validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         assert_eq!(
@@ -1192,8 +1192,8 @@ let vpc = awscc.ec2.vpc {
         );
 
         let mut parsed = empty_parsed();
-        parsed.resources.push(igw);
-        parsed.resources.push(route);
+        parsed.resources.push(igw); // allow: direct — fixture test inspection
+        parsed.resources.push(route); // allow: direct — fixture test inspection
         let result =
             validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         let err = result.unwrap_err();
@@ -1229,8 +1229,8 @@ let vpc = awscc.ec2.vpc {
         );
 
         let mut parsed = empty_parsed();
-        parsed.resources.push(vpc);
-        parsed.resources.push(subnet);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
+        parsed.resources.push(subnet); // allow: direct — fixture test inspection
         let result =
             validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
         let err = result.unwrap_err();
@@ -1616,7 +1616,7 @@ let vpc = awscc.ec2.vpc {
 
         let caller = Resource::with_provider("aws", "sts.caller_identity", "caller_identity")
             .with_binding("_");
-        parsed.resources.push(caller);
+        parsed.resources.push(caller); // allow: direct — fixture test inspection
 
         assert!(check_unused_bindings(&parsed).is_empty());
     }
@@ -2092,7 +2092,7 @@ let vpc = awscc.ec2.vpc {
         known.insert("awscc".to_string());
 
         let mut parsed = empty_parsed();
-        parsed.resources.push(vpc);
+        parsed.resources.push(vpc); // allow: direct — fixture test inspection
         let err = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known).unwrap_err();
         assert!(
             err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),


### PR DESCRIPTION
Task 9/13 of the unified resource walk. Every surviving direct use of
\`parsed.resources.\` in application code now carries an explicit
\`// allow: direct — <reason>\` comment so the upcoming Task 10 CI lint
can distinguish allowed from forbidden accesses.

## Summary
- \`parser-internal, pre-expansion\`: parser/mod.rs:4467
- \`fixture test inspection\`: 31 test-only sites in parser/mod.rs and validation.rs
- \`module expansion, handled separately\`: module_resolver/mod.rs:255, :598
- \`plan-time reconciliation\`: commands/destroy.rs:149, commands/plan.rs
- \`display/reporting\`: commands/validate.rs:104, :105, :120

plan.rs's access has a \`#[rustfmt::skip]\` attribute so the allow marker
stays on the same line within the 100-char limit.

## Test plan
- [x] Acceptance grep \`grep -rn "parsed\\.resources\\." ... | grep -v "// allow: direct" | grep -v iter_all_resources\` returns no results
- [x] \`cargo test -p carina-core\` (1256 pass)
- [x] \`cargo test -p carina-cli\` (all pass)
- [x] \`cargo clippy -p carina-core -p carina-cli -p carina-lsp --all-targets -- -D warnings\` clean

## Note for Task 10
The Task 10 lint spec uses a broader regex \`\\.resources\\.\` that also
matches \`state.resources.\`, \`self.resources.\`, etc. — not just
\`parsed.resources.\`. Since those are different types/contexts, the
lint regex should be refined in Task 10's PR to focus on \`parsed.resources\`
/ \`ParsedFile\` field access. Current PR satisfies issue #2055's stated
acceptance (\`parsed.resources.\` specifically).

Closes #2055
Refs #2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)