### PR TITLE
refactor(core): assert closures never escape parse_and_resolve

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -5174,7 +5174,30 @@ fn resolve_value_with_config(
 pub fn parse_and_resolve(input: &str) -> Result<ParsedFile, ParseError> {
     let mut parsed = parse(input, &ProviderContext::default())?;
     resolve_resource_refs(&mut parsed)?;
+    debug_assert!(
+        !parsed_contains_closure(&parsed),
+        "Value::Closure leaked past parse_and_resolve — closures are evaluator-internal \
+         and must be fully applied or folded into a FunctionCall before reaching consumers"
+    );
     Ok(parsed)
+}
+
+/// True when any `Value` reachable from `parsed` is a `Value::Closure`.
+///
+/// Backs the debug-only contract on `parse_and_resolve`. The walk covers
+/// every public surface that downstream consumers iterate.
+fn parsed_contains_closure(parsed: &ParsedFile) -> bool {
+    parsed
+        .resources
+        .iter()
+        .flat_map(|r| r.attributes.values())
+        .any(|expr| expr.as_value().contains_closure())
+        || parsed.variables.values().any(Value::contains_closure)
+        || parsed
+            .providers
+            .iter()
+            .flat_map(|p| p.attributes.values())
+            .any(Value::contains_closure)
 }
 
 #[cfg(test)]
@@ -12501,5 +12524,92 @@ awscc.ec2.Vpc {
             vec!["z_first", "a_second", "m_third"],
             "nested block Value::Map must preserve source key order; got {keys:?}"
         );
+    }
+
+    /// `Value::Closure` is an evaluator-internal representation produced
+    /// during partial application (e.g. `subnets |> map(".id")`). It must
+    /// never survive `parse_and_resolve`: by the time the parser hands a
+    /// `ParsedFile` back, every closure has either been fully applied or
+    /// folded into a `FunctionCall`. If a closure leaks out, downstream
+    /// consumers (validator, plan display, state serializer) silently
+    /// match it as "some other Value variant" and produce wrong output.
+    #[test]
+    fn parse_and_resolve_returns_no_closures() {
+        // A pipe call that fully applies its argument — this is the
+        // common case and the result should be a fully-resolved value
+        // (FunctionCall or evaluated literal), never a Closure.
+        let input = r#"
+            let xs = ["a", "b", "c"]
+            let joined = xs |> join("-")
+        "#;
+        let parsed = parse_and_resolve(input).expect("parse_and_resolve should succeed");
+        assert_no_closure_in_parsed(&parsed);
+    }
+
+    /// Even when the source explicitly partially applies a builtin
+    /// (`join("-")` with arity 2), the closure must not survive
+    /// `parse_and_resolve` — pipelines or other call sites are expected
+    /// to finish the application. If a parse-time partial-application
+    /// shape can't be folded, the parser must surface an error rather
+    /// than letting a closure leak to consumers.
+    ///
+    /// This test currently exercises the "fully consumed via pipe" path;
+    /// any future regression that lets a bare partial application escape
+    /// will trip the `debug_assert!` inside `parse_and_resolve`.
+    #[test]
+    fn partial_application_via_pipe_is_fully_applied() {
+        let input = r#"
+            let parts = ["a", "b"]
+            let joined = parts |> join("-")
+        "#;
+        let parsed = parse_and_resolve(input).expect("parse_and_resolve should succeed");
+        assert_no_closure_in_parsed(&parsed);
+    }
+
+    /// A user-defined function whose body produces a fully-applied call
+    /// must produce a closure-free `ParsedFile`: the closure lives strictly
+    /// inside the evaluator's call frame.
+    #[test]
+    fn parse_and_resolve_with_user_function_returns_no_closures() {
+        let input = r#"
+            fn join_two(a: String, b: String): String {
+                join("-", [a, b])
+            }
+            let result = join_two("begin", "end")
+        "#;
+        let parsed = parse_and_resolve(input).expect("parse_and_resolve should succeed");
+        assert_no_closure_in_parsed(&parsed);
+    }
+
+    /// Walk every `Value` reachable from a `ParsedFile` and panic if any
+    /// is a `Value::Closure`.
+    fn assert_no_closure_in_parsed(parsed: &ParsedFile) {
+        for resource in &parsed.resources {
+            for (key, expr) in &resource.attributes {
+                assert!(
+                    !expr.as_value().contains_closure(),
+                    "resource {} attribute {} contains a Closure",
+                    resource.id.display_type(),
+                    key
+                );
+            }
+        }
+        for (name, value) in &parsed.variables {
+            assert!(
+                !value.contains_closure(),
+                "variable {} contains a Closure",
+                name
+            );
+        }
+        for provider in &parsed.providers {
+            for (name, value) in &provider.attributes {
+                assert!(
+                    !value.contains_closure(),
+                    "provider {} attribute {} contains a Closure",
+                    provider.name,
+                    name
+                );
+            }
+        }
     }
 }

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -383,6 +383,30 @@ impl Value {
         }
     }
 
+    /// Recursively check whether this value contains a `Value::Closure`
+    /// anywhere in its tree. `Value::Closure` is an evaluator-internal
+    /// variant produced during partial application of user functions; it
+    /// must not survive resolution. This walker is the cheap check that
+    /// `parse_and_resolve` and tests use to enforce the contract.
+    pub fn contains_closure(&self) -> bool {
+        match self {
+            Value::Closure { .. } => true,
+            Value::List(items) => items.iter().any(Value::contains_closure),
+            Value::Map(map) => map.values().any(Value::contains_closure),
+            Value::Interpolation(parts) => parts.iter().any(|p| match p {
+                InterpolationPart::Expr(v) => v.contains_closure(),
+                InterpolationPart::Literal(_) => false,
+            }),
+            Value::FunctionCall { args, .. } => args.iter().any(Value::contains_closure),
+            Value::Secret(inner) => inner.contains_closure(),
+            Value::String(_)
+            | Value::Int(_)
+            | Value::Float(_)
+            | Value::Bool(_)
+            | Value::ResourceRef { .. } => false,
+        }
+    }
+
     /// Recursively walk this value, invoking `f` on each `ResourceRef`'s `AccessPath`.
     pub fn visit_refs(&self, f: &mut impl FnMut(&AccessPath)) {
         match self {

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -946,7 +946,10 @@ impl Value {
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),
-            Value::Closure { name, .. } => format!("Closure({})", name),
+            Value::Closure { name, .. } => unreachable!(
+                "Value::Closure({name}) reached schema::Value::type_name — closures are \
+                 evaluator-internal and must not survive resolution"
+            ),
         }
     }
 }


### PR DESCRIPTION
## Summary

Takes the lighter of the two approaches in #2230 — keep ``Value::Closure`` in the public ``Value`` enum, but prove via ``debug_assert!`` that it never survives ``parse_and_resolve``.

- ``Value::contains_closure(&self)`` — recursive walker over every variant that can hold a ``Value``.
- ``parse_and_resolve`` ends with a ``debug_assert!`` that walks every ``Value`` reachable from the returned ``ParsedFile``. Any surviving closure trips loudly.
- ``schema::Value::type_name``'s ``Value::Closure`` arm is now ``unreachable!()`` rather than returning ``\"Closure(name)\"``. Schema diagnostics are post-resolve; a closure there is a contract break.

The full split (``InternalValue`` vs ``Value``) was rejected as too invasive for the value: every consumer would need to pivot, and the leak is structural-but-rare.

## Acceptance criteria (from #2230)

- [x] Validation, LSP, display, and state code no longer need explicit ``Value::Closure`` arms (or they assert-unreachable). ``schema::Value::type_name`` now ``unreachable!()``s; LSP/CLI/state never had explicit arms.
- [x] Internal evaluator tests still pass for partial application (19 ``partial_application_*`` tests pass).
- [x] A test verifies that ``parse_and_resolve`` never returns a ``Closure`` to its caller (``parse_and_resolve_returns_no_closures``, ``parse_and_resolve_with_user_function_returns_no_closures``, ``partial_application_via_pipe_is_fully_applied``).

## Test plan

- [x] ``cargo test -p carina-core --lib`` — 1385 passed
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo fmt --check``

Closes #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)