### PR TITLE
refactor(core): preserve attribute insertion order with IndexMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ version = "0.4.0"
 dependencies = [
  "argon2",
  "futures",
+ "indexmap",
  "pest",
  "pest_derive",
  "semver",
@@ -898,6 +899,7 @@ dependencies = [
  "carina-provider-protocol",
  "dirs",
  "hyper 1.8.1",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/carina-cli/src/commands/apply.rs
+++ b/carina-cli/src/commands/apply.rs
@@ -21,7 +21,7 @@ use carina_core::module_resolver;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
-use carina_core::resource::{Expr, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::ResourceSchema;
 use carina_core::value::format_value;
 use carina_state::{LockInfo, ResourceState, StateBackend, StateFile, resolve_backend};
@@ -1305,7 +1305,7 @@ async fn run_apply_locked(
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for resource in &sorted_resources {
         if let Some(ref binding_name) = resource.binding {
-            let mut attrs: HashMap<String, Value> = Expr::resolve_map(&resource.attributes);
+            let mut attrs: HashMap<String, Value> = resource.resolved_attributes();
             // Merge existing state if available
             if let Some(state) = current_states.get(&resource.id)
                 && state.exists
@@ -1760,7 +1760,7 @@ async fn run_apply_from_plan_locked(
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for resource in sorted_resources {
         if let Some(ref binding_name) = resource.binding {
-            let mut attrs: HashMap<String, Value> = Expr::resolve_map(&resource.attributes);
+            let mut attrs: HashMap<String, Value> = resource.resolved_attributes();
             if let Some(state) = current_states.get(&resource.id)
                 && state.exists
             {

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -356,8 +356,7 @@ pub(crate) fn resolve_export_values_for_display(
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for resource in resources {
         if let Some(ref binding_name) = resource.binding {
-            let mut attrs: HashMap<String, Value> =
-                carina_core::resource::Expr::resolve_map(&resource.attributes);
+            let mut attrs: HashMap<String, Value> = resource.resolved_attributes();
             if let Some(state) = current_states.get(&resource.id)
                 && state.exists
             {

--- a/carina-cli/src/wiring.rs
+++ b/carina-cli/src/wiring.rs
@@ -489,6 +489,12 @@ pub fn resolve_enum_aliases_with_ctx(ctx: &WiringContext, resources: &mut [Resou
         };
         let mut value_attrs = resource.resolved_attributes();
         resolve_attrs_aliases(&mut value_attrs, &resource.id.resource_type, factory);
+        // `value_attrs` is `HashMap`-shaped (state-side ordering doesn't
+        // survive AWS round-trips), so the order produced by `wrap_map`
+        // is whatever `HashMap` iteration gives. Stage 1 of #2222
+        // preserves order on the *parse* path; alias resolution
+        // rebuilds the map and that ordering is lost — acceptable for
+        // this PR's scope.
         resource.attributes = carina_core::resource::Expr::wrap_map(value_attrs);
     }
 }

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -17,6 +17,7 @@ semver = "1"
 argon2 = "0.5"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
+indexmap = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -333,6 +333,11 @@ pub fn create_plan(
             } else {
                 let temp_resource = Resource {
                     id: id.clone(),
+                    // `state.attributes` is `HashMap` — no source order
+                    // survives round-tripping through the provider. The
+                    // ordering of this synthetic temp resource doesn't
+                    // matter (it only feeds the dependency walker), so
+                    // a plain clone-through `wrap_map` is fine.
                     attributes: Expr::wrap_map(state.attributes.clone()),
                     kind: ResourceKind::Real,
                     lifecycle: lifecycle.clone(),

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -75,8 +75,10 @@ pub fn resolve_attr_prefixes(
                 continue;
             }
 
-            // Remove the _prefix attribute
-            resource.attributes.remove(&prefix_key);
+            // Remove the _prefix attribute. `shift_remove` (not
+            // `swap_remove`) preserves the source-order of the rest of
+            // the attributes, which is the whole point of #2222.
+            resource.attributes.shift_remove(&prefix_key);
 
             // Store prefix
             resource

--- a/carina-core/src/module_resolver/mod.rs
+++ b/carina-core/src/module_resolver/mod.rs
@@ -16,6 +16,8 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use indexmap::IndexMap;
+
 use crate::parser::{
     ModuleCall, ParseError, ParsedFile, ProviderContext, TypeExpr, UseStatement,
     validate_custom_type,
@@ -414,7 +416,9 @@ impl<'cfg> ModuleResolver<'cfg> {
             // This ensures that caller-provided ResourceRef values (which may
             // coincidentally share a binding name with a module-internal binding)
             // are not incorrectly prefixed.
-            let mut substituted_attrs = HashMap::new();
+            // Preserve user-authored attribute order across the
+            // module-call expansion (#2222) — `IndexMap`, not `HashMap`.
+            let mut substituted_attrs: IndexMap<String, Expr> = IndexMap::new();
             for (key, expr) in &new_resource.attributes {
                 let rewritten =
                     rewrite_intra_module_refs(expr, instance_prefix, &intra_module_bindings);
@@ -430,7 +434,7 @@ impl<'cfg> ModuleResolver<'cfg> {
         if !module.attribute_params.is_empty()
             && let Some(binding_name) = &call.binding_name
         {
-            let mut virtual_attrs: HashMap<String, Expr> = HashMap::new();
+            let mut virtual_attrs: IndexMap<String, Expr> = IndexMap::new();
 
             // Copy attribute values from the module definition
             for attr_param in &module.attribute_params {

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -6,6 +6,8 @@ mod config;
 
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 
+use indexmap::IndexMap;
+
 use crate::resource::{Expr, LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
 use crate::schema::{
     validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address, validate_ipv6_cidr,
@@ -4008,8 +4010,11 @@ fn is_plain_string_without_interpolation(pair: &pest::iterators::Pair<Rule>) -> 
 fn parse_block_contents(
     pairs: pest::iterators::Pairs<Rule>,
     ctx: &ParseContext,
-) -> Result<HashMap<String, Value>, ParseError> {
-    let mut attributes: HashMap<String, Value> = HashMap::new();
+) -> Result<IndexMap<String, Value>, ParseError> {
+    // Source-order preserving (#2222) — `IndexMap` so the order in which
+    // the user wrote attributes in the .crn file flows all the way to
+    // `Resource.attributes`.
+    let mut attributes: IndexMap<String, Value> = IndexMap::new();
     let mut nested_blocks: HashMap<String, Vec<Value>> = HashMap::new();
 
     // Local scope extends the parent context with block-scoped let bindings
@@ -4053,11 +4058,15 @@ fn parse_block_contents(
                         // Recursively parse nested block contents (supports arbitrary depth)
                         let block_attrs = parse_block_contents(block_inner, &local_ctx)?;
 
-                        // Add to the list of blocks with this name
+                        // Add to the list of blocks with this name. Convert
+                        // back to `HashMap` here because `Value::Map`'s
+                        // payload is still a `HashMap` (#2222 Stage 1
+                        // touches only `Resource.attributes`); preserving
+                        // intra-`Map` order is left to a later stage.
                         nested_blocks
                             .entry(block_name)
                             .or_default()
-                            .push(Value::Map(block_attrs));
+                            .push(Value::Map(block_attrs.into_iter().collect()));
                     }
                     _ => {}
                 }
@@ -4087,8 +4096,8 @@ fn parse_block_contents(
 /// Extract lifecycle configuration from attributes.
 /// The parser parses `lifecycle { ... }` as a nested block, which becomes
 /// a List of Maps in attributes. We extract it and convert to LifecycleConfig.
-fn extract_lifecycle_config(attributes: &mut HashMap<String, Value>) -> LifecycleConfig {
-    if let Some(Value::List(blocks)) = attributes.remove("lifecycle") {
+fn extract_lifecycle_config(attributes: &mut IndexMap<String, Value>) -> LifecycleConfig {
+    if let Some(Value::List(blocks)) = attributes.shift_remove("lifecycle") {
         // Take the first lifecycle block (there should only be one)
         if let Some(Value::Map(map)) = blocks.into_iter().next() {
             let force_delete = matches!(map.get("force_delete"), Some(Value::Bool(true)));
@@ -4413,7 +4422,7 @@ fn parse_primary_value(
                         nested_blocks
                             .entry(block_name)
                             .or_default()
-                            .push(Value::Map(block_attrs));
+                            .push(Value::Map(block_attrs.into_iter().collect()));
                     }
                     _ => {}
                 }
@@ -4796,12 +4805,15 @@ fn resolve_forward_references(
     export_params: &mut [ExportParameter],
 ) {
     for resource in resources.iter_mut() {
-        let keys: Vec<String> = resource.attributes.keys().cloned().collect();
-        for key in keys {
-            if let Some(expr) = resource.attributes.remove(&key) {
-                let resolved = resolve_forward_ref_in_value(expr.into_value(), resource_bindings);
-                resource.attributes.insert(key, Expr(resolved));
-            }
+        // In-place replace via `iter_mut`: avoids the O(n²) cost of
+        // `shift_remove` + re-insert per key, and naturally preserves
+        // the user-authored attribute order without a key-collection
+        // round-trip. The placeholder is overwritten on the next line,
+        // so its identity doesn't matter.
+        for (_, expr) in resource.attributes.iter_mut() {
+            let placeholder = Value::Bool(false);
+            let value = std::mem::replace(&mut expr.0, placeholder);
+            expr.0 = resolve_forward_ref_in_value(value, resource_bindings);
         }
     }
     for attr_param in attribute_params.iter_mut() {
@@ -4911,10 +4923,10 @@ pub fn resolve_resource_refs_with_config(
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for resource in &parsed.resources {
         if let Some(ref binding_name) = resource.binding {
-            binding_map.insert(
-                binding_name.clone(),
-                Expr::resolve_map(&resource.attributes),
-            );
+            // `binding_map` only needs key-based lookup, not source order
+            // (callers consume it via `.get(name)` for ResourceRef
+            // resolution), so the inner map stays `HashMap`.
+            binding_map.insert(binding_name.clone(), resource.resolved_attributes());
         }
     }
 
@@ -4937,9 +4949,10 @@ pub fn resolve_resource_refs_with_config(
         binding_map.entry(us.binding.clone()).or_default();
     }
 
-    // Resolve references in each resource
+    // Resolve references in each resource. Keep `IndexMap` to preserve
+    // the user's source order through resolution (#2222).
     for resource in &mut parsed.resources {
-        let mut resolved_attrs: HashMap<String, Expr> = HashMap::new();
+        let mut resolved_attrs: IndexMap<String, Expr> = IndexMap::new();
 
         for (key, expr) in &resource.attributes {
             let resolved = resolve_value_with_config(expr, &binding_map, config)?;

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -51,7 +51,11 @@ pub fn resolve_refs_with_state_and_remote(
 
     for resource in resources.iter() {
         if let Some(ref binding_name) = resource.binding {
-            let mut attrs: HashMap<String, Value> = Expr::resolve_map(&resource.attributes);
+            // `attrs` only needs key-based lookup for state merging
+            // and ResourceRef resolution, so it stays `HashMap`. The
+            // source-ordered `IndexMap` view lives only on
+            // `Resource.attributes` (#2222).
+            let mut attrs: HashMap<String, Value> = resource.resolved_attributes();
 
             // Merge AWS state attributes (like `id`) if available
             if let Some(state) = current_states.get(&resource.id)
@@ -75,9 +79,11 @@ pub fn resolve_refs_with_state_and_remote(
         binding_map.insert(remote_binding.clone(), remote_attrs.clone());
     }
 
-    // Resolve ResourceRef values in all resources
+    // Resolve ResourceRef values in all resources. Stay in `IndexMap`
+    // so the user's authored attribute order survives resolution
+    // (#2222).
     for resource in resources.iter_mut() {
-        let mut resolved_attrs = HashMap::new();
+        let mut resolved_attrs: indexmap::IndexMap<String, Expr> = indexmap::IndexMap::new();
         for (key, expr) in &resource.attributes {
             resolved_attrs.insert(key.clone(), Expr(resolve_ref_value(expr, &binding_map)?));
         }
@@ -240,10 +246,8 @@ mod tests {
     use crate::resource::ResourceId;
 
     fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
-        let attributes: HashMap<String, Value> =
-            attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
         let mut r = Resource::new("test.resource", name);
-        r.attributes = Expr::wrap_map(attributes);
+        r.attributes = Expr::wrap_map(attrs.into_iter().map(|(k, v)| (k.to_string(), v)));
         r.binding = binding.map(|b| b.to_string());
         r
     }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::hash::{Hash, Hasher};
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// The `name` portion of a `ResourceId`.
@@ -449,17 +450,27 @@ impl Expr {
     /// `carina_core::resolver::resolve_refs_with_state_and_remote` (or an
     /// equivalent) first. See #1683 for a regression caused by assuming
     /// this method performed resolution.
-    pub fn resolve_map(attrs: &HashMap<String, Expr>) -> HashMap<String, Value> {
+    /// Project an `IndexMap<String, Expr>` (the shape `Resource.attributes`
+    /// uses since #2222) into a plain `HashMap<String, Value>` for callers
+    /// that only need key-based lookup (state merging, ResourceRef
+    /// resolution, provider trait inputs). Source-order is dropped on
+    /// purpose at this boundary — keep it on `Resource.attributes` itself
+    /// when iteration order matters.
+    pub fn resolve_map(attrs: &IndexMap<String, Expr>) -> HashMap<String, Value> {
         attrs
             .iter()
             .map(|(k, e)| (k.clone(), e.0.clone()))
             .collect()
     }
 
-    /// Wrap a `HashMap<String, Value>` into a `HashMap<String, Expr>`.
-    ///
-    /// This is the inverse of `resolve_map()`.
-    pub fn wrap_map(attrs: HashMap<String, Value>) -> HashMap<String, Expr> {
+    /// Wrap any `(String, Value)` iterator (`HashMap<String, Value>`,
+    /// `IndexMap<String, Value>`, `Vec<(String, Value)>`, …) into the
+    /// `IndexMap<String, Expr>` that `Resource.attributes` expects.
+    /// Source order follows the iteration order of `attrs`.
+    pub fn wrap_map<I>(attrs: I) -> IndexMap<String, Expr>
+    where
+        I: IntoIterator<Item = (String, Value)>,
+    {
         attrs.into_iter().map(|(k, v)| (k, Expr(v))).collect()
     }
 }
@@ -896,7 +907,13 @@ pub enum ResourceKind {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Resource {
     pub id: ResourceId,
-    pub attributes: HashMap<String, Expr>,
+    /// Source-order preserving map of attribute name → expression.
+    ///
+    /// `IndexMap` (not `HashMap`) so iteration order matches the order
+    /// the user wrote attributes in the `.crn` file. Anything that
+    /// re-renders attributes — diagnostic messages, formatter output,
+    /// plan display, snapshot tests — depends on this stability (#2222).
+    pub attributes: IndexMap<String, Expr>,
     /// Classification of this resource (real, virtual, or data source)
     #[serde(default)]
     pub kind: ResourceKind,
@@ -927,7 +944,7 @@ impl Resource {
     pub fn new(resource_type: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             id: ResourceId::new(resource_type, name),
-            attributes: HashMap::new(),
+            attributes: IndexMap::new(),
             kind: ResourceKind::Real,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
@@ -944,7 +961,7 @@ impl Resource {
     ) -> Self {
         Self {
             id: ResourceId::with_provider(provider, resource_type, name),
-            attributes: HashMap::new(),
+            attributes: IndexMap::new(),
             kind: ResourceKind::Real,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
@@ -955,8 +972,17 @@ impl Resource {
     }
 
     /// Returns the resolved attributes as a `HashMap<String, Value>`.
+    ///
+    /// Lookup-only callers (validation, differ, plan display) still
+    /// receive a `HashMap` — iteration over user-authored order is done
+    /// directly via `self.attributes` (`IndexMap`), so flipping this
+    /// helper would just force every downstream caller to widen its
+    /// signature for no order benefit.
     pub fn resolved_attributes(&self) -> HashMap<String, Value> {
-        Expr::resolve_map(&self.attributes)
+        self.attributes
+            .iter()
+            .map(|(k, e)| (k.clone(), e.0.clone()))
+            .collect()
     }
 
     /// Get an attribute value by key, returning `Option<&Value>`.
@@ -988,7 +1014,7 @@ impl Resource {
 
     /// Set attributes from a `HashMap<String, Value>`, wrapping each value in `Expr`.
     pub fn with_value_attributes(mut self, attrs: HashMap<String, Value>) -> Self {
-        self.attributes = attrs.into_iter().map(|(k, v)| (k, Expr(v))).collect();
+        self.attributes = Expr::wrap_map(attrs);
         self
     }
 
@@ -1845,7 +1871,7 @@ mod tests {
 
     #[test]
     fn expr_resolve_map() {
-        let mut attrs = HashMap::new();
+        let mut attrs = IndexMap::new();
         attrs.insert("name".to_string(), Expr(Value::String("test".to_string())));
         attrs.insert("count".to_string(), Expr(Value::Int(5)));
         let resolved = Expr::resolve_map(&attrs);

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -1627,7 +1627,10 @@ pub fn resolve_block_names(
                 continue;
             }
 
-            let expr = resource.attributes.remove(&block_key).unwrap();
+            // `shift_remove` keeps the rest of the source-authored
+            // order intact; `swap_remove` would reorder remaining
+            // attributes — see #2222.
+            let expr = resource.attributes.shift_remove(&block_key).unwrap();
             resource.attributes.insert(canon_key, expr);
         }
 

--- a/carina-plugin-host/Cargo.toml
+++ b/carina-plugin-host/Cargo.toml
@@ -25,3 +25,4 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
+indexmap = "2"

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -590,7 +590,7 @@ mod tests {
     #[test]
     fn test_resource_roundtrip() {
         let mut resource = CoreResource::with_provider("aws", "s3.Bucket", "my-bucket");
-        resource.attributes = HashMap::from([
+        resource.attributes = indexmap::IndexMap::from([
             ("name".into(), Expr(CoreValue::String("my-bucket".into()))),
             ("region".into(), Expr(CoreValue::String("us-east-1".into()))),
         ]);

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -81,7 +81,7 @@ async fn test_wasm_mock_provider_create_and_read() {
 
     // Create a resource
     let mut resource = Resource::with_provider("mock", "test.resource", "my-resource");
-    resource.attributes = HashMap::from([
+    resource.attributes = indexmap::IndexMap::from([
         ("name".into(), Expr(Value::String("my-resource".into()))),
         ("region".into(), Expr(Value::String("us-east-1".into()))),
         ("count".into(), Expr(Value::Int(42))),
@@ -129,7 +129,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 
     // Create first
     let mut resource = Resource::with_provider("mock", "test.resource", "updatable");
-    resource.attributes = HashMap::from([
+    resource.attributes = indexmap::IndexMap::from([
         ("color".into(), Expr(Value::String("red".into()))),
         ("size".into(), Expr(Value::Int(10))),
     ]);
@@ -145,7 +145,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 
     // Update with new attributes
     let mut updated_resource = Resource::with_provider("mock", "test.resource", "updatable");
-    updated_resource.attributes = HashMap::from([
+    updated_resource.attributes = indexmap::IndexMap::from([
         ("color".into(), Expr(Value::String("blue".into()))),
         ("size".into(), Expr(Value::Int(20))),
     ]);
@@ -195,7 +195,8 @@ async fn test_wasm_mock_provider_normalizer() {
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
         let mut r = Resource::with_provider("mock", "test.resource", "norm-test");
-        r.attributes = HashMap::from([("key".into(), Expr(Value::String("value".into())))]);
+        r.attributes =
+            indexmap::IndexMap::from([("key".into(), Expr(Value::String("value".into())))]);
         r
     }];
     let original_attrs = resources[0].resolved_attributes();
@@ -229,7 +230,7 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     let provider = factory.create_provider(&HashMap::new()).await;
 
     let mut resource = Resource::with_provider("mock", "test.data_source", "example");
-    resource.attributes = HashMap::from([
+    resource.attributes = indexmap::IndexMap::from([
         (
             "identity_store_id".into(),
             Expr(Value::String("d-1234567890".into())),


### PR DESCRIPTION
## Summary

Replaces `Resource.attributes: HashMap<String, Expr>` with `IndexMap<String, Expr>` so the order in which the user wrote attributes in a `.crn` file flows through parse → resolve → display. Anything that re-renders attributes (diagnostics, formatter, plan display, snapshot tests) now sees a stable, deterministic order across runs.

## Stage 1 only

Closes #2222 with `Resource.attributes` only. The remaining `HashMap<String, _>` cases that mirror user-authored ordering — `Value::Map`, `ProviderConfig.attributes`, `ParsedFile.variables` — are tracked in #2255 (Stage 2). Folding all four would expand `Value::Map`'s payload and bleed into the provider trait API, which is a polyrepo-lockstep change with `carina-provider-aws` / `carina-provider-awscc`.

## Plumbing details

- `parse_block_contents` now returns `IndexMap<String, Value>` so parser-stage attribute order survives. `Value::Map(...)` conversions still go through `HashMap` because that variant is Stage-2 territory; the loss of intra-`Map` order is documented at the conversion sites.
- `Expr::resolve_map` re-typed to take `&IndexMap<String, Expr>` and return `HashMap<String, Value>` (the lookup-only shape callers consume — validate, differ, plan display, provider trait). The generic-ised `Expr::wrap_map` accepts any `IntoIterator<Item=(String, Value)>` so `HashMap`-shaped state and `IndexMap`-shaped parser output both round-trip without bespoke conversions.
- `IndexMap::shift_remove` (not `swap_remove`) at the three removal sites that must preserve the rest of the source-authored order: `_prefix` strip in `identifier`, `lifecycle` extraction in the parser, and the block-rename rewrite in `schema`.
- `resolve_forward_references` rewritten with `iter_mut + mem::replace` to avoid an O(n²) `shift_remove` + re-insert per key (caught in the efficiency review).
- `carina-plugin-host`'s `indexmap` lives in `[dev-dependencies]` because only fixtures touch it.

## Test plan

- [x] `cargo test --workspace` — all green:
  - carina-cli 264 + 6 + 1 + 4
  - carina-core 1377
  - carina-lsp 341 unit + 12 e2e + 4 integration
  - carina-plugin-host integration tests
  - **plan_fixture (snapshot) 6/6 stable**
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `carina validate` against `carina-rs/infra/aws/management/{carina-state,github-oidc,identity-center,organizations,route53}` — all 5 dirs validate, no diff vs. main

Closes #2222
Refs #2255
