### PR TITLE
docs: align DSL reference with Phase C PascalCase type names

### DIFF
--- a/docs/src/content/docs/guides/functions.md
+++ b/docs/src/content/docs/guides/functions.md
@@ -11,12 +11,12 @@ Carina provides built-in functions for common operations and lets you define you
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `upper` | `upper(string) -> string` | Converts to uppercase |
-| `lower` | `lower(string) -> string` | Converts to lowercase |
-| `trim` | `trim(string) -> string` | Removes leading/trailing whitespace |
-| `replace` | `replace(search, replacement, string) -> string` | Replaces all occurrences |
-| `split` | `split(separator, string) -> list` | Splits string into a list |
-| `join` | `join(separator, list) -> string` | Joins list elements into a string |
+| `upper` | `upper(string) -> String` | Converts to uppercase |
+| `lower` | `lower(string) -> String` | Converts to lowercase |
+| `trim` | `trim(string) -> String` | Removes leading/trailing whitespace |
+| `replace` | `replace(search, replacement, string) -> String` | Replaces all occurrences |
+| `split` | `split(separator, string) -> list(String)` | Splits string into a list |
+| `join` | `join(separator, list) -> String` | Joins list elements into a string |
 
 Examples:
 
@@ -36,13 +36,13 @@ awscc.ec2.Vpc {
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `length` | `length(list \| map \| string) -> int` | Returns element/character count |
-| `concat` | `concat(items, base_list) -> list` | Appends items to a list |
-| `flatten` | `flatten(list) -> list` | Flattens nested lists by one level |
-| `keys` | `keys(map) -> list` | Returns map keys as a sorted list |
-| `values` | `values(map) -> list` | Returns map values sorted by key |
-| `lookup` | `lookup(map, key, default) -> any` | Looks up a key with a fallback |
-| `map` | `map(accessor, collection) -> list \| map` | Extracts a field from each element |
+| `length` | `length(list \| map \| String) -> Int` | Returns element/character count |
+| `concat` | `concat(items, base_list) -> list(Any)` | Appends items to a list |
+| `flatten` | `flatten(list) -> list(Any)` | Flattens nested lists by one level |
+| `keys` | `keys(map) -> list(String)` | Returns map keys as a sorted list |
+| `values` | `values(map) -> list(Any)` | Returns map values sorted by key |
+| `lookup` | `lookup(map, key, default) -> Any` | Looks up a key with a fallback |
+| `map` | `map(accessor, collection) -> list(Any) \| map(Any)` | Extracts a field from each element |
 
 Examples:
 
@@ -63,14 +63,14 @@ awscc.ec2.Vpc {
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `min` | `min(a, b) -> number` | Returns the smaller value |
-| `max` | `max(a, b) -> number` | Returns the larger value |
+| `min` | `min(a, b) -> Number` | Returns the smaller value |
+| `max` | `max(a, b) -> Number` | Returns the larger value |
 
 ### Network functions
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `cidr_subnet` | `cidr_subnet(prefix, newbits, netnum) -> string` | Calculates a subnet CIDR block |
+| `cidr_subnet` | `cidr_subnet(prefix, newbits, netnum) -> Ipv4Cidr` | Calculates a subnet CIDR block |
 
 Example:
 
@@ -121,8 +121,8 @@ fn name(param1: type1, param2: type2): return_type {
 }
 ```
 
-- **Parameters** can have type annotations (`: string`, `: int`, etc.)
-- **Return type** annotation is optional (`: string`)
+- **Parameters** can have type annotations (`: String`, `: Int`, etc.)
+- **Return type** annotation is optional (`: String`)
 - The function body is a single expression (the return value)
 
 ### Local variables in functions
@@ -141,7 +141,7 @@ fn subnet_name(env: String, tier: String, index: Int): String {
 Parameters can have default values:
 
 ```crn
-fn make_tags(name: String, env: String = 'dev'): map(string) {
+fn make_tags(name: String, env: String = 'dev'): map(String) {
   {
     Name        = name
     Environment = env

--- a/docs/src/content/docs/guides/using-modules.md
+++ b/docs/src/content/docs/guides/using-modules.md
@@ -53,7 +53,7 @@ arguments {
 }
 ```
 
-Supported types include `string`, `bool`, `int`, `float`, `list(string)`, `map(string)`, and resource type references like `awscc.ec2.Vpc`.
+Supported types include `String`, `Bool`, `Int`, `Float`, `list(String)`, `map(String)`, and resource type references like `awscc.ec2.Vpc`.
 
 ### Attributes block
 

--- a/docs/src/content/docs/reference/dsl/built-in-functions.md
+++ b/docs/src/content/docs/reference/dsl/built-in-functions.md
@@ -12,7 +12,7 @@ Carina provides built-in functions for string manipulation, list operations, map
 Converts a string to uppercase.
 
 ```
-upper(string: string) -> string
+upper(string: String) -> String
 ```
 
 ```crn
@@ -25,7 +25,7 @@ upper('Hello World')  # => 'HELLO WORLD'
 Converts a string to lowercase.
 
 ```
-lower(string: string) -> string
+lower(string: String) -> String
 ```
 
 ```crn
@@ -38,7 +38,7 @@ lower('Hello World')  # => 'hello world'
 Removes leading and trailing whitespace from a string.
 
 ```
-trim(string: string) -> string
+trim(string: String) -> String
 ```
 
 ```crn
@@ -51,7 +51,7 @@ trim('\n hello \t')  # => 'hello'
 Replaces all occurrences of a search string. Data-last argument order for pipe compatibility.
 
 ```
-replace(search: string, replacement: string, string: string) -> string
+replace(search: String, replacement: String, string: String) -> String
 ```
 
 ```crn
@@ -65,7 +65,7 @@ replace('::', '.', 'foo::bar::baz')   # => 'foo.bar.baz'
 Splits a string into a list using a separator.
 
 ```
-split(separator: string, string: string) -> list
+split(separator: String, string: String) -> list(String)
 ```
 
 ```crn
@@ -79,7 +79,7 @@ split('::', 'a::b::c')   # => ['a', 'b', 'c']
 Joins list elements into a string using a separator.
 
 ```
-join(separator: string, list: list) -> string
+join(separator: String, list: list(String)) -> String
 ```
 
 ```crn
@@ -95,7 +95,7 @@ join(', ', ['hello', 42])     # => 'hello, 42'
 Appends items to a list. Data-last argument order for pipe compatibility. The result is `base_list` followed by `items`.
 
 ```
-concat(items: list, base_list: list) -> list
+concat(items: list(Any), base_list: list(Any)) -> list(Any)
 ```
 
 ```crn
@@ -109,7 +109,7 @@ concat(['c'], ['a', 'b'])        # => ['a', 'b', 'c']
 Flattens nested lists by one level. Non-list elements are kept as-is.
 
 ```
-flatten(list: list) -> list
+flatten(list: list(Any)) -> list(Any)
 ```
 
 ```crn
@@ -129,7 +129,7 @@ flatten([[1, [2, 3]]])  # => [1, [2, 3]]
 Returns the number of elements in a list or map, or the number of characters in a string.
 
 ```
-length(value: list | map | string) -> int
+length(value: list(Any) | map(Any) | String) -> Int
 ```
 
 ```crn
@@ -144,7 +144,7 @@ length([])              # => 0
 Extracts a field from each element of a collection. The accessor must be a dot-prefixed string.
 
 ```
-map(accessor: string, collection: list | map) -> list | map
+map(accessor: String, collection: list(Any) | map(Any)) -> list(Any) | map(Any)
 ```
 
 When applied to a list of maps, returns a list of the extracted values:
@@ -177,7 +177,7 @@ envs |> map('.cidr')  # => { dev = '10.0.0.0/16', stg = '10.1.0.0/16' }
 Returns the keys of a map as a sorted list of strings.
 
 ```
-keys(map: map) -> list
+keys(map: map(Any)) -> list(String)
 ```
 
 ```crn
@@ -190,7 +190,7 @@ keys({})                         # => []
 Returns the values of a map as a list, ordered by sorted keys.
 
 ```
-values(map: map) -> list
+values(map: map(Any)) -> list(Any)
 ```
 
 ```crn
@@ -203,7 +203,7 @@ values({})                         # => []
 Looks up a key in a map, returning a default value if the key is not found.
 
 ```
-lookup(map: map, key: string, default: any) -> any
+lookup(map: map(Any), key: String, default: Any) -> Any
 ```
 
 ```crn
@@ -218,7 +218,7 @@ lookup({ a = 'one', b = 'two' }, 'c', 'default')  # => 'default'
 Returns the smaller of two numbers. If both are integers, returns an integer. If either is a float, returns a float.
 
 ```
-min(a: number, b: number) -> number
+min(a: Number, b: Number) -> Number
 ```
 
 ```crn
@@ -232,7 +232,7 @@ min(1, 2.5)    # => 1.0
 Returns the larger of two numbers. If both are integers, returns an integer. If either is a float, returns a float.
 
 ```
-max(a: number, b: number) -> number
+max(a: Number, b: Number) -> Number
 ```
 
 ```crn
@@ -248,7 +248,7 @@ max(1, 2.5)    # => 2.5
 Calculates a subnet CIDR block within a given IP network address prefix.
 
 ```
-cidr_subnet(prefix: string, newbits: int, netnum: int) -> string
+cidr_subnet(prefix: Ipv4Cidr, newbits: Int, netnum: Int) -> Ipv4Cidr
 ```
 
 - `prefix`: base CIDR string (e.g., `"10.0.0.0/16"`)
@@ -279,7 +279,7 @@ let vpcs = for (i, env) in ['dev', 'stg'] {
 Reads an environment variable. Returns an error if the variable is not set.
 
 ```
-env(name: string) -> string
+env(name: String) -> String
 ```
 
 ```crn
@@ -294,7 +294,7 @@ let db_host = env('DB_HOST')
 Marks a value as secret. The value is sent to the provider but stored only as a SHA256 hash in state. Plan output displays `(secret)` instead of the actual value.
 
 ```
-secret(value: any) -> secret
+secret(value: Any) -> Secret
 ```
 
 ```crn
@@ -308,7 +308,7 @@ awscc.rds.db_instance {
 Decrypts ciphertext using the configured provider's encryption service (e.g., AWS KMS). The key argument is optional when the key identifier is embedded in the ciphertext.
 
 ```
-decrypt(ciphertext: string, key?: string) -> string
+decrypt(ciphertext: String, key?: String) -> String
 ```
 
 ```crn

--- a/docs/src/content/docs/reference/dsl/expressions.md
+++ b/docs/src/content/docs/reference/dsl/expressions.md
@@ -263,8 +263,8 @@ fn tag_name(env: String, service: String): String {
 ### Parameters
 
 Function parameters support:
-- Type annotations: `name: string`
-- Default values: `name: string = "default"`
+- Type annotations: `name: String`
+- Default values: `name: String = "default"`
 - No annotation: `name` (any type accepted)
 
 ```crn

--- a/docs/src/content/docs/reference/dsl/modules.md
+++ b/docs/src/content/docs/reference/dsl/modules.md
@@ -105,9 +105,9 @@ arguments {
   count      : Int
   ratio      : Float
   enabled    : Bool
-  subnet_ids : list(string)
-  tags       : map(string)
-  cidr_block : cidr
+  subnet_ids : list(String)
+  tags       : map(String)
+  cidr_block : Ipv4Cidr
   role_arn   : Arn
 }
 ```

--- a/docs/src/content/docs/reference/dsl/types-and-values.md
+++ b/docs/src/content/docs/reference/dsl/types-and-values.md
@@ -9,16 +9,56 @@ The Carina DSL is a statically-aware language with the following value types.
 
 ### String
 
-Strings are enclosed in double quotes:
+Strings can be enclosed in either single or double quotes. The two forms have
+different semantics, and the recommended style is to pick the form based on
+whether interpolation is needed.
+
+#### Single-Quoted Strings (Literal)
+
+Single quotes produce a literal string. `${...}` inside single quotes is **not**
+interpreted as interpolation — it is kept verbatim.
 
 ```crn
 let name = 'my-vpc'
 let region = 'ap-northeast-1'
+let literal = 'price is ${amount}'   # the six characters ${amount} stay as-is
 ```
+
+The only escape sequences recognized inside single quotes are `\'` (single
+quote) and `\\` (backslash).
+
+#### Double-Quoted Strings (Interpolation)
+
+Double quotes support `${...}` interpolation and the full set of escape
+sequences. Use them whenever you need to embed an expression in a string.
+
+```crn
+let env  = 'prod'
+let name = "vpc-${env}"           # => 'vpc-prod'
+let cidr = "${base_cidr}"         # => value of base_cidr
+let tag  = "${env}-${service}"    # => 'prod-web'
+```
+
+Any expression can appear inside `${}`, including function calls:
+
+```crn
+let tag = "vpc-${join('-', ['prod', 'web'])}"
+```
+
+#### Recommended Style
+
+- **Use single quotes** for literal strings that do not need interpolation
+  (the common case).
+- **Use double quotes** only when you need `${...}` interpolation or an
+  escape sequence that is not supported in single quotes.
+
+Both forms are always valid — this is a style guideline, not a correctness
+requirement. A literal written with double quotes (e.g. `"ap-northeast-1"`)
+is accepted and behaves identically to the single-quoted form.
 
 #### Escape Sequences
 
-Strings support the following escape sequences:
+Double-quoted strings support the following escape sequences:
 
 | Sequence | Meaning |
 |----------|---------|
@@ -29,22 +69,7 @@ Strings support the following escape sequences:
 | `\t` | Tab |
 | `\$` | Literal dollar sign (prevents interpolation) |
 
-#### String Interpolation
-
-Embed expressions inside strings with `${}`:
-
-```crn
-let env = 'prod'
-let name = "vpc-${env}"           # => 'vpc-prod'
-let cidr = "${base_cidr}"         # => value of base_cidr
-let tag = "${env}-${service}"     # => 'prod-web'
-```
-
-Any expression can appear inside `${}`, including function calls:
-
-```crn
-let tag = "vpc-${join("-", ["prod", "web"])}"
-```
+Single-quoted strings recognize only `\'` and `\\`.
 
 ### Int
 
@@ -209,7 +234,7 @@ arguments {
   count     : Int
   ratio     : Float
   enabled   : Bool
-  cidr_block: cidr
+  cidr_block: Ipv4Cidr
   role_arn  : Arn
 }
 ```
@@ -220,9 +245,9 @@ arguments {
 
 ```crn
 arguments {
-  subnet_ids  : list(string)
-  cidr_blocks : list(cidr)
-  tags        : map(string)
+  subnet_ids  : list(String)
+  cidr_blocks : list(Ipv4Cidr)
+  tags        : map(String)
 }
 ```
 


### PR DESCRIPTION
## Summary

- Phase C (commit 5217efc8) closed the naming-conventions transition window; the parser now rejects snake_case primitive type names, but several docs pages still taught the old spellings. Copy-pasted examples failed to parse.
- Rewrite every DSL reference / guide page to use the PascalCase type names accepted by the current parser.
- Fix the self-contradicting \"Strings are enclosed in double quotes\" line in `types-and-values.md` and add a short section covering single- vs. double-quoted string semantics.

## Changes

**#2182 — PascalCase type names**

- Primitives: `string`/`int`/`bool`/`float` → `String`/`Int`/`Bool`/`Float`
- Generic constructors: `list(...)` / `map(...)` stay lowercase (matches `TypeExpr::Display`); inner type parameters moved to PascalCase.
- Custom types in docs examples: `cidr` → `Ipv4Cidr`; `Arn` unchanged.
- Pseudo types used only in built-in function signatures: `any` → `Any`, `number` → `Number`, `secret` return type → `Secret`.

Files touched:
- `docs/src/content/docs/reference/dsl/modules.md`
- `docs/src/content/docs/reference/dsl/types-and-values.md`
- `docs/src/content/docs/reference/dsl/expressions.md`
- `docs/src/content/docs/reference/dsl/built-in-functions.md`
- `docs/src/content/docs/guides/using-modules.md`
- `docs/src/content/docs/guides/functions.md`

**#2187 — string quote style guidance**

In `docs/src/content/docs/reference/dsl/types-and-values.md`:
- Dropped the \"Strings are enclosed in double quotes\" line (it contradicted the single-quoted example immediately below).
- Added side-by-side sections for single-quoted (literal) and double-quoted (interpolation) strings, including escape-sequence differences and a brief recommended style: single for literals, double for interpolation.

## Verification

- `grep -rn ': string\b\|: int\b\|: bool\b\|: float\b\|: cidr\b\|list(string)\|list(int)\|list(cidr)\|map(string)\|map(int)\|map(cidr)' docs/src/content/docs/` → no matches.
- `npx astro build` completed: 85 pages built, no errors.
- Provider reference pages under `docs/src/content/docs/reference/providers/` are out of scope: their snake_case mentions come from AWS API field descriptions, not DSL syntax.

## Test plan

- [x] Astro build succeeds.
- [x] No snake_case primitive type annotations remain in DSL reference / guide pages.
- [ ] Reviewer spot-check of updated pages for tone / consistency.

Closes #2182
Closes #2187

🤖 Generated with [Claude Code](https://claude.com/claude-code)