### PR TITLE
parser: move check_undefined_bindings out of per-file parse into post-merge pass

### DIFF
--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -48,7 +48,7 @@ pub fn run_validate(
     let mut error_reports: Vec<String> = Vec::new();
     error_reports.extend(
         loaded
-            .iterable_binding_errors
+            .identifier_scope_errors
             .iter()
             .map(ToString::to_string),
     );

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -20,12 +20,14 @@ pub struct LoadedConfig {
     /// so this preserves the original references for accurate unused binding analysis.
     pub unresolved_parsed: ParsedFile,
     pub backend_file: Option<PathBuf>,
-    /// Deferred for-iterables whose binding didn't resolve against the
-    /// directory-wide merge. Empty when every iterable is in scope. The
-    /// caller is responsible for surfacing these — the loader does not
-    /// short-circuit on them so that later validators can also run and
-    /// their findings can be reported alongside.
-    pub iterable_binding_errors: Vec<parser::ParseError>,
+    /// Identifier-scope errors surfaced by the post-merge passes:
+    /// `check_undefined_references` (ResourceRef roots in resources /
+    /// attribute / module / export values) and
+    /// `check_deferred_for_iterables` (for-expression iterables). Empty
+    /// when every reference resolves against the directory-wide binding
+    /// set. The loader does not short-circuit on these so that later
+    /// validators can also run in a single pass.
+    pub identifier_scope_errors: Vec<parser::ParseError>,
 }
 
 /// Load configuration from a directory containing .crn files
@@ -163,17 +165,18 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
-        // Deferred for-iterable binding errors are accumulated rather than
-        // short-circuited so `carina validate` can keep going and report
-        // every static error in one pass (#2102). The caller reads
-        // `iterable_binding_errors` and merges them with its own findings.
-        let iterable_binding_errors = parser::check_deferred_for_iterables(&merged);
+        // Identifier-scope checks are accumulated rather than short-
+        // circuited so `carina validate` can keep going and report every
+        // static error in one pass (#2102, #2126). The caller reads
+        // `identifier_scope_errors` and merges them with its own findings.
+        let mut identifier_scope_errors = parser::check_undefined_references(&merged);
+        identifier_scope_errors.extend(parser::check_deferred_for_iterables(&merged));
 
         Ok(LoadedConfig {
             parsed: merged,
             unresolved_parsed: unresolved_merged,
             backend_file,
-            iterable_binding_errors,
+            identifier_scope_errors,
         })
     } else {
         Err(format!("Path not found: {}", path.display()))
@@ -928,7 +931,7 @@ awscc.ec2.security_group {
         }
 
         // `load_configuration_with_config` surfaces the error via
-        // `LoadedConfig::iterable_binding_errors` rather than short-
+        // `LoadedConfig::identifier_scope_errors` rather than short-
         // circuiting, so the CLI caller can collect it together with
         // findings from later validators in a single pass (#2102).
         let dir2 = create_temp_dir("undefined_for_iterable_cli");
@@ -943,19 +946,51 @@ awscc.ec2.security_group {
         )
         .unwrap();
         let loaded = load_configuration_with_config(&dir2, &ProviderContext::default())
-            .expect("load_configuration should not short-circuit on iterable binding errors");
+            .expect("load_configuration should not short-circuit on identifier-scope errors");
         cleanup(&dir2);
         assert_eq!(
-            loaded.iterable_binding_errors.len(),
+            loaded.identifier_scope_errors.len(),
             1,
-            "expected one iterable binding error, got {:?}",
-            loaded.iterable_binding_errors,
+            "expected one identifier-scope error, got {:?}",
+            loaded.identifier_scope_errors,
         );
-        match &loaded.iterable_binding_errors[0] {
+        match &loaded.identifier_scope_errors[0] {
             parser::ParseError::UndefinedIdentifier { name, .. } => {
                 assert_eq!(name, "does_not_exist");
             }
             other => panic!("unexpected error: {other}"),
         }
+    }
+
+    // Acceptance for #2126. Per-file parse must not reject a ResourceRef
+    // whose root is declared in a sibling `.crn`. The check has to live on
+    // the merged `ParsedFile`, same place `check_deferred_for_iterables`
+    // already lives.
+    #[test]
+    fn parse_directory_accepts_cross_file_resource_ref() {
+        let dir = create_temp_dir("cross_file_resource_ref");
+        fs::write(
+            dir.join("main.crn"),
+            r#"let attach = aws.organizations.attach {
+    target_id = caller.account_id
+}
+"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("backend.crn"),
+            r#"let caller = read aws.sts.caller_identity {}
+"#,
+        )
+        .unwrap();
+
+        let loaded = load_configuration_with_config(&dir, &ProviderContext::default())
+            .expect("directory with cross-file ResourceRef must load without error");
+        cleanup(&dir);
+        assert!(
+            loaded.identifier_scope_errors.is_empty(),
+            "no identifier-scope errors expected, got: {:?}",
+            loaded.identifier_scope_errors,
+        );
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1092,16 +1092,12 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         &mut export_params,
     );
 
-    // Third pass: every remaining ResourceRef must point at a declared binding.
-    // Anything else is a typo or a stale reference to something the user removed.
-    let known_bindings = collect_known_bindings(&ctx);
-    check_undefined_bindings(
-        &known_bindings,
-        &resources,
-        &attribute_params,
-        &module_calls,
-        &export_params,
-    )?;
+    // "Is every ResourceRef root declared somewhere?" is a semantic
+    // question the per-file parse cannot answer: the referent may live
+    // in a sibling `.crn`. The check runs post-merge via
+    // `check_undefined_references(&ParsedFile)` — wired into
+    // `load_configuration_with_config` alongside
+    // `check_deferred_for_iterables`. See #2126.
 
     let string_literal_paths = ctx.string_literal_paths.borrow().clone();
     Ok(ParsedFile {
@@ -4613,79 +4609,6 @@ fn unescape_single_quoted(s: &str) -> String {
     result
 }
 
-/// Collect every identifier that is a valid binding source in the fully parsed
-/// context. Anything not in this set that appears as the root of a dotted
-/// reference is a typo / missing binding.
-fn collect_known_bindings<'ctx>(
-    ctx: &'ctx ParseContext<'_>,
-) -> std::collections::HashSet<&'ctx str> {
-    let mut set: std::collections::HashSet<&'ctx str> = std::collections::HashSet::new();
-    set.extend(ctx.resource_bindings.keys().map(String::as_str));
-    set.extend(ctx.upstream_states.keys().map(String::as_str));
-    set.extend(ctx.imported_modules.keys().map(String::as_str));
-    set.extend(ctx.user_functions.keys().map(String::as_str));
-    set.extend(ctx.structural_bindings.iter().map(String::as_str));
-    set.extend(ctx.variables.keys().map(String::as_str));
-    set
-}
-
-/// Reject references whose root identifier is not declared anywhere in scope.
-///
-/// Note: deferred for-expression iterables are not checked here. They may name
-/// bindings declared in sibling files (e.g. an `upstream_state` in `backend.crn`
-/// iterated from `main.crn`) that only become visible after directory-wide
-/// merging. That check runs in `check_deferred_for_iterables` instead.
-fn check_undefined_bindings(
-    known: &std::collections::HashSet<&str>,
-    resources: &[Resource],
-    attribute_params: &[AttributeParameter],
-    module_calls: &[ModuleCall],
-    export_params: &[ExportParameter],
-) -> Result<(), ParseError> {
-    for resource in resources {
-        for expr in resource.attributes.values() {
-            check_undefined_in_value(known, &expr.0)?;
-        }
-    }
-    for attr in attribute_params {
-        if let Some(value) = &attr.value {
-            check_undefined_in_value(known, value)?;
-        }
-    }
-    for call in module_calls {
-        for v in call.arguments.values() {
-            check_undefined_in_value(known, v)?;
-        }
-    }
-    for export in export_params {
-        if let Some(value) = &export.value {
-            check_undefined_in_value(known, value)?;
-        }
-    }
-    Ok(())
-}
-
-fn check_undefined_in_value(
-    known: &std::collections::HashSet<&str>,
-    value: &Value,
-) -> Result<(), ParseError> {
-    let mut undefined: Option<String> = None;
-    value.visit_refs(&mut |path| {
-        if undefined.is_some() {
-            return;
-        }
-        let root = path.binding();
-        let root_ident = root.split(['[', ']']).next().unwrap_or(root);
-        if !known.contains(root_ident) {
-            undefined = Some(root_ident.to_string());
-        }
-    });
-    if let Some(name) = undefined {
-        return Err(undefined_identifier_error(known, name, 0));
-    }
-    Ok(())
-}
-
 /// Build an `UndefinedIdentifier` error enriched with the best
 /// did-you-mean suggestion and the sorted in-scope binding list.
 fn undefined_identifier_error(
@@ -4905,12 +4828,16 @@ pub fn resolve_resource_refs_with_config(
     Ok(())
 }
 
-/// Verify that every deferred for-expression iterable names a declared binding.
+/// Every binding name declared in the merged `ParsedFile`: resources,
+/// arguments, module calls, upstream states, imports, user functions,
+/// variables, and for/if structural bindings.
 ///
-/// This must run on a fully merged `ParsedFile` (directory-wide), not on a
-/// single-file parse — iterables commonly reference `upstream_state` or `let`
-/// bindings declared in sibling files that only become visible after merging.
-pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
+/// This is the canonical answer to "is this identifier in scope?" for
+/// directory-wide checks. The same set feeds
+/// [`check_deferred_for_iterables`] and [`check_undefined_references`],
+/// and the LSP borrows it (via `carina_lsp::diagnostics::checks`) to
+/// keep diagnostic suggestions consistent with the CLI.
+pub fn collect_known_bindings_merged(parsed: &ParsedFile) -> std::collections::HashSet<&str> {
     let mut known: std::collections::HashSet<&str> = std::collections::HashSet::new();
     known.extend(parsed.resources.iter().filter_map(|r| r.binding.as_deref())); // allow: direct — parser-internal, pre-expansion
     known.extend(parsed.arguments.iter().map(|a| a.name.as_str()));
@@ -4925,13 +4852,72 @@ pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseErro
     known.extend(parsed.user_functions.keys().map(String::as_str));
     known.extend(parsed.variables.keys().map(String::as_str));
     known.extend(parsed.structural_bindings.iter().map(String::as_str));
+    known
+}
 
+/// Verify that every deferred for-expression iterable names a declared binding.
+///
+/// This must run on a fully merged `ParsedFile` (directory-wide), not on a
+/// single-file parse — iterables commonly reference `upstream_state` or `let`
+/// bindings declared in sibling files that only become visible after merging.
+pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
+    let known = collect_known_bindings_merged(parsed);
     parsed
         .deferred_for_expressions
         .iter()
         .filter(|d| !known.contains(d.iterable_binding.as_str()))
         .map(|d| undefined_identifier_error(&known, d.iterable_binding.clone(), d.line))
         .collect()
+}
+
+/// Verify that every ResourceRef in the merged file names a declared binding.
+///
+/// Walks resources, attribute parameters, module calls, and export
+/// parameters; emits `UndefinedIdentifier` for each ResourceRef whose
+/// root is not in [`collect_known_bindings_merged`]. Runs post-merge
+/// — per-file parse cannot answer the question because the referent
+/// may live in a sibling `.crn`.
+pub fn check_undefined_references(parsed: &ParsedFile) -> Vec<ParseError> {
+    let known = collect_known_bindings_merged(parsed);
+    let mut errors = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let mut check = |value: &Value| {
+        value.visit_refs(&mut |path| {
+            let root = path.binding();
+            let root_ident = root.split(['[', ']']).next().unwrap_or(root);
+            if !known.contains(root_ident) && seen.insert(root_ident.to_string()) {
+                errors.push(undefined_identifier_error(
+                    &known,
+                    root_ident.to_string(),
+                    0,
+                ));
+            }
+        });
+    };
+
+    for resource in &parsed.resources {
+        for expr in resource.attributes.values() {
+            check(&expr.0);
+        }
+    }
+    for attr in &parsed.attribute_params {
+        if let Some(value) = &attr.value {
+            check(value);
+        }
+    }
+    for call in &parsed.module_calls {
+        for v in call.arguments.values() {
+            check(v);
+        }
+    }
+    for export in &parsed.export_params {
+        if let Some(value) = &export.value {
+            check(value);
+        }
+    }
+
+    errors
 }
 
 fn resolve_value_with_config(

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -125,25 +125,12 @@ fn find_for_iterable_binding_column(
     Some((start_col, end_col))
 }
 
-/// Binding names declared anywhere in the merged parse — the same set
-/// `carina_core::parser::check_deferred_for_iterables` uses to decide whether
-/// a for-iterable's root is in scope.
+/// Binding names declared anywhere in the merged parse. Delegates to
+/// [`carina_core::parser::collect_known_bindings_merged`] so LSP
+/// diagnostics stay consistent with the CLI's post-merge checks
+/// (`check_deferred_for_iterables`, `check_undefined_references`).
 fn collect_known_bindings(merged: &ParsedFile) -> HashSet<&str> {
-    let mut known: HashSet<&str> = HashSet::new();
-    known.extend(merged.resources.iter().filter_map(|r| r.binding.as_deref()));
-    known.extend(merged.arguments.iter().map(|a| a.name.as_str()));
-    known.extend(
-        merged
-            .module_calls
-            .iter()
-            .filter_map(|c| c.binding_name.as_deref()),
-    );
-    known.extend(merged.upstream_states.iter().map(|u| u.binding.as_str()));
-    known.extend(merged.imports.iter().map(|i| i.alias.as_str()));
-    known.extend(merged.user_functions.keys().map(String::as_str));
-    known.extend(merged.variables.keys().map(String::as_str));
-    known.extend(merged.structural_bindings.iter().map(String::as_str));
-    known
+    carina_core::parser::collect_known_bindings_merged(merged)
 }
 
 /// Whether `deferred` was parsed from the editor's current document.


### PR DESCRIPTION
First slice of the #2104 umbrella.

## Summary

- Remove the \`check_undefined_bindings\` / \`check_undefined_in_value\` / per-file \`collect_known_bindings\` helpers and the call at the end of \`parse()\`. Per-file parse is now purely grammar + expression shape.
- Extract \`pub fn collect_known_bindings_merged(&ParsedFile)\` as the single source of truth for "what bindings are in scope at directory level?". \`check_deferred_for_iterables\` and the new \`check_undefined_references\` both consume it; LSP \`carina_lsp::diagnostics::checks\` delegates so diagnostics stay in lockstep with the CLI.
- Add \`pub fn check_undefined_references(&ParsedFile) -> Vec<ParseError>\` — mirrors the shape of \`check_deferred_for_iterables\`, walks resources / attribute_params / module_calls / export_params for \`Value::ResourceRef\` whose root isn't in the merged known set.
- Wire the new pass into \`load_configuration_with_config\` next to \`check_deferred_for_iterables\`; both error streams flow into a renamed \`LoadedConfig::identifier_scope_errors\` (was \`iterable_binding_errors\`). Caller (\`carina-cli validate\`) updated.

## Scope

**In**: move the existing per-file check to the post-merge pass. Pure refactor — the old check was already dead code for cross-file cases (it only ran against the current file's \`ctx\`, and legitimate cross-file refs were resolved via \`resolve_forward_references\` before the check would have fired).

**Deferred to other #2104 subtasks**:

- Stringly-typed typos: \`target_id = cllar.account_id\` where the root \`cllar\` is unknown is stored by \`namespaced_id\` as \`Value::String("cllar.account_id")\`, not as a \`ResourceRef\` — so it doesn't surface via \`visit_refs\`. Catching this requires a separate pass and is broader than the original issue scope (main doesn't catch it today either; verified via \`carina validate\`).
- LSP \`check_for_iterable_bindings\` / \`parse_error_to_diagnostic\` single-file branches.
- Folding iterable + undefined-reference checks into one "directory-scope validation" entry point.

Each will be filed as a separate subtask comment on #2104 after this lands.

Refs #2104
Closes #2126

## Test plan

- [x] \`cargo test --workspace\` — all tests pass (1293 carina-core + rest of workspace).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Real-infra smoke: \`carina validate carina-rs/infra/aws/management/organizations/\` succeeds as before (3 resources validated).
- [x] New acceptance test \`parse_directory_accepts_cross_file_resource_ref\` pins the legit cross-file case.