### PR TITLE
formatter: add upstream_state_expr + for-binding discard; parity test

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -220,9 +220,16 @@ function_call = {
 // Import expression: import "path" (used in let binding RHS)
 import_expr = { kw_import ~ trivia+ ~ string }
 
+// Upstream state expression: upstream_state { source = '..' }
+// Used as the RHS of a `let` binding — mirrors carina.pest:14.
+upstream_state_expr = {
+    kw_upstream_state ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+}
+
 // Primary value
 primary = {
     read_resource_expr
+  | upstream_state_expr
   | resource_expr
   | import_expr
   | for_expr
@@ -261,9 +268,13 @@ for_expr = {
 
 // For binding: simple (x), indexed ((i, x)), or map (k, v)
 for_binding = { for_indexed_binding | for_map_binding | for_simple_binding }
-for_simple_binding = { identifier }
-for_indexed_binding = { open_paren ~ trivia* ~ identifier ~ trivia* ~ comma ~ trivia* ~ identifier ~ trivia* ~ close_paren }
-for_map_binding = { identifier ~ trivia* ~ comma ~ trivia+ ~ identifier }
+for_simple_binding = { discard_pattern | identifier }
+for_indexed_binding = {
+    open_paren ~ trivia* ~ (discard_pattern | identifier) ~ trivia* ~ comma ~ trivia* ~ (discard_pattern | identifier) ~ trivia* ~ close_paren
+}
+for_map_binding = {
+    (discard_pattern | identifier) ~ trivia* ~ comma ~ trivia+ ~ (discard_pattern | identifier)
+}
 
 // For iterable: restricted to simple expressions
 for_iterable = { function_call | list | variable_ref | open_paren ~ trivia* ~ expression ~ trivia* ~ close_paren }
@@ -355,3 +366,4 @@ kw_to = { "to" }
 kw_from = { "from" }
 kw_id = { "id" }
 kw_require = { "require" }
+kw_upstream_state = { "upstream_state" }

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -73,6 +73,7 @@ pub enum NodeKind {
     AnonymousResource,
     ResourceExpr,
     ReadResourceExpr,
+    UpstreamStateExpr,
     FnDef,
     FnParam,
     ForExpr,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -148,6 +148,9 @@ impl<'a> CstBuilder<'a> {
             Rule::read_resource_expr => Some(CstChild::Node(
                 self.build_node(NodeKind::ReadResourceExpr, pair),
             )),
+            Rule::upstream_state_expr => Some(CstChild::Node(
+                self.build_node(NodeKind::UpstreamStateExpr, pair),
+            )),
             Rule::fn_def => Some(CstChild::Node(self.build_node(NodeKind::FnDef, pair))),
             Rule::fn_param => Some(CstChild::Node(self.build_node(NodeKind::FnParam, pair))),
             Rule::fn_local_let => Some(CstChild::Node(
@@ -286,6 +289,10 @@ impl<'a> CstBuilder<'a> {
             ))),
 
             Rule::kw_require => Some(CstChild::Token(Token::new("require".to_string(), span))),
+            Rule::kw_upstream_state => Some(CstChild::Token(Token::new(
+                "upstream_state".to_string(),
+                span,
+            ))),
 
             // Validate expression rules - treat as opaque node preserving source text
             Rule::validate_expr => Some(CstChild::Node(

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -167,6 +167,7 @@ impl Formatter {
             NodeKind::AnonymousResource => self.format_anonymous_resource(node),
             NodeKind::ResourceExpr => self.format_resource_expr(node),
             NodeKind::ReadResourceExpr => self.format_read_resource_expr(node),
+            NodeKind::UpstreamStateExpr => self.format_upstream_state_expr(node),
             NodeKind::FnDef => self.format_fn_def(node),
             NodeKind::FnParam => self.format_default(node),
             NodeKind::ForExpr => self.format_for_expr(node),
@@ -834,20 +835,12 @@ impl Formatter {
                 break;
             }
         }
+        self.format_block_body_tail(node);
+    }
 
-        if self.block_has_content(node) {
-            self.write(" {");
-            self.write_newline();
-            self.current_indent += 1;
-
-            self.format_block_attributes(node);
-
-            self.current_indent -= 1;
-            self.write_indent();
-            self.write("}");
-        } else {
-            self.write(" {}");
-        }
+    fn format_upstream_state_expr(&mut self, node: &CstNode) {
+        self.write("upstream_state");
+        self.format_block_body_tail(node);
     }
 
     fn format_read_resource_expr(&mut self, node: &CstNode) {
@@ -861,14 +854,19 @@ impl Formatter {
                 break;
             }
         }
+        self.format_block_body_tail(node);
+    }
 
+    /// Emit the ` { ... }` tail (or ` {}` when empty) for block-shaped
+    /// expressions. Caller is responsible for writing the keyword or
+    /// type prefix; this fn only formats the brace block and its
+    /// attributes.
+    fn format_block_body_tail(&mut self, node: &CstNode) {
         if self.block_has_content(node) {
             self.write(" {");
             self.write_newline();
             self.current_indent += 1;
-
             self.format_block_attributes(node);
-
             self.current_indent -= 1;
             self.write_indent();
             self.write("}");
@@ -3036,6 +3034,56 @@ require   port >= 1 && port <= 65535  , "port must be valid"
             thumbprint_line,
             "Comment should be directly above thumbprint_list. Got:\n{}",
             result
+        );
+    }
+
+    /// Regression for #2117: the formatter grammar missed `upstream_state`
+    /// entirely, so `let orgs = upstream_state { source = '..' }` couldn't
+    /// be formatted.
+    #[test]
+    fn test_format_upstream_state_expr() {
+        let input = "let orgs = upstream_state {\n    source = '../organizations'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("upstream_state"),
+            "upstream_state keyword must be preserved. Got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("source = '../organizations'"),
+            "source attribute must be preserved. Got:\n{}",
+            result
+        );
+    }
+
+    /// Regression for #2117: `for _, v in map { ... }` uses the discard
+    /// pattern `_`, which the formatter's `for_*_binding` productions did
+    /// not accept.
+    #[test]
+    fn test_format_for_binding_discard_pattern() {
+        let input =
+            "for _, account_id in orgs {\n  aws.s3.bucket {\n    name = account_id\n  }\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("for _, account_id in orgs"),
+            "discard pattern `_` must survive formatting. Got:\n{}",
+            result
+        );
+    }
+
+    /// Idempotence for both constructs above.
+    #[test]
+    fn test_format_upstream_state_and_for_discard_idempotent() {
+        let input = "let orgs = upstream_state {\n  source = '../organizations'\n}\n\nfor _, account_id in orgs {\n  aws.s3.bucket {\n    name = account_id\n  }\n}\n";
+        let config = FormatConfig::default();
+        let first = format(input, &config).unwrap();
+        let second = format(&first, &config).unwrap();
+        assert_eq!(
+            first, second,
+            "Formatting must be idempotent.\nfirst:\n{}\nsecond:\n{}",
+            first, second
         );
     }
 }

--- a/carina-core/tests/pest_grammar_parity.rs
+++ b/carina-core/tests/pest_grammar_parity.rs
@@ -1,0 +1,158 @@
+//! Drift-detection test for the two pest grammar files.
+//!
+//! The main parser (`carina-core/src/parser/carina.pest`) and the
+//! formatter's trivia-preserving parser (`carina-core/src/formatter/
+//! carina_fmt.pest`) define overlapping but not identical rule sets —
+//! the formatter carries extra trivia productions, and the main parser
+//! has some constructs the formatter doesn't surface. The two grammars
+//! have drifted silently before (#2117: missing `upstream_state_expr`,
+//! missing discard pattern in for-bindings), so this test flags every
+//! main-grammar rule whose name isn't also present in the formatter's
+//! grammar.
+//!
+//! The check is one-directional: every rule defined in `carina.pest`
+//! must have a same-named production in `carina_fmt.pest`. The reverse
+//! direction is not required — the formatter legitimately introduces
+//! `trivia`, `ws`, `comment`, `newline`, keyword (`kw_*`), and various
+//! delimiter rules that the canonical parser folds into implicit
+//! whitespace.
+//!
+//! `ALLOWED_MISSING` is an explicit escape hatch for rules that exist
+//! only as an implementation detail in one grammar. Add entries there
+//! deliberately, with a comment justifying each — the default is to add
+//! the production to the formatter grammar.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+const MAIN_GRAMMAR: &str = "src/parser/carina.pest";
+const FMT_GRAMMAR: &str = "src/formatter/carina_fmt.pest";
+
+/// Main-grammar rule names that deliberately have no formatter
+/// counterpart. Keep this list short and justify each entry in a
+/// comment — the default response to drift should be to add the rule
+/// to the formatter, not to allow-list it here.
+const ALLOWED_MISSING: &[&str] = &[
+    // pest built-ins with matching semantics but different spellings —
+    // the formatter uses explicit `trivia` / `ws` / `newline` / `comment`
+    // productions instead of the implicit `WHITESPACE` / `COMMENT` hooks.
+    "WHITESPACE",
+    "COMMENT",
+    // Lexer-level string/comment helpers. The formatter consumes these
+    // inline via its own string/comment productions.
+    "string_char",
+    "string_literal",
+    "string_part",
+    "single_quoted_content",
+    "interpolation",
+    "line_comment",
+    "block_comment",
+    // Operator/precedence intermediate rules — folded into the
+    // formatter's pipe/compose chain and primary.
+    "coalesce_expr",
+    // Body wrappers for `fn`, `for`, `if` — the formatter uses
+    // `fn_body_content`, `for_body_content`, `if_body_content` silent
+    // rules instead.
+    "fn_body",
+    "fn_params",
+    "for_body",
+    "if_body",
+    // Module call argument — the formatter uses the generic
+    // `block_content*` inside `module_call` rather than a dedicated
+    // per-argument rule.
+    "module_call_arg",
+    // Type expression sub-rules — the formatter exposes a single
+    // `type_expr` / `type_list` / `type_map` surface; the main
+    // parser's `type_simple` / `type_generic` / `resource_type_path`
+    // collapse into those.
+    "type_simple",
+    "type_generic",
+    "resource_type_path",
+    // State-block attributes — the formatter names them more
+    // granularly (`import_to_attr`, `import_id_attr`,
+    // `removed_from_attr`, `moved_from_attr`, `moved_to_attr`) rather
+    // than the main parser's umbrella `import_state_attr`,
+    // `removed_attr`, `moved_attr`. Different surface, same content.
+    "import_state_attr",
+    "removed_attr",
+    "moved_attr",
+    // Arguments-block sub-rules — the formatter uses
+    // `arguments_param_attr` with inline keyword branches instead of
+    // distinct `arg_description_attr` / `arg_default_attr` /
+    // `arg_validation_block` productions.
+    "arg_description_attr",
+    "arg_default_attr",
+    "arg_validation_block",
+    "validation_condition_attr",
+    "validation_error_message_attr",
+];
+
+fn collect_rule_names(pest_path: &str) -> BTreeSet<String> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let full_path = manifest_dir.join(pest_path);
+    let content = fs::read_to_string(&full_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", full_path.display(), e));
+
+    let mut names = BTreeSet::new();
+    for raw_line in content.lines() {
+        // Strip line comments so `//` inside a rule body doesn't count.
+        let line = raw_line.split("//").next().unwrap_or("").trim_start();
+        if line.is_empty() {
+            continue;
+        }
+        // A pest rule looks like `name = { ... }` or `name = _{ ... }`
+        // or `name = @{ ... }`. The name is always the first token on
+        // the line and uses only ASCII identifier characters.
+        let Some((ident, rest)) = line.split_once('=') else {
+            continue;
+        };
+        let ident = ident.trim();
+        if ident.is_empty() || !ident.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            continue;
+        }
+        // Confirm what follows `=` is a pest rule body: `{`, `_{`
+        // (silent), `@{` (atomic), or `${` (compound-atomic). Otherwise
+        // this is a stray `=` sign we don't care about.
+        let rest = rest.trim_start();
+        if rest.starts_with('{')
+            || rest.starts_with("_{")
+            || rest.starts_with("@{")
+            || rest.starts_with("${")
+        {
+            names.insert(ident.to_string());
+        }
+    }
+    names
+}
+
+#[test]
+fn every_main_rule_has_a_formatter_counterpart() {
+    let main_rules = collect_rule_names(MAIN_GRAMMAR);
+    let fmt_rules = collect_rule_names(FMT_GRAMMAR);
+    assert!(
+        !main_rules.is_empty(),
+        "parsed zero rules from {} — check the rule-extraction regex",
+        MAIN_GRAMMAR
+    );
+    assert!(
+        !fmt_rules.is_empty(),
+        "parsed zero rules from {} — check the rule-extraction regex",
+        FMT_GRAMMAR
+    );
+    let allowed: BTreeSet<&str> = ALLOWED_MISSING.iter().copied().collect();
+    let missing: Vec<&String> = main_rules
+        .iter()
+        .filter(|r| !fmt_rules.contains(*r) && !allowed.contains(r.as_str()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "Main-grammar rules are missing from `{}`:\n  {}\n\nAdd the rule to the formatter grammar, or extend `ALLOWED_MISSING` with a justification.",
+        FMT_GRAMMAR,
+        missing
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}


### PR DESCRIPTION
## Summary
\`carina fmt\` failed to parse two constructs the main parser accepts:

\`\`\`crn
let orgs = upstream_state { source = '..' }
for _, account_id in orgs.accounts { ... }
\`\`\`

The formatter uses its own pest grammar (\`carina_fmt.pest\`) that
preserves trivia the canonical parser discards. The split is
legitimate, but the two grammars drifted silently. This PR covers
**Part 1** (patch the failures) and **Part A** (drift-prevention
parity test) from the issue. Part B (corpus parity) and Part C
(grammar consolidation) are left for follow-up PRs as the issue
suggests.

## Part 1 — missing productions
- **\`upstream_state_expr\`** added to \`carina_fmt.pest\` + new
  \`kw_upstream_state\`. Slotted into \`primary\` at the same position
  as \`carina.pest\` so precedence matches. \`NodeKind::UpstreamStateExpr\`,
  \`cst_builder\` arm, and \`format_upstream_state_expr\` complete the
  plumbing.
- **For-binding discard** — \`for_simple_binding\` /
  \`for_indexed_binding\` / \`for_map_binding\` now accept
  \`(discard_pattern | identifier)\` in every name slot. The grammar's
  existing \`discard_pattern\` rule is reused; the builder already
  treats \`Rule::discard_pattern\` like \`Rule::identifier\`.
- **Refactor**: \`format_resource_expr\` / \`format_read_resource_expr\`
  / \`format_upstream_state_expr\` all shared a \` { ... }\` / \` {}\`
  block tail — factored into \`format_block_body_tail\`. Future
  block-shaped expressions land in one place.

## Part A — drift-prevention parity test
\`carina-core/tests/pest_grammar_parity.rs\` (new) reads both \`.pest\`
files, extracts rule identifiers, and asserts every main-grammar rule
has a same-named production in the formatter grammar. An
\`ALLOWED_MISSING\` escape hatch lists the legitimate asymmetries
(lexer-level helpers, silent wrappers, umbrella rules the formatter
models more granularly), with a one-liner justification per entry.
Follows the established \`tmlanguage_keyword_parity.rs\` pattern.

## Test plan
- [x] \`test_format_upstream_state_expr\` — Failure 1 repro from the issue.
- [x] \`test_format_for_binding_discard_pattern\` — Failure 2 repro.
- [x] \`test_format_upstream_state_and_for_discard_idempotent\` —
      idempotence of both constructs together.
- [x] \`every_main_rule_has_a_formatter_counterpart\` — drift guard.
- [x] 87 existing formatter tests still pass.
- [x] \`cargo test --workspace\`; \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #2117

🤖 Generated with [Claude Code](https://claude.com/claude-code)