### PR TITLE
docs: refresh CLAUDE.md, README, and user docs to match current behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,11 +133,11 @@ Provider repositories depend on this repo's crates via `git` dependencies.
 
 - **carina-core**: Core library with parser, types, and traits. No AWS dependencies.
 - **carina-cli**: Binary that wires everything together.
-- **carina-aws-types**: AWS-specific type definitions shared by providers.
 - **carina-plugin-host**: WASM plugin host for loading provider plugins.
 - **carina-plugin-sdk**: SDK for building WASM provider plugins.
 - **carina-provider-mock**: Mock provider for testing.
 - **carina-provider-protocol**: Protocol definitions for provider communication.
+- **carina-provider-resolver**: Resolves and loads provider plugins for the CLI.
 - **carina-state**: State management.
 - **carina-lsp**: Language Server Protocol implementation.
 - **carina-tui**: Terminal UI for plan display.
@@ -186,7 +186,7 @@ Resource types in DSL use dot notation (`s3.bucket`, `ec2.vpc`). When mapping be
 ### Validation Formats
 
 - **Region**: Accepts both DSL format (`aws.Region.ap_northeast_1`) and AWS string format (`"ap-northeast-1"`). Validation normalizes both to AWS format for comparison.
-- **S3 Versioning**: Uses enum `.enabled`/`.suspended` in DSL (AWS SDK returns PascalCase `Enabled`/`Suspended`, normalized to snake_case DSL values).
+- **S3 Versioning**: Uses enum `aws.s3.VersioningStatus.Enabled` / `aws.s3.VersioningStatus.Suspended` in DSL (PascalCase matches the AWS SDK representation).
 
 ### Namespaced Enum Identifiers
 
@@ -203,7 +203,7 @@ Enum values use namespaced identifiers like `aws.s3.Bucket.VersioningStatus.enab
    resource.chars().all(|c| c.is_lowercase() || c.is_ascii_digit() || c == '_')
    ```
 
-2. **Update `is_dsl_enum_format()` in `carina-core/src/utils.rs`** for new patterns (e.g., 4-part identifiers like `provider.resource.TypeName.value`)
+2. **Update `is_dsl_enum_format()` in `carina-core/src/utils.rs`** for new patterns. It currently handles 2-part (`TypeName.value`), 3-part (`provider.TypeName.value`), 4-part (`provider.resource.TypeName.value`), and 5-part (`provider.service.resource.TypeName.value`) identifiers. If you introduce a new shape, add it there alongside the existing arms.
 
 3. **Plan display should not quote namespaced identifiers** - They are identifiers, not strings
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ aws.security_group.ingress_rule {
 
 ### 2. Validate
 
+Point `carina` at the directory containing your `.crn` files (all `.crn` files in that directory are merged):
+
 ```bash
-$ carina validate main.crn
+$ carina validate .
 Validating...
 ✓ 3 resources validated successfully.
   • vpc.main-vpc
@@ -79,7 +81,7 @@ Validating...
 ### 3. Plan
 
 ```bash
-$ carina plan main.crn
+$ carina plan .
 Execution Plan:
 
   + vpc
@@ -98,7 +100,7 @@ Plan: 3 to add, 0 to change, 0 to destroy.
 ### 4. Apply
 
 ```bash
-$ carina apply main.crn
+$ carina apply .
 Applying changes...
 
   ✓ Create vpc.main-vpc
@@ -327,25 +329,32 @@ carina/
 │   │   ├── plan.rs          # Plan (collection of Effects)
 │   │   ├── resource.rs      # Resource and State types
 │   │   ├── provider.rs      # Provider trait
-│   │   ├── differ.rs        # State comparison
+│   │   ├── differ/          # State comparison
 │   │   ├── parser/          # DSL parser (pest-based)
 │   │   ├── schema.rs        # Type validation (generic types only)
 │   │   ├── module.rs        # Module signature and dependency graph
-│   │   ├── module_resolver.rs # Module import and expansion
+│   │   ├── module_resolver/ # Module import and expansion
 │   │   └── formatter/       # Code formatter
 │   └── ...
 ├── carina-plugin-host/      # WASM plugin host for provider plugins
 ├── carina-plugin-sdk/       # SDK for building WASM provider plugins
 ├── carina-provider-mock/    # Mock provider for testing
 ├── carina-provider-protocol/ # Protocol definitions for provider communication
+├── carina-provider-resolver/ # Resolves and loads provider plugins
 ├── carina-state/            # State management
 │   └── src/backends/        # State backends (S3, etc.)
-└── carina-lsp/              # Language Server Protocol implementation
+├── carina-lsp/              # Language Server Protocol implementation
+└── carina-tui/              # Terminal UI for plan display
 ```
 
 ## AWS Provider
 
-The AWS provider requires valid AWS credentials. Configure via:
+AWS providers are distributed as separate repositories under [carina-rs](https://github.com/carina-rs) and loaded as WASM plugins by the core runtime:
+
+- [carina-provider-aws](https://github.com/carina-rs/carina-provider-aws) — AWS provider (Smithy-based codegen)
+- [carina-provider-awscc](https://github.com/carina-rs/carina-provider-awscc) — AWS Cloud Control provider
+
+Configure valid AWS credentials via:
 
 - Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
 - AWS credentials file (`~/.aws/credentials`)
@@ -354,7 +363,7 @@ The AWS provider requires valid AWS credentials. Configure via:
 ### Using with aws-vault
 
 ```bash
-aws-vault exec myprofile -- carina apply main.crn
+aws-vault exec myprofile -- carina apply .
 ```
 
 ## Commands
@@ -385,7 +394,7 @@ $ carina fmt --diff
 Remove all resources defined in a configuration:
 
 ```bash
-$ carina destroy main.crn
+$ carina destroy .
 Destroy Plan:
 
   - security_group.ingress_rule.http

--- a/docs/src/content/docs/getting-started/core-concepts.md
+++ b/docs/src/content/docs/getting-started/core-concepts.md
@@ -39,9 +39,9 @@ Configure a provider in your `.crn` file:
 
 ```crn
 provider awscc {
-  source  = 'file:///path/to/carina_provider_awscc.wasm'
-  version = '0.3.0'
-  region  = 'ap-northeast-1'
+  source  = 'github.com/carina-rs/carina-provider-awscc'
+  version = '0.5.0'
+  region  = awscc.Region.ap_northeast_1
 }
 ```
 

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -17,8 +17,8 @@ Download pre-built binaries from [GitHub Releases](https://github.com/carina-rs/
 
 ```bash
 # macOS (Apple Silicon)
-curl -LO https://github.com/carina-rs/carina/releases/latest/download/carina-0.3.0-macos-aarch64.tar.gz
-tar xzf carina-0.3.0-macos-aarch64.tar.gz
+curl -LO https://github.com/carina-rs/carina/releases/latest/download/carina-0.4.0-macos-aarch64.tar.gz
+tar xzf carina-0.4.0-macos-aarch64.tar.gz
 sudo mv carina carina-lsp /usr/local/bin/
 ```
 
@@ -48,9 +48,9 @@ Carina uses WASM-based provider plugins. When you specify a `source` and `versio
 
 ```crn
 provider awscc {
-    source = 'github.com/carina-rs/carina-provider-awscc'
-    version = '0.3.0'
-    region = 'ap-northeast-1'
+    source  = 'github.com/carina-rs/carina-provider-awscc'
+    version = '0.5.0'
+    region  = awscc.Region.ap_northeast_1
 }
 ```
 

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -17,8 +17,8 @@ mkdir my-infra && cd my-infra
 // main.crn
 provider awscc {
   source  = 'github.com/carina-rs/carina-provider-awscc'
-  version = '0.3.0'
-  region  = 'ap-northeast-1'
+  version = '0.5.0'
+  region  = awscc.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {
@@ -30,7 +30,7 @@ awscc.ec2.Vpc {
 }
 ```
 
-Replace the `source` path with the actual path to your built WASM provider plugin.
+Carina downloads the WASM provider plugin from the release matching `version` (or use `revision = 'main'` to track the latest commit). The plugin is cached under `.carina/providers/`.
 
 ## Validate
 

--- a/docs/src/content/docs/guides/state-management.md
+++ b/docs/src/content/docs/guides/state-management.md
@@ -146,7 +146,7 @@ awscc.ec2.SecurityGroup {
 
 The `upstream_state` expression points at an upstream project's directory. Carina loads that directory's configuration, resolves its backend, reads its state, and exposes the upstream's `exports` through the `let`-bound name. In this example, `network.vpc_id` references the `vpc_id` value published by the `../network` project's `exports` block.
 
-`source` is required and resolved relative to the enclosing `.crn` file's directory. The upstream directory must contain a valid Carina configuration (a `main.crn` or flat `*.crn` files) with an `exports` block that publishes the values consumers need.
+`source` is required and resolved relative to the enclosing `.crn` file's directory. The upstream directory must contain a valid Carina configuration (one or more `.crn` files — no filename is privileged) with an `exports` block that publishes the values consumers need.
 
 ## State CLI commands
 

--- a/docs/src/content/docs/guides/using-modules.md
+++ b/docs/src/content/docs/guides/using-modules.md
@@ -7,9 +7,9 @@ Modules let you group related resources into reusable units. A module defines it
 
 ## Creating a module
 
-A module is a `.crn` file (or a directory containing `main.crn`) that declares `arguments` and optionally `attributes`.
+A module is a directory containing one or more `.crn` files. Every `.crn` file in the directory is merged together — no filename (including `main.crn`) is privileged. Single-file modules are not supported; always point `use` at a directory.
 
-Create a file at `modules/network/main.crn`:
+Create a file at `modules/network/main.crn` (the filename is up to you):
 
 ```crn
 arguments {
@@ -110,16 +110,18 @@ awscc.ec2.RouteTable {
 
 The `net.vpc_id` reference accesses the `vpc_id` attribute declared in the module's `attributes` block.
 
-## Directory modules
+## Splitting a module across multiple files
 
-A module can be either:
+Every `.crn` file in a module directory is merged as a peer, so you can split a module across files however you like. A common convention is:
 
-- **A single file**: `modules/network.crn`
-- **A directory**: `modules/network/main.crn`
+```
+modules/network/
+  main.crn          # resources
+  arguments.crn     # arguments block
+  attributes.crn    # attributes block
+```
 
-Directory modules are useful when a module grows large or needs helper files. The entry point is always `main.crn` inside the directory.
-
-Both forms are loaded the same way:
+The filenames are arbitrary — `main.crn` is a convention, not a requirement. Load the module by pointing `use` at the directory:
 
 ```crn
 let network = use { source = './modules/network' }

--- a/docs/src/content/docs/guides/writing-resources.md
+++ b/docs/src/content/docs/guides/writing-resources.md
@@ -214,4 +214,4 @@ awscc.ec2.RouteTable {
 }
 ```
 
-Run `carina plan main.crn` to preview the changes, and `carina apply main.crn` to create the resources.
+Run `carina plan .` from the directory containing your `.crn` files to preview the changes, and `carina apply .` to create the resources.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,6 +33,6 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 ## Providers
 
 <CardGrid>
-  <LinkCard title="AWSCC Provider" description="AWS Cloud Control API — EC2, S3, IAM, CloudWatch Logs" href="/reference/providers/awscc/" />
-  <LinkCard title="AWS Provider" description="AWS SDK — EC2, S3, STS" href="/reference/providers/aws/" />
+  <LinkCard title="AWSCC Provider" description="AWS Cloud Control API — EC2, S3, IAM, Logs, Organizations, Route53, Identity Store, SSO" href="/reference/providers/awscc/" />
+  <LinkCard title="AWS Provider" description="AWS SDK — EC2, S3, IAM, STS, Logs, Organizations, Route53, Identity Store" href="/reference/providers/aws/" />
 </CardGrid>

--- a/docs/src/content/docs/reference/cli/apply.md
+++ b/docs/src/content/docs/reference/cli/apply.md
@@ -10,7 +10,7 @@ Apply changes to reach the desired infrastructure state. Carina generates a plan
 carina apply [OPTIONS] [PATH]
 ```
 
-**PATH** defaults to `.` (current directory). It can be a `.crn` file, a directory containing `.crn` files, or a saved plan JSON file.
+**PATH** defaults to `.` (current directory). It must be either a directory containing one or more `.crn` files, or a saved plan JSON file (any path ending in `.json` is treated as a saved plan).
 
 ## Flags
 

--- a/docs/src/content/docs/reference/cli/module-info.md
+++ b/docs/src/content/docs/reference/cli/module-info.md
@@ -7,10 +7,10 @@ Show the structure of a module, including its arguments, exported attributes, re
 ## Usage
 
 ```bash
-carina module info [OPTIONS] <FILE>
+carina module info [OPTIONS] <PATH>
 ```
 
-**FILE** is the path to a module `.crn` file or a module directory (containing a `main.crn`).
+**PATH** is a module directory (a directory containing one or more `.crn` files). Single-file paths are rejected.
 
 ## Flags
 
@@ -22,7 +22,7 @@ Display module info in interactive TUI mode.
 
 The output displays the module signature, including:
 
-- **Module name** -- derived from the directory name (for directory-based modules) or file stem (for single-file modules)
+- **Module name** -- derived from the module's directory name
 - **Arguments** -- parameters the module expects, defined by unresolved references
 - **Attributes** -- values exported by the module for use by the caller
 - **Resources** -- infrastructure resources defined in the module
@@ -43,23 +43,17 @@ Output shows each module's alias and path:
 ```
 Modules:
   web_tier    ./modules/web_tier
-  database    ./modules/database.crn
+  database    ./modules/database
 ```
 
 Prints "No modules imported." if no modules are used.
 
 ## Examples
 
-Show info for a directory-based module:
+Show info for a module:
 
 ```bash
 carina module info modules/web_tier/
-```
-
-Show info for a single-file module:
-
-```bash
-carina module info modules/database.crn
 ```
 
 Show info in TUI mode:

--- a/docs/src/content/docs/reference/cli/plan.md
+++ b/docs/src/content/docs/reference/cli/plan.md
@@ -10,7 +10,7 @@ Show an execution plan without applying changes. The plan compares the desired s
 carina plan [OPTIONS] [PATH]
 ```
 
-**PATH** defaults to `.` (current directory). It can be a `.crn` file or a directory containing `.crn` files.
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files — single-file paths are rejected.
 
 ## Flags
 
@@ -75,10 +75,10 @@ Plan from the current directory:
 carina plan
 ```
 
-Plan a specific file with compact output:
+Plan a specific directory with compact output:
 
 ```bash
-carina plan --detail=none infra.crn
+carina plan --detail=none path/to/config
 ```
 
 Save a plan for later apply:

--- a/docs/src/content/docs/reference/cli/validate.md
+++ b/docs/src/content/docs/reference/cli/validate.md
@@ -10,7 +10,7 @@ Validate the configuration file without communicating with cloud providers. This
 carina validate [PATH]
 ```
 
-**PATH** defaults to `.` (current directory). It can be a `.crn` file or a directory containing `.crn` files.
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files — single-file paths are rejected.
 
 ## What It Checks
 
@@ -86,8 +86,8 @@ Validate the current directory:
 carina validate
 ```
 
-Validate a specific file:
+Validate a specific directory:
 
 ```bash
-carina validate infra.crn
+carina validate path/to/config
 ```


### PR DESCRIPTION
## Summary

Walked through the repo-level docs (`CLAUDE.md`, `README.md`) and the Astro-published user docs under `docs/src/` and fixed places where the text no longer matches how the CLI / module loader / provider resolver actually behave.

### CLAUDE.md
- Crate list: drop stray `carina-aws-types` (lives in provider repos), add the real `carina-provider-resolver`.
- Validation Formats: S3 Versioning uses PascalCase (`aws.s3.VersioningStatus.Enabled` / `.Suspended`), not the previously documented `.enabled` / `.suspended`.
- Namespaced Enum Identifiers: `is_dsl_enum_format()` handles 2/3/4/**5**-part shapes; previous text only mentioned 4-part.

### README.md
- Quick Start / Using with aws-vault / destroy: CLI paths are directories. `carina validate main.crn` → `carina validate .`, etc. (file paths are rejected by `load_configuration`).
- Project Structure: `differ/` and `module_resolver/` are directories, not single files; add the missing `carina-provider-resolver/` and `carina-tui/` entries.
- AWS Provider section: link out to the separate `carina-provider-aws` / `carina-provider-awscc` repos that are loaded as WASM plugins.

### docs/src
- `getting-started/installation.md`, `quick-start.md`, `core-concepts.md`: bump carina release tarball to 0.4.0 and awscc provider to 0.5.0, use the `github.com/...` `source` with enum region, and replace the outdated "build WASM and point source at file://" instruction with the actual auto-download-from-release flow cached under `.carina/providers/`.
- `guides/using-modules.md`, `state-management.md`, `writing-resources.md`: modules are directory-scoped with no privileged filename; single-file modules / single-file CLI paths no longer work.
- `reference/cli/{validate,plan,apply,module-info}.md`: PATH must be a directory (apply also accepts `*.json` saved plans); drop single-file module examples.
- `index.mdx`: broaden the AWSCC/AWS provider service lists to match what `reference/providers/` actually ships.

## Test plan
- [ ] `docs/` Astro build passes locally (`cd docs && npm run build`).
- [ ] Visual check that the Quick Start snippet validates/plans against the 0.5.0 awscc provider.
- [ ] Spot check that no other pages under `docs/src/` still mention single-file module paths or `carina {validate,plan,apply,destroy} *.crn`.
