### PR TITLE
resource,state: use BTreeSet for dependency_bindings

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -1161,7 +1161,7 @@ async fn run_apply_locked(
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
     // Pre-build dependency_bindings from state file so we can restore them
     // after refresh. Provider.read() doesn't know about this metadata (#1565).
-    let saved_dep_bindings: HashMap<ResourceId, Vec<String>> = state_file
+    let saved_dep_bindings: HashMap<ResourceId, BTreeSet<String>> = state_file
         .as_ref()
         .map(|sf| {
             sorted_resources
@@ -1212,7 +1212,7 @@ async fn run_apply_locked(
     // Refresh orphaned resources (#844, #1685). Must run before the
     // rename transfer below so old-name entries are present for
     // `apply_anonymous_to_named_renames` to transfer.
-    let mut orphan_dependencies: HashMap<ResourceId, Vec<String>> = HashMap::new();
+    let mut orphan_dependencies: HashMap<ResourceId, BTreeSet<String>> = HashMap::new();
     if let Some(sf) = state_file.as_ref() {
         let desired_ids: HashSet<ResourceId> =
             sorted_resources.iter().map(|r| r.id.clone()).collect();

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1391,6 +1391,9 @@ mod tests {
 
         // subnet depends on vpc
         let subnet_resource = plan.effects()[1].resource().unwrap();
-        assert_eq!(subnet_resource.dependency_bindings, vec!["vpc".to_string()]);
+        assert_eq!(
+            subnet_resource.dependency_bindings,
+            std::collections::BTreeSet::from(["vpc".to_string()])
+        );
     }
 }

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -2946,7 +2946,7 @@ mod tests {
         );
         // _dependency_bindings is saved by resolve_refs_with_state() before
         // ResourceRef values are resolved to strings.
-        sg.dependency_bindings = vec!["vpc".to_string()];
+        sg.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
         let mut plan = Plan::new();
         plan.add(Effect::Update {

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -2452,7 +2452,7 @@ fn build_state_after_apply_persists_write_only_attributes() {
                 Value::String("10.0.0.0/16".to_string()),
             )]),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         },
     )]);
 
@@ -2527,7 +2527,7 @@ fn build_state_after_apply_write_only_detects_value_change() {
                 Value::String("10.0.0.0/24".to_string()),
             )]),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         },
     )]);
 

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -827,7 +827,7 @@ pub async fn create_plan_from_parsed_with_upstream(
         // Pre-build a map of dependency_bindings from the state file so we can
         // restore them after refresh. Provider.read() returns fresh attributes but
         // doesn't know about dependency_bindings (carina-only metadata).
-        let saved_dep_bindings: HashMap<ResourceId, Vec<String>> = state_file
+        let saved_dep_bindings: HashMap<ResourceId, BTreeSet<String>> = state_file
             .as_ref()
             .map(|sf| {
                 sorted_resources

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -338,7 +338,8 @@ mod tests {
             Value::resource_ref("rt", "route_table_id", vec![]),
         );
         // dependency_bindings was saved before resolution with the CORRECT deps
-        resource.dependency_bindings = vec!["rt".to_string(), "tgw_attach".to_string()];
+        resource.dependency_bindings =
+            std::collections::BTreeSet::from(["rt".to_string(), "tgw_attach".to_string()]);
 
         let deps = get_resource_dependencies(&resource);
         // Must include "tgw_attach" from dependency_bindings

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -1,6 +1,6 @@
 //! Plan generation from diffs and cascading update logic.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::deps::get_resource_dependencies;
 use crate::effect::{CascadingUpdate, Effect, TemporaryName};
@@ -156,7 +156,7 @@ pub fn create_plan(
     schemas: &HashMap<String, ResourceSchema>,
     saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     prev_desired_keys: &HashMap<ResourceId, Vec<String>>,
-    orphan_dependencies: &HashMap<ResourceId, Vec<String>>,
+    orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
 ) -> Plan {
     let mut plan = Plan::new();
 
@@ -338,7 +338,7 @@ pub fn create_plan(
                     lifecycle: lifecycle.clone(),
                     prefixes: HashMap::new(),
                     binding: None,
-                    dependency_bindings: Vec::new(),
+                    dependency_bindings: BTreeSet::new(),
                     module_source: None,
                 };
                 get_resource_dependencies(&temp_resource)

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -557,7 +557,7 @@ mod tests {
             State::existing(subnet_id.clone(), HashMap::new()).with_identifier("subnet-old");
         let mut subnet_to = Resource::new("test", "subnet");
         subnet_to.binding = Some("subnet".to_string());
-        subnet_to.dependency_bindings = vec!["vpc".to_string()];
+        subnet_to.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
         let cbd_lifecycle = LifecycleConfig {
             create_before_destroy: true,
@@ -634,7 +634,7 @@ mod tests {
             State::existing(subnet_id.clone(), HashMap::new()).with_identifier("subnet-old");
         let mut subnet_to = Resource::new("test", "subnet");
         subnet_to.binding = Some("subnet".to_string());
-        subnet_to.dependency_bindings = vec!["vpc".to_string()];
+        subnet_to.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
         let dbd_lifecycle = LifecycleConfig::default();
 
@@ -913,8 +913,11 @@ mod tests {
         // tgw_attach depends on tgw, vpc, subnet
         let mut tgw_attach = Resource::new("ec2.transit_gateway_attachment", "tgw_attach");
         tgw_attach.binding = Some("tgw_attach".to_string());
-        tgw_attach.dependency_bindings =
-            vec!["tgw".to_string(), "vpc".to_string(), "subnet".to_string()];
+        tgw_attach.dependency_bindings = std::collections::BTreeSet::from([
+            "tgw".to_string(),
+            "vpc".to_string(),
+            "subnet".to_string(),
+        ]);
 
         // route depends on rt and tgw_attach (but after partial resolution,
         // transit_gateway_id points to ResourceRef { binding: "tgw" })
@@ -923,7 +926,8 @@ mod tests {
             "transit_gateway_id".to_string(),
             Value::resource_ref("tgw".to_string(), "id".to_string(), vec![]),
         );
-        route.dependency_bindings = vec!["rt".to_string(), "tgw_attach".to_string()];
+        route.dependency_bindings =
+            std::collections::BTreeSet::from(["rt".to_string(), "tgw_attach".to_string()]);
 
         // Other resources
         let mut vpc = Resource::new("ec2.Vpc", "vpc");
@@ -934,11 +938,11 @@ mod tests {
 
         let mut subnet = Resource::new("ec2.Subnet", "subnet");
         subnet.binding = Some("subnet".to_string());
-        subnet.dependency_bindings = vec!["vpc".to_string()];
+        subnet.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
         let mut rt = Resource::new("ec2.RouteTable", "rt");
         rt.binding = Some("rt".to_string());
-        rt.dependency_bindings = vec!["vpc".to_string()];
+        rt.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
 
         let mut plan = Plan::new();
         plan.add(Effect::Create(vpc)); // idx 0
@@ -1333,7 +1337,7 @@ mod tests {
             Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
         );
         subnet.set_attr("cidr_block", Value::String("10.0.1.0/24".to_string()));
-        subnet.dependency_bindings = vec!["vpc".to_string()];
+        subnet.dependency_bindings = std::collections::BTreeSet::from(["vpc".to_string()]);
         let subnet_id = subnet.id.clone();
 
         let mut plan = Plan::new();
@@ -1509,11 +1513,11 @@ mod tests {
         // from: depends on tgw_a (recorded in state's dependency_bindings)
         let attachment_from = State::existing(attachment_id.clone(), HashMap::new())
             .with_identifier("attach-old")
-            .with_dependency_bindings(vec!["tgw_a".to_string()]);
+            .with_dependency_bindings(std::collections::BTreeSet::from(["tgw_a".to_string()]));
         // to: depends on tgw_b (different TGW — dependency changed)
         let mut attachment_to = Resource::new("test", "attachment");
         attachment_to.binding = Some("attachment".to_string());
-        attachment_to.dependency_bindings = vec!["tgw_b".to_string()];
+        attachment_to.dependency_bindings = std::collections::BTreeSet::from(["tgw_b".to_string()]);
 
         let cbd_lifecycle = LifecycleConfig {
             create_before_destroy: true,
@@ -1599,10 +1603,10 @@ mod tests {
         // attachment Replace (CBD): from depends on tgw_a (state-recorded)
         let attachment_from = State::existing(attachment_id.clone(), HashMap::new())
             .with_identifier("attach-old")
-            .with_dependency_bindings(vec!["tgw_a".to_string()]);
+            .with_dependency_bindings(std::collections::BTreeSet::from(["tgw_a".to_string()]));
         let mut attachment_to = Resource::new("test", "attachment");
         attachment_to.binding = Some("attachment".to_string());
-        attachment_to.dependency_bindings = vec!["tgw_b".to_string()];
+        attachment_to.dependency_bindings = std::collections::BTreeSet::from(["tgw_b".to_string()]);
 
         let cbd_lifecycle = LifecycleConfig {
             create_before_destroy: true,

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -12,7 +12,7 @@
 
 mod validation;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -453,7 +453,7 @@ impl<'cfg> ModuleResolver<'cfg> {
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: Some(binding_name.clone()),
-                dependency_bindings: Vec::new(),
+                dependency_bindings: BTreeSet::new(),
                 module_source: None,
             };
             expanded_resources.push(virtual_resource);
@@ -1129,7 +1129,7 @@ mod tests {
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: None,
-                dependency_bindings: Vec::new(),
+                dependency_bindings: BTreeSet::new(),
                 module_source: None,
             }],
             variables: HashMap::new(),
@@ -1257,7 +1257,7 @@ mod tests {
                     lifecycle: LifecycleConfig::default(),
                     prefixes: HashMap::new(),
                     binding: Some("vpc".to_string()),
-                    dependency_bindings: Vec::new(),
+                    dependency_bindings: BTreeSet::new(),
                     module_source: None,
                 },
                 Resource {
@@ -1274,7 +1274,7 @@ mod tests {
                     lifecycle: LifecycleConfig::default(),
                     prefixes: HashMap::new(),
                     binding: Some("subnet".to_string()),
-                    dependency_bindings: Vec::new(),
+                    dependency_bindings: BTreeSet::new(),
                     module_source: None,
                 },
             ],
@@ -1401,7 +1401,7 @@ mod tests {
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: Some("sg".to_string()),
-                dependency_bindings: Vec::new(),
+                dependency_bindings: BTreeSet::new(),
                 module_source: None,
             }],
             variables: HashMap::new(),
@@ -2202,7 +2202,7 @@ thing { name = 'unchanged-but-different' }
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: Some("vpc".to_string()),
-                dependency_bindings: Vec::new(),
+                dependency_bindings: BTreeSet::new(),
                 module_source: None,
             }],
             variables: HashMap::new(),

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -13,7 +13,7 @@ use crate::schema::{
 use crate::version_constraint::VersionConstraint;
 use pest::Parser;
 use pest_derive::Parser;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 #[derive(Parser)]
 #[grammar = "parser/carina.pest"]
@@ -3756,7 +3756,7 @@ fn parse_anonymous_resource(
         lifecycle,
         prefixes: HashMap::new(),
         binding: None,
-        dependency_bindings: Vec::new(),
+        dependency_bindings: BTreeSet::new(),
         module_source: None,
     })
 }
@@ -4147,7 +4147,7 @@ fn parse_resource_expr(
         lifecycle,
         prefixes: HashMap::new(),
         binding: Some(binding_name.to_string()),
-        dependency_bindings: Vec::new(),
+        dependency_bindings: BTreeSet::new(),
         module_source: None,
     })
 }
@@ -4197,7 +4197,7 @@ fn parse_read_resource_expr(
         lifecycle,
         prefixes: HashMap::new(),
         binding: Some(binding_name.to_string()),
-        dependency_bindings: Vec::new(),
+        dependency_bindings: BTreeSet::new(),
         module_source: None,
     })
 }
@@ -4903,8 +4903,7 @@ pub fn resolve_resource_refs_with_config(
     for resource in &mut parsed.resources {
         let deps = crate::deps::get_resource_dependencies(resource);
         if !deps.is_empty() {
-            let dep_list: Vec<String> = deps.into_iter().collect();
-            resource.dependency_bindings = dep_list;
+            resource.dependency_bindings = deps.into_iter().collect();
         }
     }
 

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -41,8 +41,7 @@ pub fn resolve_refs_with_state_and_remote(
     for resource in resources.iter_mut() {
         let deps = get_resource_dependencies(resource);
         if !deps.is_empty() {
-            let dep_list: Vec<String> = deps.into_iter().collect();
-            resource.dependency_bindings = dep_list;
+            resource.dependency_bindings = deps.into_iter().collect();
         }
     }
 
@@ -406,7 +405,7 @@ mod tests {
                 attributes: vec![("vpc_id".to_string(), Value::String("vpc-abc".to_string()))]
                     .into_iter()
                     .collect(),
-                dependency_bindings: Vec::new(),
+                dependency_bindings: std::collections::BTreeSet::new(),
             },
         );
 

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -1,6 +1,6 @@
 //! Resource - Representing resources and their state
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
@@ -812,9 +812,14 @@ pub struct Resource {
     /// Binding name from `let` bindings in DSL (e.g., `let vpc = ...`)
     #[serde(default)]
     pub binding: Option<String>,
-    /// Binding names of resources this resource depends on (via ResourceRef)
+    /// Binding names of resources this resource depends on (via ResourceRef).
+    ///
+    /// Set semantics (BTreeSet): the same binding referenced multiple times
+    /// in the resource's attributes contributes a single entry, and
+    /// iteration is alphabetically sorted so consumers (plan display,
+    /// state files) see a deterministic order. See #2228.
     #[serde(default)]
-    pub dependency_bindings: Vec<String>,
+    pub dependency_bindings: BTreeSet<String>,
     /// Module source info for resources that belong to a module
     #[serde(default)]
     pub module_source: Option<ModuleSource>,
@@ -829,7 +834,7 @@ impl Resource {
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: None,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
             module_source: None,
         }
     }
@@ -846,7 +851,7 @@ impl Resource {
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: None,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
             module_source: None,
         }
     }
@@ -906,7 +911,7 @@ impl Resource {
         self
     }
 
-    pub fn with_dependency_bindings(mut self, deps: Vec<String>) -> Self {
+    pub fn with_dependency_bindings(mut self, deps: BTreeSet<String>) -> Self {
         self.dependency_bindings = deps;
         self
     }
@@ -942,7 +947,9 @@ pub struct State {
     pub exists: bool,
     /// Binding names this resource depended on when it was last applied.
     /// Used by the executor to determine delete ordering during replace operations.
-    pub dependency_bindings: Vec<String>,
+    ///
+    /// Set semantics (BTreeSet) — see Resource::dependency_bindings (#2228).
+    pub dependency_bindings: BTreeSet<String>,
 }
 
 impl State {
@@ -952,7 +959,7 @@ impl State {
             identifier: None,
             attributes: HashMap::new(),
             exists: false,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         }
     }
 
@@ -962,7 +969,7 @@ impl State {
             identifier: None,
             attributes,
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         }
     }
 
@@ -971,7 +978,7 @@ impl State {
         self
     }
 
-    pub fn with_dependency_bindings(mut self, deps: Vec<String>) -> Self {
+    pub fn with_dependency_bindings(mut self, deps: BTreeSet<String>) -> Self {
         self.dependency_bindings = deps;
         self
     }
@@ -1435,10 +1442,46 @@ mod tests {
     #[test]
     fn resource_typed_dependency_bindings_field() {
         let resource = Resource::new("ec2.Subnet", "my-subnet")
-            .with_dependency_bindings(vec!["vpc".to_string()]);
-        assert_eq!(resource.dependency_bindings, vec!["vpc".to_string()]);
+            .with_dependency_bindings(["vpc".to_string()].into_iter().collect());
+        assert!(resource.dependency_bindings.contains("vpc"));
+        assert_eq!(resource.dependency_bindings.len(), 1);
         // dependency_bindings should NOT be in attributes
         assert!(!resource.attributes.contains_key("_dependency_bindings"));
+    }
+
+    /// Set semantics: assigning the same binding twice yields exactly one
+    /// entry (#2228).
+    #[test]
+    fn resource_dependency_bindings_dedup_on_duplicate_insert() {
+        let mut resource = Resource::new("ec2.Subnet", "my-subnet");
+        resource.dependency_bindings.insert("vpc".to_string());
+        resource.dependency_bindings.insert("vpc".to_string());
+        assert_eq!(resource.dependency_bindings.len(), 1);
+        assert!(resource.dependency_bindings.contains("vpc"));
+    }
+
+    /// Iteration order is deterministic (sorted) regardless of insertion
+    /// order (#2228).
+    #[test]
+    fn resource_dependency_bindings_iteration_is_sorted() {
+        let mut resource = Resource::new("ec2.Route", "my-route");
+        resource.dependency_bindings.insert("rt".to_string());
+        resource
+            .dependency_bindings
+            .insert("tgw_attach".to_string());
+        resource.dependency_bindings.insert("vpc".to_string());
+        let order: Vec<&String> = resource.dependency_bindings.iter().collect();
+        assert_eq!(order, vec!["rt", "tgw_attach", "vpc"]);
+    }
+
+    /// State-struct dependency_bindings has the same Set semantics so
+    /// that delete-ordering metadata is also dedup'd and stable (#2228).
+    #[test]
+    fn state_dependency_bindings_dedup_on_duplicate_insert() {
+        let mut state = State::not_found(ResourceId::new("ec2.Subnet", "my-subnet"));
+        state.dependency_bindings.insert("vpc".to_string());
+        state.dependency_bindings.insert("vpc".to_string());
+        assert_eq!(state.dependency_bindings.len(), 1);
     }
 
     #[test]

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -7,7 +7,7 @@ use carina_core::value::{
     value_to_json,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::backend::BackendError;
 
@@ -227,7 +227,7 @@ impl StateFile {
     pub fn build_orphan_dependencies(
         &self,
         desired_ids: &std::collections::HashSet<ResourceId>,
-    ) -> HashMap<ResourceId, Vec<String>> {
+    ) -> HashMap<ResourceId, BTreeSet<String>> {
         let mut result = HashMap::new();
         for rs in &self.resources {
             let id = ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
@@ -391,8 +391,13 @@ pub struct ResourceState {
     pub binding: Option<String>,
     /// Binding names of resources this resource depends on (via ResourceRef).
     /// Stored so orphan Delete effects can have tree structure.
+    ///
+    /// Set semantics (BTreeSet) — see Resource::dependency_bindings (#2228).
+    /// Old state files persisted as JSON arrays continue to deserialize
+    /// (serde transparently coerces array → BTreeSet, deduping any
+    /// duplicates and re-serializing in sorted order on next write).
     #[serde(default)]
-    pub dependency_bindings: Vec<String>,
+    pub dependency_bindings: BTreeSet<String>,
     /// Attribute names that are write-only (not returned by the provider API).
     /// Their values are persisted from the user's desired state so that changes
     /// to write-only attributes can be detected on subsequent plans.
@@ -419,7 +424,7 @@ impl ResourceState {
             name_overrides: HashMap::new(),
             desired_keys: Vec::new(),
             binding: None,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
             write_only_attributes: Vec::new(),
         }
     }
@@ -539,12 +544,11 @@ impl ResourceState {
         rs.desired_keys.sort();
         // Store binding name for tree structure in orphan Delete effects
         rs.binding = resource.binding.clone();
-        // Store dependency bindings for tree structure in orphan Delete effects
+        // Store dependency bindings for tree structure in orphan Delete effects.
+        // BTreeSet gives us dedup and sorted iteration for free (#2228).
         let deps = get_resource_dependencies(resource);
         if !deps.is_empty() {
-            let mut dep_list: Vec<String> = deps.into_iter().collect();
-            dep_list.sort();
-            rs.dependency_bindings = dep_list;
+            rs.dependency_bindings = deps.into_iter().collect();
         }
         Ok(rs)
     }
@@ -730,7 +734,10 @@ mod tests {
 
         let deserialized: ResourceState = serde_json::from_str(json).unwrap();
         assert_eq!(deserialized.binding, Some("my_bucket".to_string()));
-        assert_eq!(deserialized.dependency_bindings, vec!["vpc", "subnet"]);
+        assert_eq!(
+            deserialized.dependency_bindings,
+            BTreeSet::from(["vpc".to_string(), "subnet".to_string()])
+        );
     }
 
     #[test]
@@ -774,7 +781,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let existing = ResourceState::new("s3.Bucket", "my-bucket", "awscc").with_protected(true);
@@ -804,7 +811,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -997,12 +1004,15 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
         assert_eq!(rs.binding, Some("my_subnet".to_string()));
-        assert_eq!(rs.dependency_bindings, vec!["my_vpc".to_string()]);
+        assert_eq!(
+            rs.dependency_bindings,
+            BTreeSet::from(["my_vpc".to_string()])
+        );
     }
 
     #[test]
@@ -1013,7 +1023,7 @@ mod tests {
         let mut rs = ResourceState::new("ec2.Subnet", "orphan-subnet", "awscc")
             .with_identifier("subnet-123");
         rs.binding = Some("my_subnet".to_string());
-        rs.dependency_bindings = vec!["my_vpc".to_string()];
+        rs.dependency_bindings = BTreeSet::from(["my_vpc".to_string()]);
         state.upsert_resource(rs);
 
         let desired_ids = std::collections::HashSet::new();
@@ -1036,14 +1046,17 @@ mod tests {
         let mut rs = ResourceState::new("ec2.Subnet", "orphan-subnet", "awscc")
             .with_identifier("subnet-123");
         rs.binding = Some("my_subnet".to_string());
-        rs.dependency_bindings = vec!["my_vpc".to_string()];
+        rs.dependency_bindings = BTreeSet::from(["my_vpc".to_string()]);
         state.upsert_resource(rs);
 
         let desired_ids = std::collections::HashSet::new();
         let deps = state.build_orphan_dependencies(&desired_ids);
 
         let id = ResourceId::with_provider("awscc", "ec2.Subnet", "orphan-subnet");
-        assert_eq!(deps.get(&id).unwrap(), &vec!["my_vpc".to_string()]);
+        assert_eq!(
+            deps.get(&id).unwrap(),
+            &BTreeSet::from(["my_vpc".to_string()])
+        );
     }
 
     #[test]
@@ -1059,7 +1072,7 @@ mod tests {
         let mut state = StateFile::new();
         let mut rs =
             ResourceState::new("ec2.Subnet", "kept-subnet", "awscc").with_identifier("subnet-456");
-        rs.dependency_bindings = vec!["my_vpc".to_string()];
+        rs.dependency_bindings = BTreeSet::from(["my_vpc".to_string()]);
         state.upsert_resource(rs);
 
         let id = ResourceId::with_provider("awscc", "ec2.Subnet", "kept-subnet");
@@ -1186,7 +1199,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1230,7 +1243,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1266,7 +1279,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let mut rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1338,7 +1351,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1390,7 +1403,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1449,7 +1462,7 @@ mod tests {
                 .into_iter()
                 .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1504,7 +1517,7 @@ mod tests {
             .into_iter()
             .collect(),
             exists: true,
-            dependency_bindings: Vec::new(),
+            dependency_bindings: BTreeSet::new(),
         };
 
         let rs = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap();
@@ -1564,7 +1577,7 @@ mod tests {
             name_overrides: HashMap::new(),
             desired_keys: vec![],
             binding: Some("vpc".to_string()),
-            dependency_bindings: vec![],
+            dependency_bindings: BTreeSet::new(),
             write_only_attributes: vec![],
         });
         let bindings = state.build_remote_bindings();


### PR DESCRIPTION
## Summary

Closes #2228.

`Resource.dependency_bindings`, the matching runtime `State.dependency_bindings`, and `ResourceState.dependency_bindings` on disk were all `Vec<String>`. That shape allowed silent duplicates, leaked HashSet iteration order into plan display and on-disk state files, and made membership lookups O(n).

This PR switches all three to `BTreeSet<String>`. Set semantics are now enforced at the type level: duplicate inserts collapse to one entry, iteration is alphabetically sorted, and membership lookup is O(log n).

## Mechanical changes

- Field types in `Resource`, `State` (carina-core), and `ResourceState` (carina-state)
- Initializers: `Vec::new()` / `vec![]` → `BTreeSet::new()`; `vec!["a".to_string(), ...]` → `BTreeSet::from([...])`
- `with_dependency_bindings` builder argument type
- `create_plan`'s `orphan_dependencies` parameter and `build_orphan_dependencies` return type
- Dropped manual `dep_list.sort()` in `state.rs` — BTreeSet iterates sorted by definition
- Test assertions updated to compare against `BTreeSet`

## Serde compatibility

Old state files persist `dependency_bindings` as JSON arrays. Serde transparently deserializes those into `BTreeSet<String>` (deduping any pre-existing duplicates and re-serializing in sorted order on the next write). No state-file migration is required.

## New tests

- `resource_dependency_bindings_dedup_on_duplicate_insert` — AC test: same binding inserted twice → one entry
- `resource_dependency_bindings_iteration_is_sorted` — iteration is alphabetically deterministic regardless of insertion order
- `state_dependency_bindings_dedup_on_duplicate_insert` — same invariants for the runtime `State` struct

## Test plan

- [x] `cargo test` (full workspace) — all PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo build` — succeeds
- [x] Real-infra smoke test: `carina validate infra/aws/management/github-oidc/` still passes