### PR TITLE
Restructure AttributeType::Custom with semantic_name/pattern/length

### DIFF
--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -89,8 +89,10 @@ fn type_aware_union_numeric() {
 #[test]
 fn type_aware_custom_delegates_to_base() {
     let custom_type = AttributeType::Custom {
-        name: "Port".to_string(),
+        semantic_name: Some("Port".to_string()),
         base: Box::new(AttributeType::Float),
+        pattern: None,
+        length: None,
         validate: |_| Ok(()),
         namespace: None,
         to_dsl: None,
@@ -308,8 +310,10 @@ fn type_aware_struct_ignores_default_custom_type() {
             StructField::new(
                 "port",
                 AttributeType::Custom {
-                    name: "Port".to_string(),
+                    semantic_name: Some("Port".to_string()),
                     base: Box::new(AttributeType::Int),
+                    pattern: None,
+                    length: None,
                     validate: |_| Ok(()),
                     namespace: None,
                     to_dsl: None,

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -560,13 +560,21 @@ fn collect_validators_from_type(
     use crate::schema::AttributeType;
 
     match attr_type {
-        AttributeType::Custom { name, validate, .. } => {
+        AttributeType::Custom {
+            semantic_name: Some(name),
+            validate,
+            ..
+        } => {
             let snake_name = crate::parser::pascal_to_snake(name);
             validators.entry(snake_name).or_insert_with(|| {
                 let validate_fn = *validate;
                 Box::new(move |s: &str| validate_fn(&crate::resource::Value::String(s.to_string())))
             });
         }
+        AttributeType::Custom {
+            semantic_name: None,
+            ..
+        } => {}
         AttributeType::List { inner, .. } => {
             collect_validators_from_type(inner, validators);
         }
@@ -596,9 +604,16 @@ fn collect_type_names_from_type(
     use crate::schema::AttributeType;
 
     match attr_type {
-        AttributeType::Custom { name, .. } => {
+        AttributeType::Custom {
+            semantic_name: Some(name),
+            ..
+        } => {
             names.insert(crate::parser::pascal_to_snake(name));
         }
+        AttributeType::Custom {
+            semantic_name: None,
+            ..
+        } => {}
         AttributeType::List { inner, .. } => {
             collect_type_names_from_type(inner, names);
         }

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -90,8 +90,15 @@ pub enum AttributeType {
     },
     /// Custom type (with validation function)
     Custom {
-        name: String,
+        /// Some(name) when this type carries a semantic identity (e.g. "VpcId",
+        /// "AwsAccountId"). None when this is a generic string/int pattern type
+        /// synthesized by codegen for a property without a named semantic.
+        semantic_name: Option<String>,
         base: Box<AttributeType>,
+        /// Optional regex pattern constraint (for structural comparison).
+        pattern: Option<String>,
+        /// Optional length bounds (min, max).
+        length: Option<(Option<u64>, Option<u64>)>,
         validate: fn(&Value) -> Result<(), String>,
         /// Namespace for resolving shorthand enum values (e.g., "aws.vpc")
         /// When set, allows `dedicated` to be resolved to `aws.vpc.InstanceTenancy.dedicated`
@@ -212,7 +219,7 @@ impl AttributeType {
                 ..
             }
             | AttributeType::Custom {
-                name,
+                semantic_name: Some(name),
                 namespace: Some(namespace),
                 to_dsl,
                 ..
@@ -325,7 +332,7 @@ impl AttributeType {
             (
                 AttributeType::Custom {
                     validate,
-                    name,
+                    semantic_name,
                     namespace,
                     ..
                 },
@@ -336,7 +343,9 @@ impl AttributeType {
                 if matches!(v, Value::ResourceRef { .. } | Value::Interpolation(_)) {
                     return Ok(());
                 }
-                let resolved_value = Self::resolve_enum_input(name, namespace.as_deref(), v)?;
+                let name_for_resolve = semantic_name.as_deref().unwrap_or("");
+                let resolved_value =
+                    Self::resolve_enum_input(name_for_resolve, namespace.as_deref(), v)?;
                 validate(&resolved_value)
                     .map_err(|msg| TypeError::ValidationFailed { message: msg })
             }
@@ -460,7 +469,16 @@ impl AttributeType {
             AttributeType::Float => "Float".to_string(),
             AttributeType::Bool => "Bool".to_string(),
             AttributeType::StringEnum { name, .. } => name.clone(),
-            AttributeType::Custom { name, .. } => name.clone(),
+            AttributeType::Custom {
+                semantic_name,
+                pattern,
+                length,
+                ..
+            } => custom_display_name(
+                semantic_name.as_deref(),
+                pattern.as_deref(),
+                length.as_ref(),
+            ),
             AttributeType::List { inner, .. } => format!("List<{}>", inner.type_name()),
             AttributeType::Map { value: inner, .. } => format!("Map<{}>", inner.type_name()),
             AttributeType::Struct { name, .. } => format!("Struct({})", name),
@@ -515,6 +533,45 @@ impl AttributeType {
 impl fmt::Display for AttributeType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.type_name())
+    }
+}
+
+fn custom_display_name(
+    semantic_name: Option<&str>,
+    pattern: Option<&str>,
+    length: Option<&(Option<u64>, Option<u64>)>,
+) -> String {
+    if let Some(n) = semantic_name {
+        return n.to_string();
+    }
+    let mut s = String::from("String");
+    let has_pattern = pattern.is_some();
+    let has_length = length.is_some();
+    if has_pattern || has_length {
+        s.push('(');
+        if has_pattern {
+            s.push_str("pattern");
+        }
+        if let Some((min, max)) = length {
+            if has_pattern {
+                s.push_str(", ");
+            }
+            s.push_str(&format!(
+                "len: {}",
+                length_display(min.as_ref(), max.as_ref())
+            ));
+        }
+        s.push(')');
+    }
+    s
+}
+
+fn length_display(min: Option<&u64>, max: Option<&u64>) -> String {
+    match (min, max) {
+        (Some(lo), Some(hi)) => format!("{}..={}", lo, hi),
+        (Some(lo), None) => format!("{}..", lo),
+        (None, Some(hi)) => format!("..={}", hi),
+        (None, None) => "..".to_string(),
     }
 }
 
@@ -1295,8 +1352,10 @@ pub mod types {
     /// Positive integer type
     pub fn positive_int() -> AttributeType {
         AttributeType::Custom {
-            name: "PositiveInt".to_string(),
+            semantic_name: Some("PositiveInt".to_string()),
             base: Box::new(AttributeType::Int),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::Int(n) = value {
                     if *n > 0 {
@@ -1316,8 +1375,10 @@ pub mod types {
     /// IPv4 CIDR block type (e.g., "10.0.0.0/16")
     pub fn ipv4_cidr() -> AttributeType {
         AttributeType::Custom {
-            name: "Ipv4Cidr".to_string(),
+            semantic_name: Some("Ipv4Cidr".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     validate_ipv4_cidr(s)
@@ -1333,8 +1394,10 @@ pub mod types {
     /// IPv4 address type (e.g., "10.0.1.5", "192.168.0.1")
     pub fn ipv4_address() -> AttributeType {
         AttributeType::Custom {
-            name: "Ipv4Address".to_string(),
+            semantic_name: Some("Ipv4Address".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     validate_ipv4_address(s)
@@ -1350,8 +1413,10 @@ pub mod types {
     /// IPv6 address type (e.g., "2001:db8::1", "::1")
     pub fn ipv6_address() -> AttributeType {
         AttributeType::Custom {
-            name: "Ipv6Address".to_string(),
+            semantic_name: Some("Ipv6Address".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     validate_ipv6_address(s)
@@ -1367,8 +1432,10 @@ pub mod types {
     /// IPv6 CIDR block type (e.g., "2001:db8::/32", "::/0")
     pub fn ipv6_cidr() -> AttributeType {
         AttributeType::Custom {
-            name: "Ipv6Cidr".to_string(),
+            semantic_name: Some("Ipv6Cidr".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     validate_ipv6_cidr(s)
@@ -2544,8 +2611,10 @@ mod tests {
     fn validate_union_type() {
         // Create two Custom types that validate different prefixes
         let type_a = AttributeType::Custom {
-            name: "TypeA".to_string(),
+            semantic_name: Some("TypeA".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     if s.starts_with("a-") {
@@ -2561,8 +2630,10 @@ mod tests {
             to_dsl: None,
         };
         let type_b = AttributeType::Custom {
-            name: "TypeB".to_string(),
+            semantic_name: Some("TypeB".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |value| {
                 if let Value::String(s) = value {
                     if s.starts_with("b-") {
@@ -2645,15 +2716,19 @@ mod tests {
     #[test]
     fn union_type_name() {
         let type_a = AttributeType::Custom {
-            name: "TypeA".to_string(),
+            semantic_name: Some("TypeA".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
         };
         let type_b = AttributeType::Custom {
-            name: "TypeB".to_string(),
+            semantic_name: Some("TypeB".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -2666,15 +2741,19 @@ mod tests {
     #[test]
     fn union_accepts_type_name() {
         let type_a = AttributeType::Custom {
-            name: "TypeA".to_string(),
+            semantic_name: Some("TypeA".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
         };
         let type_b = AttributeType::Custom {
-            name: "TypeB".to_string(),
+            semantic_name: Some("TypeB".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -3353,8 +3432,10 @@ mod tests {
 
     fn make_custom(name: &str, base: AttributeType) -> AttributeType {
         AttributeType::Custom {
-            name: name.to_string(),
+            semantic_name: Some(name.to_string()),
             base: Box::new(base),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -3400,5 +3481,73 @@ mod tests {
         let int_custom = make_custom("Port", AttributeType::Int);
         let string_custom = make_custom("VpcId", AttributeType::String);
         assert!(!int_custom.is_compatible_with(&string_custom));
+    }
+
+    #[test]
+    fn custom_carries_semantic_name_pattern_length() {
+        let t = AttributeType::Custom {
+            semantic_name: Some("VpcId".to_string()),
+            base: Box::new(AttributeType::String),
+            pattern: Some("^vpc-[a-f0-9]+$".to_string()),
+            length: Some((Some(8), Some(21))),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+        };
+        match t {
+            AttributeType::Custom {
+                semantic_name,
+                pattern,
+                length,
+                ..
+            } => {
+                assert_eq!(semantic_name.as_deref(), Some("VpcId"));
+                assert_eq!(pattern.as_deref(), Some("^vpc-[a-f0-9]+$"));
+                assert_eq!(length, Some((Some(8), Some(21))));
+            }
+            _ => panic!("expected Custom"),
+        }
+    }
+
+    #[test]
+    fn custom_type_name_anonymous_pattern_only() {
+        let t = AttributeType::Custom {
+            semantic_name: None,
+            base: Box::new(AttributeType::String),
+            pattern: Some("^foo$".to_string()),
+            length: None,
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+        };
+        assert_eq!(t.type_name(), "String(pattern)");
+    }
+
+    #[test]
+    fn custom_type_name_anonymous_length_only() {
+        let t = AttributeType::Custom {
+            semantic_name: None,
+            base: Box::new(AttributeType::String),
+            pattern: None,
+            length: Some((Some(1), Some(64))),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+        };
+        assert_eq!(t.type_name(), "String(len: 1..=64)");
+    }
+
+    #[test]
+    fn custom_type_name_anonymous_pattern_and_length() {
+        let t = AttributeType::Custom {
+            semantic_name: None,
+            base: Box::new(AttributeType::String),
+            pattern: Some("^.*$".to_string()),
+            length: Some((Some(1), Some(64))),
+            validate: |_| Ok(()),
+            namespace: None,
+            to_dsl: None,
+        };
+        assert_eq!(t.type_name(), "String(pattern, len: 1..=64)");
     }
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -1002,14 +1002,18 @@ mod tests {
         let exports =
             mk_typed_exports(&[("orgs", &[("key_arn", TypeExpr::Simple("arn".to_string()))])]);
         let kms_arn = AttributeType::Custom {
-            name: "KmsKeyArn".to_string(),
+            semantic_name: Some("KmsKeyArn".to_string()),
             base: Box::new(AttributeType::Custom {
-                name: "Arn".to_string(),
+                semantic_name: Some("Arn".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: noop_validate,
                 namespace: None,
                 to_dsl: None,
             }),
+            pattern: None,
+            length: None,
             validate: noop_validate,
             namespace: None,
             to_dsl: None,

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -1712,8 +1712,10 @@ let vpc = awscc.ec2.vpc {
         role_schema = role_schema.attribute(AttributeSchema::new(
             "arn",
             AttributeType::Custom {
-                name: "IamRoleArn".to_string(),
+                semantic_name: Some("IamRoleArn".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
@@ -1863,14 +1865,18 @@ let vpc = awscc.ec2.vpc {
     fn type_compat_subtype_accepted() {
         // arn accepts KmsKeyArn (subtype via base chain: KmsKeyArn → Arn)
         let kms_key_arn = AttributeType::Custom {
-            name: "KmsKeyArn".to_string(),
+            semantic_name: Some("KmsKeyArn".to_string()),
             base: Box::new(AttributeType::Custom {
-                name: "Arn".to_string(),
+                semantic_name: Some("Arn".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
             }),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -1885,14 +1891,18 @@ let vpc = awscc.ec2.vpc {
     fn type_compat_sibling_rejected() {
         // kms_key_arn rejects IamRoleArn (sibling: IamRoleArn → Arn, not KmsKeyArn)
         let iam_role_arn = AttributeType::Custom {
-            name: "IamRoleArn".to_string(),
+            semantic_name: Some("IamRoleArn".to_string()),
             base: Box::new(AttributeType::Custom {
-                name: "Arn".to_string(),
+                semantic_name: Some("Arn".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
             }),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -1907,14 +1917,18 @@ let vpc = awscc.ec2.vpc {
     fn type_compat_resource_id_subtype() {
         // aws_resource_id accepts VpcId (subtype)
         let vpc_id = AttributeType::Custom {
-            name: "VpcId".to_string(),
+            semantic_name: Some("VpcId".to_string()),
             base: Box::new(AttributeType::Custom {
-                name: "AwsResourceId".to_string(),
+                semantic_name: Some("AwsResourceId".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
             }),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -1929,14 +1943,18 @@ let vpc = awscc.ec2.vpc {
     fn type_compat_resource_id_siblings_rejected() {
         // vpc_id rejects SubnetId (sibling)
         let subnet_id = AttributeType::Custom {
-            name: "SubnetId".to_string(),
+            semantic_name: Some("SubnetId".to_string()),
             base: Box::new(AttributeType::Custom {
-                name: "AwsResourceId".to_string(),
+                semantic_name: Some("AwsResourceId".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
             }),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,
@@ -1950,8 +1968,10 @@ let vpc = awscc.ec2.vpc {
     #[test]
     fn type_compat_exact_match() {
         let arn = AttributeType::Custom {
-            name: "Arn".to_string(),
+            semantic_name: Some("Arn".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()),
             namespace: None,
             to_dsl: None,

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -372,7 +372,10 @@ impl CompletionProvider {
     /// Extract the Custom type name from an AttributeType, if it is a Custom type.
     fn extract_custom_type_name(attr_type: &AttributeType) -> Option<&str> {
         match attr_type {
-            AttributeType::Custom { name, .. } => Some(name),
+            AttributeType::Custom {
+                semantic_name: Some(name),
+                ..
+            } => Some(name),
             _ => None,
         }
     }
@@ -419,15 +422,22 @@ impl CompletionProvider {
             AttributeType::Float => {
                 vec![] // No specific completions for floats
             }
-            AttributeType::Custom { name, .. } if name == "Cidr" || name == "Ipv4Cidr" => {
-                self.cidr_completions()
-            }
-            AttributeType::Custom { name, .. } if name == "Ipv6Cidr" => {
-                self.ipv6_cidr_completions()
-            }
-            AttributeType::Custom { name, .. } if name == "Arn" => self.arn_completions(),
             AttributeType::Custom {
-                name, namespace, ..
+                semantic_name: Some(name),
+                ..
+            } if name == "Cidr" || name == "Ipv4Cidr" => self.cidr_completions(),
+            AttributeType::Custom {
+                semantic_name: Some(name),
+                ..
+            } if name == "Ipv6Cidr" => self.ipv6_cidr_completions(),
+            AttributeType::Custom {
+                semantic_name: Some(name),
+                ..
+            } if name == "Arn" => self.arn_completions(),
+            AttributeType::Custom {
+                semantic_name: Some(name),
+                namespace,
+                ..
             } if name == "AvailabilityZone" => {
                 self.availability_zone_completions(namespace.as_deref().unwrap_or(""), name)
             }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -427,13 +427,14 @@ impl DiagnosticEngine {
                                 }
                                 (
                                     carina_core::schema::AttributeType::Custom {
-                                        name,
+                                        semantic_name,
                                         validate,
                                         namespace,
                                         ..
                                     },
                                     value,
                                 ) => {
+                                    let name = semantic_name.as_deref().unwrap_or("");
                                     // Handle bare/shorthand enum identifiers by expanding to full namespace format.
                                     // These are String values like "dedicated" or "InstanceTenancy.dedicated".
                                     let resolved_value = match value {

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1191,8 +1191,10 @@ fn resource_ref_type_check_helper_regression() {
         .attribute(AttributeSchema::new(
             "my_id",
             AttributeType::Custom {
-                name: "MyId".to_string(),
+                semantic_name: Some("MyId".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: dummy_validate,
                 namespace: Some("test".to_string()),
                 to_dsl: None,
@@ -1217,8 +1219,10 @@ fn resource_ref_type_check_helper_regression() {
         .attribute(AttributeSchema::new(
             "custom_attr",
             AttributeType::Custom {
-                name: "MyId".to_string(),
+                semantic_name: Some("MyId".to_string()),
                 base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
                 validate: dummy_validate,
                 namespace: Some("test".to_string()),
                 to_dsl: None,
@@ -1647,8 +1651,10 @@ fn string_based_custom_types_are_compatible() {
     let source_schema = ResourceSchema::new("sts.caller_identity").attribute(AttributeSchema::new(
         "account_id",
         AttributeType::Custom {
-            name: "AwsAccountId".to_string(),
+            semantic_name: Some("AwsAccountId".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: validate_account_id,
             namespace: Some("aws".to_string()),
             to_dsl: None,
@@ -1659,8 +1665,10 @@ fn string_based_custom_types_are_compatible() {
     let target_schema = ResourceSchema::new("sso.assignment").attribute(AttributeSchema::new(
         "target_id",
         AttributeType::Custom {
-            name: "TargetId".to_string(),
+            semantic_name: Some("TargetId".to_string()),
             base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
             validate: validate_target_id,
             namespace: Some("awscc".to_string()),
             to_dsl: None,
@@ -1701,8 +1709,10 @@ fn exports_cross_file_ref_no_false_positive() {
     use std::collections::HashMap;
 
     let aws_account_id_type = AttributeType::Custom {
-        name: "AwsAccountId".to_string(),
+        semantic_name: Some("AwsAccountId".to_string()),
         base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
         validate: |v| match v {
             Value::String(s) if s.len() == 12 && s.chars().all(|c| c.is_ascii_digit()) => Ok(()),
             Value::String(s) => Err(format!(

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -374,8 +374,14 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            name: name.clone(),
+            semantic_name: if name.is_empty() {
+                None
+            } else {
+                Some(name.clone())
+            },
             base: Box::new(proto_attr_type_to_core(base)),
+            pattern: None,
+            length: None,
             validate: |_| Ok(()), // Validation is handled via ProviderContext.validators
             namespace: namespace.clone(),
             to_dsl: None,


### PR DESCRIPTION
## Summary

Replace the overloaded `name: String` field on `AttributeType::Custom` with a structured triple that distinguishes semantic identity from pattern/length constraints:

- `semantic_name: Option<String>` — Some when the type carries semantic identity (e.g. `"VpcId"`, `"AwsAccountId"`), None for anonymous codegen types
- `pattern: Option<String>` — regex constraint, structured for comparison
- `length: Option<(Option<u64>, Option<u64>)>` — length bounds

`type_name()` now derives a display string from these fields (e.g. `"String(pattern, len: 1..=64)"` for anonymous types).

All literal `Custom` inits and match arms across carina-core, carina-lsp, and carina-plugin-host are migrated mechanically. **No behavior changes yet** — this is purely structural groundwork for directional assignability (`is_assignable_to`) that will replace the permissive `is_compatible_with` in a follow-up PR.

Closes #2081 #2082 #2083 #2084
Refs #2079 (design spec: `docs/specs/2026-04-19-type-compat-redesign-design.md`)

## Test plan

- [x] `cargo build -p carina-core` / `-p carina-lsp` / `-p carina-plugin-host`
- [x] `cargo test -p carina-core` (1260 pass), `-p carina-lsp` (281 pass), `-p carina-cli`, `-p carina-plugin-host`, `-p carina-state`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean