### PR TITLE
parser: 3-segment PascalCase via schema-type registry (6/18)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -147,6 +147,7 @@ fn enrich_provider_context(
             }
             Ok(())
         })),
+        schema_types: Default::default(),
     }
 }
 

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -289,6 +289,7 @@ fn create_provider_context() -> carina_core::parser::ProviderContext {
         })),
         validators: std::collections::HashMap::new(),
         custom_type_validator: None,
+        schema_types: Default::default(),
     }
 }
 

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -93,6 +93,7 @@ mod tests {
             decryptor: Some(decrypt_fn),
             validators: HashMap::new(),
             custom_type_validator: None,
+            schema_types: Default::default(),
         }
     }
 

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -2534,6 +2534,7 @@ mod tests {
             decryptor: None,
             validators,
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         let mut module = create_test_module();
@@ -2606,6 +2607,7 @@ mod tests {
             decryptor: None,
             validators,
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         let mut module = create_test_module();

--- a/carina-core/src/parser/config.rs
+++ b/carina-core/src/parser/config.rs
@@ -3,7 +3,7 @@
 //! `ProviderContext` allows CLI/providers to inject custom type validators
 //! and a decryptor function into the parser without using global mutable state.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Signature for a custom type validator function.
 ///
@@ -35,6 +35,40 @@ pub struct ProviderContext {
     /// Factory-based custom type validator that calls through to provider factories
     /// (e.g., WASM plugins) for types not covered by `validators`.
     pub custom_type_validator: Option<CustomTypeValidatorFn>,
+    /// Schema types registered by providers, keyed by
+    /// `(provider, path, type_name)` (e.g., `("awscc", "ec2", "VpcId")`).
+    ///
+    /// Used by the parser to disambiguate 3+ segment paths: without this set,
+    /// both `aws.ec2.Vpc` (resource kind) and `awscc.ec2.VpcId` (schema type)
+    /// look identical. When a triple is present, the parser classifies the
+    /// path as `TypeExpr::SchemaType`; otherwise it falls back to
+    /// `TypeExpr::Ref`.
+    pub schema_types: HashSet<(String, String, String)>,
+}
+
+impl ProviderContext {
+    /// Register `(provider, path, type_name)` as a schema type so the parser
+    /// classifies matching 3+ segment paths as `TypeExpr::SchemaType` rather
+    /// than `TypeExpr::Ref`. Provider crates call this during setup.
+    pub fn register_schema_type(
+        &mut self,
+        provider: impl Into<String>,
+        path: impl Into<String>,
+        type_name: impl Into<String>,
+    ) {
+        self.schema_types
+            .insert((provider.into(), path.into(), type_name.into()));
+    }
+
+    /// Return `true` iff `(provider, path, type_name)` has been registered via
+    /// [`register_schema_type`]. Used by the parser to route 3+ segment paths.
+    pub fn is_schema_type(&self, provider: &str, path: &str, type_name: &str) -> bool {
+        self.schema_types.contains(&(
+            provider.to_string(),
+            path.to_string(),
+            type_name.to_string(),
+        ))
+    }
 }
 
 impl std::fmt::Debug for ProviderContext {
@@ -46,6 +80,7 @@ impl std::fmt::Debug for ProviderContext {
                 "custom_type_validator",
                 &self.custom_type_validator.as_ref().map(|_| "..."),
             )
+            .field("schema_types", &self.schema_types)
             .finish()
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1158,11 +1158,10 @@ fn parse_arguments_block(
             let name = next_pair(&mut param_inner, "parameter name", "arguments block")?
                 .as_str()
                 .to_string();
-            let type_expr = parse_type_expr(next_pair(
-                &mut param_inner,
-                "type expression",
-                "arguments parameter",
-            )?)?;
+            let type_expr = parse_type_expr(
+                next_pair(&mut param_inner, "type expression", "arguments parameter")?,
+                config,
+            )?;
 
             // Check if the next element is a block form or simple default
             if let Some(next) = param_inner.next() {
@@ -1433,7 +1432,7 @@ fn parse_attributes_block(
             )?;
             let (type_expr, value) = if next.as_rule() == Rule::type_expr {
                 // Has explicit type annotation: name: type = expr
-                let type_expr = Some(parse_type_expr(next)?);
+                let type_expr = Some(parse_type_expr(next, ctx.config)?);
                 let expr = next_pair(&mut param_inner, "value expression", "attributes parameter")?;
                 let value = Some(parse_expression(expr, ctx)?);
                 (type_expr, value)
@@ -1469,7 +1468,7 @@ fn parse_exports_block(
 
             let next = next_pair(&mut param_inner, "type or expression", "exports parameter")?;
             let (type_expr, value) = if next.as_rule() == Rule::type_expr {
-                let type_expr = Some(parse_type_expr(next)?);
+                let type_expr = Some(parse_type_expr(next, ctx.config)?);
                 let expr = next_pair(&mut param_inner, "value expression", "exports parameter")?;
                 let value = Some(parse_expression(expr, ctx)?);
                 (type_expr, value)
@@ -1490,7 +1489,10 @@ fn parse_exports_block(
 }
 
 /// Parse type expression
-fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseError> {
+fn parse_type_expr(
+    pair: pest::iterators::Pair<Rule>,
+    config: &ProviderContext,
+) -> Result<TypeExpr, ParseError> {
     let inner = first_inner(pair, "type", "type expression")?;
     match inner.as_rule() {
         Rule::type_simple => match inner.as_str() {
@@ -1516,11 +1518,10 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
 
             // Get the inner type expression
             let mut generic_inner = inner.into_inner();
-            let inner_type = parse_type_expr(next_pair(
-                &mut generic_inner,
-                "inner type",
-                "generic type expression",
-            )?)?;
+            let inner_type = parse_type_expr(
+                next_pair(&mut generic_inner, "inner type", "generic type expression")?,
+                config,
+            )?;
 
             if is_list {
                 Ok(TypeExpr::List(Box::new(inner_type)))
@@ -1534,29 +1535,31 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
             let path_str = next_pair(&mut ref_inner, "resource type path", "type ref")?.as_str();
             let parts: Vec<&str> = path_str.split('.').collect();
 
-            // Check if the last segment starts with uppercase (PascalCase) → SchemaType
-            if parts.len() >= 3
+            // A 3+ segment path with a PascalCase final segment is ambiguous:
+            // `aws.ec2.Vpc` is a resource kind (Ref), `awscc.ec2.VpcId` is a
+            // schema type. Disambiguate by asking the provider context:
+            // registered schema types become SchemaType, everything else
+            // falls back to Ref.
+            let has_pascal_tail = parts.len() >= 3
                 && parts
                     .last()
-                    .is_some_and(|s| s.starts_with(|c: char| c.is_uppercase()))
-            {
-                let provider = parts[0].to_string();
+                    .is_some_and(|s| s.starts_with(|c: char| c.is_uppercase()));
+            if has_pascal_tail {
+                let provider = parts[0];
                 let path = parts[1..parts.len() - 1].join(".");
-                let type_name = parts.last().unwrap().to_string();
-                Ok(TypeExpr::SchemaType {
-                    provider,
-                    path,
-                    type_name,
-                })
-            } else {
-                let path = ResourceTypePath::parse(path_str).ok_or_else(|| {
-                    ParseError::InvalidResourceType(format!(
-                        "Invalid resource type path: {}",
-                        path_str
-                    ))
-                })?;
-                Ok(TypeExpr::Ref(path))
+                let type_name = parts.last().unwrap();
+                if config.is_schema_type(provider, &path, type_name) {
+                    return Ok(TypeExpr::SchemaType {
+                        provider: provider.to_string(),
+                        path,
+                        type_name: type_name.to_string(),
+                    });
+                }
             }
+            let path = ResourceTypePath::parse(path_str).ok_or_else(|| {
+                ParseError::InvalidResourceType(format!("Invalid resource type path: {}", path_str))
+            })?;
+            Ok(TypeExpr::Ref(path))
         }
         Rule::type_struct => {
             let mut fields: Vec<(String, TypeExpr)> = Vec::new();
@@ -1572,11 +1575,10 @@ fn parse_type_expr(pair: pest::iterators::Pair<Rule>) -> Result<TypeExpr, ParseE
                     let name = next_pair(&mut field_inner, "field name", "struct field")?
                         .as_str()
                         .to_string();
-                    let ty = parse_type_expr(next_pair(
-                        &mut field_inner,
-                        "field type",
-                        "struct field",
-                    )?)?;
+                    let ty = parse_type_expr(
+                        next_pair(&mut field_inner, "field type", "struct field")?,
+                        config,
+                    )?;
                     if fields.iter().any(|(existing, _)| existing == &name) {
                         return Err(ParseError::InvalidResourceType(format!(
                             "struct has duplicate field name '{name}'"
@@ -2938,7 +2940,7 @@ fn parse_fn_def(
                 for remaining in param_inner {
                     match remaining.as_rule() {
                         Rule::type_expr => {
-                            param_type = Some(parse_type_expr(remaining)?);
+                            param_type = Some(parse_type_expr(remaining, ctx.config)?);
                         }
                         _ => {
                             // This is the default expression
@@ -2967,7 +2969,7 @@ fn parse_fn_def(
 
     // Parse optional return type annotation (: type_expr)
     let (return_type, body_pair) = if next_token.as_rule() == Rule::type_expr {
-        let rt = parse_type_expr(next_token)?;
+        let rt = parse_type_expr(next_token, ctx.config)?;
         let bp = next_pair(&mut inner, "fn_body", "fn_def")?;
         (Some(rt), bp)
     } else {
@@ -9015,6 +9017,47 @@ aws.s3.bucket {
     }
 
     #[test]
+    fn parse_three_segment_resource_path_is_ref() {
+        let input = r#"
+            arguments {
+                vpc: aws.ec2.Vpc
+                bucket: aws.s3.Bucket
+            }
+        "#;
+        let result = parse(input, &ProviderContext::default()).unwrap();
+        match &result.arguments[0].type_expr {
+            TypeExpr::Ref(path) => {
+                assert_eq!(path.provider, "aws");
+                assert_eq!(path.resource_type, "ec2.Vpc");
+            }
+            other => panic!("expected Ref, got {other:?}"),
+        }
+        match &result.arguments[1].type_expr {
+            TypeExpr::Ref(path) => {
+                assert_eq!(path.provider, "aws");
+                assert_eq!(path.resource_type, "s3.Bucket");
+            }
+            other => panic!("expected Ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_four_segment_path_with_pascal_tail_is_schema_type() {
+        let input = r#"
+            arguments {
+                vpc_id: awscc.ec2.VpcId
+            }
+        "#;
+        let mut ctx = ProviderContext::default();
+        ctx.register_schema_type("awscc", "ec2", "VpcId");
+        let result = parse(input, &ctx).unwrap();
+        assert!(matches!(
+            result.arguments[0].type_expr,
+            TypeExpr::SchemaType { .. }
+        ));
+    }
+
+    #[test]
     fn parse_arguments_block_form_default_only() {
         let input = r#"
             arguments {
@@ -10193,6 +10236,7 @@ aws.s3.bucket {
             })),
             validators: HashMap::new(),
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         // decrypt() in resource attributes is resolved during resolve_resource_refs,
@@ -10251,6 +10295,7 @@ aws.s3.bucket {
             decryptor: None,
             validators,
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         let result = validate_custom_type(
@@ -10291,6 +10336,7 @@ aws.s3.bucket {
             decryptor: None,
             validators,
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         // Test validate_custom_type directly since the grammar may not accept
@@ -10354,7 +10400,9 @@ arguments {
   vpc_id: awscc.ec2.VpcId
 }
 "#;
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        let mut ctx = ProviderContext::default();
+        ctx.register_schema_type("awscc", "ec2", "VpcId");
+        let parsed = parse(input, &ctx).unwrap();
         assert_eq!(parsed.arguments.len(), 1);
         let arg = &parsed.arguments[0];
         assert_eq!(arg.name, "vpc_id");
@@ -10389,7 +10437,9 @@ arguments {
   subnet_ids: list(awscc.ec2.SubnetId)
 }
 "#;
-        let parsed = parse(input, &ProviderContext::default()).unwrap();
+        let mut ctx = ProviderContext::default();
+        ctx.register_schema_type("awscc", "ec2", "SubnetId");
+        let parsed = parse(input, &ctx).unwrap();
         assert_eq!(parsed.arguments.len(), 1);
         let arg = &parsed.arguments[0];
         match &arg.type_expr {

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -853,6 +853,7 @@ mod tests {
             decryptor: None,
             validators,
             custom_type_validator: None,
+            schema_types: Default::default(),
         }
     }
 

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -84,6 +84,7 @@ impl DiagnosticEngine {
                 }
                 Ok(())
             })),
+            schema_types: Default::default(),
         };
         Self {
             schemas,

--- a/carina-lsp/src/main.rs
+++ b/carina-lsp/src/main.rs
@@ -129,6 +129,7 @@ async fn main() {
             decryptor: None,
             validators: HashMap::new(),
             custom_type_validator: None,
+            schema_types: Default::default(),
         };
 
         // Pass factory builder callback — actual WASM loading happens asynchronously

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -24,6 +24,7 @@ impl TestClient {
                 decryptor: None,
                 validators: HashMap::new(),
                 custom_type_validator: None,
+                schema_types: Default::default(),
             };
             Backend::new(client, provider_context, None)
         });


### PR DESCRIPTION
Closes #2150. Part of #2143 (naming-conventions task 6/18).

## Summary

Resolve the `aws.ec2.Vpc` vs `awscc.ec2.VpcId` ambiguity. The old heuristic (3+ segments with PascalCase final → `SchemaType`) misrouted every resource kind with a PascalCase tail. The new rule consults a per-`ProviderContext` registry.

- 3+ segments, PascalCase tail, triple registered in `schema_types` → `TypeExpr::SchemaType`
- otherwise → `TypeExpr::Ref`

### API additions on `ProviderContext`

- `pub schema_types: HashSet<(String, String, String)>`
- `fn register_schema_type(provider, path, type_name)` — provider crates call this during setup
- `fn is_schema_type(provider, path, type_name) -> bool`

Thread `&ProviderContext` through `parse_type_expr` and all its callers (`parse_arguments_block`, `parse_attributes_block`, `parse_exports_block`, `parse_fn_def`, the `type_struct` field recursion).

### Behavior changes

Default registry is empty → without provider registration every PascalCase-tail path routes to `Ref`. Two existing schema-type tests (`parse_schema_type_in_arguments`, `parse_schema_type_list`) now register their types explicitly — mirroring how providers will register in Phase A (provider-aws #139, provider-awscc #148).

## Test plan

- [x] `cargo test -p carina-core --lib parse_three_segment_resource_path_is_ref` passes
- [x] `cargo test -p carina-core --lib parse_four_segment_path_with_pascal_tail_is_schema_type` passes
- [x] `cargo test` full workspace — all green (1321 carina-core lib tests, plus all integration tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Out of scope

- Provider Phase A (registering schema types in provider-aws / provider-awscc) — tracked separately.
- `TypeExpr::Ref` Display round-trip for 3-segment paths — task 7/18 (#2151).