### PR TITLE
parser: fold identifier-scope checks into one check_identifier_scope entry point

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -20,13 +20,12 @@ pub struct LoadedConfig {
     /// so this preserves the original references for accurate unused binding analysis.
     pub unresolved_parsed: ParsedFile,
     pub backend_file: Option<PathBuf>,
-    /// Identifier-scope errors surfaced by the post-merge passes:
-    /// `check_undefined_references` (ResourceRef roots in resources /
-    /// attribute / module / export values) and
-    /// `check_deferred_for_iterables` (for-expression iterables). Empty
-    /// when every reference resolves against the directory-wide binding
-    /// set. The loader does not short-circuit on these so that later
-    /// validators can also run in a single pass.
+    /// Identifier-scope errors surfaced by [`parser::check_identifier_scope`]
+    /// on the merged directory parse: ResourceRef roots in resources /
+    /// attribute / module / export values and unresolved for-expression
+    /// iterables. Empty when every reference resolves against the
+    /// directory-wide binding set. The loader does not short-circuit on
+    /// these so that later validators can also run in a single pass.
     pub identifier_scope_errors: Vec<parser::ParseError>,
 }
 
@@ -167,10 +166,8 @@ pub fn load_configuration_with_config(
 
         // Identifier-scope checks are accumulated rather than short-
         // circuited so `carina validate` can keep going and report every
-        // static error in one pass (#2102, #2126). The caller reads
-        // `identifier_scope_errors` and merges them with its own findings.
-        let mut identifier_scope_errors = parser::check_undefined_references(&merged);
-        identifier_scope_errors.extend(parser::check_deferred_for_iterables(&merged));
+        // static error in one pass (#2102, #2126, #2138).
+        let identifier_scope_errors = parser::check_identifier_scope(&merged);
 
         Ok(LoadedConfig {
             parsed: merged,
@@ -262,10 +259,11 @@ pub fn parse_directory_with_overrides(
         return Err(e.to_string());
     }
 
-    // Deferred-for-iterable validation is left to callers. LSP needs the
-    // ParsedFile even when an iterable names an undefined binding, so it
-    // can surface the error as a diagnostic; CLI entry points run
-    // `check_deferred_for_iterables` themselves.
+    // Identifier-scope validation is left to callers. LSP needs the
+    // ParsedFile even when a reference is unresolved, so it can surface
+    // the error as a diagnostic; CLI entry points call
+    // `parser::check_identifier_scope` themselves (see
+    // `load_configuration_with_config`).
     Ok(merged)
 }
 
@@ -921,7 +919,7 @@ awscc.ec2.security_group {
         let result = parse_directory(&dir, &ProviderContext::default());
         cleanup(&dir);
         let parsed = result.expect("parse_directory should not fail on undefined iterable");
-        let errs = parser::check_deferred_for_iterables(&parsed);
+        let errs = parser::check_identifier_scope(&parsed);
         assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
         match &errs[0] {
             parser::ParseError::UndefinedIdentifier { name, .. } => {
@@ -963,9 +961,8 @@ awscc.ec2.security_group {
     }
 
     // Acceptance for #2126. Per-file parse must not reject a ResourceRef
-    // whose root is declared in a sibling `.crn`. The check has to live on
-    // the merged `ParsedFile`, same place `check_deferred_for_iterables`
-    // already lives.
+    // whose root is declared in a sibling `.crn`. The check lives on the
+    // merged `ParsedFile` via `check_identifier_scope` (#2138).
     #[test]
     fn parse_directory_accepts_cross_file_resource_ref() {
         let dir = create_temp_dir("cross_file_resource_ref");

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1095,9 +1095,8 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
     // "Is every ResourceRef root declared somewhere?" is a semantic
     // question the per-file parse cannot answer: the referent may live
     // in a sibling `.crn`. The check runs post-merge via
-    // `check_undefined_references(&ParsedFile)` — wired into
-    // `load_configuration_with_config` alongside
-    // `check_deferred_for_iterables`. See #2126.
+    // `check_identifier_scope(&ParsedFile)` — wired into
+    // `load_configuration_with_config`. See #2126 / #2138.
 
     let string_literal_paths = ctx.string_literal_paths.borrow().clone();
     Ok(ParsedFile {
@@ -2141,11 +2140,11 @@ fn parse_for_expr(
             // `iterable is string "org"` is misleading: the user wrote an
             // identifier, not a literal, and the likely fault is a typo for
             // a known binding. Record them as deferred for-expressions so
-            // `check_deferred_for_iterables` (which runs on the merged
+            // `check_identifier_scope` (which runs on the merged
             // directory-wide ParsedFile, so cross-file upstream_state /
             // module bindings are visible) can emit a proper
             // UndefinedIdentifier with the did-you-mean machinery from
-            // #2038 / #2100. See #2101.
+            // #2038 / #2100. See #2101 / #2138.
             if let Value::String(s) = &iterable
                 && is_bare_identifier(s)
             {
@@ -4833,8 +4832,7 @@ pub fn resolve_resource_refs_with_config(
 /// variables, and for/if structural bindings.
 ///
 /// This is the canonical answer to "is this identifier in scope?" for
-/// directory-wide checks. The same set feeds
-/// [`check_deferred_for_iterables`] and [`check_undefined_references`],
+/// directory-wide checks. The same set feeds [`check_identifier_scope`]
 /// and the LSP borrows it (via `carina_lsp::diagnostics::checks`) to
 /// keep diagnostic suggestions consistent with the CLI.
 pub fn collect_known_bindings_merged(parsed: &ParsedFile) -> std::collections::HashSet<&str> {
@@ -4855,31 +4853,38 @@ pub fn collect_known_bindings_merged(parsed: &ParsedFile) -> std::collections::H
     known
 }
 
-/// Verify that every deferred for-expression iterable names a declared binding.
+/// Directory-wide identifier-scope validation for a merged [`ParsedFile`].
 ///
-/// This must run on a fully merged `ParsedFile` (directory-wide), not on a
-/// single-file parse — iterables commonly reference `upstream_state` or `let`
-/// bindings declared in sibling files that only become visible after merging.
-pub(crate) fn check_deferred_for_iterables(parsed: &ParsedFile) -> Vec<ParseError> {
-    let known = collect_known_bindings_merged(parsed);
-    parsed
-        .deferred_for_expressions
-        .iter()
-        .filter(|d| !known.contains(d.iterable_binding.as_str()))
-        .map(|d| undefined_identifier_error(&known, d.iterable_binding.clone(), d.line))
-        .collect()
-}
-
-/// Verify that every ResourceRef in the merged file names a declared binding.
+/// Emits one flat list of `UndefinedIdentifier` errors covering:
 ///
-/// Walks resources, attribute parameters, module calls, and export
-/// parameters; emits `UndefinedIdentifier` for each ResourceRef whose
-/// root is not in [`collect_known_bindings_merged`]. Runs post-merge
-/// — per-file parse cannot answer the question because the referent
-/// may live in a sibling `.crn`.
-pub fn check_undefined_references(parsed: &ParsedFile) -> Vec<ParseError> {
+/// - Every `ResourceRef` whose root binding is not in scope (roots in
+///   resource attributes, attribute-parameter values, module-call
+///   arguments, and export-parameter values).
+/// - Every deferred for-expression iterable whose root is not in scope.
+///
+/// Errors are returned in a deterministic order: ResourceRef findings
+/// first (in resource / attribute / module / export order), then
+/// deferred-iterable findings. The caller (CLI `load_configuration_with_config`,
+/// LSP analysis pipeline) just inspects the returned `Vec` — both
+/// checks share the same `collect_known_bindings_merged` pass, so there
+/// is no performance reason to split them at the callsite.
+///
+/// **This is the canonical entry point for "is this identifier in
+/// scope?" checks.** Follow the #2104 rule: any new semantic check in
+/// that family gets added *here*, not as a new sibling function.
+pub fn check_identifier_scope(parsed: &ParsedFile) -> Vec<ParseError> {
     let known = collect_known_bindings_merged(parsed);
     let mut errors = Vec::new();
+    accumulate_undefined_reference_errors(parsed, &known, &mut errors);
+    accumulate_deferred_iterable_errors(parsed, &known, &mut errors);
+    errors
+}
+
+fn accumulate_undefined_reference_errors(
+    parsed: &ParsedFile,
+    known: &std::collections::HashSet<&str>,
+    errors: &mut Vec<ParseError>,
+) {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     let mut check = |value: &Value| {
@@ -4887,11 +4892,7 @@ pub fn check_undefined_references(parsed: &ParsedFile) -> Vec<ParseError> {
             let root = path.binding();
             let root_ident = root.split(['[', ']']).next().unwrap_or(root);
             if !known.contains(root_ident) && seen.insert(root_ident.to_string()) {
-                errors.push(undefined_identifier_error(
-                    &known,
-                    root_ident.to_string(),
-                    0,
-                ));
+                errors.push(undefined_identifier_error(known, root_ident.to_string(), 0));
             }
         });
     };
@@ -4916,8 +4917,22 @@ pub fn check_undefined_references(parsed: &ParsedFile) -> Vec<ParseError> {
             check(value);
         }
     }
+}
 
-    errors
+fn accumulate_deferred_iterable_errors(
+    parsed: &ParsedFile,
+    known: &std::collections::HashSet<&str>,
+    errors: &mut Vec<ParseError>,
+) {
+    for d in &parsed.deferred_for_expressions {
+        if !known.contains(d.iterable_binding.as_str()) {
+            errors.push(undefined_identifier_error(
+                known,
+                d.iterable_binding.clone(),
+                d.line,
+            ));
+        }
+    }
 }
 
 fn resolve_value_with_config(
@@ -11303,13 +11318,13 @@ awscc.ec2.vpc {
                 }
             }
         "#;
-        // Iterable-binding validation runs in `check_deferred_for_iterables`
+        // Iterable-binding validation runs in `check_identifier_scope`
         // on the merged directory-level `ParsedFile`, so that cross-file
         // `upstream_state` bindings in sibling files aren't rejected during
         // per-file parsing.
         let parsed = parse(input, &ProviderContext::default())
             .expect("single-file parse must not reject cross-file iterables");
-        let errs = check_deferred_for_iterables(&parsed);
+        let errs = check_identifier_scope(&parsed);
         assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
         match &errs[0] {
             ParseError::UndefinedIdentifier { name, .. } => {
@@ -11334,7 +11349,7 @@ awscc.ec2.vpc {
         "#;
         let parsed = parse(input, &ProviderContext::default())
             .expect("single-file parse must not reject cross-file iterables");
-        let errs = check_deferred_for_iterables(&parsed);
+        let errs = check_identifier_scope(&parsed);
         assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
         let msg = errs[0].to_string();
         assert!(
@@ -11363,7 +11378,7 @@ awscc.ec2.vpc {
         "#;
         let parsed = parse(input, &ProviderContext::default())
             .expect("single-file parse must not reject cross-file iterables");
-        let errs = check_deferred_for_iterables(&parsed);
+        let errs = check_identifier_scope(&parsed);
         assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
         let msg = errs[0].to_string();
         assert!(
@@ -11389,7 +11404,7 @@ awscc.ec2.vpc {
         // a string and leaving the user with no did-you-mean.
         //
         // The fix records these as `DeferredForExpression` so
-        // `check_deferred_for_iterables` validates them against the merged
+        // `check_identifier_scope` validates them against the merged
         // directory-wide binding set (mirrors the dotted-form path). That
         // gives us cross-file visibility for the did-you-mean candidates.
         let input = r#"
@@ -11402,7 +11417,7 @@ awscc.ec2.vpc {
         "#;
         let parsed = parse(input, &ProviderContext::default())
             .expect("single-file parse must not reject bare-iterable identifiers; the cross-file check runs later");
-        let errs = check_deferred_for_iterables(&parsed);
+        let errs = check_identifier_scope(&parsed);
         assert_eq!(errs.len(), 1, "expected one error, got {errs:?}");
         let err = &errs[0];
         let msg = err.to_string();

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -127,8 +127,8 @@ fn find_for_iterable_binding_column(
 
 /// Binding names declared anywhere in the merged parse. Delegates to
 /// [`carina_core::parser::collect_known_bindings_merged`] so LSP
-/// diagnostics stay consistent with the CLI's post-merge checks
-/// (`check_deferred_for_iterables`, `check_undefined_references`).
+/// diagnostics stay consistent with the CLI's
+/// [`carina_core::parser::check_identifier_scope`] pass.
 fn collect_known_bindings(merged: &ParsedFile) -> HashSet<&str> {
     carina_core::parser::collect_known_bindings_merged(merged)
 }
@@ -481,11 +481,11 @@ impl DiagnosticEngine {
         let known = collect_known_bindings(merged);
         let text = doc.text();
         let mut diagnostics = Vec::new();
-        // Iterating the deferred list directly (rather than the error list
-        // from `check_deferred_for_iterables`) keeps a 1:1 mapping between
-        // deferred expressions and diagnostics; two sibling files with
-        // `for _ in <same>.attr` on the same line would otherwise collide on
-        // the error's `(name, line)` key.
+        // Iterating the deferred list directly (rather than the subset of
+        // errors `check_identifier_scope` produces for iterables) keeps a
+        // 1:1 mapping between deferred expressions and diagnostics; two
+        // sibling files with `for _ in <same>.attr` on the same line
+        // would otherwise collide on the error's `(name, line)` key.
         for deferred in &merged.deferred_for_expressions {
             if !deferred_in_current_file(deferred, current_file_name) {
                 continue;


### PR DESCRIPTION
Closes #2138. Closes #2104 (umbrella).

Final slice of the `#2104` identifier-scope refactor. After #2126 / #2127 (CLI side) and #2132 / #2133 / #2134 / #2135 (LSP side), the CLI still called two sibling helpers back-to-back:

```rust
let mut identifier_scope_errors = parser::check_undefined_references(&merged);
identifier_scope_errors.extend(parser::check_deferred_for_iterables(&merged));
```

Both walk the same merged `ParsedFile` and both consume `collect_known_bindings_merged`. Shipping them as a pair cost one extra traversal of the binding set and leaked the split between them to every caller. The `#2104` rule — "every identifier-scope check lives on one post-merge pass" — should be one public function, not two.

## Summary

- Add `pub fn check_identifier_scope(&ParsedFile) -> Vec<ParseError>` that computes `collect_known_bindings_merged` once and runs both walks (undefined `ResourceRef` roots, unresolved deferred iterables) into a single errors vector. Deterministic ordering: resources / attribute_params / module_calls / export_params first, then deferred iterables.
- Delete `check_undefined_references` and `check_deferred_for_iterables`. Their bodies move to private `accumulate_undefined_reference_errors` / `accumulate_deferred_iterable_errors`. No external callers outside this repo touched either (verified across carina-provider-aws / carina-provider-awscc).
- Update CLI `config_loader.rs` and parser-internal tests to call the new entry point.
- Refresh docstrings and code comments so the next person hunting for "where do identifier-scope checks go?" lands on `check_identifier_scope` in one step.

## Test plan

- [x] `cargo test --workspace` — all crates green (1293 carina-core, 319 carina-lsp, rest unchanged).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Real-infra smoke: `carina validate carina-rs/infra/aws/management/organizations/` succeeds.