### PR TITLE
formatter: accept // and /* */ comments; acceptance smoke test

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -5,11 +5,19 @@
 file = { SOI ~ file_content* ~ EOI }
 file_content = _{ trivia | statement }
 
-// Trivia: whitespace and comments that we want to preserve
+// Trivia: whitespace and comments that we want to preserve.
+//
+// The main parser accepts `//` and `#` line comments plus `/* ... */`
+// block comments (see `carina.pest`'s `line_comment` / `block_comment`).
+// The formatter has to accept the same three forms or it can't parse
+// real source — for example the `identity-center/` fixture uses `//`
+// comments inside attribute blocks.
 trivia = { ws | comment | newline }
 ws = @{ (" " | "\t")+ }
 newline = @{ NEWLINE }
-comment = @{ "#" ~ (!NEWLINE ~ ANY)* }
+comment = _{ line_comment | block_comment }
+line_comment = @{ ("//" | "#") ~ (!NEWLINE ~ ANY)* }
+block_comment = @{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
 
 statement = { backend_block | provider_block | arguments_block | attributes_block | exports_block | import_state_block | removed_block | moved_block | require_statement | if_expr | for_expr | fn_def | let_binding | module_call | anonymous_resource }
 

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -24,8 +24,10 @@ pub enum Trivia {
     Whitespace(String),
     /// Single newline
     Newline,
-    /// Line comment including the # prefix
+    /// Line comment including its prefix (`#` or `//`)
     LineComment(String),
+    /// Block comment including its `/* */` delimiters.
+    BlockComment(String),
 }
 
 impl Trivia {
@@ -34,6 +36,7 @@ impl Trivia {
             Trivia::Whitespace(s) => s,
             Trivia::Newline => "\n",
             Trivia::LineComment(s) => s,
+            Trivia::BlockComment(s) => s,
         }
     }
 }

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -54,7 +54,10 @@ impl<'a> CstBuilder<'a> {
                 pair.as_str().to_string(),
             ))),
             Rule::newline => Some(CstChild::Trivia(Trivia::Newline)),
-            Rule::comment => Some(CstChild::Trivia(Trivia::LineComment(
+            Rule::line_comment => Some(CstChild::Trivia(Trivia::LineComment(
+                pair.as_str().to_string(),
+            ))),
+            Rule::block_comment => Some(CstChild::Trivia(Trivia::BlockComment(
                 pair.as_str().to_string(),
             ))),
 
@@ -321,6 +324,11 @@ impl<'a> CstBuilder<'a> {
             Rule::validation_block_attr => None,
 
             Rule::file => None,
+
+            // `comment` is a silent alternation; the matching `line_comment`
+            // / `block_comment` branches above emit the actual trivia. This
+            // arm exists only so the exhaustive match compiles.
+            Rule::comment => None,
         }
     }
 

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -95,7 +95,7 @@ impl Formatter {
         for child in &node.children {
             match child {
                 CstChild::Trivia(trivia) => match trivia {
-                    Trivia::LineComment(_) => {
+                    Trivia::LineComment(_) | Trivia::BlockComment(_) => {
                         pending_comments.push(trivia);
                         blank_line_count = 0;
                     }
@@ -1170,7 +1170,10 @@ impl Formatter {
     fn block_has_content(&self, node: &CstNode) -> bool {
         node.children.iter().any(|child| {
             matches!(child, CstChild::Node(n) if n.kind == NodeKind::Attribute || n.kind == NodeKind::NestedBlock || n.kind == NodeKind::LocalBinding)
-                || matches!(child, CstChild::Trivia(Trivia::LineComment(_)))
+                || matches!(
+                    child,
+                    CstChild::Trivia(Trivia::LineComment(_) | Trivia::BlockComment(_))
+                )
         })
     }
 
@@ -1206,7 +1209,7 @@ impl Formatter {
                     attr_index += 1;
                     newline_count = 0;
                 }
-                CstChild::Trivia(Trivia::LineComment(s)) => {
+                CstChild::Trivia(Trivia::LineComment(s) | Trivia::BlockComment(s)) => {
                     // Check if this is an inline comment (on same line as previous attribute)
                     if attr_index > 0 && !s.is_empty() && newline_count == 0 {
                         inline_comments.insert(
@@ -1932,7 +1935,7 @@ impl Formatter {
 
     fn write_trivia(&mut self, trivia: &Trivia) {
         match trivia {
-            Trivia::LineComment(s) => self.write(s),
+            Trivia::LineComment(s) | Trivia::BlockComment(s) => self.write(s),
             Trivia::Newline => self.write_newline(),
             Trivia::Whitespace(s) => self.write(s),
         }

--- a/carina-core/tests/fixtures/fmt_smoke/identity-center/backend.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/identity-center/backend.crn
@@ -1,0 +1,8 @@
+backend s3 {
+  bucket = 'carina-rs-state'
+  key    = 'management/identity-center/carina.state.json'
+}
+
+let orgs = upstream_state {
+  source = '../organizations'
+}

--- a/carina-core/tests/fixtures/fmt_smoke/identity-center/main.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/identity-center/main.crn
@@ -1,0 +1,70 @@
+# IAM Identity Center
+#
+# Manages Identity Center (SSO) for the management account.
+#
+# Note: AWS::IdentityStore::User is not supported by CloudFormation, so users
+# must be created manually via `aws identitystore create-user`. Groups,
+# memberships, permission sets, and assignments are managed here.
+
+let caller = read aws.sts.caller_identity {}
+
+let sso = awscc.sso.instance {
+  name = 'carina-rs'
+
+  tags = {
+    Project   = 'carina-rs'
+    ManagedBy = 'carina'
+  }
+}
+
+let admins = awscc.identitystore.group {
+  display_name      = 'admins'
+  description       = 'Administrator group'
+  identity_store_id = sso.identity_store_id
+}
+
+let mizzy = read aws.identitystore.user {
+  identity_store_id = sso.identity_store_id
+  user_name         = 'gosukenator@gmail.com'
+}
+
+awscc.identitystore.group_membership {
+  group_id          = admins.group_id
+  identity_store_id = sso.identity_store_id
+
+  member_id = {
+    user_id = mizzy.user_id
+  }
+}
+
+let administrator_access = awscc.sso.permission_set {
+  name         = 'AdministratorAccess'
+  description  = 'Provides full access to AWS services and resources'
+  instance_arn = sso.instance_arn
+
+  managed_policies = ['arn:aws:iam::aws:policy/AdministratorAccess']
+
+  session_duration = 'PT8H'
+}
+
+awscc.sso.assignment {
+  instance_arn       = sso.instance_arn
+  permission_set_arn = administrator_access.permission_set_arn
+  principal_id       = admins.group_id
+  principal_type     = GROUP
+  target_id          = caller.account_id
+  target_type        = AWS_ACCOUNT
+}
+
+# admins → AdministratorAccess on the registry child accounts.
+for _, account_id in orgs.accounts {
+  awscc.sso.assignment {
+    instance_arn       = sso.instance_arn
+    permission_set_arn = administrator_access.permission_set_arn
+    principal_id       = admins.group_id
+    principal_type     = GROUP
+    target_id          = account_id
+    //target_type        = awscc.sso.assignment.TargetType.AWS_ACCOUNT
+    target_type = "aaa"
+  }
+}

--- a/carina-core/tests/fixtures/fmt_smoke/identity-center/providers.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/identity-center/providers.crn
@@ -1,0 +1,11 @@
+provider awscc {
+  source   = 'github.com/carina-rs/carina-provider-awscc'
+  revision = 'main'
+  region   = awscc.Region.ap_northeast_1
+}
+
+provider aws {
+  source   = 'github.com/carina-rs/carina-provider-aws'
+  revision = 'main'
+  region   = aws.Region.ap_northeast_1
+}

--- a/carina-core/tests/fmt_infra_smoke.rs
+++ b/carina-core/tests/fmt_infra_smoke.rs
@@ -1,0 +1,81 @@
+//! Smoke test for `carina fmt` against real-world `.crn` files.
+//!
+//! #2117 repro lives in `fixtures/fmt_smoke/identity-center/` — verbatim
+//! copies of `carina-rs/infra/aws/management/identity-center/`. If this
+//! test fails, the formatter grammar has drifted away from something the
+//! main parser accepts. Fix the formatter, don't modify the fixture.
+//!
+//! This test was added after a round of fixes that passed synthetic unit
+//! tests but silently missed additional grammar gaps in the same file.
+//! Running the formatter end-to-end over the actual source guards the
+//! acceptance condition the original issue called out.
+
+use std::fs;
+use std::path::PathBuf;
+
+use carina_core::formatter::{FormatConfig, format};
+
+fn fixture_dir(name: &str) -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("tests/fixtures/fmt_smoke").join(name)
+}
+
+fn format_all_crn_files(dir: &PathBuf) -> Result<(), String> {
+    let config = FormatConfig::default();
+    let entries = fs::read_dir(dir).map_err(|e| format!("read_dir {}: {}", dir.display(), e))?;
+    let mut failures: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn") {
+            let source =
+                fs::read_to_string(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+            if let Err(e) = format(&source, &config) {
+                failures.push(format!(
+                    "{}: {}",
+                    path.file_name().unwrap().to_string_lossy(),
+                    e
+                ));
+            }
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("\n"))
+    }
+}
+
+#[test]
+fn fmt_accepts_identity_center_fixture() {
+    let dir = fixture_dir("identity-center");
+    let result = format_all_crn_files(&dir);
+    assert!(
+        result.is_ok(),
+        "`carina fmt` must parse every .crn file in {}. Failures:\n{}\n\nAdd the missing construct to `carina-core/src/formatter/carina_fmt.pest` rather than modifying the fixture.",
+        dir.display(),
+        result.unwrap_err()
+    );
+}
+
+#[test]
+fn fmt_idempotent_on_identity_center_fixture() {
+    let dir = fixture_dir("identity-center");
+    let config = FormatConfig::default();
+    let entries = fs::read_dir(&dir).expect("read_dir");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn") {
+            let source = fs::read_to_string(&path).expect("read file");
+            let first = format(&source, &config)
+                .unwrap_or_else(|e| panic!("{}: format failed: {}", path.display(), e));
+            let second = format(&first, &config)
+                .unwrap_or_else(|e| panic!("{}: second format failed: {}", path.display(), e));
+            assert_eq!(
+                first,
+                second,
+                "format must be idempotent on {}",
+                path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #2118 (which I prematurely closed #2117 on). My unit
tests passed, but I never ran \`carina fmt\` against the real
acceptance fixture the issue spelled out:

> Acceptance smoke test: \`carina fmt\` runs cleanly against \`carina-rs/infra/\`.

Running fmt on the repro file (\`identity-center/main.crn\`) still
failed at line 67:

\`\`\`
//target_type = awscc.sso.assignment.TargetType.AWS_ACCOUNT
\`\`\`

The formatter grammar's \`comment\` rule only matched \`#\`. The main
parser (\`carina.pest\`) accepts \`//\`, \`#\`, and \`/* */\` — a third
drift in the same file I was supposed to be fixing.

## What changed
- **\`carina_fmt.pest\`**: split \`comment\` into silent \`line_comment\` /
  \`block_comment\` alternatives, matching \`carina.pest\` shape.
- **\`cst.rs\`**: new \`Trivia::BlockComment(String)\` variant. \`text()\`
  and every \`match\` arm across \`format.rs\` / \`cst_builder.rs\`
  updated.
- **\`block_has_content\`**: block comments count as content now.
- **\`carina-core/tests/fmt_infra_smoke.rs\`** (new): formats every
  \`.crn\` in \`carina-core/tests/fixtures/fmt_smoke/identity-center/\`
  — verbatim copies of the issue's repro directory. Asserts both
  parse success and idempotence.

## Verification
Ran \`carina fmt\` against every directory in \`carina-rs/infra/\`
(6 dirs, 17 \`.crn\` files). Every one formats cleanly and idempotent.

## Test plan
- [x] \`fmt_accepts_identity_center_fixture\` — real repro formats
      cleanly.
- [x] \`fmt_idempotent_on_identity_center_fixture\` — two passes
      converge.
- [x] Existing 87 formatter unit tests + rule-parity test (#2118)
      still pass.
- [x] Manual: \`carina fmt\` clean on every \`infra/\` dir.
- [x] \`cargo test --workspace\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #2117

🤖 Generated with [Claude Code](https://claude.com/claude-code)