### PR TITLE
module_resolver: dedup state SimHash candidates across resource types

### DIFF
--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -221,6 +221,39 @@ fn deterministic_value_string(value: &Value) -> String {
 /// with modified attributes.
 pub(crate) const SIMHASH_HAMMING_THRESHOLD: u32 = 20;
 
+/// Find the unique candidate closest (by Hamming distance) to `target` SimHash
+/// among `candidates`, below `SIMHASH_HAMMING_THRESHOLD`. Returns `None` when
+/// no candidate qualifies, or when two or more candidates tie at the minimum
+/// distance — the latter is an ambiguous match the caller should refuse to
+/// commit to (rebinding to the wrong state entry would silently corrupt
+/// addresses).
+pub(crate) fn closest_unique_simhash_match<C: Copy>(
+    target: u64,
+    candidates: impl IntoIterator<Item = C>,
+    hash_of: impl Fn(C) -> u64,
+) -> Option<C> {
+    let mut best: Option<(C, u32)> = None;
+    let mut unique = true;
+    for c in candidates {
+        let distance = (target ^ hash_of(c)).count_ones();
+        if distance >= SIMHASH_HAMMING_THRESHOLD {
+            continue;
+        }
+        match best {
+            None => best = Some((c, distance)),
+            Some((_, prev)) => {
+                if distance < prev {
+                    best = Some((c, distance));
+                    unique = true;
+                } else if distance == prev {
+                    unique = false;
+                }
+            }
+        }
+    }
+    best.and_then(|(c, _)| if unique { Some(c) } else { None })
+}
+
 /// Flatten a Value into individual SimHash features.
 ///
 /// Map values are expanded so each entry becomes a separate feature (e.g., `tags.Environment`),
@@ -725,36 +758,18 @@ pub fn detect_anonymous_to_named_renames(
             // entry closest to the computed SimHash; tie → ambiguous, skip.
             let resource_hash =
                 compute_resource_simhash(resource, providers, identity_attributes_fn);
-            let mut best: Option<(&str, u32)> = None;
-            let mut best_unique = true;
-            for entry in &state_entries {
-                if used_in_dsl.contains(&entry.name) {
-                    continue;
-                }
+            let candidates = state_entries
+                .iter()
+                .filter(|e| !used_in_dsl.contains(&e.name))
                 // Only consider state entries written via the SimHash path
                 // (16-hex suffix). 8-hex entries come from the create-only
                 // hash scheme and are meaningless to XOR with a 64-bit SimHash.
-                if entry.name.rsplit('_').next().map(str::len) != Some(16) {
-                    continue;
-                }
-                let Some(state_hash) = extract_hash_from_identifier(&entry.name) else {
-                    continue;
-                };
-                let distance = (resource_hash ^ state_hash).count_ones();
-                if distance >= SIMHASH_HAMMING_THRESHOLD {
-                    continue;
-                }
-                match best {
-                    None => best = Some((&entry.name, distance)),
-                    Some((_, d)) if distance < d => {
-                        best = Some((&entry.name, distance));
-                        best_unique = true;
-                    }
-                    Some((_, d)) if distance == d => best_unique = false,
-                    _ => {}
-                }
-            }
-            best.and_then(|(name, _)| if best_unique { Some(name) } else { None })
+                .filter(|e| e.name.rsplit('_').next().map(str::len) == Some(16))
+                .filter_map(|e| {
+                    extract_hash_from_identifier(&e.name).map(|h| (e.name.as_str(), h))
+                });
+            closest_unique_simhash_match(resource_hash, candidates, |(_, h)| h)
+                .map(|(name, _)| name)
         };
 
         if let Some(name) = matched_name {

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -655,28 +655,26 @@ pub fn reconcile_anonymous_module_instances(
     resources: &mut [Resource],
     find_state_names_by_type: &dyn Fn(&str, &str) -> Vec<String>,
 ) {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     // Collect current (provider, resource_type) pairs that appear in the
     // expanded DSL — we'll query state for matching entries.
-    let mut touched_types: HashMap<(String, String), Vec<usize>> = HashMap::new();
-    for (idx, r) in resources.iter().enumerate() {
+    let mut touched_types: HashSet<(String, String)> = HashSet::new();
+    for r in resources.iter() {
         if split_instance_prefix(&r.id.name).is_none() {
             continue;
         }
-        touched_types
-            .entry((r.id.provider.clone(), r.id.resource_type.clone()))
-            .or_default()
-            .push(idx);
+        touched_types.insert((r.id.provider.clone(), r.id.resource_type.clone()));
     }
 
     if touched_types.is_empty() {
         return;
     }
 
-    // (module_name, simhash) → set of resource names currently using it.
-    // Used to skip prefixes that already line up with state exactly.
-    let mut current_names_by_prefix: HashMap<(String, u64), Vec<String>> = HashMap::new();
+    // Current DSL synthetic prefixes per module — only one entry per
+    // distinct prefix (a multi-resource module instance shares one prefix
+    // across all of its resources).
+    let mut current_synthetic_by_module: HashMap<String, HashSet<u64>> = HashMap::new();
     for r in resources.iter() {
         let Some((prefix, _)) = split_instance_prefix(&r.id.name) else {
             continue;
@@ -684,77 +682,64 @@ pub fn reconcile_anonymous_module_instances(
         let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
             continue;
         };
-        current_names_by_prefix
-            .entry((module.to_string(), simhash))
+        current_synthetic_by_module
+            .entry(module.to_string())
             .or_default()
-            .push(r.id.name.clone());
+            .insert(simhash);
     }
 
-    // For each touched (provider, type), build the set of state prefixes and
-    // decide orphan prefixes per module.
-    let mut prefix_remap: HashMap<(String, u64), u64> = HashMap::new();
+    // State synthetic prefixes per module. Use a set so a multi-resource
+    // module instance — which contributes one state entry per resource
+    // type, all under the same prefix — collapses to one candidate. With a
+    // Vec the same hash would appear N times and the Hamming-distance
+    // search below would mistake duplicates for ambiguous candidates and
+    // refuse to remap (#2211).
+    let mut state_synthetic_by_module: HashMap<String, HashSet<u64>> = HashMap::new();
 
-    // Accumulate state SimHash values per module name to pool across all
-    // resource types of a given module.
-    let mut state_hashes_by_module: HashMap<String, Vec<u64>> = HashMap::new();
-    let mut state_fully_matches_current: HashMap<(String, u64), bool> = HashMap::new();
-
-    for (provider, resource_type) in touched_types.keys() {
-        let state_names = find_state_names_by_type(provider, resource_type);
-        for name in state_names {
+    for (provider, resource_type) in &touched_types {
+        for name in find_state_names_by_type(provider, resource_type) {
             let Some((prefix, _)) = split_instance_prefix(&name) else {
                 continue;
             };
             let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
                 continue;
             };
-            let key = (module.to_string(), simhash);
-            let already_in_current = current_names_by_prefix.contains_key(&key);
-            if already_in_current {
-                state_fully_matches_current.insert(key.clone(), true);
-            } else {
-                state_hashes_by_module
-                    .entry(module.to_string())
-                    .or_default()
-                    .push(simhash);
-            }
+            state_synthetic_by_module
+                .entry(module.to_string())
+                .or_default()
+                .insert(simhash);
         }
     }
 
     // For each current DSL prefix that has no matching state prefix, find the
-    // closest orphan state prefix for the same module.
-    for (module, current_hash) in current_names_by_prefix.keys() {
-        if state_fully_matches_current.contains_key(&(module.clone(), *current_hash)) {
-            continue;
-        }
-        let Some(candidates) = state_hashes_by_module.get(module) else {
+    // closest orphan state prefix for the same module. Candidate state hashes
+    // exclude any prefix already used by a current DSL instance — without
+    // that filter, two distinct anonymous calls could collapse onto the same
+    // state entry when only one of them existed before.
+    let mut prefix_remap: HashMap<(String, u64), u64> = HashMap::new();
+    for (module, current_hashes) in &current_synthetic_by_module {
+        let Some(state_hashes) = state_synthetic_by_module.get(module) else {
             continue;
         };
-
-        let mut best: Option<(u64, u32)> = None;
-        let mut best_is_unique = true;
-        for &state_hash in candidates {
-            let distance = (current_hash ^ state_hash).count_ones();
-            if distance >= crate::identifier::SIMHASH_HAMMING_THRESHOLD {
+        let orphan_state_hashes: Vec<u64> = state_hashes
+            .iter()
+            .copied()
+            .filter(|h| !current_hashes.contains(h))
+            .collect();
+        if orphan_state_hashes.is_empty() {
+            continue;
+        }
+        for current_hash in current_hashes {
+            if state_hashes.contains(current_hash) {
                 continue;
             }
-            match best {
-                None => best = Some((state_hash, distance)),
-                Some((_, prev_distance)) => {
-                    if distance < prev_distance {
-                        best = Some((state_hash, distance));
-                        best_is_unique = true;
-                    } else if distance == prev_distance {
-                        best_is_unique = false;
-                    }
-                }
+            if let Some(state_hash) = crate::identifier::closest_unique_simhash_match(
+                *current_hash,
+                orphan_state_hashes.iter().copied(),
+                |h| h,
+            ) {
+                prefix_remap.insert((module.clone(), *current_hash), state_hash);
             }
-        }
-
-        if let Some((state_hash, _)) = best
-            && best_is_unique
-        {
-            prefix_remap.insert((module.clone(), *current_hash), state_hash);
         }
     }
 
@@ -1791,6 +1776,98 @@ thing { name = 'a' }
         assert_eq!(before_name, after_name);
     }
 
+    // Regression for #2211: a single anonymous module instance whose module
+    // expands to multiple resource types means the same state prefix shows up
+    // once per resource type when `find_state_names_by_type` is queried per
+    // (provider, type). The reconciler must treat repeated identical hashes
+    // as the same candidate, not as multiple ambiguous candidates.
+    #[test]
+    fn test_reconcile_anonymous_module_instances_dedups_state_prefixes_across_types() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_dir = tmp.path().join("modules/thing");
+        fs::create_dir_all(&module_dir).unwrap();
+        fs::write(
+            module_dir.join("main.crn"),
+            r#"
+arguments {
+  name: String
+}
+
+let provider_res = awscc.iam.OidcProvider {
+  url             = 'https://example.com'
+  client_id_list  = ['x']
+  thumbprint_list = ['y']
+}
+
+let role = awscc.iam.Role {
+  role_name = name
+  assume_role_policy_document = {}
+}
+"#,
+        )
+        .unwrap();
+
+        let root_dir = tmp.path().join("root");
+        fs::create_dir_all(&root_dir).unwrap();
+        fs::write(
+            root_dir.join("main.crn"),
+            r#"
+let thing = use { source = '../modules/thing' }
+
+thing { name = 'after-edit' }
+"#,
+        )
+        .unwrap();
+
+        let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+        let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+        resolve_modules(&mut parsed, &root_dir).expect("resolve_modules should succeed");
+
+        // Discover the new prefix from the parsed Role.
+        let role_name_before = parsed
+            .resources
+            .iter()
+            .find(|r| r.id.resource_type == "iam.Role")
+            .unwrap()
+            .id
+            .name
+            .clone();
+        let (new_prefix, _) = role_name_before.split_once('.').unwrap();
+        let (_, new_hash) = parse_synthetic_instance_prefix(new_prefix).unwrap();
+
+        // State holds the *same* instance prefix at two resource types, one
+        // bit away from the current SimHash — i.e. a small argument edit.
+        let state_hash = new_hash ^ 1;
+        let state_lookup = move |_: &str, resource_type: &str| match resource_type {
+            "iam.OidcProvider" => vec![format!("thing_{:016x}.provider_res", state_hash)],
+            "iam.Role" => vec![format!("thing_{:016x}.role", state_hash)],
+            _ => vec![],
+        };
+
+        reconcile_anonymous_module_instances(&mut parsed.resources, &state_lookup);
+
+        let role_after = parsed
+            .resources
+            .iter()
+            .find(|r| r.id.resource_type == "iam.Role")
+            .unwrap();
+        assert_eq!(
+            role_after.id.name,
+            format!("thing_{:016x}.role", state_hash),
+            "Role address must be remapped to the state prefix",
+        );
+        let provider_after = parsed
+            .resources
+            .iter()
+            .find(|r| r.id.resource_type == "iam.OidcProvider")
+            .unwrap();
+        assert_eq!(
+            provider_after.id.name,
+            format!("thing_{:016x}.provider_res", state_hash),
+            "OidcProvider address must be remapped to the state prefix",
+        );
+    }
+
     // Reconciliation must not run when there are multiple candidate state
     // prefixes within threshold — ambiguity means we can't tell which is the
     // "same instance."
@@ -1833,6 +1910,51 @@ thing { name = 'a' }
             .name
             .clone();
         assert_eq!(before_name, after_name, "ambiguous match must not remap");
+    }
+
+    // When state holds prefix A and the DSL has both A (unchanged) and a new
+    // A' (a new anonymous call with similar args), A' must not be remapped
+    // onto A — they are two distinct instances even though their SimHashes
+    // are close. State prefixes already in use by current DSL must not serve
+    // as remap candidates.
+    #[test]
+    fn test_reconcile_anonymous_module_instances_does_not_steal_in_use_prefix() {
+        let mut parsed = resolve_thing_fixture(
+            r#"
+let thing = use { source = '../modules/thing' }
+
+thing { name = 'unchanged' }
+thing { name = 'unchanged-but-different' }
+"#,
+        );
+
+        let prefixes_before: HashSet<String> = parsed
+            .resources
+            .iter()
+            .filter(|r| r.id.resource_type == "iam.Role")
+            .map(|r| r.id.name.split_once('.').unwrap().0.to_string())
+            .collect();
+        assert_eq!(prefixes_before.len(), 2);
+        let mut iter = prefixes_before.iter();
+        let first = iter.next().unwrap().clone();
+        let _second = iter.next().unwrap().clone();
+
+        // State only holds the *first* prefix. The reconciler must not
+        // remap the second instance onto it.
+        let first_clone = first.clone();
+        let state_lookup = move |_: &str, _: &str| vec![format!("{}.role", first_clone)];
+        reconcile_anonymous_module_instances(&mut parsed.resources, &state_lookup);
+
+        let prefixes_after: HashSet<String> = parsed
+            .resources
+            .iter()
+            .filter(|r| r.id.resource_type == "iam.Role")
+            .map(|r| r.id.name.split_once('.').unwrap().0.to_string())
+            .collect();
+        assert_eq!(
+            prefixes_after, prefixes_before,
+            "in-use state prefix must not be reassigned to a different DSL instance",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix #2211: anonymous module-call SimHash reconciler refused to remap state on small argument edits, forcing destroy + create.
- Root cause: `find_state_names_by_type` is invoked once per (provider, resource_type), so a multi-resource module instance contributes its state prefix N times to `state_hashes_by_module`. The duplicate entries tripped the Hamming-distance ambiguity guard, even though they all referred to the same instance.
- Fix is at the data structure: `Vec<u64>` → `HashSet<u64>` for both current-DSL and state-side hashes per module. Duplicate prefixes collapse to one candidate; the ambiguity guard now only triggers on genuinely distinct candidates.
- Restored an orphan filter that was lost during simplification: state prefixes already in use by a current DSL instance are excluded from the remap-candidate pool, so two distinct DSL instances cannot collapse onto the same state entry.
- Factored the shared "find unique closest match by Hamming distance" loop (also present in `identifier::detect_anonymous_to_named_renames`) into `identifier::closest_unique_simhash_match`.

## Repro (from #2211)

State holds `github_0f0410c052a82050.{oidc_provider,role}`. Edit `github_repo` from `carina-rs/infra` to `carina-rs/infraX` (1 char). New SimHash differs by 12 bits, well under `SIMHASH_HAMMING_THRESHOLD = 20`.

**Before:** `Plan: 2 to add, 0 to change, 2 to destroy.` (destructive replacement)

**After:** `Plan: 0 to add, 1 to change, 0 to destroy.` (in-place update of the policy document on the existing Role)

Verified end-to-end against a copy of the user's real `github-oidc` state with `aws-vault exec carina-rs -- carina plan`.

## Test plan

- [x] New unit test: `test_reconcile_anonymous_module_instances_dedups_state_prefixes_across_types` — multi-resource-type module, state lookup returns one entry per type with a 1-bit-flipped hash, asserts both expanded resources are remapped to the state prefix.
- [x] New unit test: `test_reconcile_anonymous_module_instances_does_not_steal_in_use_prefix` — guards the orphan filter: when state holds prefix A and current DSL has both A (unchanged) and A' (new instance), A' must not collapse onto A.
- [x] Existing module-resolver and identifier tests still pass (1339 tests in `carina-core`, 264 in `carina-cli`).
- [x] Manual end-to-end: tempdir copy of `infra/aws/management/github-oidc` with the user's repro state, ran `carina plan` and got the expected `0 add, 1 change, 0 destroy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
