### PR TITLE
lsp completion: type-filter exports value position

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -88,6 +88,10 @@ impl CompletionProvider {
                 position,
                 base_path,
             ),
+            CompletionContext::AfterEqualsInExports {
+                type_expr_text,
+                in_nested,
+            } => self.exports_value_completions(&type_expr_text, in_nested, &text),
             CompletionContext::InsideStructBlock {
                 resource_type,
                 attr_path,
@@ -175,6 +179,12 @@ impl CompletionProvider {
         let mut in_args_or_attrs_block = false;
         let mut in_exports_block = false;
         let mut in_upstream_state_block = false;
+        // Type annotation of the most recent `<name>: <type> = ...` entry
+        // inside an `exports { ... }` block. Recorded at brace_depth 1 and
+        // consulted when the cursor lands inside that entry's value
+        // position (depth 1 for top-level, depth 2+ for nested map/list).
+        // Cleared when the entry closes or a new one starts.
+        let mut exports_entry_type: Option<String> = None;
         // Track nested block names at each depth level (index 0 = depth 1, etc.)
         let mut nested_block_names: Vec<String> = Vec::new();
         // Depth-of-for-bodies currently open. A `for ... { <body> }` stacks a
@@ -273,6 +283,18 @@ impl CompletionProvider {
                 }
             }
 
+            // Inside an `exports` block, capture the type annotation of
+            // the current entry: `<name>: <type> = ...`. Recorded at
+            // depth 1 (the exports block body itself). Used by value-
+            // position completion to filter candidates by the declared
+            // type.
+            if in_exports_block
+                && brace_depth == 1
+                && let Some(ty) = extract_exports_entry_type(trimmed)
+            {
+                exports_entry_type = Some(ty);
+            }
+
             // Track for-body opens so the opening `{` increments both
             // brace_depth and for_body_depth. The matching `}` drops
             // for_body_depth alongside brace_depth.
@@ -298,7 +320,12 @@ impl CompletionProvider {
                         in_args_or_attrs_block = false;
                         in_exports_block = false;
                         in_upstream_state_block = false;
+                        exports_entry_type = None;
                         nested_block_names.clear();
+                    } else if brace_depth == 1 && in_exports_block {
+                        // Closing a nested `{ ... }` inside an exports
+                        // map/list value — the next entry starts fresh.
+                        exports_entry_type = None;
                     } else if brace_depth == for_body_depth {
                         // Closed the resource/module block that was inside the
                         // current for body — forget its type so the next
@@ -390,14 +417,24 @@ impl CompletionProvider {
             let after_eq = prefix.split('=').next_back().unwrap_or("").trim();
             // Don't show completions if user is typing a string literal (except just starting)
             if !after_eq.starts_with('"') || after_eq == "\"" {
-                // Exports-block values are type-annotated (e.g.
-                // `accounts: map(aws_account_id) = ...`); until the
-                // completion engine can read that annotation and filter
-                // by it, returning nothing beats the old behavior of
-                // dumping every built-in function and region into the
-                // popup (#1993). Matches the "prefer empty to generic"
-                // stance established by #1974.
+                // Inside an `exports` block, filter value-position
+                // candidates by the entry's declared type. If the
+                // annotation can't be resolved the original empty
+                // fallback from #1993 still applies — it is preferable
+                // to silence than to dump every built-in.
                 if in_exports_block {
+                    if let Some(entry_type) = exports_entry_type.as_deref() {
+                        // `brace_depth == 1` means the value sits
+                        // directly after `= ` at the top of the exports
+                        // entry; `>= 2` means it's inside the entry's
+                        // `{ ... }` map or list body, so the relevant
+                        // type is unwrapped by one level.
+                        let in_nested = brace_depth >= 2;
+                        return CompletionContext::AfterEqualsInExports {
+                            type_expr_text: entry_type.to_string(),
+                            in_nested,
+                        };
+                    }
                     return CompletionContext::None;
                 }
                 // Extract attribute name from current line
@@ -642,6 +679,16 @@ enum CompletionContext {
         attr_name: String,
         current_binding: Option<String>,
     },
+    /// Cursor is at a value position inside an `exports { ... }` block
+    /// for an entry that carries a type annotation. `type_expr_text` is
+    /// the raw annotation text (`string`, `map(aws_account_id)`, etc.);
+    /// `in_nested` is true when the cursor is inside that entry's
+    /// `{ ... }` map or list body, meaning the effective type is the
+    /// annotation unwrapped by one level.
+    AfterEqualsInExports {
+        type_expr_text: String,
+        in_nested: bool,
+    },
     InsideStructBlock {
         resource_type: String,
         attr_path: Vec<String>,
@@ -676,6 +723,21 @@ enum CompletionContext {
 
 /// Detect a `let <binding> = upstream_state {` opening line, where `<binding>`
 /// is a bare identifier. Used to enter the upstream_state block context.
+/// Extract the type annotation from a line that opens an `exports`
+/// entry, e.g. `accounts: map(aws_account_id) = { ...` returns
+/// `Some("map(aws_account_id)")`. Returns `None` when the line doesn't
+/// match the `<name>: <type> =` shape — either because there's no
+/// colon, no equals, or the type portion is empty.
+fn extract_exports_entry_type(line: &str) -> Option<String> {
+    let (before_eq, _) = line.split_once('=')?;
+    let (_name, after_colon) = before_eq.split_once(':')?;
+    let type_text = after_colon.trim();
+    if type_text.is_empty() {
+        return None;
+    }
+    Some(type_text.to_string())
+}
+
 fn is_let_upstream_state_line(trimmed: &str) -> bool {
     let Some((_, rhs)) = crate::let_parse::parse_let_header(trimmed) else {
         return false;

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1805,11 +1805,14 @@ for _, id in orgs.
 // =====================================================================
 
 #[test]
-fn exports_value_position_excludes_builtin_functions() {
-    // `exports { accounts: map(string) = { k = <HERE> } }` must not suggest
-    // built-in functions like `replace` — they don't produce a string the
-    // map entry could use without an extra call site, and offering every
-    // function clutters the popup.
+fn exports_value_position_excludes_region_pollution() {
+    // `exports { accounts: map(string) = { k = <HERE> } }` — the map
+    // value type is `string`, which accepts `replace` et al. What must
+    // NOT appear is provider-specific literal noise like
+    // `aws.Region.*`, whose type is an enum that can't reach a plain
+    // `string` entry. Regression guard for the #1993 repro: the popup
+    // should be driven by the declared type, never by "everything
+    // the provider knows about".
     let provider = test_provider();
     let source = "\
 exports {
@@ -1825,18 +1828,19 @@ exports {
     };
 
     let completions = provider.complete(&doc, position, None);
-
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
-        !completions.iter().any(|c| c.label == "replace"),
-        "`replace` must not appear at exports value position, got: {:?}",
-        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        !labels.iter().any(|l| l.contains(".Region.")),
+        "no region literals at map(string) value position, got: {:?}",
+        labels
     );
 }
 
 #[test]
-fn exports_top_level_value_excludes_builtin_functions() {
-    // `exports { id: string = <HERE> }` — directly at the top-level of the
-    // exports block, not nested in a map.
+fn exports_top_level_value_excludes_region_pollution() {
+    // Same guard at the top level of the exports block. The type
+    // filter should keep the popup useful without falling back to the
+    // old noisy "all regions + all built-ins" set.
     let provider = test_provider();
     let source = "\
 exports {
@@ -1850,38 +1854,12 @@ exports {
     };
 
     let completions = provider.complete(&doc, position, None);
-
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
-        !completions.iter().any(|c| c.label == "replace"),
-        "`replace` must not appear at exports value position, got: {:?}",
-        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+        !labels.iter().any(|l| l.contains(".Region.")),
+        "no region literals at string exports value position, got: {:?}",
+        labels
     );
-}
-
-#[test]
-fn exports_value_position_returns_none_context() {
-    // Stronger guarantee than "no `replace` / no `.Region.`": the context
-    // itself must be `None`, so no handler fires and no generic candidate
-    // set can leak through — regardless of which providers are registered.
-    let provider = test_provider();
-    for source in [
-        "exports {\n  id: string = re\n}\n",
-        "exports {\n  accounts: map(string) = {\n    k = re\n  }\n}\n",
-    ] {
-        let last_line = source.lines().find(|l| l.contains(" = ")).unwrap();
-        let line_idx = source.lines().position(|l| l == last_line).unwrap() as u32;
-        let position = Position {
-            line: line_idx,
-            character: last_line.chars().count() as u32,
-        };
-        let context = provider.get_completion_context(source, position);
-        assert!(
-            matches!(context, CompletionContext::None),
-            "expected None, got {:?} for source:\n{}",
-            context,
-            source
-        );
-    }
 }
 
 /// At a value position whose attribute type is a `Custom` semantic
@@ -2108,6 +2086,240 @@ fn for_loop_binding_without_resolvable_iterable_falls_back_to_unconditional() {
     assert!(
         labels.contains(&"account_id"),
         "unresolvable iterable should preserve the permissive fallback. Got: {:?}",
+        labels
+    );
+}
+
+/// Top-level `exports { region: string = ▉ }` must offer string-
+/// returning built-in helpers. The annotation sits on the same line;
+/// the LSP previously returned nothing because the type was ignored.
+#[test]
+fn exports_top_level_string_position_offers_string_builtins() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"exports {
+  region: string =
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: "  region: string = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for expected in ["join", "lower", "upper", "trim"] {
+        assert!(
+            labels.contains(&expected),
+            "string-returning built-in '{}' must appear at `exports {{ region: string = ▉ }}`. Got: {:?}",
+            expected,
+            labels
+        );
+    }
+}
+
+/// Non-string built-ins must not appear when the declared type is
+/// `string` — filter correctness.
+#[test]
+fn exports_top_level_string_position_excludes_non_string_builtins() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"exports {
+  region: string =
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: "  region: string = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for banned in ["flatten", "keys"] {
+        assert!(
+            !labels.contains(&banned),
+            "list-returning '{}' must not appear at a `string` exports position. Got: {:?}",
+            banned,
+            labels
+        );
+    }
+}
+
+/// Inside a nested `{ ... }` block that is the value of
+/// `accounts: map(T) = { ... }`, the element type is `T` and only
+/// `T`-compatible candidates should appear. Guards against the repro
+/// where `registry_dev = re|` suggests `replace`.
+#[test]
+fn exports_map_value_position_filters_by_element_type() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"exports {
+  accounts: map(aws_account_id) = {
+    registry_prod = x
+  }
+}
+"#,
+    );
+    // Cursor on the `registry_prod = ` line after `= `.
+    let position = Position {
+        line: 2,
+        character: "    registry_prod = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    // `replace` returns `string`; `aws_account_id` is a Custom
+    // semantic subtype — no built-in produces it, so `replace` must
+    // not appear.
+    assert!(
+        !labels.contains(&"replace"),
+        "`replace` must not be suggested inside a `map(aws_account_id)` value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"join"),
+        "`join` must not be suggested inside a `map(aws_account_id)` value position. Got: {:?}",
+        labels
+    );
+}
+
+/// Fall back to empty when the annotation can't be resolved —
+/// unknown entry, missing colon, etc. Silent beats noisy; this
+/// guards against a regression that would dump every built-in.
+#[test]
+fn exports_value_without_type_annotation_returns_empty() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"exports {
+  mystery =
+}
+"#,
+    );
+    let position = Position {
+        line: 1,
+        character: "  mystery = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    // Empty is acceptable; what's NOT acceptable is dumping every
+    // built-in.
+    assert!(
+        !completions.iter().any(|c| c.label == "replace"),
+        "no annotation must not surface `replace`. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+/// Real-world acceptance: the repro `exports.crn` used by
+/// `carina-rs/infra/aws/management/organizations/`. Completion at the
+/// `registry_dev = re|` position must not offer `replace` (it returns
+/// a plain String, the map element type is `aws_account_id`).
+#[test]
+fn exports_map_value_real_world_shape_filters_unrelated_builtins() {
+    let provider = test_provider();
+    let source = "\
+exports {
+  accounts: map(aws_account_id) = {
+    registry_prod = registry_prod.account_id
+    registry_dev  = re
+  }
+}
+";
+    let doc = create_document(source);
+    let position = Position {
+        line: 3,
+        character: "  registry_dev  = re".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for banned in ["replace", "join", "lower", "upper", "trim", "env", "lookup"] {
+        assert!(
+            !labels.contains(&banned),
+            "String-returning '{}' must not appear in a `map(aws_account_id)` value position. Got: {:?}",
+            banned,
+            labels
+        );
+    }
+}
+
+/// Resource-ref candidates: a binding whose resource schema exposes an
+/// attribute of the target type should appear as `<binding>.<attr>`
+/// at the value position. Guards the "offer matching refs" half of
+/// the issue spec.
+#[test]
+fn exports_map_value_offers_matching_resource_refs() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("AwsAccountId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_noop,
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", account_id));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let source = "\
+let registry_prod = awscc.organizations.account {
+  name = 'prod'
+}
+
+exports {
+  accounts: map(aws_account_id) = {
+    registry_prod = re
+  }
+}
+";
+    let doc = create_document(source);
+    let position = Position {
+        line: 6,
+        character: "    registry_prod = re".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod.account_id"),
+        "expected `registry_prod.account_id` at `map(aws_account_id)` value position. Got: {:?}",
+        labels
+    );
+}
+
+/// List element position: `exports { items: list(string) = [▉] }` —
+/// string-returning built-ins should appear inside the list.
+#[test]
+fn exports_list_value_position_filters_by_element_type() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"exports {
+  items: list(string) = [
+    re
+  ]
+}
+"#,
+    );
+    // Cursor on `    re` line.
+    let position = Position {
+        line: 2,
+        character: "    re".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    // The list-element case is harder to detect from text alone
+    // (square brackets don't change brace_depth). The conservative
+    // acceptable behaviour is either (a) type-filtered suggestions or
+    // (b) nothing — but never a regional/builtin dump. Guard the
+    // never-dump half.
+    assert!(
+        !labels.iter().any(|l| l.contains(".Region.")),
+        "list-element position must not regress into region dump. Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -758,6 +758,90 @@ impl CompletionProvider {
         Self::builtin_completions_matching(|_| true)
     }
 
+    /// Type-aware completions at a value position inside an `exports`
+    /// block. `type_expr_text` is the raw annotation (`string`,
+    /// `map(aws_account_id)`, `list(string)`, …) pulled off the
+    /// enclosing entry. When `in_nested` is true the cursor is inside
+    /// that entry's `{ ... }` map/list body, so the effective type is
+    /// the annotation unwrapped by one level.
+    ///
+    /// When the annotation can't be parsed this returns the empty
+    /// list — "silent rather than noisy" stays the right fallback
+    /// since an unknown type offers no basis for suggestion.
+    pub(super) fn exports_value_completions(
+        &self,
+        type_expr_text: &str,
+        in_nested: bool,
+        text: &str,
+    ) -> Vec<CompletionItem> {
+        let Some(annotation) = parse_exports_type_text(type_expr_text) else {
+            return Vec::new();
+        };
+        let effective = if in_nested {
+            match &annotation {
+                AttributeType::List { inner, .. } | AttributeType::Map { value: inner, .. } => {
+                    (**inner).clone()
+                }
+                // Inside `{ ... }` of a non-collection annotation we
+                // don't know what the user means — fall silent.
+                _ => return Vec::new(),
+            }
+        } else {
+            annotation
+        };
+
+        let mut items = Self::builtin_function_completions_for_type(&effective);
+        items.extend(self.resource_ref_completions_for_type(&effective, text));
+        items
+    }
+
+    /// Find resource-ref paths (`<binding>.<attr>`) whose leaf
+    /// attribute is assignable to `target` and return them as
+    /// completion items. `text` is the current buffer; we scan it for
+    /// `let <binding> = <resource_type> { ... }` declarations and look
+    /// up each binding's resource schema. Used by the `exports`
+    /// value-position handler to surface matching references alongside
+    /// type-compatible built-ins.
+    fn resource_ref_completions_for_type(
+        &self,
+        target: &AttributeType,
+        text: &str,
+    ) -> Vec<CompletionItem> {
+        let mut items: Vec<CompletionItem> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (binding_name, resource_type) in self.extract_resource_bindings(text) {
+            if resource_type.is_empty() {
+                continue;
+            }
+            let Some(schema) = self.schemas.get(&resource_type) else {
+                continue;
+            };
+            for attr in schema.attributes.values() {
+                if !attr.attr_type.is_assignable_to(target) {
+                    continue;
+                }
+                let full_ref = format!("{}.{}", binding_name, attr.name);
+                if !seen.insert(full_ref.clone()) {
+                    continue;
+                }
+                items.push(CompletionItem {
+                    label: full_ref.clone(),
+                    kind: Some(CompletionItemKind::REFERENCE),
+                    detail: Some(format!(
+                        "Reference to {}'s {} ({})",
+                        binding_name,
+                        attr.name,
+                        attr.attr_type.type_name()
+                    )),
+                    insert_text: Some(full_ref),
+                    ..Default::default()
+                });
+            }
+        }
+        items.sort_by(|a, b| a.label.cmp(&b.label));
+        items
+    }
+
     /// Return built-in function completions whose declared return type is
     /// compatible with the attribute's declared `AttributeType`. Used by
     /// value-position completion to avoid suggesting `concat` / `join` /
@@ -1159,6 +1243,95 @@ fn return_type_fits(ret: builtins::BuiltinReturnType, attr_type: &AttributeType)
         AttributeType::Float => false,
         AttributeType::Struct { .. } => false,
     }
+}
+
+/// Parse the raw text of an `exports` entry's type annotation into an
+/// `AttributeType` good enough to drive value-position completion
+/// filtering. Accepts the shapes the DSL grammar produces at this
+/// surface:
+///
+/// * primitive names (`string`, `int`, `float`, `bool`)
+/// * `list(T)` / `map(T)` with recursive inner parsing
+/// * a bare identifier interpreted as a custom semantic subtype — the
+///   name is PascalCase'd (`aws_account_id` → `AwsAccountId`) and
+///   stored as `Custom { semantic_name: Some(PascalCase), base: String }`
+///   so `is_assignable_to` matches schemas that declare the same
+///   semantic name.
+///
+/// Namespaced identifiers (`aws.vpc.VpcId`) are **not** parsed today —
+/// they fall into `None` and the caller silently drops to the empty
+/// completion set. Add a dotted-path branch when a real corpus shows
+/// users reaching for that shape in `exports` annotations.
+///
+/// Returns `None` for anything we don't understand; the caller falls
+/// back to the empty completion set rather than dumping everything.
+fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
+    let text = text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    if let Some(inner) = strip_generic("list", text) {
+        return parse_exports_type_text(inner).map(AttributeType::list);
+    }
+    if let Some(inner) = strip_generic("map", text) {
+        let inner_ty = parse_exports_type_text(inner)?;
+        return Some(AttributeType::Map {
+            key: Box::new(AttributeType::String),
+            value: Box::new(inner_ty),
+        });
+    }
+    match text {
+        "string" => Some(AttributeType::String),
+        "int" => Some(AttributeType::Int),
+        "float" => Some(AttributeType::Float),
+        "bool" => Some(AttributeType::Bool),
+        name if is_valid_custom_name(name) => Some(AttributeType::Custom {
+            semantic_name: Some(snake_to_pascal(name)),
+            base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
+            validate: noop_validate,
+            namespace: None,
+            to_dsl: None,
+        }),
+        _ => None,
+    }
+}
+
+/// `list(...)` / `map(...)` wrapper stripper. Returns the inner text
+/// between balanced parens, `None` for any other shape.
+fn strip_generic<'a>(prefix: &str, text: &'a str) -> Option<&'a str> {
+    let rest = text.strip_prefix(prefix)?;
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('(')?;
+    let rest = rest.strip_suffix(')')?;
+    Some(rest)
+}
+
+fn is_valid_custom_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+}
+
+fn snake_to_pascal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut next_upper = true;
+    for ch in s.chars() {
+        if ch == '_' {
+            next_upper = true;
+        } else if next_upper {
+            out.extend(ch.to_uppercase());
+            next_upper = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {
+    Ok(())
 }
 
 /// Scan `ancestor` for directories that look like carina projects.


### PR DESCRIPTION
## Summary
Inside \`exports { key: T = ▉ }\` (and its nested \`{ ... }\` map / list
body), value-position completion now consults the declared type \`T\`
and offers only candidates whose result is assignable to it.

Previous behaviour returned nothing — the empty fallback from
#1993 / #2042. Filter-correct but unhelpful.

## What changed
- \`CompletionContext::AfterEqualsInExports { type_expr_text, in_nested }\`
  carries the raw annotation + a flag for whether the cursor sits
  inside the entry's collection body. Stays as text so partial /
  unparseable buffers don't break detection.
- The line-by-line context detector tracks the most recent
  \`<name>: <type> = ...\` annotation at the exports block's depth
  and clears it when the entry closes.
- \`exports_value_completions\` parses the annotation via a small
  hand-rolled \`parse_exports_type_text\` (primitives, \`list(T)\` /
  \`map(T)\`, bare custom-name identifiers — namespaced identifiers
  fall through to the empty fallback for now). When \`in_nested\`,
  the annotation is unwrapped one level.
- Built-in candidates reuse \`builtin_function_completions_for_type\`
  from #2096; resource-ref candidates iterate in-scope bindings and
  accept any attribute \`is_assignable_to(target)\`.
- When the annotation can't be parsed the handler returns empty.

## Test plan
- [x] String position offers string-returning built-ins.
- [x] Non-string built-ins excluded for \`string\` annotation.
- [x] \`map(aws_account_id)\` value position filters out string-only
      built-ins.
- [x] Real-world repro from \`organizations/exports.crn\`.
- [x] Resource-ref \`<binding>.<attr>\` appears for matching types.
- [x] List element position doesn't regress into region dump.
- [x] No-annotation case stays empty.
- [x] Pre-existing #1993 tests rewritten to encode "no noise" rather
      than "bare empty".
- [x] \`cargo test --workspace\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

Closes #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)