### PR TITLE
validate: collect every static error instead of bailing on the first

### DIFF
--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -42,10 +42,29 @@ pub fn run_validate(
 
     let base_dir = get_base_dir(path);
 
-    // Surface bad `upstream_state.source` paths before printing warnings —
-    // otherwise the "validate does not inspect" warning implies the
-    // source is reachable and misdirects the user.
-    check_upstream_state_sources(base_dir, &parsed.upstream_states)?;
+    // Collect every static error before reporting, so the user sees them
+    // all in one pass instead of fixing one, re-running, and finding the
+    // next. See #2102.
+    //
+    // Dependency ordering still applies: `validate_and_resolve_with_config`
+    // performs module expansion and name resolution that later steps rely
+    // on. We don't delay those errors behind other checks — but we _do_
+    // accumulate the deferred for-iterable errors (already collected by
+    // `load_configuration_with_config`) and run the `upstream_state.source`
+    // existence check up front so both categories of findings surface
+    // together with anything the validators downstream report.
+    let mut error_reports: Vec<String> = Vec::new();
+    error_reports.extend(
+        loaded
+            .iterable_binding_errors
+            .iter()
+            .map(ToString::to_string),
+    );
+    if let Err(AppError::Validation(msg)) =
+        check_upstream_state_sources(base_dir, &parsed.upstream_states)
+    {
+        error_reports.push(msg);
+    }
 
     parsed.print_warnings();
 
@@ -53,7 +72,27 @@ pub fn run_validate(
         println!("{}", "Validating...".cyan());
     }
 
-    validate_and_resolve_with_config(&mut parsed, base_dir, false)?;
+    if let Err(err) = validate_and_resolve_with_config(&mut parsed, base_dir, false) {
+        match err {
+            AppError::Validation(msg) => error_reports.push(msg),
+            other => {
+                // Non-validation error (IO, config, etc.) — surface
+                // immediately alongside whatever we already collected.
+                if !error_reports.is_empty() {
+                    return Err(AppError::Validation(format!(
+                        "{}\n{}",
+                        error_reports.join("\n"),
+                        other
+                    )));
+                }
+                return Err(other);
+            }
+        }
+    }
+
+    if !error_reports.is_empty() {
+        return Err(AppError::Validation(error_reports.join("\n")));
+    }
 
     // Check for unused let bindings (warnings, not errors)
     let unused_warnings = check_unused_bindings(&loaded.unresolved_parsed);

--- a/carina-cli/tests/fixtures/negative/multiple_errors/main.crn
+++ b/carina-cli/tests/fixtures/negative/multiple_errors/main.crn
@@ -1,0 +1,20 @@
+# Negative test for #2102: validate must emit every static error in one pass.
+#
+# This fixture seeds two independent errors:
+#  - Error 1: `for _ in org.accounts` — `org` is not declared.
+#  - Error 2: `for _ in missing.stuff` — `missing` is not declared either.
+# Both should surface in a single `carina validate` run.
+
+let orgs = upstream_state { source = "../nonexistent_sibling" }
+
+for _, id in org.accounts {
+  aws.s3_bucket {
+    name = id
+  }
+}
+
+for _, id in missing.stuff {
+  aws.s3_bucket {
+    name = id
+  }
+}

--- a/carina-cli/tests/negative_validation.rs
+++ b/carina-cli/tests/negative_validation.rs
@@ -98,3 +98,36 @@ fn invalid_region() {
 fn missing_provider_plugin() {
     assert_validate_fails("missing_provider_plugin", "has no source configured");
 }
+
+#[test]
+fn validate_reports_multiple_static_errors_in_one_pass() {
+    // Regression for #2102. Independent static errors in the same project
+    // must all surface in a single `carina validate` run so the user fixes
+    // them in one pass.
+    //
+    // The fixture declares `let orgs = upstream_state { ... }` (source
+    // path intentionally missing) plus two for-expressions with typo'd
+    // iterable bindings. Three distinct diagnostics are expected in the
+    // combined output: the missing upstream source and both undefined
+    // identifiers.
+    let output = carina_validate("multiple_errors");
+    assert!(
+        !output.status.success(),
+        "expected validation to fail, got:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`org`"),
+        "missing `org` identifier diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("`missing`"),
+        "missing `missing` identifier diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("nonexistent_sibling"),
+        "missing upstream_state source diagnostic: {stderr}"
+    );
+}

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -6,7 +6,13 @@ use std::path::{Path, PathBuf};
 
 use crate::parser::{self, ParsedFile, ProviderContext};
 
-/// Result of loading configuration, includes the file path containing backend block
+/// Result of loading configuration, includes the file path containing backend block.
+///
+/// The struct holds non-blocking diagnostics (e.g. deferred for-iterable
+/// binding errors) so the caller can decide to keep running the rest of
+/// the static-analysis pipeline and report them together with downstream
+/// findings (#2102). Blocking errors (bad parse, missing modules) still
+/// come back as `Err` from the loader.
 pub struct LoadedConfig {
     pub parsed: ParsedFile,
     /// Resources before reference resolution, for unused binding detection.
@@ -14,6 +20,12 @@ pub struct LoadedConfig {
     /// so this preserves the original references for accurate unused binding analysis.
     pub unresolved_parsed: ParsedFile,
     pub backend_file: Option<PathBuf>,
+    /// Deferred for-iterables whose binding didn't resolve against the
+    /// directory-wide merge. Empty when every iterable is in scope. The
+    /// caller is responsible for surfacing these — the loader does not
+    /// short-circuit on them so that later validators can also run and
+    /// their findings can be reported alongside.
+    pub iterable_binding_errors: Vec<parser::ParseError>,
 }
 
 /// Load configuration from a directory containing .crn files
@@ -168,19 +180,17 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
-        let iterable_errors = parser::check_deferred_for_iterables(&merged);
-        if !iterable_errors.is_empty() {
-            return Err(iterable_errors
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join("\n"));
-        }
+        // Deferred for-iterable binding errors are accumulated rather than
+        // short-circuited so `carina validate` can keep going and report
+        // every static error in one pass (#2102). The caller reads
+        // `iterable_binding_errors` and merges them with its own findings.
+        let iterable_binding_errors = parser::check_deferred_for_iterables(&merged);
 
         Ok(LoadedConfig {
             parsed: merged,
             unresolved_parsed: unresolved_merged,
             backend_file,
+            iterable_binding_errors,
         })
     } else {
         Err(format!("Path not found: {}", path.display()))
@@ -934,7 +944,10 @@ awscc.ec2.security_group {
             other => panic!("unexpected error: {other}"),
         }
 
-        // `load_configuration_with_config` still fails fast for CLI callers.
+        // `load_configuration_with_config` surfaces the error via
+        // `LoadedConfig::iterable_binding_errors` rather than short-
+        // circuiting, so the CLI caller can collect it together with
+        // findings from later validators in a single pass (#2102).
         let dir2 = create_temp_dir("undefined_for_iterable_cli");
         fs::write(
             dir2.join("main.crn"),
@@ -946,15 +959,20 @@ awscc.ec2.security_group {
 "#,
         )
         .unwrap();
-        let cli_result = load_configuration_with_config(&dir2, &ProviderContext::default());
+        let loaded = load_configuration_with_config(&dir2, &ProviderContext::default())
+            .expect("load_configuration should not short-circuit on iterable binding errors");
         cleanup(&dir2);
-        let err = match cli_result {
-            Ok(_) => panic!("CLI load path should fail on undefined iterable"),
-            Err(e) => e,
-        };
-        assert!(
-            err.contains("Undefined identifier `does_not_exist`"),
-            "unexpected error: {err}"
+        assert_eq!(
+            loaded.iterable_binding_errors.len(),
+            1,
+            "expected one iterable binding error, got {:?}",
+            loaded.iterable_binding_errors,
         );
+        match &loaded.iterable_binding_errors[0] {
+            parser::ParseError::UndefinedIdentifier { name, .. } => {
+                assert_eq!(name, "does_not_exist");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`carina validate` used to stop at the first error. A deferred for-iterable binding failure short-circuited `load_configuration_with_config`, so attribute/type errors later in the same file only surfaced after the user fixed the first error and re-ran. Each fix-and-retry cycle was a round trip.

Now the loader carries non-blocking diagnostics forward and the CLI accumulates errors across validators in one pass.

### Before

\`\`\`
$ carina validate .
Error: Undefined identifier \`org\`. Did you mean \`orgs\`?
\`\`\`

### After (same fixture — one typo'd iterable + two enum mismatches)

\`\`\`
$ carina validate .
Validating...
Error: Undefined identifier \`org\`. Did you mean \`orgs\`?
Error: awscc.sso.assignment.: Invalid value 'aaaa' for 'target_type' (TargetType): expected one of awscc.sso.assignment.TargetType.AWS_ACCOUNT
Error: awscc.sso.assignment._accounts[?]: Invalid value 'aaaa' for 'target_type' (TargetType): expected one of awscc.sso.assignment.TargetType.AWS_ACCOUNT
\`\`\`

## Changes

- \`LoadedConfig\` gains \`iterable_binding_errors: Vec<ParseError>\`. The loader runs \`check_deferred_for_iterables\` but keeps its findings in the struct instead of short-circuiting.
- \`run_validate\` accumulates a \`Vec<String>\` of error reports: seed with \`iterable_binding_errors\`, run \`check_upstream_state_sources\` without \`?\`, then \`validate_and_resolve_with_config\` and merge its \`AppError::Validation\` result. Non-validation errors (IO, config) still bubble up immediately but get joined with whatever was already collected.
- The schema-level validators reached from \`validate_and_resolve_with_config\` already accumulate internally (\`validate_resources\`, \`validate_resource_ref_types\` return multi-error \`Vec\`s joined by newlines), so wiring them through the accumulator surfaces all their findings in one report.

## Dependency ordering

Preserved. Steps that downstream work genuinely depends on (module expansion, name resolution) still short-circuit internally so later validators don't fire on malformed inputs. Only **independent** findings are collected and reported together.

## Follow-up

#2105 tracks the internal API refactor to give every validator a \`Vec<AppError>\` return so the accumulator becomes a clean \`extend\` chain instead of needing special-case handling for \`Result\`-shaped validators.

## Test plan

- [x] New \`validate_reports_multiple_static_errors_in_one_pass\` integration test with a fixture that has two undefined iterables plus a missing \`upstream_state.source\` — all three surface in one run.
- [x] Existing \`parse_directory_leaves_undefined_iterable_for_caller_to_check\` updated to match the new contract: the loader no longer short-circuits.
- [x] \`cargo test --workspace\` passes (core 1276 / LSP 283 / CLI et al).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] End-to-end on \`infra/aws/management/identity-center/\` with the issue's repro.

Closes #2102
Refs #2105