### PR TITLE
parser: Ref Display round-trip test for 3-segment paths (7/18)

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -9058,6 +9058,16 @@ aws.s3.bucket {
     }
 
     #[test]
+    fn type_expr_ref_display_roundtrips_three_segment_path() {
+        let ty = TypeExpr::Ref(ResourceTypePath::new("aws", "ec2.Vpc"));
+        assert_eq!(ty.to_string(), "aws.ec2.Vpc");
+
+        let input = format!(r#"arguments {{ v: {} }}"#, ty);
+        let parsed = parse(&input, &ProviderContext::default()).unwrap();
+        assert_eq!(parsed.arguments[0].type_expr, ty);
+    }
+
+    #[test]
     fn parse_arguments_block_form_default_only() {
         let input = r#"
             arguments {


### PR DESCRIPTION
Closes #2151. Part of #2143 (naming-conventions task 7/18).

## Summary

Assert that `TypeExpr::Ref(ResourceTypePath::new("aws", "ec2.Vpc"))` renders to `"aws.ec2.Vpc"` via Display and parses back to an equal `TypeExpr::Ref` under a default `ProviderContext`. Verifies the Display impl and the task 6/18 parser changes agree — a regression here would indicate asymmetry between the two.

No code change required; the existing Display and parser already support this shape.

## Test plan

- [x] `cargo test -p carina-core --lib type_expr_ref_display_roundtrips_three_segment_path` passes
- [x] `cargo test -p carina-core` — 1322 passed, 0 failed
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean