### PR TITLE
parser: restrict use_expr to let-binding RHS only

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -37,9 +37,12 @@ anonymous_resource = {
 }
 
 // Module call: module_name { key = value, ... }
+// Mirrors carina.pest: `use` is reserved (only valid as a let-binding RHS),
+// so it cannot be a module-call identifier (issue #2233).
 module_call = {
-    identifier ~ trivia* ~ open_brace ~ block_content* ~ close_brace
+    !use_keyword ~ identifier ~ trivia* ~ open_brace ~ block_content* ~ close_brace
 }
+use_keyword = @{ "use" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Provider block: provider aws { ... }
 provider_block = {
@@ -193,7 +196,7 @@ fn_local_let = { kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ ex
 // discard_pattern allows `let _ = expr` to suppress unused binding warnings
 discard_pattern = @{ "_" }
 let_binding = {
-    kw_let ~ trivia+ ~ (discard_pattern | identifier) ~ trivia* ~ equals ~ trivia* ~ expression
+    kw_let ~ trivia+ ~ (discard_pattern | identifier) ~ trivia* ~ equals ~ trivia* ~ (use_expr | expression)
 }
 
 // Block content: local let bindings, attributes, trivia, nested blocks, or nested elements
@@ -244,11 +247,12 @@ upstream_state_expr = {
 }
 
 // Primary value
+// `use_expr` is intentionally NOT here — mirrors carina.pest. It is only
+// valid as the RHS of a let binding (see `let_binding`). Issue #2233.
 primary = {
     read_resource_expr
   | upstream_state_expr
   | resource_expr
-  | use_expr
   | for_expr
   | if_expr
   | function_call

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -336,6 +336,10 @@ impl<'a> CstBuilder<'a> {
             // / `block_comment` branches above emit the actual trivia. This
             // arm exists only so the exhaustive match compiles.
             Rule::comment => None,
+
+            // `use_keyword` is a negative-predicate helper used inside
+            // `module_call`; it never produces a child node here.
+            Rule::use_keyword => None,
         }
     }
 

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -138,9 +138,14 @@ moved_from_attr = { "from" ~ "=" ~ resource_address }
 moved_to_attr = { "to" ~ "=" ~ resource_address }
 
 // Module call: module_name { key = value, ... }
+// `use` is reserved: it can only appear as the RHS of a top-level `let`
+// binding (see `let_binding`). Without this guard, `use { ... }` would
+// silently parse as a `module_call` named "use" once `use_expr` was
+// removed from `primary` (issue #2233).
 module_call = {
-    identifier ~ "{" ~ module_call_arg* ~ "}"
+    !use_keyword ~ identifier ~ "{" ~ module_call_arg* ~ "}"
 }
+use_keyword = @{ "use" ~ !(ASCII_ALPHANUMERIC | "_") }
 
 // Module call argument: key = value
 module_call_arg = { identifier ~ "=" ~ expression }
@@ -155,7 +160,10 @@ provider_block = {
 
 // Variable/resource definition: let name = value
 // discard_pattern allows `let _ = expr` to suppress unused binding warnings
-let_binding = { "let" ~ (discard_pattern | identifier) ~ "=" ~ expression }
+// `use_expr` is allowed only here (not in `expression`/`primary`) because it is
+// not a value: it is a meta-statement handled specially by the let-binding
+// evaluator. See issue #2233.
+let_binding = { "let" ~ (discard_pattern | identifier) ~ "=" ~ (use_expr | expression) }
 discard_pattern = @{ "_" }
 
 // Block content: a local let binding, an attribute (key = value), or a nested block (key { ... })
@@ -195,11 +203,14 @@ compose_expr = { primary ~ (">>" ~ primary)* }
 function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 
 // Primary value
+// Note: `use_expr` is intentionally NOT a primary. It is a meta-statement,
+// not a value, and is only valid as the RHS of a top-level `let` binding
+// (see `let_binding`). Allowing it here would let it parse silently in
+// positions the evaluator cannot handle (issue #2233).
 primary = {
     read_resource_expr   // Must come before resource_expr for "read aws..." parsing
   | upstream_state_expr  // Must come before module_call so "upstream_state { ... }" is not parsed as a module call
   | resource_expr
-  | use_expr             // Must come before module_call so "use { ... }" is not parsed as a module call
   | for_expr             // Must come before module_call so "for" is not parsed as module name
   | if_expr              // Must come before module_call so "if" is not parsed as module name
   | module_call          // Must come before variable_ref so "name { ... }" is parsed as module call

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1755,14 +1755,23 @@ fn parse_let_binding_extended(
     let name = next_pair(&mut inner, "binding name", "let binding")?
         .as_str()
         .to_string();
-    let expr_pair = next_pair(&mut inner, "expression", "let binding")?;
+    let rhs_pair = next_pair(&mut inner, "expression", "let binding")?;
+
+    // `use` is the only meta-statement allowed as a let-binding RHS. The
+    // grammar permits it here and only here (see carina.pest); everywhere
+    // else it is a parse error.
+    if rhs_pair.as_rule() == Rule::use_expr {
+        let use_stmt = parse_use_expr(rhs_pair, &name, ctx)?;
+        let value = Value::String(format!("${{use:{}}}", use_stmt.path));
+        return Ok((name, value, vec![], vec![], Some(use_stmt), false));
+    }
 
     // Detect if the RHS is a structurally-required expression (if/for/read)
-    let is_structural = detect_structural_rhs(&expr_pair);
+    let is_structural = detect_structural_rhs(&rhs_pair);
 
-    // Check if it's a module call, resource expression, import, or for expression
+    // Check if it's a module call, resource expression, or for expression
     let (value, expanded_resources, module_calls, maybe_import) =
-        parse_expression_with_resource_or_module(expr_pair, ctx, &name)?;
+        parse_expression_with_resource_or_module(rhs_pair, ctx, &name)?;
 
     Ok((
         name,
@@ -1968,11 +1977,6 @@ fn parse_primary_with_resource_or_module(
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
             Ok((ref_value, vec![resource], vec![], None))
-        }
-        Rule::use_expr => {
-            let use_stmt = parse_use_expr(inner, binding_name, ctx)?;
-            let value = Value::String(format!("${{use:{}}}", use_stmt.path));
-            Ok((value, vec![], vec![], Some(use_stmt)))
         }
         Rule::for_expr => {
             let (resources, module_calls) = parse_for_expr(inner, ctx, binding_name)?;
@@ -5723,6 +5727,70 @@ mod tests {
         assert!(
             msg.contains("bogus"),
             "error should mention unexpected attribute, got: {msg}"
+        );
+    }
+
+    // The `use` expression is only valid as a top-level `let` binding RHS.
+    // The grammar previously accepted it in any primary-value position, which
+    // produced silent evaluator failures (issue #2233). These tests pin the
+    // grammar boundary: any non-let-RHS position must be a parse error.
+
+    #[test]
+    fn parse_use_expression_rejected_as_module_call_argument() {
+        let input = r#"
+            some_module {
+              network = use { source = "./modules/network" }
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "use expression as module-call argument must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_use_expression_rejected_in_list() {
+        let input = r#"
+            let mods = [use { source = "./modules/a" }]
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "use expression inside a list must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_use_expression_rejected_in_if_branch() {
+        let input = r#"
+            let net = if true { use { source = "./a" } } else { use { source = "./b" } }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "use expression inside an if branch must be rejected, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_use_expression_rejected_in_local_let() {
+        // `local_binding` (block-scoped `let`) goes through `parse_expression`,
+        // which has no `use_expr` handling. Must be a parse error, not silent failure.
+        let input = r#"
+            aws.s3.bucket {
+              name = "my-bucket"
+              let mod_x = use { source = "./modules/x" }
+            }
+        "#;
+
+        let result = parse(input, &ProviderContext::default());
+        assert!(
+            result.is_err(),
+            "use expression inside a local let binding must be rejected, got: {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

The pest grammar accepted `use_expr` in any primary-value position, but the evaluator only handled it as the RHS of a top-level `let` binding. The mismatch produced silent failures (e.g. `use { ... }` inside a list became a literal string; inside an if branch it was misparsed as a `module_call` named "use").

This PR implements direction 1 from #2233 (tighten the grammar to match the evaluator):

- `let_binding`'s RHS now allows `(use_expr | expression)`. `use_expr` is the only meta-statement allowed there.
- Remove `use_expr` from `primary`.
- `module_call` gains a `!use_keyword` guard so `use { ... }` cannot silently parse as a module call named "use" now that `use_expr` is no longer ahead of it in `primary`.
- Mirror the same shape in the formatter grammar (`carina_fmt.pest`) so the `pest_grammar_parity` invariant holds.
- Drop the now-unreachable `Rule::use_expr` arm from `parse_primary_with_resource_or_module`; handle it directly in `parse_let_binding_extended`.

## Why direction 1, not 2 or 3

- Direction 2 (`Value::Module`, modules-as-first-class-values) would be a much bigger design change with implications for module resolution, exports, and the resolver. There is no current roadmap need for dynamic module selection.
- Direction 3 (keep grammar drift, emit a runtime error) just pushes an error that can be a parse error down to runtime. Direction 1 is strictly better.
- Direction 1 is reversible: if `Value::Module` is wanted later, loosening the grammar is easy.

## Test plan

- [x] Added 4 new parser tests covering the four positions named in the issue (module-call argument, list element, if branch, local-let RHS). All Red → Green confirmed.
- [x] `cargo test` (full workspace) — all PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo build` — succeeds
- [x] Real-infra smoke test: `carina validate infra/aws/management/github-oidc/` still passes (`let X = use { ... }` still works)
- [x] Existing `nested_modules` and `module_list` fixtures continue to pass

Closes #2233