### PR TITLE
wiring: return Vec<AppError> from independent validator wrappers

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -198,19 +198,33 @@ pub fn validate_and_resolve_with_config(
     resolve_names_with_ctx(&ctx, &mut parsed.resources)?;
 
     if !skip_resource_validation {
-        validate_resources_with_ctx(&ctx, parsed)?;
+        let mut errors: Vec<AppError> = Vec::new();
+        errors.extend(validate_resources_with_ctx(&ctx, parsed));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation
         for us in &parsed.upstream_states {
             argument_names.insert(us.binding.clone());
         }
-        validate_resource_ref_types_with_ctx(&ctx, parsed, &argument_names)?;
-        validate_attribute_param_ref_types_with_ctx(
+        errors.extend(validate_resource_ref_types_with_ctx(
+            &ctx,
+            parsed,
+            &argument_names,
+        ));
+        errors.extend(validate_attribute_param_ref_types_with_ctx(
             &ctx,
             &parsed.attribute_params,
             &parsed.resources,
-        )?;
+        ));
+        if !errors.is_empty() {
+            return Err(AppError::Validation(
+                errors
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ));
+        }
     }
 
     // Validate export values against their type annotations

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -156,50 +156,59 @@ pub fn build_factories_from_providers(
     (factories, load_errors)
 }
 
-pub fn validate_resources_with_ctx(
-    ctx: &WiringContext,
-    parsed: &ParsedFile,
-) -> Result<(), AppError> {
+/// Lift a core-validation `Result<(), String>` into per-finding
+/// `AppError::Validation` entries. The underlying `validation::*`
+/// helpers join every finding with `\n`, so splitting here lets
+/// callers surface each finding as its own `AppError`.
+fn lift_validation_result(res: Result<(), String>) -> Vec<AppError> {
+    let Err(joined) = res else {
+        return Vec::new();
+    };
+    joined
+        .split('\n')
+        .filter(|s| !s.is_empty())
+        .map(|s| AppError::Validation(s.to_string()))
+        .collect()
+}
+
+pub fn validate_resources_with_ctx(ctx: &WiringContext, parsed: &ParsedFile) -> Vec<AppError> {
     let known_providers: HashSet<String> = ctx
         .factories()
         .iter()
         .map(|f| f.name().to_string())
         .collect();
-    validation::validate_resources(
+    lift_validation_result(validation::validate_resources(
         parsed,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &known_providers,
-    )
-    .map_err(AppError::Validation)
+    ))
 }
 
 pub fn validate_resource_ref_types_with_ctx(
     ctx: &WiringContext,
     parsed: &ParsedFile,
     argument_names: &HashSet<String>,
-) -> Result<(), AppError> {
-    validation::validate_resource_ref_types(
+) -> Vec<AppError> {
+    lift_validation_result(validation::validate_resource_ref_types(
         parsed,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         argument_names,
-    )
-    .map_err(AppError::Validation)
+    ))
 }
 
 pub fn validate_attribute_param_ref_types_with_ctx(
     ctx: &WiringContext,
     attribute_params: &[carina_core::parser::AttributeParameter],
     resources: &[Resource],
-) -> Result<(), AppError> {
-    validation::validate_attribute_param_ref_types(
+) -> Vec<AppError> {
+    lift_validation_result(validation::validate_attribute_param_ref_types(
         attribute_params,
         resources,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
-    )
-    .map_err(AppError::Validation)
+    ))
 }
 
 /// Resolve block name aliases and attribute prefixes in one step.
@@ -1372,7 +1381,18 @@ pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
         resources: resources.to_vec(),
         ..ParsedFile::default()
     };
-    validate_resources_with_ctx(&ctx, &parsed)
+    let errors = validate_resources_with_ctx(&ctx, &parsed);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(AppError::Validation(
+            errors
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -1888,5 +1908,29 @@ mod tests {
             Some(&Value::String("gosukenator@gmail.com".into())),
             "literal inputs should pass through untouched"
         );
+    }
+
+    // Two resources with unknown types must surface as two distinct
+    // `AppError::Validation` entries instead of one joined string, so
+    // the driver can accumulate diagnostics across validators.
+    #[test]
+    fn validate_resources_with_ctx_returns_each_error_as_app_error() {
+        let ctx = WiringContext::new(vec![]);
+
+        // Empty provider string sidesteps the "unknown provider, skip"
+        // escape hatch (`known_providers` is empty), so each bad resource
+        // produces its own "Unknown resource type" entry.
+        let r1 = Resource::new("foo.nothing", "first");
+        let r2 = Resource::new("bar.nothing", "second");
+        let parsed = ParsedFile {
+            resources: vec![r1, r2],
+            ..ParsedFile::default()
+        };
+
+        let errors = validate_resources_with_ctx(&ctx, &parsed);
+        assert_eq!(errors.len(), 2, "got {errors:?}");
+        for err in &errors {
+            assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
+        }
     }
 }


### PR DESCRIPTION
Refs #2105 — Part 1 of 4

## Summary

- Flip three independent-check validator wrappers in `carina-cli/src/wiring.rs` from `Result<(), AppError>` to `Vec<AppError>`:
  - `validate_resources_with_ctx`
  - `validate_resource_ref_types_with_ctx`
  - `validate_attribute_param_ref_types_with_ctx`
- Rewrite the relevant block in `validate_and_resolve_with_config` to accumulate findings with `errors.extend(...)` and gate the rest of the pipeline behind a single guard.
- Add a small internal helper `lift_validation_result` that splits the core validators' newline-joined error string into per-finding `AppError::Validation` entries.

Follow-up PRs in the series:
- PR 2: dependency-chain validators (`resolve_names_with_ctx`, `resolve_attr_prefixes_with_ctx`, `compute_anonymous_identifiers_with_ctx`)
- PR 3: module / provider validators
- PR 4: remove the `run_validate` special-case from #2106 and retire the join-then-split round-trip, `Closes #2105`

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New unit test `validate_resources_with_ctx_returns_each_error_as_app_error` verifies two bad resources yield two distinct `AppError` entries
- [x] `test_provider_load_error_shows_actual_reason`, `test_provider_without_source_shows_source_hint`, `upstream_field_check_honors_skip_resource_validation` still pass, confirming the outer `validate_and_resolve_with_config` contract is unchanged