### PR TITLE
parser: close the naming-conventions transition window (Phase C)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -571,7 +571,7 @@ mod tests {
         fs::create_dir(&upstream_dir).unwrap();
         fs::write(
             upstream_dir.join("exports.crn"),
-            "exports { accounts: string = \"x\" }\n",
+            "exports { accounts: String = \"x\" }\n",
         )
         .unwrap();
         let base = tmp.path().join("downstream");
@@ -580,7 +580,7 @@ mod tests {
             base.join("main.crn"),
             r#"let orgs = upstream_state { source = "../organizations" }
 exports {
-    bad: string = orgs.missing
+    bad: String = orgs.missing
 }
 "#,
         )

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -732,7 +732,7 @@ mod run_plan_upstream_state_tests {
         fs::write(
             dir_a.join("main.crn"),
             r#"backend local { path = "carina.state.json" }
-exports { region: string = "ap-northeast-1" }"#,
+exports { region: String = "ap-northeast-1" }"#,
         )
         .unwrap();
 

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -131,7 +131,7 @@ macro_rules! register_builtins {
 
 register_builtins! {
     cidr_subnet(cidr_subnet::builtin_cidr_subnet, arity: 3) {
-        signature: "cidr_subnet(prefix: string, newbits: int, netnum: int) -> string",
+        signature: "cidr_subnet(prefix: String, newbits: Int, netnum: Int) -> String",
         description: "Calculates a subnet CIDR block within a given IP network address prefix.",
         return_type: BuiltinReturnType::String,
     },
@@ -141,12 +141,12 @@ register_builtins! {
         return_type: BuiltinReturnType::List,
     },
     decrypt(decrypt::builtin_decrypt, arity: 1) {
-        signature: "decrypt(ciphertext: string, key?: string) -> string",
+        signature: "decrypt(ciphertext: String, key?: String) -> String",
         description: "Decrypts ciphertext using the configured provider's encryption service (e.g., AWS KMS). Key is optional when embedded in ciphertext.",
         return_type: BuiltinReturnType::String,
     },
     env(env::builtin_env, arity: 1) {
-        signature: "env(name: string) -> string",
+        signature: "env(name: String) -> String",
         description: "Reads an environment variable. Errors if the variable is not set.",
         return_type: BuiltinReturnType::String,
     },
@@ -156,7 +156,7 @@ register_builtins! {
         return_type: BuiltinReturnType::List,
     },
     join(join::builtin_join, arity: 2) {
-        signature: "join(separator: string, list: list) -> string",
+        signature: "join(separator: String, list: list) -> String",
         description: "Joins list elements into a string using the separator.",
         return_type: BuiltinReturnType::String,
     },
@@ -166,57 +166,57 @@ register_builtins! {
         return_type: BuiltinReturnType::List,
     },
     length(length::builtin_length, arity: 1) {
-        signature: "length(value: list | map | string) -> int",
+        signature: "length(value: list | map | String) -> Int",
         description: "Returns the number of elements in a list or map, or characters in a string.",
         return_type: BuiltinReturnType::Int,
     },
     lookup(lookup::builtin_lookup, arity: 3) {
-        signature: "lookup(map: map, key: string, default: any) -> any",
+        signature: "lookup(map: map, key: String, default: Any) -> Any",
         description: "Looks up a key in a map, returning the default value if the key is not found.",
         return_type: BuiltinReturnType::Any,
     },
     lower(upper_lower::builtin_lower, arity: 1) {
-        signature: "lower(string: string) -> string",
+        signature: "lower(string: String) -> String",
         description: "Converts a string to lowercase.",
         return_type: BuiltinReturnType::String,
     },
     map(map::builtin_map, arity: 2) {
-        signature: "map(accessor: string, collection: list | map) -> list | map",
+        signature: "map(accessor: String, collection: list | map) -> list | map",
         description: "Extracts a field from each element. Use a dot-prefixed accessor (e.g., \".field_name\"). Pipe form: collection |> map(\".field\").",
         return_type: BuiltinReturnType::Any,
     },
     max(min_max::builtin_max, arity: 2) {
-        signature: "max(a: number, b: number) -> number",
+        signature: "max(a: Number, b: Number) -> Number",
         description: "Returns the maximum of two numbers.",
         return_type: BuiltinReturnType::Any,
     },
     min(min_max::builtin_min, arity: 2) {
-        signature: "min(a: number, b: number) -> number",
+        signature: "min(a: Number, b: Number) -> Number",
         description: "Returns the minimum of two numbers.",
         return_type: BuiltinReturnType::Any,
     },
     replace(replace::builtin_replace, arity: 3) {
-        signature: "replace(search: string, replacement: string, string: string) -> string",
-        description: "Replaces all occurrences of a search string. Data-last: string |> replace(search, replacement).",
+        signature: "replace(search: String, replacement: String, string: String) -> String",
+        description: "Replaces all occurrences of a search string. Data-last: String |> replace(search, replacement).",
         return_type: BuiltinReturnType::String,
     },
     secret(secret::builtin_secret, arity: 1) {
-        signature: "secret(value: any) -> secret",
+        signature: "secret(value: Any) -> Secret",
         description: "Marks a value as secret. The value is sent to the provider but stored only as a SHA256 hash in state.",
         return_type: BuiltinReturnType::Secret,
     },
     split(split::builtin_split, arity: 2) {
-        signature: "split(separator: string, string: string) -> list",
+        signature: "split(separator: String, string: String) -> list",
         description: "Splits a string into a list using the separator.",
         return_type: BuiltinReturnType::List,
     },
     trim(trim::builtin_trim, arity: 1) {
-        signature: "trim(string: string) -> string",
+        signature: "trim(string: String) -> String",
         description: "Removes leading and trailing whitespace from a string.",
         return_type: BuiltinReturnType::String,
     },
     upper(upper_lower::builtin_upper, arity: 1) {
-        signature: "upper(string: string) -> string",
+        signature: "upper(string: String) -> String",
         description: "Converts a string to uppercase.",
         return_type: BuiltinReturnType::String,
     },

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -2109,10 +2109,10 @@ mod tests {
 
     #[test]
     fn test_format_struct_type_canonical_spacing() {
-        let input = "attributes {\n  config: struct{a:int,b:string} = { a = 1, b = 'x' }\n}\n";
+        let input = "attributes {\n  config: struct{a: Int,b: String} = { a = 1, b = 'x' }\n}\n";
         let result = format(input, &FormatConfig::default()).unwrap();
         assert!(
-            result.contains("struct { a: int, b: string }"),
+            result.contains("struct { a: Int, b: String }"),
             "expected canonical struct spacing, got:\n{result}"
         );
     }
@@ -2130,25 +2130,25 @@ mod tests {
     #[test]
     fn test_format_struct_type_nested_in_list_and_map() {
         let input =
-            "attributes {\n  xs: list(struct{a:int}) = []\n  m: map(struct{b:string}) = {}\n}\n";
+            "attributes {\n  xs: list(struct{a: Int}) = []\n  m: map(struct{b: String}) = {}\n}\n";
         let result = format(input, &FormatConfig::default()).unwrap();
         assert!(
-            result.contains("list(struct { a: int })"),
-            "expected list(struct {{ a: int }}), got:\n{result}"
+            result.contains("list(struct { a: Int })"),
+            "expected list(struct {{ a: Int }}), got:\n{result}"
         );
         assert!(
-            result.contains("map(struct { b: string })"),
-            "expected map(struct {{ b: string }}), got:\n{result}"
+            result.contains("map(struct { b: String })"),
+            "expected map(struct {{ b: String }}), got:\n{result}"
         );
     }
 
     #[test]
     fn test_format_struct_type_field_is_itself_struct() {
         let input =
-            "attributes {\n  outer: struct{inner:struct{x:int}} = { inner = { x = 1 } }\n}\n";
+            "attributes {\n  outer: struct{inner:struct{x: Int}} = { inner = { x = 1 } }\n}\n";
         let result = format(input, &FormatConfig::default()).unwrap();
         assert!(
-            result.contains("struct { inner: struct { x: int } }"),
+            result.contains("struct { inner: struct { x: Int } }"),
             "expected nested struct spacing, got:\n{result}"
         );
     }
@@ -2808,7 +2808,7 @@ mod tests {
   vpc: awscc.ec2.Vpc {
     description = "The VPC to deploy into"
   }
-  port: int {
+  port: Int {
     description = "Web server port"
     default     = 8080
   }
@@ -2816,18 +2816,18 @@ mod tests {
 "#;
         let config = FormatConfig::default();
         let result = format(input, &config).unwrap();
-        let expected = "arguments {\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC to deploy into'\n  }\n  port: int {\n    description = 'Web server port'\n    default     = 8080\n  }\n}\n";
+        let expected = "arguments {\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC to deploy into'\n  }\n  port: Int {\n    description = 'Web server port'\n    default     = 8080\n  }\n}\n";
         assert_eq!(result, expected);
     }
 
     #[test]
     fn format_arguments_mixed_simple_and_block_form() {
         let input = r#"arguments {
-  enable_https: bool = true
+  enable_https: Bool = true
   vpc: awscc.ec2.Vpc {
     description = "The VPC to deploy into"
   }
-  port: int {
+  port: Int {
     description = "Web server port"
     default     = 8080
   }
@@ -2835,7 +2835,7 @@ mod tests {
 "#;
         let config = FormatConfig::default();
         let result = format(input, &config).unwrap();
-        let expected = "arguments {\n  enable_https: bool = true\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC to deploy into'\n  }\n  port: int {\n    description = 'Web server port'\n    default     = 8080\n  }\n}\n";
+        let expected = "arguments {\n  enable_https: Bool = true\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC to deploy into'\n  }\n  port: Int {\n    description = 'Web server port'\n    default     = 8080\n  }\n}\n";
         assert_eq!(result, expected);
     }
 
@@ -2845,7 +2845,7 @@ mod tests {
   vpc: awscc.ec2.Vpc {
     description = "The VPC"
   }
-  port: int {
+  port: Int {
     description = "Port"
     default     = 8080
   }
@@ -2860,8 +2860,8 @@ mod tests {
     #[test]
     fn format_arguments_mixed_with_alignment() {
         let input = r#"arguments {
-  short: bool = true
-  longer_name: string = "hello"
+  short: Bool = true
+  longer_name: String = "hello"
   vpc: awscc.ec2.Vpc {
     description = "The VPC"
   }
@@ -2871,7 +2871,7 @@ mod tests {
             align_attributes: true,
             ..Default::default()
         };
-        let expected = "arguments {\n  short      : bool = true\n  longer_name: string = 'hello'\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC'\n  }\n}\n";
+        let expected = "arguments {\n  short      : Bool = true\n  longer_name: String = 'hello'\n  vpc: awscc.ec2.Vpc {\n    description = 'The VPC'\n  }\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2880,7 +2880,7 @@ mod tests {
     #[ignore] // TODO: formatter doesn't handle validation { ... } block yet
     fn format_arguments_block_form_with_validation_block() {
         let input = r#"arguments {
-  port: int {
+  port: Int {
     description = "Web server port"
     default     = 8080
     validation {
@@ -2925,8 +2925,8 @@ mod tests {
     #[test]
     fn format_fn_def_with_typed_params() {
         let config = FormatConfig::default();
-        let input = "fn greet(name:string) {\n  name\n}\n";
-        let expected = "fn greet(name: string) {\n  name\n}\n";
+        let input = "fn greet(name:String) {\n  name\n}\n";
+        let expected = "fn greet(name: String) {\n  name\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2935,9 +2935,9 @@ mod tests {
     fn format_fn_def_with_typed_param_and_default() {
         let config = FormatConfig::default();
         let input =
-            "fn tag(env:string,suffix:string=\"default\") {\n  join(\"-\", [env, suffix])\n}\n";
+            "fn tag(env:String,suffix:String=\"default\") {\n  join(\"-\", [env, suffix])\n}\n";
         let expected =
-            "fn tag(env: string, suffix: string = 'default') {\n  join('-', [env, suffix])\n}\n";
+            "fn tag(env: String, suffix: String = 'default') {\n  join('-', [env, suffix])\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2945,8 +2945,8 @@ mod tests {
     #[test]
     fn format_fn_def_with_resource_type_param() {
         let config = FormatConfig::default();
-        let input = "fn make(vpc:awscc.ec2.Vpc,cidr:string) {\n  vpc\n}\n";
-        let expected = "fn make(vpc: awscc.ec2.Vpc, cidr: string) {\n  vpc\n}\n";
+        let input = "fn make(vpc:awscc.ec2.Vpc,cidr:String) {\n  vpc\n}\n";
+        let expected = "fn make(vpc: awscc.ec2.Vpc, cidr: String) {\n  vpc\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2954,8 +2954,8 @@ mod tests {
     #[test]
     fn format_fn_def_mixed_typed_untyped() {
         let config = FormatConfig::default();
-        let input = "fn tag(env,suffix:string) {\n  suffix\n}\n";
-        let expected = "fn tag(env, suffix: string) {\n  suffix\n}\n";
+        let input = "fn tag(env,suffix:String) {\n  suffix\n}\n";
+        let expected = "fn tag(env, suffix: String) {\n  suffix\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2963,8 +2963,8 @@ mod tests {
     #[test]
     fn format_fn_def_with_return_type() {
         let config = FormatConfig::default();
-        let input = "fn greet(name:string):string {\n  name\n}\n";
-        let expected = "fn greet(name: string): string {\n  name\n}\n";
+        let input = "fn greet(name:String):String {\n  name\n}\n";
+        let expected = "fn greet(name: String): String {\n  name\n}\n";
         let result = format(input, &config).unwrap();
         assert_eq!(result, expected);
     }
@@ -2991,26 +2991,26 @@ mod tests {
     fn format_custom_schema_type_annotations() {
         let config = FormatConfig::default();
 
-        // Custom type in arguments block
-        let input = "arguments {\nvpc_cidr: cidr\nserver_ip: ipv4_address\n}\n";
+        // Custom type in arguments block — PascalCase per Strategy Y.
+        let input = "arguments {\nvpc_cidr: Cidr\nserver_ip: Ipv4Address\n}\n";
         let result = format(input, &config).unwrap();
         assert!(
-            result.contains("vpc_cidr") && result.contains("cidr"),
-            "Expected 'vpc_cidr' and 'cidr' in:\n{}",
+            result.contains("vpc_cidr") && result.contains("Cidr"),
+            "Expected 'vpc_cidr' and 'Cidr' in:\n{}",
             result
         );
         assert!(
-            result.contains("server_ip") && result.contains("ipv4_address"),
-            "Expected 'server_ip' and 'ipv4_address' in:\n{}",
+            result.contains("server_ip") && result.contains("Ipv4Address"),
+            "Expected 'server_ip' and 'Ipv4Address' in:\n{}",
             result
         );
 
         // Custom type in fn param
-        let input = "fn f(addr: arn) {\n  addr\n}\n";
+        let input = "fn f(addr: Arn) {\n  addr\n}\n";
         let result = format(input, &config).unwrap();
         assert!(
-            result.contains("addr: arn"),
-            "Expected 'addr: arn' in:\n{}",
+            result.contains("addr: Arn"),
+            "Expected 'addr: Arn' in:\n{}",
             result
         );
     }
@@ -3018,7 +3018,7 @@ mod tests {
     #[test]
     fn test_format_require_statement() {
         let input = r#"arguments {
-  port: int
+  port: Int
 }
 require   port >= 1 && port <= 65535  , "port must be valid"
 "#;

--- a/carina-core/src/lint.rs
+++ b/carina-core/src/lint.rs
@@ -783,7 +783,7 @@ let e = replace("old", "new", str)
         // `map(aws_account_id)` in a type position is a type annotation, not a
         // function call. Should not trigger pipe-form warning.
         let source = r#"exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     prod = x.y
   }
 }"#;
@@ -798,7 +798,7 @@ let e = replace("old", "new", str)
     #[test]
     fn test_pipe_preferred_type_annotation_list_no_warning() {
         let source = r#"attributes {
-  items: list(string) = ["a", "b"]
+  items: list(String) = ["a", "b"]
 }"#;
         let results = find_pipe_preferred_direct_calls(source);
         // `list` is not in PIPE_PREFERRED_FUNCTIONS, but ensure no regression

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -1261,7 +1261,7 @@ mod tests {
         let input = r#"
             arguments {
                 vpc: aws.vpc
-                enable_https: bool = true
+                enable_https: Bool = true
             }
 
             attributes {
@@ -1306,20 +1306,20 @@ mod tests {
 
         let input = r#"
             arguments {
-                enable_https: bool = true
+                enable_https: Bool = true
 
-                vpc_id: string {
+                vpc_id: String {
                     description = "The VPC to deploy into"
                 }
 
-                port: int {
+                port: Int {
                     description = "Web server port"
                     default     = 8080
                 }
             }
 
             attributes {
-                sg_id: string = web_sg.id
+                sg_id: String = web_sg.id
             }
 
             let web_sg = aws.security_group {
@@ -1405,7 +1405,7 @@ mod tests {
         let input = r#"
             arguments {
                 vpc: aws.vpc
-                enable_https: bool = true
+                enable_https: Bool = true
             }
 
             attributes {

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -1794,7 +1794,7 @@ mod tests {
         let tmp_root = std::env::temp_dir().join("carina_test_module_rejects_file");
         let _ = fs::remove_dir_all(&tmp_root);
         fs::create_dir_all(&tmp_root).unwrap();
-        fs::write(tmp_root.join("single.crn"), "arguments {\n  x: string\n}\n").unwrap();
+        fs::write(tmp_root.join("single.crn"), "arguments {\n  x: String\n}\n").unwrap();
 
         let mut resolver = ModuleResolver::new(&tmp_root);
         let err = resolver
@@ -2680,7 +2680,7 @@ mod tests {
         fs::write(tmp_dir.join("main.crn"), "# main module file\n").unwrap();
         fs::write(
             tmp_dir.join("arguments.crn"),
-            "arguments {\n  env: string\n}\n",
+            "arguments {\n  env: String\n}\n",
         )
         .unwrap();
         fs::write(
@@ -2718,11 +2718,11 @@ mod tests {
         fs::create_dir_all(&tmp_dir).unwrap();
 
         // Create files out of lexicographic order to make the sort observable.
-        fs::write(tmp_dir.join("z_last.crn"), "arguments {\n  c: string\n}\n").unwrap();
-        fs::write(tmp_dir.join("a_first.crn"), "arguments {\n  a: string\n}\n").unwrap();
+        fs::write(tmp_dir.join("z_last.crn"), "arguments {\n  c: String\n}\n").unwrap();
+        fs::write(tmp_dir.join("a_first.crn"), "arguments {\n  a: String\n}\n").unwrap();
         fs::write(
             tmp_dir.join("m_middle.crn"),
-            "arguments {\n  b: string\n}\n",
+            "arguments {\n  b: String\n}\n",
         )
         .unwrap();
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1517,46 +1517,37 @@ fn parse_type_expr(
     config: &ProviderContext,
     warnings: &mut Vec<ParseWarning>,
 ) -> Result<TypeExpr, ParseError> {
+    let _ = warnings;
     let inner = first_inner(pair, "type", "type expression")?;
     match inner.as_rule() {
         Rule::type_simple => {
             let line = inner.as_span().start_pos().line_col().0;
             let text = inner.as_str();
-            let mut warn_deprecated = |new: &str| {
-                warnings.push(ParseWarning {
-                    file: None,
-                    line,
-                    message: format!("deprecated type spelling '{text}'; use '{new}' instead"),
-                });
-            };
             match text {
                 "String" => Ok(TypeExpr::String),
-                "string" => {
-                    warn_deprecated("String");
-                    Ok(TypeExpr::String)
-                }
                 "Bool" => Ok(TypeExpr::Bool),
-                "bool" => {
-                    warn_deprecated("Bool");
-                    Ok(TypeExpr::Bool)
-                }
                 "Int" => Ok(TypeExpr::Int),
-                "int" => {
-                    warn_deprecated("Int");
-                    Ok(TypeExpr::Int)
-                }
                 "Float" => Ok(TypeExpr::Float),
-                "float" => {
-                    warn_deprecated("Float");
-                    Ok(TypeExpr::Float)
-                }
+                // Phase C: the transition window for snake_case primitives
+                // and custom types has closed. The parser accepts only
+                // PascalCase type names (naming-conventions design D1).
+                "string" | "bool" | "int" | "float" => Err(ParseError::InvalidExpression {
+                    line,
+                    message: format!(
+                        "unknown type '{text}'; primitive types are PascalCase — use '{}' instead",
+                        snake_to_pascal(text)
+                    ),
+                }),
                 other if other.chars().next().is_some_and(|c| c.is_ascii_uppercase()) => {
                     Ok(TypeExpr::Simple(pascal_to_snake(other)))
                 }
-                other => {
-                    warn_deprecated(&snake_to_pascal(other));
-                    Ok(TypeExpr::Simple(other.to_string()))
-                }
+                other => Err(ParseError::InvalidExpression {
+                    line,
+                    message: format!(
+                        "unknown type '{other}'; custom types are PascalCase — use '{}' instead",
+                        snake_to_pascal(other)
+                    ),
+                }),
             }
         }
         Rule::type_generic => {
@@ -5643,12 +5634,12 @@ mod tests {
     fn parse_directory_module() {
         let input = r#"
             arguments {
-                vpc_id: string
-                enable_https: bool = true
+                vpc_id: String
+                enable_https: Bool = true
             }
 
             attributes {
-                sg_id: string = web_sg.id
+                sg_id: String = web_sg.id
             }
 
             let web_sg = aws.security_group {
@@ -5703,13 +5694,13 @@ mod tests {
     fn parse_generic_type_expressions() {
         let input = r#"
             arguments {
-                ports: list(int)
-                tags: map(string)
-                cidrs: list(string)
+                ports: list(Int)
+                tags: map(String)
+                cidrs: list(String)
             }
 
             attributes {
-                result: list(string) = items.ids
+                result: list(String) = items.ids
             }
 
             let items = aws.item {
@@ -5743,7 +5734,7 @@ mod tests {
         let input = r#"
             arguments {
                 vpc: aws.vpc
-                enable_https: bool = true
+                enable_https: Bool = true
             }
 
             attributes {
@@ -5786,7 +5777,7 @@ mod tests {
             }
 
             attributes {
-                out: string = sg.name
+                out: String = sg.name
             }
         "#;
 
@@ -5810,8 +5801,8 @@ mod tests {
         let input = r#"
             exports {
                 accounts: struct {
-                    registry_prod: aws_account_id,
-                    registry_dev:  aws_account_id,
+                    registry_prod: AwsAccountId,
+                    registry_dev: AwsAccountId,
                 } = {
                     registry_prod = "111111111111"
                     registry_dev  = "222222222222"
@@ -5842,8 +5833,8 @@ mod tests {
     fn parse_struct_type_nested_in_list_and_map() {
         let input = r#"
             arguments {
-                items: list(struct { name: string, value: int })
-                registry: map(struct { arn: string, id: string })
+                items: list(struct { name: String, value: Int })
+                registry: map(struct { arn: String, id: String })
             }
         "#;
 
@@ -5872,7 +5863,7 @@ mod tests {
     fn parse_struct_type_rejects_duplicate_field_name() {
         let input = r#"
             exports {
-                x: struct { a: string, a: int } = { a = "hi" }
+                x: struct { a: String, a: Int } = { a = "hi" }
             }
         "#;
         let err = parse(input, &ProviderContext::default()).unwrap_err();
@@ -5936,7 +5927,7 @@ mod tests {
             attributes {
                 vpc_id: awscc.ec2.VpcId = vpc.vpc_id
                 security_group = sg.id
-                subnet_ids: list(string) = subnets.ids
+                subnet_ids: list(String) = subnets.ids
             }
 
             let vpc = awscc.ec2.Vpc {
@@ -7485,9 +7476,9 @@ aws.s3.Bucket {
     fn resolve_resource_refs_with_argument_parameters() {
         let input = r#"
             arguments {
-                cidr_block: string
-                subnet_cidr: string
-                az: string
+                cidr_block: String
+                subnet_cidr: String
+                az: String
             }
 
             let vpc = awscc.ec2.Vpc {
@@ -8928,7 +8919,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_description_and_default() {
         let input = r#"
             arguments {
-                port: int {
+                port: Int {
                     description = "Web server port"
                     default     = 8080
                 }
@@ -8950,13 +8941,13 @@ aws.s3.Bucket {
     fn parse_arguments_mixed_simple_and_block_form() {
         let input = r#"
             arguments {
-                enable_https: bool = true
+                enable_https: Bool = true
 
                 vpc: awscc.ec2.Vpc {
                     description = "The VPC to deploy into"
                 }
 
-                port: int {
+                port: Int {
                     description = "Web server port"
                     default     = 8080
                 }
@@ -8998,8 +8989,8 @@ aws.s3.Bucket {
     fn parse_arguments_simple_form_has_no_description() {
         let input = r#"
             arguments {
-                vpc_id: string
-                port: int = 8080
+                vpc_id: String
+                port: Int = 8080
             }
         "#;
 
@@ -9030,10 +9021,10 @@ aws.s3.Bucket {
     fn parse_still_accepts_lowercase_primitives_during_transition() {
         let input = r#"
             arguments {
-                a: string
-                b: int
-                c: bool
-                d: float
+                a: String
+                b: Int
+                c: Bool
+                d: Float
             }
         "#;
         let result = parse(input, &ProviderContext::default()).unwrap();
@@ -9119,31 +9110,27 @@ aws.s3.Bucket {
     }
 
     #[test]
-    fn parser_warns_on_lowercase_primitive() {
-        let input = r#"arguments { a: string }"#;
-        let result = parse(input, &ProviderContext::default()).unwrap();
+    fn parser_rejects_lowercase_primitive_after_phase_c() {
+        // Intentionally uses the old snake_case spelling to verify Phase C
+        // rejection, so the type annotation below must NOT be mechanically
+        // rewritten to PascalCase.
+        let input = "arguments { a: string }";
+        let err = parse(input, &ProviderContext::default()).unwrap_err();
+        let msg = format!("{err}");
         assert!(
-            result
-                .warnings
-                .iter()
-                .any(|w| w.message.contains("deprecated type spelling 'string'")
-                    && w.message.contains("'String'")),
-            "expected deprecation warning, got {:?}",
-            result.warnings
+            msg.contains("unknown type 'string'") && msg.contains("'String'"),
+            "expected rejection with hint pointing at 'String', got: {msg}"
         );
     }
 
     #[test]
-    fn parser_warns_on_snake_case_custom_type() {
-        let input = r#"arguments { a: aws_account_id }"#;
-        let result = parse(input, &ProviderContext::default()).unwrap();
+    fn parser_rejects_snake_case_custom_type_after_phase_c() {
+        let input = "arguments { a: aws_account_id }";
+        let err = parse(input, &ProviderContext::default()).unwrap_err();
+        let msg = format!("{err}");
         assert!(
-            result.warnings.iter().any(|w| w
-                .message
-                .contains("deprecated type spelling 'aws_account_id'")
-                && w.message.contains("'AwsAccountId'")),
-            "expected deprecation warning, got {:?}",
-            result.warnings
+            msg.contains("unknown type 'aws_account_id'") && msg.contains("'AwsAccountId'"),
+            "expected rejection with hint pointing at 'AwsAccountId', got: {msg}"
         );
     }
 
@@ -9170,7 +9157,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_default_only() {
         let input = r#"
             arguments {
-                port: int {
+                port: Int {
                     default = 8080
                 }
             }
@@ -9187,7 +9174,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_empty_block() {
         let input = r#"
             arguments {
-                port: int {}
+                port: Int {}
             }
         "#;
 
@@ -9202,7 +9189,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_string_default_not_confused_with_description() {
         let input = r#"
             arguments {
-                name: string {
+                name: String {
                     description = "Name of the resource"
                     default     = "my-resource"
                 }
@@ -9227,7 +9214,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_validation_block() {
         let input = r#"
             arguments {
-                port: int {
+                port: Int {
                     description = "Web server port"
                     default     = 8080
                     validation {
@@ -9280,7 +9267,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_validate_no_description() {
         let input = r#"
             arguments {
-                count: int {
+                count: Int {
                     validation {
                         condition = count > 0
                     }
@@ -9301,7 +9288,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_validate_with_not() {
         let input = r#"
             arguments {
-                enabled: bool {
+                enabled: Bool {
                     validation {
                         condition = !enabled == false
                     }
@@ -9317,7 +9304,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_validate_with_or() {
         let input = r#"
             arguments {
-                port: int {
+                port: Int {
                     validation {
                         condition   = port == 80 || port == 443
                         error_message = "Port must be 80 or 443"
@@ -9337,7 +9324,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_validate_with_len() {
         let input = r#"
             arguments {
-                name: string {
+                name: String {
                     validation {
                         condition   = len(name) >= 1 && len(name) <= 64
                         error_message = "Name must be between 1 and 64 characters"
@@ -9358,7 +9345,7 @@ aws.s3.Bucket {
     fn parse_arguments_block_form_multiple_validation_blocks() {
         let input = r#"
             arguments {
-                port: int {
+                port: Int {
                     validation {
                         condition   = port >= 1
                         error_message = "Port must be positive"
@@ -9770,7 +9757,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_typed_param_string() {
         let input = r#"
-            fn greet(name: string) {
+            fn greet(name: String) {
                 join(" ", ["hello", name])
             }
 
@@ -9790,7 +9777,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_typed_param_type_mismatch() {
         let input = r#"
-            fn greet(name: string) {
+            fn greet(name: String) {
                 name
             }
 
@@ -9810,7 +9797,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_typed_param_int() {
         let input = r#"
-            fn double(x: int) {
+            fn double(x: Int) {
                 x
             }
 
@@ -9830,7 +9817,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_typed_param_with_default() {
         let input = r#"
-            fn tag(env: string, suffix: string = "default") {
+            fn tag(env: String, suffix: String = "default") {
                 join("-", [env, suffix])
             }
 
@@ -9849,7 +9836,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_mixed_typed_and_untyped() {
         let input = r#"
-            fn tag(env, suffix: string) {
+            fn tag(env, suffix: String) {
                 join("-", [env, suffix])
             }
 
@@ -9868,7 +9855,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_typed_param_bool_mismatch() {
         let input = r#"
-            fn check(flag: bool) {
+            fn check(flag: Bool) {
                 flag
             }
 
@@ -9888,7 +9875,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_param_type_stored_in_parsed_file() {
         let input = r#"
-            fn greet(name: string, count: int) {
+            fn greet(name: String, count: Int) {
                 name
             }
         "#;
@@ -9915,7 +9902,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_return_type_string() {
         let input = r#"
-            fn greet(name: string): string {
+            fn greet(name: String): String {
                 name
             }
 
@@ -9945,7 +9932,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_return_type_mismatch_value() {
         let input = r#"
-            fn bad(): string {
+            fn bad(): String {
                 42
             }
 
@@ -9966,7 +9953,7 @@ aws.s3.Bucket {
     fn parse_custom_schema_type_in_fn_param() {
         // Custom schema types like ipv4_cidr, ipv4_address, arn should be accepted as type annotations
         let input = r#"
-            fn format_cidr(cidr_block: ipv4_cidr) {
+            fn format_cidr(cidr_block: Ipv4Cidr) {
                 cidr_block
             }
         "#;
@@ -9982,7 +9969,7 @@ aws.s3.Bucket {
     #[test]
     fn parse_ipv4_address_type_in_fn_param() {
         let input = r#"
-            fn f(addr: ipv4_address) {
+            fn f(addr: Ipv4Address) {
                 addr
             }
         "#;
@@ -9997,7 +9984,7 @@ aws.s3.Bucket {
     #[test]
     fn parse_arn_type_in_fn_param() {
         let input = r#"
-            fn f(role: arn) {
+            fn f(role: Arn) {
                 role
             }
         "#;
@@ -10012,7 +9999,7 @@ aws.s3.Bucket {
     #[test]
     fn parse_custom_type_in_list_generic() {
         let input = r#"
-            fn f(cidrs: list(ipv4_cidr)) {
+            fn f(cidrs: list(Ipv4Cidr)) {
                 cidrs
             }
         "#;
@@ -10030,8 +10017,8 @@ aws.s3.Bucket {
     fn parse_custom_type_in_module_arguments() {
         let input = r#"
             arguments {
-                vpc_cidr: ipv4_cidr
-                server_ip: ipv4_address
+                vpc_cidr: Ipv4Cidr
+                server_ip: Ipv4Address
             }
 
             awscc.ec2.Vpc {
@@ -10056,7 +10043,7 @@ aws.s3.Bucket {
     fn parse_custom_type_in_attributes() {
         let input = r#"
             attributes {
-                block: ipv4_cidr = vpc.cidr_block
+                block: Ipv4Cidr = vpc.cidr_block
             }
 
             let vpc = awscc.ec2.Vpc {
@@ -10102,7 +10089,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_cidr_arg_valid() {
         let input = r#"
-            fn f(x: ipv4_cidr) { x }
+            fn f(x: Ipv4Cidr) { x }
 
             let b = aws.s3_bucket {
                 name = f("10.0.0.0/16")
@@ -10115,7 +10102,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_cidr_arg_invalid() {
         let input = r#"
-            fn f(x: ipv4_cidr) { x }
+            fn f(x: Ipv4Cidr) { x }
 
             let b = aws.s3_bucket {
                 name = f("invalid")
@@ -10132,7 +10119,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv4_address_arg_valid() {
         let input = r#"
-            fn f(x: ipv4_address) { x }
+            fn f(x: Ipv4Address) { x }
 
             let b = aws.s3_bucket {
                 name = f("10.0.0.1")
@@ -10145,7 +10132,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv4_address_arg_invalid() {
         let input = r#"
-            fn f(x: ipv4_address) { x }
+            fn f(x: Ipv4Address) { x }
 
             let b = aws.s3_bucket {
                 name = f("invalid")
@@ -10162,7 +10149,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv6_cidr_arg_valid() {
         let input = r#"
-            fn f(x: ipv6_cidr) { x }
+            fn f(x: Ipv6Cidr) { x }
 
             let b = aws.s3_bucket {
                 name = f("2001:db8::/32")
@@ -10175,7 +10162,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv6_cidr_arg_invalid() {
         let input = r#"
-            fn f(x: ipv6_cidr) { x }
+            fn f(x: Ipv6Cidr) { x }
 
             let b = aws.s3_bucket {
                 name = f("invalid")
@@ -10192,7 +10179,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv6_address_arg_valid() {
         let input = r#"
-            fn f(x: ipv6_address) { x }
+            fn f(x: Ipv6Address) { x }
 
             let b = aws.s3_bucket {
                 name = f("2001:db8::1")
@@ -10205,7 +10192,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_ipv6_address_arg_invalid() {
         let input = r#"
-            fn f(x: ipv6_address) { x }
+            fn f(x: Ipv6Address) { x }
 
             let b = aws.s3_bucket {
                 name = f("invalid")
@@ -10223,7 +10210,7 @@ aws.s3.Bucket {
     fn user_fn_custom_type_arn_arg_accepts_string() {
         // arn format varies too much, just accept any string
         let input = r#"
-            fn f(x: arn) { x }
+            fn f(x: Arn) { x }
 
             let b = aws.s3_bucket {
                 name = f("arn:aws:s3:::my-bucket")
@@ -10237,7 +10224,7 @@ aws.s3.Bucket {
     fn user_fn_custom_type_arg_resource_ref_skipped() {
         // ResourceRef values should be accepted (resolved later)
         let input = r#"
-            fn f(x: ipv4_cidr) { x }
+            fn f(x: Ipv4Cidr) { x }
 
             let vpc = awscc.ec2.Vpc {
                 cidr_block = "10.0.0.0/16"
@@ -10256,7 +10243,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_return_cidr_valid() {
         let input = r#"
-            fn f(): ipv4_cidr { "10.0.0.0/16" }
+            fn f(): Ipv4Cidr { "10.0.0.0/16" }
 
             let b = aws.s3_bucket {
                 name = f()
@@ -10269,7 +10256,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_return_cidr_invalid() {
         let input = r#"
-            fn f(): ipv4_cidr { "invalid" }
+            fn f(): Ipv4Cidr { "invalid" }
 
             let b = aws.s3_bucket {
                 name = f()
@@ -10286,7 +10273,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_return_ipv4_address_invalid() {
         let input = r#"
-            fn f(): ipv4_address { "invalid" }
+            fn f(): Ipv4Address { "invalid" }
 
             let b = aws.s3_bucket {
                 name = f()
@@ -10303,7 +10290,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_return_ipv6_cidr_invalid() {
         let input = r#"
-            fn f(): ipv6_cidr { "invalid" }
+            fn f(): Ipv6Cidr { "invalid" }
 
             let b = aws.s3_bucket {
                 name = f()
@@ -10320,7 +10307,7 @@ aws.s3.Bucket {
     #[test]
     fn user_fn_custom_type_return_ipv6_address_invalid() {
         let input = r#"
-            fn f(): ipv6_address { "invalid" }
+            fn f(): Ipv6Address { "invalid" }
 
             let b = aws.s3_bucket {
                 name = f()
@@ -10614,8 +10601,8 @@ arguments {
     fn test_parse_require_statement() {
         let input = r#"
             arguments {
-                enable_https: bool = true
-                has_cert: bool = false
+                enable_https: Bool = true
+                has_cert: Bool = false
             }
             require !enable_https || has_cert, "cert is required when HTTPS is enabled"
         "#;
@@ -10636,7 +10623,7 @@ arguments {
     fn test_parse_require_with_len_function() {
         let input = r#"
             arguments {
-                subnet_ids: list(string)
+                subnet_ids: list(String)
             }
             require len(subnet_ids) >= 2, "ALB requires at least two subnets"
         "#;
@@ -10662,7 +10649,7 @@ arguments {
     fn test_parse_require_with_null() {
         let input = r#"
             arguments {
-                cert_arn: string = "default"
+                cert_arn: String = "default"
             }
             require cert_arn != null, "cert_arn must not be null"
         "#;
@@ -10682,9 +10669,9 @@ arguments {
     fn test_parse_multiple_require_statements() {
         let input = r#"
             arguments {
-                min_size: int
-                max_size: int
-                subnet_ids: list(string)
+                min_size: Int
+                max_size: Int
+                subnet_ids: list(String)
             }
             require min_size <= max_size, "min_size must be <= max_size"
             require len(subnet_ids) >= 2, "need at least two subnets"
@@ -10705,7 +10692,7 @@ arguments {
     fn test_parse_require_with_and_operator() {
         let input = r#"
             arguments {
-                port: int = 80
+                port: Int = 80
             }
             require port >= 1 && port <= 65535, "port must be between 1 and 65535"
         "#;
@@ -10723,7 +10710,7 @@ arguments {
         // are not mis-parsed as null_literal
         let input = r#"
             arguments {
-                nullable: bool = true
+                nullable: Bool = true
             }
             require nullable, "must be true"
         "#;
@@ -11081,8 +11068,8 @@ let vpc = awscc.ec2.Vpc {
 }
 
 exports {
-  vpc_id: string = vpc.vpc_id
-  cidr: string = vpc.cidr_block
+  vpc_id: String = vpc.vpc_id
+  cidr: String = vpc.cidr_block
 }
 "#;
         let parsed = parse(input, &ProviderContext::default()).unwrap();
@@ -11104,7 +11091,7 @@ let vpc = awscc.ec2.Vpc {
 }
 
 exports {
-  vpc_ids: list(string) = [
+  vpc_ids: list(String) = [
     vpc.vpc_id,
   ]
 }
@@ -11126,7 +11113,7 @@ let vpc = awscc.ec2.Vpc {
 }
 
 exports {
-  vpc_ids: list(string) = [vpc.vpc_id]
+  vpc_ids: list(String) = [vpc.vpc_id]
 }
 "#
         );

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -436,7 +436,7 @@ mod tests {
             &upstream_dir,
             "exports.crn",
             r#"exports {
-                accounts: string = "x"
+                accounts: String = "x"
             }"#,
         );
         let base = tmp.path().join("downstream");
@@ -468,8 +468,8 @@ mod tests {
             &upstream_dir,
             "exports.crn",
             r#"exports {
-                accounts: string = "x"
-                region: string = "ap-northeast-1"
+                accounts: String = "x"
+                region: String = "ap-northeast-1"
             }"#,
         );
         let base = tmp.path().join("downstream");
@@ -494,7 +494,7 @@ mod tests {
             &upstream_dir,
             "main.crn",
             r#"exports {
-                accounts: string = "x"
+                accounts: String = "x"
             }"#,
         );
         let base = tmp.path().join("downstream");
@@ -521,14 +521,14 @@ mod tests {
             &upstream_dir,
             "accounts.crn",
             r#"exports {
-                accounts: string = "x"
+                accounts: String = "x"
             }"#,
         );
         write_crn(
             &upstream_dir,
             "region.crn",
             r#"exports {
-                region: string = "ap-northeast-1"
+                region: String = "ap-northeast-1"
             }"#,
         );
         let base = tmp.path().join("downstream");
@@ -565,8 +565,8 @@ mod tests {
             "exports.crn",
             r#"exports {
                 accounts: struct {
-                    registry_prod: string,
-                    registry_dev:  string,
+                    registry_prod: String,
+                    registry_dev: String,
                 } = {
                     registry_prod = "111111111111"
                     registry_dev  = "222222222222"
@@ -671,7 +671,7 @@ mod tests {
             let orgs = upstream_state { source = "../organizations" }
 
             exports {
-                bad: string = orgs.account
+                bad: String = orgs.account
             }
             "#,
         );
@@ -697,7 +697,7 @@ mod tests {
             let orgs = upstream_state { source = "../organizations" }
 
             exports {
-                good: string = orgs.accounts
+                good: String = orgs.accounts
             }
             "#,
         );
@@ -713,7 +713,7 @@ mod tests {
             let orgs = upstream_state { source = "../organizations" }
 
             exports {
-                x: string = orgs.anything
+                x: String = orgs.anything
             }
             "#,
         );
@@ -734,7 +734,7 @@ mod tests {
             let other = upstream_state { source = "../other" }
 
             exports {
-                x: string = other.foo
+                x: String = other.foo
             }
             "#,
         );

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -2370,7 +2370,7 @@ let vpc = awscc.ec2.Vpc {
         );
         assert!(
             result.is_ok(),
-            "map(string) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
+            "map(String) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
             result
         );
     }
@@ -2417,7 +2417,7 @@ let vpc = awscc.ec2.Vpc {
         );
         assert!(
             result.is_err(),
-            "map(bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
+            "map(Bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
         );
         let err = result.unwrap_err();
         assert!(

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -359,7 +359,7 @@ impl CompletionProvider {
         }
 
         // Check if we're in a type position inside a fn definition (at top level)
-        // e.g., "fn greet(name: " or "fn greet(name: string): "
+        // e.g., "fn greet(name: " or "fn greet(name: String): "
         if brace_depth == 0 {
             let trimmed_prefix = prefix.trim_start();
             if trimmed_prefix.starts_with("fn ") && prefix.contains(':') {
@@ -728,7 +728,7 @@ enum CompletionContext {
 /// is a bare identifier. Used to enter the upstream_state block context.
 /// Extract the type annotation from a line that opens an `exports`
 /// entry, e.g. `accounts: map(aws_account_id) = { ...` returns
-/// `Some("map(aws_account_id)")`. Returns `None` when the line doesn't
+/// `Some("map(AwsAccountId)")`. Returns `None` when the line doesn't
 /// match the `<name>: <type> =` shape — either because there's no
 /// colon, no equals, or the type portion is empty.
 fn extract_exports_entry_type(line: &str) -> Option<String> {

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -122,8 +122,8 @@ fn module_parameter_completion_with_directory_module() {
     let module_content = r#"
 arguments {
 vpc: aws.ec2.Vpc
-cidr_blocks: list(cidr)
-enable_https: bool = true
+cidr_blocks: list(Cidr)
+enable_https: Bool = true
 }
 
 let web_sg = aws.ec2.SecurityGroup {
@@ -877,7 +877,7 @@ fn context_detection_type_position_in_fn_parameter() {
 #[test]
 fn context_detection_type_position_in_fn_return_type() {
     let provider = test_provider();
-    let text = "fn greet(name: string): ";
+    let text = "fn greet(name: String): ";
     let context = provider.get_completion_context(
         text,
         Position {
@@ -895,7 +895,7 @@ fn context_detection_type_position_in_fn_return_type() {
 #[test]
 fn context_detection_not_type_position_inside_fn_body() {
     let provider = test_provider();
-    let text = "fn greet(name: string) {\n  let x = ";
+    let text = "fn greet(name: String) {\n  let x = ";
     let context = provider.get_completion_context(
         text,
         Position {
@@ -1081,7 +1081,7 @@ fn module_call_scaffolding_includes_arguments() {
     std::fs::create_dir_all(&module_dir).unwrap();
     std::fs::write(
         module_dir.join("main.crn"),
-        "arguments {\n  name: string\n  port: int\n}\n",
+        "arguments {\n  name: String\n  port: Int\n}\n",
     )
     .unwrap();
 
@@ -1326,7 +1326,7 @@ fn import_path_completion_lists_directories_only() {
     std::fs::create_dir_all(&modules_dir).unwrap();
     std::fs::write(
         modules_dir.join("web.crn"),
-        "arguments {\n  name: string\n}\n",
+        "arguments {\n  name: String\n}\n",
     )
     .unwrap();
     std::fs::create_dir_all(modules_dir.join("shared")).unwrap();

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -657,7 +657,7 @@ fn builtin_function_completions_have_function_kind_and_signature() {
     assert_eq!(join.kind, Some(CompletionItemKind::FUNCTION));
     assert_eq!(
         join.detail.as_deref(),
-        Some("join(separator: string, list: list) -> string")
+        Some("join(separator: String, list: list) -> String")
     );
     assert_eq!(join.insert_text.as_deref(), Some("join($0)"));
     assert_eq!(join.insert_text_format, Some(InsertTextFormat::SNIPPET));
@@ -1643,7 +1643,7 @@ fn set_up_upstream_project(
 fn upstream_state_dot_completion_in_for_iterable_lists_exports() {
     let provider = test_provider();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(string) = \"x\"\n  region: string = \"ap-northeast-1\"\n}\n",
+        "exports {\n  accounts: map(String) = \"x\"\n  region: String = \"ap-northeast-1\"\n}\n",
         "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.\n",
     );
     let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
@@ -1679,7 +1679,7 @@ fn upstream_state_dot_completion_cross_file_binding() {
     std::fs::create_dir(&upstream).unwrap();
     std::fs::write(
         upstream.join("exports.crn"),
-        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
     )
     .unwrap();
     let base = tmp.path().join("downstream");
@@ -1712,7 +1712,7 @@ fn upstream_state_dot_completion_text_edit_replaces_partial() {
     // accepting `accounts` yields `orgs.accounts`, not `orgs.accaccounts`.
     let provider = test_provider();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
         "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.acc\n",
     );
     let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
@@ -1769,7 +1769,7 @@ fn upstream_state_dot_completion_ignores_unrelated_let_source() {
     std::fs::create_dir(&upstream).unwrap();
     std::fs::write(
         upstream.join("exports.crn"),
-        "exports {\n  accounts: map(string) = \"x\"\n}\n",
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
     )
     .unwrap();
     let other = tmp.path().join("other");
@@ -1801,14 +1801,14 @@ for _, id in orgs.
 }
 
 // #2128: surface the export's declared `TypeExpr` in the completion
-// detail so the user sees `map(aws_account_id)` instead of the generic
+// detail so the user sees `map(AwsAccountId)` instead of the generic
 // "export from upstream_state `orgs`". Untyped exports keep the fallback
 // phrasing.
 #[test]
 fn upstream_state_dot_completion_detail_shows_type_expr() {
     let provider = test_provider();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(aws_account_id) = \"x\"\n  untyped = \"y\"\n}\n",
+        "exports {\n  accounts: map(AwsAccountId) = \"x\"\n  untyped = \"y\"\n}\n",
         "let orgs = upstream_state { source = '../organizations' }\nfor _, id in orgs.\n",
     );
     let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
@@ -1863,7 +1863,7 @@ fn exports_value_position_excludes_region_pollution() {
     let provider = test_provider();
     let source = "\
 exports {
-  accounts: map(string) = {
+  accounts: map(String) = {
     k = re
   }
 }
@@ -1878,7 +1878,7 @@ exports {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
         !labels.iter().any(|l| l.contains(".Region.")),
-        "no region literals at map(string) value position, got: {:?}",
+        "no region literals at map(String) value position, got: {:?}",
         labels
     );
 }
@@ -1891,13 +1891,13 @@ fn exports_top_level_value_excludes_region_pollution() {
     let provider = test_provider();
     let source = "\
 exports {
-  id: string = re
+  id: String = re
 }
 ";
     let doc = create_document(source);
     let position = Position {
         line: 1,
-        character: "  id: string = re".chars().count() as u32,
+        character: "  id: String = re".chars().count() as u32,
     };
 
     let completions = provider.complete(&doc, position, None);
@@ -2048,12 +2048,12 @@ fn string_returning_builtins_still_offered_for_plain_string_attr() {
 #[test]
 fn for_loop_binding_not_offered_at_incompatible_enum_attribute() {
     // `for _, account_id in orgs.accounts` where `orgs.accounts` is
-    // `map(aws_account_id)`. Inside the body, `principal_type` is a
+    // `map(AwsAccountId)`. Inside the body, `principal_type` is a
     // `StringEnum` — `account_id` (semantic type `aws_account_id`)
     // can't type-check as `PrincipalType`, so it must be filtered out.
     let provider = test_provider_with_custom_semantic_attr();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+        "exports {\n  accounts: map(AwsAccountId) = \"x\"\n}\n",
         r#"let orgs = upstream_state { source = '../organizations' }
 for _, account_id in orgs.accounts {
   awscc.sso.Assignment {
@@ -2084,7 +2084,7 @@ fn for_loop_binding_offered_at_matching_custom_attribute() {
     // matches, so it must appear.
     let provider = test_provider_with_custom_semantic_attr();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+        "exports {\n  accounts: map(AwsAccountId) = \"x\"\n}\n",
         r#"let orgs = upstream_state { source = '../organizations' }
 for _, account_id in orgs.accounts {
   awscc.sso.Assignment {
@@ -2137,7 +2137,7 @@ fn for_loop_binding_without_resolvable_iterable_falls_back_to_unconditional() {
     );
 }
 
-/// Top-level `exports { region: string = ▉ }` must offer string-
+/// Top-level `exports { region: String = ▉ }` must offer string-
 /// returning built-in helpers. The annotation sits on the same line;
 /// the LSP previously returned nothing because the type was ignored.
 #[test]
@@ -2145,20 +2145,20 @@ fn exports_top_level_string_position_offers_string_builtins() {
     let provider = test_provider();
     let doc = create_document(
         r#"exports {
-  region: string =
+  region: String =
 }
 "#,
     );
     let position = Position {
         line: 1,
-        character: "  region: string = ".chars().count() as u32,
+        character: "  region: String = ".chars().count() as u32,
     };
     let completions = provider.complete(&doc, position, None);
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     for expected in ["join", "lower", "upper", "trim"] {
         assert!(
             labels.contains(&expected),
-            "string-returning built-in '{}' must appear at `exports {{ region: string = ▉ }}`. Got: {:?}",
+            "string-returning built-in '{}' must appear at `exports {{ region: String = ▉ }}`. Got: {:?}",
             expected,
             labels
         );
@@ -2172,13 +2172,13 @@ fn exports_top_level_string_position_excludes_non_string_builtins() {
     let provider = test_provider();
     let doc = create_document(
         r#"exports {
-  region: string =
+  region: String =
 }
 "#,
     );
     let position = Position {
         line: 1,
-        character: "  region: string = ".chars().count() as u32,
+        character: "  region: String = ".chars().count() as u32,
     };
     let completions = provider.complete(&doc, position, None);
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
@@ -2201,7 +2201,7 @@ fn exports_map_value_position_filters_by_element_type() {
     let provider = test_provider();
     let doc = create_document(
         r#"exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     registry_prod = x
   }
 }
@@ -2219,12 +2219,12 @@ fn exports_map_value_position_filters_by_element_type() {
     // not appear.
     assert!(
         !labels.contains(&"replace"),
-        "`replace` must not be suggested inside a `map(aws_account_id)` value position. Got: {:?}",
+        "`replace` must not be suggested inside a `map(AwsAccountId)` value position. Got: {:?}",
         labels
     );
     assert!(
         !labels.contains(&"join"),
-        "`join` must not be suggested inside a `map(aws_account_id)` value position. Got: {:?}",
+        "`join` must not be suggested inside a `map(AwsAccountId)` value position. Got: {:?}",
         labels
     );
 }
@@ -2264,7 +2264,7 @@ fn exports_map_value_real_world_shape_filters_unrelated_builtins() {
     let provider = test_provider();
     let source = "\
 exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     registry_prod = registry_prod.account_id
     registry_dev  = re
   }
@@ -2280,7 +2280,7 @@ exports {
     for banned in ["replace", "join", "lower", "upper", "trim", "env", "lookup"] {
         assert!(
             !labels.contains(&banned),
-            "String-returning '{}' must not appear in a `map(aws_account_id)` value position. Got: {:?}",
+            "String-returning '{}' must not appear in a `map(AwsAccountId)` value position. Got: {:?}",
             banned,
             labels
         );
@@ -2320,7 +2320,7 @@ let registry_prod = awscc.organizations.account {
 }
 
 exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     registry_prod = re
   }
 }
@@ -2334,7 +2334,7 @@ exports {
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
     assert!(
         labels.contains(&"registry_prod.account_id"),
-        "expected `registry_prod.account_id` at `map(aws_account_id)` value position. Got: {:?}",
+        "expected `registry_prod.account_id` at `map(AwsAccountId)` value position. Got: {:?}",
         labels
     );
 }
@@ -2346,7 +2346,7 @@ fn exports_list_value_position_filters_by_element_type() {
     let provider = test_provider();
     let doc = create_document(
         r#"exports {
-  items: list(string) = [
+  items: list(String) = [
     re
   ]
 }
@@ -2372,7 +2372,7 @@ fn exports_list_value_position_filters_by_element_type() {
 }
 
 /// Repro: in the real `organizations/exports.crn`, the user types
-/// `registry_dev = r|` at depth 2 (inside the `map(aws_account_id)`
+/// `registry_dev = r|` at depth 2 (inside the `map(AwsAccountId)`
 /// body with a preceding entry on the line above). LSP currently
 /// returns zero LSP items — VSCode falls back to word-based. We
 /// expect matching resource-ref refs.
@@ -2409,7 +2409,7 @@ let registry_dev = awscc.organizations.account {
 }
 
 exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     registry_prod = r
     registry_dev = r
   }
@@ -2466,7 +2466,7 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
     .unwrap();
     let exports_src = "\
 exports {
-  accounts: map(aws_account_id) = {
+  accounts: map(AwsAccountId) = {
     registry_prod = r
   }
 }
@@ -2568,7 +2568,7 @@ fn argument_parameters_include_sibling_file_args() {
     let base = tmp.path();
     std::fs::write(
         base.join("arguments.crn"),
-        "arguments {\n  stage_name: string\n}\n",
+        "arguments {\n  stage_name: String\n}\n",
     )
     .unwrap();
     let main_src = "\

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -931,7 +931,7 @@ impl CompletionProvider {
                 "'arn:aws:${1:service}:${2:region}:${3:account}:${4:resource}'".to_string(),
             ),
             insert_text_format: Some(InsertTextFormat::SNIPPET),
-            detail: Some("ARN format: arn:partition:service:region:account:resource".to_string()),
+            detail: Some("ARN format: Arn:partition:service:region:account:resource".to_string()),
             ..Default::default()
         }]
     }
@@ -1286,19 +1286,28 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
         });
     }
     match text {
-        "string" => Some(AttributeType::String),
-        "int" => Some(AttributeType::Int),
-        "float" => Some(AttributeType::Float),
-        "bool" => Some(AttributeType::Bool),
-        name if is_valid_custom_name(name) => Some(AttributeType::Custom {
-            semantic_name: Some(snake_to_pascal(name)),
-            base: Box::new(AttributeType::String),
-            pattern: None,
-            length: None,
-            validate: noop_validate,
-            namespace: None,
-            to_dsl: None,
-        }),
+        // Post-Phase C, primitive types are PascalCase. Accept only the new
+        // spellings at the surface.
+        "String" => Some(AttributeType::String),
+        "Int" => Some(AttributeType::Int),
+        "Float" => Some(AttributeType::Float),
+        "Bool" => Some(AttributeType::Bool),
+        // Custom types also ship in PascalCase now (e.g. `AwsAccountId`,
+        // `Ipv4Cidr`). Carry the PascalCase form as `semantic_name` and
+        // canonicalise the internal key to snake_case.
+        name if name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+            && name.chars().all(|c| c.is_ascii_alphanumeric()) =>
+        {
+            Some(AttributeType::Custom {
+                semantic_name: Some(name.to_string()),
+                base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
+                validate: noop_validate,
+                namespace: None,
+                to_dsl: None,
+            })
+        }
         _ => None,
     }
 }
@@ -1311,12 +1320,6 @@ fn strip_generic<'a>(prefix: &str, text: &'a str) -> Option<&'a str> {
     let rest = rest.strip_prefix('(')?;
     let rest = rest.strip_suffix(')')?;
     Some(rest)
-}
-
-fn is_valid_custom_name(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-        && s.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
 }
 
 fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -483,7 +483,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    sg_id: string = nonexistent.id
+    sg_id: String = nonexistent.id
 }"#,
     );
 
@@ -512,7 +512,7 @@ group_description = "Test security group"
 }
 
 attributes {
-    sg_id: string = sg.group_id
+    sg_id: String = sg.group_id
 }"#,
     );
 
@@ -537,7 +537,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    flag: string = true
+    flag: String = true
 }"#,
     );
 
@@ -566,10 +566,10 @@ group_description = "Test security group"
 }
 
 attributes {
-    sg_id: string = sg.group_id
-    name: string = "hello"
-    enabled: bool = true
-    count: int = 42
+    sg_id: String = sg.group_id
+    name: String = "hello"
+    enabled: Bool = true
+    count: Int = 42
 }"#,
     );
 
@@ -648,7 +648,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    flag: string = true
+    flag: String = true
 }"#,
     );
 
@@ -733,7 +733,7 @@ fn provider_in_module_emits_error() {
     let engine = test_engine();
     let doc = create_document(
         r#"arguments {
-    vpc_cidr: string
+    vpc_cidr: String
 }
 
 provider awscc {
@@ -1081,7 +1081,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    ip: ipv4_address = "not-an-ip"
+    ip: Ipv4Address = "not-an-ip"
 }"#,
     );
 
@@ -1106,7 +1106,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    ip: ipv4_address = "192.168.1.1"
+    ip: Ipv4Address = "192.168.1.1"
 }"#,
     );
 
@@ -1131,7 +1131,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    network: ipv4_cidr = "not-a-cidr"
+    network: Ipv4Cidr = "not-a-cidr"
 }"#,
     );
 
@@ -1156,7 +1156,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    addr: ipv6_address = "not-ipv6"
+    addr: Ipv6Address = "not-ipv6"
 }"#,
     );
 
@@ -1324,7 +1324,7 @@ region = awscc.Region.ap_northeast_1
 }
 
 attributes {
-    net6: ipv6_cidr = "not-a-cidr"
+    net6: Ipv6Cidr = "not-a-cidr"
 }"#,
     );
 
@@ -1735,7 +1735,7 @@ fn exports_cross_file_ref_no_false_positive() {
     // exports.crn parsed alone: "registry_prod.account_id" stays as String
     let doc = create_document(
         r#"exports {
-  accounts: list(aws_account_id) = [
+  accounts: list(AwsAccountId) = [
     registry_prod.account_id,
   ]
 }"#,
@@ -1758,7 +1758,7 @@ fn exports_type_warning_survives_formatter_round_trip() {
     use carina_core::formatter::{FormatConfig, format};
 
     let original = r#"exports {
-  values: list(bool) = [
+  values: list(Bool) = [
     "nope",
   ]
 }"#;
@@ -1777,7 +1777,7 @@ fn exports_type_warning_survives_formatter_round_trip() {
         .find(|d| d.message.contains("expected Bool, got string"))
         .map(|d| d.message.clone());
 
-    assert_eq!(formatted, "exports {\n  values: list(bool) = ['nope']\n}\n");
+    assert_eq!(formatted, "exports {\n  values: list(Bool) = ['nope']\n}\n");
     assert_eq!(before_warning, after_warning);
     assert!(
         after_warning.is_some(),
@@ -1804,7 +1804,7 @@ fn exports_ref_type_warning_survives_formatter_round_trip() {
 }
 
 exports {
-  values: list(string) = [
+  values: list(String) = [
     item.enabled,
   ]
 }"#;
@@ -1824,7 +1824,7 @@ exports {
 
     assert_eq!(
         formatted,
-        "let item = test.sample.resource {\n  enabled = true\n}\n\nexports {\n  values: list(string) = [item.enabled]\n}\n"
+        "let item = test.sample.resource {\n  enabled = true\n}\n\nexports {\n  values: list(String) = [item.enabled]\n}\n"
     );
     assert_eq!(before_warning, after_warning);
     assert!(
@@ -1852,7 +1852,7 @@ fn exports_ref_type_warning_survives_document_reparse_after_format_edit() {
 }
 
 exports {
-  values: list(string) = [
+  values: list(String) = [
     item.enabled,
   ]
 }"#;
@@ -1904,7 +1904,7 @@ fn exports_type_warning_after_format_with_cross_file_ref() {
     // After format-on-save, list is on one line. User changes string→bool.
     let doc = create_document(
         r#"exports {
-  accounts: list(bool) = [registry_prod.account_id, registry_dev.account_id]
+  accounts: list(Bool) = [registry_prod.account_id, registry_dev.account_id]
 }"#,
     );
     let diagnostics = engine.analyze(&doc, None);
@@ -1935,7 +1935,7 @@ fn exports_type_warning_for_literal_mismatch() {
     let engine = test_engine();
     let doc = create_document(
         r#"exports {
-  flag: bool = 'hello'
+  flag: Bool = 'hello'
 }"#,
     );
     let diagnostics = engine.analyze(&doc, None);
@@ -1957,7 +1957,7 @@ fn exports_type_warning_for_literal_mismatch() {
 fn exports_type_warning_multiline_vs_oneline() {
     let engine = test_engine();
     // Multi-line (before format)
-    let doc_multi = create_document("exports {\n  flag: bool = 'hello'\n}");
+    let doc_multi = create_document("exports {\n  flag: Bool = 'hello'\n}");
     let diag_multi = engine.analyze(&doc_multi, None);
     eprintln!(
         "multi-line: {:?}",
@@ -1966,10 +1966,10 @@ fn exports_type_warning_multiline_vs_oneline() {
 
     // After user types but before format - with wrong type and literal
     let doc_literal =
-        create_document("exports {\n  accounts: list(bool) = ['literal1', 'literal2']\n}");
+        create_document("exports {\n  accounts: list(Bool) = ['literal1', 'literal2']\n}");
     let diag_literal = engine.analyze(&doc_literal, None);
     eprintln!(
-        "literal list(bool): {:?}",
+        "literal list(Bool): {:?}",
         diag_literal.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -1995,7 +1995,7 @@ fn exports_map_type_warning_for_cross_file_ref() {
         "let registry_prod = awscc.organizations.account { name = 'prod' }\nlet registry_dev = awscc.organizations.account { name = 'dev' }\n",
     )
     .unwrap();
-    let exports = "exports {\n  accounts: map(bool) = {\n    prod = registry_prod.account_id\n    dev  = registry_dev.account_id\n  }\n}";
+    let exports = "exports {\n  accounts: map(Bool) = {\n    prod = registry_prod.account_id\n    dev  = registry_dev.account_id\n  }\n}";
     std::fs::write(base.join("exports.crn"), exports).unwrap();
 
     let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
@@ -2005,7 +2005,7 @@ fn exports_map_type_warning_for_cross_file_ref() {
         .find(|d| d.message.contains("type mismatch") || d.message.contains("expected"));
     assert!(
         type_warning.is_some(),
-        "Should warn about map(bool) vs String account_id. Got: {:?}",
+        "Should warn about map(Bool) vs String account_id. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -2025,7 +2025,7 @@ fn no_undefined_resource_for_sibling_binding_in_exports() {
         "let registry_prod = awscc.organizations.account { name = 'prod' }\nlet registry_dev = awscc.organizations.account { name = 'dev' }\n",
     )
     .unwrap();
-    let exports = "exports {\n  accounts: map(aws_account_id) = {\n    prod = registry_prod.account_id\n    dev = registry_dev.account_id\n  }\n}\n";
+    let exports = "exports {\n  accounts: map(AwsAccountId) = {\n    prod = registry_prod.account_id\n    dev = registry_dev.account_id\n  }\n}\n";
     std::fs::write(base.join("exports.crn"), exports).unwrap();
 
     let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
@@ -2183,7 +2183,7 @@ for name, _ in orgs.account {
 }
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2213,7 +2213,7 @@ for name, _ in orgs.accounts {
 }
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2240,7 +2240,7 @@ fn upstream_state_buffer_differs_from_disk_uses_buffer() {
 let x = orgs.accounts
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2269,7 +2269,7 @@ fn upstream_state_buffer_fix_clears_diagnostic() {
 let x = orgs.account
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2299,7 +2299,7 @@ fn upstream_state_buffer_retypo_reflags() {
 let x = orgs.accounts
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2330,7 +2330,7 @@ fn upstream_state_cross_file_declaration_is_checked() {
     std::fs::create_dir(&upstream).unwrap();
     std::fs::write(
         upstream.join("exports.crn"),
-        r#"exports { accounts: string = "x" }
+        r#"exports { accounts: String = "x" }
 "#,
     )
     .unwrap();
@@ -2387,7 +2387,7 @@ for other, _ in orgs.bad {
 }
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2488,7 +2488,7 @@ for name, _ in org.accounts {
 }
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2519,7 +2519,7 @@ for name, _ in orgs.accounts {
 }
 "#,
         Some(
-            r#"exports { accounts: string = "x" }
+            r#"exports { accounts: String = "x" }
 "#,
         ),
     );
@@ -2546,7 +2546,7 @@ fn for_iterable_undefined_binding_cross_file_is_flagged() {
     std::fs::create_dir(&upstream).unwrap();
     std::fs::write(
         upstream.join("exports.crn"),
-        r#"exports { accounts: string = "x" }
+        r#"exports { accounts: String = "x" }
 "#,
     )
     .unwrap();
@@ -2872,7 +2872,7 @@ fn upstream_state_binding_in_sibling_file_is_not_undefined() {
     std::fs::create_dir(&upstream).unwrap();
     std::fs::write(
         upstream.join("exports.crn"),
-        "exports {\n  accounts: map(aws_account_id) = \"x\"\n}\n",
+        "exports {\n  accounts: map(AwsAccountId) = \"x\"\n}\n",
     )
     .unwrap();
     let base = tmp.path().join("downstream");
@@ -2911,7 +2911,7 @@ fn import_binding_in_sibling_file_is_not_undefined() {
     let tmp = tempfile::tempdir().unwrap();
     let module = tmp.path().join("modules").join("vpc");
     std::fs::create_dir_all(&module).unwrap();
-    std::fs::write(module.join("main.crn"), "arguments {\n  name: string\n}\n").unwrap();
+    std::fs::write(module.join("main.crn"), "arguments {\n  name: String\n}\n").unwrap();
     let base = tmp.path().join("downstream");
     std::fs::create_dir(&base).unwrap();
     std::fs::write(
@@ -3066,7 +3066,7 @@ fn exports_type_check_resolves_resource_binding_from_sibling_file() {
     // String, so we expect a type-mismatch warning — which is what
     // proves the sibling-binding resolution actually happened.
     let exports =
-        "exports {\n  accounts: map(bool) = {\n    prod = registry_prod.account_id\n  }\n}\n";
+        "exports {\n  accounts: map(Bool) = {\n    prod = registry_prod.account_id\n  }\n}\n";
     std::fs::write(base.join("exports.crn"), exports).unwrap();
 
     let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
@@ -3074,7 +3074,7 @@ fn exports_type_check_resolves_resource_binding_from_sibling_file() {
         diagnostics
             .iter()
             .any(|d| { d.message.contains("type mismatch") || d.message.contains("expected") }),
-        "type-mismatch warning should fire for map(bool) vs String. Got: {:?}",
+        "type-mismatch warning should fire for map(Bool) vs String. Got: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -995,7 +995,7 @@ awscc.ec2.vpc_gateway_attachment {
             "Should have function name header"
         );
         assert!(
-            content.contains("join(separator: string, list: list) -> string"),
+            content.contains("join(separator: String, list: list) -> String"),
             "Should show signature. Got:\n{}",
             content
         );
@@ -1023,7 +1023,7 @@ awscc.ec2.vpc_gateway_attachment {
         };
 
         assert!(
-            content.contains("cidr_subnet(prefix: string, newbits: int, netnum: int) -> string"),
+            content.contains("cidr_subnet(prefix: String, newbits: Int, netnum: Int) -> String"),
             "Should show cidr_subnet signature. Got:\n{}",
             content
         );
@@ -1192,10 +1192,10 @@ awscc.ec2.vpc_gateway_attachment {
     #[test]
     fn test_no_builtin_hover_for_map_in_type_annotation() {
         let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
-        // Line 1 (0-indexed): "  accounts: map(aws_account_id) = {"
+        // Line 1 (0-indexed): "  accounts: map(AwsAccountId) = {"
         // Position on "map" → should NOT show function hover
         let doc = Document::new(
-            "exports {\n  accounts: map(aws_account_id) = {}\n}".to_string(),
+            "exports {\n  accounts: map(AwsAccountId) = {}\n}".to_string(),
             Arc::new(ProviderContext::default()),
         );
         // Column 14 is inside "map" on line 1

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -1187,9 +1187,9 @@ mod tests {
             "provider aws { region = aws.Region.ap_northeast_1 }",
             "backend s3 { bucket = \"b\" }",
             "let orgs = upstream_state { source = \"../o\" }",
-            "attributes { a: string = \"x\" }",
-            "arguments { a: string }",
-            "exports { a: string = \"x\" }",
+            "attributes { a: String = \"x\" }",
+            "arguments { a: String }",
+            "exports { a: String = \"x\" }",
             "import { to = aws.s3_bucket \"x\" }",
             "moved { from = aws.s3_bucket \"a\" to = aws.s3_bucket \"b\" }",
             "removed { from = aws.s3_bucket \"x\" }",
@@ -1262,9 +1262,10 @@ mod tests {
 
     #[test]
     fn semantic_tokens_does_not_tag_lowercase_after_colon_as_type() {
-        // A lowercase identifier after `:` is either the old spelling (still
-        // accepted by the parser but not a bare PascalCase type) or a
-        // binding/property name; don't emit a type token for it.
+        // A lowercase identifier after `:` is no longer a valid type (Phase
+        // C rejects the old spellings at parse time), and in any case is a
+        // binding/property name in the editor — it must not be tagged as
+        // a TYPE token.
         let provider = SemanticTokensProvider::new(&[]);
         let line = "    port: int";
         let tokens = provider.tokenize_line(line, 0);

--- a/carina-lsp/src/workspace.rs
+++ b/carina-lsp/src/workspace.rs
@@ -438,7 +438,7 @@ mod tests {
         )
         .unwrap();
         // Module has arguments (no provider)
-        fs::write(module.join("main.crn"), "arguments {\n  repo: string\n}\n").unwrap();
+        fs::write(module.join("main.crn"), "arguments {\n  repo: String\n}\n").unwrap();
 
         let import_map = discover_import_map(dir.path());
 

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -839,7 +839,7 @@ mod tests {
         let input = r#"
             arguments {
                 vpc: aws.vpc
-                enable_https: bool = true
+                enable_https: Bool = true
             }
             attributes {
                 sg: aws.security_group = web_sg.id

--- a/carina-tui/src/module_info_tui_snapshot_tests.rs
+++ b/carina-tui/src/module_info_tui_snapshot_tests.rs
@@ -45,7 +45,7 @@ fn build_module_signature() -> FileSignature {
             vpc: aws.vpc {
                 description = "The VPC to deploy into"
             }
-            enable_https: bool = true
+            enable_https: Bool = true
         }
 
         attributes {


### PR DESCRIPTION
Closes #2161. Refs #2143.

Task 17/18 — Phase C. The transition window that let both snake_case primitives (\`string\`/\`int\`/\`bool\`/\`float\`) and snake_case custom types (\`aws_account_id\`, \`ipv4_cidr\`, …) parse alongside the PascalCase spellings is now closed. All providers and infra have already migrated in their own Phase A / Phase B PRs (carina-rs/carina-provider-aws#140, carina-rs/carina-provider-awscc#150 + #151, carina-rs/infra#19).

## Summary

- \`carina-core/src/parser/mod.rs\` (\`parse_type_expr\`): the \`Rule::type_simple\` arm rejects every lowercase primitive and any non-PascalCase identifier with an \`InvalidExpression\` error that names the correct new spelling. The \`warn_deprecated\` closure and the \`ParseWarning\`-based fallback are removed.
- New regression tests: \`parser_rejects_lowercase_primitive_after_phase_c\` and \`parser_rejects_snake_case_custom_type_after_phase_c\`.

## Housekeeping

- Inline DSL fragments inside Rust string literals (\`r#\"...\"#\` and regular \`\"...\"\`) across carina-core, carina-cli, and carina-lsp had primitives, custom types, and \`list(...)\` / \`map(...)\` wrappers rewritten to PascalCase (\`string\` → \`String\`, \`aws_account_id\` → \`AwsAccountId\`, \`list(cidr)\` → \`list(Cidr)\`, …).
- \`carina-core/src/builtins/mod.rs\` built-in function signatures shown in LSP hover / completion (\`signature: \"join(separator: String, list: list) -> String\"\` etc.) use the new spellings.
- \`carina-core/src/formatter/format.rs\` formatter tests — both inputs and expected outputs are PascalCase.
- \`carina-lsp/src/completion/values.rs\` \`parse_exports_type_text\` now only matches the new spellings and accepts any PascalCase identifier as a custom type. The dead \`is_valid_custom_name\` + \`snake_to_pascal\` shim is removed.
- \`carina-lsp/src/semantic_tokens.rs\` and \`carina-lsp/src/completion/tests/**\` regression tests updated to reflect Phase C behaviour (parser rejection) and the new spellings in fixture sources.

## Verification

- \`cargo test\` — full workspace green (26 result sets, 0 failures).
- \`cargo clippy --all-targets -- -D warnings\` — clean.
- \`cargo fmt --check\` — clean.
- \`scripts/check-docs-use-new-spellings.sh\` — \`docs OK\`.
- \`parser_rejects_lowercase_primitive_after_phase_c\` / \`parser_rejects_snake_case_custom_type_after_phase_c\` pass; error messages point at the PascalCase spelling.

## Test plan

- [x] \`cargo test\` workspace-wide green
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`scripts/check-docs-use-new-spellings.sh\` green
- [x] New rejection tests exercise both primitives and custom types