### PR TITLE
wiring: return Vec<AppError> from module/provider validator wrappers

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -196,25 +196,36 @@ pub fn validate_and_resolve_with_config(
         }
     }
 
+    let mut errors: Vec<AppError> = Vec::new();
+
     // Validate provider region
-    validate_provider_region_with_ctx(&ctx, parsed)?;
+    errors.extend(validate_provider_region_with_ctx(&ctx, parsed));
 
     // Enrich provider context with custom type validators from loaded schemas
     let enriched_context = enrich_provider_context(ctx.schemas(), ctx.factories_arc());
 
-    // Validate module call arguments before expansion (needs enriched context for custom type validators)
-    validate_module_calls(parsed, base_dir, &enriched_context)?;
+    // Validate module call arguments before expansion (needs enriched
+    // context for custom type validators)
+    errors.extend(validate_module_calls(parsed, base_dir, &enriched_context));
 
     // Validate module attribute parameter ref types before expansion
     if !skip_resource_validation {
-        validate_module_attribute_param_types(&ctx, parsed, base_dir)?;
+        errors.extend(validate_module_attribute_param_types(
+            &ctx, parsed, base_dir,
+        ));
+    }
+
+    // Module expansion assumes the checks above succeeded — feeding
+    // broken module calls into `resolve_modules_with_config` can
+    // surface confusing secondary errors, so gate it on a clean
+    // accumulator.
+    if !errors.is_empty() {
+        return Err(collapse_errors(errors));
     }
 
     // Resolve module imports and expand module calls
     module_resolver::resolve_modules_with_config(parsed, base_dir, &enriched_context)
         .map_err(|e| format!("Module resolution error: {}", e))?;
-
-    let mut errors: Vec<AppError> = Vec::new();
 
     // Resolve names (let bindings -> resource names) — must succeed
     // before per-resource schema checks can look up the renamed

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -565,15 +565,18 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
 pub fn validate_provider_region_with_ctx(
     ctx: &WiringContext,
     parsed: &ParsedFile,
-) -> Result<(), AppError> {
-    validation::validate_provider_config(parsed, ctx.factories()).map_err(AppError::Validation)
+) -> Vec<AppError> {
+    lift_validation_result(validation::validate_provider_config(
+        parsed,
+        ctx.factories(),
+    ))
 }
 
 pub fn validate_module_calls(
     parsed: &ParsedFile,
     base_dir: &Path,
     config: &carina_core::parser::ProviderContext,
-) -> Result<(), AppError> {
+) -> Vec<AppError> {
     let mut imported_modules = HashMap::new();
     for import in &parsed.imports {
         let module_path = base_dir.join(&import.path);
@@ -582,15 +585,19 @@ pub fn validate_module_calls(
         }
     }
 
-    validation::validate_module_calls(&parsed.module_calls, &imported_modules, config)
-        .map_err(AppError::Validation)
+    lift_validation_result(validation::validate_module_calls(
+        &parsed.module_calls,
+        &imported_modules,
+        config,
+    ))
 }
 
 pub fn validate_module_attribute_param_types(
     ctx: &WiringContext,
     parsed: &ParsedFile,
     base_dir: &Path,
-) -> Result<(), AppError> {
+) -> Vec<AppError> {
+    let mut errors = Vec::new();
     for import in &parsed.imports {
         let module_path = base_dir.join(&import.path);
         let Some(module_parsed) = module_resolver::load_module(&module_path) else {
@@ -599,15 +606,24 @@ pub fn validate_module_attribute_param_types(
         if module_parsed.attribute_params.is_empty() {
             continue;
         }
-        validation::validate_attribute_param_ref_types(
+        if let Err(joined) = validation::validate_attribute_param_ref_types(
             &module_parsed.attribute_params,
             &module_parsed.resources,
             ctx.schemas(),
             &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
-        )
-        .map_err(|e| AppError::Validation(format!("{}: {}", import.path, e)))?;
+        ) {
+            // Preserve the module-path prefix the legacy wrapper emitted
+            // so diagnostics point at which imported module failed.
+            let prefix = import.path.to_string();
+            errors.extend(
+                joined
+                    .split('\n')
+                    .filter(|s| !s.is_empty())
+                    .map(|s| AppError::Validation(format!("{}: {}", prefix, s))),
+            );
+        }
     }
-    Ok(())
+    errors
 }
 
 pub async fn get_provider_with_ctx(
@@ -1966,6 +1982,29 @@ mod tests {
         assert!(
             errors.is_empty(),
             "compute_anonymous_identifiers: got {errors:?}",
+        );
+    }
+
+    // Smoke test for the module/provider wrappers: empty input exercises
+    // each wrapper and pins the `Vec<AppError>` return type. A regression
+    // back to `Result` fails to compile here.
+    #[test]
+    fn module_and_provider_wrappers_return_vec_app_error() {
+        let ctx = WiringContext::new(vec![]);
+        let parsed = ParsedFile::default();
+        let base_dir = std::path::Path::new("/tmp/nonexistent-carina-pr3-test");
+        let provider_ctx = carina_core::parser::ProviderContext::default();
+
+        let errors = validate_provider_region_with_ctx(&ctx, &parsed);
+        assert!(errors.is_empty(), "provider_region: got {errors:?}");
+
+        let errors = validate_module_calls(&parsed, base_dir, &provider_ctx);
+        assert!(errors.is_empty(), "module_calls: got {errors:?}");
+
+        let errors = validate_module_attribute_param_types(&ctx, &parsed, base_dir);
+        assert!(
+            errors.is_empty(),
+            "module_attribute_param_types: got {errors:?}",
         );
     }
 }


### PR DESCRIPTION
Refs #2105 — Part 3 of 4

## Summary

- Flip the three module- and provider-level wrappers in `carina-cli/src/wiring.rs` from `Result<(), AppError>` to `Vec<AppError>`:
  - `validate_provider_region_with_ctx`
  - `validate_module_calls`
  - `validate_module_attribute_param_types`
- Feed their findings into the top-level `errors` accumulator in `validate_and_resolve_with_config` and place a single guard before `module_resolver::resolve_modules_with_config` so broken module calls don't cascade into confusing secondary errors during expansion.

Follow-up:
- PR 4: retire the `run_validate` special-case from #2106, drop the join-then-split round-trip, `Closes #2105`.

## Test plan

- [x] `cargo test --workspace` passes (264 carina-cli tests; full workspace green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] New `module_and_provider_wrappers_return_vec_app_error` smoke test pins the `Vec<AppError>` signature; a regression fails to compile