### PR TITLE
Reject arguments blocks in root configurations

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -197,6 +197,14 @@ pub fn validate_and_resolve_errors(
 
     let mut errors: Vec<AppError> = Vec::new();
 
+    // `arguments` is a module-input declaration; the CLI only ever feeds
+    // root configurations into this function (modules go through
+    // `module_resolver::load_module`), so any `arguments` block reaching
+    // here is misplaced (#2198).
+    if let Err(msg) = carina_core::validation::validate_no_arguments_in_root(parsed) {
+        errors.push(AppError::Validation(msg));
+    }
+
     // Check for declared providers whose plugins failed to load.
     if !skip_resource_validation {
         for provider in &parsed.providers {

--- a/carina-cli/tests/fixtures/negative/arguments_in_root/main.crn
+++ b/carina-cli/tests/fixtures/negative/arguments_in_root/main.crn
@@ -1,0 +1,13 @@
+# Negative test: arguments block placed in a root configuration.
+# `arguments` is a module-input declaration; root configs have no caller
+# to pass values, so its `default` would silently become a de-facto root
+# variable. Reject the configuration with a clear diagnostic instead
+# (issue #2198).
+
+arguments {
+  state_path: String = "state.json"
+}
+
+backend local {
+  path = arguments.state_path
+}

--- a/carina-cli/tests/negative_validation.rs
+++ b/carina-cli/tests/negative_validation.rs
@@ -15,6 +15,13 @@ fn carina_validate(fixture: &str) -> std::process::Output {
         .expect("failed to execute carina")
 }
 
+fn carina_validate_path(path: &std::path::Path) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_carina"))
+        .args(["validate", path.to_str().unwrap()])
+        .output()
+        .expect("failed to execute carina")
+}
+
 fn assert_validate_fails(fixture: &str, expected_substring: &str) {
     let output = carina_validate(fixture);
     assert!(
@@ -108,6 +115,33 @@ fn arguments_block_rejected_in_root() {
     assert_validate_fails(
         "arguments_in_root",
         "arguments blocks are only valid inside module definitions",
+    );
+}
+
+#[test]
+fn module_directory_validates_directly() {
+    // Issue #2198 follow-up. A directory written as a module (only
+    // `arguments` and resources, no `backend` / `provider`) must still
+    // pass `carina validate <module-dir>` — users do that to check
+    // module syntax in isolation. Without root markers we cannot prove
+    // the directory is a root, so the rejection must not fire.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let module = tmp.path();
+    std::fs::write(
+        module.join("main.crn"),
+        r#"arguments {
+  vpc_cidr: String
+}
+"#,
+    )
+    .unwrap();
+
+    let output = carina_validate_path(module);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("arguments blocks are only valid"),
+        "module directory must not be rejected as misplaced root arguments.\nstdout: {stdout}\nstderr: {stderr}",
     );
 }
 

--- a/carina-cli/tests/negative_validation.rs
+++ b/carina-cli/tests/negative_validation.rs
@@ -100,6 +100,18 @@ fn missing_provider_plugin() {
 }
 
 #[test]
+fn arguments_block_rejected_in_root() {
+    // Issue #2198. An `arguments` block belongs on the module side of a
+    // module boundary; placing it in a root configuration silently turns
+    // its `default` values into a de-facto root variable. Reject it with
+    // a clear diagnostic instead.
+    assert_validate_fails(
+        "arguments_in_root",
+        "arguments blocks are only valid inside module definitions",
+    );
+}
+
+#[test]
 fn validate_reports_multiple_static_errors_in_one_pass() {
     // Regression for #2102. Independent static errors in the same project
     // must all surface in a single `carina validate` run so the user fixes

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -470,6 +470,22 @@ pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
     }
 }
 
+/// Check that a root configuration does not contain `arguments` blocks.
+///
+/// `arguments` is a module-input declaration: it belongs on the module side
+/// of a module boundary and is paired with `use` on the caller side. In a
+/// root configuration there is no caller to pass values, so the block has
+/// no meaning — its `default` would silently become a de-facto root
+/// variable, which is not a documented feature (issue #2198).
+pub fn validate_no_arguments_in_root(parsed: &ParsedFile) -> Result<(), String> {
+    if !parsed.arguments.is_empty() {
+        return Err(
+            "arguments blocks are only valid inside module definitions, not in root configurations.".to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Check that a module file does not contain provider blocks.
 ///
 /// Provider configuration should only be defined at the root configuration level,
@@ -1497,6 +1513,34 @@ let vpc = awscc.ec2.Vpc {
         });
 
         let result = validate_no_provider_in_module(&parsed);
+        assert!(result.is_ok());
+    }
+
+    // --- validate_no_arguments_in_root tests ---
+
+    #[test]
+    fn arguments_in_root_errors() {
+        let mut parsed = empty_parsed();
+        parsed.arguments.push(crate::parser::ArgumentParameter {
+            name: "state_path".to_string(),
+            type_expr: TypeExpr::String,
+            default: Some(Value::String("state.json".to_string())),
+            description: None,
+            validations: Vec::new(),
+        });
+
+        let result = validate_no_arguments_in_root(&parsed);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "arguments blocks are only valid inside module definitions, not in root configurations."
+        );
+    }
+
+    #[test]
+    fn empty_arguments_in_root_ok() {
+        let parsed = empty_parsed();
+        let result = validate_no_arguments_in_root(&parsed);
         assert!(result.is_ok());
     }
 

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -477,8 +477,14 @@ pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
 /// root configuration there is no caller to pass values, so the block has
 /// no meaning — its `default` would silently become a de-facto root
 /// variable, which is not a documented feature (issue #2198).
+///
+/// A directory loaded via the CLI may be either a root config or a module
+/// the user is validating in isolation. We only flag the misplaced block
+/// when a `backend` or `provider` block is also present, since both are
+/// root-only constructs and unambiguously identify a root configuration.
 pub fn validate_no_arguments_in_root(parsed: &ParsedFile) -> Result<(), String> {
-    if !parsed.arguments.is_empty() {
+    let is_root = parsed.backend.is_some() || !parsed.providers.is_empty();
+    if !parsed.arguments.is_empty() && is_root {
         return Err(
             "arguments blocks are only valid inside module definitions, not in root configurations.".to_string(),
         );
@@ -1518,23 +1524,63 @@ let vpc = awscc.ec2.Vpc {
 
     // --- validate_no_arguments_in_root tests ---
 
-    #[test]
-    fn arguments_in_root_errors() {
-        let mut parsed = empty_parsed();
-        parsed.arguments.push(crate::parser::ArgumentParameter {
-            name: "state_path".to_string(),
+    fn argument_param(name: &str) -> crate::parser::ArgumentParameter {
+        crate::parser::ArgumentParameter {
+            name: name.to_string(),
             type_expr: TypeExpr::String,
-            default: Some(Value::String("state.json".to_string())),
+            default: None,
             description: None,
             validations: Vec::new(),
+        }
+    }
+
+    fn provider(name: &str) -> crate::parser::ProviderConfig {
+        crate::parser::ProviderConfig {
+            name: name.to_string(),
+            attributes: HashMap::new(),
+            default_tags: HashMap::new(),
+            source: None,
+            version: None,
+            revision: None,
+        }
+    }
+
+    #[test]
+    fn arguments_with_backend_errors() {
+        let mut parsed = empty_parsed();
+        parsed.arguments.push(argument_param("state_path"));
+        parsed.backend = Some(crate::parser::BackendConfig {
+            backend_type: "local".to_string(),
+            attributes: HashMap::new(),
         });
 
         let result = validate_no_arguments_in_root(&parsed);
-        assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
             "arguments blocks are only valid inside module definitions, not in root configurations."
         );
+    }
+
+    #[test]
+    fn arguments_with_provider_errors() {
+        let mut parsed = empty_parsed();
+        parsed.arguments.push(argument_param("vpc_cidr"));
+        parsed.providers.push(provider("aws"));
+
+        let result = validate_no_arguments_in_root(&parsed);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn arguments_alone_is_ok() {
+        // A directory with only `arguments` looks like a module the user
+        // is validating in isolation; we cannot prove it is a root, so
+        // do not flag it (issue #2198).
+        let mut parsed = empty_parsed();
+        parsed.arguments.push(argument_param("vpc_cidr"));
+
+        let result = validate_no_arguments_in_root(&parsed);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -172,21 +172,22 @@ impl DiagnosticEngine {
     /// `arguments` is a module-input declaration; it has no caller in a
     /// root config. Without a `use` site to feed values, its `default`
     /// would silently become a de-facto root variable (issue #2198).
-    /// A `backend` block is a root-only construct, so its presence next
-    /// to `arguments` — possibly in a sibling `.crn` file — is an
-    /// unambiguous signal that this directory is being authored as a
-    /// root configuration. `merged` (the directory-scoped parse) takes
-    /// precedence so the signal can come from a sibling file.
+    /// `backend` and `provider` blocks are root-only constructs, so the
+    /// presence of either next to `arguments` — possibly in a sibling
+    /// `.crn` file — unambiguously identifies a root configuration. The
+    /// merged directory parse takes precedence so the signal can come
+    /// from a sibling file.
     pub(super) fn check_arguments_in_root(
         &self,
         doc: &Document,
         parsed: &ParsedFile,
         merged: Option<&ParsedFile>,
     ) -> Vec<Diagnostic> {
-        let backend_present = merged
-            .map(|m| m.backend.is_some())
-            .unwrap_or_else(|| parsed.backend.is_some());
-        if parsed.arguments.is_empty() || !backend_present {
+        let is_root = match merged {
+            Some(m) => m.backend.is_some() || !m.providers.is_empty(),
+            None => parsed.backend.is_some() || !parsed.providers.is_empty(),
+        };
+        if parsed.arguments.is_empty() || !is_root {
             return Vec::new();
         }
 

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -167,6 +167,58 @@ fn is_dot_notation_ref(s: &str) -> bool {
 }
 
 impl DiagnosticEngine {
+    /// Flag `arguments` blocks placed in a root configuration.
+    ///
+    /// `arguments` is a module-input declaration; it has no caller in a
+    /// root config. Without a `use` site to feed values, its `default`
+    /// would silently become a de-facto root variable (issue #2198).
+    /// A `backend` block is a root-only construct, so its presence next
+    /// to `arguments` — possibly in a sibling `.crn` file — is an
+    /// unambiguous signal that this directory is being authored as a
+    /// root configuration. `merged` (the directory-scoped parse) takes
+    /// precedence so the signal can come from a sibling file.
+    pub(super) fn check_arguments_in_root(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+        merged: Option<&ParsedFile>,
+    ) -> Vec<Diagnostic> {
+        let backend_present = merged
+            .map(|m| m.backend.is_some())
+            .unwrap_or_else(|| parsed.backend.is_some());
+        if parsed.arguments.is_empty() || !backend_present {
+            return Vec::new();
+        }
+
+        let mut diagnostics = Vec::new();
+        let text = doc.text();
+
+        for (line_idx, line) in text.lines().enumerate() {
+            let trimmed = line.trim();
+            // Match the `arguments` keyword as a token, not a prefix —
+            // `arguments_foo` (an unrelated identifier) must not match.
+            let after_keyword = trimmed.strip_prefix("arguments");
+            let is_keyword_block = after_keyword
+                .is_some_and(|rest| rest.starts_with('{') || rest.starts_with(char::is_whitespace));
+            if is_keyword_block && trimmed.contains('{') {
+                let col = position::leading_whitespace_chars(line);
+                let end_col = trimmed
+                    .find('{')
+                    .map(|p| col + p as u32)
+                    .unwrap_or(col + trimmed.len() as u32);
+                diagnostics.push(carina_diagnostic(
+                    line_idx as u32,
+                    col,
+                    end_col,
+                    DiagnosticSeverity::ERROR,
+                    "arguments blocks are only valid inside module definitions, not in root configurations.".to_string(),
+                ));
+            }
+        }
+
+        diagnostics
+    }
+
     /// Check that provider blocks are not defined inside modules.
     pub(super) fn check_provider_in_module(
         &self,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -167,6 +167,12 @@ impl DiagnosticEngine {
             // Check provider in module
             diagnostics.extend(self.check_provider_in_module(doc, parsed));
 
+            // Check arguments in root. The "is this a root config?"
+            // signal — a sibling `backend` block — can live in another
+            // .crn file in the same directory, so the check needs the
+            // merged directory parse when available (#2198).
+            diagnostics.extend(self.check_arguments_in_root(doc, parsed, merged.as_ref()));
+
             // Check provider region
             diagnostics.extend(self.check_provider_region(doc, parsed));
 

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -761,6 +761,105 @@ awscc.ec2.Vpc {
 }
 
 #[test]
+fn arguments_with_backend_emits_error() {
+    // Issue #2198. `arguments` is a module-input declaration. A `backend`
+    // block is root-only, so the combination is unambiguously a misplaced
+    // `arguments` block in a root configuration.
+    let engine = test_engine();
+    let doc = create_document(
+        r#"arguments {
+    state_path: String = "state.json"
+}
+
+backend local {
+    path = arguments.state_path
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let arguments_diag = diagnostics.iter().find(|d| {
+        d.message
+            .contains("arguments blocks are only valid inside module definitions")
+    });
+    assert!(
+        arguments_diag.is_some(),
+        "Should error about arguments block in root config. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let diag = arguments_diag.unwrap();
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn arguments_with_sibling_backend_emits_error() {
+    // Issue #2198 repro shape: arguments live in main.crn, backend lives
+    // in backend.crn. The directory-scoped parse must merge them and the
+    // diagnostic must still fire — single-file inspection would miss it.
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("main.crn"),
+        r#"arguments {
+    state_path: String = "state.json"
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        r#"backend local {
+    path = arguments.state_path
+}
+"#,
+    )
+    .unwrap();
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&buffer);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    assert!(
+        diagnostics.iter().any(|d| d
+            .message
+            .contains("arguments blocks are only valid inside module definitions")),
+        "Should error about arguments block when sibling file declares a backend. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn arguments_without_backend_no_error() {
+    // A directory with only `arguments` (no `backend`/`provider`) is
+    // indistinguishable from a module being authored, so the LSP must
+    // not flag it. The CLI's root-config check at validate time still
+    // catches the case where such a directory is loaded as a root.
+    let engine = test_engine();
+    let doc = create_document(
+        r#"arguments {
+    vpc_cidr: String
+}
+
+awscc.ec2.Vpc {
+    cidr_block = args.vpc_cidr
+}"#,
+    );
+
+    let diagnostics = engine.analyze(&doc, None);
+
+    let arguments_diag = diagnostics.iter().find(|d| {
+        d.message
+            .contains("arguments blocks are only valid inside module definitions")
+    });
+    assert!(
+        arguments_diag.is_none(),
+        "Should NOT flag arguments block when no backend is present. Got diagnostics: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn provider_without_module_markers_no_error() {
     let engine = test_engine();
     let doc = create_document(


### PR DESCRIPTION
## Summary

`arguments` is a module-input declaration paired with `use` on the caller side. In a root configuration there is no caller to pass values, so the block has no meaning — its `default` would silently become a de-facto root variable, masquerading as a documented feature.

This PR rejects the misplaced block at validate time with a clear diagnostic, mirroring the existing rule that forbids `provider` blocks inside modules. The LSP raises the same warning when an `arguments` block sits next to a `backend` block — `backend` is root-only, so the combination unambiguously identifies a root configuration (the signal can come from a sibling `.crn` file via the merged directory parse).

This PR follows **Option 1** in the issue. Promoting `arguments` to a first-class root variable construct (Option 2) is a separate language-design decision and out of scope.

## Changes

- `carina-core/src/validation.rs`: new `validate_no_arguments_in_root`, parallel in shape to the existing `validate_no_provider_in_module`.
- `carina-cli/src/commands/mod.rs`: hook the check into the validation pipeline above the `skip_resource_validation` gate so structural errors surface from `destroy` / `state` too.
- `carina-lsp/src/diagnostics/`: matching diagnostic, gated on a sibling `backend` block detected via the merged directory parse.
- Tests: 2 unit tests in core, 1 CLI integration test (with fixture under `tests/fixtures/negative/arguments_in_root/`), 3 LSP tests including a multi-file directory case per the directory-scoped rule.

## Test plan

- [x] `cargo test` (workspace) — all green
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] Real-infra smoke: `carina validate infra/aws/management/github-oidc` and `…/organizations` still validate cleanly (existing modules with legitimate `arguments` blocks unaffected)
- [x] Repro from the issue (`arguments` + `backend` root) is now rejected with the new diagnostic

Closes #2198