### PR TITLE
feat(core): add email() to schema::types

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1789,6 +1789,29 @@ pub mod types {
     pub fn cidr() -> AttributeType {
         AttributeType::Union(vec![ipv4_cidr(), ipv6_cidr()])
     }
+
+    /// Email address type (RFC 5322-ish lightweight validation).
+    ///
+    /// Validation is intentionally pragmatic, not a full RFC 5322 parser:
+    /// requires a non-empty local part, a single `@`, and a domain that
+    /// contains at least one dot with non-empty labels.
+    pub fn email() -> AttributeType {
+        AttributeType::Custom {
+            semantic_name: Some("Email".to_string()),
+            base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
+            validate: |value| {
+                if let Value::String(s) = value {
+                    validate_email(s)
+                } else {
+                    Err("Expected string".to_string())
+                }
+            },
+            namespace: None,
+            to_dsl: None,
+        }
+    }
 }
 
 /// Validate an IPv4 address (e.g., "10.0.1.5", "192.168.0.1")
@@ -1921,6 +1944,68 @@ pub fn validate_ipv6_address(addr: &str) -> Result<(), String> {
         }
         for group in &groups {
             validate_ipv6_group(group, addr)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate an email address using a pragmatic, RFC 5322-ish lightweight check.
+///
+/// Requirements:
+/// - Exactly one `@` separator
+/// - Non-empty local part (no whitespace)
+/// - Non-empty domain containing at least one `.`
+/// - Every dot-separated domain label is non-empty (no leading/trailing dot,
+///   no consecutive dots) and free of whitespace
+///
+/// This is intentionally not a full RFC 5322 parser; it catches the common
+/// formatting mistakes without rejecting unusual-but-valid addresses.
+pub fn validate_email(email: &str) -> Result<(), String> {
+    if email.is_empty() {
+        return Err("Empty email address".to_string());
+    }
+
+    let parts: Vec<&str> = email.split('@').collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "Invalid email '{}': expected exactly one '@'",
+            email
+        ));
+    }
+
+    let local = parts[0];
+    let domain = parts[1];
+
+    if local.is_empty() {
+        return Err(format!("Invalid email '{}': empty local part", email));
+    }
+    if local.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "Invalid email '{}': local part contains whitespace",
+            email
+        ));
+    }
+
+    if domain.is_empty() {
+        return Err(format!("Invalid email '{}': empty domain", email));
+    }
+    if !domain.contains('.') {
+        return Err(format!(
+            "Invalid email '{}': domain must contain at least one dot",
+            email
+        ));
+    }
+
+    for label in domain.split('.') {
+        if label.is_empty() {
+            return Err(format!("Invalid email '{}': domain has empty label", email));
+        }
+        if label.chars().any(char::is_whitespace) {
+            return Err(format!(
+                "Invalid email '{}': domain label contains whitespace",
+                email
+            ));
         }
     }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2494,3 +2494,80 @@ fn custom_type_name_anonymous_pattern_and_length() {
     };
     assert_eq!(t.type_name(), "String(pattern, len: 1..=64)");
 }
+
+#[test]
+fn validate_email_function_directly() {
+    // Valid
+    assert!(validate_email("user@example.com").is_ok());
+    assert!(validate_email("user.name+tag@sub.example.co.jp").is_ok());
+    assert!(validate_email("a@b.c").is_ok());
+
+    // Invalid: no '@'
+    assert!(validate_email("no-at-sign.com").is_err());
+    // Invalid: no dot in domain
+    assert!(validate_email("noTLD@host").is_err());
+    // Invalid: empty local-part
+    assert!(validate_email("@example.com").is_err());
+    // Invalid: empty domain
+    assert!(validate_email("user@").is_err());
+    // Invalid: empty input
+    assert!(validate_email("").is_err());
+    // Invalid: more than one '@'
+    assert!(validate_email("a@b@c.com").is_err());
+    // Invalid: empty domain label (consecutive dots)
+    assert!(validate_email("user@example..com").is_err());
+    // Invalid: trailing dot in domain creates empty label
+    assert!(validate_email("user@example.com.").is_err());
+    // Invalid: whitespace
+    assert!(validate_email("us er@example.com").is_err());
+    assert!(validate_email("user@exa mple.com").is_err());
+}
+
+#[test]
+fn validate_email_type() {
+    let t = types::email();
+
+    // Type identity: Custom with semantic_name "Email" and String base
+    match &t {
+        AttributeType::Custom {
+            semantic_name,
+            base,
+            ..
+        } => {
+            assert_eq!(semantic_name.as_deref(), Some("Email"));
+            assert!(matches!(**base, AttributeType::String));
+        }
+        other => panic!("Expected AttributeType::Custom, got: {:?}", other),
+    }
+
+    // Valid emails
+    assert!(
+        t.validate(&Value::String("user@example.com".to_string()))
+            .is_ok()
+    );
+    assert!(
+        t.validate(&Value::String(
+            "user.name+tag@sub.example.co.jp".to_string()
+        ))
+        .is_ok()
+    );
+
+    // Invalid emails
+    assert!(
+        t.validate(&Value::String("no-at-sign.com".to_string()))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::String("noTLD@host".to_string()))
+            .is_err()
+    );
+    assert!(
+        t.validate(&Value::String("@example.com".to_string()))
+            .is_err()
+    );
+    assert!(t.validate(&Value::String("user@".to_string())).is_err());
+    assert!(t.validate(&Value::String("".to_string())).is_err());
+
+    // Wrong type
+    assert!(t.validate(&Value::Int(42)).is_err());
+}


### PR DESCRIPTION
## Summary

- Adds `pub fn email()` to `carina-core/src/schema.rs::types`, alongside the existing `ipv4_cidr`/`ipv4_address`/`ipv6_cidr`/`ipv6_address`/`cidr` helpers.
- Adds `pub fn validate_email()` — pragmatic, RFC 5322-ish lightweight validation (single `@`, non-empty local-part, dotted domain with no empty labels). Not a full RFC 5322 parser.
- Two new unit tests covering happy + error paths (`validate_email_function_directly`, `validate_email_type`).

## LSP wiring

No extra wiring needed. `carina-lsp/src/diagnostics/mod.rs` already invokes the `validate` fn for every `AttributeType::Custom` (line 476 — "Use schema's validate function for all Custom types"), so the new type is picked up automatically by LSP diagnostics.

## Test plan

- [x] `cargo test -p carina-core` — 2 new tests pass
- [x] `cargo test --workspace` — green
- [x] `cargo build` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — all pass

## Follow-ups (separate repos)

- carina-rs/carina-provider-aws#93 — switch `aws.organizations.account.email` from `AttributeType::String` to `types::email()`
- carina-rs/carina-provider-awscc#102 — switch `awscc.organizations.account.email` from the ad-hoc pattern-length Custom to `types::email()`

Closes #1747