### PR TITLE
editors/vscode: disable word-based suggestions for .crn files

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -43,7 +43,8 @@
     },
     "configurationDefaults": {
       "[carina]": {
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.wordBasedSuggestions": "off"
       }
     }
   },


### PR DESCRIPTION
Closes #2201.

## Problem

When the LSP returns an empty completion list at a position where the grammar offers nothing (the most visible case is the `use { source = '...' }` path walker resolving to a directory with no module subdirs), VSCode falls back to **word-based suggestions** — tokens scraped from the open file. The user ends up with `account`, `Actions`, `Allow`, `apply`, `aws`, `carina`, `for`, … offered where only a file-system path makes sense. The UI is worse than showing nothing.

## Approach

LSP has no wire-level way to say "no results *and* suppress word-based fallback". The fix has to happen on the client side. For VSCode that means setting `editor.wordBasedSuggestions` to `off` for the `carina` language scope.

Done via `contributes.configurationDefaults."[carina]"` in the extension's `package.json`, next to the existing `editor.formatOnSave: true` default. The setting only applies as a default — if the user has explicitly configured their own value, that still wins.

Carina is an LSP-complete language: every meaningful candidate should come from the LSP. Word-based guesses add noise and no value.

## Verification

- `jq '.contributes.configurationDefaults."[carina]"."editor.wordBasedSuggestions"' editors/vscode/package.json` → `"off"`
- Built and reinstalled the extension locally (`vsce package`, `code --install-extension --force`) against the `#2196` repro: inside `infra/aws/management/github-oidc/main.crn`, typing `source = '../management/carina-state/` previously surfaced `account`/`Actions`/`aws`/`for`/... word-based candidates; after the change the completion UI stays empty, as expected.

## Out of scope

While verifying, noticed that `source` itself isn't suggested as an attribute name inside `use { | }` — that's #2200, a separate LSP-side gap (no `InsideUseBlock` completion context; falls through to the generic attribute path with an empty `resource_type`). Tracked there, not in this PR.

## Test plan

- [x] `jq` key check
- [x] Manual editor verification after `code --install-extension`