### PR TITLE
wiring: return Vec<AppError> from dependency-chain validator wrappers

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1014,7 +1014,10 @@ pub async fn run_apply(
                     ) {
                         return Err(AppError::Config(format!("Module resolution error: {}", e)));
                     }
-                    resolve_names_with_ctx(&ctx, &mut parsed.resources)?;
+                    let name_errors = resolve_names_with_ctx(&ctx, &mut parsed.resources);
+                    if !name_errors.is_empty() {
+                        return Err(super::collapse_errors(name_errors));
+                    }
                 } else {
                     return Err(AppError::Config(format!(
                         "Backend bucket '{}' not found and auto_create is disabled",

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -150,6 +150,26 @@ fn enrich_provider_context(
     }
 }
 
+/// Collapse an accumulated error Vec into a single `AppError`.
+///
+/// Panics on empty input — callers must guard with `is_empty()` first.
+/// A single accumulated error passes through unchanged so variants like
+/// `AppError::Config` reach callers (e.g. `run_validate`) with their
+/// original kind; multiple errors are joined as one
+/// `AppError::Validation` for the existing combined-message surface.
+pub(crate) fn collapse_errors(errors: Vec<AppError>) -> AppError {
+    if errors.len() == 1 {
+        return errors.into_iter().next().unwrap();
+    }
+    AppError::Validation(
+        errors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
 pub fn validate_and_resolve_with_config(
     parsed: &mut ParsedFile,
     base_dir: &Path,
@@ -194,11 +214,17 @@ pub fn validate_and_resolve_with_config(
     module_resolver::resolve_modules_with_config(parsed, base_dir, &enriched_context)
         .map_err(|e| format!("Module resolution error: {}", e))?;
 
-    // Resolve names (let bindings -> resource names)
-    resolve_names_with_ctx(&ctx, &mut parsed.resources)?;
+    let mut errors: Vec<AppError> = Vec::new();
+
+    // Resolve names (let bindings -> resource names) — must succeed
+    // before per-resource schema checks can look up the renamed
+    // attributes, so its failures gate the remaining pipeline.
+    errors.extend(resolve_names_with_ctx(&ctx, &mut parsed.resources));
+    if !errors.is_empty() {
+        return Err(collapse_errors(errors));
+    }
 
     if !skip_resource_validation {
-        let mut errors: Vec<AppError> = Vec::new();
         errors.extend(validate_resources_with_ctx(&ctx, parsed));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
@@ -217,13 +243,7 @@ pub fn validate_and_resolve_with_config(
             &parsed.resources,
         ));
         if !errors.is_empty() {
-            return Err(AppError::Validation(
-                errors
-                    .iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-            ));
+            return Err(collapse_errors(errors));
         }
     }
 
@@ -240,8 +260,17 @@ pub fn validate_and_resolve_with_config(
         )?;
     }
 
-    // Compute anonymous identifiers
-    compute_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, &parsed.providers)?;
+    // Compute anonymous identifiers — downstream plan code assumes
+    // every resource has a stable id, so a collision error must stop
+    // the pipeline here.
+    errors.extend(compute_anonymous_identifiers_with_ctx(
+        &ctx,
+        &mut parsed.resources,
+        &parsed.providers,
+    ));
+    if !errors.is_empty() {
+        return Err(collapse_errors(errors));
+    }
 
     // Reject references to `upstream_state` fields that the upstream's
     // `exports { }` block does not declare. Gated like the other

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -212,25 +212,23 @@ pub fn validate_attribute_param_ref_types_with_ctx(
 }
 
 /// Resolve block name aliases and attribute prefixes in one step.
-pub fn resolve_names_with_ctx(
-    ctx: &WiringContext,
-    resources: &mut [Resource],
-) -> Result<(), AppError> {
-    resolve_block_names(resources, ctx.schemas(), |r| {
+pub fn resolve_names_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) -> Vec<AppError> {
+    let mut errors = lift_validation_result(resolve_block_names(resources, ctx.schemas(), |r| {
         provider_mod::schema_key_for_resource(ctx.factories(), r)
-    })
-    .map_err(AppError::Validation)?;
-    resolve_attr_prefixes_with_ctx(ctx, resources)
+    }));
+    errors.extend(resolve_attr_prefixes_with_ctx(ctx, resources));
+    errors
 }
 
 pub fn resolve_attr_prefixes_with_ctx(
     ctx: &WiringContext,
     resources: &mut [Resource],
-) -> Result<(), AppError> {
-    identifier::resolve_attr_prefixes(resources, ctx.schemas(), &|r| {
-        provider_mod::schema_key_for_resource(ctx.factories(), r)
-    })
-    .map_err(AppError::Validation)
+) -> Vec<AppError> {
+    lift_validation_result(identifier::resolve_attr_prefixes(
+        resources,
+        ctx.schemas(),
+        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
+    ))
 }
 
 pub fn reconcile_prefixed_names(resources: &mut [Resource], state_file: &Option<StateFile>) {
@@ -377,15 +375,17 @@ pub fn compute_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
     resources: &mut [Resource],
     providers: &[ProviderConfig],
-) -> Result<(), AppError> {
-    identifier::compute_anonymous_identifiers(
+) -> Vec<AppError> {
+    match identifier::compute_anonymous_identifiers(
         resources,
         providers,
         ctx.schemas(),
         &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &|name| identity_attributes_for_provider(ctx, name),
-    )
-    .map_err(AppError::Config)
+    ) {
+        Ok(()) => Vec::new(),
+        Err(msg) => vec![AppError::Config(msg)],
+    }
 }
 
 /// Encapsulates the plan-time normalization pipeline.
@@ -1381,7 +1381,41 @@ pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
         resources: resources.to_vec(),
         ..ParsedFile::default()
     };
-    let errors = validate_resources_with_ctx(&ctx, &parsed);
+    errors_to_legacy_result(validate_resources_with_ctx(&ctx, &parsed))
+}
+
+#[cfg(test)]
+pub fn resolve_names(resources: &mut [Resource]) -> Result<(), AppError> {
+    let ctx = WiringContext::new(vec![]);
+    errors_to_legacy_result(resolve_names_with_ctx(&ctx, resources))
+}
+
+#[cfg(test)]
+pub fn resolve_attr_prefixes(resources: &mut [Resource]) -> Result<(), AppError> {
+    let ctx = WiringContext::new(vec![]);
+    errors_to_legacy_result(resolve_attr_prefixes_with_ctx(&ctx, resources))
+}
+
+#[cfg(test)]
+pub fn compute_anonymous_identifiers(
+    resources: &mut [Resource],
+    providers: &[ProviderConfig],
+) -> Result<(), AppError> {
+    let ctx = WiringContext::new(vec![]);
+    let errors = compute_anonymous_identifiers_with_ctx(&ctx, resources, providers);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(crate::commands::collapse_errors(errors))
+    }
+}
+
+/// Test-only adapter: collapse a `Vec<AppError>` back into the
+/// `Result<(), AppError>` shape pre-#2105 callers expect. Always
+/// joins as `AppError::Validation` — the three wrappers that use it
+/// only return validation-kind errors.
+#[cfg(test)]
+fn errors_to_legacy_result(errors: Vec<AppError>) -> Result<(), AppError> {
     if errors.is_empty() {
         Ok(())
     } else {
@@ -1393,27 +1427,6 @@ pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
                 .join("\n"),
         ))
     }
-}
-
-#[cfg(test)]
-pub fn resolve_names(resources: &mut [Resource]) -> Result<(), AppError> {
-    let ctx = WiringContext::new(vec![]);
-    resolve_names_with_ctx(&ctx, resources)
-}
-
-#[cfg(test)]
-pub fn resolve_attr_prefixes(resources: &mut [Resource]) -> Result<(), AppError> {
-    let ctx = WiringContext::new(vec![]);
-    resolve_attr_prefixes_with_ctx(&ctx, resources)
-}
-
-#[cfg(test)]
-pub fn compute_anonymous_identifiers(
-    resources: &mut [Resource],
-    providers: &[ProviderConfig],
-) -> Result<(), AppError> {
-    let ctx = WiringContext::new(vec![]);
-    compute_anonymous_identifiers_with_ctx(&ctx, resources, providers)
 }
 
 #[cfg(test)]
@@ -1932,5 +1945,27 @@ mod tests {
         for err in &errors {
             assert!(matches!(err, AppError::Validation(_)), "got {err:?}");
         }
+    }
+
+    // Smoke test for the dependency-chain wrappers: empty input
+    // exercises each wrapper and pins the `Vec<AppError>` return
+    // type. A regression back to `Result` fails to compile here.
+    #[test]
+    fn dependency_chain_wrappers_return_vec_app_error() {
+        let ctx = WiringContext::new(vec![]);
+        let mut resources: Vec<Resource> = Vec::new();
+        let providers: Vec<ProviderConfig> = Vec::new();
+
+        let errors = resolve_names_with_ctx(&ctx, &mut resources);
+        assert!(errors.is_empty(), "resolve_names: got {errors:?}");
+
+        let errors = resolve_attr_prefixes_with_ctx(&ctx, &mut resources);
+        assert!(errors.is_empty(), "resolve_attr_prefixes: got {errors:?}");
+
+        let errors = compute_anonymous_identifiers_with_ctx(&ctx, &mut resources, &providers);
+        assert!(
+            errors.is_empty(),
+            "compute_anonymous_identifiers: got {errors:?}",
+        );
     }
 }


### PR DESCRIPTION
Refs #2105 — Part 2 of 4

## Summary

- Flip the three dependency-ordered wrappers in `carina-cli/src/wiring.rs` from `Result<(), AppError>` to `Vec<AppError>`:
  - `resolve_names_with_ctx` (concats `resolve_block_names` + `resolve_attr_prefixes` findings)
  - `resolve_attr_prefixes_with_ctx`
  - `compute_anonymous_identifiers_with_ctx` (uses `AppError::Config`)
- Drive `validate_and_resolve_with_config` with a single top-level accumulator; guards halt the pipeline only where downstream steps assume earlier work succeeded (name resolution before per-resource schema checks; identifier computation before plan generation).
- Introduce `commands::collapse_errors(Vec<AppError>) -> AppError`: preserves the variant for a single finding (so `AppError::Config` reaches `run_validate` unchanged) and joins multiple findings as `AppError::Validation`.

Follow-up PRs:
- PR 3: module / provider validators
- PR 4: remove the `run_validate` special-case from #2106 and retire the join-then-split round-trip; `Closes #2105`

## Test plan

- [x] `cargo test --workspace` passes (263 carina-cli tests; full workspace green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] New `dependency_chain_wrappers_return_vec_app_error` test pins the `Vec<AppError>` signature; a regression fails to compile
- [x] Existing `test_resolve_attr_prefixes_*`, `test_resolve_names_*`, `test_plan_verify_idempotency_*` snapshot tests continue to pass, confirming the test-facing `Result` wrappers preserve prior semantics