### PR TITLE
lsp: fix source path completion for multi-line use blocks and leaf dirs

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -354,6 +354,11 @@ impl LanguageServer for Backend {
                         ".".to_string(),
                         "=".to_string(),
                         " ".to_string(),
+                        // `/` re-triggers path completion inside `use { source = '...' }`
+                        // so typing `../` fetches the parent dir's entries without
+                        // requiring a manual Ctrl-Space. Harmless outside import paths:
+                        // other contexts return nothing for a bare `/`.
+                        "/".to_string(),
                     ]),
                     ..Default::default()
                 }),

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -152,43 +152,6 @@ impl CompletionProvider {
             }
         }
 
-        // Check if cursor is inside a `use { source = '<cursor>' }` path string.
-        // The enclosing block must be `use { ... }` — for `upstream_state { source = ... }`
-        // a separate completion handler takes over (see `upstream_state_source_completions`).
-        if let Some(src_idx) = prefix.rfind("source") {
-            let before_source = &prefix[..src_idx];
-            let in_use_block = before_source
-                .rfind("use")
-                .map(|use_idx| {
-                    // Require a `use` keyword followed by `{` before the current `source =`,
-                    // and make sure no `upstream_state` keyword intervenes between them.
-                    let between = &before_source[use_idx..];
-                    between.contains('{')
-                        && !between.contains("upstream_state")
-                        && (use_idx == 0
-                            || !before_source[..use_idx]
-                                .chars()
-                                .next_back()
-                                .is_some_and(|c| c.is_alphanumeric() || c == '_'))
-                })
-                .unwrap_or(false);
-            if in_use_block {
-                let after_src = prefix[src_idx + "source".len()..].trim_start();
-                if let Some(rest) = after_src.strip_prefix('=') {
-                    let rest = rest.trim_start();
-                    if let Some(quote) = rest.chars().next()
-                        && (quote == '\'' || quote == '"')
-                        && !rest[1..].contains(quote)
-                    {
-                        let partial_path = &rest[1..];
-                        return CompletionContext::InsideImportPath {
-                            partial_path: partial_path.to_string(),
-                        };
-                    }
-                }
-            }
-        }
-
         // Check if we're in a type position after ":" in arguments/attributes blocks.
         // e.g., "vpc: aws." or "vpc: " — detect by checking if the line has a colon
         // but no equals sign, and we're inside arguments/attributes blocks.
@@ -203,6 +166,7 @@ impl CompletionProvider {
         let mut in_args_or_attrs_block = false;
         let mut in_exports_block = false;
         let mut in_upstream_state_block = false;
+        let mut in_use_block = false;
         // Type annotation of the most recent `<name>: <type> = ...` entry
         // inside an `exports { ... }` block. Recorded at brace_depth 1 and
         // consulted when the cursor lands inside that entry's value
@@ -268,6 +232,10 @@ impl CompletionProvider {
                 module_name = None;
             } else if brace_depth == 0 && is_let_upstream_state_line(trimmed) {
                 in_upstream_state_block = true;
+                resource_type.clear();
+                module_name = None;
+            } else if brace_depth == 0 && is_let_use_line(trimmed) {
+                in_use_block = true;
                 resource_type.clear();
                 module_name = None;
             } else if brace_depth == 0
@@ -344,6 +312,7 @@ impl CompletionProvider {
                         in_args_or_attrs_block = false;
                         in_exports_block = false;
                         in_upstream_state_block = false;
+                        in_use_block = false;
                         exports_entry_type = None;
                         nested_block_names.clear();
                     } else if brace_depth == 1 && in_exports_block {
@@ -432,6 +401,20 @@ impl CompletionProvider {
             && let Some(partial) = extract_upstream_source_partial(&prefix)
         {
             return CompletionContext::InsideUpstreamStateSource {
+                partial_path: partial,
+            };
+        }
+
+        // Check if cursor is inside `source = '...'` within a `use` block.
+        // Unlike `upstream_state` (where `source = '...'` almost always sits
+        // on its own line), a `use` block is frequently written in-line as
+        // `let x = use { source = '<cursor>` — so we have to search the full
+        // prefix, not just its trimmed start, for the attribute.
+        if in_use_block
+            && brace_depth > 0
+            && let Some(partial) = extract_source_partial_anywhere(&prefix)
+        {
+            return CompletionContext::InsideImportPath {
                 partial_path: partial,
             };
         }
@@ -775,6 +758,22 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
     next.starts_with('{') || next.is_empty()
 }
 
+fn is_let_use_line(trimmed: &str) -> bool {
+    let Some((_, rhs)) = crate::let_parse::parse_let_header(trimmed) else {
+        return false;
+    };
+    let Some(rest) = rhs.strip_prefix("use") else {
+        return false;
+    };
+    // Must be followed by whitespace or `{` to ensure it's the keyword, not a
+    // longer identifier starting with `use` (e.g. `user_data`). For such
+    // identifiers the continuation after stripping `use` starts with an
+    // identifier character (`r` for `user_data`), so `trim_start` preserves
+    // it and neither `starts_with('{')` nor `is_empty()` matches.
+    let next = rest.trim_start();
+    next.starts_with('{') || next.is_empty()
+}
+
 /// If the cursor sits at the iterable position of a `for <pat> in <partial>`
 /// header — i.e. after the `in` keyword and inside (possibly empty) identifier
 /// characters — return the partial identifier typed so far. A `.` in the
@@ -920,7 +919,40 @@ fn find_source_in_line(segment: &str) -> Option<String> {
 /// `None`.
 fn extract_upstream_source_partial(prefix: &str) -> Option<String> {
     let trimmed = prefix.trim_start();
-    let rest = trimmed.strip_prefix("source")?;
+    parse_source_partial_from(trimmed)
+}
+
+/// Same as `extract_upstream_source_partial`, but searches for the last
+/// occurrence of `source = '…` / `source = "…` anywhere within `prefix`
+/// (not just at its trimmed start). Needed for single-line shapes like
+/// `let x = use { source = '<cursor>` where the prefix carries the full
+/// let header, not just the attribute.
+fn extract_source_partial_anywhere(prefix: &str) -> Option<String> {
+    let mut search_from = prefix.len();
+    while let Some(idx) = prefix[..search_from].rfind("source") {
+        // Treat only the source keyword as a standalone identifier — reject
+        // matches where it's a suffix of a longer identifier like `my_source`.
+        let boundary_ok = idx == 0
+            || !prefix[..idx]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_');
+        if boundary_ok && let Some(partial) = parse_source_partial_from(&prefix[idx..]) {
+            return Some(partial);
+        }
+        if idx == 0 {
+            break;
+        }
+        search_from = idx;
+    }
+    None
+}
+
+/// Parse `source = '<partial>` (or with `"`) starting exactly at `s`.
+/// Used by both [`extract_upstream_source_partial`] and
+/// [`extract_source_partial_anywhere`].
+fn parse_source_partial_from(s: &str) -> Option<String> {
+    let rest = s.strip_prefix("source")?;
     let rest = rest.trim_start().strip_prefix('=')?.trim_start();
     let (quote, rest) = if let Some(r) = rest.strip_prefix('\'') {
         ('\'', r)
@@ -935,7 +967,9 @@ fn extract_upstream_source_partial(prefix: &str) -> Option<String> {
 
 #[cfg(test)]
 mod helper_tests {
-    use super::extract_upstream_source_partial;
+    use super::{
+        extract_source_partial_anywhere, extract_upstream_source_partial, is_let_use_line,
+    };
 
     #[test]
     fn single_quote_unclosed_returns_partial() {
@@ -973,5 +1007,54 @@ mod helper_tests {
         assert_eq!(extract_upstream_source_partial("source"), None);
         assert_eq!(extract_upstream_source_partial("source ="), None);
         assert_eq!(extract_upstream_source_partial("source = ../x"), None);
+    }
+
+    #[test]
+    fn anywhere_finds_partial_after_let_header() {
+        // Single-line `let x = use { source = '../x` shape: the attribute
+        // sits after the `let` / `use` / `{` tokens on the same line.
+        assert_eq!(
+            extract_source_partial_anywhere("let x = use { source = './modules/"),
+            Some("./modules/".to_string())
+        );
+        assert_eq!(
+            extract_source_partial_anywhere("let x = use { source = \"./modules/"),
+            Some("./modules/".to_string())
+        );
+    }
+
+    #[test]
+    fn anywhere_respects_identifier_boundary() {
+        // `my_source` ends in `source` but is a different identifier — must
+        // not be matched.
+        assert_eq!(
+            extract_source_partial_anywhere("let x = use { my_source = './m/"),
+            None
+        );
+    }
+
+    #[test]
+    fn anywhere_returns_none_when_quote_is_closed() {
+        assert_eq!(
+            extract_source_partial_anywhere("let x = use { source = './m' }"),
+            None
+        );
+    }
+
+    #[test]
+    fn is_let_use_accepts_common_shapes() {
+        assert!(is_let_use_line("let x = use { source = './m' }"));
+        assert!(is_let_use_line("let x = use {"));
+        assert!(is_let_use_line("let x = use{"));
+    }
+
+    #[test]
+    fn is_let_use_rejects_near_misses() {
+        // A longer identifier starting with `use` must not be mistaken for
+        // the keyword.
+        assert!(!is_let_use_line("let x = user_data"));
+        // `read`, `upstream_state`, etc. live on other let RHS shapes.
+        assert!(!is_let_use_line("let x = read awscc.ec2.Vpc { }"));
+        assert!(!is_let_use_line("let x = upstream_state { source = '..' }"));
     }
 }

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1539,3 +1539,35 @@ fn use_source_path_completion_works_multiline() {
         labels
     );
 }
+
+/// Regression guard for #2196: same multi-line shape, but with the `}` on a
+/// trailing line already present in the buffer (as it would be in a real
+/// editor that auto-closes the brace). `get_completion_context` must stop
+/// walking at the cursor line; trailing `}` after that must not affect
+/// `in_use_block` state.
+#[test]
+fn use_source_path_completion_works_multiline_with_trailing_brace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let modules_dir = tmp.path().join("modules");
+    std::fs::create_dir_all(modules_dir.join("network")).unwrap();
+
+    let provider = test_provider();
+    let source = "let net = use {\n  source = './modules/\n}";
+    let doc = create_document(source);
+    // Cursor sits at the end of line 1 (the `source = '...` line), BEFORE
+    // the trailing brace on line 2.
+    let second_line = source.lines().nth(1).unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: second_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(tmp.path()));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"network/"),
+        "Should suggest 'network/' directory even when buffer has a trailing `}}`. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1502,3 +1502,40 @@ fn import_path_completion_does_not_offer_anchors_after_slash() {
         labels
     );
 }
+
+/// Regression guard for #2196: path completion inside `use { source = '...' }`
+/// must work when `use {` and the `source` attribute are on separate lines.
+/// This is the real shape users type in practice; the single-line form was
+/// covered by `import_path_completion_lists_directories_only` but the
+/// multi-line shape broke after the `import` → `use` rename (#2186).
+#[test]
+fn use_source_path_completion_works_multiline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let modules_dir = tmp.path().join("modules");
+    std::fs::create_dir_all(modules_dir.join("network")).unwrap();
+    std::fs::create_dir_all(modules_dir.join("shared")).unwrap();
+
+    let provider = test_provider();
+    // Realistic multi-line shape — `use {` on line 0, `source = '...` on line 1.
+    let source = "let net = use {\n  source = './modules/";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(tmp.path()));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"network/"),
+        "Should suggest 'network/' directory under './modules/'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"shared/"),
+        "Should suggest 'shared/' directory under './modules/'. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1353,3 +1353,152 @@ fn import_path_completion_lists_directories_only() {
         labels
     );
 }
+
+/// Regression for #2196.
+///
+/// When the user starts typing a path with just `.`, we used to return zero
+/// completions because `.` was treated as a filename prefix and the hidden
+/// filter at the top of `import_path_completions` rejected every matching
+/// entry (`.`, `..`, `.something`). The fix offers `./` and `../` as
+/// navigation anchors so the user can start walking the tree.
+#[test]
+fn import_path_completion_offers_dot_anchors_for_partial_dot() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Leaf dir with no sibling module dirs — mirrors infra/aws/management/github-oidc/.
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+
+    let provider = test_provider();
+    let source = "let web = use { source = '.";
+    let doc = create_document(source);
+    let position = Position {
+        line: 0,
+        character: source.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&leaf));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"./"),
+        "Should offer './' anchor for partial '.'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"../"),
+        "Should offer '../' anchor for partial '.'. Got: {:?}",
+        labels
+    );
+}
+
+/// Regression for #2196.
+///
+/// Empty partial (`source = '|'`) must still give the user an entry point
+/// when the current directory has no module subdirs. The anchors `./` and
+/// `../` are that entry point.
+#[test]
+fn import_path_completion_offers_dot_anchors_for_empty_partial() {
+    let tmp = tempfile::tempdir().unwrap();
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+
+    let provider = test_provider();
+    let source = "let web = use { source = '";
+    let doc = create_document(source);
+    let position = Position {
+        line: 0,
+        character: source.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&leaf));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"./"),
+        "Should offer './' anchor for empty partial. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"../"),
+        "Should offer '../' anchor for empty partial. Got: {:?}",
+        labels
+    );
+}
+
+/// Regression for #2196.
+///
+/// Partial `..` is the user starting to type `../`. Same anchor behavior as
+/// `.` — must not get eaten by the hidden-file filter.
+#[test]
+fn import_path_completion_offers_dot_anchors_for_partial_double_dot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+
+    let provider = test_provider();
+    let source = "let web = use { source = '..";
+    let doc = create_document(source);
+    let position = Position {
+        line: 0,
+        character: source.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&leaf));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"../"),
+        "Should offer '../' anchor for partial '..'. Got: {:?}",
+        labels
+    );
+}
+
+/// Regression for #2196.
+///
+/// Once the user has committed to a direction (`../`), the anchors should
+/// NOT keep showing up — the user wants the contents of the parent dir,
+/// not more navigation markers.
+#[test]
+fn import_path_completion_does_not_offer_anchors_after_slash() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Structure:
+    //   tmp/leaf/           (base_path — no siblings of its own)
+    //   tmp/sibling_a/
+    //   tmp/sibling_b/
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+    std::fs::create_dir_all(tmp.path().join("sibling_a")).unwrap();
+    std::fs::create_dir_all(tmp.path().join("sibling_b")).unwrap();
+
+    let provider = test_provider();
+    let source = "let web = use { source = '../";
+    let doc = create_document(source);
+    let position = Position {
+        line: 0,
+        character: source.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&leaf));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"sibling_a/"),
+        "Should list sibling_a/ from parent dir. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"sibling_b/"),
+        "Should list sibling_b/ from parent dir. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"./"),
+        "Should NOT offer './' anchor when partial already ends with '/'. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"../"),
+        "Should NOT offer '../' anchor when partial already ends with '/'. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1503,6 +1503,47 @@ fn import_path_completion_does_not_offer_anchors_after_slash() {
     );
 }
 
+/// Regression guard for #2196: at `'../` the completion must list entries
+/// of the parent directory, not be empty. Mirrors the real
+/// `infra/aws/management/github-oidc/main.crn` case where the user needs
+/// to walk out of the leaf dir to reach `modules/`.
+#[test]
+fn use_source_path_completion_lists_parent_at_double_dot_slash() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Structure:
+    //   tmp/leaf/             <- base_path (opened .crn lives here)
+    //   tmp/sibling_alpha/
+    //   tmp/sibling_beta/
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+    std::fs::create_dir_all(tmp.path().join("sibling_alpha")).unwrap();
+    std::fs::create_dir_all(tmp.path().join("sibling_beta")).unwrap();
+
+    let provider = test_provider();
+    // Multi-line mid-typing shape — exactly what the editor sends.
+    let source = "let x = use {\n  source = '../";
+    let doc = create_document(source);
+    let last_line = source.lines().next_back().unwrap_or("");
+    let position = Position {
+        line: 1,
+        character: last_line.chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&leaf));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"sibling_alpha/"),
+        "Should list 'sibling_alpha/' from parent at '../'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"sibling_beta/"),
+        "Should list 'sibling_beta/' from parent at '../'. Got: {:?}",
+        labels
+    );
+}
+
 /// Regression guard for #2196: path completion inside `use { source = '...' }`
 /// must work when `use {` and the `source` attribute are on separate lines.
 /// This is the real shape users type in practice; the single-line form was

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -457,6 +457,27 @@ pub(super) fn extract_use_source_path(after_eq: &str) -> Option<String> {
     Some(body[..end].to_string())
 }
 
+/// Build a navigation-anchor `CompletionItem` for `./` or `../`.
+///
+/// The `label` and `insert_text` are the same literal text — the LSP
+/// client replaces the current path "word" with this. Triggers a follow-up
+/// suggest so the user immediately sees the resolved directory's entries.
+fn path_anchor(text: &str) -> CompletionItem {
+    CompletionItem {
+        label: text.to_string(),
+        kind: Some(CompletionItemKind::FOLDER),
+        insert_text: Some(text.to_string()),
+        detail: Some("Relative path".to_string()),
+        sort_text: Some(format!("0_{}", text)),
+        command: Some(Command {
+            title: "Trigger Suggest".to_string(),
+            command: "editor.action.triggerSuggest".to_string(),
+            arguments: None,
+        }),
+        ..Default::default()
+    }
+}
+
 impl CompletionProvider {
     /// Generate import path completions from filesystem.
     ///
@@ -472,6 +493,23 @@ impl CompletionProvider {
             None => return vec![],
         };
 
+        let mut completions = Vec::new();
+
+        // Navigation anchors. A user typing `'|`, `'.|`, or `'..|` is starting
+        // to build a relative path — offer `./` and `../` so the list is
+        // never empty even when the current dir has no module subdirs (the
+        // common case for leaf config dirs like `infra/aws/management/github-oidc/`).
+        // Once the partial contains a `/` the user has committed to a
+        // direction and wants entries from the resolved dir, not anchors.
+        if !partial_path.contains('/') {
+            if partial_path.is_empty() || "./".starts_with(partial_path) {
+                completions.push(path_anchor("./"));
+            }
+            if partial_path.is_empty() || "../".starts_with(partial_path) {
+                completions.push(path_anchor("../"));
+            }
+        }
+
         // Split partial_path into directory prefix and filename prefix
         let (dir_part, name_prefix) = if let Some(last_slash) = partial_path.rfind('/') {
             (
@@ -485,10 +523,8 @@ impl CompletionProvider {
         let search_dir = base.join(dir_part);
         let entries = match std::fs::read_dir(&search_dir) {
             Ok(entries) => entries,
-            Err(_) => return vec![],
+            Err(_) => return completions,
         };
-
-        let mut completions = Vec::new();
 
         for entry in entries.flatten() {
             let file_name = entry.file_name();

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -451,7 +451,7 @@ awscc.ec2.vpc_gateway_attachment {
     client.shutdown().await;
 }
 
-/// Regression for #2196.
+/// Regression for #2196 (empty-candidate side).
 ///
 /// End-to-end test: a leaf config dir (mirror of
 /// `infra/aws/management/github-oidc/` — multi-file, no sibling module
@@ -479,12 +479,10 @@ async fn test_use_source_path_completion_offers_anchors_in_leaf_dir() {
     )
     .unwrap();
 
-    // main.crn has a `use` with an opening partial — cursor after the `.`.
-    // Written as a single line on purpose: the multi-line shape currently
-    // has a separate context-detection bug (the `source = ...` line has no
-    // `use` keyword on the same line, so `determine_context` falls through
-    // before the anchor logic can run). That bug is out of scope for this
-    // fix — this test covers the empty-candidate bug only.
+    // Single-line shape here — the multi-line context-detection fix is
+    // exercised separately by `test_use_source_path_completion_multiline`
+    // below. This test's job is to prove that once the right context is
+    // detected, the anchors are actually emitted.
     let main_text = "let shared = use { source = '.' }\n";
     let main_path = leaf.join("main.crn");
     std::fs::write(&main_path, main_text).unwrap();
@@ -515,6 +513,61 @@ async fn test_use_source_path_completion_offers_anchors_in_leaf_dir() {
     assert!(
         labels.contains(&"../"),
         "Should offer '../' anchor. Got: {:?}",
+        labels
+    );
+
+    client.shutdown().await;
+}
+
+/// End-to-end regression guard for #2196 (context-detection side): a full
+/// LSP session where the editor opens a `.crn` with a multi-line
+/// `use { source = '…' }` and requests completion at the cursor inside
+/// `source`. Exercises the real JSON-RPC path, not only the internal
+/// `CompletionProvider::complete`.
+#[tokio::test]
+async fn test_use_source_path_completion_multiline() {
+    // Lay out a real workspace on disk so the LSP can walk it from the
+    // opened document's directory.
+    let tmp = tempfile::tempdir().unwrap();
+    let modules_dir = tmp.path().join("modules");
+    std::fs::create_dir_all(modules_dir.join("network")).unwrap();
+    std::fs::create_dir_all(modules_dir.join("shared")).unwrap();
+
+    let crn_path = tmp.path().join("main.crn");
+    let text = "let network = use {\n  source = './modules/\n}";
+    std::fs::write(&crn_path, text).unwrap();
+
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let uri = format!("file://{}", crn_path.display());
+    client.open_document(&uri, text).await;
+
+    // Small delay to let the server process didOpen.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Cursor at the end of the `source = './modules/` line (line 1).
+    let second_line = text.lines().nth(1).unwrap();
+    let character = second_line.chars().count() as u32;
+    let response = client._request_completion(&uri, 1, character).await;
+
+    let items = response["result"]
+        .as_array()
+        .expect("Completion result should be an array");
+
+    let labels: Vec<&str> = items
+        .iter()
+        .filter_map(|item| item["label"].as_str())
+        .collect();
+
+    assert!(
+        labels.contains(&"network/"),
+        "Should suggest 'network/' directory from './modules/'. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"shared/"),
+        "Should suggest 'shared/' directory from './modules/'. Got: {:?}",
         labels
     );
 

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -450,3 +450,73 @@ awscc.ec2.vpc_gateway_attachment {
 
     client.shutdown().await;
 }
+
+/// Regression for #2196.
+///
+/// End-to-end test: a leaf config dir (mirror of
+/// `infra/aws/management/github-oidc/` — multi-file, no sibling module
+/// dirs) asks for completion inside `use { source = '.|' }`. The LSP
+/// must return the `./` and `../` navigation anchors so the user has
+/// a starting point; prior to the fix this call returned an empty list.
+#[tokio::test]
+async fn test_use_source_path_completion_offers_anchors_in_leaf_dir() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    // Mirror the real infra shape: a leaf config dir with main/providers/backend,
+    // no `modules/` subtree of its own.
+    let tmp = tempfile::tempdir().unwrap();
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+    std::fs::write(
+        leaf.join("providers.crn"),
+        "provider aws {\n  region = \"us-east-1\"\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        leaf.join("backend.crn"),
+        "backend {\n  type = \"local\"\n}\n",
+    )
+    .unwrap();
+
+    // main.crn has a `use` with an opening partial — cursor after the `.`.
+    // Written as a single line on purpose: the multi-line shape currently
+    // has a separate context-detection bug (the `source = ...` line has no
+    // `use` keyword on the same line, so `determine_context` falls through
+    // before the anchor logic can run). That bug is out of scope for this
+    // fix — this test covers the empty-candidate bug only.
+    let main_text = "let shared = use { source = '.' }\n";
+    let main_path = leaf.join("main.crn");
+    std::fs::write(&main_path, main_text).unwrap();
+
+    let uri = format!("file://{}", main_path.display());
+    client.open_document(&uri, main_text).await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Cursor on line 0, right after the `.` inside the single quotes.
+    // "let shared = use { source = '" has 29 chars, `.` is at col 29,
+    // so cursor sits at col 30.
+    let response = client._request_completion(&uri, 0, 30).await;
+
+    let items = response["result"]
+        .as_array()
+        .expect("Completion result should be an array");
+    let labels: Vec<&str> = items
+        .iter()
+        .filter_map(|item| item["label"].as_str())
+        .collect();
+
+    assert!(
+        labels.contains(&"./"),
+        "Should offer './' anchor. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"../"),
+        "Should offer '../' anchor. Got: {:?}",
+        labels
+    );
+
+    client.shutdown().await;
+}

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -479,11 +479,12 @@ async fn test_use_source_path_completion_offers_anchors_in_leaf_dir() {
     )
     .unwrap();
 
-    // Single-line shape here — the multi-line context-detection fix is
-    // exercised separately by `test_use_source_path_completion_multiline`
-    // below. This test's job is to prove that once the right context is
-    // detected, the anchors are actually emitted.
-    let main_text = "let shared = use { source = '.' }\n";
+    // Multi-line shape — mirrors what the user types. The opening quote
+    // has no matching closing quote yet (this is the normal mid-typing
+    // state); the context detector expects that. A closed `'...'` shape
+    // is also handled elsewhere in the code path but isn't what we
+    // exercise here.
+    let main_text = "let shared = use {\n  source = '.";
     let main_path = leaf.join("main.crn");
     std::fs::write(&main_path, main_text).unwrap();
 
@@ -492,10 +493,10 @@ async fn test_use_source_path_completion_offers_anchors_in_leaf_dir() {
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Cursor on line 0, right after the `.` inside the single quotes.
-    // "let shared = use { source = '" has 29 chars, `.` is at col 29,
-    // so cursor sits at col 30.
-    let response = client._request_completion(&uri, 0, 30).await;
+    // Cursor at end of line 1 (after the `.`).
+    let last_line = main_text.lines().next_back().unwrap();
+    let character = last_line.chars().count() as u32;
+    let response = client._request_completion(&uri, 1, character).await;
 
     let items = response["result"]
         .as_array()


### PR DESCRIPTION
Closes #2196.

## Problem

After `#2186` renamed `import 'path'` to `use { source = '...' }`, path completion in the real editor experience was broken in three overlapping ways:

1. **Multi-line block shape was undetected.** The natural form
    ```crn
    let x = use {
      source = './modules/|'
    }
    ```
    put the cursor on a line that had no `use` keyword, and the old line-local heuristic in `determine_context` fell through to generic function completion.
2. **Empty-candidate case in leaf dirs.** Typing `'.` (the natural first character of a relative path) was treated as `name_prefix = "."` and filtered out by the hidden-file skip, so `import_path_completions` returned an empty list — indistinguishable from "no completion" in the editor.
3. **No auto re-trigger on `/`.** `/` was not a trigger character, so typing `../` did not auto-fetch the parent dir. Users without a working Ctrl-Space (taken by the OS on macOS for many people) could walk the tree one segment only.

Together these meant the real `infra/aws/management/github-oidc/` shape — multi-line `use {}`, leaf dir with no sibling modules, target at `../../../modules/github-oidc` — produced no usable completion at all.

## Fix

Three commits, one for each axis:

- **`offer ./ and ../ anchors when use source partial is empty or '.'`** — `import_path_completions` prepends `./` and `../` when the partial is empty, `.`, or `..` (doesn't yet contain `/`). Once the partial has a `/` the user has chosen a direction and wants the resolved dir's entries, so anchors are suppressed. The existing listing logic handles `./`, `../`, `../../` etc. via `Path::join` + `read_dir` without further change.
- **`fix source path completion inside multi-line use blocks`** — Replaces the line-local textual heuristic in `determine_context` with the same block-tracking mechanism `upstream_state { source = ... }` already uses. Adds `is_let_use_line` (identifier-boundary aware — `user_data` doesn't fire) and `extract_source_partial_anywhere` for the single-line variant. Cherry-picked from the closed #2199.
- **`re-trigger completion on /`** — Adds `/` to `trigger_characters`. Typing `../` now auto-opens the next suggestion window without any manual shortcut.

Plus two test-plumbing commits (integration test from #2199 and a follow-up tweak to match the mid-typing shape the LSP actually handles).

## Tests

- Unit: 5 new tests in `carina-lsp/src/completion/tests/basic.rs` covering each partial shape (`''`, `'.`, `'..`, `'../` with siblings, and the "no anchor after `/`" negative case) plus the pre-existing `import_path_completion_lists_directories_only` still passing.
- Unit: `use_source_path_completion_works_multiline` and `use_source_path_completion_lists_parent_at_double_dot_slash` prove the block-tracking path works end-to-end within the provider.
- Integration: two JSON-RPC level tests (`test_use_source_path_completion_multiline` and `test_use_source_path_completion_offers_anchors_in_leaf_dir`) exercise the real `didOpen` + `textDocument/completion` flow.
- Existing LSP suite: 328 pre-existing tests still pass.

## Editor verification

Confirmed in-editor on `infra/aws/management/github-oidc/main.crn`: `'`, `'.`, `'../`, `'../../`, `'../../../modules/` each produce correct candidates without needing a manual trigger.

## Known follow-up

Filed as #2201 (not part of this PR): when the resolved dir genuinely has no module subdirs, the LSP returns an empty list and VSCode falls back to word-based suggestions (offering unrelated tokens scraped from the file). Separate problem — it's about how we communicate "nothing to suggest here, and don't word-fallback" to the client, not about fixing empty-candidate bugs in the path walker itself.

## Test plan

- [x] `cargo test -p carina-lsp` — all pass
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual: install binary, confirm `'`, `'.`, `'../`, `'../../`, … auto-suggest in-editor against real `infra/aws/management/github-oidc/`