### PR TITLE
resource: encode unresolved resource names in the type

### DIFF
--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -649,7 +649,7 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
         let existing = state.find_resource(
             &resource.id.provider,
             &resource.id.resource_type,
-            &resource.id.name,
+            resource.id.name_str(),
         );
         // Collect write-only attribute names from the schema for this resource type.
         // Schema keys include the provider prefix (e.g., "awscc.ec2.Vpc"), so we must
@@ -695,7 +695,7 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
                 state.remove_resource(
                     &resource.id.provider,
                     &resource.id.resource_type,
-                    &resource.id.name,
+                    resource.id.name_str(),
                 );
             }
         }
@@ -704,7 +704,7 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
     for effect in plan.effects() {
         match effect {
             Effect::Delete { id, .. } if successfully_deleted.contains(id) => {
-                state.remove_resource(&id.provider, &id.resource_type, &id.name);
+                state.remove_resource(&id.provider, &id.resource_type, id.name_str());
             }
             Effect::Import { .. } => {
                 // Already handled in the sorted_resources loop above via applied_states.
@@ -712,19 +712,19 @@ pub fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, Ap
                 // desired_keys, binding, dependency_bindings) with bare defaults.
             }
             Effect::Remove { id } => {
-                state.remove_resource(&id.provider, &id.resource_type, &id.name);
+                state.remove_resource(&id.provider, &id.resource_type, id.name_str());
             }
             Effect::Move { from, to } => {
                 // Move: update the resource's identity in state
                 if let Some(existing) = state
-                    .find_resource(&from.provider, &from.resource_type, &from.name)
+                    .find_resource(&from.provider, &from.resource_type, from.name_str())
                     .cloned()
                 {
-                    state.remove_resource(&from.provider, &from.resource_type, &from.name);
+                    state.remove_resource(&from.provider, &from.resource_type, from.name_str());
                     let mut moved_resource = existing;
                     moved_resource.provider = to.provider.clone();
                     moved_resource.resource_type = to.resource_type.clone();
-                    moved_resource.name = to.name.clone();
+                    moved_resource.name = to.name_str().to_string();
                     state.upsert_resource(moved_resource);
                 }
             }
@@ -1167,7 +1167,8 @@ async fn run_apply_locked(
             sorted_resources
                 .iter()
                 .filter_map(|r| {
-                    let rs = sf.find_resource(&r.id.provider, &r.id.resource_type, &r.id.name)?;
+                    let rs =
+                        sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
                     if rs.dependency_bindings.is_empty() {
                         None
                     } else {

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -470,10 +470,9 @@ async fn run_destroy_locked(
                 binding: resource.binding.clone(),
                 dependencies,
             };
-            let binding = resource
-                .binding
-                .clone()
-                .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            let binding = resource.binding.clone().unwrap_or_else(|| {
+                format!("{}:{}", resource.id.resource_type, resource.id.name_str())
+            });
             (binding, identifier, effect)
         })
         .collect();
@@ -921,7 +920,7 @@ async fn run_destroy_locked(
 /// clear any exports (since exports reference attributes of destroyed resources).
 fn apply_destroy_to_state(state: &mut carina_state::StateFile, destroyed_ids: &[ResourceId]) {
     for id in destroyed_ids {
-        state.remove_resource(&id.provider, &id.resource_type, &id.name);
+        state.remove_resource(&id.provider, &id.resource_type, id.name_str());
     }
     state.exports.clear();
 }
@@ -933,7 +932,7 @@ fn apply_destroy_to_state(state: &mut carina_state::StateFile, destroyed_ids: &[
 /// and tree display work correctly.
 fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceId) -> Resource {
     let rs = sf
-        .find_resource(&id.provider, &id.resource_type, &id.name)
+        .find_resource(&id.provider, &id.resource_type, id.name_str())
         .expect("orphan must exist in state file");
     let attributes: HashMap<String, Value> = rs
         .attributes

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -786,7 +786,7 @@ fn diff_display_update_resource(
     updated_count: &mut u32,
     unchanged_count: &mut u32,
 ) -> Result<(), AppError> {
-    let existing = state.find_resource(&id.provider, &id.resource_type, &id.name);
+    let existing = state.find_resource(&id.provider, &id.resource_type, id.name_str());
     let existing_rs = match existing {
         Some(rs) => rs,
         None => return Ok(()),
@@ -875,15 +875,16 @@ fn diff_display_update_resource(
         let res = match resource {
             Some(r) => r,
             None => {
-                owned_resource = Resource::with_provider(&id.provider, &id.resource_type, &id.name);
+                owned_resource =
+                    Resource::with_provider(&id.provider, &id.resource_type, id.name_str());
                 &owned_resource
             }
         };
-        let existing_rs = state.find_resource(&id.provider, &id.resource_type, &id.name);
+        let existing_rs = state.find_resource(&id.provider, &id.resource_type, id.name_str());
         let resource_state = ResourceState::from_provider_state(res, fresh_state, existing_rs)?;
         state.upsert_resource(resource_state);
     } else {
-        state.remove_resource(&id.provider, &id.resource_type, &id.name);
+        state.remove_resource(&id.provider, &id.resource_type, id.name_str());
     }
 
     Ok(())

--- a/carina-cli/src/display.rs
+++ b/carina-cli/src/display.rs
@@ -432,7 +432,7 @@ impl<'a> TreeRenderContext<'a> {
         match effect {
             Effect::Create(r) => {
                 if self.detail == DetailLevel::None {
-                    let name_part = format_compact_name(r, &r.id.name, parent_binding);
+                    let name_part = format_compact_name(r, r.id.name_str(), parent_binding);
                     writeln!(
                         self.out,
                         "{}{}{} {} {}",
@@ -451,7 +451,7 @@ impl<'a> TreeRenderContext<'a> {
                         connector,
                         colored_symbol,
                         r.id.display_type().cyan().bold(),
-                        r.id.name.white().bold()
+                        r.id.name_str().white().bold()
                     )
                     .unwrap();
                 }
@@ -462,7 +462,7 @@ impl<'a> TreeRenderContext<'a> {
                     .get(id)
                     .map(|from| format!(" (moved from: {}.{})", from.display_type(), from.name));
                 if self.detail == DetailLevel::None {
-                    let name_part = format_compact_name(to, &id.name, parent_binding);
+                    let name_part = format_compact_name(to, id.name_str(), parent_binding);
                     writeln!(
                         self.out,
                         "{}{}{} {} {}{}",
@@ -482,7 +482,7 @@ impl<'a> TreeRenderContext<'a> {
                         connector,
                         colored_symbol,
                         id.display_type().cyan().bold(),
-                        id.name.yellow().bold(),
+                        id.name_str().yellow().bold(),
                         moved_note.as_deref().unwrap_or("").yellow()
                     )
                     .unwrap();
@@ -501,7 +501,7 @@ impl<'a> TreeRenderContext<'a> {
                     .get(id)
                     .map(|from| format!(" (moved from: {}.{})", from.display_type(), from.name));
                 if self.detail == DetailLevel::None {
-                    let name_part = format_compact_name(to, &id.name, parent_binding);
+                    let name_part = format_compact_name(to, id.name_str(), parent_binding);
                     writeln!(
                         self.out,
                         "{}{}{} {} {} {}{}",
@@ -522,7 +522,7 @@ impl<'a> TreeRenderContext<'a> {
                         connector,
                         colored_symbol,
                         id.display_type().cyan().bold(),
-                        id.name.magenta().bold(),
+                        id.name_str().magenta().bold(),
                         replace_note.magenta(),
                         moved_note.as_deref().unwrap_or("").magenta()
                     )
@@ -530,7 +530,7 @@ impl<'a> TreeRenderContext<'a> {
                 }
             }
             Effect::Delete { id, binding, .. } => {
-                let display_name = binding.as_deref().unwrap_or(&id.name);
+                let display_name = binding.as_deref().unwrap_or(id.name_str());
                 writeln!(
                     self.out,
                     "{}{}{} {} {}",
@@ -545,7 +545,7 @@ impl<'a> TreeRenderContext<'a> {
             Effect::Read { resource } => {
                 if self.detail == DetailLevel::None {
                     let name_part =
-                        format_compact_name(resource, &resource.id.name, parent_binding);
+                        format_compact_name(resource, resource.id.name_str(), parent_binding);
                     writeln!(
                         self.out,
                         "{}{}{} {} {} {}",
@@ -565,7 +565,7 @@ impl<'a> TreeRenderContext<'a> {
                         connector,
                         colored_symbol,
                         resource.id.display_type().cyan().bold(),
-                        resource.id.name.cyan().bold(),
+                        resource.id.name_str().cyan().bold(),
                         "(data source)".dimmed()
                     )
                     .unwrap();
@@ -579,7 +579,7 @@ impl<'a> TreeRenderContext<'a> {
                     connector,
                     colored_symbol,
                     id.display_type().cyan().bold(),
-                    id.name.cyan().bold(),
+                    id.name_str().cyan().bold(),
                     format!("(import: {})", identifier).dimmed()
                 )
                 .unwrap();
@@ -592,7 +592,7 @@ impl<'a> TreeRenderContext<'a> {
                     connector,
                     colored_symbol,
                     id.display_type().cyan().bold(),
-                    id.name.red().bold(),
+                    id.name_str().red().bold(),
                     "(remove from state)".dimmed()
                 )
                 .unwrap();
@@ -611,7 +611,7 @@ impl<'a> TreeRenderContext<'a> {
                     connector,
                     colored_symbol,
                     to.display_type().cyan().bold(),
-                    to.name.yellow().bold(),
+                    to.name_str().yellow().bold(),
                     format!("(moved from: {})", from).dimmed()
                 )
                 .unwrap();
@@ -1360,7 +1360,7 @@ pub fn format_effect(effect: &Effect) -> String {
             }
         }
         Effect::Delete { id, binding, .. } => {
-            let display_name = binding.as_deref().unwrap_or(&id.name);
+            let display_name = binding.as_deref().unwrap_or(id.name_str());
             format!("Delete {}.{}", id.display_type(), display_name)
         }
         Effect::Read { resource } => {

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -437,7 +437,7 @@ fn collect_unused_let_bindings_in_fixtures(
             .iter()
             .filter_map(|sb| {
                 if let carina_core::parser::StateBlock::Moved { to, .. } = sb {
-                    Some(to.name.clone())
+                    Some(to.name_str().to_string())
                 } else {
                     None
                 }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -588,10 +588,13 @@ fn test_anonymous_id_different_regions_produce_different_identifiers() {
     compute_anonymous_identifiers(&mut resources_west, &providers_west).unwrap();
 
     // Both should have identifiers assigned
-    assert!(!resources_east[0].id.name.is_empty());
-    assert!(!resources_west[0].id.name.is_empty());
+    assert!(!resources_east[0].id.name_str().is_empty());
+    assert!(!resources_west[0].id.name_str().is_empty());
     // They must be different because providers have different regions
-    assert_ne!(resources_east[0].id.name, resources_west[0].id.name);
+    assert_ne!(
+        resources_east[0].id.name_str(),
+        resources_west[0].id.name_str()
+    );
 }
 
 #[test]
@@ -637,9 +640,9 @@ fn test_anonymous_id_different_create_only_same_region_no_collision() {
     let mut resources = vec![r1, r2];
     compute_anonymous_identifiers(&mut resources, &providers).unwrap();
 
-    assert!(!resources[0].id.name.is_empty());
-    assert!(!resources[1].id.name.is_empty());
-    assert_ne!(resources[0].id.name, resources[1].id.name);
+    assert!(!resources[0].id.name_str().is_empty());
+    assert!(!resources[1].id.name_str().is_empty());
+    assert_ne!(resources[0].id.name_str(), resources[1].id.name_str());
 }
 
 #[test]
@@ -656,7 +659,7 @@ fn test_anonymous_id_named_resources_are_skipped() {
     compute_anonymous_identifiers(&mut resources, &providers).unwrap();
 
     // Name should remain unchanged
-    assert_eq!(resources[0].id.name, "my_vpc");
+    assert_eq!(resources[0].id.name_str(), "my_vpc");
 }
 
 #[test]
@@ -837,7 +840,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // 3. compute_anonymous_identifiers
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name.clone();
+    let run1_name = resources_run1[0].id.name_str().to_string();
     assert!(
         !run1_name.is_empty(),
         "Anonymous identifier should be assigned"
@@ -877,7 +880,7 @@ fn test_plan_verify_idempotency_anonymous_resource_with_prefix() {
 
     // 3. compute_anonymous_identifiers - should produce SAME identifier
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name.clone();
+    let run2_name = resources_run2[0].id.name_str().to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -937,7 +940,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resources_run1 = vec![resource_run1];
     resolve_names(&mut resources_run1).unwrap();
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name.clone();
+    let run1_name = resources_run1[0].id.name_str().to_string();
 
     // Simulate state after apply
     let run1_role_name = match resources_run1[0].get_attr("role_name") {
@@ -991,7 +994,7 @@ fn test_plan_verify_idempotency_iam_role_with_prefix_and_path() {
     let mut resources_run2 = vec![resource_run2];
     resolve_names(&mut resources_run2).unwrap();
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name.clone();
+    let run2_name = resources_run2[0].id.name_str().to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -1051,7 +1054,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
     let mut resources_run1 = vec![resource_run1];
     compute_anonymous_identifiers(&mut resources_run1, &providers).unwrap();
-    let run1_name = resources_run1[0].id.name.clone();
+    let run1_name = resources_run1[0].id.name_str().to_string();
 
     // Simulate state after apply
     let applied_state = State::existing(resources_run1[0].id.clone(), HashMap::new())
@@ -1099,7 +1102,7 @@ fn test_plan_verify_idempotency_anonymous_flow_log_with_resource_refs() {
 
     let mut resources_run2 = vec![resource_run2];
     compute_anonymous_identifiers(&mut resources_run2, &providers).unwrap();
-    let run2_name = resources_run2[0].id.name.clone();
+    let run2_name = resources_run2[0].id.name_str().to_string();
 
     assert_eq!(
         run1_name, run2_name,
@@ -1274,7 +1277,7 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     match &delete_effects[0] {
         Effect::Delete { id, identifier, .. } => {
-            assert_eq!(id.name, "removed-bucket");
+            assert_eq!(id.name_str(), "removed-bucket");
             assert_eq!(identifier, "removed-bucket");
         }
         _ => unreachable!(),

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -834,7 +834,7 @@ pub async fn create_plan_from_parsed_with_upstream(
                     .iter()
                     .filter_map(|r| {
                         let rs =
-                            sf.find_resource(&r.id.provider, &r.id.resource_type, &r.id.name)?;
+                            sf.find_resource(&r.id.provider, &r.id.resource_type, r.id.name_str())?;
                         if rs.dependency_bindings.is_empty() {
                             None
                         } else {
@@ -1109,7 +1109,7 @@ pub fn materialize_moved_states(
     for block in state_blocks {
         if let StateBlock::Moved { from, to } = block {
             let old_in_state = state_file.as_ref().is_some_and(|sf| {
-                sf.find_resource(&from.provider, &from.resource_type, &from.name)
+                sf.find_resource(&from.provider, &from.resource_type, from.name_str())
                     .is_some()
             });
             if old_in_state {
@@ -1184,7 +1184,7 @@ pub fn add_state_block_effects(
                     sf.find_resource(
                         &effective_to.provider,
                         &effective_to.resource_type,
-                        &effective_to.name,
+                        effective_to.name_str(),
                     )
                     .is_some()
                 });
@@ -1199,7 +1199,7 @@ pub fn add_state_block_effects(
             StateBlock::Removed { from } => {
                 // Skip if resource is not in state
                 let in_state = state_file.as_ref().is_some_and(|sf| {
-                    sf.find_resource(&from.provider, &from.resource_type, &from.name)
+                    sf.find_resource(&from.provider, &from.resource_type, from.name_str())
                         .is_some()
                 });
                 if in_state {
@@ -1279,7 +1279,7 @@ fn resolve_import_target(
         }
         if let Some(attr) = name_attr
             && let Some(Value::String(s)) = resource.get_attr(attr)
-            && s == &to.name
+            && s == to.name_str()
         {
             fallback_id = Some(resource.id.clone());
         }
@@ -1294,7 +1294,7 @@ fn resolve_import_target(
     {
         for rs in sf.resources_by_type(&to.provider, &to.resource_type) {
             if let Some(serde_json::Value::String(s)) = rs.attributes.get(attr)
-                && s == &to.name
+                && s == to.name_str()
             {
                 return ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
             }
@@ -1830,7 +1830,8 @@ mod tests {
         match &effects[0] {
             Effect::Import { id, identifier } => {
                 assert_eq!(
-                    id.name, "s3_bucket_1d43a664",
+                    id.name_str(),
+                    "s3_bucket_1d43a664",
                     "Import should target the anonymous hash name"
                 );
                 assert_eq!(identifier, "carina-rs-state");

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -116,10 +116,9 @@ fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<R
 
         let mut depth_visiting: HashSet<String> = HashSet::new();
         for resource in resources {
-            let binding = resource
-                .binding
-                .clone()
-                .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            let binding = resource.binding.clone().unwrap_or_else(|| {
+                format!("{}:{}", resource.id.resource_type, resource.id.name_str())
+            });
             compute_depth(
                 &binding,
                 &binding_to_resource,
@@ -137,11 +136,11 @@ fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<R
             let a_binding = a
                 .binding
                 .clone()
-                .unwrap_or_else(|| format!("{}:{}", a.id.resource_type, a.id.name));
+                .unwrap_or_else(|| format!("{}:{}", a.id.resource_type, a.id.name_str()));
             let b_binding = b
                 .binding
                 .clone()
-                .unwrap_or_else(|| format!("{}:{}", b.id.resource_type, b.id.name));
+                .unwrap_or_else(|| format!("{}:{}", b.id.resource_type, b.id.name_str()));
             let a_depth = depth_cache.get(&a_binding).copied().unwrap_or(0);
             let b_depth = depth_cache.get(&b_binding).copied().unwrap_or(0);
             a_depth.cmp(&b_depth) // Ascending: shallower first
@@ -163,7 +162,7 @@ fn topological_sort(resources: &[Resource], depth_presort: bool) -> Result<Vec<R
         let binding_name = resource
             .binding
             .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
 
         if visited.contains(&binding_name) {
             return Ok(());
@@ -217,7 +216,7 @@ pub fn build_dependents_map(resources: &[&Resource]) -> HashMap<String, HashSet<
         let binding = resource
             .binding
             .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
 
         let deps = get_resource_dependencies(resource);
         for dep in deps {
@@ -698,7 +697,7 @@ mod tests {
             .map(|r| {
                 r.binding
                     .clone()
-                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name))
+                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name_str()))
             })
             .collect();
 
@@ -782,7 +781,7 @@ mod tests {
             .map(|r| {
                 r.binding
                     .clone()
-                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name))
+                    .unwrap_or_else(|| format!("{}:{}", r.id.resource_type, r.id.name_str()))
             })
             .collect();
 

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -618,7 +618,7 @@ fn build_replace_rows(
 
             updates.push(CascadingUpdateIR {
                 display_type: cascade.id.display_type(),
-                name: cascade.id.name.clone(),
+                name: cascade.id.name_str().to_string(),
                 changed_attrs,
             });
         }

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -329,7 +329,7 @@ pub(super) fn find_changed_attributes(
 
         // Build secret hash context from resource ID and attribute key
         let secret_ctx =
-            resource_id.map(|id| SecretHashContext::new(id.display_type(), &id.name, key));
+            resource_id.map(|id| SecretHashContext::new(id.display_type(), id.name_str(), key));
 
         let is_equal = match saved.and_then(|s| s.get(key)) {
             Some(saved_value) => {

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -672,7 +672,7 @@ fn secret_with_context_no_change_when_hash_matches() {
     let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db");
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
-        &resource_id.name,
+        resource_id.name_str(),
         "master_password",
     );
 
@@ -701,7 +701,7 @@ fn secret_with_context_detects_change() {
     let resource_id = ResourceId::with_provider("awscc", "rds.db_instance", "my-db");
     let ctx = SecretHashContext::new(
         resource_id.display_type(),
-        &resource_id.name,
+        resource_id.name_str(),
         "master_password",
     );
 

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -385,7 +385,7 @@ pub fn cascade_dependent_updates(
         let key = resource
             .binding
             .clone()
-            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name));
+            .unwrap_or_else(|| format!("{}:{}", resource.id.resource_type, resource.id.name_str()));
         binding_to_unresolved.insert(key, resource);
     }
 
@@ -461,7 +461,7 @@ pub fn cascade_dependent_updates(
         for dep in &deps {
             if replaced_bindings.contains(dep) {
                 let binding = resource.binding.clone().unwrap_or_else(|| {
-                    format!("{}:{}", resource.id.resource_type, resource.id.name)
+                    format!("{}:{}", resource.id.resource_type, resource.id.name_str())
                 });
                 dependents_of_replaced
                     .entry(dep.clone())

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -1013,7 +1013,7 @@ mod tests {
 
             fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
                 let id = resource.id.clone();
-                let name = resource.id.name.clone();
+                let name = resource.id.name_str().to_string();
                 let delay = self.delays.get(&name).copied().unwrap_or(Duration::ZERO);
                 let log = self.call_log.clone();
                 Box::pin(async move {

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -38,7 +38,7 @@ pub(super) fn build_dependency_map(
         if let Effect::Delete { id, binding, .. } = effect
             && binding.is_none()
         {
-            name_to_delete_idx.insert(id.name.clone(), idx);
+            name_to_delete_idx.insert(id.name_str().to_string(), idx);
         }
     }
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -122,7 +122,7 @@ pub fn reconcile_prefixed_names(
         let state_info = find_state(
             &resource.id.provider,
             &resource.id.resource_type,
-            &resource.id.name,
+            resource.id.name_str(),
         );
         let state_info = match state_info {
             Some(si) => si,
@@ -391,7 +391,7 @@ pub fn compute_anonymous_identifiers(
     let mut computed: Vec<(usize, String)> = Vec::new();
 
     for (idx, resource) in resources.iter().enumerate() {
-        if !resource.id.name.is_empty() {
+        if !resource.id.name.is_pending() {
             continue;
         }
 
@@ -535,7 +535,7 @@ pub fn reconcile_anonymous_identifiers(
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
 ) {
     for resource in resources.iter_mut() {
-        if resource.id.name.is_empty() {
+        if resource.id.name.is_pending() {
             continue;
         }
 
@@ -555,7 +555,10 @@ pub fn reconcile_anonymous_identifiers(
         let state_entries = find_state_by_type(&resource.id.provider, &resource.id.resource_type);
 
         // If the resource's name already exists in state, no reconciliation is needed.
-        if state_entries.iter().any(|e| e.name == resource.id.name) {
+        if state_entries
+            .iter()
+            .any(|e| e.name == resource.id.name_str())
+        {
             continue;
         }
 
@@ -570,13 +573,13 @@ pub fn reconcile_anonymous_identifiers(
         if create_only_attrs.is_empty() || resource_co_values.is_empty() {
             // No create-only properties or none set: use SimHash-based Hamming distance
             // matching to find the closest state entry.
-            let Some(resource_hash) = extract_hash_from_identifier(&resource.id.name) else {
+            let Some(resource_hash) = extract_hash_from_identifier(resource.id.name_str()) else {
                 continue;
             };
 
             let mut best_match: Option<(&str, u32)> = None;
             for entry in &state_entries {
-                if entry.name == resource.id.name {
+                if entry.name == resource.id.name_str() {
                     continue;
                 }
                 let Some(state_hash) = extract_hash_from_identifier(&entry.name) else {
@@ -605,7 +608,7 @@ pub fn reconcile_anonymous_identifiers(
         // reconciliation to avoid rebinding to the wrong state entry.
         let mut partial_matches: Vec<&str> = Vec::new();
         for entry in &state_entries {
-            if entry.name == resource.id.name {
+            if entry.name == resource.id.name_str() {
                 // Same identifier, no reconciliation needed
                 continue;
             }
@@ -686,7 +689,7 @@ pub fn detect_anonymous_to_named_renames(
         used_names
             .entry(key)
             .or_default()
-            .insert(resource.id.name.clone());
+            .insert(resource.id.name_str().to_string());
     }
 
     let mut renames: Vec<(ResourceId, ResourceId)> = Vec::new();
@@ -705,7 +708,10 @@ pub fn detect_anonymous_to_named_renames(
         let state_entries = find_state_by_type(&resource.id.provider, &resource.id.resource_type);
 
         // Skip if the binding name already exists in state — nothing to rename.
-        if state_entries.iter().any(|e| e.name == resource.id.name) {
+        if state_entries
+            .iter()
+            .any(|e| e.name == resource.id.name_str())
+        {
             continue;
         }
 

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -232,7 +232,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         &identity_fn,
     )
     .unwrap();
-    let step1_id = resources1[0].id.name.clone();
+    let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
     let mut r2 = Resource::with_provider("awscc", "iam.role", "");
@@ -250,7 +250,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         &identity_fn,
     )
     .unwrap();
-    let step2_id = resources2[0].id.name.clone();
+    let step2_id = resources2[0].id.name_str().to_string();
 
     // Hash includes path, so identifiers differ
     assert_ne!(step1_id, step2_id);
@@ -273,7 +273,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     );
 
     // After reconciliation, step2 resource should have step1's identifier
-    assert_eq!(resources2[0].id.name, step1_id);
+    assert_eq!(resources2[0].id.name_str(), step1_id);
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     );
     resource.set_attr("path".to_string(), Value::String("/new/".to_string()));
 
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     // State has completely different values
@@ -314,7 +314,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     );
 
     // Identifier should remain unchanged
-    assert_eq!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
     );
     resource.set_attr("path".to_string(), Value::String("/".to_string()));
 
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     // State has same values but different ID (shouldn't happen in practice,
@@ -357,7 +357,7 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
     );
 
     // Identifier should remain unchanged (all values match = no partial match)
-    assert_eq!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -376,7 +376,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
         Value::String("10.1.0.0/16".to_string()),
     );
 
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     let state_entries = vec![AnonymousIdStateInfo {
@@ -393,7 +393,7 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     );
 
     // No reconciliation: only one create-only prop and it changed
-    assert_eq!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -437,8 +437,8 @@ fn test_anonymous_resource_no_create_only_properties() {
     .unwrap();
 
     // Should have computed an identifier
-    assert!(!resources[0].id.name.is_empty());
-    assert!(resources[0].id.name.starts_with("ec2_eip_"));
+    assert!(!resources[0].id.name_str().is_empty());
+    assert!(resources[0].id.name_str().starts_with("ec2_eip_"));
 }
 
 #[test]
@@ -489,7 +489,7 @@ fn test_anonymous_resource_no_create_only_deterministic() {
     )
     .unwrap();
 
-    assert_eq!(resources1[0].id.name, resources2[0].id.name);
+    assert_eq!(resources1[0].id.name_str(), resources2[0].id.name_str());
 }
 
 #[test]
@@ -591,11 +591,12 @@ fn test_identity_attribute_prevents_collision() {
     .expect("should not collide when identity attrs differ");
 
     // Both should have identifiers assigned
-    assert!(!resources[0].id.name.is_empty());
-    assert!(!resources[1].id.name.is_empty());
+    assert!(!resources[0].id.name_str().is_empty());
+    assert!(!resources[1].id.name_str().is_empty());
     // Identifiers should be different
     assert_ne!(
-        resources[0].id.name, resources[1].id.name,
+        resources[0].id.name_str(),
+        resources[1].id.name_str(),
         "different identity attr values should produce different identifiers"
     );
 }
@@ -703,7 +704,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         &identity_fn,
     )
     .unwrap();
-    let old_id = resources1[0].id.name.clone();
+    let old_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
@@ -719,7 +720,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         &identity_fn,
     )
     .unwrap();
-    let new_id = resources2[0].id.name.clone();
+    let new_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different attributes)
     assert_ne!(old_id, new_id);
@@ -737,7 +738,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     );
 
     // After reconciliation, should have the old identifier (Hamming distance match)
-    assert_eq!(resources2[0].id.name, old_id);
+    assert_eq!(resources2[0].id.name_str(), old_id);
 }
 
 #[test]
@@ -753,7 +754,7 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
     resource.set_attr("domain".to_string(), Value::String("vpc".to_string()));
 
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     // State has a very different hash (flipped many bits)
@@ -769,7 +770,7 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     );
 
     // Identifier should remain unchanged (too distant)
-    assert_eq!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -806,11 +807,11 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     .unwrap();
 
     // Should have computed an identifier (not errored)
-    assert!(!resources[0].id.name.is_empty());
-    assert!(resources[0].id.name.starts_with("ec2_eip_"));
+    assert!(!resources[0].id.name_str().is_empty());
+    assert!(resources[0].id.name_str().starts_with("ec2_eip_"));
 
     // Reconciliation should use Hamming distance (create-only values empty)
-    let current_id = resources[0].id.name.clone();
+    let current_id = resources[0].id.name_str().to_string();
     let state_id = current_id.clone(); // Same id in state = no reconciliation needed
     let state_entries = vec![AnonymousIdStateInfo {
         name: state_id,
@@ -824,7 +825,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     );
 
     // Same identifier in state, no change needed
-    assert_eq!(resources[0].id.name, current_id);
+    assert_eq!(resources[0].id.name_str(), current_id);
 }
 
 // ==================== SimHash acceptance tests ====================
@@ -1004,7 +1005,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         &identity_fn,
     )
     .unwrap();
-    let orig_id = resources_orig[0].id.name.clone();
+    let orig_id = resources_orig[0].id.name_str().to_string();
 
     // Distant: env=dev, team=frontend (2 attrs changed)
     let mut resources_distant = vec![make_resource("development", "frontend")];
@@ -1016,7 +1017,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         &identity_fn,
     )
     .unwrap();
-    let distant_id = resources_distant[0].id.name.clone();
+    let distant_id = resources_distant[0].id.name_str().to_string();
 
     // Current: env=staging, team=infra (1 attr changed from orig)
     let mut resources_current = vec![make_resource("staging", "infra")];
@@ -1051,7 +1052,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     // Should match orig (closer: 1 attr changed) rather than distant (2 attrs changed)
     // Note: This depends on SimHash producing closer hashes for more similar inputs.
     // If the Hamming distance for both is below the threshold, the closest is picked.
-    let current_hash = extract_hash_from_identifier(&resources_current[0].id.name).unwrap();
+    let current_hash = extract_hash_from_identifier(resources_current[0].id.name_str()).unwrap();
     let orig_hash = extract_hash_from_identifier(&orig_id).unwrap();
     let distant_hash = extract_hash_from_identifier(&distant_id).unwrap();
     let dist_to_orig = (current_hash ^ orig_hash).count_ones();
@@ -1059,7 +1060,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 
     if dist_to_orig < SIMHASH_HAMMING_THRESHOLD {
         // If orig is within threshold, it should have been picked (as closest)
-        assert_eq!(resources_current[0].id.name, orig_id);
+        assert_eq!(resources_current[0].id.name_str(), orig_id);
     }
     if dist_to_orig < dist_to_distant {
         // Orig should be closer than distant
@@ -1101,7 +1102,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         &identity_fn,
     )
     .unwrap();
-    let id = resources[0].id.name.clone();
+    let id = resources[0].id.name_str().to_string();
 
     // State has the exact same identifier
     let state_entries = vec![AnonymousIdStateInfo {
@@ -1116,7 +1117,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     );
 
     // Should remain unchanged
-    assert_eq!(resources[0].id.name, id);
+    assert_eq!(resources[0].id.name_str(), id);
 }
 
 #[test]
@@ -1130,7 +1131,7 @@ fn test_reconcile_no_create_only_empty_state() {
 
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
     resource.set_attr("domain".to_string(), Value::String("vpc".to_string()));
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     reconcile_anonymous_identifiers(
@@ -1140,7 +1141,7 @@ fn test_reconcile_no_create_only_empty_state() {
         &|_provider, _rt| vec![],
     );
 
-    assert_eq!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -1183,11 +1184,11 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
         .unwrap();
 
     // Different identifiers
-    assert_ne!(r1[0].id.name, r2[0].id.name);
+    assert_ne!(r1[0].id.name_str(), r2[0].id.name_str());
 
     // But nearby (SimHash locality-sensitive property)
-    let hash1 = extract_hash_from_identifier(&r1[0].id.name).unwrap();
-    let hash2 = extract_hash_from_identifier(&r2[0].id.name).unwrap();
+    let hash1 = extract_hash_from_identifier(r1[0].id.name_str()).unwrap();
+    let hash2 = extract_hash_from_identifier(r2[0].id.name_str()).unwrap();
     let distance = (hash1 ^ hash2).count_ones();
     assert!(
         distance < SIMHASH_HAMMING_THRESHOLD,
@@ -1245,12 +1246,12 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     .unwrap();
 
     // Both should have identifiers computed
-    assert!(resources[0].id.name.starts_with("ec2_vpc_"));
-    assert!(resources[1].id.name.starts_with("ec2_eip_"));
+    assert!(resources[0].id.name_str().starts_with("ec2_vpc_"));
+    assert!(resources[1].id.name_str().starts_with("ec2_eip_"));
 
     // VPC uses standard hash (8 hex chars), EIP uses SimHash (16 hex chars)
-    let vpc_hash_part = resources[0].id.name.rsplit('_').next().unwrap();
-    let eip_hash_part = resources[1].id.name.rsplit('_').next().unwrap();
+    let vpc_hash_part = resources[0].id.name_str().rsplit('_').next().unwrap();
+    let eip_hash_part = resources[1].id.name_str().rsplit('_').next().unwrap();
     assert_eq!(vpc_hash_part.len(), 8);
     assert_eq!(eip_hash_part.len(), 16);
 }
@@ -1274,7 +1275,7 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     );
     resource.set_attr("path".to_string(), Value::String("/new/".to_string()));
 
-    let original_id = resource.id.name.clone();
+    let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
     // State with partial match (role_name matches, path differs)
@@ -1296,8 +1297,8 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     );
 
     // Should reconcile via partial create-only match (not Hamming distance)
-    assert_eq!(resources[0].id.name, "iam_role_11223344");
-    assert_ne!(resources[0].id.name, original_id);
+    assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
+    assert_ne!(resources[0].id.name_str(), original_id);
 }
 
 #[test]
@@ -1341,7 +1342,8 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     // Same prefix should produce the same anonymous identifier
     assert_eq!(
-        r1[0].id.name, r2[0].id.name,
+        r1[0].id.name_str(),
+        r2[0].id.name_str(),
         "Prefixed create-only attributes should produce stable identifiers"
     );
 }
@@ -1384,7 +1386,8 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
 
     // Different prefixes should produce different identifiers
     assert_ne!(
-        r1[0].id.name, r2[0].id.name,
+        r1[0].id.name_str(),
+        r2[0].id.name_str(),
         "Different prefixes should produce different identifiers"
     );
 }
@@ -1440,7 +1443,8 @@ fn test_reconcile_skips_let_bound_resources() {
 
     // Named resource must keep its original name
     assert_eq!(
-        resources[0].id.name, "ingress_new",
+        resources[0].id.name_str(),
+        "ingress_new",
         "let-bound resource should not be reconciled"
     );
 }
@@ -1475,7 +1479,7 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
         Value::String("Allow gRPC".to_string()),
     );
 
-    let original_id = new_rule.id.name.clone();
+    let original_id = new_rule.id.name_str().to_string();
     let mut resources = vec![new_rule];
 
     // State has TWO entries that partially match (same cidr_ip + ip_protocol,
@@ -1512,7 +1516,8 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
 
     // With multiple partial matches, reconciliation should be skipped
     assert_eq!(
-        resources[0].id.name, original_id,
+        resources[0].id.name_str(),
+        original_id,
         "ambiguous partial matches should not reconcile"
     );
 }
@@ -1576,7 +1581,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         &identity_fn,
     )
     .unwrap();
-    let step1_id = resources1[0].id.name.clone();
+    let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
     let mut r2 = Resource::with_provider("awscc", "ec2.eip", "");
@@ -1601,7 +1606,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         &identity_fn,
     )
     .unwrap();
-    let step2_id = resources2[0].id.name.clone();
+    let step2_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different tag values)
     assert_ne!(step1_id, step2_id);
@@ -1620,7 +1625,8 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
 
     // After reconciliation, step2 should have step1's identifier (in-place update)
     assert_eq!(
-        resources2[0].id.name, step1_id,
+        resources2[0].id.name_str(),
+        step1_id,
         "Tag-only change on EIP with unset create-only props should reconcile to same identifier"
     );
 }
@@ -1702,11 +1708,13 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
 
     // Names must remain unchanged - no swapping
     assert_eq!(
-        resources[0].id.name, "ingress_http",
+        resources[0].id.name_str(),
+        "ingress_http",
         "ingress_http should not be renamed to ingress_https"
     );
     assert_eq!(
-        resources[1].id.name, "ingress_https",
+        resources[1].id.name_str(),
+        "ingress_https",
         "ingress_https should not be renamed to ingress_http"
     );
 }
@@ -1748,8 +1756,8 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     );
 
     assert_eq!(renames.len(), 1);
-    assert_eq!(renames[0].0.name, "sso_instance_0ac0620303071530");
-    assert_eq!(renames[0].1.name, "sso");
+    assert_eq!(renames[0].0.name_str(), "sso_instance_0ac0620303071530");
+    assert_eq!(renames[0].1.name_str(), "sso");
 }
 
 #[test]
@@ -1909,7 +1917,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
         &identity_fn,
     )
     .unwrap();
-    let anonymous_name = anon_vec[0].id.name.clone();
+    let anonymous_name = anon_vec[0].id.name_str().to_string();
     assert!(
         anonymous_name.starts_with("sso_instance_"),
         "expected hash-derived name, got {anonymous_name}"
@@ -1938,8 +1946,8 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     );
 
     assert_eq!(renames.len(), 1, "expected one rename, got {:?}", renames);
-    assert_eq!(renames[0].0.name, anonymous_name);
-    assert_eq!(renames[0].1.name, "sso");
+    assert_eq!(renames[0].0.name_str(), anonymous_name);
+    assert_eq!(renames[0].1.name_str(), "sso");
 }
 
 #[test]
@@ -1969,7 +1977,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
         &identity_fn,
     )
     .unwrap();
-    let anonymous_name = anon_vec[0].id.name.clone();
+    let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Let-bound resource with wildly different attributes.
     let mut let_bound = Resource::with_provider("awscc", "sso.Instance", "sso");
@@ -2027,7 +2035,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
         &identity_fn,
     )
     .unwrap();
-    let exact_name = anon_vec[0].id.name.clone();
+    let exact_name = anon_vec[0].id.name_str().to_string();
 
     // Construct a "close but not equal" orphan by flipping the last hex
     // char of the SimHash — guarantees a small nonzero Hamming distance
@@ -2067,7 +2075,8 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
 
     assert_eq!(renames.len(), 1);
     assert_eq!(
-        renames[0].0.name, exact_name,
+        renames[0].0.name_str(),
+        exact_name,
         "should prefer the exact SimHash match over the nearby one"
     );
 }
@@ -2129,7 +2138,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
         &identity_fn,
     )
     .unwrap();
-    let anonymous_name = anon_vec[0].id.name.clone();
+    let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Two state entries with the exact same name hash → same distance (0).
     let state_entries = vec![

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -366,7 +366,7 @@ impl RootConfigSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name.clone());
+                .unwrap_or_else(|| resource.id.name_str().to_string());
 
             let resource_type_str = resource
                 .attributes
@@ -410,7 +410,7 @@ impl RootConfigSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name.clone());
+                .unwrap_or_else(|| resource.id.name_str().to_string());
 
             for (attr_key, value) in &resource.attributes {
                 if attr_key.starts_with('_') {
@@ -761,7 +761,7 @@ impl ModuleSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name.clone());
+                .unwrap_or_else(|| resource.id.name_str().to_string());
 
             let resource_type_str = resource
                 .attributes
@@ -794,7 +794,7 @@ impl ModuleSignature {
             let binding_name = resource
                 .binding
                 .clone()
-                .unwrap_or_else(|| resource.id.name.clone());
+                .unwrap_or_else(|| resource.id.name_str().to_string());
 
             for (attr_key, value) in &resource.attributes {
                 if attr_key.starts_with('_') {

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -391,7 +391,7 @@ impl<'cfg> ModuleResolver<'cfg> {
             let mut new_resource = resource.clone();
 
             // Prefix the resource name with instance path (dot-separated)
-            let new_name = format!("{}.{}", instance_prefix, new_resource.id.name);
+            let new_name = format!("{}.{}", instance_prefix, new_resource.id.name_str());
             new_resource.id = ResourceId::with_provider(
                 &new_resource.id.provider,
                 &new_resource.id.resource_type,
@@ -661,7 +661,7 @@ pub fn reconcile_anonymous_module_instances(
     // expanded DSL — we'll query state for matching entries.
     let mut touched_types: HashSet<(String, String)> = HashSet::new();
     for r in resources.iter() {
-        if split_instance_prefix(&r.id.name).is_none() {
+        if split_instance_prefix(r.id.name_str()).is_none() {
             continue;
         }
         touched_types.insert((r.id.provider.clone(), r.id.resource_type.clone()));
@@ -676,7 +676,7 @@ pub fn reconcile_anonymous_module_instances(
     // across all of its resources).
     let mut current_synthetic_by_module: HashMap<String, HashSet<u64>> = HashMap::new();
     for r in resources.iter() {
-        let Some((prefix, _)) = split_instance_prefix(&r.id.name) else {
+        let Some((prefix, _)) = split_instance_prefix(r.id.name_str()) else {
             continue;
         };
         let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
@@ -750,7 +750,7 @@ pub fn reconcile_anonymous_module_instances(
     // Apply remaps: rewrite `id.name` and `binding` for every resource whose
     // instance prefix is in the remap table.
     for r in resources.iter_mut() {
-        let Some((prefix, rest)) = split_instance_prefix(&r.id.name) else {
+        let Some((prefix, rest)) = split_instance_prefix(r.id.name_str()) else {
             continue;
         };
         let Some((module, simhash)) = parse_synthetic_instance_prefix(prefix) else {
@@ -1221,7 +1221,7 @@ mod tests {
         assert_eq!(expanded.len(), 1);
 
         let sg = &expanded[0];
-        assert_eq!(sg.id.name, "my_instance.sg");
+        assert_eq!(sg.id.name_str(), "my_instance.sg");
         assert_eq!(
             sg.get_attr("vpc_id"),
             Some(&Value::String("vpc-456".to_string()))
@@ -1376,8 +1376,8 @@ mod tests {
         );
 
         // Resource names should also be distinct (dot notation)
-        assert_eq!(expanded_a[0].id.name, "prod.main_vpc");
-        assert_eq!(expanded_b[0].id.name, "staging.main_vpc");
+        assert_eq!(expanded_a[0].id.name_str(), "prod.main_vpc");
+        assert_eq!(expanded_b[0].id.name_str(), "staging.main_vpc");
     }
 
     /// Module with an attributes block that exposes a security_group binding.
@@ -1642,11 +1642,11 @@ thing { name = 'beta'  }
 "#,
         );
 
-        let role_addresses: HashSet<&String> = parsed
+        let role_addresses: HashSet<String> = parsed
             .resources
             .iter()
             .filter(|r| r.id.resource_type == "iam.Role")
-            .map(|r| &r.id.name)
+            .map(|r| r.id.name_str().to_string())
             .collect();
         assert_eq!(role_addresses.len(), 2, "got {:?}", role_addresses);
 
@@ -1702,7 +1702,7 @@ thing { name = 'after-edit' }
             .resources
             .iter()
             .filter(|r| r.id.resource_type == "iam.Role")
-            .map(|r| r.id.name.clone())
+            .map(|r| r.id.name_str().to_string())
             .collect();
         assert_eq!(before.len(), 1);
         let (new_prefix, _) = before[0].split_once('.').unwrap();
@@ -1721,7 +1721,7 @@ thing { name = 'after-edit' }
             .resources
             .iter()
             .filter(|r| r.id.resource_type == "iam.Role")
-            .map(|r| r.id.name.clone())
+            .map(|r| r.id.name_str().to_string())
             .collect();
         assert_eq!(
             after,
@@ -1758,8 +1758,8 @@ thing { name = 'a' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name
-            .clone();
+            .name_str()
+            .to_string();
 
         // State entry uses a different module name.
         let state_lookup = |_: &str, _: &str| vec!["other_0000000000000001.role".to_string()];
@@ -1771,8 +1771,8 @@ thing { name = 'a' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name
-            .clone();
+            .name_str()
+            .to_string();
         assert_eq!(before_name, after_name);
     }
 
@@ -1830,8 +1830,8 @@ thing { name = 'after-edit' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name
-            .clone();
+            .name_str()
+            .to_string();
         let (new_prefix, _) = role_name_before.split_once('.').unwrap();
         let (_, new_hash) = parse_synthetic_instance_prefix(new_prefix).unwrap();
 
@@ -1852,7 +1852,7 @@ thing { name = 'after-edit' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap();
         assert_eq!(
-            role_after.id.name,
+            role_after.id.name_str(),
             format!("thing_{:016x}.role", state_hash),
             "Role address must be remapped to the state prefix",
         );
@@ -1862,7 +1862,7 @@ thing { name = 'after-edit' }
             .find(|r| r.id.resource_type == "iam.OidcProvider")
             .unwrap();
         assert_eq!(
-            provider_after.id.name,
+            provider_after.id.name_str(),
             format!("thing_{:016x}.provider_res", state_hash),
             "OidcProvider address must be remapped to the state prefix",
         );
@@ -1887,8 +1887,8 @@ thing { name = 'a' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name
-            .clone();
+            .name_str()
+            .to_string();
         let (prefix, _) = before_name.split_once('.').unwrap();
         let (_, cur_hash) = parse_synthetic_instance_prefix(prefix).unwrap();
 
@@ -1907,8 +1907,8 @@ thing { name = 'a' }
             .find(|r| r.id.resource_type == "iam.Role")
             .unwrap()
             .id
-            .name
-            .clone();
+            .name_str()
+            .to_string();
         assert_eq!(before_name, after_name, "ambiguous match must not remap");
     }
 
@@ -1932,7 +1932,7 @@ thing { name = 'unchanged-but-different' }
             .resources
             .iter()
             .filter(|r| r.id.resource_type == "iam.Role")
-            .map(|r| r.id.name.split_once('.').unwrap().0.to_string())
+            .map(|r| r.id.name_str().split_once('.').unwrap().0.to_string())
             .collect();
         assert_eq!(prefixes_before.len(), 2);
         let mut iter = prefixes_before.iter();
@@ -1949,7 +1949,7 @@ thing { name = 'unchanged-but-different' }
             .resources
             .iter()
             .filter(|r| r.id.resource_type == "iam.Role")
-            .map(|r| r.id.name.split_once('.').unwrap().0.to_string())
+            .map(|r| r.id.name_str().split_once('.').unwrap().0.to_string())
             .collect();
         assert_eq!(
             prefixes_after, prefixes_before,
@@ -2000,7 +2000,7 @@ thing { name = 'unchanged-but-different' }
 
         let sg = &expanded[0];
         // Resource name should use dot notation, not underscore
-        assert_eq!(sg.id.name, "my_instance.sg");
+        assert_eq!(sg.id.name_str(), "my_instance.sg");
     }
 
     #[test]
@@ -2025,8 +2025,8 @@ thing { name = 'unchanged-but-different' }
         let expanded = resolver.expand_module_call(&call, "prod").unwrap();
 
         // Resource names should use dot notation
-        assert_eq!(expanded[0].id.name, "prod.main_vpc");
-        assert_eq!(expanded[1].id.name, "prod.sub");
+        assert_eq!(expanded[0].id.name_str(), "prod.main_vpc");
+        assert_eq!(expanded[1].id.name_str(), "prod.sub");
 
         // binding should use dot notation
         assert_eq!(expanded[0].binding, Some("prod.vpc".to_string()));

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -616,7 +616,7 @@ impl ParsedFile {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
-                        resource.id.name = address.clone();
+                        resource.id.set_name(address.clone());
                         resource.binding = Some(address);
                         for (_k, expr) in resource.attributes.iter_mut() {
                             substitute_placeholder(&mut expr.0, None, None, item);
@@ -630,7 +630,7 @@ impl ParsedFile {
                     for (i, item) in items.iter().enumerate() {
                         let address = format!("{}[{}]", deferred.binding_name, i);
                         let mut resource = deferred.template_resource.clone();
-                        resource.id.name = address.clone();
+                        resource.id.set_name(address.clone());
                         resource.binding = Some(address);
                         for (_k, expr) in resource.attributes.iter_mut() {
                             substitute_placeholder(&mut expr.0, Some(i as i64), None, item);
@@ -647,7 +647,7 @@ impl ParsedFile {
                         let val = &map[key];
                         let address = format!("{}[\"{}\"]", deferred.binding_name, key);
                         let mut resource = deferred.template_resource.clone();
-                        resource.id.name = address.clone();
+                        resource.id.set_name(address.clone());
                         resource.binding = Some(address);
                         for (_k, expr) in resource.attributes.iter_mut() {
                             substitute_placeholder(&mut expr.0, None, Some(key), val);
@@ -5230,7 +5230,7 @@ mod tests {
 
         let resource = &result.resources[0];
         assert_eq!(resource.id.resource_type, "s3_bucket");
-        assert_eq!(resource.id.name, "my_bucket"); // binding name becomes the resource ID
+        assert_eq!(resource.id.name_str(), "my_bucket"); // binding name becomes the resource ID
         assert_eq!(
             resource.get_attr("name"),
             Some(&Value::String("my-bucket".to_string()))
@@ -5255,8 +5255,8 @@ mod tests {
 
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.resources.len(), 2);
-        assert_eq!(result.resources[0].id.name, "logs"); // binding name becomes the resource ID
-        assert_eq!(result.resources[1].id.name, "data");
+        assert_eq!(result.resources[0].id.name_str(), "logs"); // binding name becomes the resource ID
+        assert_eq!(result.resources[1].id.name_str(), "data");
     }
 
     #[test]
@@ -5366,7 +5366,7 @@ mod tests {
 
         let resource = &result.resources[0];
         assert_eq!(resource.id.resource_type, "s3_bucket");
-        assert_eq!(resource.id.name, ""); // anonymous resources get empty name (computed later)
+        assert_eq!(resource.id.name_str(), ""); // anonymous resources get empty name (computed later)
     }
 
     #[test]
@@ -5385,8 +5385,8 @@ mod tests {
 
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.resources.len(), 2);
-        assert_eq!(result.resources[0].id.name, ""); // anonymous gets empty name
-        assert_eq!(result.resources[1].id.name, "named"); // binding name becomes the resource ID
+        assert_eq!(result.resources[0].id.name_str(), ""); // anonymous gets empty name
+        assert_eq!(result.resources[1].id.name_str(), "named"); // binding name becomes the resource ID
     }
 
     #[test]
@@ -5400,7 +5400,7 @@ mod tests {
         let result = parse(input, &ProviderContext::default());
         assert!(result.is_ok());
         let parsed = result.unwrap();
-        assert_eq!(parsed.resources[0].id.name, ""); // empty name, computed later
+        assert_eq!(parsed.resources[0].id.name_str(), ""); // empty name, computed later
     }
 
     #[test]
@@ -6258,7 +6258,7 @@ mod tests {
 
         let resource = &result.resources[0];
         assert_eq!(resource.id.resource_type, "s3_bucket");
-        assert_eq!(resource.id.name, "existing"); // binding name becomes the resource ID
+        assert_eq!(resource.id.name_str(), "existing"); // binding name becomes the resource ID
         assert!(resource.is_data_source());
         assert_eq!(resource.get_attr("_data_source"), Some(&Value::Bool(true)));
     }
@@ -6274,7 +6274,7 @@ mod tests {
         let result = parse(input, &ProviderContext::default());
         assert!(result.is_ok());
         let parsed = result.unwrap();
-        assert_eq!(parsed.resources[0].id.name, "existing"); // binding name
+        assert_eq!(parsed.resources[0].id.name_str(), "existing"); // binding name
     }
 
     #[test]
@@ -6296,11 +6296,11 @@ mod tests {
 
         // First resource is read-only (data source)
         assert!(result.resources[0].is_data_source());
-        assert_eq!(result.resources[0].id.name, "existing_bucket"); // binding name
+        assert_eq!(result.resources[0].id.name_str(), "existing_bucket"); // binding name
 
         // Second resource is a regular resource
         assert!(!result.resources[1].is_data_source());
-        assert_eq!(result.resources[1].id.name, "new_bucket"); // binding name
+        assert_eq!(result.resources[1].id.name_str(), "new_bucket"); // binding name
     }
 
     #[test]
@@ -6369,7 +6369,7 @@ mod tests {
         assert_eq!(result.resources.len(), 1);
 
         let resource = &result.resources[0];
-        assert_eq!(resource.id.name, ""); // anonymous → empty name
+        assert_eq!(resource.id.name_str(), ""); // anonymous → empty name
         // "name" must NOT appear in attributes unless the user explicitly wrote it
         assert!(
             !resource.attributes.contains_key("name"),
@@ -6392,7 +6392,7 @@ mod tests {
         assert_eq!(result.resources.len(), 1);
 
         let resource = &result.resources[0];
-        assert_eq!(resource.id.name, "vpc"); // binding name → resource name
+        assert_eq!(resource.id.name_str(), "vpc"); // binding name → resource name
         // "name" must NOT appear in attributes (it's only the id.name, not an attribute)
         assert!(
             !resource.attributes.contains_key("name"),
@@ -8002,8 +8002,8 @@ aws.s3.Bucket {
         assert_eq!(result.resources.len(), 2);
 
         // Resources should be addressed as subnets[0] and subnets[1]
-        assert_eq!(result.resources[0].id.name, "subnets[0]");
-        assert_eq!(result.resources[1].id.name, "subnets[1]");
+        assert_eq!(result.resources[0].id.name_str(), "subnets[0]");
+        assert_eq!(result.resources[1].id.name_str(), "subnets[1]");
 
         // Each resource should have the loop variable substituted
         assert_eq!(
@@ -8030,8 +8030,8 @@ aws.s3.Bucket {
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.resources.len(), 2);
 
-        assert_eq!(result.resources[0].id.name, "subnets[0]");
-        assert_eq!(result.resources[1].id.name, "subnets[1]");
+        assert_eq!(result.resources[0].id.name_str(), "subnets[0]");
+        assert_eq!(result.resources[1].id.name_str(), "subnets[1]");
 
         // Check index variable is substituted
         if let Some(Value::FunctionCall { args, .. }) = result.resources[0].get_attr("cidr_block") {
@@ -8373,7 +8373,7 @@ aws.s3.Bucket {
             StateBlock::Import { to, id } => {
                 assert_eq!(to.provider, "awscc");
                 assert_eq!(to.resource_type, "ec2.Vpc");
-                assert_eq!(to.name, "main-vpc");
+                assert_eq!(to.name_str(), "main-vpc");
                 assert_eq!(id, "vpc-0abc123def456");
             }
             other => panic!("Expected Import, got {:?}", other),
@@ -8394,7 +8394,7 @@ aws.s3.Bucket {
             StateBlock::Removed { from } => {
                 assert_eq!(from.provider, "awscc");
                 assert_eq!(from.resource_type, "ec2.Vpc");
-                assert_eq!(from.name, "legacy-vpc");
+                assert_eq!(from.name_str(), "legacy-vpc");
             }
             other => panic!("Expected Removed, got {:?}", other),
         }
@@ -8415,10 +8415,10 @@ aws.s3.Bucket {
             StateBlock::Moved { from, to } => {
                 assert_eq!(from.provider, "awscc");
                 assert_eq!(from.resource_type, "ec2.Subnet");
-                assert_eq!(from.name, "old-name");
+                assert_eq!(from.name_str(), "old-name");
                 assert_eq!(to.provider, "awscc");
                 assert_eq!(to.resource_type, "ec2.Subnet");
-                assert_eq!(to.name, "new-name");
+                assert_eq!(to.name_str(), "new-name");
             }
             other => panic!("Expected Moved, got {:?}", other),
         }
@@ -8442,8 +8442,8 @@ aws.s3.Bucket {
         let result = parse(input, &ProviderContext::default()).unwrap();
         // keys({Name = "web", Env = "prod"}) should evaluate to ["Env", "Name"] (sorted)
         assert_eq!(result.resources.len(), 2);
-        assert_eq!(result.resources[0].id.name, "resources[0]");
-        assert_eq!(result.resources[1].id.name, "resources[1]");
+        assert_eq!(result.resources[0].id.name_str(), "resources[0]");
+        assert_eq!(result.resources[1].id.name_str(), "resources[1]");
         assert_eq!(
             result.resources[0].get_attr("name"),
             Some(&Value::String("Env".to_string()))
@@ -8545,7 +8545,7 @@ aws.s3.Bucket {
 
         let result = parse(input, &ProviderContext::default()).unwrap();
         assert_eq!(result.resources.len(), 1);
-        assert_eq!(result.resources[0].id.name, "alarm");
+        assert_eq!(result.resources[0].id.name_str(), "alarm");
         assert_eq!(
             result.resources[0].get_attr("alarm_name"),
             Some(&Value::String("cpu-high".to_string()))

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -5,6 +5,72 @@ use std::hash::{Hash, Hasher};
 
 use serde::{Deserialize, Serialize};
 
+/// The `name` portion of a `ResourceId`.
+///
+/// Anonymous resources start out as `Pending` because the parser sees
+/// the resource block before it has extracted the `name` attribute.
+/// A later post-processing pass converts `Pending` to `Bound(name)`
+/// once the attribute has been read. Encoding this transient state in
+/// the type makes it impossible to confuse "anonymous, ID not yet
+/// assigned" with "actual ID is the empty string" (#2225).
+///
+/// On disk the variant is collapsed to a plain JSON string for
+/// backward compatibility with v5 state files: `Pending` round-trips
+/// through `""`, `Bound(s)` through `s`. The discriminant is
+/// reconstructed on deserialization.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResourceName {
+    /// An identifier already extracted (from a `let` binding or the
+    /// `name` attribute of an anonymous resource).
+    Bound(String),
+    /// An anonymous resource whose `name` attribute has not yet been
+    /// promoted to the `ResourceId`. Must be replaced with `Bound`
+    /// before the value can flow to plan generation, state, or
+    /// providers.
+    Pending,
+}
+
+impl ResourceName {
+    /// True when this `ResourceName` has not yet been bound to a
+    /// concrete identifier.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Borrow the bound identifier as a `&str`. `Pending` returns the
+    /// empty string — sites that need to distinguish must `match` on
+    /// the variant directly.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Bound(s) => s,
+            Self::Pending => "",
+        }
+    }
+}
+
+impl std::fmt::Display for ResourceName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ResourceName {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ResourceName {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(if s.is_empty() {
+            Self::Pending
+        } else {
+            Self::Bound(s)
+        })
+    }
+}
+
 /// Unique identifier for a resource
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ResourceId {
@@ -12,8 +78,13 @@ pub struct ResourceId {
     pub provider: String,
     /// Resource type (e.g., "s3.Bucket", "ec2.Instance")
     pub resource_type: String,
-    /// Resource name (identifier specified in DSL)
-    pub name: String,
+    /// Resource name (identifier specified in DSL).
+    ///
+    /// `Pending` means the resource is anonymous and the `name`
+    /// attribute has not yet been promoted into the `ResourceId`.
+    /// All downstream consumers (state, plan, providers) require
+    /// `Bound`.
+    pub name: ResourceName,
 }
 
 impl ResourceId {
@@ -21,7 +92,7 @@ impl ResourceId {
         Self {
             provider: String::new(),
             resource_type: resource_type.into(),
-            name: name.into(),
+            name: ResourceName::from_string(name.into()),
         }
     }
 
@@ -33,8 +104,21 @@ impl ResourceId {
         Self {
             provider: provider.into(),
             resource_type: resource_type.into(),
-            name: name.into(),
+            name: ResourceName::from_string(name.into()),
         }
+    }
+
+    /// Borrow the resolved identifier as `&str`. `Pending` returns
+    /// the empty string; sites that distinguish should `match` on
+    /// `self.name` directly.
+    pub fn name_str(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Set the resource's name, replacing any existing `Pending` or
+    /// `Bound` variant with `Bound(name)`.
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = ResourceName::Bound(name.into());
     }
 
     /// Returns the display type including provider prefix if available
@@ -43,6 +127,20 @@ impl ResourceId {
             self.resource_type.clone()
         } else {
             format!("{}.{}", self.provider, self.resource_type)
+        }
+    }
+}
+
+impl ResourceName {
+    /// Convert a string into a `ResourceName`. Empty input becomes
+    /// `Pending`; any other input becomes `Bound`. Used by
+    /// `ResourceId::new` / `with_provider` to keep the legacy
+    /// `String` constructors compatible.
+    fn from_string(s: String) -> Self {
+        if s.is_empty() {
+            Self::Pending
+        } else {
+            Self::Bound(s)
         }
     }
 }
@@ -1039,6 +1137,74 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
         assert_eq!(id, deserialized);
+    }
+
+    // The "anonymous, awaiting `name` extraction" state is type-distinct
+    // from a bound name, so the parser cannot accidentally produce a
+    // `ResourceId` whose `name` is the empty string and have it be
+    // mistaken for a valid identifier (#2225).
+
+    #[test]
+    fn resource_name_pending_is_distinct_from_bound_empty() {
+        let pending = ResourceName::Pending;
+        let bound_empty = ResourceName::Bound(String::new());
+        assert_ne!(pending, bound_empty);
+        assert!(pending.is_pending());
+        assert!(!bound_empty.is_pending());
+    }
+
+    #[test]
+    fn resource_id_pending_serde_round_trips_as_empty_string() {
+        // V5 state files persist `name` as a plain JSON string. To preserve
+        // backward compatibility, ResourceName::Pending serializes to "" and
+        // deserializes from "" — round-trip is exact.
+        let id = ResourceId {
+            provider: "aws".to_string(),
+            resource_type: "ec2.Subnet".to_string(),
+            name: ResourceName::Pending,
+        };
+        let json = serde_json::to_string(&id).unwrap();
+        assert!(json.contains("\"name\":\"\""), "got: {json}");
+        let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, deserialized);
+        assert!(deserialized.name.is_pending());
+    }
+
+    #[test]
+    fn resource_id_bound_serde_round_trips_as_string() {
+        let id = ResourceId::with_provider("aws", "ec2.Subnet", "my-subnet");
+        let json = serde_json::to_string(&id).unwrap();
+        assert!(json.contains("\"name\":\"my-subnet\""), "got: {json}");
+        let deserialized: ResourceId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, deserialized);
+        match deserialized.name {
+            ResourceName::Bound(s) => assert_eq!(s, "my-subnet"),
+            _ => panic!("expected Bound"),
+        }
+    }
+
+    /// The AC test from #2225: lookups keyed by `ResourceId` must remain
+    /// valid across the name-resolution pass. This is achieved by ensuring
+    /// that the parser starts with `Pending`, then any rename to `Bound`
+    /// also propagates to sibling structures (StringLiteralPath etc.).
+    /// We assert that two different mutation paths produce equal IDs.
+    #[test]
+    fn resource_id_rename_pending_to_bound() {
+        let mut id = ResourceId {
+            provider: "aws".to_string(),
+            resource_type: "ec2.Subnet".to_string(),
+            name: ResourceName::Pending,
+        };
+        // The post-pass converts Pending → Bound with the extracted name.
+        id.set_name("app-subnet".to_string());
+        match &id.name {
+            ResourceName::Bound(s) => assert_eq!(s, "app-subnet"),
+            _ => panic!("expected Bound after set_name"),
+        }
+        // After renaming, the same string can produce an equal ResourceId
+        // from any other code path (e.g. building a key for a sibling map).
+        let constructed = ResourceId::with_provider("aws", "ec2.Subnet", "app-subnet");
+        assert_eq!(id, constructed);
     }
 
     #[test]

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -1078,7 +1078,7 @@ let route = awscc.ec2.route {
         let route = parsed
             .resources
             .iter()
-            .find(|r| r.id.name == "route")
+            .find(|r| r.id.name_str() == "route")
             .unwrap();
         let gateway_id = route.get_attr("gateway_id").unwrap();
         match gateway_id {

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -147,7 +147,7 @@ pub fn core_to_wit_resource_id(id: &CoreResourceId) -> wit::ResourceId {
     wit::ResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name.clone(),
+        name: id.name_str().to_string(),
     }
 }
 
@@ -188,7 +188,8 @@ pub fn core_to_wit_resource(resource: &CoreResource) -> wit::ResourceDef {
 
 pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
     let id = wit_to_core_resource_id(&resource.id);
-    let mut core_resource = CoreResource::with_provider(&id.provider, &id.resource_type, &id.name);
+    let mut core_resource =
+        CoreResource::with_provider(&id.provider, &id.resource_type, id.name_str());
     core_resource.attributes = resource
         .attributes
         .iter()

--- a/carina-state/src/state.rs
+++ b/carina-state/src/state.rs
@@ -115,7 +115,7 @@ impl StateFile {
         if let Some(resource_state) = self.find_resource(
             &resource.id.provider,
             &resource.id.resource_type,
-            &resource.id.name,
+            resource.id.name_str(),
         ) {
             return resource_state.identifier.clone();
         }
@@ -165,7 +165,7 @@ impl StateFile {
         let rs = self.find_resource(
             &resource.id.provider,
             &resource.id.resource_type,
-            &resource.id.name,
+            resource.id.name_str(),
         );
         if let Some(identifier) = rs.and_then(|r| r.identifier.as_deref()) {
             let attrs: HashMap<String, Value> = rs
@@ -499,7 +499,7 @@ impl ResourceState {
     ) -> Result<Self, String> {
         let mut rs = Self::new(
             &resource.id.resource_type,
-            &resource.id.name,
+            resource.id.name_str(),
             resource.id.provider.clone(),
         );
         rs.identifier = state.identifier.clone();
@@ -514,7 +514,8 @@ impl ResourceState {
         // the provider-returned structure to preserve extra keys from the provider.
         for (k, v) in &resource.attributes {
             if contains_secret(v) {
-                let ctx = SecretHashContext::new(resource.id.display_type(), &resource.id.name, k);
+                let ctx =
+                    SecretHashContext::new(resource.id.display_type(), resource.id.name_str(), k);
                 if let Some(provider_json) = rs.attributes.get(k).cloned() {
                     rs.attributes.insert(
                         k.clone(),

--- a/carina-tui/src/app.rs
+++ b/carina-tui/src/app.rs
@@ -644,7 +644,9 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
 
             let name_part = if has_binding {
                 // For bound resources, show the binding name
-                r.binding.clone().unwrap_or_else(|| r.id.name.clone())
+                r.binding
+                    .clone()
+                    .unwrap_or_else(|| r.id.name_str().to_string())
             } else {
                 // For anonymous resources, try to extract a compact hint
                 let parent_binding = nodes[idx].parent.and_then(|p_idx| {
@@ -667,7 +669,7 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
                 if let Some(hint) = extract_compact_hint(r, parent_binding.as_deref()) {
                     format!("({})", hint)
                 } else {
-                    r.id.name.clone()
+                    r.id.name_str().to_string()
                 }
             };
 
@@ -677,7 +679,7 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
         } else if let Effect::Delete { id, .. } = effect {
             let display_type = id.display_type();
             nodes[idx].resource_type = display_type.clone();
-            nodes[idx].name_part = id.name.clone();
+            nodes[idx].name_part = id.name_str().to_string();
             nodes[idx].effect_label = format!("{} {}", display_type, id.name);
         }
     }
@@ -690,7 +692,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Read { resource } => TreeNode {
             effect_label: format!("{}", resource.id),
             resource_type: resource.id.display_type(),
-            name_part: resource.id.name.clone(),
+            name_part: resource.id.name_str().to_string(),
             symbol: "<=".to_string(),
             kind: EffectKind::Read,
             detail_rows,
@@ -701,7 +703,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Create(resource) => TreeNode {
             effect_label: format!("{}", resource.id),
             resource_type: resource.id.display_type(),
-            name_part: resource.id.name.clone(),
+            name_part: resource.id.name_str().to_string(),
             symbol: "+".to_string(),
             kind: EffectKind::Create,
             detail_rows,
@@ -712,7 +714,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Update { id, .. } => TreeNode {
             effect_label: format!("{}", id),
             resource_type: id.display_type(),
-            name_part: id.name.clone(),
+            name_part: id.name_str().to_string(),
             symbol: "~".to_string(),
             kind: EffectKind::Update,
             detail_rows,
@@ -729,7 +731,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
             TreeNode {
                 effect_label: format!("{}", id),
                 resource_type: id.display_type(),
-                name_part: id.name.clone(),
+                name_part: id.name_str().to_string(),
                 symbol,
                 kind: EffectKind::Replace,
                 detail_rows,
@@ -753,7 +755,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
             TreeNode {
                 effect_label: format!("{}", id),
                 resource_type: id.display_type(),
-                name_part: id.name.clone(),
+                name_part: id.name_str().to_string(),
                 symbol: "-".to_string(),
                 kind: EffectKind::Delete,
                 detail_rows: rows,
@@ -765,7 +767,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Import { id, .. } => TreeNode {
             effect_label: format!("{}", id),
             resource_type: id.display_type(),
-            name_part: id.name.clone(),
+            name_part: id.name_str().to_string(),
             symbol: "<-".to_string(),
             kind: EffectKind::Read,
             detail_rows,
@@ -776,7 +778,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Remove { id } => TreeNode {
             effect_label: format!("{}", id),
             resource_type: id.display_type(),
-            name_part: id.name.clone(),
+            name_part: id.name_str().to_string(),
             symbol: "x".to_string(),
             kind: EffectKind::Delete,
             detail_rows,
@@ -787,7 +789,7 @@ fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSche
         Effect::Move { from, to } => TreeNode {
             effect_label: format!("{} -> {}", from, to),
             resource_type: to.display_type(),
-            name_part: to.name.clone(),
+            name_part: to.name_str().to_string(),
             symbol: "->".to_string(),
             kind: EffectKind::Update,
             detail_rows,


### PR DESCRIPTION
## Summary

Closes #2225 (Phase 1).

`Resource.id.name` was a `String` whose empty value (`""`) was a sentinel for "anonymous resource, name not yet extracted from the `name` attribute". This PR makes that transient state explicit in the type system:

```rust
pub enum ResourceName {
    Bound(String),
    Pending,
}
```

The empty-string sentinel is gone. `id.name.is_empty()` checks that semantically meant "still anonymous" now use the explicit `is_pending()`.

## Backward compatibility

A custom serde impl collapses the variant to a plain JSON string (`Pending` ↔ `""`, `Bound(s)` ↔ `s`), so v5 state files round-trip unchanged. No state-file migration is required.

`ResourceId::new` / `ResourceId::with_provider` keep their `impl Into<String>` signatures — internal `ResourceName::from_string()` maps `""` to `Pending`, anything else to `Bound`. Most call sites don't change.

## Migration helpers

Three new methods on `ResourceId`:

- `name_str() -> &str` — borrow as `&str` (`""` for `Pending`)
- `set_name(s)` — promote to `Bound(s)` (used by parser's for-expression expansion and the identifier assignment pass)
- `is_pending()` — match the transient state without enumerating variants

## Phase 1 scope

This PR migrates the **carina** repo only. The provider repos (`carina-provider-aws`, `carina-provider-awscc`) cross the WIT boundary via `carina-plugin-host::wasm_convert`, which already does the `name_str()` ↔ `String` conversion at the edge — they consume no `ResourceId.name` directly, so they remain unaffected. Follow-up PRs in those repos can adopt the enum natively if desired.

## New tests

In `carina-core/src/resource.rs`:

- `resource_name_pending_is_distinct_from_bound_empty` — `Pending` ≠ `Bound("")`
- `resource_id_pending_serde_round_trips_as_empty_string` — the backward-compat contract for v5 state files
- `resource_id_bound_serde_round_trips_as_string`
- `resource_id_rename_pending_to_bound` — `set_name` produces an ID equal to one constructed directly with the same string

## Test plan

- [x] `cargo build` (workspace) — succeeds
- [x] `cargo test` (workspace, ~1700 tests) — all PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] Real-infra smoke test: `carina validate infra/aws/management/github-oidc/` still passes
- [x] No snapshot drift

## Diff stats

24 files, +411/-222.
