### PR TITLE
parser: add snake_to_pascal helper (1/18)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -3281,6 +3281,27 @@ pub fn pascal_to_snake(s: &str) -> String {
     result
 }
 
+/// Convert snake_case to PascalCase (e.g., "vpc_id" → "VpcId", "aws_account_id" → "AwsAccountId").
+///
+/// Acronyms are treated as regular words (`iam_policy_arn` → `IamPolicyArn`,
+/// `ipv4_cidr` → `Ipv4Cidr`) so that the result matches `semantic_name` values
+/// already produced by `pascal_to_snake` and is a round-trip inverse for them.
+pub fn snake_to_pascal(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut capitalize_next = true;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 /// Return a human-readable type name for a Value
 pub(crate) fn value_type_name(value: &Value) -> &'static str {
     match value {
@@ -10208,6 +10229,26 @@ aws.s3.bucket {
         );
         assert_eq!(super::pascal_to_snake("Arn"), "arn");
         assert_eq!(super::pascal_to_snake("IamRoleArn"), "iam_role_arn");
+    }
+
+    #[test]
+    fn snake_to_pascal_conversion() {
+        use super::snake_to_pascal;
+        assert_eq!(snake_to_pascal("vpc_id"), "VpcId");
+        assert_eq!(snake_to_pascal("aws_account_id"), "AwsAccountId");
+        assert_eq!(snake_to_pascal("iam_policy_arn"), "IamPolicyArn");
+        assert_eq!(snake_to_pascal("ipv4_cidr"), "Ipv4Cidr");
+        assert_eq!(snake_to_pascal("arn"), "Arn");
+        assert_eq!(snake_to_pascal("kms_key_arn"), "KmsKeyArn");
+        for name in [
+            "vpc_id",
+            "aws_account_id",
+            "iam_policy_arn",
+            "ipv4_cidr",
+            "arn",
+        ] {
+            assert_eq!(pascal_to_snake(&snake_to_pascal(name)), name);
+        }
     }
 
     #[test]

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -7,6 +7,7 @@ use tower_lsp::lsp_types::{
 };
 
 use carina_core::builtins;
+use carina_core::parser::snake_to_pascal;
 use carina_core::schema::AttributeType;
 
 use super::{CompletionProvider, DslSource};
@@ -1317,22 +1318,6 @@ fn is_valid_custom_name(s: &str) -> bool {
     !s.is_empty()
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
         && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
-}
-
-fn snake_to_pascal(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut next_upper = true;
-    for ch in s.chars() {
-        if ch == '_' {
-            next_upper = true;
-        } else if next_upper {
-            out.extend(ch.to_uppercase());
-            next_upper = false;
-        } else {
-            out.push(ch);
-        }
-    }
-    out
 }
 
 fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {


### PR DESCRIPTION
Closes #2145. Part of #2143 (naming-conventions task 1/18).

## Summary

Add `snake_to_pascal` next to the existing `pascal_to_snake` in `carina-core/src/parser/mod.rs`. Acronyms are treated as regular words (`iam_policy_arn` → `IamPolicyArn`, `ipv4_cidr` → `Ipv4Cidr`) so the function is a round-trip inverse for `semantic_name` values already produced by `pascal_to_snake` elsewhere in the codebase.

Replace the private duplicate in `carina-lsp/src/completion/values.rs` with an import of the new canonical helper, preventing the two copies from drifting.

## Test plan

- [x] `cargo test -p carina-core --lib snake_to_pascal` passes (new test with 6 assertions + round-trip check against `pascal_to_snake`)
- [x] `cargo test -p carina-core` — 1314 passed, 0 failed
- [x] `cargo test -p carina-lsp` — 319 passed, 0 failed (LSP still uses `semantic_name` via the new canonical helper)
- [x] `cargo clippy -p carina-core -p carina-lsp --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean