### PR TITLE
lsp completion: filter for-loop bindings by inferred element type

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -86,6 +86,7 @@ impl CompletionProvider {
                 &text,
                 current_binding.as_deref(),
                 position,
+                base_path,
             ),
             CompletionContext::InsideStructBlock {
                 resource_type,

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2019,3 +2019,95 @@ fn string_returning_builtins_still_offered_for_plain_string_attr() {
         labels
     );
 }
+
+#[test]
+fn for_loop_binding_not_offered_at_incompatible_enum_attribute() {
+    // `for _, account_id in orgs.accounts` where `orgs.accounts` is
+    // `map(aws_account_id)`. Inside the body, `principal_type` is a
+    // `StringEnum` — `account_id` (semantic type `aws_account_id`)
+    // can't type-check as `PrincipalType`, so it must be filtered out.
+    let provider = test_provider_with_custom_semantic_attr();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+        r#"let orgs = upstream_state { source = '../organizations' }
+for _, account_id in orgs.accounts {
+  awscc.sso.assignment {
+    principal_type =
+  }
+}
+"#,
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 3,
+        character: "    principal_type = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"account_id"),
+        "for-loop binding 'account_id' (aws_account_id) must not be offered at a PrincipalType enum attribute. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn for_loop_binding_offered_at_matching_custom_attribute() {
+    // Same repro as above but the cursor is on `target_id`, which is
+    // `Custom{aws_account_id}`. The for-loop binding's element type
+    // matches, so it must appear.
+    let provider = test_provider_with_custom_semantic_attr();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+        r#"let orgs = upstream_state { source = '../organizations' }
+for _, account_id in orgs.accounts {
+  awscc.sso.assignment {
+    target_id =
+  }
+}
+"#,
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 3,
+        character: "    target_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"account_id"),
+        "for-loop binding 'account_id' must appear at a matching `aws_account_id` attribute. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn for_loop_binding_without_resolvable_iterable_falls_back_to_unconditional() {
+    // If the iterable can't be resolved (e.g. no upstream_state,
+    // unknown binding), preserve the old permissive behaviour so the
+    // user still gets autocomplete on the name.
+    let provider = test_provider_with_custom_semantic_attr();
+    let doc = create_document(
+        r#"for _, account_id in unknown_source.accounts {
+  awscc.sso.assignment {
+    principal_type =
+  }
+}
+"#,
+    );
+    let position = Position {
+        line: 2,
+        character: "    principal_type = ".chars().count() as u32,
+    };
+    // No base path → no upstream resolution possible. The binding still
+    // shows (permissive fallback).
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"account_id"),
+        "unresolvable iterable should preserve the permissive fallback. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -522,20 +522,59 @@ fn is_after_let_binding(line: &str, prefix_start: usize) -> bool {
     crate::let_parse::parse_let_header(&line[..byte_end]).is_some()
 }
 
-/// Extract `for`-loop binding names that are in scope at the given position.
-///
-/// Walks the text up to `position`, tracking a stack of open `for` bodies.
-/// Each `for <bindings> in ... {` pushes the bindings (after filtering out
-/// `_` discards); the matching `}` pops them. The returned vector preserves
-/// declaration order (outer loops first, then inner).
+/// Which slot of a `for` header introduced a given binding. Encodes the
+/// header shape so a downstream type inferencer can project the correct
+/// element type out of the iterable's own type: e.g. `Value` against
+/// `list(T)` yields `T`, `PairKey` against `map(T)` yields `String`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ForBindingSlot {
+    /// `for x in iter` — `x` is the element.
+    Value,
+    /// First slot of `for a, b in iter` — the index (for lists) or key
+    /// (for maps). The scanner can't distinguish `for (i, x) in list`
+    /// from `for k, v in map` from text alone; the type inferencer
+    /// resolves the ambiguity using the iterable's actual type.
+    PairKey,
+    /// Second slot of `for a, b in iter` — the element value.
+    PairValue,
+}
+
+/// An `upstream_state` export referenced by a `for` header's iterable.
+/// Only the two-segment `binding.export` shape is captured because it's
+/// the only form we can currently resolve to a declared type.
+#[derive(Debug, Clone)]
+pub(super) struct IterableExportRef {
+    pub binding: String,
+    pub export: String,
+}
+
+/// One binding introduced by a `for` header that is in scope at a given
+/// position. Carries enough context for the LSP to resolve the binding's
+/// inferred type: the iterable export the header refers to and the
+/// binding's slot in the header.
+#[derive(Debug, Clone)]
+pub(super) struct ForScopeBinding {
+    /// The bare identifier the user typed (never `_`).
+    pub name: String,
+    /// Slot in the header that introduced this name — see `ForBindingSlot`.
+    pub slot: ForBindingSlot,
+    /// Parsed iterable reference. `None` when the iterable isn't a
+    /// two-segment `binding.export` shape (e.g. a local `let`, a
+    /// function call, or a bare identifier) — the type inferencer bails
+    /// in that case and the caller falls back to the permissive suggest.
+    pub iterable: Option<IterableExportRef>,
+}
+
+/// Extract the full binding info for every `for`-loop binding in scope at
+/// `position`. See `ForScopeBinding` for what each entry carries.
 ///
 /// Parsing is intentionally line- and brace-based rather than AST-based:
 /// the document may not parse while the user is typing, so we cannot
 /// depend on a successful parse of the partial text.
-pub(super) fn extract_for_binding_names_in_scope(
+pub(super) fn extract_for_bindings_in_scope(
     text: &str,
     position: tower_lsp::lsp_types::Position,
-) -> Vec<String> {
+) -> Vec<ForScopeBinding> {
     // Byte offset of the cursor inside `text`.
     let cursor_byte_offset: usize = {
         let mut offset = 0usize;
@@ -555,10 +594,10 @@ pub(super) fn extract_for_binding_names_in_scope(
         offset
     };
 
-    // Each frame on the stack represents one open `for` body: the bindings it
-    // introduced plus a depth counter of *nested* `{` inside it. The frame
-    // pops when that depth reaches -1 (the loop's own `}`).
-    let mut stack: Vec<(Vec<String>, i32)> = Vec::new();
+    // Each frame on the stack represents one open `for` body: the bindings
+    // it introduced plus a depth counter of *nested* `{` inside it. The
+    // frame pops when that depth reaches -1 (the loop's own `}`).
+    let mut stack: Vec<(Vec<ForScopeBinding>, i32)> = Vec::new();
     let bytes = text.as_bytes();
     let mut i = 0usize;
 
@@ -576,28 +615,48 @@ pub(super) fn extract_for_binding_names_in_scope(
         let trimmed = line.trim_start();
         // `for ...` header: collect bindings; the body opens at the first `{`
         // on this line.
-        let mut pending_frame: Option<Vec<String>> = None;
+        let mut pending_frame: Option<Vec<ForScopeBinding>> = None;
         if let Some(rest) = trimmed.strip_prefix("for ")
-            && let Some(header) = rest.split(" in ").next()
+            && let Some((header, after_in)) = rest.split_once(" in ")
         {
-            let mut names: Vec<String> = Vec::new();
+            let iterable_raw = after_in.split_once('{').map(|(l, _)| l).unwrap_or(after_in);
+            let mut segments = iterable_raw.trim().split('.').filter(|s| !s.is_empty());
+            let iterable = match (segments.next(), segments.next(), segments.next()) {
+                (Some(binding), Some(export), None) => Some(IterableExportRef {
+                    binding: binding.to_string(),
+                    export: export.to_string(),
+                }),
+                _ => None,
+            };
             let cleaned = header.trim().trim_start_matches('(').trim_end_matches(')');
-            for part in cleaned.split(',') {
-                let name = part.trim();
-                if name.is_empty() || name == "_" {
+            let raw_parts: Vec<&str> = cleaned.split(',').map(|p| p.trim()).collect();
+            let is_pair = raw_parts.len() == 2;
+            let mut bindings: Vec<ForScopeBinding> = Vec::new();
+            for (index, part) in raw_parts.iter().enumerate() {
+                if part.is_empty() || *part == "_" {
                     continue;
                 }
-                names.push(name.to_string());
+                let slot = match (is_pair, index) {
+                    (false, _) => ForBindingSlot::Value,
+                    (true, 0) => ForBindingSlot::PairKey,
+                    (true, 1) => ForBindingSlot::PairValue,
+                    _ => continue,
+                };
+                bindings.push(ForScopeBinding {
+                    name: part.to_string(),
+                    slot,
+                    iterable: iterable.clone(),
+                });
             }
-            pending_frame = Some(names);
+            pending_frame = Some(bindings);
         }
 
         for b in line.bytes() {
             match b {
                 b'{' => {
-                    if let Some(names) = pending_frame.take() {
+                    if let Some(bindings) = pending_frame.take() {
                         // This `{` starts the body of the `for` header on this line.
-                        stack.push((names, 0));
+                        stack.push((bindings, 0));
                     } else if let Some(frame) = stack.last_mut() {
                         frame.1 += 1;
                     }
@@ -616,13 +675,23 @@ pub(super) fn extract_for_binding_names_in_scope(
         }
     }
 
-    stack.into_iter().flat_map(|(names, _)| names).collect()
+    stack
+        .into_iter()
+        .flat_map(|(bindings, _)| bindings)
+        .collect()
 }
 
 #[cfg(test)]
 mod helper_tests {
-    use super::{extract_for_binding_names_in_scope, is_after_let_binding};
+    use super::{extract_for_bindings_in_scope, is_after_let_binding};
     use tower_lsp::lsp_types::Position;
+
+    fn names(text: &str, position: Position) -> Vec<String> {
+        extract_for_bindings_in_scope(text, position)
+            .into_iter()
+            .map(|b| b.name)
+            .collect()
+    }
 
     #[test]
     fn detects_after_let_binding() {
@@ -649,21 +718,21 @@ mod helper_tests {
     fn for_scope_simple_binding_inside_body() {
         let text = "for item in items {\n  x\n}\n";
         // cursor on line 1 ("  x")
-        let names = extract_for_binding_names_in_scope(text, pos(1, 3));
+        let names = names(text, pos(1, 3));
         assert_eq!(names, vec!["item".to_string()]);
     }
 
     #[test]
     fn for_scope_map_bindings_inside_body() {
         let text = "for name, account_id in orgs.accounts {\n  x\n}\n";
-        let names = extract_for_binding_names_in_scope(text, pos(1, 3));
+        let names = names(text, pos(1, 3));
         assert_eq!(names, vec!["name".to_string(), "account_id".to_string()]);
     }
 
     #[test]
     fn for_scope_indexed_bindings_inside_body() {
         let text = "for (i, item) in items {\n  x\n}\n";
-        let names = extract_for_binding_names_in_scope(text, pos(1, 3));
+        let names = names(text, pos(1, 3));
         assert_eq!(names, vec!["i".to_string(), "item".to_string()]);
     }
 
@@ -671,7 +740,7 @@ mod helper_tests {
     fn for_scope_discard_excluded() {
         // `_` is a discard marker and must not appear as a candidate.
         let text = "for _, v in m {\n  x\n}\n";
-        let names = extract_for_binding_names_in_scope(text, pos(1, 3));
+        let names = names(text, pos(1, 3));
         assert_eq!(names, vec!["v".to_string()]);
     }
 
@@ -679,7 +748,7 @@ mod helper_tests {
     fn for_scope_outside_body_no_bindings() {
         // Cursor after the closing `}` — loop variable out of scope.
         let text = "for item in items {\n  x\n}\nfoo\n";
-        let names = extract_for_binding_names_in_scope(text, pos(3, 2));
+        let names = names(text, pos(3, 2));
         assert!(names.is_empty(), "expected empty, got: {:?}", names);
     }
 
@@ -687,7 +756,7 @@ mod helper_tests {
     fn for_scope_nested_stacks_outer_and_inner() {
         let text = "for outer in xs {\n  for inner in ys {\n    x\n  }\n}\n";
         // cursor on line 2 ("    x") — both outer and inner visible
-        let names = extract_for_binding_names_in_scope(text, pos(2, 5));
+        let names = names(text, pos(2, 5));
         assert_eq!(names, vec!["outer".to_string(), "inner".to_string()]);
     }
 
@@ -698,7 +767,7 @@ mod helper_tests {
         // values (e.g. JSON embedded as a string).
         let text = "for item in items {\n  test.foo.bar {\n    attr = \"hello { world }\"\n    x\n  }\n}\n";
         // Cursor on line 3 ("    x") — still inside the for body
-        let names = extract_for_binding_names_in_scope(text, pos(3, 5));
+        let names = names(text, pos(3, 5));
         assert_eq!(names, vec!["item".to_string()]);
     }
 
@@ -707,7 +776,7 @@ mod helper_tests {
         // After the first loop closes, its binding must go out of scope
         // even while a second loop with a different binding is open.
         let text = "for a in xs {\n  x\n}\nfor b in ys {\n  y\n}\n";
-        let on_b = extract_for_binding_names_in_scope(text, pos(4, 3));
+        let on_b = names(text, pos(4, 3));
         assert_eq!(on_b, vec!["b".to_string()]);
     }
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -120,6 +120,7 @@ impl CompletionProvider {
         text: &str,
         current_binding: Option<&str>,
         position: Position,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
 
@@ -200,17 +201,54 @@ impl CompletionProvider {
             });
         }
 
-        // Add for-loop binding names in scope at the cursor.
-        // Type inference for loop variables is a follow-up; for now we offer
-        // the bare identifier so the user at least gets autocomplete on the
-        // name itself.
-        let for_bindings = super::top_level::extract_for_binding_names_in_scope(text, position);
-        for name in &for_bindings {
+        // Add for-loop binding names in scope, filtered by inferred element
+        // type where possible. When the iterable is an `upstream_state`
+        // export with a declared type, we infer the binding's type and
+        // only suggest it at attribute positions whose type accepts it.
+        // Inference failure (no type annotation, non-upstream iterable,
+        // no schema for the target attribute) falls back to an
+        // unconditional suggest so the user still gets autocomplete on
+        // the bare name.
+        let attr_type_for_for_filter = self
+            .schemas
+            .get(resource_type)
+            .and_then(|s| s.attributes.get(attr_name))
+            .map(|a| &a.attr_type);
+        let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
+        // Cache upstream binding → source text scan and the resolved
+        // exports per upstream. Without this, each for-binding re-scans
+        // every sibling `.crn` plus re-parses the upstream project —
+        // every keystroke in a value position.
+        let upstream_sources: std::collections::HashMap<String, String> =
+            if for_bindings.iter().any(|b| b.iterable.is_some()) {
+                super::collect_upstream_state_bindings(text, base_path)
+            } else {
+                std::collections::HashMap::new()
+            };
+        let mut exports_cache: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+        > = std::collections::HashMap::new();
+        for binding in &for_bindings {
+            if let Some(attr_type) = attr_type_for_for_filter
+                && let Some(element_type) = infer_for_binding_type(
+                    binding,
+                    &upstream_sources,
+                    base_path,
+                    &mut exports_cache,
+                )
+                && !carina_core::validation::is_type_expr_compatible_with_schema(
+                    &element_type,
+                    attr_type,
+                )
+            {
+                continue;
+            }
             completions.push(CompletionItem {
-                label: name.clone(),
+                label: binding.name.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
                 detail: Some("for-loop binding".to_string()),
-                insert_text: Some(name.clone()),
+                insert_text: Some(binding.name.clone()),
                 ..Default::default()
             });
         }
@@ -1018,6 +1056,65 @@ impl CompletionProvider {
                 })
                 .collect(),
         }
+    }
+}
+
+/// Infer the static type of a for-loop binding by resolving its iterable
+/// to an `upstream_state` export's declared `TypeExpr`. Returns `None`
+/// when inference isn't possible — the caller falls back to
+/// unconditional suggestion so the user still gets autocomplete on the
+/// bare name.
+///
+/// Current reach: `for _, v in <binding>.<export>` where `<binding>` is
+/// an `upstream_state` binding and `<export>` has a `: map(T) = ...` or
+/// `: list(T) = ...` annotation. Direct `let` iterables and inferred
+/// `ResourceRef` types are future work.
+///
+/// `exports_cache` memoizes the per-upstream exports map across bindings
+/// in the same call site so multiple `for`-variables in scope don't each
+/// re-read and re-parse the upstream project directory.
+fn infer_for_binding_type(
+    binding: &super::top_level::ForScopeBinding,
+    upstream_sources: &std::collections::HashMap<String, String>,
+    base_path: Option<&Path>,
+    exports_cache: &mut std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+    >,
+) -> Option<carina_core::parser::TypeExpr> {
+    use super::top_level::ForBindingSlot;
+    use carina_core::parser::TypeExpr;
+
+    let iterable = binding.iterable.as_ref()?;
+    let base = base_path?;
+    let source = upstream_sources.get(&iterable.binding)?;
+
+    let exports = exports_cache
+        .entry(iterable.binding.clone())
+        .or_insert_with(|| {
+            let upstream = carina_core::parser::UpstreamState {
+                binding: iterable.binding.clone(),
+                source: std::path::PathBuf::from(source),
+            };
+            let (resolved, _errors) = carina_core::upstream_exports::resolve_upstream_exports(
+                base,
+                &[upstream],
+                &Default::default(),
+            );
+            resolved.get(&iterable.binding).cloned().unwrap_or_default()
+        });
+    let export_type = exports.get(&iterable.export)?.as_ref()?;
+
+    match (export_type, binding.slot) {
+        (TypeExpr::List(inner), ForBindingSlot::Value | ForBindingSlot::PairValue) => {
+            Some((**inner).clone())
+        }
+        (TypeExpr::List(_), ForBindingSlot::PairKey) => Some(TypeExpr::Int),
+        (TypeExpr::Map(inner), ForBindingSlot::Value | ForBindingSlot::PairValue) => {
+            Some((**inner).clone())
+        }
+        (TypeExpr::Map(_), ForBindingSlot::PairKey) => Some(TypeExpr::String),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #2096 / #2114. A for-loop variable used to appear as a
value-position completion candidate on every attribute inside the loop
body, regardless of the attribute's declared type:

\`\`\`crn
for _, account_id in orgs.accounts {
  awscc.sso.assignment {
    principal_type = ▉   # a StringEnum
  }
}
\`\`\`

The popup offered \`account_id\` even though its element type
(\`aws_account_id\`) can never type-check against \`PrincipalType\`.

## What changed
1. \`ForScopeBinding\` now carries the iterable reference
   (\`upstream.export\`) and the binding's slot in the header
   (\`ForBindingSlot::Value\` / \`PairKey\` / \`PairValue\`). Replaces
   the old flat name-only return.
2. New \`infer_for_binding_type\` resolves the iterable back to an
   \`upstream_state\` export's declared \`TypeExpr\`, then projects
   the binding's own type out of it using the slot
   (\`map(T)\` × \`PairValue\` → \`T\`, \`list(T)\` × \`PairKey\` → \`Int\`,
   etc.). Falls through to \`None\` for non-upstream iterables and
   un-annotated exports.
3. Filter via the existing
   \`carina_core::validation::is_type_expr_compatible_with_schema\`,
   which already handles \`Simple("aws_account_id")\` matching
   \`Custom{semantic_name: Some("AwsAccountId")}\` via
   \`pascal_to_snake\`.
4. Permissive fallback when inference can't decide — user still gets
   autocomplete on the bare name.
5. Hoist the upstream source scan and per-upstream exports cache out
   of the per-binding loop so the disk I/O stays at once per
   completion request, not once per for-variable in scope.

## Test plan
- [x] \`for_loop_binding_not_offered_at_incompatible_enum_attribute\` —
      \`principal_type\` (StringEnum) no longer sees \`account_id\`.
- [x] \`for_loop_binding_offered_at_matching_custom_attribute\` —
      \`target_id\` (Custom{aws_account_id}) still sees \`account_id\`.
- [x] \`for_loop_binding_without_resolvable_iterable_falls_back_to_unconditional\`
      — preserves current permissive behavior.
- [x] Existing for-scope tracking tests (simple, map, indexed, discard,
      outside-body, nested, braces-in-strings, sibling loops) migrated
      to the new API and still pass.
- [x] \`cargo test --workspace\` clean; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Scope
Upstream-state iterables with \`: map(T) = ...\` / \`: list(T) = ...\`
annotations are covered. Direct \`let\` iterables and inferred
\`ResourceRef\` types are left to a future follow-up — they require
typing the full downstream buffer rather than just the upstream
exports, which is a larger refactor.

Closes #2115

🤖 Generated with [Claude Code](https://claude.com/claude-code)