### PR TITLE
lsp diagnostics: use merged-parse known-bindings for undefined-ref check

### DIFF
--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -128,38 +128,49 @@ impl DiagnosticEngine {
         let mut diagnostics = Vec::new();
         let text = doc.text();
 
-        // Extract defined resource bindings. BufferOnly is intentional:
-        // sibling-file bindings are pre-resolved by the caller and come in
-        // via `sibling_bindings` below.
-        let defined_bindings =
-            self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text));
-
         // Parse errors
         if let Some(error) = doc.parse_error() {
             diagnostics.push(parse_error_to_diagnostic(error));
         }
 
-        // Check for undefined resource references in the raw text
-        // Include sibling file bindings to avoid false positives for cross-file refs
-        let mut all_bindings = defined_bindings.clone();
-        for name in sibling_bindings.keys() {
-            all_bindings.insert(name.clone());
-        }
-        let declared_providers = self.extract_declared_provider_names(&text);
-        let undef_diags =
-            self.check_undefined_references(&text, &all_bindings, &declared_providers);
-        diagnostics.extend(undef_diags);
-
         // Checks that need cross-file context share one directory-scoped parse
-        // (buffer substituted for its on-disk copy). Both must run even when
+        // (buffer substituted for its on-disk copy). All must run even when
         // the current document fails to parse on its own — a `for` or `let`
         // commonly references a binding declared in a sibling file.
-        if let Some(base) = base_path
+        //
+        // The merged parse is also the authoritative source of "what
+        // bindings are in scope?" for the text-scan undefined-reference
+        // check below. Falling back to the current file's bindings +
+        // `sibling_bindings` (populated by a hand-rolled text scan in
+        // `Backend::scan_sibling_context`) used to miss `upstream_state`,
+        // `import`, and module-call bindings, producing false positives
+        // like "Undefined resource: 'orgs'" when `orgs` was declared in
+        // `backend.crn` (#2131 / #2132).
+        let declared_providers = self.extract_declared_provider_names(&text);
+        let known_bindings: HashSet<String> = if let Some(base) = base_path
             && let Some(merged) = self.parse_merged_with_buffer(doc, current_file_name, base)
         {
             diagnostics.extend(self.check_upstream_state_field_references(doc, &merged, base));
             diagnostics.extend(self.check_for_iterable_bindings(doc, &merged, current_file_name));
-        }
+            carina_core::parser::collect_known_bindings_merged(&merged)
+                .into_iter()
+                .map(String::from)
+                .collect()
+        } else {
+            // No base_path or merge failed — fall back to the current
+            // file plus any bindings the caller pre-scanned.
+            let mut bindings =
+                self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text));
+            for name in sibling_bindings.keys() {
+                bindings.insert(name.clone());
+            }
+            bindings
+        };
+        diagnostics.extend(self.check_undefined_references(
+            &text,
+            &known_bindings,
+            &declared_providers,
+        ));
 
         // Semantic analysis on parsed file
         if let Some(parsed) = doc.parsed() {

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2903,3 +2903,103 @@ fn lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal() {
         bad.message
     );
 }
+
+// #2131 / #2132: a ResourceRef whose root is declared in a sibling `.crn`
+// must NOT be flagged `Undefined resource`. The LSP text-scan used to
+// feed on the current file's bindings plus a hand-rolled sibling scan
+// that skipped `upstream_state`, `import`, and module-call bindings.
+// Merged-parse is the source of truth.
+#[test]
+fn upstream_state_binding_in_sibling_file_is_not_undefined() {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    // The #2131 repro: `orgs.accounts` on the RHS of an assignment.
+    // The text-scan `check_undefined_references` only inspects lines
+    // that contain `=`, so the bug surfaces inside a resource block.
+    let main = "awscc.ec2.vpc {\n  target_id = orgs.accounts\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    let undefined: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| {
+            d.message.contains("Undefined resource") || d.message.contains("Undefined identifier")
+        })
+        .collect();
+    assert!(
+        undefined.is_empty(),
+        "sibling-declared `upstream_state` binding must not be flagged. Got: {:?}",
+        undefined.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// `import` bindings in a sibling file were also invisible to the old
+// text-scan (no `provider.service.type` RHS). Cover that shape too.
+#[test]
+fn import_binding_in_sibling_file_is_not_undefined() {
+    let tmp = tempfile::tempdir().unwrap();
+    let module = tmp.path().join("modules").join("vpc");
+    std::fs::create_dir_all(&module).unwrap();
+    std::fs::write(module.join("main.crn"), "arguments {\n  name: string\n}\n").unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("imports.crn"),
+        "let vpc_mod = import '../modules/vpc'\n",
+    )
+    .unwrap();
+    let main = "awscc.ec2.vpc {\n  name = vpc_mod.name\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    let undefined: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| {
+            d.message.contains("Undefined resource") || d.message.contains("Undefined identifier")
+        })
+        .collect();
+    assert!(
+        undefined.is_empty(),
+        "sibling-declared `import` binding must not be flagged. Got: {:?}",
+        undefined.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// Genuine undefined still fires (typo against no declared binding at all).
+#[test]
+fn undefined_binding_in_current_file_still_flagged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    let main = "awscc.ec2.vpc {\n  name = nowhere.value\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Undefined resource")
+                || d.message.contains("Undefined identifier")),
+        "typo against a truly undeclared root must still be flagged. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Third slice of #2104. The LSP undefined-reference text-scan built its "what's in scope?" set from (1) the current buffer's \`let\` headers and (2) a hand-rolled sibling scan (\`Backend::scan_sibling_context\`) that only accepted \`let x = provider.service.type {\` form. \`upstream_state\`, \`import\`, and bare module-call bindings slipped through.

Result: opening \`carina-rs/infra/aws/management/identity-center/main.crn\` in VS Code flagged \`target_id = orgs.accounts\` as \`Undefined resource: 'orgs'\` even though \`orgs\` was declared in the sibling \`backend.crn\`. The CLI's \`carina validate\` on the same directory passed cleanly — the CLI already uses the post-merge identifier-scope pass from #2126 / #2127.

## Summary

- \`analyze_with_filename\` now feeds \`carina_core::parser::collect_known_bindings_merged(&merged)\` into \`check_undefined_references\` when \`parse_merged_with_buffer\` returns a merged \`ParsedFile\`. The merged parse is the authoritative source of "what bindings are in scope?" across the directory and covers every binding shape.
- The text-scan itself (for diagnostic range info) is unchanged — only the known-binding set changed.
- Fallback path (current buffer + \`sibling_bindings\`) retained for the unusual \`base_path == None\` / merge-fail case.

## Scope

**Closes #2131**, **Closes #2132**. Refs #2104 umbrella.

**Out of scope (follow-up on #2104):**

- \`Backend::scan_sibling_context\` still exists because \`check_exports_blocks\` (cross-file type-ref validation) and \`check_unused_bindings\` (via \`sibling_referenced\`) still consume it. Those two paths have the same \`upstream_state\`/\`import\` blind spot and should move to merged parse too.

## Test plan

- [x] \`cargo test -p carina-lsp --lib\` — 311 pass (3 new multi-file regression tests).
- [x] \`cargo clippy -p carina-lsp --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Real-infra smoke: \`carina validate carina-rs/infra/aws/management/identity-center/\` succeeds.
- [x] Interactive verify: ran \`cargo install --path carina-lsp --locked --target-dir /tmp/carina-install-2132 --force\` (per memory note on shared target-dir drift). Open \`identity-center/main.crn\` after reloading the VS Code window — the \`Undefined resource: 'orgs'\` squiggle is gone.