### PR TITLE
lsp completion: scan sibling .crn files for exports value refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,41 @@ merged uniformly — no file name (including `main.crn`) is privileged.
 - CLI: `load_module()` / `ModuleResolver::load_module` require a directory path.
 - LSP: Module loading in `diagnostics/checks.rs` handles directory modules for proper validation.
 
+### Directory-scoped, never single-file
+
+**Carina configurations are directory units.** Every feature that reads DSL
+source — completion, diagnostics, validation, formatting, hover, code lens,
+etc. — must consider sibling `.crn` files in the same directory as
+first-class input, not as an afterthought. A `let` binding in `main.crn`
+must be visible from `exports.crn`; a `provider` block in `providers.crn`
+must apply to `main.crn`. Anything that looks at only one file is a bug.
+
+When implementing or modifying such a feature:
+
+1. **Acceptance test must use multiple files.** A unit test built from a
+   single string is not sufficient evidence. Write a `tempfile::tempdir()`
+   fixture that mirrors the real `infra/aws/management/<dir>/` shape —
+   typically `main.crn` + `exports.crn` + `providers.crn` + `backend.crn` —
+   and assert behavior under that shape. The bare-string variant is fine
+   *in addition to* the directory variant, never *instead of* it.
+2. **Real-infra smoke test.** Where feasible, run the built binary
+   (`carina fmt`, `carina validate`, etc.) against `carina-rs/infra/`
+   directly before declaring the issue done. The acceptance condition
+   in the original issue almost always names a real path; respect it.
+3. **API signal.** Helpers that take a single `&str` of source text
+   (`extract_resource_bindings`, `extract_let_bindings`, similar
+   text-scan utilities) silently invite single-file thinking. When you
+   see one in the call path, the question to ask is "does this caller
+   need the sibling files too?" — most of the time the answer is yes.
+
+Past breakage from violating this rule: PR #2120 (closed #2043 too
+early) shipped `exports` value-position completion that scanned only
+the current buffer; the real `exports.crn` references bindings in
+`main.crn`, so users got zero LSP candidates. PR #2121 fixed it by
+threading `base_path` into the same handler. Same class of mistake
+recurred from PR #2118 (closed #2117 prematurely) where the formatter
+fix passed unit tests but never ran against the real infra fixture.
+
 ## Git Workflow
 
 ### Worktree-Based Development

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -91,7 +91,7 @@ impl CompletionProvider {
             CompletionContext::AfterEqualsInExports {
                 type_expr_text,
                 in_nested,
-            } => self.exports_value_completions(&type_expr_text, in_nested, &text),
+            } => self.exports_value_completions(&type_expr_text, in_nested, &text, base_path),
             CompletionContext::InsideStructBlock {
                 resource_type,
                 attr_path,

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2323,3 +2323,119 @@ fn exports_list_value_position_filters_by_element_type() {
         labels
     );
 }
+
+/// Repro: in the real `organizations/exports.crn`, the user types
+/// `registry_dev = r|` at depth 2 (inside the `map(aws_account_id)`
+/// body with a preceding entry on the line above). LSP currently
+/// returns zero LSP items — VSCode falls back to word-based. We
+/// expect matching resource-ref refs.
+#[test]
+fn exports_map_value_multiple_entries_returns_refs() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("AwsAccountId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_noop,
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", account_id));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let source = "\
+let registry_prod = awscc.organizations.account {
+  name = 'prod'
+}
+
+let registry_dev = awscc.organizations.account {
+  name = 'dev'
+}
+
+exports {
+  accounts: map(aws_account_id) = {
+    registry_prod = r
+    registry_dev = r
+  }
+}
+";
+    let doc = create_document(source);
+    // Cursor on `    registry_dev = r|` — line 11 (0-indexed).
+    let position = Position {
+        line: 11,
+        character: "    registry_dev = r".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_dev.account_id"),
+        "expected `registry_dev.account_id` with earlier `registry_prod = ...` sibling present. Got: {:?}",
+        labels
+    );
+}
+
+/// Sibling-file case: `exports.crn` references bindings declared in
+/// `main.crn` — the real shape used by `carina-rs/infra`. Completion
+/// must surface those bindings as `<binding>.<attr>` candidates
+/// scanning sibling `.crn` files, not just the current buffer.
+#[test]
+fn exports_map_value_includes_bindings_from_sibling_files() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("AwsAccountId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_noop,
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", account_id));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",
+    )
+    .unwrap();
+    let exports_src = "\
+exports {
+  accounts: map(aws_account_id) = {
+    registry_prod = r
+  }
+}
+";
+    std::fs::write(base.join("exports.crn"), exports_src).unwrap();
+
+    let doc = create_document(exports_src);
+    let position = Position {
+        line: 2,
+        character: "    registry_prod = r".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod.account_id"),
+        "cross-file binding must be offered. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -773,6 +773,7 @@ impl CompletionProvider {
         type_expr_text: &str,
         in_nested: bool,
         text: &str,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let Some(annotation) = parse_exports_type_text(type_expr_text) else {
             return Vec::new();
@@ -791,51 +792,55 @@ impl CompletionProvider {
         };
 
         let mut items = Self::builtin_function_completions_for_type(&effective);
-        items.extend(self.resource_ref_completions_for_type(&effective, text));
+        items.extend(self.resource_ref_completions_for_type(&effective, text, base_path));
         items
     }
 
     /// Find resource-ref paths (`<binding>.<attr>`) whose leaf
     /// attribute is assignable to `target` and return them as
-    /// completion items. `text` is the current buffer; we scan it for
-    /// `let <binding> = <resource_type> { ... }` declarations and look
-    /// up each binding's resource schema. Used by the `exports`
-    /// value-position handler to surface matching references alongside
-    /// type-compatible built-ins.
+    /// completion items. Scans both the current buffer and every
+    /// sibling `.crn` file under `base_path` — exports commonly live
+    /// in `exports.crn` while the resource bindings they reference
+    /// are declared in `main.crn`, so a current-buffer-only scan
+    /// misses them entirely (see #2043 follow-up).
     fn resource_ref_completions_for_type(
         &self,
         target: &AttributeType,
         text: &str,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let mut items: Vec<CompletionItem> = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for (binding_name, resource_type) in self.extract_resource_bindings(text) {
-            if resource_type.is_empty() {
-                continue;
-            }
-            let Some(schema) = self.schemas.get(&resource_type) else {
-                continue;
-            };
-            for attr in schema.attributes.values() {
-                if !attr.attr_type.is_assignable_to(target) {
+        let sibling_text = read_sibling_crn(base_path);
+        for source in [text, sibling_text.as_str()] {
+            for (binding_name, resource_type) in self.extract_resource_bindings(source) {
+                if resource_type.is_empty() {
                     continue;
                 }
-                let full_ref = format!("{}.{}", binding_name, attr.name);
-                if !seen.insert(full_ref.clone()) {
+                let Some(schema) = self.schemas.get(&resource_type) else {
                     continue;
+                };
+                for attr in schema.attributes.values() {
+                    if !attr.attr_type.is_assignable_to(target) {
+                        continue;
+                    }
+                    let full_ref = format!("{}.{}", binding_name, attr.name);
+                    if !seen.insert(full_ref.clone()) {
+                        continue;
+                    }
+                    items.push(CompletionItem {
+                        label: full_ref.clone(),
+                        kind: Some(CompletionItemKind::REFERENCE),
+                        detail: Some(format!(
+                            "Reference to {}'s {} ({})",
+                            binding_name,
+                            attr.name,
+                            attr.attr_type.type_name()
+                        )),
+                        insert_text: Some(full_ref),
+                        ..Default::default()
+                    });
                 }
-                items.push(CompletionItem {
-                    label: full_ref.clone(),
-                    kind: Some(CompletionItemKind::REFERENCE),
-                    detail: Some(format!(
-                        "Reference to {}'s {} ({})",
-                        binding_name,
-                        attr.name,
-                        attr.attr_type.type_name()
-                    )),
-                    insert_text: Some(full_ref),
-                    ..Default::default()
-                });
             }
         }
         items.sort_by(|a, b| a.label.cmp(&b.label));


### PR DESCRIPTION
## Summary
Follow-up to #2120. Type-aware completion at `exports { key: T = ▉ }`
landed, but `resource_ref_completions_for_type` only scanned the
current buffer. The real-world shape used by `carina-rs/infra` has:

- `main.crn`: `let registry_prod = awscc.organizations.account { ... }`
- `exports.crn`: `exports { accounts: map(aws_account_id) = { registry_prod = ▉ } }`

With the previous PR, completion at the `▉` returned zero LSP items
because the let-binding lives in a sibling file, and VSCode fell
back to word-based matches (just tokens from the same file).

## Fix
- Thread `base_path` down from `AfterEqualsInExports` to
  `exports_value_completions` → `resource_ref_completions_for_type`.
- Scan both the current buffer **and** every sibling `.crn` under
  `base_path` via the existing `read_sibling_crn` helper — same
  pattern already used by `let`-binding dot-completions.

## Test
- `exports_map_value_includes_bindings_from_sibling_files` — writes
  `main.crn` and `exports.crn` to a tempdir, cursor at the exports
  value position, asserts `registry_prod.account_id` appears.
- Full LSP suite (301 tests + 41 ignored) clean.
- Local manual verification pending on user's VSCode after reload.

Refs #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)