### PR TITLE
lsp: offer 'source' at attribute-name position inside use { ... }

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -76,6 +76,7 @@ impl CompletionProvider {
                 self.attribute_completions_for_type(&resource_type)
             }
             CompletionContext::InsideUpstreamStateBlock => self.upstream_state_block_completions(),
+            CompletionContext::InsideUseBlock => self.use_block_completions(),
             CompletionContext::InsideModuleCall { module_name } => {
                 self.module_parameter_completions(&module_name, &text, base_path)
             }
@@ -419,6 +420,17 @@ impl CompletionProvider {
             };
         }
 
+        // Attribute-name position inside a `use { ... }` block. The sole
+        // valid attribute is `source`. Handled before the generic
+        // `contains('=')` fallback so the in-line shape
+        // `let x = use { <cursor>` — whose prefix still contains the
+        // binding's own `=` — doesn't get routed to value-position
+        // builtins. The `source = '...'` value position is already caught
+        // by the `InsideImportPath` branch above.
+        if in_use_block && brace_depth > 0 {
+            return CompletionContext::InsideUseBlock;
+        }
+
         // Check if we're after an equals sign (value position) inside a block
         if brace_depth > 0 && prefix.contains('=') {
             let after_eq = prefix.split('=').next_back().unwrap_or("").trim();
@@ -678,6 +690,7 @@ enum CompletionContext {
         resource_type: String,
     },
     InsideUpstreamStateBlock,
+    InsideUseBlock,
     InsideModuleCall {
         module_name: String,
     },

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -853,6 +853,66 @@ fn upstream_state_block_completes_source_attribute() {
     );
 }
 
+/// Regression for #2200. Same shape as `upstream_state`: a `use { ... }`
+/// block has exactly one legal attribute name (`source`), and that's what
+/// the LSP must offer at the attribute-name position. Previously the code
+/// fell through to `InsideResourceBlock` with an empty resource_type and
+/// returned nothing.
+#[test]
+fn use_block_completes_source_attribute() {
+    let provider = test_provider();
+    let doc = create_document(
+        r#"let mod = use {
+
+}"#,
+    );
+    // Cursor on the empty line inside the block
+    let position = Position {
+        line: 1,
+        character: 0,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"source"),
+        "use block should offer 'source' attribute. Got: {:?}",
+        labels
+    );
+    assert_eq!(
+        labels.len(),
+        1,
+        "use block has exactly one attribute; no other candidates should leak in. Got: {:?}",
+        labels
+    );
+}
+
+/// Regression for #2200. The in-line shape (`let m = use { |`) must behave
+/// the same as the multi-line shape above — same single `source` candidate,
+/// no fallthrough noise.
+#[test]
+fn use_block_completes_source_attribute_single_line() {
+    let provider = test_provider();
+    let source = "let mod = use { ";
+    let doc = create_document(source);
+    let position = Position {
+        line: 0,
+        character: source.chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"source"),
+        "use block (single-line) should offer 'source'. Got: {:?}",
+        labels
+    );
+    assert_eq!(
+        labels.len(),
+        1,
+        "use block has exactly one attribute. Got: {:?}",
+        labels
+    );
+}
+
 #[test]
 fn struct_field_completion_with_assignment_syntax() {
     // Bug #1627: `outer = {` (assignment syntax) was not detected as nested struct block

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -678,6 +678,19 @@ impl CompletionProvider {
         }]
     }
 
+    /// Sole attribute of a `use { ... }` block. Mirrors the
+    /// `upstream_state` version, which has the same `source = '...'` shape.
+    pub(super) fn use_block_completions(&self) -> Vec<CompletionItem> {
+        vec![CompletionItem {
+            label: "source".to_string(),
+            kind: Some(CompletionItemKind::PROPERTY),
+            detail: Some("Module directory path".to_string()),
+            insert_text: Some("source = '$0'".to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        }]
+    }
+
     /// Suggest sibling (and uncle/grand-uncle) directories that look like carina
     /// projects, for use as the `source` attribute of an `upstream_state` block.
     pub(super) fn upstream_state_source_completions(

--- a/carina-lsp/tests/lsp_integration.rs
+++ b/carina-lsp/tests/lsp_integration.rs
@@ -574,3 +574,58 @@ async fn test_use_source_path_completion_multiline() {
 
     client.shutdown().await;
 }
+
+/// Regression for #2200: attribute-name position inside `use { ... }` must
+/// offer `source`. Multi-file directory fixture mirrors the real
+/// `infra/aws/management/<leaf>/` shape per CLAUDE.md's directory-scoped
+/// rule, so we're exercising the handler against the same shape users
+/// actually edit.
+#[tokio::test]
+async fn test_use_block_offers_source_attribute() {
+    let mut client = TestClient::new().await;
+    client.initialize().await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let leaf = tmp.path().join("leaf");
+    std::fs::create_dir_all(&leaf).unwrap();
+    std::fs::write(
+        leaf.join("providers.crn"),
+        "provider aws {\n  region = \"us-east-1\"\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        leaf.join("backend.crn"),
+        "backend {\n  type = \"local\"\n}\n",
+    )
+    .unwrap();
+
+    // Multi-line mid-typing shape. Cursor on the empty line inside the block.
+    let main_text = "let shared = use {\n\n}\n";
+    let main_path = leaf.join("main.crn");
+    std::fs::write(&main_path, main_text).unwrap();
+
+    let uri = format!("file://{}", main_path.display());
+    client.open_document(&uri, main_text).await;
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Line 1, col 0 — inside the block, attribute-name position.
+    let response = client._request_completion(&uri, 1, 0).await;
+
+    let items = response["result"]
+        .as_array()
+        .expect("Completion result should be an array");
+    let labels: Vec<&str> = items
+        .iter()
+        .filter_map(|item| item["label"].as_str())
+        .collect();
+
+    assert_eq!(
+        labels,
+        vec!["source"],
+        "use block should offer exactly one attribute ('source'). Got: {:?}",
+        labels
+    );
+
+    client.shutdown().await;
+}


### PR DESCRIPTION
Closes #2200.

## Problem

Inside `let x = use { | }`, the LSP offered nothing at the attribute-name position. `use` has exactly one valid attribute (`source`), but there was no dedicated handler — `determine_context` fell through to `InsideResourceBlock { resource_type: "" }` and the attribute-completion helper, finding no schema to narrow against, returned an empty list.

The gap was masked until recently: VSCode's word-based fallback happened to surface `source` whenever the word appeared somewhere in the open file. #2203 disabled word-based fallback for `.crn`, exposing the LSP-side hole directly.

For the in-line shape `let x = use { <cursor>`, the prefix still contains the binding's own `=`, so the cursor was also reaching the value-position branch and getting redirected to builtin-function candidates (`concat`, `decrypt`, `env`, …). Worse than empty.

## Fix

Parity with `upstream_state`:

- New `CompletionContext::InsideUseBlock` variant.
- New `use_block_completions()` returning one `source` item with snippet `source = '$0'`. Single quotes per the existing `use` path style; `upstream_state` uses double quotes in its own snippet — both conventions preserved.
- `determine_context` routes to `InsideUseBlock` immediately after `InsideImportPath`, before the generic value-position branch, so the in-line shape no longer leaks builtin candidates.

## Tests

- **Unit, multi-line** (`use_block_completes_source_attribute`): `let mod = use {\n\n}` cursor on the empty line — asserts `source` present and exactly one candidate.
- **Unit, single-line** (`use_block_completes_source_attribute_single_line`): `let mod = use { ` — same assertion. Before the fix this returned the builtin-function list.
- **Integration, multi-file fixture** (`test_use_block_offers_source_attribute`): `tempdir` with `main.crn` + `providers.crn` + `backend.crn` mirroring the `infra/aws/management/<leaf>/` shape, opened via the real LSP JSON-RPC path.
- 338 pre-existing LSP tests still pass — `upstream_state` parity untouched.

## Editor verification

`carina-lsp` installed from this worktree, confirmed in-editor against `infra/aws/management/github-oidc/main.crn`: `let github = use { | }` now suggests `source`, selecting it expands to `source = ''` with cursor inside the quotes (ready for the `#2196` path-completion flow).

## Test plan

- [x] `cargo test -p carina-lsp` — 338 passed
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual editor verification