### PR TITLE
LSP: anchor for-body attribute diagnostics inside the for body

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -189,9 +189,13 @@ impl DiagnosticEngine {
 
             // Check resource types — include for-body template resources so
             // attribute/type/enum validation fires inside `for` loops too.
-            for (_ctx, resource) in parsed.iter_all_resources() {
+            for (ctx, resource) in parsed.iter_all_resources() {
                 let provider = &resource.id.provider;
                 let full_resource_type = format!("{}.{}", provider, resource.id.resource_type);
+                // Source-range hint for attribute position lookups. Without
+                // this, a `for`-body diagnostic like `mode = "aaa"` would
+                // anchor on the first top-level `mode =` in the file.
+                let scope = resource_source_range(doc, ctx, provider, &resource.id.resource_type);
 
                 if !self.schemas.contains_key(&full_resource_type) {
                     let provider_loaded = self.provider_names.contains(&provider.to_string());
@@ -312,7 +316,8 @@ impl DiagnosticEngine {
                             && canon != attr_name
                             && resource.attributes.contains_key(canon)
                         {
-                            if let Some((line, col)) = self.find_attribute_position(doc, attr_name)
+                            if let Some((line, col)) =
+                                self.find_attribute_position(doc, attr_name, scope)
                             {
                                 diagnostics.push(carina_diagnostic(
                                     line,
@@ -330,7 +335,8 @@ impl DiagnosticEngine {
 
                         // Check for unknown attributes
                         if !schema.attributes.contains_key(canonical_name) {
-                            if let Some((line, col)) = self.find_attribute_position(doc, attr_name)
+                            if let Some((line, col)) =
+                                self.find_attribute_position(doc, attr_name, scope)
                             {
                                 // Check if there's a similar attribute (e.g., vpc -> vpc_id)
                                 let suggestion =
@@ -524,7 +530,7 @@ impl DiagnosticEngine {
 
                             if let Some(message) = type_error
                                 && let Some((line, col)) =
-                                    self.find_attribute_position(doc, attr_name)
+                                    self.find_attribute_position(doc, attr_name, scope)
                             {
                                 diagnostics.push(carina_diagnostic(
                                     line,
@@ -586,7 +592,7 @@ impl DiagnosticEngine {
                                     ..
                                 } = &error
                                 {
-                                    self.find_attribute_position(doc, attr)
+                                    self.find_attribute_position(doc, attr, scope)
                                 } else {
                                     None
                                 };
@@ -805,10 +811,31 @@ impl DiagnosticEngine {
         None
     }
 
-    fn find_attribute_position(&self, doc: &Document, attr_name: &str) -> Option<(u32, u32)> {
+    /// Find the source position of an attribute assignment (`attr_name = ...`).
+    ///
+    /// `scope` optionally restricts the search to a half-open line range
+    /// `[start, end)` (both 0-indexed). Without a scope, the first matching
+    /// line anywhere in the document wins — which produces wrong anchors
+    /// when the same attribute name appears in multiple resource blocks.
+    /// Callers walking resources should pass the resource's source range
+    /// (see `resource_source_range`).
+    fn find_attribute_position(
+        &self,
+        doc: &Document,
+        attr_name: &str,
+        scope: Option<(u32, u32)>,
+    ) -> Option<(u32, u32)> {
         let text = doc.text();
+        let (start, end) = scope.unwrap_or((0, u32::MAX));
 
         for (line_idx, line) in text.lines().enumerate() {
+            let line_idx = line_idx as u32;
+            if line_idx < start {
+                continue;
+            }
+            if line_idx >= end {
+                break;
+            }
             let trimmed = line.trim_start();
             // Must start with attr_name followed by whitespace or '='
             if !trimmed.starts_with(attr_name) {
@@ -819,10 +846,96 @@ impl DiagnosticEngine {
                 continue;
             }
             // Calculate column position (account for leading whitespace)
-            return Some((line_idx as u32, position::leading_whitespace_chars(line)));
+            return Some((line_idx, position::leading_whitespace_chars(line)));
         }
         None
     }
+}
+
+/// Derive the source line range (0-indexed, half-open) of a resource block.
+///
+/// - For `Deferred(for_expr)` the scope starts at the `for` line and ends
+///   at the closing brace of the for expression.
+/// - For `Direct` we locate the `provider.resource_type` token and scan
+///   forward from there.
+///
+/// Returns `None` when the block can't be located (e.g., during partial
+/// parses). Callers that fall back to `None` get document-wide search —
+/// the historic behavior — which is still correct when there's no
+/// ambiguity.
+fn resource_source_range(
+    doc: &Document,
+    ctx: carina_core::parser::ResourceContext<'_>,
+    provider: &str,
+    resource_type: &str,
+) -> Option<(u32, u32)> {
+    use carina_core::parser::ResourceContext;
+    let text = doc.text();
+    let lines: Vec<&str> = text.lines().collect();
+
+    let start = match ctx {
+        // `DeferredForExpression.line` is 1-indexed (pest line_col). Convert to 0-indexed.
+        ResourceContext::Deferred(d) => d.line.saturating_sub(1) as u32,
+        ResourceContext::Direct => {
+            let pattern = format!("{}.{}", provider, resource_type);
+            let (idx, _) = lines
+                .iter()
+                .enumerate()
+                .find(|(_, l)| l.contains(pattern.as_str()))?;
+            idx as u32
+        }
+    };
+
+    // Scan forward from `start`, tracking brace balance. The block ends when
+    // the balance returns to zero after we've seen at least one `{`.
+    let mut balance: i32 = 0;
+    let mut seen_open = false;
+    for (idx, line) in lines.iter().enumerate().skip(start as usize) {
+        // Skip comments (`#` or `//`) by trimming from the first marker.
+        let stripped = strip_line_comment(line);
+        for ch in stripped.chars() {
+            match ch {
+                '{' => {
+                    balance += 1;
+                    seen_open = true;
+                }
+                '}' => {
+                    balance -= 1;
+                    if seen_open && balance == 0 {
+                        return Some((start, idx as u32 + 1));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    // Unterminated: treat as extending to end of file.
+    Some((start, lines.len() as u32))
+}
+
+fn strip_line_comment(line: &str) -> &str {
+    // Conservative: only strip `#` or `//` outside of strings. For source
+    // ranges we only need brace-balance accuracy, so missing a comment
+    // inside a string is acceptable — strings in .crn don't normally
+    // contain unbalanced braces.
+    let mut in_string = false;
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'"' || b == b'\'' {
+            in_string = !in_string;
+        } else if !in_string {
+            if b == b'#' {
+                return &line[..i];
+            }
+            if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+                return &line[..i];
+            }
+        }
+        i += 1;
+    }
+    line
 }
 
 /// Check whether a ResourceRef value is type-compatible with the expected attribute type.

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2724,3 +2724,50 @@ for _, id in orgs.xs {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn for_body_diagnostic_anchors_inside_for_not_at_prior_sibling() {
+    // Regression for #2078. The same attribute name (`mode`) appears both at
+    // top level (valid) and inside a `for` body (invalid). The diagnostic
+    // must anchor on the for-body line, not the earlier top-level line that
+    // happens to share the attribute name.
+    let provider = test_engine_with_enum_attr();
+    // Line layout (0-indexed):
+    //   0: (empty)
+    //   1: test.r.mode_holder {
+    //   2:   mode = "fast"           <- valid
+    //   3: }
+    //   4:
+    //   5: for _, id in orgs.xs {
+    //   6:   test.r.mode_holder {
+    //   7:     mode = "aaaa"         <- INVALID, should anchor here
+    //   8:   }
+    //   9: }
+    let source = r#"
+test.r.mode_holder {
+  mode = "fast"
+}
+
+for _, id in orgs.xs {
+  test.r.mode_holder {
+    mode = "aaaa"
+  }
+}
+"#;
+    let doc = create_document(source);
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let bad = diagnostics
+        .iter()
+        .find(|d| d.message.contains("aaaa"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected enum-mismatch diagnostic for 'aaaa', got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(
+        bad.range.start.line, 7,
+        "diagnostic must anchor on the for-body line (0-indexed 7), got: line {} with range {:?}",
+        bad.range.start.line, bad.range
+    );
+}


### PR DESCRIPTION
## Summary

`find_attribute_position` scanned the whole document for the first line whose `trim_start()` began with the attribute name. When the same attribute name appears both at top level and in a `for` body — e.g. \`mode = "fast"\` above and \`mode = "aaa"\` inside a loop — the for-body diagnostic anchored on the earlier top-level line instead of the offending one.

Passes a \`scope: Option<(u32, u32)>\` (half-open, 0-indexed line range) to \`find_attribute_position\`. Scope is computed per iteration of \`parsed.iter_all_resources()\` via a new \`resource_source_range\` helper:

- \`Deferred(for_expr)\` starts at \`for_expr.line\` (pest 1-indexed → 0-indexed) and walks forward counting braces to find the matching \`}\`.
- \`Direct\` locates \`provider.resource_type\` and does the same walk.

Only \`carina-lsp/src/diagnostics/mod.rs\` call sites (5 total) needed changing — all are inside the \`iter_all_resources\` walk. \`checks.rs\` helpers don't share this failure mode: they scan bounded constructs (provider blocks, module calls, upstream_state blocks) whose boundaries they track themselves.

Incidentally also fixes the same failure for any *direct* resource whose attribute name collides with an earlier sibling — the design doc's "Option 1" benefit.

## Test plan

- [x] New regression test \`for_body_diagnostic_anchors_inside_for_not_at_prior_sibling\` reproduces the issue and passes with the fix
- [x] \`cargo test --workspace\` (1260+ core, 282 LSP, etc. all pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean

Closes #2078