### PR TITLE
lsp: completion proposes PascalCase type labels (10/18)

### DIFF
--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -730,7 +730,7 @@ fn type_completion_includes_basic_types() {
     let completions = provider.complete(&doc, position, None);
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
-    for basic_type in &["string", "int", "bool", "float"] {
+    for basic_type in &["String", "Int", "Bool", "Float"] {
         assert!(
             labels.contains(basic_type),
             "Type completions should include '{}'. Got: {:?}",
@@ -742,15 +742,15 @@ fn type_completion_includes_basic_types() {
     // Basic types should have TYPE_PARAMETER kind
     let string_completion = completions
         .iter()
-        .find(|c| c.label == "string")
-        .expect("Should have 'string' completion");
+        .find(|c| c.label == "String")
+        .expect("Should have 'String' completion");
     assert_eq!(
         string_completion.kind,
         Some(CompletionItemKind::TYPE_PARAMETER)
     );
 
     // Built-in custom types should always appear (no provider needed)
-    for builtin_custom in &["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"] {
+    for builtin_custom in &["Ipv4Cidr", "Ipv4Address", "Ipv6Cidr", "Ipv6Address"] {
         assert!(
             labels.contains(builtin_custom),
             "Type completions should include built-in custom type '{}'. Got: {:?}",
@@ -758,6 +758,29 @@ fn type_completion_includes_basic_types() {
             labels
         );
     }
+}
+
+#[test]
+fn completion_at_type_position_proposes_pascal_case_primitives() {
+    let provider = test_provider();
+    let doc = create_document("arguments {\nx: ");
+    let position = Position {
+        line: 1,
+        character: 3,
+    };
+
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(labels.contains(&"String"), "got: {:?}", labels);
+    assert!(labels.contains(&"Int"), "got: {:?}", labels);
+    assert!(labels.contains(&"Bool"), "got: {:?}", labels);
+    assert!(labels.contains(&"Float"), "got: {:?}", labels);
+    assert!(
+        !labels.contains(&"string"),
+        "lowercase 'string' should no longer appear, got: {:?}",
+        labels
+    );
 }
 
 #[test]
@@ -798,18 +821,18 @@ fn type_completion_includes_custom_types() {
 
     // Custom types from provider validators should appear
     assert!(
-        labels.contains(&"arn"),
-        "Type completions should include 'arn'. Got: {:?}",
+        labels.contains(&"Arn"),
+        "Type completions should include 'Arn'. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"iam_policy_arn"),
-        "Type completions should include 'iam_policy_arn'. Got: {:?}",
+        labels.contains(&"IamPolicyArn"),
+        "Type completions should include 'IamPolicyArn'. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"availability_zone"),
-        "Type completions should include 'availability_zone'. Got: {:?}",
+        labels.contains(&"AvailabilityZone"),
+        "Type completions should include 'AvailabilityZone'. Got: {:?}",
         labels
     );
 }
@@ -827,7 +850,7 @@ fn type_completion_custom_types_inside_list() {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"iam_policy_arn"),
+        labels.contains(&"IamPolicyArn"),
         "Custom types should appear inside list(). Got: {:?}",
         labels
     );
@@ -994,8 +1017,8 @@ fn type_completion_inside_list_shows_basic_types() {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"string"),
-        "Type completions inside list() should include 'string'. Got: {:?}",
+        labels.contains(&"String"),
+        "Type completions inside list() should include 'String'. Got: {:?}",
         labels
     );
     assert!(
@@ -1018,13 +1041,13 @@ fn type_completion_inside_map_shows_basic_types() {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
     assert!(
-        labels.contains(&"string"),
-        "Type completions inside map() should include 'string'. Got: {:?}",
+        labels.contains(&"String"),
+        "Type completions inside map() should include 'String'. Got: {:?}",
         labels
     );
     assert!(
-        labels.contains(&"int"),
-        "Type completions inside map() should include 'int'. Got: {:?}",
+        labels.contains(&"Int"),
+        "Type completions inside map() should include 'Int'. Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -978,10 +978,10 @@ impl CompletionProvider {
 
         // Basic types
         let basic = [
-            ("string", "String type"),
-            ("int", "Integer type"),
-            ("bool", "Boolean type"),
-            ("float", "Float type"),
+            ("String", "String type"),
+            ("Int", "Integer type"),
+            ("Bool", "Boolean type"),
+            ("Float", "Float type"),
         ]
         .iter()
         .map(|(name, detail)| {
@@ -1003,7 +1003,8 @@ impl CompletionProvider {
             .collect()
         };
 
-        // Custom types: built-in types + provider-extracted types (deduplicated)
+        // Custom types: built-in types + provider-extracted types (deduplicated).
+        // Internal registry is snake_case; the LSP surface is PascalCase.
         let builtin_custom = ["ipv4_cidr", "ipv4_address", "ipv6_cidr", "ipv6_address"];
         let mut seen_custom = std::collections::HashSet::new();
         let custom: Vec<CompletionItem> = builtin_custom
@@ -1011,12 +1012,10 @@ impl CompletionProvider {
             .map(|s| s.to_string())
             .chain(self.custom_type_names.iter().cloned())
             .filter(|name| seen_custom.insert(name.clone()))
-            .map(|name| {
-                type_completion_item(
-                    name.clone(),
-                    format!("Custom type: {}", name),
-                    replacement_range,
-                )
+            .map(|snake| {
+                let label = snake_to_pascal(&snake);
+                let detail = format!("Custom type: {label}");
+                type_completion_item(label, detail, replacement_range)
             })
             .collect();
 


### PR DESCRIPTION
Closes #2154. Part of #2143 (naming-conventions task 10/18).

## Summary

In the type-annotation completion (`arguments { x: <HERE> }`), emit `String`/`Int`/`Bool`/`Float` instead of lowercase, and render custom types through `snake_to_pascal` before surfacing them as completion labels. The internal `custom_type_names` registry stays snake_case — only the user-facing label is converted.

Examples:

- primitives: `String`, `Int`, `Bool`, `Float`
- built-in custom: `Ipv4Cidr`, `Ipv4Address`, `Ipv6Cidr`, `Ipv6Address`
- provider-registered: `Arn`, `IamPolicyArn`, `AvailabilityZone`

Generic constructors (`list(`, `map(`) are unchanged — they're function-like constructors, not types.

Updates the existing completion-label assertions to expect the new casing.

## Out of scope

`carina-lsp/src/completion/top_level.rs::format_type_expr` (module-argument detail text) is a separate code path and stays lowercase for now. It can fold into `TypeExpr::Display` in a follow-up cleanup; not required by the A10 spec.

## Test plan

- [x] `cargo test -p carina-lsp --lib completion_at_type_position_proposes_pascal_case_primitives` passes
- [x] `cargo test -p carina-lsp --lib type_completion` — all green
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean