### PR TITLE
docs: add dagayn MCP usage and markdown directive policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ docs/.astro/
 
 # Superpowers brainstorm sessions
 .superpowers/
+# Added by dagayn
+.dagayn/
+.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,89 @@
 
 - Changes under `carina-state/` or `carina-cli` apply/save paths must preserve atomic lock behavior and avoid writing stale state after partial failures.
 - Changes that affect DSL syntax or schema resolution should also be checked against LSP behavior and docs expectations.
+
+<!-- dagayn MCP tools -->
+## MCP Tools: dagayn
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+dagayn MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+| ------ | ---------- |
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.
+
+<!-- dagayn markdown policy -->
+## Markdown documentation policy: declare dependencies via directive comments
+
+When authoring or editing a Markdown document in this repository, declare
+inter-section and inter-document dependencies as HTML directive comments so
+they are captured by the dagayn graph (`DEPENDS_ON` / `IMPORTS_FROM` edges)
+and discoverable via `query_graph` / `get_impact_radius`.
+
+### Required form
+
+```markdown
+<!-- <kind> <target> -->
+```
+
+`<kind>` MUST be one of: `constrained-by`, `blocked-by`, `supersedes`,
+`derived-from`. Choose the kind whose semantics best match the dependency:
+
+| Kind | Use when |
+| ---- | -------- |
+| `constrained-by` | This section's design is bounded by the referenced document/section |
+| `blocked-by` | This item cannot proceed until the referenced item resolves |
+| `supersedes` | This document replaces the referenced content |
+| `derived-from` | This section is derived from the referenced source |
+
+### Three target shapes
+
+| Dependency type | Target syntax | Example |
+| --------------- | ------------- | ------- |
+| Within-document section | `#section-slug` | `<!-- derived-from #background -->` |
+| Other document (whole file) | `./relative/path.md` | `<!-- blocked-by ./specs/open-issue.md -->` |
+| Other document + section | `./path.md#slug` | `<!-- constrained-by ./adr.md#context -->` |
+
+Slugs follow GitHub Markdown rules: lowercase, non-alphanumerics removed,
+spaces and hyphens collapsed to `-`. Place the directive immediately under
+the heading whose content depends on the target. External URLs
+(`http://`, `https://`) are not graph-resolvable — keep them as ordinary
+Markdown links, not directive targets.
+
+### When to add a directive
+
+- Section design references an ADR, spec, or research note → `constrained-by` or `derived-from`.
+- A document replaces an older one → `supersedes` (place in the new document).
+- A spec/task section is blocked on another being resolved → `blocked-by`.
+- A later section extends an earlier one non-obviously → `derived-from #earlier-section`.
+
+If no real dependency exists, do not invent one. Directives are signal, not decoration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,3 +316,89 @@ git remote prune origin           # Remove stale remote tracking branches
 
 - **Commit messages**: Write in English
 - **Code comments**: Write in English
+
+<!-- dagayn MCP tools -->
+## MCP Tools: dagayn
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+dagayn MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+| ------ | ---------- |
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.
+
+<!-- dagayn markdown policy -->
+## Markdown documentation policy: declare dependencies via directive comments
+
+When authoring or editing a Markdown document in this repository, declare
+inter-section and inter-document dependencies as HTML directive comments so
+they are captured by the dagayn graph (`DEPENDS_ON` / `IMPORTS_FROM` edges)
+and discoverable via `query_graph` / `get_impact_radius`.
+
+### Required form
+
+```markdown
+<!-- <kind> <target> -->
+```
+
+`<kind>` MUST be one of: `constrained-by`, `blocked-by`, `supersedes`,
+`derived-from`. Choose the kind whose semantics best match the dependency:
+
+| Kind | Use when |
+| ---- | -------- |
+| `constrained-by` | This section's design is bounded by the referenced document/section |
+| `blocked-by` | This item cannot proceed until the referenced item resolves |
+| `supersedes` | This document replaces the referenced content |
+| `derived-from` | This section is derived from the referenced source |
+
+### Three target shapes
+
+| Dependency type | Target syntax | Example |
+| --------------- | ------------- | ------- |
+| Within-document section | `#section-slug` | `<!-- derived-from #background -->` |
+| Other document (whole file) | `./relative/path.md` | `<!-- blocked-by ./specs/open-issue.md -->` |
+| Other document + section | `./path.md#slug` | `<!-- constrained-by ./adr.md#context -->` |
+
+Slugs follow GitHub Markdown rules: lowercase, non-alphanumerics removed,
+spaces and hyphens collapsed to `-`. Place the directive immediately under
+the heading whose content depends on the target. External URLs
+(`http://`, `https://`) are not graph-resolvable — keep them as ordinary
+Markdown links, not directive targets.
+
+### When to add a directive
+
+- Section design references an ADR, spec, or research note → `constrained-by` or `derived-from`.
+- A document replaces an older one → `supersedes` (place in the new document).
+- A spec/task section is blocked on another being resolved → `blocked-by`.
+- A later section extends an earlier one non-obviously → `derived-from #earlier-section`.
+
+If no real dependency exists, do not invent one. Directives are signal, not decoration.


### PR DESCRIPTION
## Summary

- Adds dagayn knowledge-graph usage guidance to `CLAUDE.md` and `AGENTS.md` so contributors prefer `query_graph` / `get_impact_radius` over Grep/Glob when exploring the codebase
- Adds the markdown directive comment policy (`<!-- constrained-by ... -->`, `<!-- derived-from ... -->`, etc.) so dagayn can capture inter-document dependencies as `DEPENDS_ON` / `IMPORTS_FROM` edges
- Ignores `.dagayn/` (graph working files) and the local `.mcp.json` (kept per-developer rather than checked in to avoid forcing the dagayn server on every contributor)

## Notes

- Other editor-specific files dropped by the dagayn installer (`.cursorrules`, `.windsurfrules`, `GEMINI.md`, `QODER.md`, `.kiro/`, `.qoder/`, `.opencode.json`) are not committed and have been removed from the working tree
- No source code changes; documentation and ignore rules only

## Test plan

- [x] `git diff --stat` shows only `.gitignore`, `AGENTS.md`, `CLAUDE.md`
- [ ] CI green (docs-only change, no Rust impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
