### PR TITLE
parser: plumb string-literal origin tag for enum diagnostics (1/3)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -494,6 +494,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: std::collections::HashSet::new(),
         }
     }
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -681,6 +681,7 @@ fn test_find_state_bucket_resource_matching_type() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        string_literal_paths: std::collections::HashSet::new(),
     };
 
     // Matching resource type
@@ -1976,6 +1977,7 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
         structural_bindings: HashSet::new(),
         warnings: vec![],
         deferred_for_expressions: vec![],
+        string_literal_paths: std::collections::HashSet::new(),
     };
 
     // MockProvider returns not_found for both resources (simulates external deletion)

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -1,6 +1,6 @@
 //! Configuration loading and .crn file discovery utilities
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -49,24 +49,7 @@ pub fn load_configuration_with_config(
             return Err(format!("No .crn files found in {}", path.display()));
         }
 
-        let empty_parsed = || ParsedFile {
-            providers: vec![],
-            resources: vec![],
-            variables: HashMap::new(),
-            imports: vec![],
-            module_calls: vec![],
-            arguments: vec![],
-            attribute_params: vec![],
-            export_params: vec![],
-            backend: None,
-            state_blocks: vec![],
-            user_functions: HashMap::new(),
-            upstream_states: vec![],
-            requires: vec![],
-            structural_bindings: HashSet::new(),
-            warnings: vec![],
-            deferred_for_expressions: vec![],
-        };
+        let empty_parsed = ParsedFile::default;
         let mut merged = empty_parsed();
         let mut unresolved_merged = empty_parsed();
         let mut parse_errors = Vec::new();

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -897,6 +897,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         }
     }
 
@@ -1033,6 +1034,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         }
     }
 
@@ -1160,6 +1162,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         }
     }
 
@@ -1510,6 +1513,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         }
     }
 
@@ -1827,6 +1831,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         }
     }
 
@@ -1999,6 +2004,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {
@@ -2064,6 +2070,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {
@@ -2157,6 +2164,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {
@@ -2226,6 +2234,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {
@@ -2292,6 +2301,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {
@@ -2384,6 +2394,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: vec![],
             deferred_for_expressions: vec![],
+            string_literal_paths: HashSet::new(),
         };
 
         let resolver = {

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -454,6 +454,24 @@ pub struct UpstreamState {
     pub source: std::path::PathBuf,
 }
 
+/// Path identifying a single attribute (possibly nested) on a specific resource.
+///
+/// Used to tag which attribute values were written as a quoted string literal
+/// in the DSL (e.g. `target_type = "aaa"`) versus a bare identifier or
+/// namespaced identifier (e.g. `target_type = AWS_ACCOUNT`). The parser drops
+/// both of those origins into `Value::String`, so consumers that care about
+/// the distinction (enum-variant diagnostics, primarily) consult this set.
+///
+/// `attribute_chain` uses the field name for struct / map descents and the
+/// decimal string index for list descents, matching the path shape used by
+/// nested-struct validation. The top-level attribute name (e.g.
+/// `["target_type"]`) is the common case.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StringLiteralPath {
+    pub resource_id: ResourceId,
+    pub attribute_chain: Vec<String>,
+}
+
 /// Parse result
 #[derive(Debug, Clone, Default)]
 pub struct ParsedFile {
@@ -487,6 +505,10 @@ pub struct ParsedFile {
     pub warnings: Vec<ParseWarning>,
     /// For-expressions whose iterables are unresolved; displayed as deferred in plan.
     pub deferred_for_expressions: Vec<DeferredForExpression>,
+    /// Attribute paths whose value was written as a quoted string literal in
+    /// the source (as opposed to a bare or namespaced identifier). Parse-time
+    /// information only; not persisted in state.
+    pub string_literal_paths: HashSet<StringLiteralPath>,
 }
 
 impl ParsedFile {
@@ -740,6 +762,12 @@ struct ParseContext<'cfg> {
     warnings: Vec<ParseWarning>,
     /// Deferred for-expressions collected during parsing
     deferred_for_expressions: Vec<DeferredForExpression>,
+    /// Attribute paths whose RHS in the source is a plain quoted string
+    /// literal. Populated by `parse_block_contents` while walking attribute
+    /// values of a resource; handed back to `ParsedFile` at the top level.
+    /// Wrapped in `Rc<RefCell<..>>` so that `ctx.clone()` (done for local
+    /// block scopes) shares the same underlying set.
+    string_literal_paths: std::rc::Rc<std::cell::RefCell<HashSet<StringLiteralPath>>>,
 }
 
 impl<'cfg> ParseContext<'cfg> {
@@ -755,7 +783,12 @@ impl<'cfg> ParseContext<'cfg> {
             upstream_states: HashMap::new(),
             warnings: Vec::new(),
             deferred_for_expressions: Vec::new(),
+            string_literal_paths: std::rc::Rc::new(std::cell::RefCell::new(HashSet::new())),
         }
+    }
+
+    fn record_string_literal(&self, path: StringLiteralPath) {
+        self.string_literal_paths.borrow_mut().insert(path);
     }
 
     fn set_variable(&mut self, name: String, value: Value) {
@@ -1070,6 +1103,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         &export_params,
     )?;
 
+    let string_literal_paths = ctx.string_literal_paths.borrow().clone();
     Ok(ParsedFile {
         providers,
         resources,
@@ -1087,6 +1121,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         structural_bindings: ctx.structural_bindings,
         warnings: ctx.warnings,
         deferred_for_expressions: ctx.deferred_for_expressions,
+        string_literal_paths,
     })
 }
 
@@ -3520,6 +3555,7 @@ fn parse_anonymous_resource(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
 ) -> Result<Resource, ParseError> {
+    let body_pairs_clone = pair.clone().into_inner();
     let mut inner = pair.into_inner();
 
     let namespaced_type = next_pair(&mut inner, "resource type", "anonymous resource")?
@@ -3547,8 +3583,11 @@ fn parse_anonymous_resource(
     // Extract lifecycle block from attributes (it's a meta-argument, not a real attribute)
     let lifecycle = extract_lifecycle_config(&mut attributes);
 
+    let id = ResourceId::with_provider(provider, resource_type, resource_name);
+    record_string_literal_paths_for_resource(body_pairs_clone, &id, ctx);
+
     Ok(Resource {
-        id: ResourceId::with_provider(provider, resource_type, resource_name),
+        id,
         attributes: Expr::wrap_map(attributes),
         kind: ResourceKind::Real,
         lifecycle,
@@ -3557,6 +3596,246 @@ fn parse_anonymous_resource(
         dependency_bindings: Vec::new(),
         module_source: None,
     })
+}
+
+/// Walk a parsed resource body and record every attribute whose value is a
+/// plain quoted string literal (as opposed to a bare identifier or a
+/// namespaced identifier). The parser collapses all three into
+/// `Value::String`, so downstream diagnostics that need to distinguish them
+/// (e.g. "expected an enum identifier, got a string literal") consult this
+/// set. See #2094.
+///
+/// `pairs` is the `into_inner()` of the resource expression (starting with
+/// the namespaced resource type); the type pair is skipped here.
+fn record_string_literal_paths_for_resource(
+    pairs: pest::iterators::Pairs<Rule>,
+    resource_id: &ResourceId,
+    ctx: &ParseContext,
+) {
+    let mut remaining = pairs;
+    // Skip the leading namespaced type pair (e.g. `aws.s3_bucket`).
+    let _ = remaining.next();
+    record_string_literal_paths_in_block(remaining, resource_id, &[], ctx);
+}
+
+fn record_string_literal_paths_in_block(
+    pairs: pest::iterators::Pairs<Rule>,
+    resource_id: &ResourceId,
+    base_path: &[String],
+    ctx: &ParseContext,
+) {
+    // Track occurrence count per nested block name so a path like
+    // `["rules", "0", "protocol"]` vs `["rules", "1", "protocol"]` stays
+    // distinct — the schema validator walks list items by index.
+    let mut nested_block_counts: HashMap<String, usize> = HashMap::new();
+
+    for content_pair in pairs {
+        let item = match content_pair.as_rule() {
+            Rule::block_content => match content_pair.into_inner().next() {
+                Some(inner) => inner,
+                None => continue,
+            },
+            Rule::attribute => content_pair,
+            _ => continue,
+        };
+
+        match item.as_rule() {
+            Rule::attribute => {
+                let mut attr_inner = item.into_inner();
+                let key_pair = match attr_inner.next() {
+                    Some(k) => k,
+                    None => continue,
+                };
+                let key = match attribute_key_text(key_pair) {
+                    Some(k) => k,
+                    None => continue,
+                };
+                let value_pair = match attr_inner.next() {
+                    Some(v) => v,
+                    None => continue,
+                };
+                let mut chain = base_path.to_vec();
+                chain.push(key);
+                record_string_literals_in_expression(value_pair, resource_id, &chain, ctx);
+            }
+            Rule::nested_block => {
+                let mut block_inner = item.into_inner();
+                let name_pair = match block_inner.next() {
+                    Some(n) => n,
+                    None => continue,
+                };
+                let block_name = name_pair.as_str().to_string();
+                let index = nested_block_counts.entry(block_name.clone()).or_insert(0);
+                let idx = *index;
+                *index += 1;
+                let mut chain = base_path.to_vec();
+                chain.push(block_name);
+                chain.push(idx.to_string());
+                record_string_literal_paths_in_block(block_inner, resource_id, &chain, ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn attribute_key_text(pair: pest::iterators::Pair<Rule>) -> Option<String> {
+    match pair.as_rule() {
+        Rule::identifier => Some(pair.as_str().to_string()),
+        Rule::string => extract_plain_string_key(pair),
+        _ => None,
+    }
+}
+
+/// Best-effort extraction of the textual content of a `Rule::string` pair used
+/// as an attribute key. Interpolation in keys is already disallowed elsewhere
+/// in the parser; here we just read the literal segments and concatenate.
+fn extract_plain_string_key(pair: pest::iterators::Pair<Rule>) -> Option<String> {
+    let inner = pair.into_inner().next()?;
+    match inner.as_rule() {
+        Rule::single_quoted_string => inner.into_inner().next().map(|p| p.as_str().to_string()),
+        Rule::double_quoted_string => {
+            let mut out = String::new();
+            for part in inner.into_inner() {
+                if part.as_rule() == Rule::string_part {
+                    for leaf in part.into_inner() {
+                        if leaf.as_rule() == Rule::string_literal {
+                            out.push_str(leaf.as_str());
+                        }
+                    }
+                }
+            }
+            Some(out)
+        }
+        _ => None,
+    }
+}
+
+/// Walk an `expression` pair and, if it unwraps to a plain string primary
+/// (no function calls, no operators, no interpolation), record the attribute
+/// at `chain` as coming from a quoted string literal. Also descends into
+/// list/map literals to tag their elements.
+fn record_string_literals_in_expression(
+    pair: pest::iterators::Pair<Rule>,
+    resource_id: &ResourceId,
+    chain: &[String],
+    ctx: &ParseContext,
+) {
+    // expression -> coalesce_expr -> pipe_expr -> compose_expr -> primary
+    // Only "bare" chains (no pipes, no composes, no coalesce) can represent a
+    // pure literal.
+    let primary = match unwrap_to_primary(pair) {
+        Some(p) => p,
+        None => return,
+    };
+    let inner = match primary.into_inner().next() {
+        Some(i) => i,
+        None => return,
+    };
+    match inner.as_rule() {
+        // A `Rule::string` primary that has no interpolation is the one shape
+        // we tag; interpolated values like `"prefix-${name}"` do not count.
+        Rule::string if is_plain_string_without_interpolation(&inner) => {
+            ctx.record_string_literal(StringLiteralPath {
+                resource_id: resource_id.clone(),
+                attribute_chain: chain.to_vec(),
+            });
+        }
+        Rule::list => {
+            for (i, item) in inner.into_inner().enumerate() {
+                let mut c = chain.to_vec();
+                c.push(i.to_string());
+                record_string_literals_in_expression(item, resource_id, &c, ctx);
+            }
+        }
+        Rule::map => {
+            let mut nested_counts: HashMap<String, usize> = HashMap::new();
+            for entry in inner.into_inner() {
+                match entry.as_rule() {
+                    Rule::map_entry => {
+                        let mut ei = entry.into_inner();
+                        let key_pair = match ei.next() {
+                            Some(k) => k,
+                            None => continue,
+                        };
+                        let key = match attribute_key_text(key_pair) {
+                            Some(k) => k,
+                            None => continue,
+                        };
+                        let value_pair = match ei.next() {
+                            Some(v) => v,
+                            None => continue,
+                        };
+                        let mut c = chain.to_vec();
+                        c.push(key);
+                        record_string_literals_in_expression(value_pair, resource_id, &c, ctx);
+                    }
+                    Rule::nested_block => {
+                        let mut bi = entry.into_inner();
+                        let name_pair = match bi.next() {
+                            Some(n) => n,
+                            None => continue,
+                        };
+                        let block_name = name_pair.as_str().to_string();
+                        let index = nested_counts.entry(block_name.clone()).or_insert(0);
+                        let idx = *index;
+                        *index += 1;
+                        let mut c = chain.to_vec();
+                        c.push(block_name);
+                        c.push(idx.to_string());
+                        record_string_literal_paths_in_block(bi, resource_id, &c, ctx);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Walk `expression` (or any intermediate operator rule) down to the first
+/// `primary`, returning `None` if any operator (|>, >>, ??) has more than
+/// one operand — such chains are expressions, not pure literals.
+fn unwrap_to_primary(pair: pest::iterators::Pair<Rule>) -> Option<pest::iterators::Pair<Rule>> {
+    let rule = pair.as_rule();
+    match rule {
+        Rule::primary => Some(pair),
+        Rule::expression | Rule::coalesce_expr | Rule::pipe_expr | Rule::compose_expr => {
+            let mut inner = pair.into_inner();
+            let first = inner.next()?;
+            if inner.next().is_some() {
+                // Second operand means an operator is applied — not a literal.
+                return None;
+            }
+            unwrap_to_primary(first)
+        }
+        _ => None,
+    }
+}
+
+fn is_plain_string_without_interpolation(pair: &pest::iterators::Pair<Rule>) -> bool {
+    // Rule::string -> (single_quoted_string | double_quoted_string)
+    let inner = match pair.clone().into_inner().next() {
+        Some(i) => i,
+        None => return false,
+    };
+    match inner.as_rule() {
+        // Single-quoted strings do not support interpolation.
+        Rule::single_quoted_string => true,
+        Rule::double_quoted_string => {
+            for part in inner.into_inner() {
+                if part.as_rule() != Rule::string_part {
+                    continue;
+                }
+                for leaf in part.into_inner() {
+                    if leaf.as_rule() == Rule::interpolation {
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Parse block contents (attributes, nested blocks, and local let bindings)
@@ -3668,6 +3947,7 @@ fn parse_resource_expr(
     ctx: &ParseContext,
     binding_name: &str,
 ) -> Result<Resource, ParseError> {
+    let body_pairs_clone = pair.clone().into_inner();
     let mut inner = pair.into_inner();
 
     let namespaced_type = next_pair(&mut inner, "resource type", "resource expression")?
@@ -3694,8 +3974,11 @@ fn parse_resource_expr(
 
     attributes.insert("_type".to_string(), Value::String(namespaced_type.clone()));
 
+    let id = ResourceId::with_provider(provider, resource_type, resource_name);
+    record_string_literal_paths_for_resource(body_pairs_clone, &id, ctx);
+
     Ok(Resource {
-        id: ResourceId::with_provider(provider, resource_type, resource_name),
+        id,
         attributes: Expr::wrap_map(attributes),
         kind: ResourceKind::Real,
         lifecycle,
@@ -3712,6 +3995,7 @@ fn parse_read_resource_expr(
     ctx: &ParseContext,
     binding_name: &str,
 ) -> Result<Resource, ParseError> {
+    let body_pairs_clone = pair.clone().into_inner();
     let mut inner = pair.into_inner();
 
     let namespaced_type = next_pair(&mut inner, "resource type", "read resource expression")?
@@ -3740,8 +4024,11 @@ fn parse_read_resource_expr(
     // Mark as data source
     attributes.insert("_data_source".to_string(), Value::Bool(true));
 
+    let id = ResourceId::with_provider(provider, resource_type, resource_name);
+    record_string_literal_paths_for_resource(body_pairs_clone, &id, ctx);
+
     Ok(Resource {
-        id: ResourceId::with_provider(provider, resource_type, resource_name),
+        id,
         attributes: Expr::wrap_map(attributes),
         kind: ResourceKind::DataSource,
         lifecycle,
@@ -11404,6 +11691,109 @@ awscc.ec2.vpc {
             result.is_ok(),
             "Reference to upstream_state binding must parse: {:?}",
             result.err()
+        );
+    }
+
+    /// Issue #2094: distinguish quoted string literals from bare identifiers
+    /// and namespaced identifiers at the parser level, so downstream enum
+    /// diagnostics can report shape mismatches ("got a string literal") vs.
+    /// variant mismatches ("invalid enum variant").
+    #[test]
+    fn string_literal_paths_distinguish_quoted_from_bare_and_namespaced() {
+        let input = r#"
+            let a = aws.sso_admin.principal_assignment {
+                target_type = "aaa"
+            }
+
+            let b = aws.sso_admin.principal_assignment {
+                target_type = AWS_ACCOUNT
+            }
+
+            let c = aws.sso_admin.principal_assignment {
+                target_type = awscc.sso.assignment.TargetType.AWS_ACCOUNT
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+
+        let paths = &parsed.string_literal_paths;
+
+        let quoted = StringLiteralPath {
+            resource_id: ResourceId::with_provider("aws", "sso_admin.principal_assignment", "a"),
+            attribute_chain: vec!["target_type".to_string()],
+        };
+        assert!(
+            paths.contains(&quoted),
+            "quoted literal `target_type = \"aaa\"` must be recorded; paths = {:?}",
+            paths
+        );
+
+        let bare = StringLiteralPath {
+            resource_id: ResourceId::with_provider("aws", "sso_admin.principal_assignment", "b"),
+            attribute_chain: vec!["target_type".to_string()],
+        };
+        assert!(
+            !paths.contains(&bare),
+            "bare identifier `target_type = AWS_ACCOUNT` must NOT be recorded as a string literal; paths = {:?}",
+            paths
+        );
+
+        let namespaced = StringLiteralPath {
+            resource_id: ResourceId::with_provider("aws", "sso_admin.principal_assignment", "c"),
+            attribute_chain: vec!["target_type".to_string()],
+        };
+        assert!(
+            !paths.contains(&namespaced),
+            "namespaced identifier must NOT be recorded as a string literal; paths = {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn string_literal_paths_record_nested_block_attributes() {
+        // Nested block `rules { protocol = "tcp" }` should produce a path
+        // with the block name and its per-occurrence index, matching how the
+        // schema validator walks list-of-struct values.
+        let input = r#"
+            let sg = aws.ec2.security_group {
+                name = "sg-1"
+                rules {
+                    protocol = "tcp"
+                }
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+
+        let expected = StringLiteralPath {
+            resource_id: ResourceId::with_provider("aws", "ec2.security_group", "sg"),
+            attribute_chain: vec!["rules".to_string(), "0".to_string(), "protocol".to_string()],
+        };
+        assert!(
+            parsed.string_literal_paths.contains(&expected),
+            "nested-block string literal must be recorded with index path; paths = {:?}",
+            parsed.string_literal_paths
+        );
+    }
+
+    #[test]
+    fn string_literal_paths_skip_interpolated_strings() {
+        // An interpolated string is not a "plain" literal — users who write
+        // "${x}" are constructing a value, not typing an enum by mistake.
+        let input = r#"
+            let x = "env"
+            let r = aws.s3_bucket {
+                name = "bucket-${x}"
+            }
+        "#;
+        let parsed = parse(input, &ProviderContext::default()).unwrap();
+
+        let interpolated = StringLiteralPath {
+            resource_id: ResourceId::with_provider("aws", "s3_bucket", "r"),
+            attribute_chain: vec!["name".to_string()],
+        };
+        assert!(
+            !parsed.string_literal_paths.contains(&interpolated),
+            "interpolated strings must not be tagged as plain literals; paths = {:?}",
+            parsed.string_literal_paths
         );
     }
 }

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -709,6 +709,7 @@ mod tests {
             structural_bindings: HashSet::new(),
             warnings: Vec::new(),
             deferred_for_expressions: Vec::new(),
+            string_literal_paths: std::collections::HashSet::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
First of three PRs for #2094. Adds parse-time tracking of which attribute
values were written as a quoted string literal (e.g. `target_type = \"aaa\"`)
versus a bare identifier (`AWS_ACCOUNT`) or namespaced identifier
(`awscc.sso.assignment.TargetType.AWS_ACCOUNT`). The parser collapses all
three into `Value::String`, so downstream StringEnum validation can't tell a
shape mismatch from a variant mismatch today.

This PR is plumbing only — no diagnostics change. PR 2 will consume the new
`ParsedFile::string_literal_paths` set from the enum validator to emit
`StringLiteralExpectedEnum`. PR 3 extends the same to LSP + Custom namespaced
types.

## What changed
- New `StringLiteralPath { resource_id, attribute_chain }` type on
  `carina_core::parser`. `attribute_chain` uses the field name for struct /
  map descents and the decimal index for list / nested-block repetitions,
  matching how the schema validator walks nested values.
- `ParsedFile::string_literal_paths: HashSet<StringLiteralPath>` populated
  by walking each resource body's pest tree after parse.
- Not persisted: this is parse-time-only information, so existing state
  files are untouched.
- Existing `ParsedFile { .. }` struct literals in tests and wiring updated to
  supply the new field (or switched to `Default::default()`).

## Test plan
- [x] `string_literal_paths_distinguish_quoted_from_bare_and_namespaced` —
  only the quoted-literal form is tagged.
- [x] `string_literal_paths_record_nested_block_attributes` — `rules { protocol = \"tcp\" }`
  produces `[\"rules\", \"0\", \"protocol\"]`.
- [x] `string_literal_paths_skip_interpolated_strings` — `\"prefix-\${x}\"` is
  not tagged.
- [x] `cargo test --workspace` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Refs #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)