### PR TITLE
lsp: filter built-ins by return type; emit fully-qualified namespaced enum completions

### DIFF
--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -23,11 +23,45 @@ mod upper_lower;
 use crate::parser::ProviderContext;
 use crate::resource::Value;
 
+/// Coarse-grained return type for a built-in function. Used by the LSP to
+/// filter value-position completion candidates to those whose return type
+/// fits the attribute's declared type.
+///
+/// Deliberately coarse: the enum carries only the base type (String, Int,
+/// List, Map, Secret) — not semantic subtypes (Cidr, AwsAccountId, Arn,
+/// etc.). A String-returning built-in like `join` is therefore not
+/// considered compatible with a `Custom { semantic_name: Some(..) }`
+/// attribute, because no built-in can guarantee the semantic invariant
+/// the Custom type requires.
+///
+/// `Bool` and `Float` variants are intentionally omitted because no
+/// built-in currently returns those types; add them when one does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinReturnType {
+    /// Returns a plain `Value::String` (no semantic subtype).
+    String,
+    /// Returns a `Value::Int`.
+    Int,
+    /// Returns a `Value::List` of some element type.
+    List,
+    /// Returns a `Value::Map`.
+    Map,
+    /// Return shape depends on the arguments (e.g. `lookup`, `min`, `max`,
+    /// `map`). Matches any base type the attribute accepts, but still fails
+    /// to match `Custom` / `StringEnum` attributes — the caller has no
+    /// evidence the returned value satisfies those semantic constraints.
+    Any,
+    /// Returns a `Value::Secret` wrapper.
+    Secret,
+}
+
 /// Metadata for a built-in function, used by the LSP for completion, hover, and validation.
 pub struct BuiltinFunctionInfo {
     pub name: &'static str,
     pub signature: &'static str,
     pub description: &'static str,
+    /// Coarse return-type classification — see `BuiltinReturnType`.
+    pub return_type: BuiltinReturnType,
 }
 
 /// Register built-in functions in a single place.
@@ -40,6 +74,7 @@ macro_rules! register_builtins {
             $name:ident ( $handler:expr, arity: $arity:expr ) {
                 signature: $sig:expr,
                 description: $desc:expr,
+                return_type: $ret:expr,
             }
         ),* $(,)?
     ) => {
@@ -51,6 +86,7 @@ macro_rules! register_builtins {
                         name: stringify!($name),
                         signature: $sig,
                         description: $desc,
+                        return_type: $ret,
                     },
                 )*
             ];
@@ -97,78 +133,97 @@ register_builtins! {
     cidr_subnet(cidr_subnet::builtin_cidr_subnet, arity: 3) {
         signature: "cidr_subnet(prefix: string, newbits: int, netnum: int) -> string",
         description: "Calculates a subnet CIDR block within a given IP network address prefix.",
+        return_type: BuiltinReturnType::String,
     },
     concat(concat::builtin_concat, arity: 2) {
         signature: "concat(items: list, base_list: list) -> list",
         description: "Appends items to a list. Data-last: base_list |> concat(items).",
+        return_type: BuiltinReturnType::List,
     },
     decrypt(decrypt::builtin_decrypt, arity: 1) {
         signature: "decrypt(ciphertext: string, key?: string) -> string",
         description: "Decrypts ciphertext using the configured provider's encryption service (e.g., AWS KMS). Key is optional when embedded in ciphertext.",
+        return_type: BuiltinReturnType::String,
     },
     env(env::builtin_env, arity: 1) {
         signature: "env(name: string) -> string",
         description: "Reads an environment variable. Errors if the variable is not set.",
+        return_type: BuiltinReturnType::String,
     },
     flatten(flatten::builtin_flatten, arity: 1) {
         signature: "flatten(list: list) -> list",
         description: "Flattens nested lists by one level.",
+        return_type: BuiltinReturnType::List,
     },
     join(join::builtin_join, arity: 2) {
         signature: "join(separator: string, list: list) -> string",
         description: "Joins list elements into a string using the separator.",
+        return_type: BuiltinReturnType::String,
     },
     keys(keys_values::builtin_keys, arity: 1) {
         signature: "keys(map: map) -> list",
         description: "Returns the keys of a map as a sorted list.",
+        return_type: BuiltinReturnType::List,
     },
     length(length::builtin_length, arity: 1) {
         signature: "length(value: list | map | string) -> int",
         description: "Returns the number of elements in a list or map, or characters in a string.",
+        return_type: BuiltinReturnType::Int,
     },
     lookup(lookup::builtin_lookup, arity: 3) {
         signature: "lookup(map: map, key: string, default: any) -> any",
         description: "Looks up a key in a map, returning the default value if the key is not found.",
+        return_type: BuiltinReturnType::Any,
     },
     lower(upper_lower::builtin_lower, arity: 1) {
         signature: "lower(string: string) -> string",
         description: "Converts a string to lowercase.",
+        return_type: BuiltinReturnType::String,
     },
     map(map::builtin_map, arity: 2) {
         signature: "map(accessor: string, collection: list | map) -> list | map",
         description: "Extracts a field from each element. Use a dot-prefixed accessor (e.g., \".field_name\"). Pipe form: collection |> map(\".field\").",
+        return_type: BuiltinReturnType::Any,
     },
     max(min_max::builtin_max, arity: 2) {
         signature: "max(a: number, b: number) -> number",
         description: "Returns the maximum of two numbers.",
+        return_type: BuiltinReturnType::Any,
     },
     min(min_max::builtin_min, arity: 2) {
         signature: "min(a: number, b: number) -> number",
         description: "Returns the minimum of two numbers.",
+        return_type: BuiltinReturnType::Any,
     },
     replace(replace::builtin_replace, arity: 3) {
         signature: "replace(search: string, replacement: string, string: string) -> string",
         description: "Replaces all occurrences of a search string. Data-last: string |> replace(search, replacement).",
+        return_type: BuiltinReturnType::String,
     },
     secret(secret::builtin_secret, arity: 1) {
         signature: "secret(value: any) -> secret",
         description: "Marks a value as secret. The value is sent to the provider but stored only as a SHA256 hash in state.",
+        return_type: BuiltinReturnType::Secret,
     },
     split(split::builtin_split, arity: 2) {
         signature: "split(separator: string, string: string) -> list",
         description: "Splits a string into a list using the separator.",
+        return_type: BuiltinReturnType::List,
     },
     trim(trim::builtin_trim, arity: 1) {
         signature: "trim(string: string) -> string",
         description: "Removes leading and trailing whitespace from a string.",
+        return_type: BuiltinReturnType::String,
     },
     upper(upper_lower::builtin_upper, arity: 1) {
         signature: "upper(string: string) -> string",
         description: "Converts a string to uppercase.",
+        return_type: BuiltinReturnType::String,
     },
     values(keys_values::builtin_values, arity: 1) {
         signature: "values(map: map) -> list",
         description: "Returns the values of a map as a list, sorted by key.",
+        return_type: BuiltinReturnType::List,
     },
 }
 

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -908,7 +908,8 @@ fn context_detection_type_position_in_attributes() {
 #[test]
 fn string_enum_completion_derives_namespace_from_resource_type() {
     // When a StringEnum has name but no namespace (WASM provider case),
-    // completions should use the resource_type as namespace to produce DSL format.
+    // completions derive the namespace from the resource type and emit
+    // fully-qualified identifiers.
     let provider = test_provider_with_nameless_enum();
     let doc = create_document(
         r#"awscc.s3.bucket {
@@ -924,25 +925,22 @@ versioning_status =
 
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
-    // Should produce bare enum value completions (not full namespace path)
     assert!(
-        labels.contains(&"Enabled"),
-        "Should produce bare enum completion. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Enabled"),
+        "expected fully-qualified enum identifier; got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"Suspended"),
-        "Should include all enum variants as bare values"
-    );
-    // Should NOT have full namespaced format
-    assert!(
-        !completions
-            .iter()
-            .any(|c| c.label.contains("awscc.s3.bucket")),
-        "Should not show full namespace path. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Suspended"),
+        "expected all enum variants in fully-qualified form; got: {:?}",
         labels
     );
-    // Should NOT have quoted string format
+    assert!(
+        !labels.contains(&"Enabled") && !labels.contains(&"Suspended"),
+        "bare tail tokens must not be offered for namespaced enums; got: {:?}",
+        labels
+    );
+    // Should NOT have quoted string format.
     assert!(
         !completions
             .iter()
@@ -953,7 +951,8 @@ versioning_status =
 
 #[test]
 fn string_enum_completion_in_struct_derives_namespace() {
-    // StringEnum inside a struct field should also derive namespace from resource_type.
+    // StringEnum inside a struct field also resolves via the resource type
+    // and emits the fully-qualified form.
     let provider = test_provider_with_nameless_enum();
     let doc = create_document(
         r#"awscc.s3.bucket {
@@ -971,8 +970,13 @@ versioning_configuration {
 
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
-        labels.contains(&"Enabled"),
-        "Should produce bare enum completion inside struct. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Enabled"),
+        "expected fully-qualified enum identifier inside struct; got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"Enabled"),
+        "bare tail token must not be offered inside struct; got: {:?}",
         labels
     );
 }
@@ -1159,13 +1163,13 @@ for item in items {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"Enabled"),
-        "StringEnum 'Enabled' must still be offered inside a for body. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Enabled"),
+        "StringEnum 'Enabled' must still be offered (fully-qualified) inside a for body. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"Suspended"),
-        "StringEnum 'Suspended' must still be offered inside a for body. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Suspended"),
+        "StringEnum 'Suspended' must still be offered (fully-qualified) inside a for body. Got: {:?}",
         labels
     );
     assert!(
@@ -1205,8 +1209,8 @@ fn string_enum_completion_inside_nested_for_loop_body() {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"Enabled"),
-        "Enum candidate must reach nested for body. Got: {:?}",
+        labels.contains(&"awscc.s3.bucket.VersioningStatus.Enabled"),
+        "Enum candidate (fully-qualified) must reach nested for body. Got: {:?}",
         labels
     );
     assert!(

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1883,3 +1883,139 @@ fn exports_value_position_returns_none_context() {
         );
     }
 }
+
+/// At a value position whose attribute type is a `Custom` semantic
+/// subtype (e.g. `aws_account_id`), built-in function completions must not
+/// be offered — none of them can produce a value of that semantic type.
+#[test]
+fn builtin_functions_filtered_out_for_custom_semantic_value_position() {
+    let provider = test_provider_with_custom_semantic_attr();
+    let doc = create_document(
+        r#"awscc.sso.assignment {
+  target_id = 
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: 15,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for builtin in [
+        "concat",
+        "cidr_subnet",
+        "decrypt",
+        "env",
+        "flatten",
+        "join",
+        "keys",
+        "length",
+        "lookup",
+        "lower",
+        "upper",
+    ] {
+        assert!(
+            !labels.contains(&builtin),
+            "built-in '{}' must NOT appear at aws_account_id value position. Got: {:?}",
+            builtin,
+            labels
+        );
+    }
+}
+
+/// Completion at a value position must not offer bare enum-tail tokens
+/// (e.g. `GROUP`) harvested from namespaced enum values used elsewhere in
+/// the file.
+#[test]
+fn namespaced_enum_tail_tokens_do_not_leak_into_sibling_value_position() {
+    let provider = test_provider_with_custom_semantic_attr();
+    let doc = create_document(
+        r#"awscc.sso.assignment {
+  principal_type = awscc.sso.assignment.PrincipalType.GROUP
+  target_id = 
+}
+"#,
+    );
+    let position = Position {
+        line: 2,
+        character: 15,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"GROUP"),
+        "bare 'GROUP' (tail of PrincipalType.GROUP) must not leak into target_id value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"USER"),
+        "bare 'USER' must not leak into target_id value position. Got: {:?}",
+        labels
+    );
+}
+
+/// Namespaced `StringEnum` completions must offer the fully-qualified
+/// form (`awscc.sso.assignment.PrincipalType.GROUP`), not the bare tail
+/// (`GROUP`). The bare form is accepted by the DSL resolver but causes
+/// the sibling-attribute leak exercised above.
+#[test]
+fn namespaced_enum_completions_offer_full_form_not_bare_tail() {
+    let provider = test_provider_with_custom_semantic_attr();
+    let doc = create_document(
+        r#"awscc.sso.assignment {
+  principal_type = 
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: 19,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.contains("awscc.sso.assignment.PrincipalType.GROUP")),
+        "expected fully-qualified 'awscc.sso.assignment.PrincipalType.GROUP' completion, got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"GROUP"),
+        "bare 'GROUP' must not be offered for namespaced enum — use fully-qualified form. Got: {:?}",
+        labels
+    );
+}
+
+/// A plain `String` attribute still sees string-returning built-ins, and
+/// list-returning ones stay filtered out — guards against over-filtering.
+#[test]
+fn string_returning_builtins_still_offered_for_plain_string_attr() {
+    let provider = test_provider_single_attr();
+    let doc = create_document(
+        r#"test.foo.bar {
+  attr =
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: 9,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for builtin in ["join", "upper", "lower"] {
+        assert!(
+            labels.contains(&builtin),
+            "string-returning '{}' must appear at plain String attr. Got: {:?}",
+            builtin,
+            labels
+        );
+    }
+    assert!(
+        !labels.contains(&"concat"),
+        "list-returning 'concat' must not appear at String attr. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -204,3 +204,35 @@ pub(super) fn test_provider_with_nameless_enum() -> CompletionProvider {
 
     CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
 }
+
+/// Provider exposing both a namespaced `StringEnum` (`principal_type`) and a
+/// `Custom` semantic subtype (`target_id` → `aws_account_id`) on the same
+/// resource. Used to reproduce the two value-position completion leaks
+/// reported in the parent issue.
+pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
+    fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("aws_account_id".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: noop_validate,
+        namespace: None,
+        to_dsl: None,
+    };
+    let principal_type = AttributeType::StringEnum {
+        name: "PrincipalType".to_string(),
+        values: vec!["GROUP".to_string(), "USER".to_string()],
+        namespace: Some("awscc.sso.assignment".to_string()),
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("awscc.sso.assignment")
+        .attribute(AttributeSchema::new("principal_type", principal_type))
+        .attribute(AttributeSchema::new("target_id", account_id));
+
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.sso.assignment".to_string(), schema);
+    CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -232,8 +232,13 @@ impl CompletionProvider {
                 return completions;
             }
 
-            // Include built-in function completions for non-Struct value positions
-            completions.extend(self.builtin_function_completions());
+            // Built-in function completions filtered by return-type fit.
+            // Offering every built-in at e.g. an `aws_account_id` cursor
+            // would pollute the popup with suggestions that can't produce
+            // the right value.
+            completions.extend(Self::builtin_function_completions_for_type(
+                &attr_schema.attr_type,
+            ));
 
             // First check if schema defines completions for this attribute
             if let Some(schema_completions) = &attr_schema.completions {
@@ -712,8 +717,25 @@ impl CompletionProvider {
 
     /// Provide completions for built-in function names.
     pub(super) fn builtin_function_completions(&self) -> Vec<CompletionItem> {
+        Self::builtin_completions_matching(|_| true)
+    }
+
+    /// Return built-in function completions whose declared return type is
+    /// compatible with the attribute's declared `AttributeType`. Used by
+    /// value-position completion to avoid suggesting `concat` / `join` /
+    /// etc. at cursors whose type is e.g. an `aws_account_id`.
+    pub(super) fn builtin_function_completions_for_type(
+        attr_type: &AttributeType,
+    ) -> Vec<CompletionItem> {
+        Self::builtin_completions_matching(|ret| return_type_fits(ret, attr_type))
+    }
+
+    fn builtin_completions_matching(
+        accept: impl Fn(builtins::BuiltinReturnType) -> bool,
+    ) -> Vec<CompletionItem> {
         builtins::builtin_functions()
             .iter()
+            .filter(|func| accept(func.return_type))
             .map(|func| CompletionItem {
                 label: func.name.to_string(),
                 kind: Some(CompletionItemKind::FUNCTION),
@@ -959,22 +981,28 @@ impl CompletionProvider {
 
     pub(super) fn string_enum_completions(
         &self,
-        _type_name: &str,
+        type_name: &str,
         values: &[String],
         namespace: Option<&str>,
         to_dsl: Option<fn(&str) -> String>,
     ) -> Vec<CompletionItem> {
         match namespace {
-            Some(_) => {
-                // Bare enum values — the schema context resolves them automatically
+            Some(ns) => {
+                // Offer the fully-qualified form
+                // `<namespace>.<TypeName>.<Variant>`. The bare tail alone
+                // used to leak into sibling-attribute popups via the
+                // generic identifier pool; the qualified form is always
+                // valid and unambiguous.
                 values
                     .iter()
                     .map(|value| {
                         let dsl_value = to_dsl.map_or_else(|| value.clone(), |f| f(value));
+                        let full = format!("{}.{}.{}", ns, type_name, dsl_value);
                         CompletionItem {
-                            label: dsl_value,
+                            label: full.clone(),
                             kind: Some(CompletionItemKind::ENUM_MEMBER),
                             detail: Some(value.clone()),
+                            insert_text: Some(full),
                             ..Default::default()
                         }
                     })
@@ -990,6 +1018,49 @@ impl CompletionProvider {
                 })
                 .collect(),
         }
+    }
+}
+
+/// Decide whether a built-in's declared return type is assignable to the
+/// attribute's declared `AttributeType`.
+///
+/// Matching rules:
+/// * `BuiltinReturnType::Any` fits any base-typed attribute (String, Int,
+///   List, Map) — the built-in's concrete shape depends on its arguments.
+///   It does not fit `Custom` or `StringEnum`: no argument-derived result
+///   can prove the semantic invariant those types require.
+/// * A built-in returning plain `String` fits only a schema-declared
+///   `String` or a `Union` containing one. It does **not** fit a `Custom`
+///   type (even one whose base is `String`) because the Custom type
+///   carries a semantic meaning the built-in cannot produce (e.g. an
+///   `aws_account_id` must be a 12-digit string, and `join(...)` offers
+///   no such guarantee).
+/// * `List`, `Map`, `Int`, `Secret` match their corresponding
+///   `AttributeType` constructor. For `List` / `Map` the inner type
+///   doesn't participate in the check — the built-in's declared element
+///   type is unknown at this layer.
+fn return_type_fits(ret: builtins::BuiltinReturnType, attr_type: &AttributeType) -> bool {
+    use builtins::BuiltinReturnType as R;
+    match attr_type {
+        AttributeType::Union(members) => members.iter().any(|m| return_type_fits(ret, m)),
+        AttributeType::String => matches!(ret, R::String | R::Any),
+        AttributeType::Int => matches!(ret, R::Int | R::Any),
+        // No built-in currently returns a Bool; leave as unfit.
+        AttributeType::Bool => false,
+        AttributeType::List { .. } => matches!(ret, R::List | R::Any),
+        AttributeType::Map { .. } => matches!(ret, R::Map | R::Any),
+        // StringEnum expects a specific identifier form; no built-in
+        // currently produces such values, and `Any` alone doesn't give us
+        // enough confidence to suggest one.
+        AttributeType::StringEnum { .. } => false,
+        // Custom types carry a semantic meaning (Cidr, AwsAccountId, Arn,
+        // …) that built-ins don't declare. Not even `Any` fits — we need
+        // a semantic return annotation before a built-in can be suggested
+        // here.
+        AttributeType::Custom { .. } => false,
+        // Float and Struct attributes — no matching built-in today.
+        AttributeType::Float => false,
+        AttributeType::Struct { .. } => false,
     }
 }
 


### PR DESCRIPTION
## Summary
Two value-position completion leaks reported in #2096:

1. Every built-in function was offered regardless of the attribute's
   declared type. Typing `target_id = ▉` (type: `aws_account_id`) put
   `concat`, `cidr_subnet`, `join`, etc. into the popup — none of them
   can produce an account id.
2. Namespaced `StringEnum` completions emitted the bare variant
   (`GROUP`, `USER`) as the label/insert text. That bare identifier then
   leaked into sibling-attribute popups via the generic identifier
   pool.

This PR fixes both.

## What changed
**`carina-core/src/builtins/mod.rs`** — new `BuiltinReturnType` enum
(String/Int/List/Map/Any/Secret) and a `return_type` field on
`BuiltinFunctionInfo`. Every registered built-in is annotated. The enum
is deliberately coarse: Custom semantic subtypes (Cidr, AwsAccountId,
Arn) aren't modelled, because no built-in can guarantee their
invariants. `Bool` and `Float` are omitted because no built-in
currently returns them — add when one does.

**`carina-lsp/src/completion/values.rs`** —
`builtin_function_completions_for_type` filters via a new
`return_type_fits` helper. Rules:
- `Any` matches base types (String/Int/List/Map) but not `Custom` or
  `StringEnum` — those demand a provably-typed source.
- `String` returns fit `String` attrs and `Union` members containing
  `String`, but not `Custom` (even with base `String`).
- `List`, `Map`, `Int`, `Secret` match their corresponding constructor.

**`string_enum_completions`** — namespaced branch now emits
`<namespace>.<TypeName>.<Variant>` for both `label` and `insert_text`.
No completion candidate is ever a bare enum tail anymore, so the
sibling-attribute leak is impossible by construction.

## Test plan
- [x] `builtin_functions_filtered_out_for_custom_semantic_value_position`.
- [x] `string_returning_builtins_still_offered_for_plain_string_attr` — anti-over-filter guard.
- [x] `namespaced_enum_completions_offer_full_form_not_bare_tail`.
- [x] `namespaced_enum_tail_tokens_do_not_leak_into_sibling_value_position`.
- [x] Four existing tests asserting the old bare behaviour updated to expect the fully-qualified form.
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)