### PR TITLE
parser: TypeExpr::Display Simple emits PascalCase (3/18)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -241,7 +241,7 @@ impl std::fmt::Display for TypeExpr {
             TypeExpr::Bool => write!(f, "Bool"),
             TypeExpr::Int => write!(f, "Int"),
             TypeExpr::Float => write!(f, "Float"),
-            TypeExpr::Simple(name) => write!(f, "{}", name),
+            TypeExpr::Simple(name) => write!(f, "{}", snake_to_pascal(name)),
             TypeExpr::List(inner) => write!(f, "list({})", inner),
             TypeExpr::Map(inner) => write!(f, "map({})", inner),
             TypeExpr::Ref(path) => write!(f, "{}", path),
@@ -9856,13 +9856,26 @@ aws.s3.bucket {
     fn type_expr_display_simple() {
         assert_eq!(
             TypeExpr::Simple("ipv4_cidr".to_string()).to_string(),
-            "ipv4_cidr"
+            "Ipv4Cidr"
         );
         assert_eq!(
             TypeExpr::Simple("ipv4_address".to_string()).to_string(),
-            "ipv4_address"
+            "Ipv4Address"
         );
-        assert_eq!(TypeExpr::Simple("arn".to_string()).to_string(), "arn");
+        assert_eq!(TypeExpr::Simple("arn".to_string()).to_string(), "Arn");
+    }
+
+    #[test]
+    fn type_expr_display_simple_is_pascal_case() {
+        assert_eq!(
+            TypeExpr::Simple("aws_account_id".to_string()).to_string(),
+            "AwsAccountId"
+        );
+        assert_eq!(
+            TypeExpr::Simple("ipv4_cidr".to_string()).to_string(),
+            "Ipv4Cidr"
+        );
+        assert_eq!(TypeExpr::Simple("arn".to_string()).to_string(), "Arn");
     }
 
     // --- Issue #1285: Validate fn call arguments for custom types ---

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1825,7 +1825,7 @@ fn upstream_state_dot_completion_detail_shows_type_expr() {
         .expect("expected `accounts` in completions");
     let detail = accounts.detail.as_deref().unwrap_or("");
     assert!(
-        detail.contains("map(aws_account_id)"),
+        detail.contains("map(AwsAccountId)"),
         "typed export detail must include the TypeExpr rendering, got: {:?}",
         detail
     );


### PR DESCRIPTION
Closes #2147. Part of #2143 (naming-conventions task 3/18).

## Summary

Change the `TypeExpr::Simple(name)` Display arm to render the internal snake_case name through `snake_to_pascal`. Internal representation is unchanged — only the user-facing Display output moves to PascalCase.

Examples:
- `Simple("aws_account_id").to_string()` → `"AwsAccountId"`
- `Simple("ipv4_cidr").to_string()` → `"Ipv4Cidr"`
- `Map(Simple("aws_account_id")).to_string()` → `"map(AwsAccountId)"`

Updates `type_expr_display_simple` to expect PascalCase and updates the LSP completion-detail assertion (`map(aws_account_id)` → `map(AwsAccountId)`) — both "purely assertion-string changes" per the issue body. No snapshot regeneration needed this round.

## Test plan

- [x] `cargo test -p carina-core --lib type_expr_display_simple_is_pascal_case` passes
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean