### PR TITLE
parser: add TypeExpr::Struct for `struct { field: type, ... }` DSL form

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -133,9 +133,9 @@ exports_param = {
   | identifier ~ trivia* ~ equals ~ trivia* ~ expression
 }
 
-// Type expression: string, bool, int, cidr, arn, etc., list(type), map(type), aws.resource (resource ref)
+// Type expression: string, bool, int, cidr, arn, etc., list(type), map(type), aws.resource (resource ref), struct { field: type, ... }
 type_expr = {
-    type_ref | type_list | type_map | type_primitive
+    type_struct | type_ref | type_list | type_map | type_primitive
 }
 
 type_primitive = @{ identifier }
@@ -145,6 +145,12 @@ type_list = { kw_list ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ c
 type_map = { kw_map ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ close_paren }
 
 type_ref = { namespaced_id }
+
+type_struct = { kw_struct ~ trivia* ~ open_brace ~ trivia* ~ struct_field_list? ~ trivia* ~ close_brace }
+
+struct_field_list = { struct_field ~ (trivia* ~ comma ~ trivia* ~ struct_field)* ~ (trivia* ~ comma)? }
+
+struct_field = { identifier ~ trivia* ~ colon ~ trivia* ~ type_expr }
 
 // State manipulation blocks
 
@@ -362,6 +368,7 @@ kw_attributes = { "attributes" }
 kw_exports = { "exports" }
 kw_list = { "list" }
 kw_map = { "map" }
+kw_struct = { "struct" }
 kw_for = { "for" }
 kw_in = { "in" }
 kw_if = { "if" }

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -137,6 +137,11 @@ impl<'a> CstBuilder<'a> {
             Rule::type_list => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
             Rule::type_map => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
             Rule::type_ref => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
+            Rule::type_struct => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
+            Rule::struct_field_list => {
+                Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair)))
+            }
+            Rule::struct_field => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
             Rule::let_binding => Some(CstChild::Node(self.build_node(NodeKind::LetBinding, pair))),
             Rule::local_binding => Some(CstChild::Node(
                 self.build_node(NodeKind::LocalBinding, pair),
@@ -267,6 +272,7 @@ impl<'a> CstBuilder<'a> {
             Rule::kw_exports => Some(CstChild::Token(Token::new("exports".to_string(), span))),
             Rule::kw_list => Some(CstChild::Token(Token::new("list".to_string(), span))),
             Rule::kw_map => Some(CstChild::Token(Token::new("map".to_string(), span))),
+            Rule::kw_struct => Some(CstChild::Token(Token::new("struct".to_string(), span))),
             Rule::kw_for => Some(CstChild::Token(Token::new("for".to_string(), span))),
             Rule::kw_in => Some(CstChild::Token(Token::new("in".to_string(), span))),
             Rule::kw_if => Some(CstChild::Token(Token::new("if".to_string(), span))),

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -736,7 +736,16 @@ impl Formatter {
     }
 
     fn format_type_expr(&mut self, node: &CstNode) {
-        // Type expressions: aws.vpc, list(cidr), map(string), string, bool, int, cidr
+        // Type expressions: aws.vpc, list(cidr), map(string), string, bool,
+        // int, cidr, struct { name: type, ... }.
+        //
+        // Struct types need canonical spacing (`struct { a: int, b: string }`);
+        // handle them via a dedicated path so the default fall-through
+        // doesn't collapse whitespace between `struct`, `{`, `:`, `,`, `}`.
+        if Self::type_expr_is_struct(node) {
+            self.format_struct_type_expr(node);
+            return;
+        }
         for child in &node.children {
             match child {
                 CstChild::Token(token) => {
@@ -749,7 +758,115 @@ impl Formatter {
                     }
                 }
                 CstChild::Node(n) => {
-                    // Recursively format nested type expressions
+                    self.format_type_expr(n);
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+    }
+
+    /// A `type_expr` node is a struct when it either carries the `struct`
+    /// keyword directly or wraps a single child that does. Intermediate
+    /// wrapping happens because `type_struct` is itself reparented to
+    /// `NodeKind::TypeExpr` by the CST builder.
+    fn type_expr_is_struct(node: &CstNode) -> bool {
+        for child in &node.children {
+            match child {
+                CstChild::Token(t) if t.text == "struct" => return true,
+                CstChild::Token(_) => return false,
+                CstChild::Node(_) | CstChild::Trivia(_) => continue,
+            }
+        }
+        false
+    }
+
+    fn format_struct_type_expr(&mut self, node: &CstNode) {
+        // Emit `struct ` from the first Token child (the `struct` keyword),
+        // then format each nested struct_field child. struct_field_list is a
+        // single wrapper node; we descend into it transparently.
+        let mut wrote_struct_kw = false;
+        let mut fields: Vec<&CstNode> = Vec::new();
+        Self::collect_struct_parts(node, &mut wrote_struct_kw, &mut fields);
+
+        self.write("struct");
+        if fields.is_empty() {
+            self.write(" {}");
+            return;
+        }
+        self.write(" { ");
+        for (i, field) in fields.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.format_struct_field(field);
+        }
+        self.write(" }");
+    }
+
+    /// Walk the struct subtree and collect the per-field nodes while
+    /// tolerating the CstBuilder's flattening of struct_field_list /
+    /// struct_field into NodeKind::TypeExpr.
+    fn collect_struct_parts<'a>(
+        node: &'a CstNode,
+        saw_kw: &mut bool,
+        fields: &mut Vec<&'a CstNode>,
+    ) {
+        for child in &node.children {
+            match child {
+                CstChild::Token(t) if t.text == "struct" => *saw_kw = true,
+                CstChild::Token(_) => {}
+                CstChild::Node(n) => {
+                    if Self::type_expr_is_struct_field(n) {
+                        fields.push(n);
+                    } else {
+                        Self::collect_struct_parts(n, saw_kw, fields);
+                    }
+                }
+                CstChild::Trivia(_) => {}
+            }
+        }
+    }
+
+    /// Heuristic: a struct_field node contains a name Token, a `:` Token,
+    /// and a nested type_expr Node — and crucially no `struct` keyword at
+    /// its own top level. We recognize it by "has an identifier Token
+    /// directly followed (ignoring trivia) by a `:` Token."
+    fn type_expr_is_struct_field(node: &CstNode) -> bool {
+        let mut saw_ident = false;
+        for child in &node.children {
+            match child {
+                CstChild::Token(t) => {
+                    if t.text == ":" && saw_ident {
+                        return true;
+                    }
+                    if t.text == "struct" || t.text == "{" || t.text == "}" {
+                        return false;
+                    }
+                    saw_ident = true;
+                }
+                CstChild::Node(_) => return false,
+                CstChild::Trivia(_) => {}
+            }
+        }
+        false
+    }
+
+    fn format_struct_field(&mut self, node: &CstNode) {
+        let mut wrote_name = false;
+        for child in &node.children {
+            match child {
+                CstChild::Token(t) => {
+                    if t.text == ":" {
+                        self.write(": ");
+                    } else if !wrote_name {
+                        self.write(&t.text);
+                        wrote_name = true;
+                    } else {
+                        // Unexpected extra token in field; emit defensively.
+                        self.write_token(&t.text);
+                    }
+                }
+                CstChild::Node(n) => {
                     self.format_type_expr(n);
                 }
                 CstChild::Trivia(_) => {}
@@ -1988,6 +2105,52 @@ mod tests {
         let result = format(input, &config).unwrap();
 
         assert!(result.contains("  name = 'test'"));
+    }
+
+    #[test]
+    fn test_format_struct_type_canonical_spacing() {
+        let input = "attributes {\n  config: struct{a:int,b:string} = { a = 1, b = 'x' }\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("struct { a: int, b: string }"),
+            "expected canonical struct spacing, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn test_format_struct_type_empty() {
+        let input = "attributes {\n  x: struct{} = {}\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("struct {}"),
+            "expected `struct {{}}`, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn test_format_struct_type_nested_in_list_and_map() {
+        let input =
+            "attributes {\n  xs: list(struct{a:int}) = []\n  m: map(struct{b:string}) = {}\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("list(struct { a: int })"),
+            "expected list(struct {{ a: int }}), got:\n{result}"
+        );
+        assert!(
+            result.contains("map(struct { b: string })"),
+            "expected map(struct {{ b: string }}), got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn test_format_struct_type_field_is_itself_struct() {
+        let input =
+            "attributes {\n  outer: struct{inner:struct{x:int}} = { inner = { x = 1 } }\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("struct { inner: struct { x: int } }"),
+            "expected nested struct spacing, got:\n{result}"
+        );
     }
 
     #[test]

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -1050,6 +1050,25 @@ impl ModuleSignature {
                     c.reset
                 )
             }
+            TypeExpr::Struct { fields } => {
+                if fields.is_empty() {
+                    format!("{}struct {{}}{}", c.green, c.reset)
+                } else {
+                    let mut out = format!("{}struct {{ ", c.green);
+                    for (i, (name, ty)) in fields.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        out.push_str(name);
+                        out.push_str(": ");
+                        out.push_str(&self.format_type_expr(ty, c));
+                        out.push_str(c.green);
+                    }
+                    out.push_str(" }");
+                    out.push_str(c.reset);
+                    out
+                }
+            }
             _ => format!("{}{}{}", c.green, type_expr, c.reset),
         }
     }

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -743,6 +743,23 @@ fn check_type_match(
                 TypeCheckResult::Mismatch
             }
         }
+        TypeExpr::Struct { fields } => {
+            let Value::Map(entries) = value else {
+                return TypeCheckResult::Mismatch;
+            };
+            if crate::validation::struct_field_shape_errors(fields, entries).is_some() {
+                return TypeCheckResult::Mismatch;
+            }
+            for (name, ty) in fields {
+                if let Some(v) = entries.get(name) {
+                    match check_type_match(ty, v, config) {
+                        TypeCheckResult::Ok => {}
+                        other => return other,
+                    }
+                }
+            }
+            TypeCheckResult::Ok
+        }
     }
 }
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -90,12 +90,15 @@ exports_param = {
   | identifier ~ "=" ~ expression
 }
 
-// Type expression: string, bool, int, float, cidr, arn, etc., list(type), map(type), aws.vpc (resource ref)
-type_expr = { type_ref | type_generic | type_simple }
+// Type expression: string, bool, int, float, cidr, arn, etc., list(type), map(type), aws.vpc (resource ref), struct { field: type, ... }
+type_expr = { type_struct | type_ref | type_generic | type_simple }
 type_simple = @{ identifier }
 type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
 type_ref = { resource_type_path }
 resource_type_path = @{ identifier ~ ("." ~ identifier)+ }
+type_struct = { "struct" ~ "{" ~ struct_field_list? ~ "}" }
+struct_field_list = { struct_field ~ ("," ~ struct_field)* ~ ","? }
+struct_field = { identifier ~ ":" ~ type_expr }
 
 // Import expression: import "path" (used in let binding RHS)
 import_expr = { "import" ~ string }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -200,7 +200,7 @@ impl std::fmt::Display for ResourceTypePath {
 }
 
 /// Type expression for arguments/attributes parameters
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TypeExpr {
     String,
     Bool,
@@ -222,6 +222,16 @@ pub enum TypeExpr {
         /// Type name in PascalCase (e.g., "VpcId")
         type_name: String,
     },
+    /// Structural record type: `struct { name: type, ... }`.
+    ///
+    /// Field order matches source order and participates in `PartialEq` —
+    /// two struct types with the same fields in different order are not
+    /// equal. A `Value::Map` satisfies a struct type when every field
+    /// name appears as a key with a value that matches the field's type,
+    /// with no extra keys.
+    Struct {
+        fields: Vec<(String, TypeExpr)>,
+    },
 }
 
 impl std::fmt::Display for TypeExpr {
@@ -240,6 +250,20 @@ impl std::fmt::Display for TypeExpr {
                 path,
                 type_name,
             } => write!(f, "{}.{}.{}", provider, path, type_name),
+            TypeExpr::Struct { fields } => {
+                if fields.is_empty() {
+                    write!(f, "struct {{}}")
+                } else {
+                    write!(f, "struct {{ ")?;
+                    for (i, (name, ty)) in fields.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}: {}", name, ty)?;
+                    }
+                    write!(f, " }}")
+                }
+            }
         }
     }
 }
@@ -1524,6 +1548,30 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
                 })?;
                 Ok(TypeExpr::Ref(path))
             }
+        }
+        Rule::type_struct => {
+            let mut fields = Vec::new();
+            for child in inner.into_inner() {
+                if child.as_rule() != Rule::struct_field_list {
+                    continue;
+                }
+                for field_pair in child.into_inner() {
+                    if field_pair.as_rule() != Rule::struct_field {
+                        continue;
+                    }
+                    let mut field_inner = field_pair.into_inner();
+                    let name = next_pair(&mut field_inner, "field name", "struct field")?
+                        .as_str()
+                        .to_string();
+                    let ty = parse_type_expr(next_pair(
+                        &mut field_inner,
+                        "field type",
+                        "struct field",
+                    )?)?;
+                    fields.push((name, ty));
+                }
+            }
+            Ok(TypeExpr::Struct { fields })
         }
         _ => Ok(TypeExpr::String),
     }
@@ -3138,6 +3186,7 @@ fn check_fn_arg_type(
                 true
             }
         }
+        TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
     };
     if !type_matches {
         let actual_type = value_type_name(value);
@@ -3200,6 +3249,7 @@ fn check_fn_return_type(
                 true
             }
         }
+        TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
     };
     if !type_matches {
         let actual_type = value_type_name(value);
@@ -3227,7 +3277,7 @@ pub fn pascal_to_snake(s: &str) -> String {
 }
 
 /// Return a human-readable type name for a Value
-fn value_type_name(value: &Value) -> &'static str {
+pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
         Value::String(_) => "string",
         Value::Int(_) => "int",
@@ -5665,6 +5715,96 @@ mod tests {
             result.arguments[1].type_expr,
             TypeExpr::Ref(ResourceTypePath::new("aws", "security_group.ingress_rule"))
         );
+    }
+
+    #[test]
+    fn parse_struct_type_expression() {
+        let input = r#"
+            exports {
+                accounts: struct {
+                    registry_prod: aws_account_id,
+                    registry_dev:  aws_account_id,
+                } = {
+                    registry_prod = "111111111111"
+                    registry_dev  = "222222222222"
+                }
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.export_params.len(), 1);
+        let ep = &result.export_params[0];
+        assert_eq!(ep.name, "accounts");
+        let expected = TypeExpr::Struct {
+            fields: vec![
+                (
+                    "registry_prod".to_string(),
+                    TypeExpr::Simple("aws_account_id".to_string()),
+                ),
+                (
+                    "registry_dev".to_string(),
+                    TypeExpr::Simple("aws_account_id".to_string()),
+                ),
+            ],
+        };
+        assert_eq!(ep.type_expr, Some(expected));
+    }
+
+    #[test]
+    fn parse_struct_type_nested_in_list_and_map() {
+        let input = r#"
+            arguments {
+                items: list(struct { name: string, value: int })
+                registry: map(struct { arn: string, id: string })
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(
+            result.arguments[0].type_expr,
+            TypeExpr::List(Box::new(TypeExpr::Struct {
+                fields: vec![
+                    ("name".to_string(), TypeExpr::String),
+                    ("value".to_string(), TypeExpr::Int),
+                ],
+            }))
+        );
+        assert_eq!(
+            result.arguments[1].type_expr,
+            TypeExpr::Map(Box::new(TypeExpr::Struct {
+                fields: vec![
+                    ("arn".to_string(), TypeExpr::String),
+                    ("id".to_string(), TypeExpr::String),
+                ],
+            }))
+        );
+    }
+
+    #[test]
+    fn struct_type_expr_display_renders_with_braces() {
+        let t = TypeExpr::Struct {
+            fields: vec![
+                ("name".to_string(), TypeExpr::String),
+                ("value".to_string(), TypeExpr::Int),
+            ],
+        };
+        assert_eq!(t.to_string(), "struct { name: string, value: int }");
+
+        let empty = TypeExpr::Struct { fields: vec![] };
+        assert_eq!(empty.to_string(), "struct {}");
+    }
+
+    #[test]
+    fn struct_type_expr_roundtrips_through_serde_json() {
+        let t = TypeExpr::Struct {
+            fields: vec![
+                ("name".to_string(), TypeExpr::String),
+                ("value".to_string(), TypeExpr::Int),
+            ],
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let back: TypeExpr = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, back);
     }
 
     #[test]

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1550,7 +1550,7 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
             }
         }
         Rule::type_struct => {
-            let mut fields = Vec::new();
+            let mut fields: Vec<(String, TypeExpr)> = Vec::new();
             for child in inner.into_inner() {
                 if child.as_rule() != Rule::struct_field_list {
                     continue;
@@ -1568,6 +1568,11 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
                         "field type",
                         "struct field",
                     )?)?;
+                    if fields.iter().any(|(existing, _)| existing == &name) {
+                        return Err(ParseError::InvalidResourceType(format!(
+                            "struct has duplicate field name '{name}'"
+                        )));
+                    }
                     fields.push((name, ty));
                 }
             }
@@ -5777,6 +5782,21 @@ mod tests {
                     ("id".to_string(), TypeExpr::String),
                 ],
             }))
+        );
+    }
+
+    #[test]
+    fn parse_struct_type_rejects_duplicate_field_name() {
+        let input = r#"
+            exports {
+                x: struct { a: string, a: int } = { a = "hi" }
+            }
+        "#;
+        let err = parse(input, &ProviderContext::default()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("duplicate field name 'a'"),
+            "expected duplicate-name error, got: {msg}"
         );
     }
 

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -551,6 +551,51 @@ mod tests {
     }
 
     #[test]
+    fn resolve_reads_struct_typed_export_from_multi_file_directory() {
+        // Mirrors the real infra/aws/management/organizations/ shape:
+        // main.crn declares the let bindings, exports.crn annotates their
+        // public shape with `struct { ... }`, and a sibling backend.crn is
+        // parsed at the same time. The resolver must see the struct type
+        // on the export.
+        use crate::parser::TypeExpr;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "exports.crn",
+            r#"exports {
+                accounts: struct {
+                    registry_prod: string,
+                    registry_dev:  string,
+                } = {
+                    registry_prod = "111111111111"
+                    registry_dev  = "222222222222"
+                }
+            }"#,
+        );
+        write_crn(
+            &upstream_dir,
+            "backend.crn",
+            r#"backend local { path = "carina.state.json" }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let keys = got.get("orgs").expect("resolved");
+        let accounts_ty = keys.get("accounts").expect("accounts export").as_ref();
+        let ty = accounts_ty.expect("type annotation present");
+        assert!(
+            matches!(ty, TypeExpr::Struct { fields } if fields.len() == 2),
+            "expected struct with 2 fields, got {ty:?}"
+        );
+    }
+
+    #[test]
     fn resolve_skips_missing_source_directory() {
         // Missing-directory is `check_upstream_state_sources`' job; this
         // resolver stays quiet about it.

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -552,11 +552,9 @@ mod tests {
 
     #[test]
     fn resolve_reads_struct_typed_export_from_multi_file_directory() {
-        // Mirrors the real infra/aws/management/organizations/ shape:
-        // main.crn declares the let bindings, exports.crn annotates their
-        // public shape with `struct { ... }`, and a sibling backend.crn is
-        // parsed at the same time. The resolver must see the struct type
-        // on the export.
+        // Multi-file upstream: `exports.crn` carries the struct-typed export
+        // while a sibling `backend.crn` is parsed in the same directory.
+        // The resolver must surface the struct annotation on the export.
         use crate::parser::TypeExpr;
 
         let tmp = tempfile::tempdir().unwrap();

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -363,6 +363,21 @@ fn collect_ref_type_errors(
                 );
             }
         }
+        (TypeExpr::Struct { fields }, Value::Map(map)) => {
+            for (name, field_ty) in fields {
+                if let Some(value) = map.get(name) {
+                    collect_ref_type_errors(
+                        field_ty,
+                        value,
+                        param_name,
+                        binding_map,
+                        schemas,
+                        schema_key_fn,
+                        errors,
+                    );
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -406,6 +421,36 @@ pub fn is_type_expr_compatible_with_schema(
                 value: schema_inner,
                 ..
             } => is_type_expr_compatible_with_schema(inner, schema_inner),
+            _ => false,
+        },
+        TypeExpr::Struct {
+            fields: expr_fields,
+        } => match attr_type {
+            AttributeType::Struct {
+                fields: schema_fields,
+                ..
+            } => {
+                if expr_fields.len() != schema_fields.len() {
+                    return false;
+                }
+                expr_fields.iter().all(|(name, expr_ty)| {
+                    schema_fields
+                        .iter()
+                        .find(|f| &f.name == name)
+                        .is_some_and(|f| {
+                            is_type_expr_compatible_with_schema(expr_ty, &f.field_type)
+                        })
+                })
+            }
+            // A consumer annotated as `map(T)` may receive a `struct { a: T,
+            // b: T }` value — the shape coerces as long as every field type
+            // satisfies T.
+            AttributeType::Map {
+                value: schema_inner,
+                ..
+            } => expr_fields
+                .iter()
+                .all(|(_, ty)| is_type_expr_compatible_with_schema(ty, schema_inner)),
             _ => false,
         },
         _ => true, // Ref, SchemaType — conservatively accept
@@ -681,6 +726,14 @@ pub fn validate_type_expr_value(
             }
             None
         }
+        (TypeExpr::Struct { fields }, Value::Map(entries)) => {
+            validate_struct_fields(fields, entries, config)
+        }
+        (TypeExpr::Struct { .. }, _) => Some(format!(
+            "expected {}, got {}.",
+            type_expr,
+            crate::parser::value_type_name(value)
+        )),
         (TypeExpr::Bool, Value::String(s)) => Some(format!(
             "expected bool, got string \"{}\". Use true or false.",
             s
@@ -707,6 +760,44 @@ pub fn validate_type_expr_value(
         }
         _ => None,
     }
+}
+
+/// Check shape-level problems of a `Value::Map` against a struct field
+/// list: extra keys and missing keys. Returns `None` when the key sets
+/// match. Callers then walk each field with their own type-check pass.
+pub fn struct_field_shape_errors(
+    fields: &[(String, TypeExpr)],
+    entries: &HashMap<String, Value>,
+) -> Option<String> {
+    for key in entries.keys() {
+        if !fields.iter().any(|(name, _)| name == key) {
+            return Some(format!("expected struct, unknown field '{}'.", key));
+        }
+    }
+    for (name, _) in fields {
+        if !entries.contains_key(name) {
+            return Some(format!("expected struct, missing field '{}'.", name));
+        }
+    }
+    None
+}
+
+fn validate_struct_fields(
+    fields: &[(String, TypeExpr)],
+    entries: &HashMap<String, Value>,
+    config: &ProviderContext,
+) -> Option<String> {
+    if let Some(e) = struct_field_shape_errors(fields, entries) {
+        return Some(e);
+    }
+    for (name, ty) in fields {
+        if let Some(v) = entries.get(name)
+            && let Some(e) = validate_type_expr_value(ty, v, config)
+        {
+            return Some(format!("field '{}': {}", name, e));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -1688,6 +1779,134 @@ let vpc = awscc.ec2.vpc {
             "Expected validation error for list element"
         );
         assert!(result.unwrap().contains("Element 0"));
+    }
+
+    fn struct_type_name_value() -> TypeExpr {
+        TypeExpr::Struct {
+            fields: vec![
+                ("name".to_string(), TypeExpr::String),
+                ("value".to_string(), TypeExpr::Int),
+            ],
+        }
+    }
+
+    #[test]
+    fn validate_type_expr_struct_accepts_well_formed_map() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), Value::String("x".to_string()));
+        map.insert("value".to_string(), Value::Int(1));
+        let result = validate_type_expr_value(
+            &struct_type_name_value(),
+            &Value::Map(map),
+            &ProviderContext::default(),
+        );
+        assert!(result.is_none(), "got error: {:?}", result);
+    }
+
+    #[test]
+    fn validate_type_expr_struct_rejects_missing_field() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), Value::String("x".to_string()));
+        let result = validate_type_expr_value(
+            &struct_type_name_value(),
+            &Value::Map(map),
+            &ProviderContext::default(),
+        );
+        assert_eq!(
+            result.as_deref(),
+            Some("expected struct, missing field 'value'.")
+        );
+    }
+
+    #[test]
+    fn validate_type_expr_struct_rejects_unknown_field() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), Value::String("x".to_string()));
+        map.insert("value".to_string(), Value::Int(1));
+        map.insert("extra".to_string(), Value::String("y".to_string()));
+        let result = validate_type_expr_value(
+            &struct_type_name_value(),
+            &Value::Map(map),
+            &ProviderContext::default(),
+        );
+        assert_eq!(
+            result.as_deref(),
+            Some("expected struct, unknown field 'extra'.")
+        );
+    }
+
+    #[test]
+    fn validate_type_expr_struct_rejects_wrong_field_type() {
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), Value::String("x".to_string()));
+        map.insert("value".to_string(), Value::String("not-an-int".to_string()));
+        let result = validate_type_expr_value(
+            &struct_type_name_value(),
+            &Value::Map(map),
+            &ProviderContext::default(),
+        );
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert!(msg.contains("value"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn validate_type_expr_struct_rejects_non_map_value() {
+        let result = validate_type_expr_value(
+            &struct_type_name_value(),
+            &Value::String("oops".to_string()),
+            &ProviderContext::default(),
+        );
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("struct"));
+    }
+
+    #[test]
+    fn is_type_expr_compatible_struct_matches_same_shape_schema() {
+        use crate::schema::StructField;
+        let expr = TypeExpr::Struct {
+            fields: vec![
+                ("name".to_string(), TypeExpr::String),
+                ("value".to_string(), TypeExpr::Int),
+            ],
+        };
+        let schema = AttributeType::Struct {
+            name: "Row".to_string(),
+            fields: vec![
+                StructField::new("name", AttributeType::String),
+                StructField::new("value", AttributeType::Int),
+            ],
+        };
+        assert!(is_type_expr_compatible_with_schema(&expr, &schema));
+    }
+
+    #[test]
+    fn is_type_expr_compatible_struct_flows_into_map_when_fields_share_type() {
+        // A downstream consumer annotated `map(string)` accepts a
+        // `struct { a: string, b: string }` — every field satisfies string.
+        let expr = TypeExpr::Struct {
+            fields: vec![
+                ("a".to_string(), TypeExpr::String),
+                ("b".to_string(), TypeExpr::String),
+            ],
+        };
+        let schema = AttributeType::Map {
+            key: Box::new(AttributeType::String),
+            value: Box::new(AttributeType::String),
+        };
+        assert!(is_type_expr_compatible_with_schema(&expr, &schema));
+    }
+
+    #[test]
+    fn is_type_expr_compatible_struct_rejects_map_with_wrong_element_type() {
+        let expr = TypeExpr::Struct {
+            fields: vec![("a".to_string(), TypeExpr::String)],
+        };
+        let schema = AttributeType::Map {
+            key: Box::new(AttributeType::String),
+            value: Box::new(AttributeType::Int),
+        };
+        assert!(!is_type_expr_compatible_with_schema(&expr, &schema));
     }
 
     #[test]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -430,16 +430,18 @@ pub fn is_type_expr_compatible_with_schema(
                 fields: schema_fields,
                 ..
             } => {
+                // Bijection: every schema field must match exactly one expr
+                // field. We check schema ⇒ expr membership with equal
+                // lengths; the parser's duplicate-name rejection keeps
+                // expr_fields unique, which together forces a one-to-one
+                // correspondence.
                 if expr_fields.len() != schema_fields.len() {
                     return false;
                 }
-                expr_fields.iter().all(|(name, expr_ty)| {
-                    schema_fields
-                        .iter()
-                        .find(|f| &f.name == name)
-                        .is_some_and(|f| {
-                            is_type_expr_compatible_with_schema(expr_ty, &f.field_type)
-                        })
+                schema_fields.iter().all(|sf| {
+                    expr_fields.iter().any(|(n, t)| {
+                        n == &sf.name && is_type_expr_compatible_with_schema(t, &sf.field_type)
+                    })
                 })
             }
             // A consumer annotated as `map(T)` may receive a `struct { a: T,
@@ -769,10 +771,15 @@ pub fn struct_field_shape_errors(
     fields: &[(String, TypeExpr)],
     entries: &HashMap<String, Value>,
 ) -> Option<String> {
-    for key in entries.keys() {
-        if !fields.iter().any(|(name, _)| name == key) {
-            return Some(format!("expected struct, unknown field '{}'.", key));
-        }
+    // Sort unknown keys so the diagnostic is stable across HashMap's
+    // per-process random hash seed.
+    let mut unknown: Vec<&String> = entries
+        .keys()
+        .filter(|k| !fields.iter().any(|(name, _)| &name == k))
+        .collect();
+    unknown.sort();
+    if let Some(key) = unknown.first() {
+        return Some(format!("expected struct, unknown field '{key}'."));
     }
     for (name, _) in fields {
         if !entries.contains_key(name) {
@@ -1859,6 +1866,50 @@ let vpc = awscc.ec2.vpc {
         );
         assert!(result.is_some());
         assert!(result.unwrap().contains("struct"));
+    }
+
+    #[test]
+    fn struct_field_shape_errors_is_deterministic_for_multiple_unknowns() {
+        // Multiple unknown keys must produce the *same* alphabetically-first
+        // error on every call, independent of HashMap's per-process random
+        // hash seed.
+        let fields: Vec<(String, TypeExpr)> = vec![("a".to_string(), TypeExpr::String)];
+        let mut entries = HashMap::new();
+        entries.insert("a".to_string(), Value::String("ok".into()));
+        entries.insert("z_extra".to_string(), Value::String("x".into()));
+        entries.insert("b_extra".to_string(), Value::String("y".into()));
+        entries.insert("m_extra".to_string(), Value::String("z".into()));
+
+        let first = struct_field_shape_errors(&fields, &entries);
+        for _ in 0..20 {
+            assert_eq!(first, struct_field_shape_errors(&fields, &entries));
+        }
+        assert_eq!(
+            first.as_deref(),
+            Some("expected struct, unknown field 'b_extra'.")
+        );
+    }
+
+    #[test]
+    fn is_type_expr_compatible_struct_rejects_missing_schema_field_when_expr_has_extra() {
+        // Regression: the old `expr.iter().all(find in schema)` logic let an
+        // expr struct omit a required schema field as long as sizes matched.
+        // The bijection fix must reject this.
+        use crate::schema::StructField;
+        let expr = TypeExpr::Struct {
+            fields: vec![
+                ("a".to_string(), TypeExpr::Int),
+                ("c".to_string(), TypeExpr::Int),
+            ],
+        };
+        let schema = AttributeType::Struct {
+            name: "Row".to_string(),
+            fields: vec![
+                StructField::new("a", AttributeType::Int),
+                StructField::new("b", AttributeType::String),
+            ],
+        };
+        assert!(!is_type_expr_compatible_with_schema(&expr, &schema));
     }
 
     #[test]

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -380,6 +380,7 @@ impl CompletionProvider {
                 format!("{}.{}", resource_path.provider, resource_path.resource_type)
             }
             schema_type @ parser::TypeExpr::SchemaType { .. } => schema_type.to_string(),
+            struct_type @ parser::TypeExpr::Struct { .. } => struct_type.to_string(),
         }
     }
 

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -1189,6 +1189,20 @@ fn infer_for_binding_type(
             Some((**inner).clone())
         }
         (TypeExpr::Map(_), ForBindingSlot::PairKey) => Some(TypeExpr::String),
+        // Iterating a struct binds each field as a (name, value) pair,
+        // matching the runtime's map-iteration semantics. Field types
+        // may differ, so we only surface a value type when all fields
+        // share it — otherwise no completion is inferred.
+        (TypeExpr::Struct { fields }, ForBindingSlot::Value | ForBindingSlot::PairValue) => {
+            let mut iter = fields.iter().map(|(_, ty)| ty);
+            let first = iter.next()?;
+            if iter.all(|ty| ty == first) {
+                Some(first.clone())
+            } else {
+                None
+            }
+        }
+        (TypeExpr::Struct { .. }, ForBindingSlot::PairKey) => Some(TypeExpr::String),
         _ => None,
     }
 }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1032,6 +1032,22 @@ impl DiagnosticEngine {
                 }
                 None
             }
+            // Recurse through this ref-aware walker — not `validate_type_expr_value` —
+            // so cross-file refs inside struct fields still resolve against sibling bindings.
+            (TypeExpr::Struct { fields }, Value::Map(map)) => {
+                if let Some(e) = carina_core::validation::struct_field_shape_errors(fields, map) {
+                    return Some(e);
+                }
+                for (name, field_ty) in fields {
+                    if let Some(v) = map.get(name)
+                        && let Some(e) =
+                            self.validate_type_with_ref_awareness(field_ty, v, sibling_bindings)
+                    {
+                        return Some(format!("field '{}': {}", name, e));
+                    }
+                }
+                None
+            }
             // ResourceRef: skip (resolved at runtime)
             (_, Value::ResourceRef { .. }) => None,
             // Everything else: normal validation
@@ -1251,6 +1267,9 @@ impl DiagnosticEngine {
             }
             TypeExpr::List(inner) => self.check_unknown_type_names(inner),
             TypeExpr::Map(inner) => self.check_unknown_type_names(inner),
+            TypeExpr::Struct { fields } => fields
+                .iter()
+                .find_map(|(_, ty)| self.check_unknown_type_names(ty)),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Adds `struct { field: type, ... }` as a TypeExpr so fixed-shape values like `organizations/exports.crn`'s `accounts` can be typed as `struct { registry_prod: aws_account_id, registry_dev: aws_account_id }` instead of the semantically-wrong `map(aws_account_id)`.
- Shared `struct_field_shape_errors` helper keeps the unknown-field/missing-field diagnostics in core validation, module-call type checks, and LSP ref-aware validation from drifting.
- `is_type_expr_compatible_with_schema` adds struct↔struct (same shape) and struct→map(T) (every field type satisfies T) coercion arms.

## Scope

Foundation only. Dot-chain completion at `binding.struct_export.<HERE>` is left to #2041, which this PR unblocks.

## Acceptance coverage

- `struct { name: string, value: int }` parses, renders via `Display`, round-trips through serde_json — unit tests.
- Value literal `{ name = "x", value = 1 }` validates; missing / extra / wrong-type fields each produce a typed error — unit tests.
- `struct` nests inside `list(...)` and `map(...)` — `parse_struct_type_nested_in_list_and_map`.
- Multi-file upstream directory case — `resolve_reads_struct_typed_export_from_multi_file_directory` (tempdir fixture mirroring the real `organizations/` shape).
- Parity with `AttributeType::Struct` — `is_type_expr_compatible_struct_matches_same_shape_schema`, plus struct→map coercion and rejection tests.
- Real-infra smoke test: migrating `infra/aws/management/organizations/exports.crn` to struct form kept `carina validate` green in both that directory and downstream `identity-center/` (which iterates `orgs.accounts`). The actual commit to `carina-rs/infra` will ship in a follow-up PR.

## Test plan

- [x] \`cargo test\` — all tests pass, 13 new struct tests added.
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean.
- [x] \`pest_grammar_parity\` (main grammar ↔ formatter grammar) — passes.
- [x] \`carina validate\` run on a replica of \`infra/aws/management/organizations/\` with struct exports — succeeds.
- [x] \`carina validate\` run on a replica of \`infra/aws/management/identity-center/\` reading the struct-typed \`orgs.accounts\` — succeeds.

Closes #2140