### PR TITLE
refactor(core): split Value::Closure into evaluator-internal EvalValue

### DIFF
--- a/carina-core/src/builtins/cidr_subnet.rs
+++ b/carina-core/src/builtins/cidr_subnet.rs
@@ -149,7 +149,7 @@ fn calculate_cidr_subnet(prefix: &str, newbits: i64, netnum: i64) -> Result<Stri
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     fn cidr_subnet(prefix: &str, newbits: i64, netnum: i64) -> Result<Value, String> {
@@ -298,10 +298,12 @@ mod tests {
 
     #[test]
     fn partial_application_with_two_args() {
+        use crate::builtins::evaluate_builtin_for_tests;
+        use crate::eval_value::EvalValue;
         let args = vec![Value::String("10.0.0.0/16".to_string()), Value::Int(8)];
-        let result = evaluate_builtin("cidr_subnet", &args).unwrap();
+        let result = evaluate_builtin_for_tests("cidr_subnet", &args).unwrap();
         match result {
-            Value::Closure {
+            EvalValue::Closure {
                 name,
                 captured_args,
                 remaining_arity,

--- a/carina-core/src/builtins/concat.rs
+++ b/carina-core/src/builtins/concat.rs
@@ -56,7 +56,7 @@ pub(crate) fn builtin_concat(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]
@@ -148,8 +148,9 @@ mod tests {
 
     #[test]
     fn concat_partial_application_one_arg() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![Value::List(vec![Value::Int(1)])];
-        let result = evaluate_builtin("concat", &args).unwrap();
+        let result = evaluate_builtin_for_tests("concat", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/decrypt.rs
+++ b/carina-core/src/builtins/decrypt.rs
@@ -82,7 +82,7 @@ fn parse_decrypt_args(args: &[Value]) -> Result<(&str, Option<&str>), String> {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::builtins::evaluate_builtin_with_config;
+    use crate::builtins::evaluate_builtin_with_config_to_value as evaluate_builtin_with_config;
     use crate::parser::ProviderContext;
     use crate::resource::Value;
 

--- a/carina-core/src/builtins/env.rs
+++ b/carina-core/src/builtins/env.rs
@@ -40,7 +40,7 @@ pub(crate) fn builtin_env(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/flatten.rs
+++ b/carina-core/src/builtins/flatten.rs
@@ -46,7 +46,7 @@ pub(crate) fn builtin_flatten(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/join.rs
+++ b/carina-core/src/builtins/join.rs
@@ -60,7 +60,7 @@ pub(crate) fn builtin_join(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]
@@ -123,8 +123,9 @@ mod tests {
 
     #[test]
     fn join_partial_application() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![Value::String("-".to_string())];
-        let result = evaluate_builtin("join", &args).unwrap();
+        let result = evaluate_builtin_for_tests("join", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/keys_values.rs
+++ b/carina-core/src/builtins/keys_values.rs
@@ -66,7 +66,7 @@ pub(crate) fn builtin_values(args: &[Value]) -> Result<Value, String> {
 mod tests {
     use indexmap::IndexMap;
 
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/length.rs
+++ b/carina-core/src/builtins/length.rs
@@ -35,7 +35,7 @@ pub(crate) fn builtin_length(args: &[Value]) -> Result<Value, String> {
 mod tests {
     use indexmap::IndexMap;
 
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/lookup.rs
+++ b/carina-core/src/builtins/lookup.rs
@@ -51,7 +51,7 @@ pub(crate) fn builtin_lookup(args: &[Value]) -> Result<Value, String> {
 mod tests {
     use indexmap::IndexMap;
 
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]
@@ -114,11 +114,12 @@ mod tests {
 
     #[test]
     fn lookup_partial_application() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![
             Value::Map(IndexMap::new()),
             Value::String("key".to_string()),
         ];
-        let result = evaluate_builtin("lookup", &args).unwrap();
+        let result = evaluate_builtin_for_tests("lookup", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/map.rs
+++ b/carina-core/src/builtins/map.rs
@@ -83,7 +83,7 @@ pub(crate) fn builtin_map(args: &[Value]) -> Result<Value, String> {
 mod tests {
     use indexmap::IndexMap;
 
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     fn make_map(pairs: Vec<(&str, Value)>) -> Value {
@@ -159,8 +159,9 @@ mod tests {
 
     #[test]
     fn map_partial_application_one_arg() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![Value::String(".field".to_string())];
-        let result = evaluate_builtin("map", &args).unwrap();
+        let result = evaluate_builtin_for_tests("map", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/min_max.rs
+++ b/carina-core/src/builtins/min_max.rs
@@ -93,7 +93,7 @@ fn compare_values(
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     // ── min() tests ──
@@ -149,7 +149,8 @@ mod tests {
 
     #[test]
     fn min_partial_application_one_arg() {
-        let result = evaluate_builtin("min", &[Value::Int(1)]).unwrap();
+        use crate::builtins::evaluate_builtin_for_tests;
+        let result = evaluate_builtin_for_tests("min", &[Value::Int(1)]).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -384,12 +384,8 @@ pub fn is_known_builtin(name: &str) -> bool {
 /// `result.is_closure()` keep working without forcing each test to
 /// allocate `EvalValue` arguments by hand.
 #[cfg(test)]
-pub(crate) fn evaluate_builtin_for_tests(
-    name: &str,
-    args: &[Value],
-) -> Result<EvalValue, String> {
-    let eval_args: Vec<EvalValue> =
-        args.iter().cloned().map(EvalValue::from_value).collect();
+pub(crate) fn evaluate_builtin_for_tests(name: &str, args: &[Value]) -> Result<EvalValue, String> {
+    let eval_args: Vec<EvalValue> = args.iter().cloned().map(EvalValue::from_value).collect();
     evaluate_builtin(name, &eval_args)
 }
 
@@ -403,8 +399,7 @@ pub(crate) fn evaluate_builtin_with_config_to_value(
     args: &[Value],
     config: &ProviderContext,
 ) -> Result<Value, String> {
-    let eval_args: Vec<EvalValue> =
-        args.iter().cloned().map(EvalValue::from_value).collect();
+    let eval_args: Vec<EvalValue> = args.iter().cloned().map(EvalValue::from_value).collect();
     let result = evaluate_builtin_with_config(name, &eval_args, config)?;
     result.into_value().map_err(|leak| {
         format!(

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -20,6 +20,7 @@ mod split;
 mod trim;
 mod upper_lower;
 
+use crate::eval_value::EvalValue;
 use crate::parser::ProviderContext;
 use crate::resource::Value;
 
@@ -105,26 +106,67 @@ macro_rules! register_builtins {
 
         /// Evaluate a built-in function by name with the given arguments.
         ///
-        /// If fewer arguments than the arity are provided, returns a
-        /// `Value::Closure` capturing the partial arguments.
-        /// Returns `Err` if the function is unknown or if the arguments are invalid.
-        pub fn evaluate_builtin(name: &str, args: &[Value]) -> Result<Value, String> {
+        /// If fewer arguments than the arity are provided, returns an
+        /// `EvalValue::Closure` capturing the partial arguments.
+        /// Returns `Err` if the function is unknown, the arguments are
+        /// invalid, or one of the supplied arguments is itself a closure.
+        pub(crate) fn evaluate_builtin(
+            name: &str,
+            args: &[EvalValue],
+        ) -> Result<EvalValue, String> {
             match name {
                 $(
                     stringify!($name) => {
                         let arity: usize = $arity;
                         if !args.is_empty() && args.len() < arity {
-                            return Ok(Value::Closure {
-                                name: name.to_string(),
-                                captured_args: args.to_vec(),
-                                remaining_arity: arity - args.len(),
-                            });
+                            return Ok(EvalValue::closure(
+                                name,
+                                args.to_vec(),
+                                arity - args.len(),
+                            ));
                         }
-                        $handler(args)
+                        // Lower each argument to a `Value` for the
+                        // handler. Handlers expect fully-reduced inputs,
+                        // so a closure here is a usage error: the caller
+                        // tried to pass a partially-applied function as a
+                        // data argument.
+                        let lowered: Result<Vec<Value>, String> = args
+                            .iter()
+                            .cloned()
+                            .map(|arg| {
+                                arg.into_value().map_err(|leak| {
+                                    format!(
+                                        "{}: closure '{}' (still needs {} arg(s)) cannot be \
+                                         used as a data argument; finish the partial \
+                                         application first",
+                                        name, leak.name, leak.remaining_arity
+                                    )
+                                })
+                            })
+                            .collect();
+                        $handler(&lowered?).map(EvalValue::from_value)
                     }
                 )*
                 _ => Err(format!("Unknown built-in function: {name}")),
             }
+        }
+
+        /// Public alias that lowers an `EvalValue` result to a `Value`
+        /// for callers that don't care about the closure case (e.g.
+        /// LSP-style hover preview that just wants "what does this call
+        /// produce"). Returns `Err` if the call would produce a closure.
+        pub fn evaluate_builtin_to_value(
+            name: &str,
+            args: &[Value],
+        ) -> Result<Value, String> {
+            let eval_args: Vec<EvalValue> = args.iter().cloned().map(EvalValue::from_value).collect();
+            let result = evaluate_builtin(name, &eval_args)?;
+            result.into_value().map_err(|leak| {
+                format!(
+                    "{}: would return a closure ({} arg(s) still needed)",
+                    leak.name, leak.remaining_arity
+                )
+            })
         }
     };
 }
@@ -227,77 +269,19 @@ register_builtins! {
     },
 }
 
-/// Apply additional arguments to a Closure.
-///
-/// Merges `new_args` into the closure's captured args. If enough arguments are
-/// now present, evaluates the underlying built-in function. Otherwise returns
-/// a new Closure with updated captured args and remaining arity.
-pub fn apply_closure(
-    name: &str,
-    captured_args: &[Value],
-    remaining_arity: usize,
-    new_args: &[Value],
-) -> Result<Value, String> {
-    // Handle composed closures: pipe the argument through each function in sequence
-    if name == "__compose__" {
-        if new_args.len() != 1 {
-            return Err(format!(
-                "composed function expects exactly 1 argument, got {}",
-                new_args.len(),
-            ));
-        }
-        let mut result = new_args[0].clone();
-        for func in captured_args {
-            if let Value::Closure {
-                name: fn_name,
-                captured_args: fn_captured,
-                remaining_arity: fn_remaining,
-            } = func
-            {
-                result = apply_closure(fn_name, fn_captured, *fn_remaining, &[result])?;
-            } else {
-                return Err(format!(
-                    "composed function chain contains a non-Closure value: {:?}",
-                    func
-                ));
-            }
-        }
-        return Ok(result);
-    }
-
-    if new_args.len() > remaining_arity {
-        return Err(format!(
-            "{}() closure expects {} more argument{}, got {}",
-            name,
-            remaining_arity,
-            if remaining_arity == 1 { "" } else { "s" },
-            new_args.len(),
-        ));
-    }
-    let mut all_args = captured_args.to_vec();
-    all_args.extend_from_slice(new_args);
-    let new_remaining = remaining_arity - new_args.len();
-    if new_remaining == 0 {
-        evaluate_builtin(name, &all_args)
-    } else {
-        Ok(Value::Closure {
-            name: name.to_string(),
-            captured_args: all_args,
-            remaining_arity: new_remaining,
-        })
-    }
-}
-
 /// Apply additional arguments to a Closure using parser configuration.
 ///
-/// Same as [`apply_closure`] but routes `decrypt` through the config-aware path.
-pub fn apply_closure_with_config(
+/// Merges `new_args` into the closure's captured args. If enough arguments
+/// are now present, evaluates the underlying built-in function (routing
+/// `decrypt` through the config-aware path). Otherwise returns a new
+/// `EvalValue::Closure` with updated captured args and remaining arity.
+pub(crate) fn apply_closure_with_config(
     name: &str,
-    captured_args: &[Value],
+    captured_args: &[EvalValue],
     remaining_arity: usize,
-    new_args: &[Value],
+    new_args: &[EvalValue],
     config: &ProviderContext,
-) -> Result<Value, String> {
+) -> Result<EvalValue, String> {
     // Handle composed closures: pipe the argument through each function in sequence
     if name == "__compose__" {
         if new_args.len() != 1 {
@@ -308,7 +292,7 @@ pub fn apply_closure_with_config(
         }
         let mut result = new_args[0].clone();
         for func in captured_args {
-            if let Value::Closure {
+            if let EvalValue::Closure {
                 name: fn_name,
                 captured_args: fn_captured,
                 remaining_arity: fn_remaining,
@@ -346,11 +330,7 @@ pub fn apply_closure_with_config(
     if new_remaining == 0 {
         evaluate_builtin_with_config(name, &all_args, config)
     } else {
-        Ok(Value::Closure {
-            name: name.to_string(),
-            captured_args: all_args,
-            remaining_arity: new_remaining,
-        })
+        Ok(EvalValue::closure(name, all_args, new_remaining))
     }
 }
 
@@ -358,24 +338,37 @@ pub fn apply_closure_with_config(
 ///
 /// This dispatches `decrypt` to use the decryptor from the config instead of
 /// the global Mutex. All other builtins are delegated to [`evaluate_builtin`].
-pub fn evaluate_builtin_with_config(
+pub(crate) fn evaluate_builtin_with_config(
     name: &str,
-    args: &[Value],
+    args: &[EvalValue],
     config: &ProviderContext,
-) -> Result<Value, String> {
+) -> Result<EvalValue, String> {
     // Check for partial application before dispatching
     if let Some(arity) = builtin_arity(name)
         && !args.is_empty()
         && args.len() < arity
     {
-        return Ok(Value::Closure {
-            name: name.to_string(),
-            captured_args: args.to_vec(),
-            remaining_arity: arity - args.len(),
-        });
+        return Ok(EvalValue::closure(name, args.to_vec(), arity - args.len()));
     }
     match name {
-        "decrypt" => decrypt::builtin_decrypt_with_config(args, config),
+        "decrypt" => {
+            // `decrypt` is the only handler that needs the parser config.
+            // It still operates on `&[Value]` so we lower the arguments.
+            let lowered: Result<Vec<Value>, String> = args
+                .iter()
+                .cloned()
+                .map(|arg| {
+                    arg.into_value().map_err(|leak| {
+                        format!(
+                            "decrypt: closure '{}' (still needs {} arg(s)) cannot be \
+                             used as a data argument; finish the partial application first",
+                            leak.name, leak.remaining_arity
+                        )
+                    })
+                })
+                .collect();
+            decrypt::builtin_decrypt_with_config(&lowered?, config).map(EvalValue::from_value)
+        }
         _ => evaluate_builtin(name, args),
     }
 }
@@ -383,6 +376,42 @@ pub fn evaluate_builtin_with_config(
 /// Check if a function name is a known built-in function.
 pub fn is_known_builtin(name: &str) -> bool {
     builtin_functions().iter().any(|f| f.name == name)
+}
+
+/// Test-only helper: dispatch a built-in by lifting `&[Value]` to
+/// `&[EvalValue]` and returning the raw `EvalValue` result. Used by the
+/// per-builtin test modules so existing assertions like
+/// `result.is_closure()` keep working without forcing each test to
+/// allocate `EvalValue` arguments by hand.
+#[cfg(test)]
+pub(crate) fn evaluate_builtin_for_tests(
+    name: &str,
+    args: &[Value],
+) -> Result<EvalValue, String> {
+    let eval_args: Vec<EvalValue> =
+        args.iter().cloned().map(EvalValue::from_value).collect();
+    evaluate_builtin(name, &eval_args)
+}
+
+/// `evaluate_builtin_with_config`'s `Value`-friendly counterpart for
+/// tests. Lifts arguments to `EvalValue`, dispatches, and lowers the
+/// result back to `Value` — failing on closure leaks the same way
+/// production code does.
+#[cfg(test)]
+pub(crate) fn evaluate_builtin_with_config_to_value(
+    name: &str,
+    args: &[Value],
+    config: &ProviderContext,
+) -> Result<Value, String> {
+    let eval_args: Vec<EvalValue> =
+        args.iter().cloned().map(EvalValue::from_value).collect();
+    let result = evaluate_builtin_with_config(name, &eval_args, config)?;
+    result.into_value().map_err(|leak| {
+        format!(
+            "{}: would return a closure ({} arg(s) still needed)",
+            leak.name, leak.remaining_arity
+        )
+    })
 }
 
 /// Return a human-readable type name for a Value
@@ -398,7 +427,6 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
         Value::Secret(_) => "Secret",
-        Value::Closure { .. } => "Closure",
     }
 }
 

--- a/carina-core/src/builtins/replace.rs
+++ b/carina-core/src/builtins/replace.rs
@@ -62,7 +62,7 @@ pub(crate) fn builtin_replace(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]
@@ -146,11 +146,12 @@ mod tests {
 
     #[test]
     fn replace_partial_application() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![
             Value::String("hello".to_string()),
             Value::String("-".to_string()),
         ];
-        let result = evaluate_builtin("replace", &args).unwrap();
+        let result = evaluate_builtin_for_tests("replace", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/secret.rs
+++ b/carina-core/src/builtins/secret.rs
@@ -22,7 +22,7 @@ pub(crate) fn builtin_secret(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/split.rs
+++ b/carina-core/src/builtins/split.rs
@@ -53,7 +53,7 @@ pub(crate) fn builtin_split(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]
@@ -145,8 +145,9 @@ mod tests {
 
     #[test]
     fn split_partial_application() {
+        use crate::builtins::evaluate_builtin_for_tests;
         let args = vec![Value::String("-".to_string())];
-        let result = evaluate_builtin("split", &args).unwrap();
+        let result = evaluate_builtin_for_tests("split", &args).unwrap();
         assert!(result.is_closure());
     }
 

--- a/carina-core/src/builtins/trim.rs
+++ b/carina-core/src/builtins/trim.rs
@@ -37,7 +37,7 @@ pub(crate) fn builtin_trim(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/builtins/upper_lower.rs
+++ b/carina-core/src/builtins/upper_lower.rs
@@ -58,7 +58,7 @@ pub(crate) fn builtin_lower(args: &[Value]) -> Result<Value, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::builtins::evaluate_builtin;
+    use crate::builtins::evaluate_builtin_to_value as evaluate_builtin;
     use crate::resource::Value;
 
     #[test]

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -288,30 +288,10 @@ mod tests {
         assert_eq!(deps.len(), 2);
     }
 
-    /// Regression: a ResourceRef inside a `Closure`'s captured args must show
-    /// up as a dependency. The prior hand-rolled walk had no `Closure` arm
-    /// and silently dropped these refs, which in turn let the topological
-    /// sort place the dependent resource before its upstream.
-    #[test]
-    fn collect_dependencies_finds_refs_inside_closure() {
-        let mut resource = Resource::new("test", "a");
-        resource.binding = Some("a".to_string());
-        resource.set_attr(
-            "fn".to_string(),
-            Value::Closure {
-                name: "map".to_string(),
-                captured_args: vec![Value::resource_ref("upstream", "id", vec![])],
-                remaining_arity: 1,
-            },
-        );
-
-        let deps = get_resource_dependencies(&resource);
-        assert!(
-            deps.contains("upstream"),
-            "Expected deps to include 'upstream' from Closure captured_args. Got: {:?}",
-            deps
-        );
-    }
+    // Closure-in-attribute regression test deleted: `Value::Closure` no
+    // longer exists, so a closure can never reach `Resource.attributes`.
+    // The original concern (refs inside captured args getting silently
+    // dropped from dependency walks) is now type-impossible.
 
     /// Regression test for #1078: when resolve_refs_with_state partially resolves
     /// a transitive reference (e.g., `tgw_attach.transit_gateway_id` resolves to

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1192,15 +1192,11 @@ mod tests {
         };
         assert!(value_references_binding(&function_call, "vpc"));
 
-        let secret = Value::Secret(Box::new(refs_vpc.clone()));
+        let secret = Value::Secret(Box::new(refs_vpc));
         assert!(value_references_binding(&secret, "vpc"));
 
-        let closure = Value::Closure {
-            name: "map".to_string(),
-            captured_args: vec![refs_vpc],
-            remaining_arity: 1,
-        };
-        assert!(value_references_binding(&closure, "vpc"));
+        // Closure variant removed from `Value` (issue #2230): closures
+        // live on `EvalValue` and never reach this code path.
 
         // Still false when the binding is genuinely absent.
         assert!(!value_references_binding(

--- a/carina-core/src/eval_value.rs
+++ b/carina-core/src/eval_value.rs
@@ -1,0 +1,127 @@
+//! Evaluator-internal values.
+//!
+//! `Value` is the public, user-facing type that flows through `ParsedFile`,
+//! `Resource.attributes`, plan display, state serialization, and the LSP.
+//! Every variant of `Value` is something a `.crn` author can directly
+//! observe in their configuration.
+//!
+//! `EvalValue` is the strictly internal type used while the evaluator is
+//! reducing expressions. It adds one variant — `Closure` — to represent a
+//! partially applied builtin or user function. Closures are produced when
+//! a function receives fewer arguments than its arity, and are consumed
+//! by the next pipe / call that finishes the application.
+//!
+//! The split is enforced by the type system: a `Closure` cannot appear
+//! anywhere a `Value` is expected. The boundary is `EvalValue::into_value`,
+//! which returns `Err(ClosureLeak)` if a closure tried to escape the
+//! evaluator. Consumers that match on `Value` therefore never need a
+//! `Closure` arm — the variant does not exist for them.
+//!
+//! See #2230 for the design discussion.
+
+use crate::resource::Value;
+
+/// Evaluator-internal value. Carries everything `Value` carries plus an
+/// extra `Closure` variant for partial application.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum EvalValue {
+    /// A user-facing value. Anything reachable from `Value` is reachable
+    /// here without loss.
+    User(Value),
+
+    /// A partially applied function. Lives strictly inside the evaluator.
+    /// Constructed when `evaluate_builtin` or a user-function call sees
+    /// fewer arguments than the function's arity; consumed by the next
+    /// pipe or call that finishes the application.
+    Closure {
+        /// Original function name.
+        name: String,
+        /// Arguments already supplied, in order.
+        captured_args: Vec<EvalValue>,
+        /// How many more arguments the function still needs.
+        remaining_arity: usize,
+    },
+}
+
+/// Returned by `EvalValue::into_value` when a closure would otherwise
+/// escape the evaluator. The caller should propagate this as a
+/// configuration error: a closure that doesn't get applied means the
+/// user wrote a partial application without finishing it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ClosureLeak {
+    pub name: String,
+    pub remaining_arity: usize,
+}
+
+impl EvalValue {
+    /// Wrap a user-facing `Value`. This is the cheap, infallible
+    /// direction — every `Value` is a valid `EvalValue`.
+    pub(crate) fn from_value(value: Value) -> Self {
+        Self::User(value)
+    }
+
+    /// Build a closure value from its parts.
+    pub(crate) fn closure(
+        name: impl Into<String>,
+        captured_args: Vec<EvalValue>,
+        remaining_arity: usize,
+    ) -> Self {
+        Self::Closure {
+            name: name.into(),
+            captured_args,
+            remaining_arity,
+        }
+    }
+
+    /// True when this value is a `Closure`.
+    pub(crate) fn is_closure(&self) -> bool {
+        matches!(self, Self::Closure { .. })
+    }
+
+    /// Lower an `EvalValue` to a user-facing `Value`. This is the
+    /// boundary where the evaluator hands a result off to a public
+    /// consumer (parser-level let-binding storage, resolver output,
+    /// builtin handler input, etc.). If a closure is still here, the
+    /// caller wrote a partial application that never completed.
+    pub(crate) fn into_value(self) -> Result<Value, ClosureLeak> {
+        match self {
+            Self::User(v) => Ok(v),
+            Self::Closure {
+                name,
+                remaining_arity,
+                ..
+            } => Err(ClosureLeak {
+                name,
+                remaining_arity,
+            }),
+        }
+    }
+}
+
+impl From<Value> for EvalValue {
+    fn from(value: Value) -> Self {
+        Self::User(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resource::Value;
+
+    #[test]
+    fn user_round_trips() {
+        let original = Value::String("hi".into());
+        let eval = EvalValue::from_value(original.clone());
+        assert_eq!(eval.into_value().unwrap(), original);
+    }
+
+    #[test]
+    fn closure_into_value_returns_leak() {
+        let eval = EvalValue::closure("join", vec![], 2);
+        let err = eval.into_value().unwrap_err();
+        assert_eq!(err.name, "join");
+        assert_eq!(err.remaining_arity, 2);
+    }
+
+}

--- a/carina-core/src/eval_value.rs
+++ b/carina-core/src/eval_value.rs
@@ -123,5 +123,4 @@ mod tests {
         assert_eq!(err.name, "join");
         assert_eq!(err.remaining_arity, 2);
     }
-
 }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -199,22 +199,6 @@ fn deterministic_value_string(value: &Value) -> String {
         Value::Secret(inner) => {
             format!("Secret({})", deterministic_value_string(inner))
         }
-        Value::Closure {
-            name,
-            captured_args,
-            remaining_arity,
-        } => {
-            let arg_strs: Vec<String> = captured_args
-                .iter()
-                .map(deterministic_value_string)
-                .collect();
-            format!(
-                "Closure({}({}) remaining={})",
-                name,
-                arg_strs.join(", "),
-                remaining_arity
-            )
-        }
     }
 }
 

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod detail_rows;
 pub mod diff_helpers;
 pub mod differ;
 pub mod effect;
+pub(crate) mod eval_value;
 pub mod executor;
 pub mod formatter;
 pub mod heredoc;

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -175,19 +175,6 @@ fn format_value(value: &Value) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
-        Value::Closure {
-            name,
-            captured_args,
-            remaining_arity,
-        } => {
-            let total = captured_args.len() + remaining_arity;
-            format!(
-                "<closure: {}({}/{} args)>",
-                name,
-                captured_args.len(),
-                total
-            )
-        }
     }
 }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -1761,7 +1761,12 @@ fn parse_module_call(
 /// rather than `Value` so partial applications (closures) can survive
 /// until a later pipe finishes them; the surrounding parse pass lowers
 /// each binding to `Value` at the end of `parse(...)`.
-type LetBindingRhs = (EvalValue, Vec<Resource>, Vec<ModuleCall>, Option<UseStatement>);
+type LetBindingRhs = (
+    EvalValue,
+    Vec<Resource>,
+    Vec<ModuleCall>,
+    Option<UseStatement>,
+);
 
 /// Extended parse_let_binding that also handles module calls, imports, and for expressions.
 ///
@@ -1952,13 +1957,14 @@ fn parse_pipe_expr_with_resource_or_module(
             // Build closure-application args. The pipe value (`x` in
             // `x |> f`) goes as the last argument; we keep it as
             // EvalValue so a chained closure can pipe through.
-            let mut all_args: Vec<EvalValue> =
-                extra_args.iter().cloned().map(EvalValue::from_value).collect();
+            let mut all_args: Vec<EvalValue> = extra_args
+                .iter()
+                .cloned()
+                .map(EvalValue::from_value)
+                .collect();
             all_args.push(value.clone());
             if extra_args.iter().all(is_static_value)
-                && pipe_value_for_args
-                    .as_ref()
-                    .is_some_and(is_static_value)
+                && pipe_value_for_args.as_ref().is_some_and(is_static_value)
             {
                 value = crate::builtins::apply_closure_with_config(
                     fn_name,
@@ -2000,15 +2006,12 @@ fn parse_pipe_expr_with_resource_or_module(
         {
             let eval_args: Vec<EvalValue> =
                 args.iter().cloned().map(EvalValue::from_value).collect();
-            value = crate::builtins::evaluate_builtin_with_config(
-                &func_name,
-                &eval_args,
-                ctx.config,
-            )
-            .map_err(|e| ParseError::InvalidExpression {
-                line: 0,
-                message: format!("{}(): {}", func_name, e),
-            })?;
+            value =
+                crate::builtins::evaluate_builtin_with_config(&func_name, &eval_args, ctx.config)
+                    .map_err(|e| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!("{}(): {}", func_name, e),
+                })?;
             continue;
         }
 
@@ -2032,7 +2035,12 @@ fn parse_primary_with_resource_or_module(
         Rule::read_resource_expr => {
             let resource = parse_read_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((EvalValue::from_value(ref_value), vec![resource], vec![], None))
+            Ok((
+                EvalValue::from_value(ref_value),
+                vec![resource],
+                vec![],
+                None,
+            ))
         }
         Rule::upstream_state_expr => {
             let (line, _) = inner.as_span().start_pos().line_col();
@@ -2050,12 +2058,22 @@ fn parse_primary_with_resource_or_module(
         Rule::resource_expr => {
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((EvalValue::from_value(ref_value), vec![resource], vec![], None))
+            Ok((
+                EvalValue::from_value(ref_value),
+                vec![resource],
+                vec![],
+                None,
+            ))
         }
         Rule::for_expr => {
             let (resources, module_calls) = parse_for_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{for:{}}}", binding_name));
-            Ok((EvalValue::from_value(ref_value), resources, module_calls, None))
+            Ok((
+                EvalValue::from_value(ref_value),
+                resources,
+                module_calls,
+                None,
+            ))
         }
         Rule::if_expr => {
             let (value, resources, module_calls, import) = parse_if_expr(inner, ctx, binding_name)?;
@@ -2519,14 +2537,16 @@ fn parse_for_iterable(
     // for_iterable contains function_call | list | variable_ref | "(" expression ")"
     let inner = first_inner(pair, "iterable expression", "for iterable")?;
     let eval = parse_primary_eval(inner, ctx)?;
-    let value = eval.into_value().map_err(|leak| ParseError::InvalidExpression {
-        line: 0,
-        message: format!(
-            "for iterable evaluates to a closure '{}' (still needs {} arg(s)); \
+    let value = eval
+        .into_value()
+        .map_err(|leak| ParseError::InvalidExpression {
+            line: 0,
+            message: format!(
+                "for iterable evaluates to a closure '{}' (still needs {} arg(s)); \
              closures cannot be iterated",
-            leak.name, leak.remaining_arity
-        ),
-    })?;
+                leak.name, leak.remaining_arity
+            ),
+        })?;
     evaluate_static_value(value, ctx.config)
 }
 
@@ -2584,14 +2604,16 @@ fn evaluate_static_value(value: Value, config: &ProviderContext) -> Result<Value
                     line: 0,
                     message: format!("for iterable function call '{name}' failed: {e}"),
                 })?;
-            result.into_value().map_err(|leak| ParseError::InvalidExpression {
-                line: 0,
-                message: format!(
-                    "for iterable function call '{name}' returned a closure '{}' \
+            result
+                .into_value()
+                .map_err(|leak| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "for iterable function call '{name}' returned a closure '{}' \
                      (still needs {} arg(s)); finish the partial application",
-                    leak.name, leak.remaining_arity
-                ),
-            })
+                        leak.name, leak.remaining_arity
+                    ),
+                })
         }
         other => Ok(other),
     }
@@ -3631,14 +3653,16 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                     line: 0,
                     message: e,
                 })?;
-                return result.into_value().map_err(|leak| ParseError::InvalidExpression {
-                    line: 0,
-                    message: format!(
-                        "applying closure '{}' (still needs {} arg(s)) leaves a closure; \
+                return result
+                    .into_value()
+                    .map_err(|leak| ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "applying closure '{}' (still needs {} arg(s)) leaves a closure; \
                          finish the partial application before using the result as data",
-                        leak.name, leak.remaining_arity
-                    ),
-                });
+                            leak.name, leak.remaining_arity
+                        ),
+                    });
             }
 
             // Try built-in first (with config for decrypt support)
@@ -3648,14 +3672,16 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                 .map(EvalValue::from_value)
                 .collect();
             match crate::builtins::evaluate_builtin_with_config(name, &eval_args, ctx.config) {
-                Ok(result) => result.into_value().map_err(|leak| ParseError::InvalidExpression {
-                    line: 0,
-                    message: format!(
-                        "{}(): produced a closure '{}' (still needs {} arg(s)); \
+                Ok(result) => result
+                    .into_value()
+                    .map_err(|leak| ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "{}(): produced a closure '{}' (still needs {} arg(s)); \
                          finish the partial application before using the result as data",
-                        name, leak.name, leak.remaining_arity
-                    ),
-                }),
+                            name, leak.name, leak.remaining_arity
+                        ),
+                    }),
                 Err(_builtin_err) => {
                     // Try user-defined function
                     if let Some(user_fn) = ctx.user_functions.get(name) {
@@ -4353,14 +4379,15 @@ fn parse_expression(
     ctx: &ParseContext,
 ) -> Result<Value, ParseError> {
     let eval = parse_expression_eval(pair, ctx)?;
-    eval.into_value().map_err(|leak| ParseError::InvalidExpression {
-        line: 0,
-        message: format!(
-            "expression evaluates to a closure '{}' (still needs {} arg(s)); finish the \
+    eval.into_value()
+        .map_err(|leak| ParseError::InvalidExpression {
+            line: 0,
+            message: format!(
+                "expression evaluates to a closure '{}' (still needs {} arg(s)); finish the \
              partial application — closures are not valid as data",
-            leak.name, leak.remaining_arity
-        ),
-    })
+                leak.name, leak.remaining_arity
+            ),
+        })
 }
 
 /// Parse an expression and return the raw `EvalValue`, preserving any
@@ -4478,8 +4505,11 @@ fn parse_pipe_expr(
             remaining_arity,
         }) = ctx.get_variable(&func_name)
         {
-            let mut all_args: Vec<EvalValue> =
-                extra_args.iter().cloned().map(EvalValue::from_value).collect();
+            let mut all_args: Vec<EvalValue> = extra_args
+                .iter()
+                .cloned()
+                .map(EvalValue::from_value)
+                .collect();
             all_args.push(value.clone());
             if all_args.iter().all(is_static_eval) {
                 value = crate::builtins::apply_closure_with_config(
@@ -4531,9 +4561,7 @@ fn parse_pipe_expr(
                 let eval_args: Vec<EvalValue> =
                     args.iter().cloned().map(EvalValue::from_value).collect();
                 value = crate::builtins::evaluate_builtin_with_config(
-                    &func_name,
-                    &eval_args,
-                    ctx.config,
+                    &func_name, &eval_args, ctx.config,
                 )
                 .map_err(|e| ParseError::InvalidExpression {
                     line: 0,
@@ -4734,9 +4762,7 @@ fn parse_primary_eval(
                 let eval_args: Vec<EvalValue> =
                     args.iter().cloned().map(EvalValue::from_value).collect();
                 return crate::builtins::evaluate_builtin_with_config(
-                    &func_name,
-                    &eval_args,
-                    ctx.config,
+                    &func_name, &eval_args, ctx.config,
                 )
                 .map_err(|e| ParseError::InvalidExpression {
                     line: 0,
@@ -5358,14 +5384,16 @@ fn resolve_value_with_config(
                 .map(EvalValue::from_value)
                 .collect();
             match crate::builtins::evaluate_builtin_with_config(name, &eval_args, config) {
-                Ok(result) => result.into_value().map_err(|leak| ParseError::InvalidExpression {
-                    line: 0,
-                    message: format!(
-                        "{}(): produced a closure '{}' (still needs {} arg(s)); \
+                Ok(result) => result
+                    .into_value()
+                    .map_err(|leak| ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "{}(): produced a closure '{}' (still needs {} arg(s)); \
                          finish the partial application before using the result as data",
-                        name, leak.name, leak.remaining_arity
-                    ),
-                }),
+                            name, leak.name, leak.remaining_arity
+                        ),
+                    }),
                 Err(e) => {
                     if all_args_resolved {
                         // All args are resolved but builtin failed — propagate the error
@@ -5413,7 +5441,10 @@ mod tests {
             let joined = xs |> join("-")
         "#;
         let parsed = parse_and_resolve(input).expect("parse_and_resolve should succeed");
-        let joined = parsed.variables.get("joined").expect("joined binding present");
+        let joined = parsed
+            .variables
+            .get("joined")
+            .expect("joined binding present");
         // No `Closure` arm exists on `Value`, so the only way this
         // could fail is if the call survived as a `FunctionCall` —
         // also a valid `Value`, never a closure. The point of the
@@ -11199,8 +11230,8 @@ arguments {
         let input = r#"
             let transform = split(",") >> join("-") >> split("-")
         "#;
-        let result = parse(input, &ProviderContext::default())
-            .expect("three-way composition should parse");
+        let result =
+            parse(input, &ProviderContext::default()).expect("three-way composition should parse");
         assert!(result.variables.get("transform").is_none());
     }
 

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -8,6 +8,7 @@ pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 
 use indexmap::IndexMap;
 
+use crate::eval_value::EvalValue;
 use crate::resource::{Expr, LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
 use crate::schema::{
     validate_ipv4_address, validate_ipv4_cidr, validate_ipv6_address, validate_ipv6_cidr,
@@ -769,7 +770,13 @@ fn substitute_placeholder(v: &mut Value, index: Option<i64>, key: Option<&str>, 
 /// Parse context (variable scope)
 #[derive(Clone)]
 struct ParseContext<'cfg> {
-    variables: IndexMap<String, Value>,
+    /// Variables bound by `let` statements during parsing. Carries
+    /// `EvalValue` rather than `Value` because partial applications
+    /// (e.g. `let f = join("-")`) produce a closure that lives until a
+    /// later pipe finishes the application. Lowered to `Value` at the
+    /// end of `parse(...)`; an unfinished closure surfaces as a
+    /// parse-time error.
+    variables: IndexMap<String, EvalValue>,
     /// Resource bindings (binding_name -> Resource)
     resource_bindings: HashMap<String, Resource>,
     /// Imported modules (alias -> path)
@@ -817,11 +824,11 @@ impl<'cfg> ParseContext<'cfg> {
         self.string_literal_paths.borrow_mut().insert(path);
     }
 
-    fn set_variable(&mut self, name: String, value: Value) {
-        self.variables.insert(name, value);
+    fn set_variable(&mut self, name: String, value: impl Into<EvalValue>) {
+        self.variables.insert(name, value.into());
     }
 
-    fn get_variable(&self, name: &str) -> Option<&Value> {
+    fn get_variable(&self, name: &str) -> Option<&EvalValue> {
         self.variables.get(name)
     }
 
@@ -1144,10 +1151,29 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
     // `load_configuration_with_config`. See #2126 / #2138.
 
     let string_literal_paths = ctx.string_literal_paths.borrow().clone();
+
+    // Lower the evaluator-internal `EvalValue` bindings to user-facing
+    // `Value`. Closure bindings are dropped: they are evaluator-only
+    // artifacts (partial applications produced by `let f = builtin(x)`
+    // and consumed by a later pipe like `data |> f()`). After the parse
+    // pass finishes, only fully-reduced `Value`s belong in
+    // `ParsedFile.variables`; nothing downstream knows how to handle a
+    // closure. Pipe / call paths read from `ctx.variables` directly via
+    // `get_variable`, so the closure was already available where it
+    // mattered.
+    let variables: IndexMap<String, Value> = ctx
+        .variables
+        .into_iter()
+        .filter_map(|(name, eval)| match eval.into_value() {
+            Ok(v) => Some((name, v)),
+            Err(_leak) => None,
+        })
+        .collect();
+
     Ok(ParsedFile {
         providers,
         resources,
-        variables: ctx.variables,
+        variables,
         uses,
         module_calls,
         arguments,
@@ -1731,7 +1757,11 @@ fn parse_module_call(
 }
 
 /// Result of parsing the RHS of a let binding: (value, resources, module_calls, use_statement)
-type LetBindingRhs = (Value, Vec<Resource>, Vec<ModuleCall>, Option<UseStatement>);
+/// Tuple returned by the let-binding parser. The RHS is `EvalValue`
+/// rather than `Value` so partial applications (closures) can survive
+/// until a later pipe finishes them; the surrounding parse pass lowers
+/// each binding to `Value` at the end of `parse(...)`.
+type LetBindingRhs = (EvalValue, Vec<Resource>, Vec<ModuleCall>, Option<UseStatement>);
 
 /// Extended parse_let_binding that also handles module calls, imports, and for expressions.
 ///
@@ -1745,7 +1775,7 @@ fn parse_let_binding_extended(
 ) -> Result<
     (
         String,
-        Value,
+        EvalValue,
         Vec<Resource>,
         Vec<ModuleCall>,
         Option<UseStatement>,
@@ -1765,7 +1795,14 @@ fn parse_let_binding_extended(
     if rhs_pair.as_rule() == Rule::use_expr {
         let use_stmt = parse_use_expr(rhs_pair, &name, ctx)?;
         let value = Value::String(format!("${{use:{}}}", use_stmt.path));
-        return Ok((name, value, vec![], vec![], Some(use_stmt), false));
+        return Ok((
+            name,
+            EvalValue::from_value(value),
+            vec![],
+            vec![],
+            Some(use_stmt),
+            false,
+        ));
     }
 
     // Detect if the RHS is a structurally-required expression (if/for/read)
@@ -1848,14 +1885,14 @@ fn parse_pipe_expr_with_resource_or_module(
     if !compose_rhs.is_empty() {
         // Process the compose chain
         for rhs_pair in compose_rhs {
-            let rhs = parse_primary_value(rhs_pair, ctx)?;
+            let rhs = parse_primary_eval(rhs_pair, ctx)?;
 
             if !value.is_closure() {
                 return Err(ParseError::InvalidExpression {
                     line: 0,
                     message: format!(
                         "left side of >> must be a Closure (partially applied function), got {}",
-                        value_type_name(&value)
+                        eval_type_name(&value)
                     ),
                 });
             }
@@ -1864,12 +1901,12 @@ fn parse_pipe_expr_with_resource_or_module(
                     line: 0,
                     message: format!(
                         "right side of >> must be a Closure (partially applied function), got {}",
-                        value_type_name(&rhs)
+                        eval_type_name(&rhs)
                     ),
                 });
             }
 
-            let functions = if let Value::Closure {
+            let functions = if let EvalValue::Closure {
                 name,
                 captured_args,
                 ..
@@ -1883,11 +1920,7 @@ fn parse_pipe_expr_with_resource_or_module(
                 vec![value, rhs]
             };
 
-            value = Value::Closure {
-                name: "__compose__".to_string(),
-                captured_args: functions,
-                remaining_arity: 1,
-            };
+            value = EvalValue::closure("__compose__", functions, 1);
         }
     }
 
@@ -1901,49 +1934,88 @@ fn parse_pipe_expr_with_resource_or_module(
             fc_inner.map(|arg| parse_expression(arg, ctx)).collect();
         let extra_args = extra_args?;
 
-        // Build args: pipe value goes as the last argument (data-last convention)
-        let mut args = extra_args;
-        args.push(value);
+        // Lower the running pipe value to a `Value` for the builtin
+        // dispatch path (which expects fully-reduced data arguments).
+        // Closures are handled separately just below.
+        let pipe_value_for_args = match &value {
+            EvalValue::User(v) => Some(v.clone()),
+            EvalValue::Closure { .. } => None,
+        };
 
         // Check if the pipe target is a Closure variable
-        if let Some(Value::Closure {
+        if let Some(EvalValue::Closure {
             name: fn_name,
             captured_args,
             remaining_arity,
         }) = ctx.get_variable(&func_name)
-            && args.iter().all(is_static_value)
         {
-            value = crate::builtins::apply_closure_with_config(
-                fn_name,
-                captured_args,
-                *remaining_arity,
-                &args,
-                ctx.config,
-            )
-            .map_err(|e| ParseError::InvalidExpression {
-                line: 0,
-                message: e,
-            })?;
-            continue;
+            // Build closure-application args. The pipe value (`x` in
+            // `x |> f`) goes as the last argument; we keep it as
+            // EvalValue so a chained closure can pipe through.
+            let mut all_args: Vec<EvalValue> =
+                extra_args.iter().cloned().map(EvalValue::from_value).collect();
+            all_args.push(value.clone());
+            if extra_args.iter().all(is_static_value)
+                && pipe_value_for_args
+                    .as_ref()
+                    .is_some_and(is_static_value)
+            {
+                value = crate::builtins::apply_closure_with_config(
+                    fn_name,
+                    captured_args,
+                    *remaining_arity,
+                    &all_args,
+                    ctx.config,
+                )
+                .map_err(|e| ParseError::InvalidExpression {
+                    line: 0,
+                    message: e,
+                })?;
+                continue;
+            }
         }
+
+        // Build args for the non-closure dispatch path: at this point
+        // we need a `Vec<Value>`, so the running pipe value must be a
+        // user-facing value (not a closure).
+        let pipe_value = match pipe_value_for_args {
+            Some(v) => v,
+            None => {
+                return Err(ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "cannot pipe a closure into '{}' — finish the partial application first",
+                        func_name
+                    ),
+                });
+            }
+        };
+        let mut args = extra_args;
+        args.push(pipe_value);
 
         // Eagerly evaluate partial application for builtin pipe targets
         if let Some(arity) = crate::builtins::builtin_arity(&func_name)
             && args.len() < arity
             && args.iter().all(is_static_value)
         {
-            value = crate::builtins::evaluate_builtin_with_config(&func_name, &args, ctx.config)
-                .map_err(|e| ParseError::InvalidExpression {
-                    line: 0,
-                    message: format!("{}(): {}", func_name, e),
-                })?;
+            let eval_args: Vec<EvalValue> =
+                args.iter().cloned().map(EvalValue::from_value).collect();
+            value = crate::builtins::evaluate_builtin_with_config(
+                &func_name,
+                &eval_args,
+                ctx.config,
+            )
+            .map_err(|e| ParseError::InvalidExpression {
+                line: 0,
+                message: format!("{}(): {}", func_name, e),
+            })?;
             continue;
         }
 
-        value = Value::FunctionCall {
+        value = EvalValue::from_value(Value::FunctionCall {
             name: func_name,
             args,
-        };
+        });
     }
 
     Ok((value, expanded_resources, module_calls, maybe_import))
@@ -1960,7 +2032,7 @@ fn parse_primary_with_resource_or_module(
         Rule::read_resource_expr => {
             let resource = parse_read_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, vec![resource], vec![], None))
+            Ok((EvalValue::from_value(ref_value), vec![resource], vec![], None))
         }
         Rule::upstream_state_expr => {
             let (line, _) = inner.as_span().start_pos().line_col();
@@ -1973,17 +2045,17 @@ fn parse_primary_with_resource_or_module(
             }
             ctx.upstream_states.insert(us.binding.clone(), us);
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, vec![], vec![], None))
+            Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
         }
         Rule::resource_expr => {
             let resource = parse_resource_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, vec![resource], vec![], None))
+            Ok((EvalValue::from_value(ref_value), vec![resource], vec![], None))
         }
         Rule::for_expr => {
             let (resources, module_calls) = parse_for_expr(inner, ctx, binding_name)?;
             let ref_value = Value::String(format!("${{for:{}}}", binding_name));
-            Ok((ref_value, resources, module_calls, None))
+            Ok((EvalValue::from_value(ref_value), resources, module_calls, None))
         }
         Rule::if_expr => {
             let (value, resources, module_calls, import) = parse_if_expr(inner, ctx, binding_name)?;
@@ -1992,14 +2064,14 @@ fn parse_primary_with_resource_or_module(
         Rule::module_call => {
             let call = parse_module_call(inner, ctx)?;
             let value = Value::String(format!("${{module:{}}}", call.module_name));
-            Ok((value, vec![], vec![call], None))
+            Ok((EvalValue::from_value(value), vec![], vec![call], None))
         }
         Rule::function_call => {
-            let value = parse_primary_value(inner, ctx)?;
+            let value = parse_primary_eval(inner, ctx)?;
             Ok((value, vec![], vec![], None))
         }
         _ => {
-            let value = parse_primary_value(inner, ctx)?;
+            let value = parse_primary_eval(inner, ctx)?;
             Ok((value, vec![], vec![], None))
         }
     }
@@ -2446,7 +2518,15 @@ fn parse_for_iterable(
 ) -> Result<Value, ParseError> {
     // for_iterable contains function_call | list | variable_ref | "(" expression ")"
     let inner = first_inner(pair, "iterable expression", "for iterable")?;
-    let value = parse_primary_value(inner, ctx)?;
+    let eval = parse_primary_eval(inner, ctx)?;
+    let value = eval.into_value().map_err(|leak| ParseError::InvalidExpression {
+        line: 0,
+        message: format!(
+            "for iterable evaluates to a closure '{}' (still needs {} arg(s)); \
+             closures cannot be iterated",
+            leak.name, leak.remaining_arity
+        ),
+    })?;
     evaluate_static_value(value, ctx.config)
 }
 
@@ -2459,7 +2539,17 @@ fn is_static_value(value: &Value) -> bool {
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
         Value::ResourceRef { .. } | Value::Interpolation(_) => false,
         Value::Secret(inner) => is_static_value(inner),
-        Value::Closure { captured_args, .. } => captured_args.iter().all(is_static_value),
+    }
+}
+
+/// `is_static_value` for the evaluator-internal `EvalValue` type.
+/// A closure's static-ness is decided by whether all of its captured
+/// args are themselves static. The pipe/compose paths use this when
+/// they need to decide whether to eagerly apply a partial application.
+fn is_static_eval(value: &EvalValue) -> bool {
+    match value {
+        EvalValue::User(v) => is_static_value(v),
+        EvalValue::Closure { captured_args, .. } => captured_args.iter().all(is_static_eval),
     }
 }
 
@@ -2484,12 +2574,24 @@ fn evaluate_static_value(value: Value, config: &ProviderContext) -> Result<Value
                 .map(|v| evaluate_static_value(v, config))
                 .collect();
             let evaluated_args = evaluated_args?;
-            crate::builtins::evaluate_builtin_with_config(name, &evaluated_args, config).map_err(
-                |e| ParseError::InvalidExpression {
+            let eval_args: Vec<EvalValue> = evaluated_args
+                .iter()
+                .cloned()
+                .map(EvalValue::from_value)
+                .collect();
+            let result = crate::builtins::evaluate_builtin_with_config(name, &eval_args, config)
+                .map_err(|e| ParseError::InvalidExpression {
                     line: 0,
                     message: format!("for iterable function call '{name}' failed: {e}"),
-                },
-            )
+                })?;
+            result.into_value().map_err(|leak| ParseError::InvalidExpression {
+                line: 0,
+                message: format!(
+                    "for iterable function call '{name}' returned a closure '{}' \
+                     (still needs {} arg(s)); finish the partial application",
+                    leak.name, leak.remaining_arity
+                ),
+            })
         }
         other => Ok(other),
     }
@@ -2602,7 +2704,7 @@ fn parse_if_expr(
     } else {
         // No else clause and condition is false: produce nothing
         let ref_value = Value::String(format!("${{if:{}}}", binding_name));
-        Ok((ref_value, vec![], vec![], None))
+        Ok((EvalValue::from_value(ref_value), vec![], vec![], None))
     }
 }
 
@@ -2616,13 +2718,13 @@ fn parse_if_body_to_rhs(
     match result {
         IfBodyResult::Resource(r) => {
             let ref_value = Value::String(format!("${{{}}}", binding_name));
-            Ok((ref_value, vec![*r], vec![], None))
+            Ok((EvalValue::from_value(ref_value), vec![*r], vec![], None))
         }
         IfBodyResult::ModuleCall(c) => {
             let value = Value::String(format!("${{module:{}}}", c.module_name));
-            Ok((value, vec![], vec![c], None))
+            Ok((EvalValue::from_value(value), vec![], vec![c], None))
         }
-        IfBodyResult::Value(v) => Ok((v, vec![], vec![], None)),
+        IfBodyResult::Value(v) => Ok((EvalValue::from_value(v), vec![], vec![], None)),
     }
 }
 
@@ -3410,7 +3512,16 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "string",
         Value::FunctionCall { .. } => "function call",
         Value::Secret(_) => "secret",
-        Value::Closure { .. } => "closure",
+    }
+}
+
+/// Return a human-readable type name for an `EvalValue`. Closures only
+/// exist on the evaluator-internal type, so this is the version used by
+/// pipe/compose error messages where a closure can legitimately show up.
+pub(crate) fn eval_type_name(value: &EvalValue) -> &'static str {
+    match value {
+        EvalValue::User(v) => value_type_name(v),
+        EvalValue::Closure { .. } => "closure",
     }
 }
 
@@ -3498,28 +3609,53 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
             let evaluated_args = evaluated_args?;
 
             // Check if the name refers to a Closure variable
-            if let Some(Value::Closure {
+            if let Some(EvalValue::Closure {
                 name: fn_name,
                 captured_args,
                 remaining_arity,
             }) = ctx.get_variable(name)
             {
-                return crate::builtins::apply_closure_with_config(
+                let eval_args: Vec<EvalValue> = evaluated_args
+                    .iter()
+                    .cloned()
+                    .map(EvalValue::from_value)
+                    .collect();
+                let result = crate::builtins::apply_closure_with_config(
                     fn_name,
                     captured_args,
                     *remaining_arity,
-                    &evaluated_args,
+                    &eval_args,
                     ctx.config,
                 )
                 .map_err(|e| ParseError::InvalidExpression {
                     line: 0,
                     message: e,
+                })?;
+                return result.into_value().map_err(|leak| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "applying closure '{}' (still needs {} arg(s)) leaves a closure; \
+                         finish the partial application before using the result as data",
+                        leak.name, leak.remaining_arity
+                    ),
                 });
             }
 
             // Try built-in first (with config for decrypt support)
-            match crate::builtins::evaluate_builtin_with_config(name, &evaluated_args, ctx.config) {
-                Ok(result) => Ok(result),
+            let eval_args: Vec<EvalValue> = evaluated_args
+                .iter()
+                .cloned()
+                .map(EvalValue::from_value)
+                .collect();
+            match crate::builtins::evaluate_builtin_with_config(name, &eval_args, ctx.config) {
+                Ok(result) => result.into_value().map_err(|leak| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "{}(): produced a closure '{}' (still needs {} arg(s)); \
+                         finish the partial application before using the result as data",
+                        name, leak.name, leak.remaining_arity
+                    ),
+                }),
                 Err(_builtin_err) => {
                     // Try user-defined function
                     if let Some(user_fn) = ctx.user_functions.get(name) {
@@ -4208,10 +4344,34 @@ fn parse_read_resource_expr(
     })
 }
 
+/// Parse an expression. The result is a fully-reduced `Value`: any
+/// closure that surfaces during evaluation surfaces here as a
+/// parse-time error. Use [`parse_expression_eval`] in pipe/compose
+/// paths where partial applications are legitimate intermediates.
 fn parse_expression(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
 ) -> Result<Value, ParseError> {
+    let eval = parse_expression_eval(pair, ctx)?;
+    eval.into_value().map_err(|leak| ParseError::InvalidExpression {
+        line: 0,
+        message: format!(
+            "expression evaluates to a closure '{}' (still needs {} arg(s)); finish the \
+             partial application — closures are not valid as data",
+            leak.name, leak.remaining_arity
+        ),
+    })
+}
+
+/// Parse an expression and return the raw `EvalValue`, preserving any
+/// closure produced during partial application. Only the pipe/compose
+/// paths and the let-binding RHS need this; everything else should
+/// call [`parse_expression`] and let unfinished closures surface as
+/// errors at the type boundary.
+fn parse_expression_eval(
+    pair: pest::iterators::Pair<Rule>,
+    ctx: &ParseContext,
+) -> Result<EvalValue, ParseError> {
     let inner = first_inner(pair, "expression body", "expression")?;
     parse_coalesce_expr(inner, ctx)
 }
@@ -4219,7 +4379,7 @@ fn parse_expression(
 fn parse_coalesce_expr(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<Value, ParseError> {
+) -> Result<EvalValue, ParseError> {
     let mut inner = pair.into_inner();
     let first = next_pair(&mut inner, "pipe expression", "coalesce expression")?;
     let value = parse_pipe_expr(first, ctx)?;
@@ -4228,7 +4388,7 @@ fn parse_coalesce_expr(
     if let Some(rhs_pair) = inner.next() {
         let default = parse_pipe_expr(rhs_pair, ctx)?;
         match &value {
-            Value::ResourceRef { .. } => Ok(default),
+            EvalValue::User(Value::ResourceRef { .. }) => Ok(default),
             _ => Ok(value),
         }
     } else {
@@ -4239,14 +4399,14 @@ fn parse_coalesce_expr(
 fn parse_compose_expr(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<Value, ParseError> {
+) -> Result<EvalValue, ParseError> {
     let mut inner = pair.into_inner();
     let first = next_pair(&mut inner, "primary expression", "compose expression")?;
-    let mut value = parse_primary_value(first, ctx)?;
+    let mut value = parse_primary_eval(first, ctx)?;
 
     // Collect remaining primaries for >> composition
     for rhs_pair in inner {
-        let rhs = parse_primary_value(rhs_pair, ctx)?;
+        let rhs = parse_primary_eval(rhs_pair, ctx)?;
 
         // Both sides must be Closures
         if !value.is_closure() {
@@ -4254,7 +4414,7 @@ fn parse_compose_expr(
                 line: 0,
                 message: format!(
                     "left side of >> must be a Closure (partially applied function), got {}",
-                    value_type_name(&value)
+                    eval_type_name(&value)
                 ),
             });
         }
@@ -4263,14 +4423,14 @@ fn parse_compose_expr(
                 line: 0,
                 message: format!(
                     "right side of >> must be a Closure (partially applied function), got {}",
-                    value_type_name(&rhs)
+                    eval_type_name(&rhs)
                 ),
             });
         }
 
         // Build a composed closure: __compose__ with the chain stored in captured_args
         // If the left side is already a __compose__, extend the chain; otherwise start a new one
-        let functions = if let Value::Closure {
+        let functions = if let EvalValue::Closure {
             name,
             captured_args,
             ..
@@ -4284,11 +4444,7 @@ fn parse_compose_expr(
             vec![value, rhs]
         };
 
-        value = Value::Closure {
-            name: "__compose__".to_string(),
-            captured_args: functions,
-            remaining_arity: 1,
-        };
+        value = EvalValue::closure("__compose__", functions, 1);
     }
 
     Ok(value)
@@ -4297,7 +4453,7 @@ fn parse_compose_expr(
 fn parse_pipe_expr(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<Value, ParseError> {
+) -> Result<EvalValue, ParseError> {
     let mut inner = pair.into_inner();
     let compose = next_pair(&mut inner, "compose expression", "pipe expression")?;
     let mut value = parse_compose_expr(compose, ctx)?;
@@ -4312,66 +4468,98 @@ fn parse_pipe_expr(
             fc_inner.map(|arg| parse_expression(arg, ctx)).collect();
         let extra_args = extra_args?;
 
-        // Build args: pipe value goes as the last argument (data-last convention)
-        let mut args = extra_args;
-        args.push(value);
-
-        // Check if the pipe target is a Closure variable
-        if let Some(Value::Closure {
+        // Check if the pipe target is a Closure variable. The pipe
+        // value (the running `value`) is appended last as an
+        // EvalValue, so a closure carried in the binding can finish
+        // applying through subsequent pipes.
+        if let Some(EvalValue::Closure {
             name: fn_name,
             captured_args,
             remaining_arity,
         }) = ctx.get_variable(&func_name)
-            && args.iter().all(is_static_value)
         {
-            value = crate::builtins::apply_closure_with_config(
-                fn_name,
-                captured_args,
-                *remaining_arity,
-                &args,
-                ctx.config,
-            )
-            .map_err(|e| ParseError::InvalidExpression {
-                line: 0,
-                message: e,
-            })?;
-            continue;
+            let mut all_args: Vec<EvalValue> =
+                extra_args.iter().cloned().map(EvalValue::from_value).collect();
+            all_args.push(value.clone());
+            if all_args.iter().all(is_static_eval) {
+                value = crate::builtins::apply_closure_with_config(
+                    fn_name,
+                    captured_args,
+                    *remaining_arity,
+                    &all_args,
+                    ctx.config,
+                )
+                .map_err(|e| ParseError::InvalidExpression {
+                    line: 0,
+                    message: e,
+                })?;
+                continue;
+            }
         }
+
+        // Build args for the non-closure dispatch path. The running
+        // pipe value must be a user-facing value here; a closure
+        // would mean the user piped a partial application into a
+        // non-closure-aware call, which we surface as a parse error.
+        let pipe_value = match value {
+            EvalValue::User(v) => v,
+            EvalValue::Closure {
+                ref name,
+                remaining_arity,
+                ..
+            } => {
+                return Err(ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "cannot pipe a closure '{}' (still needs {} arg(s)) into '{}' \
+                         — finish the partial application first",
+                        name, remaining_arity, func_name
+                    ),
+                });
+            }
+        };
+        let mut args = extra_args;
+        args.push(pipe_value);
 
         // Try to eagerly evaluate user-defined function calls
         if ctx.user_functions.contains_key(&func_name) && args.iter().all(is_static_value) {
             let user_fn = ctx.user_functions.get(&func_name).unwrap().clone();
-            value = evaluate_user_function(&user_fn, &args, ctx)?;
+            value = EvalValue::from_value(evaluate_user_function(&user_fn, &args, ctx)?);
         } else if let Some(arity) = crate::builtins::builtin_arity(&func_name) {
             // Eagerly evaluate partial application for builtin pipe targets
             if args.len() < arity && args.iter().all(is_static_value) {
-                value =
-                    crate::builtins::evaluate_builtin_with_config(&func_name, &args, ctx.config)
-                        .map_err(|e| ParseError::InvalidExpression {
-                            line: 0,
-                            message: format!("{}(): {}", func_name, e),
-                        })?;
+                let eval_args: Vec<EvalValue> =
+                    args.iter().cloned().map(EvalValue::from_value).collect();
+                value = crate::builtins::evaluate_builtin_with_config(
+                    &func_name,
+                    &eval_args,
+                    ctx.config,
+                )
+                .map_err(|e| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!("{}(): {}", func_name, e),
+                })?;
             } else {
-                value = Value::FunctionCall {
+                value = EvalValue::from_value(Value::FunctionCall {
                     name: func_name,
                     args,
-                };
+                });
             }
         } else {
-            value = Value::FunctionCall {
+            value = EvalValue::from_value(Value::FunctionCall {
                 name: func_name,
                 args,
-            };
+            });
         }
     }
 
     Ok(value)
 }
 
-fn parse_primary_value(
+fn parse_primary_eval(
     pair: pest::iterators::Pair<Rule>,
     ctx: &ParseContext,
-) -> Result<Value, ParseError> {
+) -> Result<EvalValue, ParseError> {
     // For primary, get inner content; otherwise process directly
     let inner = if pair.as_rule() == Rule::primary {
         first_inner(pair, "value", "primary expression")?
@@ -4392,7 +4580,7 @@ fn parse_primary_value(
                 .into_inner()
                 .map(|item| parse_expression(item, ctx))
                 .collect();
-            Ok(Value::List(items?))
+            Ok(EvalValue::from_value(Value::List(items?)))
         }
         Rule::map => {
             let mut map: IndexMap<String, Value> = IndexMap::new();
@@ -4427,7 +4615,7 @@ fn parse_primary_value(
             for (name, blocks) in nested_blocks {
                 map.insert(name, Value::List(blocks));
             }
-            Ok(Value::Map(map))
+            Ok(EvalValue::from_value(Value::Map(map)))
         }
         Rule::namespaced_id => {
             // Namespaced identifier (e.g., aws.Region.ap_northeast_1)
@@ -4449,32 +4637,35 @@ fn parse_primary_value(
                     })
                 } else if ctx.is_resource_binding(parts[0]) {
                     // Known resource binding: treat as resource reference
-                    Ok(Value::resource_ref(
+                    Ok(EvalValue::from_value(Value::resource_ref(
                         parts[0].to_string(),
                         parts[1].to_string(),
                         vec![],
-                    ))
+                    )))
                 } else {
                     // Unknown 2-part identifier: could be TypeName.value enum shorthand
                     // Will be resolved during schema validation
-                    Ok(Value::String(format!("{}.{}", parts[0], parts[1])))
+                    Ok(EvalValue::from_value(Value::String(format!(
+                        "{}.{}",
+                        parts[0], parts[1]
+                    ))))
                 }
             } else if ctx.is_resource_binding(parts[0]) {
                 // 3+ part identifier where first part is a resource binding:
                 // chained field access (e.g., web.network.vpc_id)
-                Ok(Value::resource_ref(
+                Ok(EvalValue::from_value(Value::resource_ref(
                     parts[0].to_string(),
                     parts[1].to_string(),
                     parts[2..].iter().map(|s| s.to_string()).collect(),
-                ))
+                )))
             } else {
                 // 3+ part identifier is a namespaced type (aws.Region.ap_northeast_1)
-                Ok(Value::String(full_str.to_string()))
+                Ok(EvalValue::from_value(Value::String(full_str.to_string())))
             }
         }
         Rule::boolean => {
             let b = inner.as_str() == "true";
-            Ok(Value::Bool(b))
+            Ok(EvalValue::from_value(Value::Bool(b)))
         }
         Rule::float => {
             let f: f64 = inner
@@ -4484,7 +4675,7 @@ fn parse_primary_value(
                     line: inner.line_col().0,
                     message: format!("invalid float literal: {e}"),
                 })?;
-            Ok(Value::Float(f))
+            Ok(EvalValue::from_value(Value::Float(f)))
         }
         Rule::number => {
             let n: i64 = inner
@@ -4494,9 +4685,9 @@ fn parse_primary_value(
                     line: inner.line_col().0,
                     message: format!("integer literal out of range: {e}"),
                 })?;
-            Ok(Value::Int(n))
+            Ok(EvalValue::from_value(Value::Int(n)))
         }
-        Rule::string => parse_string_value(inner, ctx),
+        Rule::string => parse_string_value(inner, ctx).map(EvalValue::from_value),
         Rule::function_call => {
             let mut fc_inner = inner.into_inner();
             let func_name = next_pair(&mut fc_inner, "function name", "function call")?
@@ -4507,18 +4698,20 @@ fn parse_primary_value(
             let args = args?;
 
             // Check if the name refers to a Closure variable (direct call on closure)
-            if let Some(Value::Closure {
+            if let Some(EvalValue::Closure {
                 name: fn_name,
                 captured_args,
                 remaining_arity,
             }) = ctx.get_variable(&func_name)
                 && args.iter().all(is_static_value)
             {
+                let eval_args: Vec<EvalValue> =
+                    args.iter().cloned().map(EvalValue::from_value).collect();
                 return crate::builtins::apply_closure_with_config(
                     fn_name,
                     captured_args,
                     *remaining_arity,
-                    &args,
+                    &eval_args,
                     ctx.config,
                 )
                 .map_err(|e| ParseError::InvalidExpression {
@@ -4530,7 +4723,7 @@ fn parse_primary_value(
             // Try to eagerly evaluate user-defined function calls
             if ctx.user_functions.contains_key(&func_name) && args.iter().all(is_static_value) {
                 let user_fn = ctx.user_functions.get(&func_name).unwrap().clone();
-                return evaluate_user_function(&user_fn, &args, ctx);
+                return evaluate_user_function(&user_fn, &args, ctx).map(EvalValue::from_value);
             }
 
             // Eagerly evaluate partial application (fewer args than arity → Closure)
@@ -4538,8 +4731,12 @@ fn parse_primary_value(
                 && args.len() < arity
                 && args.iter().all(is_static_value)
             {
+                let eval_args: Vec<EvalValue> =
+                    args.iter().cloned().map(EvalValue::from_value).collect();
                 return crate::builtins::evaluate_builtin_with_config(
-                    &func_name, &args, ctx.config,
+                    &func_name,
+                    &eval_args,
+                    ctx.config,
                 )
                 .map_err(|e| ParseError::InvalidExpression {
                     line: 0,
@@ -4547,10 +4744,10 @@ fn parse_primary_value(
                 });
             }
 
-            Ok(Value::FunctionCall {
+            Ok(EvalValue::from_value(Value::FunctionCall {
                 name: func_name,
                 args,
-            })
+            }))
         }
         Rule::variable_ref => {
             // variable_ref = { identifier ~ (field_access | index_access)* }
@@ -4566,7 +4763,9 @@ fn parse_primary_value(
                 // Simple variable reference (no access chain)
                 match ctx.get_variable(first_ident) {
                     Some(val) => Ok(val.clone()),
-                    None => Ok(Value::String(first_ident.to_string())),
+                    None => Ok(EvalValue::from_value(Value::String(
+                        first_ident.to_string(),
+                    ))),
                 }
             } else {
                 // Build binding_name, attribute_name, and field_path from access steps.
@@ -4629,22 +4828,28 @@ fn parse_primary_value(
                         None => {
                             // Return as ResourceRef with empty attribute_name
                             // (will be resolved later)
-                            Ok(Value::resource_ref(binding_name, String::new(), vec![]))
+                            Ok(EvalValue::from_value(Value::resource_ref(
+                                binding_name,
+                                String::new(),
+                                vec![],
+                            )))
                         }
                     }
                 } else {
                     let attribute_name = field_names.remove(0);
-                    Ok(Value::resource_ref(
+                    Ok(EvalValue::from_value(Value::resource_ref(
                         binding_name,
                         attribute_name,
                         field_names,
-                    ))
+                    )))
                 }
             }
         }
-        Rule::if_expr => parse_if_value_expr(inner, ctx),
-        Rule::expression => parse_expression(inner, ctx),
-        _ => Ok(Value::String(inner.as_str().to_string())),
+        Rule::if_expr => parse_if_value_expr(inner, ctx).map(EvalValue::from_value),
+        Rule::expression => parse_expression_eval(inner, ctx),
+        _ => Ok(EvalValue::from_value(Value::String(
+            inner.as_str().to_string(),
+        ))),
     }
 }
 
@@ -5147,8 +5352,20 @@ fn resolve_value_with_config(
 
             let all_args_resolved = resolved_args.iter().all(is_static_value);
 
-            match crate::builtins::evaluate_builtin_with_config(name, &resolved_args, config) {
-                Ok(result) => Ok(result),
+            let eval_args: Vec<EvalValue> = resolved_args
+                .iter()
+                .cloned()
+                .map(EvalValue::from_value)
+                .collect();
+            match crate::builtins::evaluate_builtin_with_config(name, &eval_args, config) {
+                Ok(result) => result.into_value().map_err(|leak| ParseError::InvalidExpression {
+                    line: 0,
+                    message: format!(
+                        "{}(): produced a closure '{}' (still needs {} arg(s)); \
+                         finish the partial application before using the result as data",
+                        name, leak.name, leak.remaining_arity
+                    ),
+                }),
                 Err(e) => {
                     if all_args_resolved {
                         // All args are resolved but builtin failed — propagate the error
@@ -5181,6 +5398,48 @@ pub fn parse_and_resolve(input: &str) -> Result<ParsedFile, ParseError> {
 mod tests {
     use super::*;
     use crate::resource::InterpolationPart;
+
+    #[test]
+    fn parse_and_resolve_returns_value_only_no_closure() {
+        // Issue #2230 acceptance criterion 3: `parse_and_resolve` must
+        // never expose a closure to its caller. Type-system enforcement
+        // makes the literal claim trivially true (`Value::Closure` does
+        // not exist), so this test doubles as a smoke check that
+        // legitimate partial-application expressions (data-last pipes
+        // + builtin chaining) still parse and produce a `Value` tree
+        // that no consumer needs to inspect for a closure case.
+        let input = r#"
+            let xs = ["a", "b", "c"]
+            let joined = xs |> join("-")
+        "#;
+        let parsed = parse_and_resolve(input).expect("parse_and_resolve should succeed");
+        let joined = parsed.variables.get("joined").expect("joined binding present");
+        // No `Closure` arm exists on `Value`, so the only way this
+        // could fail is if the call survived as a `FunctionCall` —
+        // also a valid `Value`, never a closure. The point of the
+        // test is that the type contract holds: whatever shape this
+        // is, downstream code does not have to consider closures.
+        match joined {
+            Value::String(_) | Value::FunctionCall { .. } => {}
+            other => panic!("unexpected variant for `joined`: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unfinished_closure_in_let_binding_is_dropped() {
+        // Issue #2230 acceptance criterion 2: a `let` binding holding
+        // an unfinished partial application must not surface a closure
+        // to the caller. The evaluator-internal `EvalValue::Closure`
+        // is dropped at the lowering boundary; the binding name simply
+        // does not appear in `ParsedFile.variables`.
+        let input = r#"let f = join("-")"#;
+        let parsed =
+            parse_and_resolve(input).expect("partial application in let binding should parse");
+        assert!(
+            parsed.variables.get("f").is_none(),
+            "closure binding must not survive into ParsedFile.variables"
+        );
+    }
 
     #[test]
     fn iter_all_resources_yields_direct_then_deferred() {
@@ -6859,24 +7118,19 @@ aws.s3.Bucket {
     }
 
     #[test]
-    fn partial_application_produces_closure() {
-        // `let f = map(".subnet_id")` should produce a Closure
+    fn partial_application_let_binding_dropped_from_variables() {
+        // After #2230 a `let` binding holding a partial application
+        // is an evaluator-only artifact: it lives on `EvalValue`
+        // during parsing so a later pipe / call can finish it, but
+        // it never reaches `ParsedFile.variables`. Parsing succeeds;
+        // the binding simply does not appear in the user-facing
+        // variable map.
         let input = r#"
             let f = map(".subnet_id")
         "#;
-        let result = parse(input, &ProviderContext::default()).unwrap();
-        match result.variables.get("f") {
-            Some(Value::Closure {
-                name,
-                captured_args,
-                remaining_arity,
-            }) => {
-                assert_eq!(name, "map");
-                assert_eq!(captured_args, &[Value::String(".subnet_id".to_string())]);
-                assert_eq!(*remaining_arity, 1);
-            }
-            other => panic!("Expected Closure, got {:?}", other),
-        }
+        let result = parse(input, &ProviderContext::default())
+            .expect("partial application in let binding should parse");
+        assert!(result.variables.get("f").is_none());
     }
 
     #[test]
@@ -10838,27 +11092,25 @@ arguments {
     }
 
     #[test]
-    fn test_compose_operator_produces_closure() {
-        // map(".id") >> join(",") should produce a composed Closure
+    fn test_compose_operator_followed_by_pipe_consumes_closure() {
+        // After #2230, the composed closure produced by `>>` lives on
+        // `EvalValue` and is consumed by the later pipe. The
+        // intermediate binding `f` is an evaluator artifact and is
+        // dropped at the parse boundary; only the fully-reduced
+        // `result` survives.
         let input = r#"
             let f = map(".id") >> join(",")
             let result = [{ id = "a" }, { id = "b" }] |> f()
         "#;
         let result = parse(input, &ProviderContext::default()).unwrap();
 
-        // f should be a Closure with name "__compose__"
-        match result.variables.get("f").unwrap() {
-            Value::Closure { name, .. } => {
-                assert_eq!(name, "__compose__");
-            }
-            other => panic!("Expected Closure, got {:?}", other),
-        }
-
-        // result should be the string "a,b"
         assert_eq!(
             result.variables.get("result").unwrap(),
             &Value::String("a,b".to_string())
         );
+        // `f` is a closure-only binding and does not appear in the
+        // user-facing variable map.
+        assert!(result.variables.get("f").is_none());
     }
 
     #[test]
@@ -10938,23 +11190,18 @@ arguments {
 
     #[test]
     fn test_compose_three_functions() {
-        // Three-way composition structure check
+        // Three-way composition: parser must accept the chain and
+        // (via #2230) keep the result confined to the evaluator-only
+        // `EvalValue` layer. The binding is dropped from the
+        // user-facing variable map; the test that the chain still
+        // *applies* correctly is covered by
+        // `test_compose_operator_followed_by_pipe_consumes_closure`.
         let input = r#"
             let transform = split(",") >> join("-") >> split("-")
         "#;
-        let result = parse(input, &ProviderContext::default()).unwrap();
-        match result.variables.get("transform").unwrap() {
-            Value::Closure {
-                name,
-                captured_args,
-                remaining_arity,
-            } => {
-                assert_eq!(name, "__compose__");
-                assert_eq!(captured_args.len(), 3);
-                assert_eq!(remaining_arity, &1);
-            }
-            other => panic!("Expected Closure, got {:?}", other),
-        }
+        let result = parse(input, &ProviderContext::default())
+            .expect("three-way composition should parse");
+        assert!(result.variables.get("transform").is_none());
     }
 
     #[test]

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -194,9 +194,24 @@ pub fn resolve_ref_value(
             let all_resolved = resolved_args.iter().all(|a| !contains_resource_ref(a));
 
             if all_resolved {
-                // Evaluate the built-in function; propagate errors since args are resolved
-                match crate::builtins::evaluate_builtin(name, &resolved_args) {
-                    Ok(result) => Ok(result),
+                // Evaluate the built-in function; propagate errors since args are resolved.
+                // The evaluator boundary is `EvalValue::into_value` — a closure
+                // returned here would mean `evaluate_builtin` saw fewer args
+                // than the function's arity, which can only happen if a
+                // partial application leaked through parsing. The parser is
+                // supposed to surface that as a parse error, so treat any
+                // closure here as a resolver-level invariant break.
+                use crate::eval_value::EvalValue;
+                let eval_args: Vec<EvalValue> =
+                    resolved_args.iter().cloned().map(EvalValue::from_value).collect();
+                match crate::builtins::evaluate_builtin(name, &eval_args) {
+                    Ok(result) => result.into_value().map_err(|leak| {
+                        format!(
+                            "{}(): produced a closure '{}' (still needs {} arg(s)); \
+                             this should have been caught at parse time",
+                            name, leak.name, leak.remaining_arity
+                        )
+                    }),
                     Err(e) => Err(format!("{}(): {}", name, e)),
                 }
             } else {
@@ -210,21 +225,6 @@ pub fn resolve_ref_value(
         Value::Secret(inner) => {
             let resolved_inner = resolve_ref_value(inner, binding_map)?;
             Ok(Value::Secret(Box::new(resolved_inner)))
-        }
-        Value::Closure {
-            name,
-            captured_args,
-            remaining_arity,
-        } => {
-            let resolved_args: Result<Vec<Value>, String> = captured_args
-                .iter()
-                .map(|a| resolve_ref_value(a, binding_map))
-                .collect();
-            Ok(Value::Closure {
-                name: name.clone(),
-                captured_args: resolved_args?,
-                remaining_arity: *remaining_arity,
-            })
         }
         _ => Ok(value.clone()),
     }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -202,8 +202,11 @@ pub fn resolve_ref_value(
                 // supposed to surface that as a parse error, so treat any
                 // closure here as a resolver-level invariant break.
                 use crate::eval_value::EvalValue;
-                let eval_args: Vec<EvalValue> =
-                    resolved_args.iter().cloned().map(EvalValue::from_value).collect();
+                let eval_args: Vec<EvalValue> = resolved_args
+                    .iter()
+                    .cloned()
+                    .map(EvalValue::from_value)
+                    .collect();
                 match crate::builtins::evaluate_builtin(name, &eval_args) {
                     Ok(result) => result.into_value().map_err(|leak| {
                         format!(

--- a/carina-core/src/resource.rs
+++ b/carina-core/src/resource.rs
@@ -299,19 +299,6 @@ pub enum Value {
     /// A secret value. The inner value is sent to the provider but stored as a
     /// SHA256 hash in state. Plan output displays `(secret)` instead of the value.
     Secret(Box<Value>),
-    /// A partially applied function (closure).
-    ///
-    /// Exists only during expression evaluation; never serialized to state.
-    /// Created when a function receives fewer arguments than it needs.
-    #[serde(skip)]
-    Closure {
-        /// Original function name
-        name: String,
-        /// Arguments already provided
-        captured_args: Vec<Value>,
-        /// How many more arguments are needed
-        remaining_arity: usize,
-    },
 }
 
 /// A part of a string interpolation expression
@@ -339,24 +326,6 @@ impl Value {
         Value::ResourceRef {
             path: AccessPath::from_ref(binding_name, attribute_name, field_path),
         }
-    }
-
-    /// Create a `Closure` value representing a partially applied function.
-    pub fn closure(
-        name: impl Into<String>,
-        captured_args: Vec<Value>,
-        remaining_arity: usize,
-    ) -> Self {
-        Value::Closure {
-            name: name.into(),
-            captured_args,
-            remaining_arity,
-        }
-    }
-
-    /// Returns true if this value is a `Closure`.
-    pub fn is_closure(&self) -> bool {
-        matches!(self, Value::Closure { .. })
     }
 
     /// If this is a `ResourceRef`, returns the binding name.
@@ -410,11 +379,6 @@ impl Value {
                 }
             }
             Value::Secret(inner) => inner.visit_refs(f),
-            Value::Closure { captured_args, .. } => {
-                for arg in captured_args {
-                    arg.visit_refs(f);
-                }
-            }
             Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
         }
     }
@@ -445,8 +409,8 @@ impl Expr {
     ///
     /// Despite the legacy name, this method does **not** resolve
     /// `Value::ResourceRef` / `Value::Interpolation` / `Value::FunctionCall`
-    /// / `Value::Closure` / `Value::Secret` — it simply unwraps
-    /// `Expr` → `Value`. Callers that need concrete values must run
+    /// / `Value::Secret` — it simply unwraps `Expr` → `Value`. Callers
+    /// that need concrete values must run
     /// `carina_core::resolver::resolve_refs_with_state_and_remote` (or an
     /// equivalent) first. See #1683 for a regression caused by assuming
     /// this method performed resolution.
@@ -588,18 +552,6 @@ impl Value {
             }
             Value::Secret(inner) => {
                 inner.hash_into(hasher);
-            }
-            Value::Closure {
-                name,
-                captured_args,
-                remaining_arity,
-            } => {
-                name.hash(hasher);
-                captured_args.len().hash(hasher);
-                for arg in captured_args {
-                    arg.hash_into(hasher);
-                }
-                remaining_arity.hash(hasher);
             }
         }
     }
@@ -1951,60 +1903,9 @@ mod tests {
         assert_eq!(non_ref.ref_binding(), None);
     }
 
-    #[test]
-    fn closure_constructor() {
-        let closure = Value::closure("map", vec![Value::String(".subnet_id".to_string())], 1);
-        match &closure {
-            Value::Closure {
-                name,
-                captured_args,
-                remaining_arity,
-            } => {
-                assert_eq!(name, "map");
-                assert_eq!(captured_args.len(), 1);
-                assert_eq!(*remaining_arity, 1);
-            }
-            _ => panic!("Expected Closure variant"),
-        }
-    }
-
-    #[test]
-    fn closure_is_closure_helper() {
-        let closure = Value::closure("map", vec![], 2);
-        assert!(closure.is_closure());
-
-        let not_closure = Value::String("hello".to_string());
-        assert!(!not_closure.is_closure());
-    }
-
-    #[test]
-    fn closure_serde_serialize_fails() {
-        // Closure with #[serde(skip)] cannot be serialized — serde rejects it.
-        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
-        let result = serde_json::to_string(&closure);
-        assert!(result.is_err(), "Closure must not be serializable");
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("cannot be serialized"),
-            "Error should mention serialization: {err}"
-        );
-    }
-
-    #[test]
-    fn closure_not_in_contains_resource_ref() {
-        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
-        assert!(!contains_resource_ref(&closure));
-    }
-
-    #[test]
-    fn closure_with_resource_ref_in_captured_args() {
-        let closure = Value::Closure {
-            name: "map".to_string(),
-            captured_args: vec![Value::resource_ref("vpc", "id", vec![])],
-            remaining_arity: 1,
-        };
-        assert!(contains_resource_ref(&closure));
-    }
+    // Closure tests moved out: `Value::Closure` no longer exists. Closure
+    // construction, helper methods, and serde-skip behavior are now
+    // properties of `EvalValue`, exercised in `eval_value.rs`.
 
     #[test]
     fn visit_refs_collects_from_all_nested_variants() {
@@ -2023,11 +1924,6 @@ mod tests {
                 args: vec![Value::resource_ref("d", "id", vec![])],
             },
             Value::Secret(Box::new(Value::resource_ref("e", "id", vec![]))),
-            Value::Closure {
-                name: "fn".to_string(),
-                captured_args: vec![Value::resource_ref("f", "id", vec![])],
-                remaining_arity: 1,
-            },
             Value::String("plain".to_string()),
         ]);
 
@@ -2036,7 +1932,7 @@ mod tests {
             collected.push(path.binding().to_string());
         });
         collected.sort();
-        assert_eq!(collected, vec!["a", "b", "c", "d", "e", "f"]);
+        assert_eq!(collected, vec!["a", "b", "c", "d", "e"]);
     }
 
     #[test]

--- a/carina-core/src/schema.rs
+++ b/carina-core/src/schema.rs
@@ -946,7 +946,6 @@ impl Value {
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),
-            Value::Closure { name, .. } => format!("Closure({})", name),
         }
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -141,16 +141,6 @@ pub fn value_to_json_with_context(
                 "{SECRET_PREFIX}{hash_hex}",
             )))
         }
-        Value::Closure {
-            name,
-            captured_args,
-            remaining_arity,
-        } => Err(format!(
-            "Closure values cannot be serialized: <closure: {}({}/{} args)>",
-            name,
-            captured_args.len(),
-            captured_args.len() + remaining_arity,
-        )),
     }
 }
 
@@ -244,19 +234,6 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
-        Value::Closure {
-            name,
-            captured_args,
-            remaining_arity,
-        } => {
-            let total = captured_args.len() + remaining_arity;
-            format!(
-                "<closure: {}({}/{} args)>",
-                name,
-                captured_args.len(),
-                total
-            )
-        }
     }
 }
 
@@ -1058,27 +1035,8 @@ mod tests {
         assert!(json.contains("my-bucket"));
     }
 
-    #[test]
-    fn closure_format_value_display() {
-        let closure = Value::closure("map", vec![Value::String(".subnet_id".to_string())], 1);
-        let display = format_value(&closure);
-        assert_eq!(display, "<closure: map(1/2 args)>");
-    }
-
-    #[test]
-    fn closure_format_value_no_captured_args() {
-        let closure = Value::closure("join", vec![], 2);
-        let display = format_value(&closure);
-        assert_eq!(display, "<closure: join(0/2 args)>");
-    }
-
-    #[test]
-    fn closure_value_to_json_errors() {
-        let closure = Value::closure("map", vec![Value::String(".id".to_string())], 1);
-        let result = value_to_json(&closure);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.contains("Closure values cannot be serialized"));
-        assert!(err.contains("map"));
-    }
+    // Closure-shaped tests deleted: `Value::Closure` no longer exists,
+    // so `format_value` and `value_to_json` only see user-facing values.
+    // The "closure cannot become data" guarantee is now enforced at the
+    // type level by `EvalValue::into_value`.
 }


### PR DESCRIPTION
## Summary

Closes #2230.

- Remove `Value::Closure` from the public `Value` enum entirely. Closures now live on a new `pub(crate) enum EvalValue { User(Value), Closure { .. } }` that is strictly internal to the evaluator.
- The conversion boundary is `EvalValue::into_value`, which errors if a closure tried to escape. Validation, LSP, plan display, and state code therefore no longer need explicit ``Value::Closure`` arms — the variant does not exist for them, the compiler enforces it.
- `ParseContext::variables` is now `IndexMap<String, EvalValue>`. Partial applications can survive across statements (so ``let f = map(\".id\")``; ``data |> f()`` keeps working). At end-of-parse, closure-only bindings are dropped from the user-facing ``ParsedFile.variables`` — they're evaluator artifacts, never needed downstream.
- `parse_expression` is a thin wrapper that lowers to `Value` at the type boundary; closures in data positions become parse errors. `parse_expression_eval` exposes raw `EvalValue` for pipe / compose paths that legitimately need closure values.

The 'Alternative' debug_assert path the issue floated was rejected in favour of the type-system split: invariants in a Rust codebase should be proven by the compiler, not asserted at runtime.

## Test plan

- [x] ``cargo build --workspace`` — green
- [x] ``cargo test --workspace`` — all suites green (carina-core 1377, carina-cli 264, carina-lsp 341, …)
- [x] ``cargo clippy --workspace --all-targets -- -D warnings`` — no warnings
- [x] New acceptance tests added (issue criteria 2 + 3):
  - ``parser::tests::parse_and_resolve_returns_value_only_no_closure`` — type-level guarantee + smoke check on legitimate pipe form
  - ``parser::tests::unfinished_closure_in_let_binding_is_dropped`` — closure-only bindings disappear from ``ParsedFile.variables``
- [x] Existing closure-shaped tests on ``Value`` either moved to ``eval_value.rs`` (closure constructor / leak detection) or deleted (the variant they exercised no longer exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)