### PR TITLE
validation: diagnostic errors use PascalCase types (9/18)

### DIFF
--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -2430,7 +2430,7 @@ mod tests {
             match v {
                 Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
                 Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
-                _ => Err("expected string".to_string()),
+                _ => Err("expected String".to_string()),
             }
         }
         let schema = ResourceSchema::new("test.r.mode_holder").attribute(

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -737,19 +737,24 @@ pub fn validate_type_expr_value(
             crate::parser::value_type_name(value)
         )),
         (TypeExpr::Bool, Value::String(s)) => Some(format!(
-            "expected bool, got string \"{}\". Use true or false.",
-            s
+            "expected {type_expr}, got string \"{s}\". Use true or false."
         )),
-        (TypeExpr::Int, Value::String(s)) => Some(format!("expected int, got string \"{}\".", s)),
-        (TypeExpr::Float, Value::String(s)) => {
-            Some(format!("expected float, got string \"{}\".", s))
+        (TypeExpr::Int, Value::String(s)) => {
+            Some(format!("expected {type_expr}, got string \"{s}\"."))
         }
-        (TypeExpr::String, Value::Bool(b)) => Some(format!("expected string, got bool ({}).", b)),
-        (TypeExpr::String, Value::Int(n)) => Some(format!("expected string, got int ({}).", n)),
-        (TypeExpr::String, Value::Float(f)) => Some(format!("expected string, got float ({}).", f)),
-        (TypeExpr::Bool, Value::Int(n)) => Some(format!("expected bool, got int ({}).", n)),
-        (TypeExpr::Int, Value::Bool(b)) => Some(format!("expected int, got bool ({}).", b)),
-        (TypeExpr::Float, Value::Bool(b)) => Some(format!("expected float, got bool ({}).", b)),
+        (TypeExpr::Float, Value::String(s)) => {
+            Some(format!("expected {type_expr}, got string \"{s}\"."))
+        }
+        (TypeExpr::String, Value::Bool(b)) => {
+            Some(format!("expected {type_expr}, got bool ({b})."))
+        }
+        (TypeExpr::String, Value::Int(n)) => Some(format!("expected {type_expr}, got int ({n}).")),
+        (TypeExpr::String, Value::Float(f)) => {
+            Some(format!("expected {type_expr}, got float ({f})."))
+        }
+        (TypeExpr::Bool, Value::Int(n)) => Some(format!("expected {type_expr}, got int ({n}).")),
+        (TypeExpr::Int, Value::Bool(b)) => Some(format!("expected {type_expr}, got bool ({b}).")),
+        (TypeExpr::Float, Value::Bool(b)) => Some(format!("expected {type_expr}, got bool ({b}).")),
         // Schema types are string subtypes — reject non-string values
         (TypeExpr::SchemaType { .. }, Value::Bool(b)) => {
             Some(format!("expected {}, got bool ({}).", type_expr, b))
@@ -1498,6 +1503,34 @@ let vpc = awscc.ec2.vpc {
     // --- validate_type_expr_value tests ---
 
     #[test]
+    fn validate_type_expr_value_error_uses_pascal_case() {
+        let msg = validate_type_expr_value(
+            &TypeExpr::String,
+            &Value::Int(42),
+            &ProviderContext::default(),
+        )
+        .expect("should error");
+        assert!(msg.contains("expected String"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_type_expr_struct_error_uses_pascal_case_in_field_type() {
+        let mut map = std::collections::HashMap::new();
+        map.insert("count".to_string(), Value::String("x".into()));
+        let fields = vec![("count".to_string(), TypeExpr::Int)];
+        let msg = validate_type_expr_value(
+            &TypeExpr::Struct { fields },
+            &Value::Map(map),
+            &ProviderContext::default(),
+        )
+        .expect("should error");
+        assert!(
+            msg.contains("field 'count'") && msg.contains("Int"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
     fn validate_type_expr_value_ipv4_cidr_valid() {
         let result = validate_type_expr_value(
             &TypeExpr::Simple("ipv4_cidr".to_string()),
@@ -1585,7 +1618,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected bool"));
+        assert!(result.unwrap().contains("expected Bool"));
     }
 
     #[test]
@@ -1596,7 +1629,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected int"));
+        assert!(result.unwrap().contains("expected Int"));
     }
 
     #[test]
@@ -1607,7 +1640,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected float"));
+        assert!(result.unwrap().contains("expected Float"));
     }
 
     #[test]
@@ -1643,7 +1676,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected string, got bool"));
+        assert!(result.unwrap().contains("expected String, got bool"));
     }
 
     #[test]
@@ -1654,7 +1687,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected string, got int"));
+        assert!(result.unwrap().contains("expected String, got int"));
     }
 
     #[test]
@@ -1665,7 +1698,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected string, got float"));
+        assert!(result.unwrap().contains("expected String, got float"));
     }
 
     #[test]
@@ -1673,7 +1706,7 @@ let vpc = awscc.ec2.vpc {
         let result =
             validate_type_expr_value(&TypeExpr::Bool, &Value::Int(1), &ProviderContext::default());
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected bool, got int"));
+        assert!(result.unwrap().contains("expected Bool, got int"));
     }
 
     #[test]
@@ -1684,7 +1717,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected int, got bool"));
+        assert!(result.unwrap().contains("expected Int, got bool"));
     }
 
     #[test]
@@ -1695,7 +1728,7 @@ let vpc = awscc.ec2.vpc {
             &ProviderContext::default(),
         );
         assert!(result.is_some());
-        assert!(result.unwrap().contains("expected float, got bool"));
+        assert!(result.unwrap().contains("expected Float, got bool"));
     }
 
     #[test]
@@ -2162,7 +2195,7 @@ let vpc = awscc.ec2.vpc {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.contains("export 'flag'"), "err={err}");
-        assert!(err.contains("expected bool"), "err={err}");
+        assert!(err.contains("expected Bool"), "err={err}");
     }
 
     #[test]

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -545,7 +545,7 @@ attributes {
 
     let type_diag = diagnostics
         .iter()
-        .find(|d| d.message.contains("expected string, got bool"));
+        .find(|d| d.message.contains("expected String, got bool"));
     assert!(
         type_diag.is_some(),
         "Should warn about type mismatch in attributes block (bool assigned to string). Got diagnostics: {:?}",
@@ -656,7 +656,7 @@ attributes {
 
     let type_diag = diagnostics
         .iter()
-        .find(|d| d.message.contains("expected string, got bool"));
+        .find(|d| d.message.contains("expected String, got bool"));
     assert!(
         type_diag.is_some(),
         "Output block detection should work with simplified condition. Got diagnostics: {:?}",
@@ -1770,11 +1770,11 @@ fn exports_type_warning_survives_formatter_round_trip() {
 
     let before_warning = before
         .iter()
-        .find(|d| d.message.contains("expected bool, got string"))
+        .find(|d| d.message.contains("expected Bool, got string"))
         .map(|d| d.message.clone());
     let after_warning = after
         .iter()
-        .find(|d| d.message.contains("expected bool, got string"))
+        .find(|d| d.message.contains("expected Bool, got string"))
         .map(|d| d.message.clone());
 
     assert_eq!(formatted, "exports {\n  values: list(bool) = ['nope']\n}\n");
@@ -1945,7 +1945,7 @@ fn exports_type_warning_for_literal_mismatch() {
     );
     let warning = diagnostics
         .iter()
-        .find(|d| d.message.contains("expected bool"));
+        .find(|d| d.message.contains("expected Bool"));
     assert!(
         warning.is_some(),
         "Should warn about bool vs string mismatch. Got: {:?}",


### PR DESCRIPTION
Closes #2153. Part of #2143 (naming-conventions task 9/18).

## Summary

Route the "expected TYPE" slot of `validate_type_expr_value` error messages through `TypeExpr::Display` instead of hand-rolled lowercase literals. After tasks 2-3/18, Display emits PascalCase, so the diagnostics now read "expected String, got bool" rather than "expected string, got bool".

### Files

- `carina-core/src/validation.rs`: 9 `format!` sites now use `{type_expr}` substitution.
- `carina-core/src/schema.rs`: test-helper validator's error string updated for consistency.
- `carina-lsp/src/diagnostics/tests/extended.rs`: downstream assertions updated to match the new casing.

`value_type_name` (the "got TYPE" slot) stays lowercase — it describes a runtime value category, not a declared type.

## Test plan

- [x] `cargo test -p carina-core --lib validate_type_expr_value_error_uses_pascal_case` passes
- [x] `cargo test -p carina-core --lib validate_type_expr_struct_error_uses_pascal_case_in_field_type` passes
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean