### PR TITLE
parser: accept PascalCase primitives alongside lowercase (4/18)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1494,10 +1494,10 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
     let inner = first_inner(pair, "type", "type expression")?;
     match inner.as_rule() {
         Rule::type_simple => match inner.as_str() {
-            "string" => Ok(TypeExpr::String),
-            "bool" => Ok(TypeExpr::Bool),
-            "int" => Ok(TypeExpr::Int),
-            "float" => Ok(TypeExpr::Float),
+            "String" | "string" => Ok(TypeExpr::String),
+            "Bool" | "bool" => Ok(TypeExpr::Bool),
+            "Int" | "int" => Ok(TypeExpr::Int),
+            "Float" | "float" => Ok(TypeExpr::Float),
             other => Ok(TypeExpr::Simple(other.to_string())),
         },
         Rule::type_generic => {
@@ -8945,6 +8945,40 @@ aws.s3.bucket {
         assert_eq!(result.arguments.len(), 2);
         assert!(result.arguments[0].description.is_none());
         assert!(result.arguments[1].description.is_none());
+    }
+
+    #[test]
+    fn parse_accepts_pascal_case_primitives() {
+        let input = r#"
+            arguments {
+                a: String
+                b: Int
+                c: Bool
+                d: Float
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.arguments[0].type_expr, TypeExpr::String);
+        assert_eq!(result.arguments[1].type_expr, TypeExpr::Int);
+        assert_eq!(result.arguments[2].type_expr, TypeExpr::Bool);
+        assert_eq!(result.arguments[3].type_expr, TypeExpr::Float);
+    }
+
+    #[test]
+    fn parse_still_accepts_lowercase_primitives_during_transition() {
+        let input = r#"
+            arguments {
+                a: string
+                b: int
+                c: bool
+                d: float
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        assert_eq!(result.arguments[0].type_expr, TypeExpr::String);
+        assert_eq!(result.arguments[1].type_expr, TypeExpr::Int);
+        assert_eq!(result.arguments[2].type_expr, TypeExpr::Bool);
+        assert_eq!(result.arguments[3].type_expr, TypeExpr::Float);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2148. Part of #2143 (naming-conventions task 4/18).

## Summary

Extend `parse_type_expr`'s `Rule::type_simple` match to accept both `String`/`string`, `Bool`/`bool`, `Int`/`int`, `Float`/`float` as the same `TypeExpr` variant. The grammar already accepts both via the generic `identifier` production; only the parser-side routing needed the additional match arms.

Transition window: both spellings work during Phase A. Phase C (task 17/18, #2161) removes the lowercase form. Deprecation warning is task 8/18 (#2152).

## Note on test syntax

The issue body's test uses comma-separated arguments (`a: String, b: Int`), but the actual grammar is newline-separated (see other `parse_arguments_*` tests). The tests in this PR follow the grammar — same pattern as the plan document's `docs/plans/2026-04-22-naming-conventions.md` version of the test.

## Test plan

- [x] `cargo test -p carina-core --lib parse_accepts_pascal_case_primitives` passes
- [x] `cargo test -p carina-core --lib parse_still_accepts_lowercase_primitives_during_transition` passes
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean