### PR TITLE
lsp completion: render upstream_state export TypeExpr in completion detail

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1800,6 +1800,53 @@ for _, id in orgs.
     );
 }
 
+// #2128: surface the export's declared `TypeExpr` in the completion
+// detail so the user sees `map(aws_account_id)` instead of the generic
+// "export from upstream_state `orgs`". Untyped exports keep the fallback
+// phrasing.
+#[test]
+fn upstream_state_dot_completion_detail_shows_type_expr() {
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(aws_account_id) = \"x\"\n  untyped = \"y\"\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "for _, id in orgs.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let accounts = completions
+        .iter()
+        .find(|c| c.label == "accounts")
+        .expect("expected `accounts` in completions");
+    let detail = accounts.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("map(aws_account_id)"),
+        "typed export detail must include the TypeExpr rendering, got: {:?}",
+        detail
+    );
+
+    let untyped = completions
+        .iter()
+        .find(|c| c.label == "untyped")
+        .expect("expected `untyped` in completions");
+    let detail = untyped.detail.as_deref().unwrap_or("");
+    assert!(
+        !detail.contains('('),
+        "untyped export detail must not render a bogus type, got: {:?}",
+        detail
+    );
+    assert!(
+        detail.contains("orgs"),
+        "untyped fallback detail should still identify the binding, got: {:?}",
+        detail
+    );
+}
+
 // =====================================================================
 // exports block: type-aware value-position completion (#1993)
 // =====================================================================

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -641,12 +641,20 @@ impl CompletionProvider {
             end: position,
         };
 
+        // Render the export's declared `TypeExpr` into the detail when it
+        // exists so the user can see `map(aws_account_id)` at the popup
+        // instead of cross-referencing the upstream's `exports.crn`. Exports
+        // declared without a type annotation fall back to the generic
+        // phrasing (still useful; tells the user which binding it came from).
         let mut items: Vec<CompletionItem> = keys
-            .keys()
-            .map(|key| CompletionItem {
+            .iter()
+            .map(|(key, type_expr)| CompletionItem {
                 label: key.clone(),
                 kind: Some(CompletionItemKind::FIELD),
-                detail: Some(format!("export from upstream_state `{}`", binding)),
+                detail: Some(match type_expr {
+                    Some(t) => format!("export from upstream_state `{}`: {}", binding, t),
+                    None => format!("export from upstream_state `{}`", binding),
+                }),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range,
                     new_text: key.clone(),


### PR DESCRIPTION
Narrow slice of #2041. Depth-2 descent into struct / list / map fields turned out to be blocked on Carina not having a \`TypeExpr::Struct\` variant and on there being no real-infra use site for dot-access into a map literal — both deferred under the umbrella.

What this PR ships: surface the existing \`TypeExpr\` in the depth-1 completion \`detail\` so users can tell at a glance whether an export is a \`string\`, \`map(aws_account_id)\`, \`list(...)\`, etc. without cross-referencing the upstream's \`exports.crn\`.

## Summary

- \`carina-lsp/src/completion/values.rs::upstream_state_dot_completions\` now reads the \`Option<TypeExpr>\` already carried by \`UpstreamExports\` and renders it into \`CompletionItem.detail\`.
- Typed: \`\"export from upstream_state \\\`orgs\\\`: map(aws_account_id)\"\`.
- Untyped: falls back to the previous phrasing verbatim.

Closes #2128
Refs #2041

## Test plan

- [x] \`cargo test -p carina-lsp --lib\` — 308 tests pass (+1 new \`upstream_state_dot_completion_detail_shows_type_expr\`).
- [x] \`cargo clippy -p carina-lsp --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Real-infra smoke: \`carina validate carina-rs/infra/aws/management/organizations/\` succeeds as before.