### PR TITLE
parser: TypeExpr::Display primitives PascalCase (2/18)

### DIFF
--- a/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info.snap
+++ b/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info.snap
@@ -8,11 +8,11 @@ Module: module_info
 
   vpc_id: awscc.ec2.vpc  (required)
     The VPC to deploy resources into
-  environment: string  (required)
+  environment: String  (required)
     Deployment environment name
-  instance_type: string = "t3.micro"  
+  instance_type: String = "t3.micro"  
     EC2 instance type
-  enable_monitoring: bool = true  
+  enable_monitoring: Bool = true  
 
 === CREATES ===
 

--- a/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info_empty_module.snap
+++ b/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info_empty_module.snap
@@ -6,9 +6,9 @@ Module: empty_module
 
 === ARGUMENTS ===
 
-  name: string  (required)
+  name: String  (required)
     Resource name prefix
-  env: string = "dev"  
+  env: String = "dev"  
     Environment label
 
 === CREATES ===

--- a/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info_no_deps.snap
+++ b/carina-cli/src/snapshots/carina_cli__module_info_snapshot_tests__snapshot_module_info_no_deps.snap
@@ -6,7 +6,7 @@ Module: no_deps
 
 === ARGUMENTS ===
 
-  region: string  (required)
+  region: String  (required)
     AWS region
 
 === CREATES ===

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_export_changes_mixed.snap
@@ -13,8 +13,8 @@ Execution Plan:
 
 Exports:
 
-  + new_export: string = 'hello'
-  ~ changed: int = 42 → 100
+  + new_export: String = 'hello'
+  ~ changed: Int = 42 → 100
   - obsolete = 'gone'
 
 Plan: 1 to add, 0 to change, 1 to destroy, 3 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports.snap
@@ -9,7 +9,7 @@ Execution Plan:
 
 Exports:
 
-  + vpc_id: string = vpc.vpc_id
+  + vpc_id: String = vpc.vpc_id
   + cidr = vpc.cidr_block
 
 Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_exports_multifile.snap
@@ -10,6 +10,6 @@ Execution Plan:
 Exports:
 
   + cidr = vpc.cidr_block
-  + vpc_id: string = vpc.vpc_id
+  + vpc_id: String = vpc.vpc_id
 
 Plan: 1 to add, 0 to change, 0 to destroy, 2 export change(s).

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -1333,7 +1333,7 @@ mod tests {
         let display = signature.display_with_color(false);
 
         // Simple form has no description line
-        assert!(display.contains("enable_https: bool"));
+        assert!(display.contains("enable_https: Bool"));
         // The line after enable_https should not contain a description
         let lines: Vec<&str> = display.lines().collect();
         let enable_idx = lines
@@ -1348,7 +1348,7 @@ mod tests {
         );
 
         // Block form descriptions are shown on the line after the argument
-        assert!(display.contains("vpc_id: string"));
+        assert!(display.contains("vpc_id: String"));
         let vpc_idx = lines
             .iter()
             .position(|l| l.contains("vpc_id"))
@@ -1359,7 +1359,7 @@ mod tests {
             lines[vpc_idx + 1]
         );
 
-        assert!(display.contains("port: int"));
+        assert!(display.contains("port: Int"));
         let port_idx = lines
             .iter()
             .position(|l| l.contains("port:"))

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -237,10 +237,10 @@ pub enum TypeExpr {
 impl std::fmt::Display for TypeExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TypeExpr::String => write!(f, "string"),
-            TypeExpr::Bool => write!(f, "bool"),
-            TypeExpr::Int => write!(f, "int"),
-            TypeExpr::Float => write!(f, "float"),
+            TypeExpr::String => write!(f, "String"),
+            TypeExpr::Bool => write!(f, "Bool"),
+            TypeExpr::Int => write!(f, "Int"),
+            TypeExpr::Float => write!(f, "Float"),
             TypeExpr::Simple(name) => write!(f, "{}", name),
             TypeExpr::List(inner) => write!(f, "list({})", inner),
             TypeExpr::Map(inner) => write!(f, "map({})", inner),
@@ -5829,7 +5829,7 @@ mod tests {
                 ("value".to_string(), TypeExpr::Int),
             ],
         };
-        assert_eq!(t.to_string(), "struct { name: string, value: int }");
+        assert_eq!(t.to_string(), "struct { name: String, value: Int }");
 
         let empty = TypeExpr::Struct { fields: vec![] };
         assert_eq!(empty.to_string(), "struct {}");
@@ -5940,12 +5940,12 @@ mod tests {
 
     #[test]
     fn type_expr_display_with_ref() {
-        assert_eq!(TypeExpr::String.to_string(), "string");
-        assert_eq!(TypeExpr::Bool.to_string(), "bool");
-        assert_eq!(TypeExpr::Int.to_string(), "int");
+        assert_eq!(TypeExpr::String.to_string(), "String");
+        assert_eq!(TypeExpr::Bool.to_string(), "Bool");
+        assert_eq!(TypeExpr::Int.to_string(), "Int");
         assert_eq!(
             TypeExpr::List(Box::new(TypeExpr::String)).to_string(),
-            "list(string)"
+            "list(String)"
         );
         assert_eq!(
             TypeExpr::Ref(ResourceTypePath::new("aws", "vpc")).to_string(),
@@ -5987,7 +5987,23 @@ mod tests {
 
     #[test]
     fn type_expr_display_float() {
-        assert_eq!(TypeExpr::Float.to_string(), "float");
+        assert_eq!(TypeExpr::Float.to_string(), "Float");
+    }
+
+    #[test]
+    fn type_expr_display_primitives_are_pascal_case() {
+        assert_eq!(TypeExpr::String.to_string(), "String");
+        assert_eq!(TypeExpr::Int.to_string(), "Int");
+        assert_eq!(TypeExpr::Bool.to_string(), "Bool");
+        assert_eq!(TypeExpr::Float.to_string(), "Float");
+        assert_eq!(
+            TypeExpr::List(Box::new(TypeExpr::Int)).to_string(),
+            "list(Int)"
+        );
+        assert_eq!(
+            TypeExpr::Map(Box::new(TypeExpr::String)).to_string(),
+            "map(String)"
+        );
     }
 
     #[test]
@@ -9567,7 +9583,7 @@ aws.s3.bucket {
         let err = parse(input, &ProviderContext::default()).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("expects type 'string'"),
+            msg.contains("expects type 'String'"),
             "Expected type mismatch error, got: {msg}"
         );
     }
@@ -9587,7 +9603,7 @@ aws.s3.bucket {
         let err = parse(input, &ProviderContext::default()).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("expects type 'int'"),
+            msg.contains("expects type 'Int'"),
             "Expected type mismatch error, got: {msg}"
         );
     }
@@ -9645,7 +9661,7 @@ aws.s3.bucket {
         let err = parse(input, &ProviderContext::default()).unwrap_err();
         let msg = format!("{err}");
         assert!(
-            msg.contains("expects type 'bool'"),
+            msg.contains("expects type 'Bool'"),
             "Expected type mismatch error, got: {msg}"
         );
     }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -1183,7 +1183,7 @@ awscc.ec2.vpc_gateway_attachment {
             content
         );
         assert!(
-            content.contains("string"),
+            content.contains("String"),
             "Should show type, got:\n{}",
             content
         );

--- a/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_default.snap
+++ b/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_default.snap
@@ -5,7 +5,7 @@ expression: output
 ┌ Module Info: web_tier ───────────────────────────────────────────────────────────────────────────┐
 │=== ARGUMENTS ===  (2 items)                                                                      │
 │  vpc: aws.vpc  (required)                                                                        │
-│  enable_https: bool = true                                                                       │
+│  enable_https: Bool = true                                                                       │
 │=== CREATES ===  (2 resources)                                                                    │
 │  web_sg: aws.security_group                                                                      │
 │  http_rule: aws.security_group.ingress_rule                                                      │

--- a/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_selected_argument.snap
+++ b/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_selected_argument.snap
@@ -5,7 +5,7 @@ expression: output
 ┌ Module Info: web_tier ───────────────────────────────────────────────────────────────────────────┐
 │=== ARGUMENTS ===  (2 items)                                                                      │
 │  vpc: aws.vpc  (required)                                                                        │
-│  enable_https: bool = true                                                                       │
+│  enable_https: Bool = true                                                                       │
 │=== CREATES ===  (2 resources)                                                                    │
 │  web_sg: aws.security_group                                                                      │
 │  http_rule: aws.security_group.ingress_rule                                                      │

--- a/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_selected_resource.snap
+++ b/carina-tui/src/snapshots/carina_tui__module_info_tui_snapshot_tests__snapshot_module_info_selected_resource.snap
@@ -5,7 +5,7 @@ expression: output
 ┌ Module Info: web_tier ───────────────────────────────────────────────────────────────────────────┐
 │=== ARGUMENTS ===  (2 items)                                                                      │
 │  vpc: aws.vpc  (required)                                                                        │
-│  enable_https: bool = true                                                                       │
+│  enable_https: Bool = true                                                                       │
 │=== CREATES ===  (2 resources)                                                                    │
 │  web_sg: aws.security_group                                                                      │
 │  http_rule: aws.security_group.ingress_rule                                                      │


### PR DESCRIPTION
Closes #2146. Part of #2143 (naming-conventions task 2/18).

## Summary

- `TypeExpr::{String, Bool, Int, Float}` Display arms now emit PascalCase (`String`, `Bool`, `Int`, `Float`).
- Wrapper types inherit the new form: `list(Int)`, `map(String)`, `struct { name: String, value: Int }`.
- Per-test assertions that checked the lowercase literals are updated in the same PR (parser tests, module display tests, LSP hover test).
- 9 insta snapshots regenerated (carina-cli × 6, carina-tui × 3) — each reviewed to confirm the only change is the casing of primitive type names.

Out of scope (tracked in later tasks):
- LSP `format_type_expr` still hand-rolls lowercase (duplicate of Display) → task A10 (#2154).
- Resource-kind 3-segment forms (`aws.ec2.Vpc`) → tasks A6/A7 (#2150/#2151).
- Broad fixture + snapshot regen → task A13 (#2157).

## Test plan

- [x] `cargo test -p carina-core --lib type_expr_display_primitives_are_pascal_case` passes
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Every `.snap.new` manually diffed against its base before `cargo insta accept`