### PR TITLE
naming-conventions: design and implementation plan (refs #2143)

### DIFF
--- a/docs/plans/2026-04-22-naming-conventions.md
+++ b/docs/plans/2026-04-22-naming-conventions.md
@@ -1,0 +1,735 @@
+# Naming conventions unification — implementation plan
+
+**Spec**: `docs/specs/2026-04-22-naming-conventions-design.md`
+**Parent issue**: [#2143](https://github.com/carina-rs/carina/issues/2143)
+
+## Scope
+
+This plan covers **only carina (this repo)**. Phase A work in `carina-provider-aws` / `carina-provider-awscc` and Phase B in `carina-rs/infra` are tracked in those repos' own issues once this plan lands; Phase C closes the transition window in carina. The tasks below are in dependency order; each is one TDD cycle.
+
+## Dependency map
+
+```
+A1 snake_to_pascal helper
+ └─ A2 TypeExpr::Display primitives emit PascalCase
+     └─ A3 TypeExpr::Display Simple/Custom emits PascalCase
+         └─ A4 parser accepts new primitives (String/Int/Bool/Float) alongside old
+             └─ A5 parser accepts PascalCase custom types via registry lookup
+                 └─ A6 grammar accepts 3-segment resource paths (aws.ec2.Vpc)
+                     └─ A7 TypeExpr::Ref Display emits 3-segment PascalCase
+                         └─ A8 deprecation warning on old spellings
+                             └─ A9 diagnostic error messages use new spellings
+                                 └─ A10 LSP completion proposes new spellings
+                                     └─ A11 LSP semantic tokens classify PascalCase as type
+                                         └─ A12 TextMate grammars updated byte-identical
+                                             └─ A13 carina-core fixtures migrated
+                                                 └─ A14 CLAUDE.md / README / docs updated
+                                                     └─ C1 Phase C: remove old-spelling support
+```
+
+## Tasks
+
+---
+
+### Task A1: Add `snake_to_pascal` helper with acronym rule
+
+**Goal**: Provide the inverse of `pascal_to_snake` that turns `"aws_account_id"` into `"AwsAccountId"`. Treat acronyms as regular words (`Iam`, not `IAM`) to match existing `semantic_name` values in the codebase.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (add function next to existing `pascal_to_snake`)
+
+**Test** (add to `parser::tests`):
+
+```rust
+#[test]
+fn snake_to_pascal_conversion() {
+    use super::snake_to_pascal;
+    assert_eq!(snake_to_pascal("vpc_id"), "VpcId");
+    assert_eq!(snake_to_pascal("aws_account_id"), "AwsAccountId");
+    assert_eq!(snake_to_pascal("iam_policy_arn"), "IamPolicyArn");
+    assert_eq!(snake_to_pascal("ipv4_cidr"), "Ipv4Cidr");
+    assert_eq!(snake_to_pascal("arn"), "Arn");
+    assert_eq!(snake_to_pascal("kms_key_arn"), "KmsKeyArn");
+    // Round-trip with existing pascal_to_snake
+    for name in ["vpc_id", "aws_account_id", "iam_policy_arn", "ipv4_cidr", "arn"] {
+        assert_eq!(pascal_to_snake(&snake_to_pascal(name)), name);
+    }
+}
+```
+
+**Implementation**:
+
+```rust
+pub fn snake_to_pascal(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut capitalize_next = true;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.extend(c.to_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+```
+
+**Verification**: `cargo test -p carina-core --lib snake_to_pascal`
+
+---
+
+### Task A2: `TypeExpr::Display` emits PascalCase for primitives
+
+**Goal**: `TypeExpr::String.to_string()` returns `"String"` (was `"string"`). Same for `Int`, `Bool`, `Float`.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (Display impl for `TypeExpr`)
+
+**Test** (add to `parser::tests`):
+
+```rust
+#[test]
+fn type_expr_display_primitives_are_pascal_case() {
+    assert_eq!(TypeExpr::String.to_string(), "String");
+    assert_eq!(TypeExpr::Int.to_string(), "Int");
+    assert_eq!(TypeExpr::Bool.to_string(), "Bool");
+    assert_eq!(TypeExpr::Float.to_string(), "Float");
+    assert_eq!(TypeExpr::List(Box::new(TypeExpr::Int)).to_string(), "list(Int)");
+    assert_eq!(TypeExpr::Map(Box::new(TypeExpr::String)).to_string(), "map(String)");
+}
+```
+
+**Implementation** (replace the 4 primitive arms in `Display`):
+
+```rust
+TypeExpr::String => write!(f, "String"),
+TypeExpr::Bool => write!(f, "Bool"),
+TypeExpr::Int => write!(f, "Int"),
+TypeExpr::Float => write!(f, "Float"),
+```
+
+**Verification**: `cargo test -p carina-core --lib type_expr_display_primitives`
+
+**Side-effect note**: This changes many existing snapshot tests. Expect `cargo insta` work in subsequent tasks (A13) — for this task, only assert the new strings; do not regenerate snapshots yet (that's task-local test, not full regen).
+
+---
+
+### Task A3: `TypeExpr::Display` emits PascalCase for Simple / custom types
+
+**Goal**: `TypeExpr::Simple("aws_account_id").to_string()` returns `"AwsAccountId"`.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (Display arm for `Simple`)
+
+**Test**:
+
+```rust
+#[test]
+fn type_expr_display_simple_is_pascal_case() {
+    assert_eq!(
+        TypeExpr::Simple("aws_account_id".to_string()).to_string(),
+        "AwsAccountId"
+    );
+    assert_eq!(
+        TypeExpr::Simple("ipv4_cidr".to_string()).to_string(),
+        "Ipv4Cidr"
+    );
+    assert_eq!(TypeExpr::Simple("arn".to_string()).to_string(), "Arn");
+}
+```
+
+**Implementation**:
+
+```rust
+TypeExpr::Simple(name) => write!(f, "{}", snake_to_pascal(name)),
+```
+
+**Verification**: `cargo test -p carina-core --lib type_expr_display_simple_is_pascal_case`
+
+---
+
+### Task A4: parser accepts both `String`/`string` for primitives (transition window)
+
+**Goal**: `arguments { x: String }` and `arguments { x: string }` both parse to `TypeExpr::String`. Phase C removes the lowercase form; during Phase A, both are accepted.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (`parse_type_expr`, `Rule::type_simple` arm)
+
+**Test**:
+
+```rust
+#[test]
+fn parse_accepts_pascal_case_primitives() {
+    let input = r#"
+        arguments {
+            a: String
+            b: Int
+            c: Bool
+            d: Float
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(result.arguments[0].type_expr, TypeExpr::String);
+    assert_eq!(result.arguments[1].type_expr, TypeExpr::Int);
+    assert_eq!(result.arguments[2].type_expr, TypeExpr::Bool);
+    assert_eq!(result.arguments[3].type_expr, TypeExpr::Float);
+}
+
+#[test]
+fn parse_still_accepts_lowercase_primitives_during_transition() {
+    let input = r#"arguments { a: string, b: int, c: bool, d: float }"#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(result.arguments[0].type_expr, TypeExpr::String);
+    assert_eq!(result.arguments[1].type_expr, TypeExpr::Int);
+    assert_eq!(result.arguments[2].type_expr, TypeExpr::Bool);
+    assert_eq!(result.arguments[3].type_expr, TypeExpr::Float);
+}
+```
+
+**Implementation** (in `parse_type_expr`, `Rule::type_simple` arm — recognize either case):
+
+```rust
+Rule::type_simple => match inner.as_str() {
+    "String" | "string" => Ok(TypeExpr::String),
+    "Bool" | "bool" => Ok(TypeExpr::Bool),
+    "Int" | "int" => Ok(TypeExpr::Int),
+    "Float" | "float" => Ok(TypeExpr::Float),
+    other => Ok(TypeExpr::Simple(other.to_string())),
+},
+```
+
+**Verification**: `cargo test -p carina-core --lib parse_accepts_pascal_case_primitives parse_still_accepts_lowercase_primitives`
+
+---
+
+### Task A5: parser accepts PascalCase custom types
+
+**Goal**: `arguments { id: AwsAccountId }` parses to `TypeExpr::Simple("aws_account_id")` (canonical internal representation is snake_case for now; the registry lookup normalizes input case).
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (`parse_type_expr`, `Rule::type_simple` other branch)
+
+**Test**:
+
+```rust
+#[test]
+fn parse_accepts_pascal_case_custom_types() {
+    let input = r#"
+        arguments {
+            id: AwsAccountId
+            cidr: Ipv4Cidr
+            bucket_arn: Arn
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert_eq!(
+        result.arguments[0].type_expr,
+        TypeExpr::Simple("aws_account_id".to_string())
+    );
+    assert_eq!(
+        result.arguments[1].type_expr,
+        TypeExpr::Simple("ipv4_cidr".to_string())
+    );
+    assert_eq!(
+        result.arguments[2].type_expr,
+        TypeExpr::Simple("arn".to_string())
+    );
+}
+```
+
+**Implementation** (extend the `other` branch of the `type_simple` match):
+
+```rust
+other => {
+    // During Phase A, accept both snake_case and PascalCase spellings.
+    // Normalize to snake_case internally (canonical form in TypeExpr::Simple).
+    let canonical = if other.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+        pascal_to_snake(other)
+    } else {
+        other.to_string()
+    };
+    Ok(TypeExpr::Simple(canonical))
+},
+```
+
+**Verification**: `cargo test -p carina-core --lib parse_accepts_pascal_case_custom_types`
+
+---
+
+### Task A6: Grammar accepts 3-segment resource paths (provider.service.TypeName)
+
+**Goal**: `aws.ec2.Vpc`, `aws.s3.Bucket`, `aws.iam.Role` parse as `TypeExpr::Ref` with the full path. The existing grammar (`resource_type_path = identifier ~ ("." ~ identifier)+`) already accepts 3+ segments; verify the parser's PascalCase-final-segment detection does *not* misroute `aws.ec2.Vpc` to `SchemaType`.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (`parse_type_expr`, `Rule::type_ref` arm — refine the PascalCase detection so 3-segment paths are routed to `Ref` not `SchemaType`)
+
+**Test**:
+
+```rust
+#[test]
+fn parse_three_segment_resource_path_is_ref() {
+    let input = r#"
+        arguments {
+            vpc: aws.ec2.Vpc
+            bucket: aws.s3.Bucket
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    match &result.arguments[0].type_expr {
+        TypeExpr::Ref(path) => {
+            assert_eq!(path.provider, "aws");
+            assert_eq!(path.resource_type, "ec2.Vpc");
+        }
+        other => panic!("expected Ref, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_four_segment_path_with_pascal_tail_is_schema_type() {
+    // awscc.ec2.VpcId is a SchemaType (provider.service.TypeName where
+    // TypeName looks like a schema value type, not a resource kind).
+    // The rule today: 3+ segments AND PascalCase final => SchemaType.
+    // After A6, we must distinguish Vpc (resource) from VpcId (schema type).
+    let input = r#"
+        arguments {
+            vpc_id: awscc.ec2.VpcId
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert!(matches!(
+        result.arguments[0].type_expr,
+        TypeExpr::SchemaType { .. }
+    ));
+}
+```
+
+**Implementation design choice**: The existing heuristic (`3+ segments AND PascalCase final => SchemaType`) collides with `aws.ec2.Vpc` (which should be `Ref`, not `SchemaType`). New rule: the `SchemaType` classification is gated on whether the final segment exists in the provider's schema-type registry (`ProviderContext`). When unknown, default to `Ref`.
+
+Concrete change in the `Rule::type_ref` arm (approx. `carina-core/src/parser/mod.rs:1498-1527`):
+
+```rust
+if parts.len() >= 3
+    && parts.last().is_some_and(|s| s.starts_with(|c: char| c.is_uppercase()))
+{
+    let provider = parts[0].to_string();
+    let path = parts[1..parts.len() - 1].join(".");
+    let type_name = parts.last().unwrap().to_string();
+    // Disambiguate: if the (provider, path, type_name) triple is a
+    // registered schema type in ctx, treat as SchemaType; otherwise it's a
+    // 3-segment resource kind (aws.ec2.Vpc).
+    if ctx.config.is_schema_type(&provider, &path, &type_name) {
+        Ok(TypeExpr::SchemaType { provider, path, type_name })
+    } else {
+        let path = ResourceTypePath::parse(path_str).ok_or_else(|| ...)?;
+        Ok(TypeExpr::Ref(path))
+    }
+}
+```
+
+The `is_schema_type` predicate is added to `ProviderContext` (see existing `validators` field pattern). Providers that want PascalCase schema types register them explicitly.
+
+**Verification**: `cargo test -p carina-core --lib parse_three_segment_resource_path parse_four_segment_path_with_pascal_tail`
+
+---
+
+### Task A7: `TypeExpr::Ref` Display emits 3-segment PascalCase form
+
+**Goal**: `TypeExpr::Ref(ResourceTypePath::new("aws", "ec2.Vpc")).to_string()` returns `"aws.ec2.Vpc"` (unchanged — the path is stored as-parsed). Assert round-trip.
+
+**Files**:
+- Modify: none structurally; add a test asserting the existing Display behavior is preserved.
+
+**Test**:
+
+```rust
+#[test]
+fn type_expr_ref_display_roundtrips_three_segment_path() {
+    let ty = TypeExpr::Ref(ResourceTypePath::new("aws", "ec2.Vpc"));
+    assert_eq!(ty.to_string(), "aws.ec2.Vpc");
+
+    // Round trip through the parser
+    let input = format!(r#"arguments {{ v: {} }}"#, ty);
+    let parsed = parse(&input, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.arguments[0].type_expr, ty);
+}
+```
+
+**Implementation**: no code change if the Display impl is already `write!(f, "{}", path)` — verify by running the test.
+
+**Verification**: `cargo test -p carina-core --lib type_expr_ref_display_roundtrips_three_segment_path`
+
+---
+
+### Task A8: Deprecation warning on old spellings
+
+**Goal**: When the parser encounters `string`, `int`, `bool`, `float`, or a snake_case custom type in a type position, emit a warning through `ParsedFile::warnings` with text pointing to the new spelling.
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (`parse_type_expr`, both primitive and custom-type arms)
+- Modify: `carina-core/src/parser/mod.rs` (`Warning` enum or equivalent — add `DeprecatedTypeSpelling { old: String, new: String, span: Span }`)
+
+**Test**:
+
+```rust
+#[test]
+fn parser_warns_on_lowercase_primitive() {
+    let input = r#"arguments { a: string }"#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert!(
+        result.warnings.iter().any(|w| matches!(
+            w,
+            Warning::DeprecatedTypeSpelling { old, new, .. }
+                if old == "string" && new == "String"
+        )),
+        "expected deprecation warning, got {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn parser_warns_on_snake_case_custom_type() {
+    let input = r#"arguments { a: aws_account_id }"#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert!(
+        result.warnings.iter().any(|w| matches!(
+            w,
+            Warning::DeprecatedTypeSpelling { old, new, .. }
+                if old == "aws_account_id" && new == "AwsAccountId"
+        )),
+        "expected deprecation warning"
+    );
+}
+
+#[test]
+fn parser_does_not_warn_on_new_spelling() {
+    let input = r#"arguments { a: String, b: AwsAccountId }"#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    assert!(
+        !result.warnings.iter().any(|w| matches!(w, Warning::DeprecatedTypeSpelling { .. })),
+        "should not warn on new spellings, got {:?}",
+        result.warnings
+    );
+}
+```
+
+**Implementation** (in the `type_simple` arm of `parse_type_expr`):
+
+```rust
+Rule::type_simple => {
+    let text = inner.as_str();
+    let span = inner.as_span();
+    let (ty, deprecated_old) = match text {
+        "String" => (TypeExpr::String, None),
+        "string" => (TypeExpr::String, Some(("string", "String"))),
+        "Int" => (TypeExpr::Int, None),
+        "int" => (TypeExpr::Int, Some(("int", "Int"))),
+        "Bool" => (TypeExpr::Bool, None),
+        "bool" => (TypeExpr::Bool, Some(("bool", "Bool"))),
+        "Float" => (TypeExpr::Float, None),
+        "float" => (TypeExpr::Float, Some(("float", "Float"))),
+        other if other.chars().next().is_some_and(|c| c.is_ascii_uppercase()) => {
+            (TypeExpr::Simple(pascal_to_snake(other)), None)
+        }
+        other => {
+            let new = snake_to_pascal(other);
+            (TypeExpr::Simple(other.to_string()), Some((other, Box::leak(new.into_boxed_str()))))
+        }
+    };
+    if let Some((old, new)) = deprecated_old {
+        ctx.push_warning(Warning::DeprecatedTypeSpelling {
+            old: old.to_string(),
+            new: new.to_string(),
+            span: span.into(),
+        });
+    }
+    Ok(ty)
+}
+```
+
+(Adjust the warning pushing to match the parser's existing warning-collection API — `ParsedFile.warnings` in this codebase.)
+
+**Verification**: `cargo test -p carina-core --lib parser_warns_on_lowercase_primitive parser_warns_on_snake_case_custom_type parser_does_not_warn_on_new_spelling`
+
+---
+
+### Task A9: Diagnostic error messages emit new spellings
+
+**Goal**: `validate_type_expr_value` and the parser's user-function type-mismatch error format type names via `TypeExpr::Display`, so they inherit the new casing automatically. Verify this with tests against the message text.
+
+**Files**:
+- Modify: `carina-core/src/validation.rs` (tests only — the code path is already `format!("{}", type_expr)`)
+- Modify: `carina-core/src/parser/mod.rs` (tests asserting function-arg mismatch error text uses new casing)
+
+**Test**:
+
+```rust
+#[test]
+fn validate_type_expr_value_error_uses_pascal_case() {
+    let result = validate_type_expr_value(
+        &TypeExpr::String,
+        &Value::Int(42),
+        &ProviderContext::default(),
+    );
+    let msg = result.expect("should error");
+    assert!(
+        msg.contains("expected String"),
+        "expected new-casing error, got: {msg}"
+    );
+}
+
+#[test]
+fn validate_type_expr_struct_error_uses_pascal_case_in_field_type() {
+    let mut map = HashMap::new();
+    map.insert("count".to_string(), Value::String("x".into()));
+    let fields = vec![("count".to_string(), TypeExpr::Int)];
+    let result = validate_type_expr_value(
+        &TypeExpr::Struct { fields },
+        &Value::Map(map),
+        &ProviderContext::default(),
+    );
+    let msg = result.expect("should error");
+    assert!(
+        msg.contains("field 'count'") && msg.contains("Int"),
+        "expected field error with Int type, got: {msg}"
+    );
+}
+```
+
+**Implementation**: update any hardcoded lowercase type names in error strings in `validation.rs` to format via `type_expr.to_string()` or accept the new Display output. Grep for `"expected string"`, `"expected int"`, etc. in `carina-core/src` and replace with the Display form.
+
+**Verification**: `cargo test -p carina-core --lib validate_type_expr_value_error_uses_pascal_case`
+
+---
+
+### Task A10: LSP completion proposes new spellings
+
+**Goal**: LSP completion at a type-annotation site (`arguments { x: <HERE> }`) proposes `String`, `Int`, `Bool`, `Float`, and each registered custom type in PascalCase.
+
+**Files**:
+- Modify: `carina-lsp/src/completion/values.rs` (or wherever the type-completion candidate list lives)
+
+**Test** (in `carina-lsp/src/completion/tests.rs` or the nearest equivalent):
+
+```rust
+#[test]
+fn completion_at_type_position_proposes_pascal_case_primitives() {
+    let source = "arguments { x: ";
+    let items = completions_at(source, position_after(source));
+    let labels: Vec<&str> = items.iter().map(|it| it.label.as_str()).collect();
+    assert!(labels.contains(&"String"));
+    assert!(labels.contains(&"Int"));
+    assert!(labels.contains(&"Bool"));
+    assert!(labels.contains(&"Float"));
+    assert!(!labels.contains(&"string"));
+}
+```
+
+**Implementation**: locate the completion list (currently emits `"string"`, `"int"`, `"bool"`, `"float"`, and registered custom types as lowercase). Emit PascalCase forms instead. For custom types registered in `ProviderContext.validators`, render each key via `snake_to_pascal`.
+
+**Verification**: `cargo test -p carina-lsp completion_at_type_position_proposes_pascal_case_primitives`
+
+---
+
+### Task A11: LSP semantic tokens classify PascalCase identifiers as types
+
+**Goal**: The LSP semantic-tokens pass tags a bare PascalCase identifier in a type-annotation position as `semanticTokenType::type`.
+
+**Files**:
+- Modify: `carina-lsp/src/semantic_tokens.rs`
+
+**Test** (within the semantic-tokens test suite):
+
+```rust
+#[test]
+fn semantic_tokens_tags_pascal_case_type_annotation() {
+    let source = "arguments { x: AwsAccountId }";
+    let tokens = tokenize_source(source);
+    let ty_tok = tokens.iter().find(|t| t.text == "AwsAccountId")
+        .expect("AwsAccountId should be tokenized");
+    assert_eq!(ty_tok.kind, SemanticTokenKind::Type);
+}
+```
+
+**Implementation**: extend the existing token classifier to recognize PascalCase identifiers in the right context. Current code already tags `SchemaType` paths as types; the extension is to tag any bare PascalCase identifier that appears after `:` in an `arguments`/`attributes`/`exports` block as type.
+
+**Verification**: `cargo test -p carina-lsp semantic_tokens_tags_pascal_case_type_annotation`
+
+---
+
+### Task A12: TextMate grammars recognize PascalCase types (byte-identical)
+
+**Goal**: Both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` have a pattern that colors PascalCase identifiers in type position as type names. The two files remain byte-identical.
+
+**Files**:
+- Modify: `editors/vscode/syntaxes/carina.tmLanguage.json`
+- Modify: `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json`
+
+**Test**: the existing parity test in `carina-core/tests/tmlanguage_keyword_parity.rs` must keep passing. Additionally, spot-check pattern:
+
+```rust
+#[test]
+fn tmlanguage_has_pascal_case_type_pattern() {
+    let vscode = std::fs::read_to_string(
+        "../editors/vscode/syntaxes/carina.tmLanguage.json"
+    ).unwrap();
+    // Pattern should cover bare PascalCase identifiers with scope entity.name.type.carina
+    assert!(
+        vscode.contains("entity.name.type.carina"),
+        "expected a type-entity pattern in vscode grammar"
+    );
+    assert!(
+        vscode.contains(r"\\b[A-Z][A-Za-z0-9]*\\b")
+            || vscode.contains(r"[A-Z][a-zA-Z0-9]*"),
+        "expected a PascalCase regex in vscode grammar"
+    );
+}
+```
+
+**Implementation**: add a pattern to the `patterns` array in both tmLanguage files (identical JSON):
+
+```json
+{
+  "name": "entity.name.type.carina",
+  "match": "\\b[A-Z][A-Za-z0-9]*\\b"
+}
+```
+
+Place it after the keyword patterns so keywords (none are PascalCase today) take priority.
+
+**Verification**:
+- `cargo test -p carina-core --test tmlanguage_keyword_parity`
+- `cargo test -p carina-core tmlanguage_has_pascal_case_type_pattern`
+
+---
+
+### Task A13: Migrate carina-core fixtures and regenerate snapshots
+
+**Goal**: Every `.crn` file under `carina-cli/tests/fixtures/` and `carina-core/tests/` uses new spellings. Regenerate all `insta` snapshots.
+
+**Files**:
+- Modify: every `.crn` under `carina-cli/tests/fixtures/plan_display/**`, `carina-cli/tests/fixtures/parse_golden/**`, `carina-core/tests/**/*.crn` (approximate count: 161)
+- Regenerate: every `.snap` file matched by the changed fixtures
+
+**Test**: none new — the existing fixture/snapshot tests become the regression surface.
+
+**Implementation**:
+
+1. For each fixture `.crn`: rewrite old spellings by hand (per the decision in 7-b-Z — manual rewrite only).
+2. `cargo test --workspace` will fail many snapshot assertions.
+3. `cargo insta review` → accept each updated snapshot after visual verification.
+
+**Verification**:
+- `cargo test --workspace` (should pass with zero snapshot pending)
+- `cargo insta pending-snapshots` (should be empty after review)
+
+Split into sub-tasks if fixture count is unmanageable:
+- A13a: `plan_display/` fixtures
+- A13b: `parse_golden/` fixtures
+- A13c: remaining `.crn` in `tests/`
+
+Each sub-task: rewrite its own directory, re-run `cargo test`, accept new snapshots.
+
+---
+
+### Task A14: Documentation, CLAUDE.md, READMEs, example blocks
+
+**Goal**: Every DSL code block in markdown files uses new spellings. CLAUDE.md updates mentions of snake_case type names.
+
+**Files**:
+- Modify: `CLAUDE.md`, `README.md` (if present), `docs/**/*.md` (example DSL code blocks only)
+- Modify: any `// example:` doc-comment in `src/**` that shows DSL code
+
+**Test** — add a script in `scripts/` that greps for old spellings inside triple-backtick `crn` code blocks in `.md` files:
+
+```bash
+# scripts/check_docs_use_new_spellings.sh
+set -e
+for f in $(git ls-files '*.md'); do
+    awk '/^```crn/,/^```$/' "$f" |
+    grep -E ':\s*(string|int|bool|float|aws_account_id|ipv4_cidr|arn)\b' && {
+        echo "OLD SPELLING in $f"; exit 1;
+    }
+done
+echo "docs OK"
+```
+
+**Implementation**: manual rewrite of each markdown file.
+
+**Verification**: `scripts/check_docs_use_new_spellings.sh` returns 0.
+
+---
+
+### Task C1: Phase C — remove old-spelling support
+
+**Goal**: After providers (aws, awscc) and `infra` have migrated (tracked in their own repos), remove the transition-window support from carina-core: the parser rejects old spellings with an error (not a warning).
+
+**Files**:
+- Modify: `carina-core/src/parser/mod.rs` (remove the `"string" | ...` OR arms, and remove the snake_case-to-PascalCase normalization in the `other` arm)
+- Modify: `carina-core/src/parser/mod.rs` (remove the `Warning::DeprecatedTypeSpelling` emission from task A8; the variant itself can stay or be removed per taste — prefer to remove since it has no remaining producer)
+
+**Test**:
+
+```rust
+#[test]
+fn parser_rejects_lowercase_primitive_after_phase_c() {
+    let input = r#"arguments { a: string }"#;
+    let err = parse(input, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("unknown type 'string'") || msg.contains("expected String"),
+        "expected rejection with hint, got: {msg}"
+    );
+}
+
+#[test]
+fn parser_rejects_snake_case_custom_type_after_phase_c() {
+    let input = r#"arguments { a: aws_account_id }"#;
+    // After C1, snake_case custom type names are treated as unknown types.
+    // The diagnostic should point at the PascalCase form.
+    let result = parse(input, &ProviderContext::default());
+    assert!(result.is_err() || result.unwrap().warnings.iter().any(|w|
+        matches!(w, Warning::UnknownType { name, .. } if name == "aws_account_id")
+    ));
+}
+```
+
+**Implementation**: delete the fallthrough arms added in A4 and A5, delete the deprecation-warning push from A8.
+
+**Verification**:
+- `cargo test --workspace` passes
+- `cargo test -p carina-core parser_rejects_lowercase_primitive_after_phase_c parser_rejects_snake_case_custom_type_after_phase_c`
+- All `.crn` files in carina repo already use new spellings (from A13); no regression
+
+---
+
+## Not in this plan (handled elsewhere)
+
+- **Phase A in carina-provider-aws**: separate repo, separate PR. Depends on A7 landing first (so carina-core published on main knows how to parse 3-segment paths).
+- **Phase A in carina-provider-awscc**: same.
+- **Phase B in carina-rs/infra**: separate repo. Depends on both provider repos' Phase A PRs being merged.
+- **Phase C providers**: once C1 lands here, aws/awscc must also remove any old-spelling references (mostly auto via codegen re-run).
+- **Q5B namespaced custom types (`aws.AccountId`)**: separate issue, design not started.
+
+## Order and parallelism
+
+- A1 → A2 → A3 are sequential (A3 depends on A1).
+- A4 and A5 both depend on A3 but are independent of each other.
+- A6 is independent of A4/A5 but depends on A3.
+- A7 can start as soon as A6 lands.
+- A8 depends on A4 and A5.
+- A9 depends on A3.
+- A10 and A11 depend on A4/A5.
+- A12 is independent — can land any time after A2.
+- A13 requires A1–A12 all merged (snapshots regenerate against the final parser/display behavior).
+- A14 can start alongside A13.
+- C1 is the final task — waits for all A1–A14 in this repo and Phase A in providers and Phase B in infra.
+
+## Verification commands
+
+- Per-task: as listed.
+- Full gate before merging each PR: `cargo test --workspace && cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`.
+- After A13: run `carina validate` on every `.crn` fixture via existing fixture tests.
+- Before C1: run `carina validate` on a local checkout of `carina-rs/infra` to confirm Phase B landed.

--- a/docs/specs/2026-04-22-naming-conventions-design.md
+++ b/docs/specs/2026-04-22-naming-conventions-design.md
@@ -1,0 +1,219 @@
+# Naming conventions unification — design document
+
+**Related issue**: [#2143](https://github.com/carina-rs/carina/issues/2143)
+**Feature branch**: `brainstorm-2143-naming-conventions`
+**Date**: 2026-04-22
+
+## Goal
+
+Unify type-name casing conventions across Carina's DSL so that **types are always PascalCase, values are always snake_case, and namespaces are always lowercase**. The current state is inconsistent (primitives are lowercase, custom types are snake_case, schema types are PascalCase, enum values mix all three), which forces readers and authors to keep a mental lookup table and blocks a clean design for upcoming type-system work (named struct declarations, future union / enum / tuple types).
+
+## Chosen strategy
+
+**Strategy Y** — PascalCase every user-facing type name, including primitives.
+
+- Primitives: `string` → `String`, `int` → `Int`, `bool` → `Bool`, `float` → `Float`
+- Custom types: `aws_account_id` → `AwsAccountId`, `ipv4_cidr` → `Ipv4Cidr`, `arn` → `Arn`, `iam_policy_arn` → `IamPolicyArn`, etc.
+- Resource kinds: `aws.vpc` → `aws.ec2.Vpc`, `aws.s3.bucket` → `aws.s3.Bucket`, `aws.security_group` → `aws.ec2.SecurityGroup`, etc. (provider and service segments stay lowercase; the final type segment becomes PascalCase)
+- Schema types (`awscc.ec2.VpcId`, `awscc.s3.VersioningStatus`): unchanged — already in the target shape.
+- Enum values: normalize **every** enum value to snake_case (strategy 3B). `.Enabled` → `.enabled`, `.GROUP` → `.group`, `.ap_northeast_1` stays.
+
+Everything else — bindings, attribute names, field names, function names, module names, provider names, service names, backend type names, built-in function names — stays snake_case (or lowercase, in the namespace case). These are all *values* or *namespaces* under the Y rule.
+
+### Rationale
+
+1. **One rule covers every type** ("types are PascalCase"). No exceptions to memorize, no historical-carve-out explanation, no "why is `string` lowercase but `AwsAccountId` capitalized" paper cut.
+2. **Casing becomes a real signal.** A reader scanning `accounts: Accounts = { ... }` can tell at a glance that `Accounts` is a type and `accounts` is a binding. Today that distinction is carried only by context.
+3. **Matches Carina's positioning.** Carina treats types as first-class (has `TypeExpr`, `AttributeType::Struct`, custom type validation, plans for unions/enums). Type-serious languages (Haskell, Scala, F#) capitalize primitives too; that's consistent with what Carina is becoming.
+4. **Aligns with AWS naming.** Provider-emitted schema types are already PascalCase (`VpcId`, `Enabled`, `Arn`); making user-facing types follow the same rule eliminates the mixed-casing pairs users see today.
+5. **Extensible.** Future constructs (`type Status = Success | Failure`, `type Pair = (Int, String)`, refinement types) read cleanly with the rule because every type-position identifier is PascalCase.
+
+### Why not Z
+
+Z would keep primitives lowercase (`string`, `int`) and change everything else to PascalCase. That preserves the Terraform/Rust/Go surface for primitives but requires teaching "primitives are the exception." Since we've accepted breaking changes anyway, the one-rule-for-every-type consistency of Y wins out.
+
+### Why not X / W
+
+- X (snake_case everywhere): fights the AWS naming surface (`Enabled`, `VpcId` are the real API spellings) and removes the casing-as-type-signal property.
+- W (do nothing): leaves the current inconsistency and kicks the can on every future type-system feature.
+
+## Key design decisions
+
+### D1. Type vs. value vs. namespace classification
+
+| Carina concept | Category | Casing |
+|---|---|---|
+| Primitive type (`String`, `Int`, `Bool`, `Float`) | type | PascalCase |
+| Custom type (`AwsAccountId`, `Ipv4Cidr`, `Arn`) | type | PascalCase |
+| Schema type (`awscc.ec2.VpcId`) | type (namespaced) | path: lowercase, final: PascalCase |
+| Resource kind (`aws.ec2.Vpc`) | type (namespaced) | path: lowercase, final: PascalCase |
+| User-defined struct type (`struct Accounts { ... }`) | type | PascalCase |
+| Enum value (`.enabled`, `.ap_northeast_1`) | value | snake_case |
+| Provider name (`aws`, `awscc`) | namespace | lowercase |
+| Service name (`ec2`, `s3`, `iam`) | namespace | lowercase |
+| Backend kind name (`s3`, `local`) | namespace | lowercase |
+| `let` binding | value | snake_case |
+| Attribute name / field name | value | snake_case |
+| Function name / function parameter | value | snake_case |
+| Module name | value (callable) | snake_case |
+| Argument / attribute parameter name | value | snake_case |
+| Arbitrary identifier inside a value literal | value | snake_case |
+
+### D2. Resource kinds get the `provider.service.TypeName` shape
+
+Today: `aws.vpc`, `aws.security_group`, `aws.s3.bucket` — inconsistent depth.
+After Y + 4C: **always** `provider.service.TypeName`. `aws.vpc` is rewritten to `aws.ec2.Vpc`; `aws.security_group` to `aws.ec2.SecurityGroup`; `aws.s3.bucket` to `aws.s3.Bucket`.
+
+This aligns resource references with the existing schema-type shape (`awscc.ec2.VpcId`) and matches AWS CloudFormation (`AWS::EC2::VPC`) at the structural level. Provider codegen gains the responsibility of producing the `service` segment correctly; this is mechanical.
+
+### D3. Enum values are snake_case; DSL ↔ AWS API mapping reuses existing alias machinery
+
+The codebase already has a DSL-alias mechanism for enum values (`known_enum_aliases` in `carina-provider-awscc/src/bin/codegen.rs`, normalizer/conversion pass in `carina-provider-awscc/src/provider/{normalizer,conversion}.rs`). That's how `"-1"` ↔ `"all"` is implemented today for security-group `ip_protocol`.
+
+Extend that exact machinery: provider codegen emits, for each `StringEnum`, a DSL-name (snake_case) ↔ API-name (whatever AWS returns — often PascalCase like `"Enabled"`, SHOUTY_SNAKE like `"GROUP"`, or already-snake like `"ap-northeast-1"`) mapping. The normalizer applies the mapping in both directions. **No new infrastructure** is needed; only one more automatic source of entries for the existing table.
+
+### D4. No compatibility shims for values that are already snake_case
+
+Binding names, attribute names, field names, etc. do not change. The DSL already puts these in a value position, and users already write them in snake_case. This issue is strictly about type-position identifiers and enum values.
+
+### D5. Breaking change, no migration tool
+
+Per user direction:
+- Existing state files (`carina.state.json`) are **not** forward-compatible; users need to destroy-and-recreate or hand-edit state.
+- No `carina migrate` subcommand. Rewrites are manual (editor find-replace, per-file review).
+- No two-mode parser that accepts both old and new spellings in steady state. (A brief transition window is allowed during implementation — see migration plan.)
+
+This keeps the parser simple, the diagnostics clean, and the codebase free of deprecation sugar. Total `.crn` files across all four Carina repos: ≈442 (carina: 161, provider-aws: 76, provider-awscc: 188, infra: 17). Rewrite is large but mechanical.
+
+### D6. Rollout in three phases (strategy 6B simplified)
+
+Four repositories must move: carina (this repo), carina-provider-aws, carina-provider-awscc, carina-rs/infra. Coordinating them in one PR is impossible (polyrepo). The plan is three sequential phases:
+
+- **Phase A — carina core + providers**: parser accepts both old and new spellings temporarily; provider codegen (aws, awscc) emits new spellings; carina-core fixtures, acceptance tests, LSP, formatter, documentation, diagnostics, error messages all updated to new spellings. Land as one PR per repo, in order: carina-core → provider-aws → provider-awscc.
+- **Phase B — infra**: rewrite every `.crn` in `carina-rs/infra` to new spellings. One PR.
+- **Phase C — remove old-spelling support from carina-core parser**: the transition window closes. One PR.
+
+The transient two-mode parser in Phase A is **not** a public feature; it's a migration scaffold that lives only from Phase A to Phase C. `carina validate` treats old spellings as warnings during this window.
+
+### D7. Enum value normalization rule
+
+Provider codegen is the single producer of `StringEnum` types. For each value `v` (the string AWS uses), emit the DSL spelling as follows:
+
+- If `v` matches `^[A-Z][A-Z0-9_]*$` (SHOUTY_SNAKE, e.g. `GROUP`): DSL is `v.to_lowercase()` → `group`.
+- If `v` matches `^[A-Z][a-z0-9]*([A-Z][a-z0-9]*)*$` (PascalCase, e.g. `Enabled`, `VersioningStatus`): DSL is snake_case(`v`) → `enabled`, `versioning_status`.
+- If `v` matches `^[a-z0-9_-]+$` (already snake/kebab, e.g. `ap-northeast-1`): DSL replaces `-` with `_` if present (`ap_northeast_1`).
+- Mixed / unrecognized: keep verbatim and log a codegen warning — this should never happen against well-formed AWS shapes.
+
+The pair (DSL spelling, API spelling) becomes an entry in the alias table described in D3.
+
+### D8. User-facing error messages use the new spellings
+
+Every diagnostic that mentions a type name must emit the PascalCase form. `expected string, got int` becomes `expected String, got Int`. `validate_type_expr_value` already formats via `TypeExpr::Display`, so the change is entirely in how `TypeExpr::Simple` renders (old: `aws_account_id`; new: `AwsAccountId`). See the plan for the concrete rendering change.
+
+### D9. State file schema
+
+State JSON (`carina.state.json`) stores resource ids that include the resource kind (`aws.ec2.vpc.web_vpc_abc123`). Under D2 this becomes `aws.ec2.Vpc.web_vpc_abc123`. Rather than write a migrator, old state files become unreadable; users re-plan against empty state (or hand-edit — the format is documented JSON). This is acceptable per D5.
+
+## File structure and architecture
+
+### In scope for this feature (carina-core)
+
+| File | Change |
+|---|---|
+| `carina-core/src/parser/mod.rs` | `TypeExpr::Simple` / `SchemaType` / `Ref` rendering (`Display`) updated; parser accepts new PascalCase primitives and custom types; transition window (Phase A) accepts both |
+| `carina-core/src/parser/carina.pest` | Keyword / identifier rules for new primitive spellings (`String`, `Int`, `Bool`, `Float`) and for `aws.ec2.Vpc`-shaped three-segment resource paths |
+| `carina-core/src/formatter/carina_fmt.pest` | Mirror any grammar change |
+| `carina-core/src/formatter/format.rs` | Type-expression formatter emits new spellings; no rewriting logic in fmt |
+| `carina-core/src/schema.rs` | `AttributeType::Custom { semantic_name }` becomes authoritative for DSL spelling (was only internal) |
+| `carina-core/src/validation.rs` | `is_type_expr_compatible_with_schema`, `validate_type_expr_value`, error messages use new spellings |
+| `carina-core/src/utils.rs` | `pascal_to_snake` / `snake_to_pascal` helpers (may already partly exist); identifier classification helpers |
+| `carina-core/src/keywords.rs` | Add `String`/`Int`/`Bool`/`Float` or handle via `TypeExpr` entirely (depends on grammar choice) |
+| `carina-lsp/src/completion/**`, `carina-lsp/src/diagnostics/**`, `carina-lsp/src/semantic_tokens.rs` | Completions, diagnostics, and tokens emit/recognize new spellings |
+| `carina-cli/tests/fixtures/**/*.crn` | Rewrite every fixture |
+| `editors/vscode/syntaxes/carina.tmLanguage.json`, `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` | Update regexes so PascalCase identifiers color as types; keep the two files byte-identical |
+| Docs in this repo | README / CLAUDE.md / example code blocks: rewrite |
+
+### In scope for this feature (provider-aws, provider-awscc, downstream)
+
+| Repo | Change |
+|---|---|
+| `carina-provider-aws` | Codegen emits new spellings for custom types and resource kinds; acceptance-test `.crn` rewritten |
+| `carina-provider-awscc` | Same as above; enum alias table in `known_enum_aliases` grows to cover every PascalCase / SHOUTY_SNAKE enum value |
+| `carina-rs/infra` | Every `.crn` rewritten (Phase B) |
+
+### Out of scope (explicit non-goals)
+
+- Moving custom type names under provider namespaces (`aws.AccountId` style) — deferred to a separate issue (Q5B).
+- Migration subcommand for `.crn` files — deferred to user direction if requested later.
+- State-file migration tool — users destroy-and-recreate or hand-edit.
+- Generics, refinement types, union / enum syntax for user-defined types — separate issues; this work just makes the casing rule uniform enough that those can plug in cleanly.
+- Renaming function names or attribute names — values stay snake_case; no work here.
+
+## Edge cases and constraints
+
+### EC1. Identifier shadowing between types and bindings
+
+With Y, type and binding names can share spelling ignoring case (`accounts: Accounts = ...`). The parser already disambiguates by position (type vs. value slot), so no scoping rule is required. Explicit test required: a binding named `string` should still be valid (lowercase position is always a value). Conversely, `String` in a value position is a free identifier / resource binding name, not a type.
+
+### EC2. Custom types whose names collide after PascalCase
+
+`iam_policy_arn` → `IamPolicyArn`, `ec2_instance_id` → `Ec2InstanceId`. After PascalCase-ization, uniqueness is preserved for every current Carina custom type (checked; none collide). Future additions must maintain uniqueness but this is already a convention for `semantic_name`.
+
+### EC3. Acronyms inside PascalCase
+
+`iam`, `ec2`, `arn`, `kms`, `sns`. Following the `semantic_name` precedent (`AwsAccountId`, not `AWSAccountId`; `IamPolicyArn`, not `IAMPolicyArn`), first letter capitalized only: `Ipv4Cidr`, `Ipv6Address`, `IamPolicyArn`, `KmsKeyArn`. Rule: treat acronyms as regular words. Consistent with Rust convention and with the existing `semantic_name` field values in the codebase.
+
+### EC4. `aws.vpc` → `aws.ec2.Vpc` requires a service-name table
+
+Today `aws.vpc` has no explicit service segment; the provider carries service info internally but the DSL path doesn't show it. After 4C, every resource kind has a three-segment path including the service. Provider codegen must attach the service segment to each resource. This is a genuine semantics-visible change and must be applied across `aws` (SDK-based) and `awscc` (CloudControl) identically.
+
+### EC5. TextMate grammar regexes
+
+The two tmLanguage files currently match type names partially by lowercase patterns. With Y, the type-name regex must match PascalCase (optionally `snake_case` during the transition window). The byte-identical parity test in `carina-core/tests/tmlanguage_keyword_parity.rs` must continue to pass.
+
+### EC6. LSP semantic tokens
+
+`carina-lsp/src/semantic_tokens.rs` needs to tokenize PascalCase identifiers in type position as `semanticTokenType::type`. The heuristic "PascalCase final segment in a dotted path" already used for `SchemaType` must be generalized to any bare PascalCase in a type context.
+
+### EC7. Transition window parser behavior
+
+During Phase A, the parser must accept `string` and `String` both as primitive. The simplest implementation: in `parse_type_expr`, the `type_simple` arm recognizes both `string`/`String`, `int`/`Int`, `bool`/`Bool`, `float`/`Float`. For custom types, look up either case in the registry. Old spellings emit a deprecation warning through the existing diagnostic path (`ParsedFile::warnings`). Phase C removes the both-cases recognition.
+
+### EC8. Error-message casing
+
+Every diagnostic that quotes a type name from a `TypeExpr::Display` output automatically inherits the new casing once `TypeExpr::Display` is changed. Sweep grep for hardcoded lowercase type names in error strings and fix them separately. Known spots: `validation.rs`, `module_resolver/mod.rs`, `parser/mod.rs` (function argument type mismatch).
+
+### EC9. Snapshot tests
+
+Every snapshot that captures `TypeExpr::Display` output or error messages must be regenerated with `cargo insta accept`. This is expected work, not a bug.
+
+### EC10. Enum value rewriting in fixtures
+
+Fixtures that use `aws.s3.VersioningStatus.Enabled` become `aws.s3.VersioningStatus.enabled`. Mechanical but non-trivial volume; count of affected fixture lines is estimated per phase plan.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Phase A's two-mode parser leaks past Phase C | Time-box Phase C landing within the same release cycle; CI lint that refuses old spellings once Phase C ships |
+| provider-aws / provider-awscc update order matters | Phase A order (carina → aws → awscc) keeps each repo's tests green against the current carina-core |
+| TextMate regex divergence | Existing byte-identical parity test catches it |
+| `aws.vpc` → `aws.ec2.Vpc` needs a service mapping that's correct | Unit-test the service table against CloudFormation shape names |
+| Acronym PascalCase-ization disagreement (`IAM` vs `Iam`) | Apply uniformly via `pascal_to_snake`'s inverse; codify with a test in `utils.rs` |
+| Snapshot churn is large | Regenerate per phase; commit snapshot updates as part of the same PR |
+
+## Success criteria
+
+1. `cargo test` passes in carina-core, provider-aws, provider-awscc after their Phase A PRs.
+2. `carina validate` passes on every `.crn` in the carina repo's fixtures, acceptance tests, and documentation examples, using new spellings only.
+3. `carina validate` passes on every `.crn` in `carina-rs/infra` after Phase B.
+4. After Phase C, the parser rejects every old spelling (`string`, `aws_account_id`, `aws.vpc`, `.Enabled`) with a clear diagnostic pointing at the new form.
+5. LSP completion at a type-annotation site proposes `String`, `Int`, `Bool`, `Float`, `AwsAccountId`, etc. — not the old spellings.
+6. `TypeExpr::Display` round-trips (`parse(type.to_string()) == type`) for every variant.
+7. TextMate grammar parity test still passes; PascalCase identifiers in type position highlight as types in VSCode.
+
+## Open follow-ups (not in this design)
+
+- Named struct declarations (#2142): decision on `struct Name { }` vs. `type Name = ...` etc. The casing-rule outcome here makes `struct Accounts { ... }` the natural spelling and settles #2142's N1/N2 casing question as N1.
+- Namespaced custom type names (`aws.AccountId`) (#2143 Q5B): separate issue.
+- Union / enum / tuple / refinement types: separate issues; now unblocked since the casing rule scales to them.


### PR DESCRIPTION
## Summary

Design document and implementation plan for #2143 (unify type-name casing conventions).

## Decisions locked in

- **Strategy Y**: every *type* becomes PascalCase (including primitives `String`/`Int`/`Bool`/`Float`), every *value* stays snake_case (including enum values — `.Enabled` → `.enabled`), every *namespace* stays lowercase (provider/service/backend kind).
- **Resource kinds** get a uniform three-segment path: `aws.vpc` → `aws.ec2.Vpc`, `aws.s3.bucket` → `aws.s3.Bucket`.
- **Custom types** PascalCase their existing `semantic_name`: `aws_account_id` → `AwsAccountId`.
- **Enum DSL ↔ AWS-API mapping** rides on the existing `known_enum_aliases` / normalizer machinery (same one that does `-1` ↔ `all` for `ip_protocol`).
- **Breaking change**, no state migration tool, no `carina migrate` subcommand — manual rewrites.
- **Three-phase rollout** across four repos: Phase A (carina + providers) → Phase B (infra) → Phase C (remove old-spelling support from carina's parser).

Full details in `docs/specs/2026-04-22-naming-conventions-design.md`.

## Implementation tasks (carina-core slice only)

A1–A14 in Phase A + C1 in Phase C, detailed in `docs/plans/2026-04-22-naming-conventions.md`. A13 (fixture + snapshot migration) is tripled: A13a/A13b/A13c.

Providers' Phase A and infra's Phase B are tracked in those repos' own issues (see the linked issues from #2143).

## Test plan

- [ ] Design reviewed by maintainers
- [ ] Plan reviewed — every task has concrete test/impl/verification
- [ ] GitHub Issues filed per task in this repo
- [ ] Cross-repo issues filed for carina-provider-aws, carina-provider-awscc, carina-rs/infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)