### PR TITLE
lsp completion: thread sibling-file scans into remaining single-buffer paths

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2439,3 +2439,169 @@ exports {
         labels
     );
 }
+
+/// Sibling-file case for Custom-type resource-ref completion inside a
+/// resource block value. When the user types
+/// `account_id = ▉` in `other.crn` and `registry_prod` is declared in
+/// `main.crn`, the completion list must include
+/// `registry_prod.account_id`.
+#[test]
+fn custom_type_value_ref_includes_sibling_file_bindings() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("AwsAccountId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_noop,
+        namespace: None,
+        to_dsl: None,
+    };
+    let account_schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", account_id.clone()));
+    let consumer_schema = ResourceSchema::new("awscc.organizations.policy_target_attachment")
+        .attribute(AttributeSchema::new("target_id", account_id));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.organizations.account".to_string(), account_schema);
+    schemas.insert(
+        "awscc.organizations.policy_target_attachment".to_string(),
+        consumer_schema,
+    );
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",
+    )
+    .unwrap();
+    let other_src = "\
+let attach = awscc.organizations.policy_target_attachment {
+  target_id =
+}
+";
+    std::fs::write(base.join("other.crn"), other_src).unwrap();
+
+    let doc = create_document(other_src);
+    // Cursor at end of `  target_id = `
+    let position = Position {
+        line: 1,
+        character: "  target_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod.account_id"),
+        "cross-file Custom-type ref must be offered. Got: {:?}",
+        labels
+    );
+}
+
+/// Sibling-file case for `arguments` parameter completion. Module shapes
+/// that declare `arguments { ... }` in a dedicated `arguments.crn` must
+/// still surface those parameters when the user is editing `main.crn`.
+#[test]
+fn argument_parameters_include_sibling_file_args() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    let schema = ResourceSchema::new("awscc.s3.bucket")
+        .attribute(AttributeSchema::new("name", AttributeType::String));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.s3.bucket".to_string(), schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    std::fs::write(
+        base.join("arguments.crn"),
+        "arguments {\n  stage_name: string\n}\n",
+    )
+    .unwrap();
+    let main_src = "\
+let b = awscc.s3.bucket {
+  name =
+}
+";
+    std::fs::write(base.join("main.crn"), main_src).unwrap();
+
+    let doc = create_document(main_src);
+    let position = Position {
+        line: 1,
+        character: "  name = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"stage_name"),
+        "cross-file arguments parameter must be offered. Got: {:?}",
+        labels
+    );
+}
+
+/// Sibling-file case for `binding.` dot-completion. Typing
+/// `account_id = registry_prod.` in `other.crn` must list
+/// `registry_prod`'s attributes even when the binding is declared in
+/// `main.crn`.
+#[test]
+fn binding_dot_completion_resolves_sibling_file_binding() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap;
+    fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let account_id = AttributeType::Custom {
+        semantic_name: Some("AwsAccountId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validate_noop,
+        namespace: None,
+        to_dsl: None,
+    };
+    let account_schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", account_id.clone()));
+    let consumer_schema = ResourceSchema::new("awscc.organizations.policy_target_attachment")
+        .attribute(AttributeSchema::new("target_id", account_id));
+    let mut schemas = HashMap::new();
+    schemas.insert("awscc.organizations.account".to_string(), account_schema);
+    schemas.insert(
+        "awscc.organizations.policy_target_attachment".to_string(),
+        consumer_schema,
+    );
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",
+    )
+    .unwrap();
+    let other_src = "\
+let attach = awscc.organizations.policy_target_attachment {
+  target_id = registry_prod.
+}
+";
+    std::fs::write(base.join("other.crn"), other_src).unwrap();
+
+    let doc = create_document(other_src);
+    let position = Position {
+        line: 1,
+        character: "  target_id = registry_prod.".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod.account_id"),
+        "dot-completion must resolve cross-file binding. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -130,9 +130,16 @@ impl CompletionProvider {
         // "igw.internet_gateway_id" replaces "igw." instead of being appended.
         let ref_edit_range = self.compute_value_prefix_range(text, position);
 
+        // Read sibling `.crn` files once and reuse across every site that
+        // needs cross-file bindings or arguments. Every keystroke in a
+        // value position triggers this helper, so re-reading the directory
+        // per site would multiply disk I/O.
+        let sibling_text = read_sibling_crn(base_path);
+
         // Check if the user has typed "binding." after "=" — if so, show only
         // that binding's resource attributes, not built-in functions or generic completions.
-        if let Some(dot_binding) = self.detect_binding_dot_context(text, position, current_binding)
+        if let Some(dot_binding) =
+            self.detect_binding_dot_context(text, position, current_binding, &sibling_text)
         {
             return self.binding_attribute_completions(
                 &dot_binding.binding_name,
@@ -144,44 +151,58 @@ impl CompletionProvider {
         // Type-based resource reference completions:
         // Look up the attribute's type from the schema. If it's a Custom type,
         // find bindings whose resource schema has an attribute with the same Custom type name.
+        // Scans both the current buffer and every sibling `.crn` in `base_path` —
+        // Carina configurations are directory-scoped, so `registry_prod` may live in
+        // `main.crn` while the consumer block lives in `other.crn`.
         if let Some(schema) = self.schemas.get(resource_type)
             && let Some(attr_schema) = schema.attributes.get(attr_name)
         {
             let target_type_name = Self::extract_custom_type_name(&attr_schema.attr_type);
             if let Some(target_name) = target_type_name {
-                let bindings = self.extract_resource_bindings(text);
-                for (binding_name, binding_resource_type) in &bindings {
-                    if binding_resource_type.is_empty() {
-                        continue;
-                    }
-                    // Skip self-references: don't suggest the current resource's own binding
-                    if current_binding.is_some_and(|cb| cb == binding_name) {
-                        continue;
-                    }
-                    // Look up the binding's resource schema and find attributes
-                    // with matching Custom type name
-                    if let Some(binding_schema) = self.schemas.get(binding_resource_type) {
-                        for binding_attr in binding_schema.attributes.values() {
-                            if let Some(binding_type_name) =
-                                Self::extract_custom_type_name(&binding_attr.attr_type)
-                                && binding_type_name == target_name
-                            {
-                                let full_ref = format!("{}.{}", binding_name, binding_attr.name);
-                                completions.push(CompletionItem {
-                                    label: full_ref.clone(),
-                                    kind: Some(CompletionItemKind::REFERENCE),
-                                    detail: Some(format!(
-                                        "Reference to {}'s {} ({})",
-                                        binding_name, binding_attr.name, target_name
-                                    )),
-                                    text_edit: Some(
-                                        tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
-                                            range: ref_edit_range,
-                                            new_text: full_ref,
-                                        }),
-                                    ),
-                                    ..Default::default()
-                                });
+                let mut seen_refs: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for source in [text, sibling_text.as_str()] {
+                    for (binding_name, binding_resource_type) in
+                        &self.extract_resource_bindings(source)
+                    {
+                        if binding_resource_type.is_empty() {
+                            continue;
+                        }
+                        // Skip self-references: don't suggest the current resource's own binding
+                        if current_binding.is_some_and(|cb| cb == binding_name) {
+                            continue;
+                        }
+                        // Look up the binding's resource schema and find attributes
+                        // with matching Custom type name
+                        if let Some(binding_schema) = self.schemas.get(binding_resource_type) {
+                            for binding_attr in binding_schema.attributes.values() {
+                                if let Some(binding_type_name) =
+                                    Self::extract_custom_type_name(&binding_attr.attr_type)
+                                    && binding_type_name == target_name
+                                {
+                                    let full_ref =
+                                        format!("{}.{}", binding_name, binding_attr.name);
+                                    if !seen_refs.insert(full_ref.clone()) {
+                                        continue;
+                                    }
+                                    completions.push(CompletionItem {
+                                        label: full_ref.clone(),
+                                        kind: Some(CompletionItemKind::REFERENCE),
+                                        detail: Some(format!(
+                                            "Reference to {}'s {} ({})",
+                                            binding_name, binding_attr.name, target_name
+                                        )),
+                                        text_edit: Some(
+                                            tower_lsp::lsp_types::CompletionTextEdit::Edit(
+                                                TextEdit {
+                                                    range: ref_edit_range,
+                                                    new_text: full_ref,
+                                                },
+                                            ),
+                                        ),
+                                        ..Default::default()
+                                    });
+                                }
                             }
                         }
                     }
@@ -189,16 +210,23 @@ impl CompletionProvider {
             }
         }
 
-        // Add argument parameter references (lexically scoped — direct name access)
-        let argument_params = self.extract_argument_parameters(text);
-        for (name, type_hint) in &argument_params {
-            completions.push(CompletionItem {
-                label: name.clone(),
-                kind: Some(CompletionItemKind::VARIABLE),
-                detail: Some(format!("argument: {}", type_hint)),
-                insert_text: Some(name.clone()),
-                ..Default::default()
-            });
+        // Add argument parameter references (lexically scoped — direct name access).
+        // Scan both the current buffer and sibling `.crn` files: module shapes
+        // sometimes split `arguments { ... }` into a dedicated `arguments.crn`.
+        let mut seen_args: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for source in [text, sibling_text.as_str()] {
+            for (name, type_hint) in self.extract_argument_parameters(source) {
+                if !seen_args.insert(name.clone()) {
+                    continue;
+                }
+                completions.push(CompletionItem {
+                    label: name.clone(),
+                    kind: Some(CompletionItemKind::VARIABLE),
+                    detail: Some(format!("argument: {}", type_hint)),
+                    insert_text: Some(name),
+                    ..Default::default()
+                });
+            }
         }
 
         // Add for-loop binding names in scope, filtered by inferred element
@@ -305,11 +333,16 @@ impl CompletionProvider {
 
     /// Detect if the user has typed `binding_name.` after `=` on the current line.
     /// Returns the binding name and its resource type if detected.
+    ///
+    /// `sibling_text` is pre-read sibling `.crn` content; the binding may be
+    /// declared in a neighbouring file (e.g. `main.crn`) while the cursor is
+    /// in `other.crn`.
     fn detect_binding_dot_context(
         &self,
         text: &str,
         position: Position,
         current_binding: Option<&str>,
+        sibling_text: &str,
     ) -> Option<BindingDotContext> {
         let lines: Vec<&str> = text.lines().collect();
         let line_idx = position.line as usize;
@@ -336,18 +369,18 @@ impl CompletionProvider {
             return None;
         }
 
-        // Look up this binding in the file's bindings
-        let bindings = self.extract_resource_bindings(text);
-        for (binding_name, binding_resource_type) in &bindings {
-            if binding_name == candidate_binding && !binding_resource_type.is_empty() {
-                // Skip self-references
-                if current_binding.is_some_and(|cb| cb == binding_name) {
-                    return None;
+        for source in [text, sibling_text] {
+            for (binding_name, binding_resource_type) in &self.extract_resource_bindings(source) {
+                if binding_name == candidate_binding && !binding_resource_type.is_empty() {
+                    // Skip self-references
+                    if current_binding.is_some_and(|cb| cb == binding_name) {
+                        return None;
+                    }
+                    return Some(BindingDotContext {
+                        binding_name: binding_name.clone(),
+                        resource_type: binding_resource_type.clone(),
+                    });
                 }
-                return Some(BindingDotContext {
-                    binding_name: binding_name.clone(),
-                    resource_type: binding_resource_type.clone(),
-                });
             }
         }
 


### PR DESCRIPTION
## Summary

- Extends the #2121 fix to the three remaining completion paths in `value_completions_for_attr` that still scanned only the current buffer:
  - Custom-type resource-ref completion (e.g. `target_id = ▉` now suggests `registry_prod.account_id` when the binding lives in a sibling `main.crn`).
  - \`arguments\` parameter references when \`arguments { ... }\` is factored into a separate \`arguments.crn\`.
  - \`binding.\` dot-completion when the binding is declared in a sibling file.
- Hoists a single \`read_sibling_crn(base_path)\` call at the top of the function and reuses the \`sibling_text\` across every site (including \`detect_binding_dot_context\`, now taking \`&str\` instead of \`Option<&Path>\`). Per-site \`HashSet\`s dedup so the current buffer still wins over stale sibling content.
- Adds three directory-shaped regression tests mirroring \`exports_map_value_includes_bindings_from_sibling_files\`.

Closes #2122

## Test plan

- [x] \`cargo test -p carina-lsp --lib\` — 304 tests pass, three new ones included
- [x] \`cargo clippy -p carina-lsp --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean