### PR TITLE
refactor(core, lsp): unify binding-schema lookup behind BindingIndex

### DIFF
--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -1,0 +1,284 @@
+//! Single source of truth for the `binding_name → (resource, schema)` lookup
+//! that validation and the LSP both need (#2231).
+//!
+//! The four pre-existing call sites that hand-rolled their own binding map
+//! (parser, resolver, validation, LSP) historically drifted in subtle ways —
+//! the LSP saw a different set of bindings than the parser, structural
+//! `for`/`if` bindings were missed in some checks, and adding a new binding
+//! source meant chasing four files. This type collapses **the schema-lookup
+//! shape** (validation + LSP) into one builder.
+//!
+//! Resolver and parser are deliberately out of scope here: resolver's map
+//! holds owned merged attribute values (DSL + AWS state), which is a
+//! different shape, and parser's notion of "in-scope names" runs before
+//! schemas are known. Both can share `BindingIndex` later by extending
+//! `BindingEntry`; for now the smaller surface keeps the refactor reviewable.
+//!
+//! Built once at the parse → validate boundary, then borrowed. The walk
+//! is **top-level only** (`parsed.resources`) on purpose: for-body
+//! template resources carry a parser-synthesised binding name used for
+//! address derivation, but those names are an internal detail and were
+//! never visible to validation's `binding_map` pre-#2231. Surfacing them
+//! through `BindingIndex` would let ResourceRefs name them, which is a
+//! behaviour change neither validation nor the LSP wants. The LSP still
+//! walks `iter_all_resources` separately for its own checks (so for-body
+//! type/enum diagnostics fire); only the binding-name table is scoped.
+//!
+//! ```ignore
+//! let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_fn);
+//! if let Some(entry) = index.get("vpc") {
+//!     // entry.resource and entry.schema are both available
+//! }
+//! ```
+
+use crate::parser::ParsedFile;
+use crate::resource::Resource;
+use crate::schema::ResourceSchema;
+use std::collections::HashMap;
+
+/// One entry in the binding index. Both fields are non-`Option` because the
+/// builder skips bindings whose schema cannot be resolved — callers never
+/// have to defend against half-populated entries.
+#[derive(Debug)]
+pub struct BindingEntry<'a> {
+    pub resource: &'a Resource,
+    pub schema: &'a ResourceSchema,
+}
+
+/// Index of `binding_name → (resource, schema)` for every named binding
+/// declared in `parsed`. Lifetime `'a` ties the index to its inputs so
+/// callers can keep it borrowed without cloning.
+///
+/// `entries` only contains bindings whose schema resolved successfully.
+/// `known_names` records every named binding regardless of schema status,
+/// so callers can tell "unknown binding" apart from "binding exists but
+/// its schema is missing" — those are separate diagnostics.
+#[derive(Debug, Default)]
+pub struct BindingIndex<'a> {
+    entries: HashMap<String, BindingEntry<'a>>,
+    known_names: std::collections::HashSet<String>,
+}
+
+impl<'a> BindingIndex<'a> {
+    /// Build the index from a parsed file and a schema map. `schema_key_fn`
+    /// converts a `Resource` to the key under which its schema is stored
+    /// (e.g. `"aws.s3.Bucket" -> "s3.Bucket"`); validation and the LSP both
+    /// already pass such a function around, so the contract here mirrors
+    /// theirs.
+    ///
+    /// Bindings whose schema is missing from `schemas` are silently skipped
+    /// — callers (validation / LSP) treat unknown resource types as a
+    /// separate diagnostic, so reporting them again here would double-count.
+    pub fn from_parsed(
+        parsed: &'a ParsedFile,
+        schemas: &'a HashMap<String, ResourceSchema>,
+        schema_key_fn: &dyn Fn(&Resource) -> String,
+    ) -> Self {
+        let mut entries = HashMap::new();
+        let mut known_names = std::collections::HashSet::new();
+        // Walk top-level resources only. The parser auto-generates a
+        // synthetic `binding` for anonymous for-body templates (used for
+        // resource address derivation), but those names are an internal
+        // detail — they were never visible to validation's binding map
+        // pre-#2231 and surfacing them here would be an unintended
+        // behaviour change for ResourceRef lookups. The LSP and
+        // validation both still walk `iter_all_resources` *separately*
+        // for their own checks; only the binding-name table is scoped to
+        // top-level here.
+        for resource in &parsed.resources {
+            let Some(binding_name) = resource.binding.as_ref() else {
+                continue;
+            };
+            known_names.insert(binding_name.clone());
+            let Some(schema) = schemas.get(&schema_key_fn(resource)) else {
+                continue;
+            };
+            entries.insert(binding_name.clone(), BindingEntry { resource, schema });
+        }
+        Self {
+            entries,
+            known_names,
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&BindingEntry<'a>> {
+        self.entries.get(name)
+    }
+
+    /// True iff a binding by this name was declared anywhere in the parsed
+    /// file, *even if its schema could not be resolved*. Used to
+    /// distinguish "unknown binding" diagnostics from "known binding but
+    /// schema missing" (which is a different diagnostic surface).
+    pub fn is_declared(&self, name: &str) -> bool {
+        self.known_names.contains(name)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Borrow-valued projection — `binding_name → &ResourceSchema`. Lets
+    /// callers that previously took a `HashMap<String, ResourceSchema>` of
+    /// schema clones switch to a borrow-only map without changing their
+    /// signatures' shape (just the value type). Saves a per-binding,
+    /// per-keystroke `ResourceSchema::clone()` on the LSP path.
+    pub fn schemas_by_name(&self) -> HashMap<&str, &'a ResourceSchema> {
+        self.entries
+            .iter()
+            .map(|(name, entry)| (name.as_str(), entry.schema))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse;
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    fn schema_key_aws(r: &Resource) -> String {
+        format!("{}.{}", r.id.provider, r.id.resource_type)
+    }
+
+    fn vpc_schema() -> ResourceSchema {
+        ResourceSchema::new("aws.ec2.Vpc")
+            .attribute(AttributeSchema::new("name", AttributeType::String))
+            .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+    }
+
+    #[test]
+    fn build_indexes_named_let_binding() {
+        let src = r#"
+let vpc = aws.ec2.Vpc {
+    name = "v"
+    cidr_block = "10.0.0.0/16"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut schemas = HashMap::new();
+        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let entry = index.get("vpc").expect("vpc binding present");
+        assert_eq!(entry.schema.resource_type, "aws.ec2.Vpc");
+        assert_eq!(entry.resource.binding.as_deref(), Some("vpc"));
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn build_skips_anonymous_resources() {
+        // No `let` binding — anonymous resources never appear in the index
+        // because they cannot be referenced by name.
+        let src = r#"
+aws.ec2.Vpc {
+    name = "v"
+    cidr_block = "10.0.0.0/16"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut schemas = HashMap::new();
+        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        assert!(index.is_empty());
+    }
+
+    #[test]
+    fn build_skips_bindings_with_unknown_schema() {
+        // The Vpc binding exists but its schema is not registered. Callers
+        // (validation / LSP) raise a separate "unknown resource type"
+        // diagnostic, so `get` returns None — but `contains_name` still
+        // says yes, so a "unknown binding" diagnostic is not double-fired
+        // on top of the "unknown resource type" one.
+        let src = r#"
+let vpc = aws.ec2.Vpc {
+    name = "v"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let schemas: HashMap<String, ResourceSchema> = HashMap::new();
+
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        assert!(index.get("vpc").is_none());
+        assert!(
+            index.is_declared("vpc"),
+            "binding declared in source must show up in `known_names`",
+        );
+    }
+
+    #[test]
+    fn build_includes_only_named_top_level_bindings_not_for_body_templates() {
+        // For-body template resources never carry a `binding`, so they
+        // must not appear in the index — the iter walks all resources
+        // (top-level and for-body) for parity with `iter_all_resources`,
+        // but the binding filter weeds out the unnamed ones.
+        let src = r#"
+let net = aws.ec2.Vpc {
+    name = "v"
+    cidr_block = "10.0.0.0/16"
+}
+
+for _, n in some_iterable {
+    aws.ec2.Vpc {
+        name = n
+        cidr_block = "10.0.0.0/16"
+    }
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut schemas = HashMap::new();
+        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        assert!(index.get("net").is_some(), "named let binding indexed");
+        assert!(
+            !index.is_declared("n"),
+            "for-body iteration variable is not a binding the index should know about",
+        );
+        // For-body templates carry parser-synthesised internal bindings
+        // (used for address derivation) — those names never surfaced in
+        // the pre-#2231 validation map and `BindingIndex::from_parsed`
+        // preserves that contract by walking top-level only.
+        assert_eq!(index.len(), 1);
+    }
+
+    #[test]
+    fn schemas_by_name_returns_borrowed_schemas() {
+        let src = r#"
+let vpc = aws.ec2.Vpc {
+    name = "v"
+    cidr_block = "10.0.0.0/16"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut schemas = HashMap::new();
+        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+
+        let by_name = index.schemas_by_name();
+        let schema = by_name.get("vpc").expect("vpc projection present");
+        assert_eq!(schema.resource_type, "aws.ec2.Vpc");
+        // The projection borrows from the index — pointer-equal to
+        // `index.get(...).schema`, which is the whole point.
+        assert!(std::ptr::eq(*schema, index.get("vpc").unwrap().schema));
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown_name() {
+        let src = r#"
+let vpc = aws.ec2.Vpc {
+    name = "v"
+    cidr_block = "10.0.0.0/16"
+}
+"#;
+        let parsed = parse(src, &Default::default()).expect("parse");
+        let mut schemas = HashMap::new();
+        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        assert!(index.get("missing").is_none());
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Core library for an infrastructure management tool that treats side effects as values
 
+pub mod binding_index;
 pub mod builtins;
 pub mod config_loader;
 pub mod deps;

--- a/carina-core/src/validation.rs
+++ b/carina-core/src/validation.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use crate::binding_index::BindingIndex;
 use crate::parser::{ModuleCall, ParsedFile, ProviderContext, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
 use crate::resource::{Resource, Value};
@@ -86,15 +87,10 @@ pub fn validate_resource_ref_types(
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
-    // Build binding_name -> resource map from direct resources only.
-    // For-body template resources never carry a `binding`, so skipping
-    // them here keeps the map correct for lookup.
-    let mut binding_map: HashMap<String, &Resource> = HashMap::new();
-    for resource in &parsed.resources {
-        if let Some(ref binding_name) = resource.binding {
-            binding_map.insert(binding_name.clone(), resource);
-        }
-    }
+    // Single source of truth for `binding_name → (resource, schema)` —
+    // shared with the LSP via `BindingIndex` so the two paths cannot drift
+    // (#2231).
+    let bindings = BindingIndex::from_parsed(parsed, schemas, schema_key_fn);
 
     for (_ctx, resource) in parsed.iter_all_resources() {
         let schema_key = schema_key_fn(resource);
@@ -126,18 +122,21 @@ pub fn validate_resource_ref_types(
                 continue;
             }
 
-            // Look up the referenced binding's schema to get the type of the referenced attribute
-            let Some(ref_resource) = binding_map.get(ref_binding.as_str()) else {
-                all_errors.push(format!(
-                    "{}: unknown binding '{}' in reference {}.{}",
-                    resource.id, ref_binding, ref_binding, ref_attr,
-                ));
+            // Look up the referenced binding's schema. `BindingIndex::get`
+            // returns `Some` only when both the binding and its schema
+            // resolved; `contains_name` distinguishes "unknown binding"
+            // from "known binding, schema absent" so we keep the original
+            // diagnostic shape (only the former gets reported here).
+            let Some(ref_entry) = bindings.get(ref_binding.as_str()) else {
+                if !bindings.is_declared(ref_binding.as_str()) {
+                    all_errors.push(format!(
+                        "{}: unknown binding '{}' in reference {}.{}",
+                        resource.id, ref_binding, ref_binding, ref_attr,
+                    ));
+                }
                 continue;
             };
-            let ref_schema_key_str = schema_key_fn(ref_resource);
-            let Some(ref_schema) = schemas.get(&ref_schema_key_str) else {
-                continue;
-            };
+            let ref_schema = ref_entry.schema;
             let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
                 let known_attrs: Vec<&str> =
                     ref_schema.attributes.keys().map(|s| s.as_str()).collect();

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1494,7 +1494,7 @@ impl DiagnosticEngine {
         &self,
         doc: &Document,
         parsed: &ParsedFile,
-        binding_schema_map: &HashMap<String, ResourceSchema>,
+        binding_schema_map: &HashMap<&str, &ResourceSchema>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
@@ -1534,7 +1534,7 @@ impl DiagnosticEngine {
         &self,
         doc: &Document,
         value: &Value,
-        binding_schema_map: &HashMap<String, ResourceSchema>,
+        binding_schema_map: &HashMap<&str, &ResourceSchema>,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         value.visit_refs(&mut |path| {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -184,18 +184,22 @@ impl DiagnosticEngine {
                 diagnostics.extend(self.check_module_calls(doc, parsed, base));
                 diagnostics.extend(self.check_upstream_state_sources(doc, parsed, base));
             }
-            // Build binding_name -> (provider, resource_type) map for ResourceRef type checking.
-            // Walk both top-level resources and for-body template resources so
-            // for-body refs can be type-checked against their referenced binding.
-            let mut binding_schema_map: HashMap<String, ResourceSchema> = HashMap::new();
-            for (_ctx, res) in parsed.iter_all_resources() {
-                if let Some(ref binding_name) = res.binding {
-                    let full_type = format!("{}.{}", res.id.provider, res.id.resource_type);
-                    if let Some(s) = self.schemas.get(&full_type).cloned() {
-                        binding_schema_map.insert(binding_name.clone(), s);
-                    }
-                }
-            }
+            // Build the canonical `binding_name → (resource, schema)`
+            // index once via the shared `BindingIndex` (#2231) so the LSP
+            // and `carina-core::validation` cannot drift over which
+            // bindings exist or how their schemas are looked up. The
+            // reference-checking helpers below consume a borrow-valued
+            // map, so no per-keystroke `ResourceSchema::clone()` is
+            // needed.
+            let schema_key_fn = |r: &carina_core::resource::Resource| {
+                format!("{}.{}", r.id.provider, r.id.resource_type)
+            };
+            let binding_index = carina_core::binding_index::BindingIndex::from_parsed(
+                parsed,
+                &self.schemas,
+                &schema_key_fn,
+            );
+            let binding_schema_map = binding_index.schemas_by_name();
 
             // Check resource types — include for-body template resources so
             // attribute/type/enum validation fires inside `for` loops too.
@@ -1009,7 +1013,7 @@ fn is_quoted_literal_attr(
 }
 
 fn check_resource_ref_type_mismatch(
-    binding_schema_map: &HashMap<String, ResourceSchema>,
+    binding_schema_map: &HashMap<&str, &ResourceSchema>,
     expected_type: &carina_core::schema::AttributeType,
     ref_binding: &str,
     ref_attr: &str,


### PR DESCRIPTION
## Summary

Adds `carina-core::binding_index::BindingIndex<'a>` and routes the two `binding_name → schema` lookup call sites through it: `carina_core::validation::validate_resource_ref_types` (was a `HashMap<String, &Resource>` plus ad-hoc schema relookup) and the LSP `DiagnosticEngine::analyze_with_filename` (was a `HashMap<String, ResourceSchema>` of per-keystroke clones).

`BindingIndex` exposes `from_parsed`, `get`, `is_declared`, `schemas_by_name`. The LSP reference-checking helpers (`check_resource_ref_type_mismatch`, `check_resource_ref_attributes`, `collect_ref_attr_diagnostics`) were updated to take `&HashMap<&str, &ResourceSchema>` so the per-keystroke `ResourceSchema::clone()` per binding is gone.

## Scope

Refs (not Closes) #2231. The original issue listed four call sites; this PR unifies the two whose shape was already the same (`binding_name → schema` lookup). The other two are tracked separately:

- **Parser** registers `let` names before schemas are loaded — different layer.
- **Resolver** owns merged DSL + AWS state attribute values — different shape.

Folding all four into one type would expand `BindingEntry` to four `Option` fields and bloat the diff. Tracked in #2251.

## Subtle behaviour preserved

- **`from_parsed` walks top-level resources only** (`parsed.resources`), not `iter_all_resources()`. The parser synthesises an internal binding name on for-body templates for address derivation; those names were never in `validation`'s pre-PR map and surfacing them would let ResourceRefs reach an internal name. The LSP still walks `iter_all_resources` separately for its own type/enum checks (so for-body diagnostics still fire); only the binding-name table is scoped to top-level. This was caught in self-review and pinned by the unit test `build_includes_only_named_top_level_bindings_not_for_body_templates`.
- **`is_declared(name)` returns true even when the binding's schema didn't resolve**, so validation can still tell "unknown binding" apart from "binding exists, schema missing" — those are two different diagnostics, and merging them would be observable from CLI / LSP error text.

## Test plan

- [x] `cargo test -p carina-core` — 1377 unit + 8 doc tests (1371 + 6 new `binding_index` tests)
- [x] `cargo test -p carina-lsp` — 341 unit + 9 e2e + 4 integration tests
- [x] `cargo clippy -p carina-core -p carina-lsp --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `carina validate` against `carina-rs/infra/aws/management/{carina-state,github-oidc,identity-center,organizations,route53}` — all 5 dirs validate, no diff vs. main
