### PR TITLE
lsp: introduce DslSource enum to force explicit buffer-vs-directory scans

### DIFF
--- a/carina-lsp/src/completion/dsl_source.rs
+++ b/carina-lsp/src/completion/dsl_source.rs
@@ -1,0 +1,138 @@
+//! Source-input abstraction for DSL text-scanning helpers.
+//!
+//! Carina configurations are directory-scoped: a `let` binding in
+//! `main.crn` is routinely referenced from `exports.crn`,
+//! `backend.crn`, etc. Historically text-scanning helpers
+//! (`extract_resource_bindings`, `extract_let_bindings`,
+//! `extract_argument_parameters`) took a bare `&str`, and the burden
+//! of gathering sibling `.crn` files sat on every caller. That's how
+//! #2043 / #2120 / #2122 shipped single-file blind spots — the signature
+//! gave no hint that the sibling scan was required.
+//!
+//! [`DslSource`] forces the caller to make the choice explicit:
+//!
+//! - [`DslSource::BufferOnly`] — deliberate single-file scan. Grep for
+//!   this variant during review to ask "is single-file really
+//!   intended here?"
+//! - [`DslSource::DirectoryScoped`] — pre-merged buffer + sibling
+//!   `.crn` content. Built once per LSP request via
+//!   [`DslSource::resolve_directory`]; every helper called under the
+//!   same `src` then shares the same `&str`, so the disk read is
+//!   single-shot even though multiple helpers scan the source.
+
+use std::path::Path;
+
+/// Explicit contract for what a text-scanning helper is allowed to see.
+///
+/// `Copy` so helpers can take it by value without ceremony. Both
+/// variants hold a borrowed `&str`; the directory variant's `&str`
+/// comes from a `String` owned by the caller's stack (see
+/// [`DslSource::resolve_directory`]).
+#[derive(Clone, Copy)]
+pub(crate) enum DslSource<'a> {
+    /// Scan only the given buffer. Use when the feature is genuinely
+    /// buffer-local (e.g. position-dependent lookup on the current
+    /// line). Cross-sibling semantics are a bug here — choose
+    /// [`DslSource::DirectoryScoped`] if in doubt.
+    BufferOnly(&'a str),
+    /// Scan the pre-merged text containing the buffer **and** every
+    /// sibling `.crn` under the original `base_path`. Construct via
+    /// [`DslSource::resolve_directory`] so the sibling read happens
+    /// exactly once per request.
+    DirectoryScoped { merged: &'a str },
+}
+
+impl<'a> DslSource<'a> {
+    /// Build a `DirectoryScoped` source, reading sibling `.crn` files
+    /// into `storage` exactly once. The returned `DslSource` borrows
+    /// from `storage`, so `storage` must outlive every helper call.
+    ///
+    /// Typical pattern at an LSP completion entry point:
+    ///
+    /// ```ignore
+    /// let mut src_buf = String::new();
+    /// let src = DslSource::resolve_directory(&text, base_path, &mut src_buf);
+    /// // pass `src` to as many helpers as needed — no extra disk reads.
+    /// ```
+    pub(crate) fn resolve_directory(
+        buffer: &'a str,
+        base_path: Option<&Path>,
+        storage: &'a mut String,
+    ) -> Self {
+        storage.clear();
+        storage.push_str(buffer);
+        if !storage.ends_with('\n') {
+            storage.push('\n');
+        }
+        storage.push_str(&read_sibling_crn(base_path));
+        DslSource::DirectoryScoped { merged: storage }
+    }
+
+    /// Borrow the scanned text. Zero-alloc for both variants.
+    pub(crate) fn merged_text(&self) -> &'a str {
+        match *self {
+            DslSource::BufferOnly(buffer) => buffer,
+            DslSource::DirectoryScoped { merged } => merged,
+        }
+    }
+}
+
+/// Concatenate every `.crn` file in `base_path` into one string.
+/// Duplicates with the buffer are expected — callers dedupe by
+/// binding name.
+pub(crate) fn read_sibling_crn(base_path: Option<&Path>) -> String {
+    let Some(base) = base_path else {
+        return String::new();
+    };
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return String::new();
+    };
+    let mut out = String::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn")
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            out.push_str(&content);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_only_returns_buffer_unchanged() {
+        let src = DslSource::BufferOnly("let a = 1\n");
+        assert_eq!(src.merged_text(), "let a = 1\n");
+    }
+
+    #[test]
+    fn resolve_directory_without_base_path_is_buffer_only() {
+        let mut storage = String::new();
+        let src = DslSource::resolve_directory("let a = 1\n", None, &mut storage);
+        assert_eq!(src.merged_text(), "let a = 1\n");
+    }
+
+    #[test]
+    fn resolve_directory_includes_sibling_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path();
+        std::fs::write(base.join("main.crn"), "let a = 1\n").unwrap();
+        std::fs::write(base.join("exports.crn"), "let b = 2\n").unwrap();
+        let buffer = "let c = 3\n"; // unsaved buffer, not on disk
+        let mut storage = String::new();
+        let src = DslSource::resolve_directory(buffer, Some(base), &mut storage);
+        let merged = src.merged_text();
+        assert!(
+            merged.contains("let a = 1")
+                && merged.contains("let b = 2")
+                && merged.contains("let c = 3"),
+            "merged_text should include buffer + every sibling .crn. Got: {:?}",
+            merged
+        );
+    }
+}

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -1,10 +1,13 @@
 //! Completion provider for the Carina LSP.
 
+pub(crate) mod dsl_source;
 mod top_level;
 mod values;
 
 #[cfg(test)]
 mod tests;
+
+pub(crate) use dsl_source::DslSource;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -816,39 +819,25 @@ fn detect_upstream_state_dot(
     {
         return None;
     }
-    let bindings = collect_upstream_state_bindings(text, base_path);
+    let mut src_buf = String::new();
+    let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
+    let bindings = collect_upstream_state_bindings(src);
     let source = bindings.get(binding)?.clone();
     Some((binding.to_string(), after_dot.to_string(), source))
 }
 
 /// Return every `let <name> = upstream_state { source = '...' }` declared
-/// in the current buffer or any sibling `.crn` under `base_path`, as a map
-/// from binding name to source path (relative, as written).
+/// in `src` as a map from binding name to source path (relative, as written).
 ///
 /// Intentionally does a text scan rather than going through `parse_directory`:
 /// completion runs on partial, often syntactically invalid buffers. We only
 /// need binding → source to feed `resolve_upstream_exports`, which then
 /// parses the *upstream* directory (separate from the downstream buffer).
 fn collect_upstream_state_bindings(
-    text: &str,
-    base_path: Option<&std::path::Path>,
+    src: DslSource<'_>,
 ) -> std::collections::HashMap<String, String> {
     let mut out = std::collections::HashMap::new();
-    scan_upstream_state_let(text, &mut out);
-    let Some(base) = base_path else {
-        return out;
-    };
-    let Ok(entries) = std::fs::read_dir(base) else {
-        return out;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_some_and(|e| e == "crn")
-            && let Ok(content) = std::fs::read_to_string(&path)
-        {
-            scan_upstream_state_let(&content, &mut out);
-        }
-    }
+    scan_upstream_state_let(src.merged_text(), &mut out);
     out
 }
 

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::{
 
 use carina_core::parser;
 
-use super::CompletionProvider;
+use super::{CompletionProvider, DslSource};
 
 impl CompletionProvider {
     pub(super) fn top_level_completions(
@@ -237,8 +237,10 @@ impl CompletionProvider {
         completions
     }
 
-    pub(super) fn extract_argument_parameters(&self, text: &str) -> Vec<(String, String)> {
+    pub(super) fn extract_argument_parameters(&self, src: DslSource<'_>) -> Vec<(String, String)> {
+        let text = src.merged_text();
         let mut params = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut in_arguments_block = false;
         let mut brace_depth = 0;
 
@@ -277,7 +279,7 @@ impl CompletionProvider {
                         } else {
                             rest.to_string()
                         };
-                        if !name.is_empty() {
+                        if !name.is_empty() && seen.insert(name.clone()) {
                             params.push((name, type_hint));
                         }
                     }
@@ -288,28 +290,32 @@ impl CompletionProvider {
         params
     }
 
-    /// Extract every `let <name> = <rhs>` from `text`.
+    /// Extract every `let <name> = <rhs>` from `src`.
     ///
     /// Returns `Vec<(name, rhs)>` where `rhs` is the trimmed text after `=`
     /// (e.g. `awscc.ec2.vpc { ... }`, `upstream_state { ... }`, `import '...'`).
     /// Callers classify the rhs themselves — `extract_resource_bindings` maps
     /// it to a schema key, the for-iterable handler keys it into a detail
-    /// label, etc.
-    pub(super) fn extract_let_bindings(text: &str) -> Vec<(String, String)> {
+    /// label, etc. Duplicates (same binding name appearing in the buffer
+    /// and in a sibling `.crn`) are deduped, buffer-first.
+    pub(super) fn extract_let_bindings(src: DslSource<'_>) -> Vec<(String, String)> {
+        let text = src.merged_text();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         text.lines()
             .filter_map(|line| {
                 crate::let_parse::parse_let_header(line)
+                    .filter(|(name, _)| seen.insert(name.to_string()))
                     .map(|(name, rhs)| (name.to_string(), rhs.to_string()))
             })
             .collect()
     }
 
-    /// Extract resource binding names and their resource types from text
-    /// (variables defined with `let binding_name = awscc.ec2.vpc {`)
+    /// Extract resource binding names and their resource types from `src`
+    /// (variables defined with `let binding_name = awscc.ec2.vpc {`).
     /// Returns Vec<(binding_name, resource_type)> where resource_type is the schema key
-    /// (e.g., "awscc.ec2.vpc")
-    pub(super) fn extract_resource_bindings(&self, text: &str) -> Vec<(String, String)> {
-        Self::extract_let_bindings(text)
+    /// (e.g., "awscc.ec2.vpc"). See [`DslSource`] for buffer-vs-directory choice.
+    pub(super) fn extract_resource_bindings(&self, src: DslSource<'_>) -> Vec<(String, String)> {
+        Self::extract_let_bindings(src)
             .into_iter()
             .map(|(name, rhs)| (name, self.extract_resource_type(&rhs).unwrap_or_default()))
             .collect()

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -9,7 +9,7 @@ use tower_lsp::lsp_types::{
 use carina_core::builtins;
 use carina_core::schema::AttributeType;
 
-use super::CompletionProvider;
+use super::{CompletionProvider, DslSource};
 
 /// How far up the directory tree to walk when suggesting upstream_state sources.
 const UPSTREAM_SOURCE_MAX_UP: usize = 6;
@@ -20,31 +20,6 @@ const UPSTREAM_SOURCE_MAX_ITEMS: usize = 100;
 struct BindingDotContext {
     binding_name: String,
     resource_type: String,
-}
-
-/// Concatenate every `.crn` file in `base_path` into one string. The
-/// current-file buffer is scanned separately by the caller (it might
-/// contain unsaved edits that differ from disk), so returning disk
-/// content for the whole directory is fine — duplicates are deduped
-/// by the completion handler's `seen` set.
-fn read_sibling_crn(base_path: Option<&Path>) -> String {
-    let Some(base) = base_path else {
-        return String::new();
-    };
-    let Ok(entries) = std::fs::read_dir(base) else {
-        return String::new();
-    };
-    let mut out = String::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().is_some_and(|e| e == "crn")
-            && let Ok(content) = std::fs::read_to_string(&path)
-        {
-            out.push_str(&content);
-            out.push('\n');
-        }
-    }
-    out
 }
 
 fn type_completion_item(label: String, detail: String, range: Range) -> CompletionItem {
@@ -130,16 +105,18 @@ impl CompletionProvider {
         // "igw.internet_gateway_id" replaces "igw." instead of being appended.
         let ref_edit_range = self.compute_value_prefix_range(text, position);
 
-        // Read sibling `.crn` files once and reuse across every site that
-        // needs cross-file bindings or arguments. Every keystroke in a
-        // value position triggers this helper, so re-reading the directory
-        // per site would multiply disk I/O.
-        let sibling_text = read_sibling_crn(base_path);
+        // Binding scans here see the current buffer *and* every sibling
+        // `.crn` under `base_path`. Helpers take `DslSource` to make the
+        // choice explicit at the call site — see `dsl_source.rs`. The
+        // sibling read happens exactly once; the same `src` is reused
+        // across every helper below.
+        let mut src_buf = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
 
         // Check if the user has typed "binding." after "=" — if so, show only
         // that binding's resource attributes, not built-in functions or generic completions.
         if let Some(dot_binding) =
-            self.detect_binding_dot_context(text, position, current_binding, &sibling_text)
+            self.detect_binding_dot_context(text, position, current_binding, src)
         {
             return self.binding_attribute_completions(
                 &dot_binding.binding_name,
@@ -151,58 +128,43 @@ impl CompletionProvider {
         // Type-based resource reference completions:
         // Look up the attribute's type from the schema. If it's a Custom type,
         // find bindings whose resource schema has an attribute with the same Custom type name.
-        // Scans both the current buffer and every sibling `.crn` in `base_path` —
-        // Carina configurations are directory-scoped, so `registry_prod` may live in
-        // `main.crn` while the consumer block lives in `other.crn`.
         if let Some(schema) = self.schemas.get(resource_type)
             && let Some(attr_schema) = schema.attributes.get(attr_name)
         {
             let target_type_name = Self::extract_custom_type_name(&attr_schema.attr_type);
             if let Some(target_name) = target_type_name {
-                let mut seen_refs: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                for source in [text, sibling_text.as_str()] {
-                    for (binding_name, binding_resource_type) in
-                        &self.extract_resource_bindings(source)
-                    {
-                        if binding_resource_type.is_empty() {
-                            continue;
-                        }
-                        // Skip self-references: don't suggest the current resource's own binding
-                        if current_binding.is_some_and(|cb| cb == binding_name) {
-                            continue;
-                        }
-                        // Look up the binding's resource schema and find attributes
-                        // with matching Custom type name
-                        if let Some(binding_schema) = self.schemas.get(binding_resource_type) {
-                            for binding_attr in binding_schema.attributes.values() {
-                                if let Some(binding_type_name) =
-                                    Self::extract_custom_type_name(&binding_attr.attr_type)
-                                    && binding_type_name == target_name
-                                {
-                                    let full_ref =
-                                        format!("{}.{}", binding_name, binding_attr.name);
-                                    if !seen_refs.insert(full_ref.clone()) {
-                                        continue;
-                                    }
-                                    completions.push(CompletionItem {
-                                        label: full_ref.clone(),
-                                        kind: Some(CompletionItemKind::REFERENCE),
-                                        detail: Some(format!(
-                                            "Reference to {}'s {} ({})",
-                                            binding_name, binding_attr.name, target_name
-                                        )),
-                                        text_edit: Some(
-                                            tower_lsp::lsp_types::CompletionTextEdit::Edit(
-                                                TextEdit {
-                                                    range: ref_edit_range,
-                                                    new_text: full_ref,
-                                                },
-                                            ),
-                                        ),
-                                        ..Default::default()
-                                    });
-                                }
+                for (binding_name, binding_resource_type) in &self.extract_resource_bindings(src) {
+                    if binding_resource_type.is_empty() {
+                        continue;
+                    }
+                    // Skip self-references: don't suggest the current resource's own binding
+                    if current_binding.is_some_and(|cb| cb == binding_name) {
+                        continue;
+                    }
+                    // Look up the binding's resource schema and find attributes
+                    // with matching Custom type name
+                    if let Some(binding_schema) = self.schemas.get(binding_resource_type) {
+                        for binding_attr in binding_schema.attributes.values() {
+                            if let Some(binding_type_name) =
+                                Self::extract_custom_type_name(&binding_attr.attr_type)
+                                && binding_type_name == target_name
+                            {
+                                let full_ref = format!("{}.{}", binding_name, binding_attr.name);
+                                completions.push(CompletionItem {
+                                    label: full_ref.clone(),
+                                    kind: Some(CompletionItemKind::REFERENCE),
+                                    detail: Some(format!(
+                                        "Reference to {}'s {} ({})",
+                                        binding_name, binding_attr.name, target_name
+                                    )),
+                                    text_edit: Some(
+                                        tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                                            range: ref_edit_range,
+                                            new_text: full_ref,
+                                        }),
+                                    ),
+                                    ..Default::default()
+                                });
                             }
                         }
                     }
@@ -211,22 +173,16 @@ impl CompletionProvider {
         }
 
         // Add argument parameter references (lexically scoped — direct name access).
-        // Scan both the current buffer and sibling `.crn` files: module shapes
-        // sometimes split `arguments { ... }` into a dedicated `arguments.crn`.
-        let mut seen_args: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for source in [text, sibling_text.as_str()] {
-            for (name, type_hint) in self.extract_argument_parameters(source) {
-                if !seen_args.insert(name.clone()) {
-                    continue;
-                }
-                completions.push(CompletionItem {
-                    label: name.clone(),
-                    kind: Some(CompletionItemKind::VARIABLE),
-                    detail: Some(format!("argument: {}", type_hint)),
-                    insert_text: Some(name),
-                    ..Default::default()
-                });
-            }
+        // The shared `src` surfaces `arguments { ... }` even when split into
+        // a dedicated `arguments.crn`.
+        for (name, type_hint) in self.extract_argument_parameters(src) {
+            completions.push(CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                detail: Some(format!("argument: {}", type_hint)),
+                insert_text: Some(name),
+                ..Default::default()
+            });
         }
 
         // Add for-loop binding names in scope, filtered by inferred element
@@ -243,13 +199,12 @@ impl CompletionProvider {
             .and_then(|s| s.attributes.get(attr_name))
             .map(|a| &a.attr_type);
         let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
-        // Cache upstream binding → source text scan and the resolved
-        // exports per upstream. Without this, each for-binding re-scans
-        // every sibling `.crn` plus re-parses the upstream project —
-        // every keystroke in a value position.
+        // Cache the resolved exports per upstream. Without this, each
+        // for-binding re-parses the upstream project every keystroke.
+        // The sibling scan itself reuses the already-resolved `src`.
         let upstream_sources: std::collections::HashMap<String, String> =
             if for_bindings.iter().any(|b| b.iterable.is_some()) {
-                super::collect_upstream_state_bindings(text, base_path)
+                super::collect_upstream_state_bindings(src)
             } else {
                 std::collections::HashMap::new()
             };
@@ -331,18 +286,18 @@ impl CompletionProvider {
         completions
     }
 
-    /// Detect if the user has typed `binding_name.` after `=` on the current line.
-    /// Returns the binding name and its resource type if detected.
+    /// Detect if the user has typed `binding_name.` after `=` on the current
+    /// line. Returns the binding name and its resource type if detected.
     ///
-    /// `sibling_text` is pre-read sibling `.crn` content; the binding may be
-    /// declared in a neighbouring file (e.g. `main.crn`) while the cursor is
-    /// in `other.crn`.
+    /// `src` must be [`DslSource::DirectoryScoped`] in normal use so that a
+    /// binding declared in a sibling `.crn` can be resolved. `BufferOnly` is
+    /// only correct when the feature is genuinely buffer-local.
     fn detect_binding_dot_context(
         &self,
         text: &str,
         position: Position,
         current_binding: Option<&str>,
-        sibling_text: &str,
+        src: DslSource<'_>,
     ) -> Option<BindingDotContext> {
         let lines: Vec<&str> = text.lines().collect();
         let line_idx = position.line as usize;
@@ -369,18 +324,16 @@ impl CompletionProvider {
             return None;
         }
 
-        for source in [text, sibling_text] {
-            for (binding_name, binding_resource_type) in &self.extract_resource_bindings(source) {
-                if binding_name == candidate_binding && !binding_resource_type.is_empty() {
-                    // Skip self-references
-                    if current_binding.is_some_and(|cb| cb == binding_name) {
-                        return None;
-                    }
-                    return Some(BindingDotContext {
-                        binding_name: binding_name.clone(),
-                        resource_type: binding_resource_type.clone(),
-                    });
+        for (binding_name, binding_resource_type) in &self.extract_resource_bindings(src) {
+            if binding_name == candidate_binding && !binding_resource_type.is_empty() {
+                // Skip self-references
+                if current_binding.is_some_and(|cb| cb == binding_name) {
+                    return None;
                 }
+                return Some(BindingDotContext {
+                    binding_name: binding_name.clone(),
+                    resource_type: binding_resource_type.clone(),
+                });
             }
         }
 
@@ -630,21 +583,20 @@ impl CompletionProvider {
             });
         };
 
-        let sibling_text = read_sibling_crn(base_path);
-        for source in [text, sibling_text.as_str()] {
-            for (name, rhs) in Self::extract_let_bindings(source) {
-                let detail = if rhs.starts_with("upstream_state") {
-                    "upstream_state binding"
-                } else if rhs.starts_with("import ") {
-                    "module import"
-                } else {
-                    "binding"
-                };
-                push(&mut items, &mut seen, name, detail);
-            }
-            for (name, _) in self.extract_argument_parameters(source) {
-                push(&mut items, &mut seen, name, "argument");
-            }
+        let mut src_buf = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
+        for (name, rhs) in Self::extract_let_bindings(src) {
+            let detail = if rhs.starts_with("upstream_state") {
+                "upstream_state binding"
+            } else if rhs.starts_with("import ") {
+                "module import"
+            } else {
+                "binding"
+            };
+            push(&mut items, &mut seen, name, detail);
+        }
+        for (name, _) in self.extract_argument_parameters(src) {
+            push(&mut items, &mut seen, name, "argument");
         }
 
         items
@@ -829,13 +781,11 @@ impl CompletionProvider {
         items
     }
 
-    /// Find resource-ref paths (`<binding>.<attr>`) whose leaf
-    /// attribute is assignable to `target` and return them as
-    /// completion items. Scans both the current buffer and every
-    /// sibling `.crn` file under `base_path` — exports commonly live
-    /// in `exports.crn` while the resource bindings they reference
-    /// are declared in `main.crn`, so a current-buffer-only scan
-    /// misses them entirely (see #2043 follow-up).
+    /// Find resource-ref paths (`<binding>.<attr>`) whose leaf attribute is
+    /// assignable to `target` and return them as completion items. Uses a
+    /// directory-scoped [`DslSource`] so exports in `exports.crn` can
+    /// reference bindings declared in a sibling `main.crn`
+    /// (see #2043 follow-up).
     fn resource_ref_completions_for_type(
         &self,
         target: &AttributeType,
@@ -843,37 +793,32 @@ impl CompletionProvider {
         base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let mut items: Vec<CompletionItem> = Vec::new();
-        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let sibling_text = read_sibling_crn(base_path);
-        for source in [text, sibling_text.as_str()] {
-            for (binding_name, resource_type) in self.extract_resource_bindings(source) {
-                if resource_type.is_empty() {
+        let mut src_buf = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
+        for (binding_name, resource_type) in self.extract_resource_bindings(src) {
+            if resource_type.is_empty() {
+                continue;
+            }
+            let Some(schema) = self.schemas.get(&resource_type) else {
+                continue;
+            };
+            for attr in schema.attributes.values() {
+                if !attr.attr_type.is_assignable_to(target) {
                     continue;
                 }
-                let Some(schema) = self.schemas.get(&resource_type) else {
-                    continue;
-                };
-                for attr in schema.attributes.values() {
-                    if !attr.attr_type.is_assignable_to(target) {
-                        continue;
-                    }
-                    let full_ref = format!("{}.{}", binding_name, attr.name);
-                    if !seen.insert(full_ref.clone()) {
-                        continue;
-                    }
-                    items.push(CompletionItem {
-                        label: full_ref.clone(),
-                        kind: Some(CompletionItemKind::REFERENCE),
-                        detail: Some(format!(
-                            "Reference to {}'s {} ({})",
-                            binding_name,
-                            attr.name,
-                            attr.attr_type.type_name()
-                        )),
-                        insert_text: Some(full_ref),
-                        ..Default::default()
-                    });
-                }
+                let full_ref = format!("{}.{}", binding_name, attr.name);
+                items.push(CompletionItem {
+                    label: full_ref.clone(),
+                    kind: Some(CompletionItemKind::REFERENCE),
+                    detail: Some(format!(
+                        "Reference to {}'s {} ({})",
+                        binding_name,
+                        attr.name,
+                        attr.attr_type.type_name()
+                    )),
+                    insert_text: Some(full_ref),
+                    ..Default::default()
+                });
             }
         }
         items.sort_by(|a, b| a.label.cmp(&b.label));

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -796,9 +796,15 @@ impl DiagnosticEngine {
         None
     }
 
-    /// Extract resource binding names from text (variables defined with `let binding_name = aws...` or `let binding_name = read aws...`)
-    pub(super) fn extract_resource_bindings(&self, text: &str) -> HashSet<String> {
+    /// Extract resource binding names from `src` (variables defined with
+    /// `let binding_name = aws...` or `let binding_name = read aws...`).
+    /// See [`DslSource`] for the explicit buffer-vs-directory choice.
+    pub(super) fn extract_resource_bindings(
+        &self,
+        src: crate::completion::DslSource<'_>,
+    ) -> HashSet<String> {
         let mut bindings = HashSet::new();
+        let text = src.merged_text();
         for line in text.lines() {
             if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
                 bindings.insert(name.to_string());

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -128,8 +128,11 @@ impl DiagnosticEngine {
         let mut diagnostics = Vec::new();
         let text = doc.text();
 
-        // Extract defined resource bindings
-        let defined_bindings = self.extract_resource_bindings(&text);
+        // Extract defined resource bindings. BufferOnly is intentional:
+        // sibling-file bindings are pre-resolved by the caller and come in
+        // via `sibling_bindings` below.
+        let defined_bindings =
+            self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text));
 
         // Parse errors
         if let Some(error) = doc.parse_error() {


### PR DESCRIPTION
## Summary

- Replaces the bare \`&str\` input of text-scanning helpers (\`extract_resource_bindings\`, \`extract_let_bindings\`, \`extract_argument_parameters\`, \`detect_binding_dot_context\`, \`collect_upstream_state_bindings\`) with a \`DslSource\` enum.
- \`DslSource::BufferOnly(&str)\` marks deliberate single-file scans — grep for this during review to ask "is single-file really intended here?"
- \`DslSource::DirectoryScoped { merged: &str }\` carries a pre-merged buffer + sibling \`.crn\` content, built once per LSP request via \`DslSource::resolve_directory(buffer, base_path, &mut storage)\` so the sibling disk read is single-shot even when the same \`src\` flows into several helpers.
- Every affected call site now picks a variant deliberately. Diagnostics intentionally uses \`BufferOnly\` with an explanatory comment (sibling bindings are pre-resolved by the caller and merged via \`sibling_bindings\`).
- Consolidates the ad-hoc \`read_sibling_crn\` reads scattered around completion into the single \`DslSource::resolve_directory\` path.

Motivates a structural fix for the recurring #2043 / #2120 / #2122 class of bug: the signature now forces the caller to make the directory-vs-buffer choice, not the signature hiding it.

Closes #2123

## Test plan

- [x] \`cargo test -p carina-lsp --lib\` — 307 tests pass (304 existing + 3 new \`DslSource\` unit tests).
- [x] \`cargo clippy -p carina-lsp --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Real-infra smoke test: \`carina fmt --check\` and \`carina validate\` run cleanly against \`carina-rs/infra/aws/management/organizations/\`.