### PR TITLE
lsp diagnostics: delete scan_sibling_context, drive exports/unused checks off merged parse

### DIFF
--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -554,6 +554,15 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
     // Collect all referenced binding names. Walk both top-level resources
     // and for-body template resources so bindings referenced only inside a
     // `for` loop are counted as used.
+    //
+    // `collect_dot_notation_refs` also runs on resource attributes: when
+    // a resource in file A references `binding.attr` where `binding` is
+    // declared in sibling file B, per-file parse stores it as
+    // `Value::String("binding.attr")`. `resolve_resource_refs_with_config`
+    // lifts those to `ResourceRef` only when the value sits at the top
+    // level of an attribute; inside a list / map / interpolation the
+    // string form survives, so a reference nested in
+    // `principals = [binding.attr]` would otherwise be missed.
     let mut referenced: HashSet<String> = HashSet::new();
     for (_ctx, resource) in parsed.iter_all_resources() {
         for (attr_name, value) in &resource.attributes {
@@ -561,11 +570,13 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
                 continue;
             }
             collect_resource_refs(value, &mut referenced);
+            collect_dot_notation_refs(value, &mut referenced);
         }
     }
     for call in &parsed.module_calls {
         for value in call.arguments.values() {
             collect_resource_refs(value, &mut referenced);
+            collect_dot_notation_refs(value, &mut referenced);
         }
     }
     for attr_param in &parsed.attribute_params {

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -264,75 +264,6 @@ impl Backend {
         self.workspace_root.get().and_then(|opt| opt.as_ref())
     }
 
-    /// Scan sibling `.crn` files in the same directory for `let` bindings
-    /// and references to the current file's bindings.
-    ///
-    /// ## Scope
-    ///
-    /// Intentionally **one directory level only** (the parent directory of
-    /// the file being edited). Carina is directory-scoped — each directory
-    /// is its own parse unit. Files in nested subdirectories are separate
-    /// modules or upstream projects with their own binding scopes, so they
-    /// must not leak bindings into this cross-file reference check.
-    /// Dedicated diagnostics
-    /// ([`crate::diagnostics::checks::DiagnosticEngine::check_upstream_state_field_references`])
-    /// handle references that do cross a directory boundary (upstream
-    /// state exports, module call arguments) via
-    /// `parse_directory_with_overrides`.
-    ///
-    /// ## Returns
-    /// - `bindings`: binding_name → resource_type for `let` bindings in the
-    ///   current file's sibling `.crn`s.
-    /// - `referenced`: binding names from the current file that appear to be
-    ///   referenced by those siblings.
-    fn scan_sibling_context(
-        dir: &Path,
-        current_uri: &Url,
-        current_bindings: &std::collections::HashSet<String>,
-    ) -> (HashMap<String, String>, std::collections::HashSet<String>) {
-        let mut bindings = HashMap::new();
-        let mut referenced = std::collections::HashSet::new();
-        let current_path = current_uri.to_file_path().ok();
-        let entries = match std::fs::read_dir(dir) {
-            Ok(e) => e,
-            Err(_) => return (bindings, referenced),
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "crn")
-                && current_path.as_ref() != Some(&path)
-                && let Ok(content) = std::fs::read_to_string(&path)
-            {
-                for line in content.lines() {
-                    let trimmed = line.trim();
-                    if let Some((binding, after_eq)) = crate::let_parse::parse_let_header(line) {
-                        // Strip "read " prefix if present
-                        let type_part = after_eq.strip_prefix("read ").unwrap_or(after_eq);
-                        // Extract "provider.service.type" before "{"
-                        if let Some(brace) = type_part.find('{') {
-                            let resource_type = type_part[..brace].trim();
-                            if resource_type.contains('.') {
-                                bindings.insert(binding.to_string(), resource_type.to_string());
-                            }
-                        }
-                    }
-
-                    // Check if this line references any binding from the current file
-                    // Look for "binding_name." patterns after "="
-                    if let Some(eq_pos) = trimmed.find('=') {
-                        let after_eq = trimmed[eq_pos + 1..].trim();
-                        for name in current_bindings.iter() {
-                            if after_eq.starts_with(&format!("{}.", name)) {
-                                referenced.insert(name.clone());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        (bindings, referenced)
-    }
-
     async fn update_diagnostics(&self, uri: Url) {
         publish_diagnostics_for(&self.client, &self.documents, &self.providers, uri).await;
     }
@@ -656,22 +587,6 @@ async fn publish_diagnostics_for(
         .ok()
         .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
-    let current_bindings: std::collections::HashSet<String> = {
-        let text = doc.text();
-        let mut bindings = std::collections::HashSet::new();
-        for line in text.lines() {
-            if let Some((name, _)) = crate::let_parse::parse_let_header(line) {
-                bindings.insert(name.to_string());
-            }
-        }
-        bindings
-    };
-
-    let (sibling_bindings, sibling_referenced) = base_path
-        .as_ref()
-        .map(|dir| Backend::scan_sibling_context(dir, &uri, &current_bindings))
-        .unwrap_or_default();
-
     let current_file_name: Option<String> = uri
         .to_file_path()
         .ok()
@@ -686,8 +601,6 @@ async fn publish_diagnostics_for(
         &doc,
         current_file_name.as_deref(),
         base_path.as_deref(),
-        &sibling_bindings,
-        &sibling_referenced,
     );
     drop(guard);
 

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -731,22 +731,23 @@ impl DiagnosticEngine {
         None
     }
 
-    /// Check for unused `let` bindings and emit warnings.
-    pub(super) fn check_unused_bindings(
+    /// Format a stream of unused-binding names into LSP diagnostics.
+    /// The caller decides which bindings count as unused (derived from
+    /// `carina_core::validation::check_unused_bindings` on the merged
+    /// parse) and which to anchor the warning on — this helper only
+    /// handles the final position lookup and diagnostic construction.
+    pub(super) fn unused_binding_diagnostics<I>(
         &self,
         doc: &Document,
-        parsed: &ParsedFile,
-    ) -> Vec<Diagnostic> {
-        let unused_bindings = carina_core::validation::check_unused_bindings(parsed);
-        if unused_bindings.is_empty() {
-            return Vec::new();
-        }
-
+        unused_bindings: I,
+    ) -> Vec<Diagnostic>
+    where
+        I: IntoIterator<Item = String>,
+    {
         let text = doc.text();
         let mut diagnostics = Vec::new();
-
-        for binding_name in &unused_bindings {
-            if let Some((line, col)) = self.find_let_binding_position(&text, binding_name) {
+        for binding_name in unused_bindings {
+            if let Some((line, col)) = self.find_let_binding_position(&text, &binding_name) {
                 diagnostics.push(carina_diagnostic(
                     line,
                     col,
@@ -759,7 +760,6 @@ impl DiagnosticEngine {
                 ));
             }
         }
-
         diagnostics
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -103,14 +103,8 @@ impl DiagnosticEngine {
         self
     }
 
-    pub fn analyze(
-        &self,
-        doc: &Document,
-        base_path: Option<&Path>,
-        sibling_bindings: &HashMap<String, String>,
-        sibling_referenced: &HashSet<String>,
-    ) -> Vec<Diagnostic> {
-        self.analyze_with_filename(doc, None, base_path, sibling_bindings, sibling_referenced)
+    pub fn analyze(&self, doc: &Document, base_path: Option<&Path>) -> Vec<Diagnostic> {
+        self.analyze_with_filename(doc, None, base_path)
     }
 
     /// Like [`analyze`] but lets the caller pass the current document's file
@@ -122,8 +116,6 @@ impl DiagnosticEngine {
         doc: &Document,
         current_file_name: Option<&str>,
         base_path: Option<&Path>,
-        sibling_bindings: &HashMap<String, String>,
-        sibling_referenced: &HashSet<String>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
         let text = doc.text();
@@ -133,38 +125,35 @@ impl DiagnosticEngine {
             diagnostics.push(parse_error_to_diagnostic(error));
         }
 
-        // Checks that need cross-file context share one directory-scoped parse
-        // (buffer substituted for its on-disk copy). All must run even when
-        // the current document fails to parse on its own — a `for` or `let`
-        // commonly references a binding declared in a sibling file.
-        //
-        // The merged parse is also the authoritative source of "what
-        // bindings are in scope?" for the text-scan undefined-reference
-        // check below. Falling back to the current file's bindings +
-        // `sibling_bindings` (populated by a hand-rolled text scan in
-        // `Backend::scan_sibling_context`) used to miss `upstream_state`,
-        // `import`, and module-call bindings, producing false positives
-        // like "Undefined resource: 'orgs'" when `orgs` was declared in
-        // `backend.crn` (#2131 / #2132).
+        // Build the directory-scoped merged parse once up-front — it is
+        // the authoritative source of truth for every check that needs
+        // cross-file context: undefined-identifier (#2132), upstream-
+        // state field references, for-iterable bindings, unused-let
+        // filtering, and exports type validation (#2134). The buffer is
+        // substituted for its on-disk copy so diagnostics update on
+        // keystrokes.
+        let merged =
+            base_path.and_then(|base| self.parse_merged_with_buffer(doc, current_file_name, base));
+
+        if let (Some(base), Some(merged)) = (base_path, merged.as_ref()) {
+            diagnostics.extend(self.check_upstream_state_field_references(doc, merged, base));
+            diagnostics.extend(self.check_for_iterable_bindings(doc, merged, current_file_name));
+        }
+
+        // `known_bindings` for the text-scan undefined-reference check.
+        // When no merged parse is available (no base_path, or directory
+        // parse fails) the fallback is the current buffer's `let` headers
+        // only — cross-file bindings become undetectable and we'd rather
+        // miss typos than manufacture false positives against
+        // `upstream_state` / `import` bindings the old text scan used to
+        // mishandle (#2131 / #2132).
         let declared_providers = self.extract_declared_provider_names(&text);
-        let known_bindings: HashSet<String> = if let Some(base) = base_path
-            && let Some(merged) = self.parse_merged_with_buffer(doc, current_file_name, base)
-        {
-            diagnostics.extend(self.check_upstream_state_field_references(doc, &merged, base));
-            diagnostics.extend(self.check_for_iterable_bindings(doc, &merged, current_file_name));
-            carina_core::parser::collect_known_bindings_merged(&merged)
+        let known_bindings: HashSet<String> = match merged.as_ref() {
+            Some(merged) => carina_core::parser::collect_known_bindings_merged(merged)
                 .into_iter()
                 .map(String::from)
-                .collect()
-        } else {
-            // No base_path or merge failed — fall back to the current
-            // file plus any bindings the caller pre-scanned.
-            let mut bindings =
-                self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text));
-            for name in sibling_bindings.keys() {
-                bindings.insert(name.clone());
-            }
-            bindings
+                .collect(),
+            None => self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text)),
         };
         diagnostics.extend(self.check_undefined_references(
             &text,
@@ -695,16 +684,38 @@ impl DiagnosticEngine {
             // Check attributes blocks
             diagnostics.extend(self.check_attributes_blocks(doc, parsed));
 
-            // Check exports blocks
-            diagnostics.extend(self.check_exports_blocks(doc, parsed, None, sibling_bindings));
+            // Exports type check. When a merged parse is available the
+            // sibling-binding → resource-type map is built from it so
+            // `upstream_state` / `import` / module-call bindings are
+            // visible (#2134); otherwise fall back to an empty map and
+            // rely on the local-to-file checks that `check_exports_blocks`
+            // performs (e.g. type annotation sanity, literal-value shape).
+            let sibling_bindings = merged
+                .as_ref()
+                .map(exports_sibling_bindings_from)
+                .unwrap_or_default();
+            diagnostics.extend(self.check_exports_blocks(doc, parsed, None, &sibling_bindings));
 
-            // Check for unused let bindings (exclude bindings referenced by sibling files)
-            let unused_diags = self.check_unused_bindings(doc, parsed);
-            diagnostics.extend(unused_diags.into_iter().filter(|d| {
-                !sibling_referenced
-                    .iter()
-                    .any(|name| d.message.contains(&format!("'{}'", name)))
-            }));
+            // Unused `let` detection. When a merged parse is available,
+            // run the core check against it (so references from sibling
+            // files count as usage) and filter the result to bindings
+            // declared in the current file — the LSP warning surface is
+            // per-document. Without a merged parse there are no sibling
+            // references to consider, so run the per-file check.
+            let unused_binding_names: Vec<String> = match merged.as_ref() {
+                Some(merged) => {
+                    let current_file_bindings: HashSet<String> = parsed
+                        .iter_all_resources()
+                        .filter_map(|(_, r)| r.binding.clone())
+                        .collect();
+                    carina_core::validation::check_unused_bindings(merged)
+                        .into_iter()
+                        .filter(|b| current_file_bindings.contains(b))
+                        .collect()
+                }
+                None => carina_core::validation::check_unused_bindings(parsed),
+            };
+            diagnostics.extend(self.unused_binding_diagnostics(doc, unused_binding_names));
 
             // Surface unused-for-binding warnings (recorded in parsed.warnings by
             // the parser) as LSP diagnostics. Other ParseWarnings (e.g. the
@@ -1032,6 +1043,26 @@ fn check_resource_ref_type_mismatch(
             ref_attr
         ))
     }
+}
+
+/// Build the binding-name → resource-type map that
+/// [`check_exports_blocks`] uses to type-check cross-file references.
+/// Replaces the hand-rolled `Backend::scan_sibling_context` output —
+/// merged parse sees every resource in the directory, including those
+/// declared in sibling files (#2134).
+fn exports_sibling_bindings_from(merged: &ParsedFile) -> HashMap<String, String> {
+    merged
+        .resources
+        .iter()
+        .filter_map(|r| {
+            r.binding.as_ref().map(|b| {
+                (
+                    b.clone(),
+                    format!("{}.{}", r.id.provider, r.id.resource_type),
+                )
+            })
+        })
+        .collect()
 }
 
 fn parse_error_to_diagnostic(error: &ParseError) -> Diagnostic {

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -18,7 +18,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unknown_field_diag = diagnostics
         .iter()
@@ -48,7 +48,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_mismatch = diagnostics.iter().find(|d| {
         (d.message.contains("Type mismatch") && d.message.contains("Int"))
@@ -80,7 +80,7 @@ ipv4_ipam_pool_id = vpc.vpc_id
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_mismatch = diagnostics
         .iter()
@@ -112,7 +112,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_mismatch = diagnostics
         .iter()
@@ -151,7 +151,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let bad_field_diag = diagnostics
         .iter()
@@ -192,7 +192,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let block_diag = diagnostics
         .iter()
@@ -235,7 +235,7 @@ private_dns_name_options_on_launch {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     // Both blocks should get errors
     let block_count = diagnostics
@@ -271,7 +271,7 @@ security_group_ingress = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -306,7 +306,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -332,7 +332,7 @@ group_description = "Test security group"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let lint_diag = diagnostics
         .iter()
@@ -356,7 +356,7 @@ region = aws.Region.ap_northeast_1
 aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -379,7 +379,7 @@ region = aws.Region.ap_northeast_1
 let identity = read aws.sts.caller_identity {}"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -404,7 +404,7 @@ name = "my-bucket"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let data_source_diag = diagnostics
         .iter()
@@ -431,8 +431,8 @@ name = "my-bucket"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_normal = engine.analyze(&doc, None);
+    let diags_reversed = engine_rev.analyze(&doc, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -461,8 +461,8 @@ cidr_block = "10.0.0.0/16"
     let engine = test_engine();
     let engine_rev = test_engine_reversed();
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_normal = engine.analyze(&doc, None);
+    let diags_reversed = engine_rev.analyze(&doc, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -493,8 +493,8 @@ name = "test-bucket"
 }"#,
     );
 
-    let diags_normal = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
-    let diags_reversed = engine_rev.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diags_normal = engine.analyze(&doc, None);
+    let diags_reversed = engine_rev.analyze(&doc, None);
 
     let messages_normal: Vec<_> = diags_normal.iter().map(|d| &d.message).collect();
     let messages_reversed: Vec<_> = diags_reversed.iter().map(|d| &d.message).collect();
@@ -523,7 +523,7 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let dup_diag = diagnostics.iter().find(|d| {
         d.message
             .contains("Duplicate attribute 'internet_gateway_id'")
@@ -556,7 +556,7 @@ let vpc = awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let dup_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Duplicate attribute"));
@@ -644,7 +644,7 @@ for name, account_id in things {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unused = diagnostics
         .iter()
@@ -675,7 +675,7 @@ for key, value in things {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     assert!(
         !diagnostics
@@ -703,7 +703,7 @@ awscc.ec2.security_group {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     assert!(
         !diagnostics

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -19,7 +19,7 @@ operating_region {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unknown = diagnostics
         .iter()
@@ -45,7 +45,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unknown = diagnostics
         .iter()
@@ -70,7 +70,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let mismatch = diagnostics
         .iter()
@@ -97,7 +97,7 @@ outer {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     // Filter to only struct-related diagnostics (ignore unknown attribute warnings from test schema)
     let struct_diags: Vec<_> = diagnostics
@@ -126,7 +126,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.invalid_value
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -152,7 +152,7 @@ instance_tenancy = awscc.ec2.vpc.InstanceTenancy.default
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -184,7 +184,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -215,7 +215,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let enum_diag = diagnostics
         .iter()
@@ -247,7 +247,7 @@ security_group_ingress {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let port_diag = diagnostics
         .iter()
@@ -289,7 +289,7 @@ protocols = ["tcp", "invalid_protocol"]
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let item_diag = diagnostics
         .iter()
@@ -322,7 +322,7 @@ operating_regions = [{
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let mixed_error = diagnostics.iter().find(|d| {
         d.message.contains("operating_region")
@@ -370,7 +370,7 @@ mode = "invalid_mode"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_error = diagnostics
         .iter()
@@ -416,7 +416,7 @@ mode = "active"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_error = diagnostics
         .iter()
@@ -462,7 +462,7 @@ mode = 42
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_error = diagnostics
         .iter()
@@ -487,7 +487,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -516,7 +516,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -541,7 +541,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -573,7 +573,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -601,7 +601,7 @@ config = {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unknown = diagnostics
         .iter()
@@ -652,7 +652,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -684,7 +684,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -716,7 +716,7 @@ cidr_block = "10.0.1.0/24"
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined_diag = diagnostics
         .iter()
@@ -745,7 +745,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -773,7 +773,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let provider_diag = diagnostics.iter().find(|d| {
         d.message
@@ -799,7 +799,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function 'not_a_function'"));
@@ -826,7 +826,7 @@ awscc.ec2.vpc {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let func_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("Unknown function"));
@@ -860,7 +860,7 @@ awscc.ec2.route {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let typo_diag = diagnostics.iter().find(|d| {
         d.message
@@ -891,7 +891,7 @@ awscc.ec2.vpc_gateway_attachment {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let ref_diag = diagnostics
         .iter()
@@ -915,7 +915,7 @@ let name = join("-", parts)
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let pipe_diag = diagnostics
         .iter()
@@ -1060,7 +1060,7 @@ let name = parts |> join("-")
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let pipe_diag = diagnostics
         .iter()
@@ -1085,7 +1085,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1110,7 +1110,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1135,7 +1135,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1160,7 +1160,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1244,7 +1244,7 @@ test.target {
 union_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let union_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1264,7 +1264,7 @@ test.target {
 enum_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let enum_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("MyId"));
@@ -1284,7 +1284,7 @@ test.target {
 custom_attr = src.my_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let custom_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("custom_attr"));
@@ -1304,7 +1304,7 @@ test.target {
 union_attr = src.name
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let string_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch") && d.message.contains("union_attr"));
@@ -1328,7 +1328,7 @@ attributes {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let type_diag = diagnostics
         .iter()
@@ -1373,7 +1373,7 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
         "mock.test.resource {\n  name = 'test'\n  tags = {\n    key = 'Project'\n    value = 'carina'\n  }\n}",
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let tags_diag = diagnostics
         .iter()
         .find(|d| d.message.contains("tags key/value error"));
@@ -1408,7 +1408,7 @@ fn warning_when_provider_loaded_but_schema_missing() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let unknown_type = diagnostics
         .iter()
@@ -1447,7 +1447,7 @@ fn error_when_provider_not_loaded_at_all() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let not_downloaded = diagnostics.iter().find(|d| {
         d.message.contains("Provider 'awscc' is not downloaded")
@@ -1490,7 +1490,7 @@ fn no_undefined_resource_for_namespaced_enum_value() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined = diagnostics
         .iter()
@@ -1522,7 +1522,7 @@ fn no_undefined_resource_for_declared_but_uninstalled_provider() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined = diagnostics
         .iter()
@@ -1548,7 +1548,7 @@ fn undefined_resource_still_fires_when_identifier_is_not_a_declared_provider() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let undefined = diagnostics
         .iter()
@@ -1615,7 +1615,7 @@ fn map_key_validation_warns_on_invalid_key() {
 }
 "#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let has_key_error = diagnostics
         .iter()
         .any(|d| d.message.contains("Map key") || d.message.contains("unknown_op"));
@@ -1688,7 +1688,7 @@ awscc.sso.assignment {
 target_id = caller.account_id
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let type_mismatch = diagnostics
         .iter()
         .find(|d| d.message.contains("Type mismatch"));
@@ -1741,7 +1741,7 @@ fn exports_cross_file_ref_no_false_positive() {
 }"#,
     );
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     let false_positive = diagnostics
         .iter()
@@ -1765,18 +1765,8 @@ fn exports_type_warning_survives_formatter_round_trip() {
     let formatted = format(original, &FormatConfig::default()).unwrap();
 
     let engine = test_engine();
-    let before = engine.analyze(
-        &create_document(original),
-        None,
-        &HashMap::new(),
-        &HashSet::new(),
-    );
-    let after = engine.analyze(
-        &create_document(&formatted),
-        None,
-        &HashMap::new(),
-        &HashSet::new(),
-    );
+    let before = engine.analyze(&create_document(original), None);
+    let after = engine.analyze(&create_document(&formatted), None);
 
     let before_warning = before
         .iter()
@@ -1820,18 +1810,8 @@ exports {
 }"#;
     let formatted = format(original, &FormatConfig::default()).unwrap();
 
-    let before = engine.analyze(
-        &create_document(original),
-        None,
-        &HashMap::new(),
-        &HashSet::new(),
-    );
-    let after = engine.analyze(
-        &create_document(&formatted),
-        None,
-        &HashMap::new(),
-        &HashSet::new(),
-    );
+    let before = engine.analyze(&create_document(original), None);
+    let after = engine.analyze(&create_document(&formatted), None);
 
     let before_warning = before
         .iter()
@@ -1895,7 +1875,7 @@ exports {
         text: formatted.clone(),
     });
 
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     let warning = diagnostics
         .iter()
         .find(|d| d.message.contains("export 'values': type mismatch"))
@@ -1927,7 +1907,7 @@ fn exports_type_warning_after_format_with_cross_file_ref() {
   accounts: list(bool) = [registry_prod.account_id, registry_dev.account_id]
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
 
     // "registry_prod.account_id" is a cross-file ref (dot-notation string).
     // It should NOT produce a false positive (12-digit check etc.).
@@ -1958,7 +1938,7 @@ fn exports_type_warning_for_literal_mismatch() {
   flag: bool = 'hello'
 }"#,
     );
-    let diagnostics = engine.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, None);
     eprintln!(
         "literal mismatch diagnostics: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -1978,7 +1958,7 @@ fn exports_type_warning_multiline_vs_oneline() {
     let engine = test_engine();
     // Multi-line (before format)
     let doc_multi = create_document("exports {\n  flag: bool = 'hello'\n}");
-    let diag_multi = engine.analyze(&doc_multi, None, &HashMap::new(), &HashSet::new());
+    let diag_multi = engine.analyze(&doc_multi, None);
     eprintln!(
         "multi-line: {:?}",
         diag_multi.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -1987,7 +1967,7 @@ fn exports_type_warning_multiline_vs_oneline() {
     // After user types but before format - with wrong type and literal
     let doc_literal =
         create_document("exports {\n  accounts: list(bool) = ['literal1', 'literal2']\n}");
-    let diag_literal = engine.analyze(&doc_literal, None, &HashMap::new(), &HashSet::new());
+    let diag_literal = engine.analyze(&doc_literal, None);
     eprintln!(
         "literal list(bool): {:?}",
         diag_literal.iter().map(|d| &d.message).collect::<Vec<_>>()
@@ -2007,26 +1987,18 @@ fn exports_map_type_warning_for_cross_file_ref() {
         .collect();
     let engine = custom_engine(schemas);
 
-    let doc = create_document(
-        r#"exports {
-  accounts: map(bool) = {
-    prod = registry_prod.account_id
-    dev  = registry_dev.account_id
-  }
-}"#,
-    );
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account { name = 'prod' }\nlet registry_dev = awscc.organizations.account { name = 'dev' }\n",
+    )
+    .unwrap();
+    let exports = "exports {\n  accounts: map(bool) = {\n    prod = registry_prod.account_id\n    dev  = registry_dev.account_id\n  }\n}";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
 
-    let mut sibling_bindings = HashMap::new();
-    sibling_bindings.insert(
-        "registry_prod".to_string(),
-        "awscc.organizations.account".to_string(),
-    );
-    sibling_bindings.insert(
-        "registry_dev".to_string(),
-        "awscc.organizations.account".to_string(),
-    );
-
-    let diagnostics = engine.analyze(&doc, None, &sibling_bindings, &HashSet::new());
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
 
     let type_warning = diagnostics
         .iter()
@@ -2045,28 +2017,18 @@ fn no_undefined_resource_for_sibling_binding_in_exports() {
         vec!["awscc".to_string()],
         Arc::new(vec![]),
     );
-    let doc = create_document(
-        r#"exports {
-  accounts: map(aws_account_id) = {
-    prod = registry_prod.account_id
-    dev = registry_dev.account_id
-  }
-}
-"#,
-    );
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account { name = 'prod' }\nlet registry_dev = awscc.organizations.account { name = 'dev' }\n",
+    )
+    .unwrap();
+    let exports = "exports {\n  accounts: map(aws_account_id) = {\n    prod = registry_prod.account_id\n    dev = registry_dev.account_id\n  }\n}\n";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
 
-    // registry_prod and registry_dev are defined in sibling files
-    let mut sibling_bindings = HashMap::new();
-    sibling_bindings.insert(
-        "registry_prod".to_string(),
-        "awscc.organizations.account".to_string(),
-    );
-    sibling_bindings.insert(
-        "registry_dev".to_string(),
-        "awscc.organizations.account".to_string(),
-    );
-
-    let diagnostics = engine.analyze(&doc, None, &sibling_bindings, &HashSet::new());
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
 
     let undefined = diagnostics
         .iter()
@@ -2091,7 +2053,7 @@ fn upstream_state_missing_source_directory_is_flagged() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, Some(&base));
 
     let diag = diagnostics
         .iter()
@@ -2134,7 +2096,7 @@ let orgs = upstream_state {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, Some(&base));
 
     let diag = diagnostics
         .iter()
@@ -2166,7 +2128,7 @@ fn upstream_state_existing_source_directory_is_ok() {
 "#,
     );
 
-    let diagnostics = engine.analyze(&doc, Some(&base), &HashMap::new(), &HashSet::new());
+    let diagnostics = engine.analyze(&doc, Some(&base));
 
     let diag = diagnostics
         .iter()
@@ -2205,13 +2167,7 @@ fn analyze_with_buffer(
     buffer: &str,
 ) -> Vec<tower_lsp::lsp_types::Diagnostic> {
     let doc = create_document(buffer);
-    engine.analyze_with_filename(
-        &doc,
-        Some(filename),
-        Some(base),
-        &HashMap::new(),
-        &HashSet::new(),
-    )
+    engine.analyze_with_filename(&doc, Some(filename), Some(base))
 }
 
 #[test]
@@ -2694,7 +2650,7 @@ for _, id in orgs.xs {
 }
 "#;
     let doc = create_document(source);
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     // Match "Unused" (LSP check_unused_bindings) and "unused" (parser warnings)
     // case-insensitively so the assertion fires whichever path flags `vpc`.
     assert!(
@@ -2717,7 +2673,7 @@ for _, id in orgs.xs {
 }
 "#;
     let doc = create_document(source);
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     assert!(
         diagnostics.iter().any(|d| d.message.contains("aaaa")),
         "expected enum-mismatch diagnostic inside for body, got: {:?}",
@@ -2755,7 +2711,7 @@ for _, id in orgs.xs {
 }
 "#;
     let doc = create_document(source);
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     let bad = diagnostics
         .iter()
         .find(|d| d.message.contains("aaaa"))
@@ -2785,7 +2741,7 @@ fn lsp_enum_diagnostic_includes_attribute_name() {
 }
 "#,
     );
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     let bad = diagnostics
         .iter()
         .find(|d| d.message.contains("aaaa"))
@@ -2815,7 +2771,7 @@ fn lsp_quoted_literal_on_namespaced_enum_says_got_a_string_literal() {
 }
 "#,
     );
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     let bad = diagnostics
         .iter()
         .find(|d| d.message.contains("got a string literal"))
@@ -2853,7 +2809,7 @@ fn lsp_bare_invalid_on_namespaced_enum_keeps_invalid_variant_wording() {
 }
 "#,
     );
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     let diag = diagnostics
         .iter()
         .find(|d| d.message.contains("aaa"))
@@ -2882,7 +2838,7 @@ fn lsp_quoted_literal_on_namespaced_custom_says_got_a_string_literal() {
 }
 "#,
     );
-    let diagnostics = provider.analyze(&doc, None, &HashMap::new(), &HashSet::new());
+    let diagnostics = provider.analyze(&doc, None);
     let bad = diagnostics
         .iter()
         .find(|d| d.message.contains("got a string literal"))
@@ -3000,6 +2956,125 @@ fn undefined_binding_in_current_file_still_flagged() {
             .any(|d| d.message.contains("Undefined resource")
                 || d.message.contains("Undefined identifier")),
         "typo against a truly undeclared root must still be flagged. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// #2134: a resource `let` binding used only from a sibling `.crn`
+// inside a list literal must not be flagged as unused. The old
+// `scan_sibling_context::referenced` text scan only matched lines
+// with `=` where the RHS *starts with* `binding_name.`; a reference
+// nested inside `[ binding.field, ... ]` or `func(binding.field)`
+// misses that heuristic.
+#[test]
+fn binding_referenced_only_from_sibling_list_literal_is_not_unused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let admin_group = awscc.identitystore.group {\n  display_name = 'admins'\n  identity_store_id = 'd-xxx'\n}\n",
+    )
+    .unwrap();
+    // The sibling references `admin_group` inside a list literal —
+    // the text scan's "starts with `admin_group.`" heuristic misses it.
+    std::fs::write(
+        base.join("policy.crn"),
+        "awscc.iam.policy {\n  name = 'admins-policy'\n  principals = [admin_group.group_id]\n}\n",
+    )
+    .unwrap();
+
+    let engine = test_engine();
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", &main_src);
+
+    let unused: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.message.contains("Unused let binding") && d.message.contains("admin_group"))
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "binding referenced from sibling list literal must not be flagged unused. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// Unused-binding detection still fires when no sibling references
+// the binding at all.
+#[test]
+fn unreferenced_binding_is_still_flagged_unused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    let main =
+        "let orphan = awscc.ec2.vpc {\n  name = 'stranded'\n  cidr_block = '10.0.0.0/16'\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    std::fs::write(
+        base.join("other.crn"),
+        "awscc.s3.bucket {\n  name = 'unrelated'\n}\n",
+    )
+    .unwrap();
+
+    let engine = test_engine();
+    let diagnostics = analyze_with_buffer(&engine, &base, "main.crn", main);
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("Unused let binding") && d.message.contains("orphan")),
+        "truly unused binding must still fire. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// #2134: `exports { key: T = sibling_binding.attr }` where
+// `sibling_binding` is declared in a sibling `.crn` as
+// `upstream_state`, `import`, or a resource must get a correct type
+// mismatch diagnostic (not silently accepted, not falsely flagged).
+// The old `scan_sibling_context` only returned a `HashMap<binding,
+// resource_type>` for bindings declared as `let x = provider.service.type {`.
+// For the `let x = <upstream_state|import>{}` shapes the map was
+// empty, so the type check short-circuited via the "can't resolve"
+// fall-through.
+//
+// This test isn't asserting a new diagnostic — it asserts no
+// regression: the existing "type mismatch" path still works when the
+// sibling binding is a real resource declared in a sibling file.
+#[test]
+fn exports_type_check_resolves_resource_binding_from_sibling_file() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use std::collections::HashMap as StdHashMap;
+
+    // Schema: registry_prod.account_id is String.
+    let schema = ResourceSchema::new("awscc.organizations.account")
+        .attribute(AttributeSchema::new("account_id", AttributeType::String));
+    let schemas: StdHashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
+        .into_iter()
+        .collect();
+    let engine = custom_engine(schemas);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    // Resource binding lives in main.crn.
+    std::fs::write(
+        base.join("main.crn"),
+        "let registry_prod = awscc.organizations.account {\n  name = 'prod'\n}\n",
+    )
+    .unwrap();
+    // exports.crn references it. `map(bool)` is incompatible with
+    // String, so we expect a type-mismatch warning — which is what
+    // proves the sibling-binding resolution actually happened.
+    let exports =
+        "exports {\n  accounts: map(bool) = {\n    prod = registry_prod.account_id\n  }\n}\n";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
+
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| { d.message.contains("type mismatch") || d.message.contains("expected") }),
+        "type-mismatch warning should fire for map(bool) vs String. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
Closes #2134. Refs #2104 umbrella.

Final slice of the LSP-side post-merge refactor. \`Backend::scan_sibling_context\` — a text scanner that only captured \`let x = provider.service.type {\` — had two consumers with the same blind spot for \`upstream_state\` / \`import\` / module-call bindings:

- \`check_exports_blocks\` took a \`sibling_bindings: HashMap<binding, resource_type>\`. Missed every non-resource binding shape.
- \`check_unused_bindings\` was filtered by \`sibling_referenced\`, populated via a \`starts_with("name.")\` text heuristic. References nested in list literals / for-iterables missed the heuristic and produced spurious "unused let binding" warnings.

Both now consume the merged \`ParsedFile\` from \`parse_merged_with_buffer\` (already built once at the top of \`analyze_with_filename\`):

- \`exports_sibling_bindings_from(merged)\` builds the binding→resource-type map from \`merged.resources\`.
- Unused-binding detection runs \`carina_core::validation::check_unused_bindings\` on the merged parse, filtered to bindings declared in the current file.

\`scan_sibling_context\` and its 87 lines of text-scan logic are gone. \`analyze\` / \`analyze_with_filename\` lose the \`sibling_bindings\` / \`sibling_referenced\` params. The 91 test call sites are updated alongside.

Also fixes a latent gap in \`carina_core::validation::check_unused_bindings\`: cross-file \`binding.attr\` references nested in list / map / function-call positions are kept as \`Value::String\` by \`resolve_resource_refs_with_config\` (only top-level attribute values are lifted to \`ResourceRef\`). Adding \`collect_dot_notation_refs\` to the resource / module-call walk makes the unused-binding check see them.

## Test plan

- [x] \`cargo test -p carina-lsp --lib\` — 314 tests pass (+3 new multi-file regressions).
- [x] \`cargo test -p carina-core --lib\` — 1293 tests pass.
- [x] \`cargo test --workspace\` green.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] Real-infra smoke: \`carina validate carina-rs/infra/aws/management/identity-center/\` succeeds (the directory that originally surfaced #2131 / #2132).