### PR TITLE
test(lsp): cover Custom-type AWS string form acceptance for Region

### DIFF
--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -163,14 +163,20 @@ test.r.mode_holder {
 // ---------------------------------------------------------------
 
 fn region_schemas() -> HashMap<String, ResourceSchema> {
-    // Validator accepts the canonical DSL form `test.Region.ap_northeast_1`
-    // that the schema's namespace + name produces from a bare identifier.
-    // The `to_dsl` callback is what real AWS Region uses to normalise
-    // hyphenated AWS strings (`ap-northeast-1`) into the underscore DSL
-    // form before validation; we mirror that shape.
+    // Mirrors the production `aws_region()` shape (#2248): the `Custom`
+    // validate path does **not** consult the schema-level `to_dsl`
+    // callback — only `StringEnum` validation does, for alias matching.
+    // So a `Custom` validator that wants to accept both DSL
+    // (`test.Region.ap_northeast_1`) and raw AWS-string (`"ap-northeast-1"`)
+    // forms must normalise inside the callback, exactly as
+    // `carina-aws-types::types::aws_region` does.
     fn validate_region(v: &carina_core::resource::Value) -> Result<(), String> {
+        const VALID: &[&str] = &["ap-northeast-1", "us-west-2"];
         if let carina_core::resource::Value::String(s) = v {
-            if s == "test.Region.ap_northeast_1" || s == "test.Region.us_west_2" {
+            // Same shape as `aws_region()`: strip any namespace prefix
+            // (DSL form) and rewrite `_` → `-` to get the AWS form.
+            let normalized = carina_core::utils::extract_enum_value(s).replace('_', "-");
+            if VALID.contains(&normalized.as_str()) {
                 return Ok(());
             }
             return Err(format!("invalid Region '{}'", s));
@@ -225,6 +231,36 @@ test.r.region_holder {
         count_with(&diags, "Region") + count_with(&diags, "region"),
         0,
         "expected no Region diagnostics, got: {:?}",
+        messages_of(&diags),
+    );
+}
+
+#[test]
+fn region_accepts_aws_string_form() {
+    // The AC of #2248: a Custom type with a hyphen-tolerant validator
+    // must accept the raw AWS string form (`"ap-northeast-1"`) just as it
+    // accepts the DSL form (`ap_northeast_1`). The schema's `to_dsl`
+    // callback alone is *not* enough — the `Custom` validate path does
+    // not consult it, so the validator itself has to handle both shapes.
+    let engine = engine_with_schemas(region_schemas());
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+test.r.region_holder {
+    name = "a"
+    region = "ap-northeast-1"
+}
+test.r.region_holder {
+    name = "b"
+    region = "us-west-2"
+}
+"#,
+    )]);
+    let diags = analyze(&engine, &fixture, "main.crn");
+    assert_eq!(
+        count_with(&diags, "Region") + count_with(&diags, "region"),
+        0,
+        "expected no Region diagnostics for raw AWS string form, got: {:?}",
         messages_of(&diags),
     );
 }


### PR DESCRIPTION
## Summary

Adds `region_accepts_aws_string_form` and rewrites the test's `validate_region` callback so both DSL form (`region = ap_northeast_1`, already covered) and raw AWS string form (`region = "ap-northeast-1"`, the AC of #2248) are accepted, matching production behaviour.

## Investigation

#2248 was filed as an open question: "is the LSP wrong to skip `to_dsl` on the `Custom` path, or is it intentional?" Tracing through `carina-core/src/schema.rs`:

- The `StringEnum` validate arm consults `to_dsl` for **alias matching** (`schema.rs:289-292`) — it asks "is the input equal to `to_dsl(canonical)` for some canonical?"
- The `Custom` validate arm just hands the value to the user-supplied callback (`schema.rs:354`) — `to_dsl` is **not** read.

This is intentional. `Custom` is the user-controlled escape hatch; the schema doesn't second-guess what shapes the callback wants to accept. Production `carina-aws-types::types::aws_region()` therefore normalises inside the callback:

```rust
let normalized = extract_enum_value(s).replace('_', "-");
if is_valid_region(&normalized) { Ok(()) } else { Err(...) }
```

PR #2250's test validator only accepted the fully-qualified DSL form, which is why the AWS-string variant had to be deferred. This PR makes the test mirror the production shape and adds the missing assertion.

## Out of scope

The issue body mentions a CLI-side parity test ("depends on the parity-test issue spawned alongside this one"). That depends on the provider-plugin test infrastructure tracked in #2247 (the existing `carina-cli/tests/negative_validation.rs` cases are all `#[ignore]` for the same reason). This PR closes #2248 for the LSP path; CLI parity will ship when #2247 lands.

Closes #2248
Refs #2215, #2247

## Test plan

- [x] `cargo test -p carina-lsp --test e2e_typecheck` — 12 tests pass (11 baseline + new `region_accepts_aws_string_form`)
- [x] `cargo test -p carina-lsp` — full suite (341 unit + 12 e2e + 4 integration) passes
- [x] `cargo clippy -p carina-lsp --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
