### PR TITLE
lsp, schema: extend string-literal enum diagnostic to LSP + Custom types (3/3)

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -690,6 +690,55 @@ fn string_enum_value_matches(input: &str, expected: &str) -> bool {
 /// context. Presence of `attribute` and `type_name` is independent — both,
 /// either, or neither may be set. `expected` is rendered as-is; callers are
 /// responsible for passing fully-qualified variants for namespaced enums.
+/// Reshape an error from `AttributeType::validate` into a shape-mismatch
+/// diagnostic when the attribute's value came from a quoted string literal
+/// and the schema expects an enum-shaped identifier (a `StringEnum`, or a
+/// namespaced `Custom` type).
+///
+/// For `StringEnum`, `into_string_literal_diagnostic` does the work since
+/// the underlying error already carries type name and variants. For a
+/// namespaced `Custom`, validation returns `ValidationFailed { message }`
+/// with no structured fields — we still emit
+/// `StringLiteralExpectedEnum` using the semantic name, leaving `expected`
+/// empty because the custom validator doesn't enumerate variants. The
+/// originating message is carried along through the formatter's
+/// `expected` slot so it doesn't get lost.
+fn reshape_for_string_literal(
+    tagged: TypeError,
+    attr_type: &AttributeType,
+    value: &Value,
+    attr_name: &str,
+) -> TypeError {
+    // StringEnum: the error already has enough structure to reshape cleanly.
+    if matches!(attr_type, AttributeType::StringEnum { .. }) {
+        return tagged.into_string_literal_diagnostic();
+    }
+
+    // Namespaced Custom: manually build the shape-mismatch diagnostic from
+    // the semantic name. `ValidationFailed` has no attribute slot so
+    // `with_attribute` is a no-op; we thread the attribute name in
+    // explicitly. `expected` is left empty — custom validators don't
+    // enumerate variants — but we carry the original validator message in
+    // it so its detail (which often lists valid forms) stays visible.
+    if let AttributeType::Custom {
+        semantic_name: Some(name),
+        namespace: Some(_),
+        ..
+    } = attr_type
+        && let Value::String(typed) = value
+        && let TypeError::ValidationFailed { message } = &tagged
+    {
+        return TypeError::StringLiteralExpectedEnum {
+            user_typed: typed.clone(),
+            attribute: Some(attr_name.to_string()),
+            type_name: name.clone(),
+            expected: vec![message.clone()],
+        };
+    }
+
+    tagged
+}
+
 fn format_string_literal_expected_enum(
     user_typed: &str,
     attribute: Option<&str>,
@@ -1369,7 +1418,7 @@ impl ResourceSchema {
                     // point back at a token that appears in their source.
                     let tagged = e.with_attribute(name);
                     let reshaped = if is_string_literal(name.as_str()) {
-                        tagged.into_string_literal_diagnostic()
+                        reshape_for_string_literal(tagged, &schema.attr_type, value, name)
                     } else {
                         tagged
                     };
@@ -2366,6 +2415,57 @@ mod tests {
         assert!(
             schema.validate_with_origins(&attrs, &|_| true).is_ok(),
             "valid enum value should pass regardless of origin tag"
+        );
+    }
+
+    #[test]
+    fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
+        // #2094 / PR 3: a quoted literal written against an
+        // `AttributeType::Custom` with a namespace must also surface as
+        // `StringLiteralExpectedEnum`. Custom validation returns
+        // `ValidationFailed { message }` with no structured type slots, so
+        // the reshape carries the original message forward in `expected`
+        // while marking the variant and type name correctly.
+        fn validate_mode(v: &Value) -> Result<(), String> {
+            match v {
+                Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
+                Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+                _ => Err("expected string".to_string()),
+            }
+        }
+        let schema = ResourceSchema::new("test.r.mode_holder").attribute(
+            AttributeSchema::new(
+                "mode",
+                AttributeType::Custom {
+                    semantic_name: Some("Mode".to_string()),
+                    base: Box::new(AttributeType::String),
+                    pattern: None,
+                    length: None,
+                    validate: validate_mode,
+                    namespace: Some("test.r".to_string()),
+                    to_dsl: None,
+                },
+            )
+            .required(),
+        );
+        let mut attrs = HashMap::new();
+        // Two-part form like "test.r.Mode.aaa" would skip the Custom
+        // branch by passing validation; use a bare-shape literal that
+        // resolve_enum_input can't save.
+        attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+        let errs = schema
+            .validate_with_origins(&attrs, &|n| n == "mode")
+            .unwrap_err();
+        let variant_match = errs.iter().any(|e| {
+            matches!(
+                e,
+                TypeError::StringLiteralExpectedEnum { type_name, .. }
+                    if type_name == "Mode"
+            )
+        });
+        assert!(
+            variant_match,
+            "expected StringLiteralExpectedEnum for Custom namespaced type, got: {errs:?}"
         );
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -425,11 +425,24 @@ impl DiagnosticEngine {
                                 ),
                                 // Custom type validation (all Custom types use their validate fn)
                                 (carina_core::schema::AttributeType::StringEnum { .. }, value) => {
-                                    attr_schema
-                                        .attr_type
-                                        .validate(value)
-                                        .err()
-                                        .map(|e| e.with_attribute(attr_name).to_string())
+                                    attr_schema.attr_type.validate(value).err().map(|e| {
+                                        let tagged = e.with_attribute(attr_name);
+                                        // Mirror PR 2 (#2112) diagnostic parity in the LSP:
+                                        // if the parser tagged this attribute as a quoted
+                                        // string literal, reshape the enum-variant error
+                                        // into the shape-mismatch variant so editor hovers
+                                        // match CLI output. See #2094.
+                                        let reshaped = if is_quoted_literal_attr(
+                                            parsed,
+                                            &resource.id,
+                                            attr_name,
+                                        ) {
+                                            tagged.into_string_literal_diagnostic()
+                                        } else {
+                                            tagged
+                                        };
+                                        reshaped.to_string()
+                                    })
                                 }
                                 (
                                     carina_core::schema::AttributeType::Custom {
@@ -471,7 +484,33 @@ impl DiagnosticEngine {
                                     };
 
                                     // Use schema's validate function for all Custom types
-                                    validate(&resolved_value).err().map(|e| e.to_string())
+                                    validate(&resolved_value).err().map(|inner_msg| {
+                                        // For namespaced Custom types (enum-like), mirror
+                                        // the CLI shape-mismatch diagnostic when the user
+                                        // wrote a quoted string literal. The Custom
+                                        // validator itself returns a free-form string, so
+                                        // we wrap its message rather than reshape a
+                                        // TypeError. See #2094.
+                                        if namespace.is_some()
+                                            && matches!(value, Value::String(s) if !s.contains('.'))
+                                            && is_quoted_literal_attr(
+                                                parsed,
+                                                &resource.id,
+                                                attr_name,
+                                            )
+                                        {
+                                            let typed = match value {
+                                                Value::String(s) => s.as_str(),
+                                                _ => "",
+                                            };
+                                            format!(
+                                                "'{}' ({}) expects an enum identifier, got a string literal \"{}\". {}",
+                                                attr_name, name, typed, inner_msg
+                                            )
+                                        } else {
+                                            inner_msg
+                                        }
+                                    })
                                 }
                                 // String type - check for bare resource binding
                                 (carina_core::schema::AttributeType::String, Value::String(s)) => {
@@ -941,6 +980,23 @@ fn strip_line_comment(line: &str) -> &str {
 /// Check whether a ResourceRef value is type-compatible with the expected attribute type.
 /// Returns `Some(message)` on mismatch, `None` when compatible or when the binding/attribute
 /// cannot be resolved (unknown bindings are not flagged here).
+/// Returns true when the parser tagged the top-level attribute `attr` on
+/// `resource_id` as having been written in the source as a quoted string
+/// literal (see #2094). Used by the enum / namespaced-Custom diagnostic
+/// arms to flip their message into the shape-mismatch form so editor
+/// warnings match CLI output.
+fn is_quoted_literal_attr(
+    parsed: &ParsedFile,
+    resource_id: &carina_core::resource::ResourceId,
+    attr: &str,
+) -> bool {
+    parsed.string_literal_paths.iter().any(|p| {
+        &p.resource_id == resource_id
+            && p.attribute_chain.len() == 1
+            && p.attribute_chain[0] == attr
+    })
+}
+
 fn check_resource_ref_type_mismatch(
     binding_schema_map: &HashMap<String, ResourceSchema>,
     expected_type: &carina_core::schema::AttributeType,

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2801,3 +2801,105 @@ fn lsp_enum_diagnostic_includes_attribute_name() {
         bad.message
     );
 }
+
+/// Regression for #2094: the LSP must mirror the CLI's
+/// `StringLiteralExpectedEnum` diagnostic when the user writes
+/// `mode = "aaa"` against a namespaced `StringEnum` attribute.
+/// See PR 2 (#2112) for the CLI side.
+#[test]
+fn lsp_quoted_literal_on_namespaced_enum_says_got_a_string_literal() {
+    let provider = test_engine_with_namespaced_enum_attr();
+    let doc = create_document(
+        r#"test.r.mode_holder {
+  mode = "aaa"
+}
+"#,
+    );
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let bad = diagnostics
+        .iter()
+        .find(|d| d.message.contains("got a string literal"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected shape-mismatch diagnostic for quoted literal on enum attribute, got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        bad.message.contains("\"aaa\""),
+        "diagnostic must echo the user's literal, got: {}",
+        bad.message
+    );
+    assert!(
+        bad.message.contains("'mode'"),
+        "diagnostic must name the attribute, got: {}",
+        bad.message
+    );
+    assert!(
+        bad.message.contains("test.r.Mode.fast") || bad.message.contains("test.r.Mode.slow"),
+        "diagnostic must list valid variants, got: {}",
+        bad.message
+    );
+}
+
+/// Bare-identifier mistake on the same namespaced enum must keep the
+/// classic InvalidEnumVariant wording — no shape-mismatch phrasing.
+#[test]
+fn lsp_bare_invalid_on_namespaced_enum_keeps_invalid_variant_wording() {
+    let provider = test_engine_with_namespaced_enum_attr();
+    let doc = create_document(
+        r#"test.r.mode_holder {
+  mode = aaa
+}
+"#,
+    );
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.message.contains("aaa"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected diagnostic for bare invalid identifier, got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        !diag.message.contains("got a string literal"),
+        "bare identifier must NOT trigger the shape-mismatch wording, got: {}",
+        diag.message
+    );
+}
+
+/// Regression for #2094 Custom-type case: a namespaced `AttributeType::Custom`
+/// written as `mode = "aaa"` must emit a shape-mismatch diagnostic just
+/// like `StringEnum`.
+#[test]
+fn lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal() {
+    let provider = test_engine_with_custom_namespaced_attr();
+    let doc = create_document(
+        r#"test.r.mode_holder {
+  mode = "aaa"
+}
+"#,
+    );
+    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let bad = diagnostics
+        .iter()
+        .find(|d| d.message.contains("got a string literal"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected shape-mismatch diagnostic for quoted literal on Custom namespaced attribute, got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+    assert!(
+        bad.message.contains("\"aaa\""),
+        "diagnostic must echo the user's literal, got: {}",
+        bad.message
+    );
+    assert!(
+        bad.message.contains("'mode'"),
+        "diagnostic must name the attribute, got: {}",
+        bad.message
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -82,6 +82,75 @@ pub(super) fn test_engine_with_enum_attr() -> DiagnosticEngine {
     )
 }
 
+/// Variant of `test_engine_with_enum_attr` whose `mode` attribute is a
+/// namespaced enum — exercises the shape-mismatch branch of #2094 where
+/// the LSP diagnostic should say "got a string literal" for
+/// `mode = "aaa"`.
+pub(super) fn test_engine_with_namespaced_enum_attr() -> DiagnosticEngine {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let mode_enum = AttributeType::StringEnum {
+        name: "Mode".to_string(),
+        values: vec!["fast".to_string(), "slow".to_string()],
+        namespace: Some("test.r".to_string()),
+        to_dsl: None,
+    };
+
+    let schema = ResourceSchema::new("test.r.mode_holder")
+        .attribute(AttributeSchema::new("mode", mode_enum));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.r.mode_holder".to_string(), schema);
+
+    DiagnosticEngine::new(
+        Arc::new(schemas),
+        vec!["test".to_string()],
+        Arc::new(vec![]),
+    )
+}
+
+/// Engine whose `mode` attribute is a `Custom` type with a namespace — the
+/// other shape #2094 wants to treat as "expects an enum identifier".
+pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    fn validate_mode(v: &carina_core::resource::Value) -> Result<(), String> {
+        match v {
+            carina_core::resource::Value::String(s)
+                if s == "test.r.Mode.fast" || s == "test.r.Mode.slow" =>
+            {
+                Ok(())
+            }
+            carina_core::resource::Value::String(s) => {
+                Err(format!("invalid Mode '{}': expected fast or slow", s))
+            }
+            _ => Err("expected string".to_string()),
+        }
+    }
+
+    let mode_custom = AttributeType::Custom {
+        semantic_name: Some("Mode".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_mode,
+        namespace: Some("test.r".to_string()),
+        to_dsl: None,
+    };
+
+    let schema = ResourceSchema::new("test.r.mode_holder")
+        .attribute(AttributeSchema::new("mode", mode_custom));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("test.r.mode_holder".to_string(), schema);
+
+    DiagnosticEngine::new(
+        Arc::new(schemas),
+        vec!["test".to_string()],
+        Arc::new(vec![]),
+    )
+}
+
 pub(super) fn test_engine_with_block_name_nested() -> DiagnosticEngine {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 


### PR DESCRIPTION
## Summary
Final of three PRs for #2094. Brings PR 2's \`StringLiteralExpectedEnum\`
behaviour to the LSP (so editor hovers match CLI output —
\`feedback_validate_lsp_parity.md\`) and to namespaced
\`AttributeType::Custom\` attributes (so user-defined enum-like custom
types get the same shape-mismatch message as \`StringEnum\`).

## What changed
**LSP (\`carina-lsp/src/diagnostics/mod.rs\`)**
- \`is_quoted_literal_attr\` helper that consults
  \`ParsedFile::string_literal_paths\` for the top-level attribute on the
  current resource.
- \`StringEnum\` branch: when the validation error fires on an attribute
  the parser tagged as a quoted literal, reshape via
  \`TypeError::into_string_literal_diagnostic\` before rendering so the
  editor shows the shape-mismatch wording.
- \`Custom\` branch: when the value is a plain \`Value::String\` and the
  Custom type is namespaced, wrap the validator's message with an
  explicit "\`'{attr}' ({type})\` expects an enum identifier, got a
  string literal \"...\"." prefix. The Custom validator returns a
  free-form \`String\` rather than a structured \`TypeError\`, so we
  can't reshape — wrapping keeps the validator's detail visible.

**Core (\`carina-core/src/schema.rs\`)**
- \`reshape_for_string_literal(tagged, attr_type, value, attr_name)\`
  used by \`ResourceSchema::validate_with_origins\`. For \`StringEnum\`
  it delegates to \`into_string_literal_diagnostic\`; for namespaced
  \`Custom\` it constructs \`StringLiteralExpectedEnum\` using the
  semantic name and carries the original \`ValidationFailed\` message
  forward in \`expected\` so the validator's detail stays in the
  rendered diagnostic.

## Test plan
- [x] Core: \`schema_validate_with_origins_reshapes_custom_namespaced_type\`.
- [x] LSP: \`lsp_quoted_literal_on_namespaced_enum_says_got_a_string_literal\`.
- [x] LSP: \`lsp_bare_invalid_on_namespaced_enum_keeps_invalid_variant_wording\`.
- [x] LSP: \`lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal\`.
- [x] #2077 / #2093 / #2098 tests continue to pass — bare-identifier and
      fully-qualified values keep the classic \`InvalidEnumVariant\` text.
- [x] \`cargo test --workspace\` and \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #2094

🤖 Generated with [Claude Code](https://claude.com/claude-code)