### PR TITLE
editors: tmLanguage paints PascalCase as type (12/18)

### DIFF
--- a/carina-core/tests/tmlanguage_keyword_parity.rs
+++ b/carina-core/tests/tmlanguage_keyword_parity.rs
@@ -110,6 +110,20 @@ fn tmbundle_grammar_matches_keywords() {
 }
 
 #[test]
+fn tmlanguage_has_pascal_case_type_pattern() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let vscode = fs::read_to_string(manifest_dir.join(VSCODE_GRAMMAR)).unwrap();
+    assert!(
+        vscode.contains("entity.name.type.carina"),
+        "tmLanguage must declare `entity.name.type.carina` scope"
+    );
+    assert!(
+        vscode.contains(r"\\b[A-Z][A-Za-z0-9]*\\b"),
+        "tmLanguage must include a PascalCase match pattern"
+    );
+}
+
+#[test]
 fn vscode_and_tmbundle_grammars_are_byte_identical() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let vscode = fs::read(manifest_dir.join(VSCODE_GRAMMAR))

--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -8,6 +8,7 @@
     { "include": "#keywords" },
     { "include": "#resource-types" },
     { "include": "#regions" },
+    { "include": "#types" },
     { "include": "#strings" },
     { "include": "#numbers" },
     { "include": "#booleans" },
@@ -62,6 +63,14 @@
         {
           "name": "constant.other.region.carina",
           "match": "\\baws\\.Region\\.[a-z][a-z0-9_]*\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "entity.name.type.carina",
+          "match": "\\b[A-Z][A-Za-z0-9]*\\b"
         }
       ]
     },

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -8,6 +8,7 @@
     { "include": "#keywords" },
     { "include": "#resource-types" },
     { "include": "#regions" },
+    { "include": "#types" },
     { "include": "#strings" },
     { "include": "#numbers" },
     { "include": "#booleans" },
@@ -62,6 +63,14 @@
         {
           "name": "constant.other.region.carina",
           "match": "\\baws\\.Region\\.[a-z][a-z0-9_]*\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "entity.name.type.carina",
+          "match": "\\b[A-Z][A-Za-z0-9]*\\b"
         }
       ]
     },


### PR DESCRIPTION
Closes #2156. Part of #2143 (naming-conventions task 12/18).

## Summary

Add a new `types` repository entry to both TextMate grammars. Bare PascalCase identifiers (`String`, `Int`, `AwsAccountId`) now paint under `entity.name.type.carina`, while dotted forms like `aws.s3.Bucket` keep matching the earlier `support.class.carina` (resource-types) pattern.

Both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` are updated byte-identically (enforced by the existing parity test). A new `tmlanguage_has_pascal_case_type_pattern` test asserts the scope and regex are present.

## Test plan

- [x] `cargo test -p carina-core --test tmlanguage_keyword_parity` — 4 passed (added `tmlanguage_has_pascal_case_type_pattern`)
- [x] `cargo test` full workspace — all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean