### PR TITLE
refactor(core): drop the Expr(Value) newtype

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -149,7 +149,7 @@ pub async fn run_plan(
                 r.id.resource_type == backend_resource_type
                     && r.attributes
                         .get("bucket")
-                        .is_some_and(|v| matches!(&**v, Value::String(s) if s == &bucket_name))
+                        .is_some_and(|v| matches!(v, Value::String(s) if s == &bucket_name))
             });
 
             if !has_bucket_resource {

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -34,10 +34,9 @@ pub(crate) fn apply_name_overrides(resources: &mut [Resource], state_file: &Opti
     for resource in resources.iter_mut() {
         if let Some(name_overrides) = overrides.get(&resource.id) {
             for (attr, value) in name_overrides {
-                resource.attributes.insert(
-                    attr.clone(),
-                    carina_core::resource::Expr(Value::String(value.clone())),
-                );
+                resource
+                    .attributes
+                    .insert(attr.clone(), Value::String(value.clone()));
             }
         }
     }
@@ -278,7 +277,7 @@ pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceI
         .collect();
     Resource {
         id: id.clone(),
-        attributes: carina_core::resource::Expr::wrap_map(attributes),
+        attributes: attributes.into_iter().collect(),
         kind: carina_core::resource::ResourceKind::Real,
         lifecycle: rs.lifecycle.clone(),
         prefixes: rs.prefixes.clone(),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1579,13 +1579,10 @@ impl Provider for RecordingProvider {
         // Return a state with a new identifier to simulate resource creation
         let mut attrs = resource.attributes.clone();
         // Simulate AWS returning a new ID
-        attrs.insert(
-            "vpc_id".to_string(),
-            carina_core::resource::Expr(Value::String("vpc-NEW".to_string())),
-        );
+        attrs.insert("vpc_id".to_string(), Value::String("vpc-NEW".to_string()));
         let state = State::existing(
             resource.id.clone(),
-            carina_core::resource::Expr::resolve_map(&attrs),
+            carina_core::resource::attrs_to_hashmap(&attrs),
         )
         .with_identifier("vpc-NEW");
         Box::pin(async move { Ok(state) })

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -495,7 +495,7 @@ pub fn resolve_enum_aliases_with_ctx(ctx: &WiringContext, resources: &mut [Resou
         // `value_attrs` is `HashMap`-shaped, so the source order written
         // by the user does not survive alias resolution. Re-rendering the
         // attributes after this point can produce a different key order.
-        resource.attributes = carina_core::resource::Expr::wrap_map(value_attrs);
+        resource.attributes = value_attrs.into_iter().collect();
     }
 }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -424,7 +424,7 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
 /// string and ships it to the remote API as a literal.
 #[test]
 fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
-    use carina_core::resource::{AccessPath, Expr, ResourceKind};
+    use carina_core::resource::{AccessPath, ResourceKind};
 
     let identity_store_id = "d-9067c29a4b";
 
@@ -437,13 +437,13 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     mizzy.kind = ResourceKind::DataSource;
     mizzy.attributes.insert(
         "identity_store_id".to_string(),
-        Expr(Value::ResourceRef {
+        Value::ResourceRef {
             path: AccessPath::new("sso", "identity_store_id"),
-        }),
+        },
     );
     mizzy.attributes.insert(
         "user_name".to_string(),
-        Expr(Value::String("gosukenator@gmail.com".into())),
+        Value::String("gosukenator@gmail.com".into()),
     );
 
     // current_states after phase 1: sso has been refreshed and its

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -268,7 +268,7 @@ fn build_create_rows(
     let default_tag_keys: HashSet<String> = r
         .attributes
         .get("_default_tag_keys")
-        .and_then(|v| match &**v {
+        .and_then(|v| match v {
             Value::List(items) => Some(
                 items
                     .iter()
@@ -294,17 +294,17 @@ fn build_create_rows(
         // Expand tags map into individual rows with default_tags annotation
         if key.as_str() == "tags"
             && !default_tag_keys.is_empty()
-            && let Value::Map(map) = &**value
+            && let Value::Map(map) = value
         {
             rows.push(build_expanded_tags_row(map, &default_tag_keys));
             continue;
         }
         if is_list_of_maps(value) {
             rows.push(build_list_of_maps_row(key, value));
-        } else if let Value::Map(map) = &**value {
+        } else if let Value::Map(map) = value {
             rows.push(build_expanded_map_row(key, map));
         } else {
-            let ref_binding = match &**value {
+            let ref_binding = match value {
                 Value::ResourceRef { path } => Some(path.binding().to_string()),
                 _ => None,
             };

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -6,7 +6,7 @@ use crate::deps::get_resource_dependencies;
 use crate::effect::{CascadingUpdate, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::plan::{Plan, PlanError};
-use crate::resource::{Expr, LifecycleConfig, Resource, ResourceId, ResourceKind, State, Value};
+use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, State, Value};
 use crate::schema::ResourceSchema;
 
 use super::{Diff, diff};
@@ -338,7 +338,7 @@ pub fn create_plan(
                     // ordering of this synthetic temp resource doesn't
                     // matter (it only feeds the dependency walker), so
                     // a plain clone-through `wrap_map` is fine.
-                    attributes: Expr::wrap_map(state.attributes.clone()),
+                    attributes: state.attributes.clone().into_iter().collect(),
                     kind: ResourceKind::Real,
                     lifecycle: lifecycle.clone(),
                     prefixes: HashMap::new(),
@@ -497,16 +497,14 @@ pub fn cascade_dependent_updates(
             let ref_attrs: Vec<String> = resource
                 .attributes
                 .iter()
-                .filter(|(_, v)| {
-                    matches!(v.as_value(), Value::ResourceRef { path } if path.binding() == dep)
-                })
+                .filter(|(_, v)| matches!(v, Value::ResourceRef { path } if path.binding() == dep))
                 .map(|(k, _)| k.clone())
                 .collect();
 
             let ref_hints: Vec<(String, String)> = resource
                 .attributes
                 .iter()
-                .filter_map(|(k, v)| match v.as_value() {
+                .filter_map(|(k, v)| match v {
                     Value::ResourceRef { path } if path.binding() == dep => Some((
                         k.clone(),
                         format!("{}.{}", path.binding(), path.attribute()),
@@ -589,7 +587,7 @@ pub fn cascade_dependent_updates(
                     .attributes
                     .iter()
                     .filter(|(_, v)| {
-                        matches!(v.as_value(), Value::ResourceRef { path } if path.binding() == replaced_binding)
+                        matches!(v, Value::ResourceRef { path } if path.binding() == replaced_binding)
                     })
                     .map(|(k, _)| k.clone())
                     .collect();
@@ -626,7 +624,7 @@ pub fn cascade_dependent_updates(
                     let ref_hints: Vec<(String, String)> = unresolved
                         .attributes
                         .iter()
-                        .filter_map(|(k, v)| match v.as_value() {
+                        .filter_map(|(k, v)| match v {
                             Value::ResourceRef { path }
                                 if path.binding() == replaced_binding
                                     && create_only_refs.contains(k) =>

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use crate::effect::Effect;
 use crate::provider::Provider;
 use crate::resolver::resolve_ref_value;
-use crate::resource::{Expr, Resource, ResourceId, State, Value};
+use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
@@ -105,7 +105,7 @@ pub(super) fn resolve_resource(
         let resolved_value = resolve_ref_value(expr, binding_map)?;
         resolved
             .attributes
-            .insert(key.clone(), Expr(unwrap_secret(resolved_value)));
+            .insert(key.clone(), unwrap_secret(resolved_value));
     }
     Ok(resolved)
 }
@@ -122,7 +122,7 @@ pub(super) fn resolve_resource_with_source(
         let resolved_value = resolve_ref_value(expr, binding_map)?;
         resolved
             .attributes
-            .insert(key.clone(), Expr(unwrap_secret(resolved_value)));
+            .insert(key.clone(), unwrap_secret(resolved_value));
     }
     Ok(resolved)
 }

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -47,7 +47,7 @@ pub fn resolve_attr_prefixes(
             .iter()
             .filter_map(|(key, value)| {
                 if let Some(base_attr) = key.strip_suffix("_prefix")
-                    && let Value::String(prefix_value) = &**value
+                    && let Value::String(prefix_value) = value
                     && let Some(attr_schema) = schema.attributes.get(base_attr)
                     && is_string_compatible_type(&attr_schema.attr_type)
                 {

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -358,7 +358,7 @@ impl RootConfigSignature {
             let resource_type_str = resource
                 .attributes
                 .get("_type")
-                .and_then(|v| match &**v {
+                .and_then(|v| match v {
                     Value::String(s) => Some(s.clone()),
                     _ => None,
                 })
@@ -753,7 +753,7 @@ impl ModuleSignature {
             let resource_type_str = resource
                 .attributes
                 .get("_type")
-                .and_then(|v| match &**v {
+                .and_then(|v| match v {
                     Value::String(s) => Some(s.clone()),
                     _ => None,
                 })

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::parser::ModuleCall;
-use crate::resource::{Expr, LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
 
 use super::error::ModuleError;
 use super::resolver::ModuleResolver;
@@ -161,12 +161,12 @@ impl ModuleResolver<'_> {
             // are not incorrectly prefixed.
             // Preserve user-authored attribute order across the
             // module-call expansion (#2222) — `IndexMap`, not `HashMap`.
-            let mut substituted_attrs: IndexMap<String, Expr> = IndexMap::new();
+            let mut substituted_attrs: IndexMap<String, Value> = IndexMap::new();
             for (key, expr) in &new_resource.attributes {
                 let rewritten =
                     rewrite_intra_module_refs(expr, instance_prefix, &intra_module_bindings);
                 let substituted = substitute_arguments(&rewritten, &argument_values);
-                substituted_attrs.insert(key.clone(), Expr(substituted));
+                substituted_attrs.insert(key.clone(), substituted);
             }
             new_resource.attributes = substituted_attrs;
 
@@ -177,7 +177,7 @@ impl ModuleResolver<'_> {
         if !module.attribute_params.is_empty()
             && let Some(binding_name) = &call.binding_name
         {
-            let mut virtual_attrs: IndexMap<String, Expr> = IndexMap::new();
+            let mut virtual_attrs: IndexMap<String, Value> = IndexMap::new();
 
             // Copy attribute values from the module definition
             for attr_param in &module.attribute_params {
@@ -186,7 +186,7 @@ impl ModuleResolver<'_> {
                     let rewritten =
                         rewrite_intra_module_refs(value, instance_prefix, &intra_module_bindings);
                     let substituted = substitute_arguments(&rewritten, &argument_values);
-                    virtual_attrs.insert(attr_param.name.clone(), Expr(substituted));
+                    virtual_attrs.insert(attr_param.name.clone(), substituted);
                 }
             }
 
@@ -502,9 +502,9 @@ pub fn reconcile_anonymous_module_instances(
     // bindings with the old prefix. Walk every value and rewrite those.
     for r in resources.iter_mut() {
         let mut replacements = Vec::new();
-        for (key, expr) in r.attributes.iter() {
-            let rewritten = rewrite_ref_prefixes(&expr.0, &prefix_remap);
-            if rewritten != expr.0 {
+        for (key, value) in r.attributes.iter() {
+            let rewritten = rewrite_ref_prefixes(value, &prefix_remap);
+            if rewritten != *value {
                 replacements.push((key.clone(), rewritten));
             }
         }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -13,7 +13,7 @@ use indexmap::IndexMap;
 
 use super::*;
 use crate::parser::{ArgumentParameter, ModuleCall, ParsedFile, ProviderContext, TypeExpr};
-use crate::resource::{Expr, LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
 
 fn create_test_module() -> ParsedFile {
     ParsedFile {
@@ -31,7 +31,7 @@ fn create_test_module() -> ParsedFile {
                     "_type".to_string(),
                     Value::String("aws.security_group".to_string()),
                 );
-                Expr::wrap_map(attrs)
+                attrs.into_iter().collect()
             },
             kind: ResourceKind::Real,
             lifecycle: LifecycleConfig::default(),
@@ -159,7 +159,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                         "cidr_block".to_string(),
                         Value::resource_ref("cidr".to_string(), String::new(), vec![]),
                     );
-                    Expr::wrap_map(attrs)
+                    attrs.into_iter().collect()
                 },
                 kind: ResourceKind::Real,
                 lifecycle: LifecycleConfig::default(),
@@ -177,7 +177,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                         "vpc_id".to_string(),
                         Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
                     );
-                    Expr::wrap_map(attrs)
+                    attrs.into_iter().collect()
                 },
                 kind: ResourceKind::Real,
                 lifecycle: LifecycleConfig::default(),
@@ -304,7 +304,7 @@ fn create_module_with_attributes() -> ParsedFile {
                     "_type".to_string(),
                     Value::String("aws.security_group".to_string()),
                 );
-                Expr::wrap_map(attrs)
+                attrs.into_iter().collect()
             },
             kind: ResourceKind::Real,
             lifecycle: LifecycleConfig::default(),
@@ -1105,7 +1105,7 @@ fn create_module_with_interpolation() -> ParsedFile {
                     "env".to_string(),
                     Value::resource_ref("env_name".to_string(), String::new(), vec![]),
                 );
-                Expr::wrap_map(attrs)
+                attrs.into_iter().collect()
             },
             kind: ResourceKind::Real,
             lifecycle: LifecycleConfig::default(),

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -491,8 +491,8 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.set_name(address.clone());
                         resource.binding = Some(address);
-                        for (_k, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, None, None, item);
+                        for (_k, value) in resource.attributes.iter_mut() {
+                            substitute_placeholder(value, None, None, item);
                         }
                         expanded_resources.push(resource);
                     }
@@ -505,8 +505,8 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.set_name(address.clone());
                         resource.binding = Some(address);
-                        for (_k, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, Some(i as i64), None, item);
+                        for (_k, value) in resource.attributes.iter_mut() {
+                            substitute_placeholder(value, Some(i as i64), None, item);
                         }
                         expanded_resources.push(resource);
                     }
@@ -522,8 +522,8 @@ impl ParsedFile {
                         let mut resource = deferred.template_resource.clone();
                         resource.id.set_name(address.clone());
                         resource.binding = Some(address);
-                        for (_k, expr) in resource.attributes.iter_mut() {
-                            substitute_placeholder(&mut expr.0, None, Some(key), val);
+                        for (_k, value) in resource.attributes.iter_mut() {
+                            substitute_placeholder(value, None, Some(key), val);
                         }
                         expanded_resources.push(resource);
                     }

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -11,7 +11,7 @@ use crate::parser::context::{ParseContext, extract_key_string, first_inner, next
 use crate::parser::error::ParseError;
 use crate::parser::parse_expression;
 use crate::parser::util::expression_is_plain_string_literal;
-use crate::resource::{Expr, Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{Resource, ResourceId, ResourceKind, Value};
 use indexmap::IndexMap;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -53,7 +53,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
 
     Ok(Resource {
         id,
-        attributes: Expr::wrap_map(attributes),
+        attributes: attributes.into_iter().collect(),
         kind: ResourceKind::Real,
         lifecycle,
         prefixes: HashMap::new(),
@@ -214,7 +214,7 @@ pub(crate) fn parse_resource_expr(
 
     Ok(Resource {
         id,
-        attributes: Expr::wrap_map(attributes),
+        attributes: attributes.into_iter().collect(),
         kind: ResourceKind::Real,
         lifecycle,
         prefixes: HashMap::new(),
@@ -265,7 +265,7 @@ pub(crate) fn parse_read_resource_expr(
 
     Ok(Resource {
         id,
-        attributes: Expr::wrap_map(attributes),
+        attributes: attributes.into_iter().collect(),
         kind: ResourceKind::DataSource,
         lifecycle,
         prefixes: HashMap::new(),

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -272,7 +272,7 @@ pub(crate) fn parse_for_expr(
                     .attributes
                     .iter()
                     .filter(|(k, _)| !k.starts_with('_'))
-                    .map(|(k, expr)| (k.clone(), expr.0.clone()))
+                    .map(|(k, value)| (k.clone(), value.clone()))
                     .collect();
                 ctx.deferred_for_expressions.push(DeferredForExpression {
                     file: None,
@@ -349,7 +349,7 @@ pub(crate) fn parse_for_expr(
                         .attributes
                         .iter()
                         .filter(|(k, _)| !k.starts_with('_'))
-                        .map(|(k, expr)| (k.clone(), expr.0.clone()))
+                        .map(|(k, value)| (k.clone(), value.clone()))
                         .collect();
                     ctx.deferred_for_expressions.push(DeferredForExpression {
                         file: None,

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -7,7 +7,7 @@ use super::ast::{AttributeParameter, ExportParameter, ModuleCall, ParsedFile};
 use super::error::{ParseError, undefined_identifier_error};
 use super::static_eval::is_static_value;
 use crate::eval_value::EvalValue;
-use crate::resource::{Expr, Resource, Value};
+use crate::resource::{Resource, Value};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
@@ -30,10 +30,10 @@ pub(super) fn resolve_forward_references(
         // the user-authored attribute order without a key-collection
         // round-trip. The placeholder is overwritten on the next line,
         // so its identity doesn't matter.
-        for (_, expr) in resource.attributes.iter_mut() {
+        for (_, attr) in resource.attributes.iter_mut() {
             let placeholder = Value::Bool(false);
-            let value = std::mem::replace(&mut expr.0, placeholder);
-            expr.0 = resolve_forward_ref_in_value(value, resource_bindings);
+            let value = std::mem::replace(attr, placeholder);
+            *attr = resolve_forward_ref_in_value(value, resource_bindings);
         }
     }
     for attr_param in attribute_params.iter_mut() {
@@ -172,11 +172,11 @@ pub fn resolve_resource_refs_with_config(
     // Resolve references in each resource. Keep `IndexMap` to preserve
     // the user's source order through resolution (#2222).
     for resource in &mut parsed.resources {
-        let mut resolved_attrs: IndexMap<String, Expr> = IndexMap::new();
+        let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
 
         for (key, expr) in &resource.attributes {
             let resolved = resolve_value_with_config(expr, &binding_map, config)?;
-            resolved_attrs.insert(key.clone(), Expr(resolved));
+            resolved_attrs.insert(key.clone(), resolved);
         }
 
         resource.attributes = resolved_attrs;
@@ -271,8 +271,8 @@ fn accumulate_undefined_reference_errors(
     };
 
     for resource in &parsed.resources {
-        for expr in resource.attributes.values() {
-            check(&expr.0);
+        for value in resource.attributes.values() {
+            check(value);
         }
     }
     for attr in &parsed.attribute_params {

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -725,7 +725,7 @@ mod tests {
             let attrs = resource.attributes.clone();
             Box::pin(async move {
                 Ok(
-                    State::existing(id, crate::resource::Expr::resolve_map(&attrs))
+                    State::existing(id, crate::resource::attrs_to_hashmap(&attrs))
                         .with_identifier("mock-id-123"),
                 )
             })
@@ -743,7 +743,7 @@ mod tests {
             Box::pin(async move {
                 Ok(State::existing(
                     id,
-                    crate::resource::Expr::resolve_map(&attrs),
+                    crate::resource::attrs_to_hashmap(&attrs),
                 ))
             })
         }
@@ -799,7 +799,7 @@ mod tests {
             Box::pin(async move {
                 Ok(State::existing(
                     id,
-                    crate::resource::Expr::resolve_map(&attrs),
+                    crate::resource::attrs_to_hashmap(&attrs),
                 ))
             })
         }
@@ -1063,7 +1063,7 @@ mod tests {
                 // Prefix all string attribute values with "normalized:"
                 for resource in resources.iter_mut() {
                     for value in resource.attributes.values_mut() {
-                        if let Value::String(s) = &mut **value {
+                        if let Value::String(s) = value {
                             *s = format!("normalized:{}", s);
                         }
                     }
@@ -1176,7 +1176,7 @@ mod tests {
                 for resource in resources.iter_mut() {
                     if resource.id.provider == "normalizing" {
                         for value in resource.attributes.values_mut() {
-                            if let Value::String(s) = &mut **value {
+                            if let Value::String(s) = value {
                                 *s = format!("norm:{}", s);
                             }
                         }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 
 use crate::deps::get_resource_dependencies;
 use crate::resource::{
-    Expr, InterpolationPart, Resource, ResourceId, State, Value, contains_resource_ref,
+    InterpolationPart, Resource, ResourceId, State, Value, contains_resource_ref,
 };
 
 /// Resolve all ResourceRef values in resources using current state.
@@ -48,7 +48,6 @@ pub fn resolve_refs_with_state_and_remote(
     }
 
     // Build a map of binding_name -> attributes (merged from DSL and AWS state)
-    // Extract Value from Expr for the binding map since resolve_ref_value works with Value
     let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
 
     for resource in resources.iter() {
@@ -85,9 +84,9 @@ pub fn resolve_refs_with_state_and_remote(
     // so the user's authored attribute order survives resolution
     // (#2222).
     for resource in resources.iter_mut() {
-        let mut resolved_attrs: indexmap::IndexMap<String, Expr> = indexmap::IndexMap::new();
-        for (key, expr) in &resource.attributes {
-            resolved_attrs.insert(key.clone(), Expr(resolve_ref_value(expr, &binding_map)?));
+        let mut resolved_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+        for (key, value) in &resource.attributes {
+            resolved_attrs.insert(key.clone(), resolve_ref_value(value, &binding_map)?);
         }
         resource.attributes = resolved_attrs;
     }
@@ -252,7 +251,7 @@ mod tests {
 
     fn make_resource(name: &str, binding: Option<&str>, attrs: Vec<(&str, Value)>) -> Resource {
         let mut r = Resource::new("test.resource", name);
-        r.attributes = Expr::wrap_map(attrs.into_iter().map(|(k, v)| (k.to_string(), v)));
+        r.attributes = attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect();
         r.binding = binding.map(|b| b.to_string());
         r
     }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -156,20 +156,6 @@ impl std::fmt::Display for ResourceId {
     }
 }
 
-/// An unevaluated expression in the DSL.
-///
-/// `Expr` is a newtype wrapper around `Value` that represents values which may need
-/// resolution before becoming final. The parser produces `Expr` values for resource
-/// attributes; the resolver resolves references within the inner `Value` (e.g.,
-/// replacing `ResourceRef` variants with concrete values).
-///
-/// `Expr` wraps `Value` to enforce a type-level distinction between pre-resolution
-/// and post-resolution data. This prevents downstream code from accidentally receiving
-/// unresolved expressions.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Expr(pub Value);
-
 /// A typed access path representing a `ResourceRef` target.
 ///
 /// The path always carries a binding name and an attribute name; nested field
@@ -291,9 +277,6 @@ pub enum InterpolationPart {
     Expr(Value),
 }
 
-/// Legacy alias for `InterpolationPart`.
-pub type ExprPart = InterpolationPart;
-
 impl Value {
     /// Create a `ResourceRef` from binding name, attribute name, and optional field path.
     ///
@@ -365,84 +348,22 @@ impl Value {
     }
 }
 
-impl Expr {
-    /// Returns a reference to the inner `Value`.
-    pub fn as_value(&self) -> &Value {
-        &self.0
-    }
-
-    /// Consumes self and returns the inner `Value`.
-    pub fn into_value(self) -> Value {
-        self.0
-    }
-
-    /// Returns true if the inner value contains no `ResourceRef` variants.
-    ///
-    /// This checks recursively: `ResourceRef`s nested inside `List`, `Map`,
-    /// `Interpolation`, `FunctionCall`, or `Secret` are detected.
-    /// Note that `Interpolation` and `FunctionCall` variants without nested
-    /// `ResourceRef`s are considered resolved by this method.
-    pub fn is_resolved(&self) -> bool {
-        !contains_resource_ref(&self.0)
-    }
-
-    /// Extract the inner `Value` of each entry in an `Expr` attribute map.
-    ///
-    /// Despite the legacy name, this method does **not** resolve
-    /// `Value::ResourceRef` / `Value::Interpolation` / `Value::FunctionCall`
-    /// / `Value::Secret` — it simply unwraps `Expr` → `Value`. Callers
-    /// that need concrete values must run
-    /// `carina_core::resolver::resolve_refs_with_state_and_remote` (or an
-    /// equivalent) first. See #1683 for a regression caused by assuming
-    /// this method performed resolution.
-    /// Project an `IndexMap<String, Expr>` (the shape `Resource.attributes`
-    /// uses since #2222) into a plain `HashMap<String, Value>` for callers
-    /// that only need key-based lookup (state merging, ResourceRef
-    /// resolution, provider trait inputs). Source-order is dropped on
-    /// purpose at this boundary — keep it on `Resource.attributes` itself
-    /// when iteration order matters.
-    pub fn resolve_map(attrs: &IndexMap<String, Expr>) -> HashMap<String, Value> {
-        attrs
-            .iter()
-            .map(|(k, e)| (k.clone(), e.0.clone()))
-            .collect()
-    }
-
-    /// Wrap any `(String, Value)` iterator (`HashMap<String, Value>`,
-    /// `IndexMap<String, Value>`, `Vec<(String, Value)>`, …) into the
-    /// `IndexMap<String, Expr>` that `Resource.attributes` expects.
-    /// Source order follows the iteration order of `attrs`.
-    pub fn wrap_map<I>(attrs: I) -> IndexMap<String, Expr>
-    where
-        I: IntoIterator<Item = (String, Value)>,
-    {
-        attrs.into_iter().map(|(k, v)| (k, Expr(v))).collect()
-    }
-}
-
-impl From<Value> for Expr {
-    fn from(value: Value) -> Self {
-        Expr(value)
-    }
-}
-
-impl PartialEq<Value> for Expr {
-    fn eq(&self, other: &Value) -> bool {
-        self.0 == *other
-    }
-}
-
-impl std::ops::Deref for Expr {
-    type Target = Value;
-    fn deref(&self) -> &Value {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Expr {
-    fn deref_mut(&mut self) -> &mut Value {
-        &mut self.0
-    }
+/// Project an `IndexMap<String, Value>` (the shape `Resource.attributes`
+/// uses since #2222) into a plain `HashMap<String, Value>` for callers
+/// that only need key-based lookup (state merging, ResourceRef
+/// resolution, provider trait inputs). Source-order is dropped on
+/// purpose at this boundary — keep it on `Resource.attributes` itself
+/// when iteration order matters.
+///
+/// Despite the historical name (the helper used to operate on the now-removed
+/// `Expr` newtype), this function does **not** resolve `Value::ResourceRef` /
+/// `Value::Interpolation` / `Value::FunctionCall` / `Value::Secret` — it just
+/// projects ordered attribute storage to a hashmap. Callers that need concrete
+/// values must run `carina_core::resolver::resolve_refs_with_state_and_remote`
+/// (or an equivalent) first. See #1683 for a regression caused by assuming
+/// this method performed resolution.
+pub fn attrs_to_hashmap(attrs: &IndexMap<String, Value>) -> HashMap<String, Value> {
+    attrs.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
 }
 
 /// Check if a Value contains any ResourceRef (possibly nested)
@@ -846,7 +767,7 @@ pub struct Resource {
     /// the user wrote attributes in the `.crn` file. Anything that
     /// re-renders attributes — diagnostic messages, formatter output,
     /// plan display, snapshot tests — depends on this stability (#2222).
-    pub attributes: IndexMap<String, Expr>,
+    pub attributes: IndexMap<String, Value>,
     /// Classification of this resource (real, virtual, or data source)
     #[serde(default)]
     pub kind: ResourceKind,
@@ -922,7 +843,7 @@ impl Resource {
         }
     }
 
-    /// Returns the resolved attributes as a `HashMap<String, Value>`.
+    /// Returns the attributes projected to a `HashMap<String, Value>`.
     ///
     /// Lookup-only callers (validation, differ, plan display) still
     /// receive a `HashMap` — iteration over user-authored order is done
@@ -930,42 +851,32 @@ impl Resource {
     /// helper would just force every downstream caller to widen its
     /// signature for no order benefit.
     pub fn resolved_attributes(&self) -> HashMap<String, Value> {
-        self.attributes
-            .iter()
-            .map(|(k, e)| (k.clone(), e.0.clone()))
-            .collect()
+        attrs_to_hashmap(&self.attributes)
     }
 
     /// Get an attribute value by key, returning `Option<&Value>`.
-    ///
-    /// Convenience method that unwraps the `Expr` wrapper.
     pub fn get_attr(&self, key: &str) -> Option<&Value> {
-        self.attributes.get(key).map(|e| &e.0)
+        self.attributes.get(key)
     }
 
     /// Get a mutable attribute value by key, returning `Option<&mut Value>`.
     pub fn get_attr_mut(&mut self, key: &str) -> Option<&mut Value> {
-        self.attributes.get_mut(key).map(|e| &mut e.0)
+        self.attributes.get_mut(key)
     }
 
-    /// Set an attribute value, wrapping it in `Expr`.
+    /// Set an attribute value.
     pub fn set_attr(&mut self, key: impl Into<String>, value: Value) {
-        self.attributes.insert(key.into(), Expr(value));
+        self.attributes.insert(key.into(), value);
     }
 
     pub fn with_attribute(mut self, key: impl Into<String>, value: Value) -> Self {
-        self.attributes.insert(key.into(), Expr(value));
+        self.attributes.insert(key.into(), value);
         self
     }
 
-    pub fn with_expr_attribute(mut self, key: impl Into<String>, expr: Expr) -> Self {
-        self.attributes.insert(key.into(), expr);
-        self
-    }
-
-    /// Set attributes from a `HashMap<String, Value>`, wrapping each value in `Expr`.
+    /// Set attributes from a `HashMap<String, Value>`.
     pub fn with_value_attributes(mut self, attrs: HashMap<String, Value>) -> Self {
-        self.attributes = Expr::wrap_map(attrs);
+        self.attributes = attrs.into_iter().collect();
         self
     }
 

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -622,62 +622,12 @@ fn resource_kind_enum_data_source() {
 }
 
 #[test]
-fn expr_wraps_value() {
-    let expr = Expr(Value::String("hello".to_string()));
-    assert!(matches!(*expr, Value::String(_)));
-}
-
-#[test]
-fn expr_wraps_resource_ref() {
-    let expr = Expr(Value::resource_ref(
-        "vpc".to_string(),
-        "id".to_string(),
-        vec![],
-    ));
-    assert!(matches!(*expr, Value::ResourceRef { .. }));
-    assert!(!expr.is_resolved());
-}
-
-#[test]
-fn expr_wraps_interpolation() {
-    let expr = Expr(Value::Interpolation(vec![
-        InterpolationPart::Literal("prefix-".to_string()),
-        InterpolationPart::Expr(Value::resource_ref(
-            "vpc".to_string(),
-            "id".to_string(),
-            vec![],
-        )),
-    ]));
-    assert!(matches!(*expr, Value::Interpolation(_)));
-    assert!(!expr.is_resolved());
-}
-
-#[test]
-fn expr_wraps_function_call() {
-    let expr = Expr(Value::FunctionCall {
-        name: "join".to_string(),
-        args: vec![
-            Value::String("-".to_string()),
-            Value::List(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
-        ],
-    });
-    assert!(matches!(*expr, Value::FunctionCall { .. }));
-}
-
-#[test]
-fn resource_attributes_use_expr_type() {
+fn resource_attributes_use_value_type() {
     let resource = Resource::new("s3.Bucket", "test")
-        .with_expr_attribute("name", Expr(Value::String("my-bucket".to_string())))
-        .with_expr_attribute(
+        .with_attribute("name", Value::String("my-bucket".to_string()))
+        .with_attribute(
             "vpc_id",
-            Expr(Value::resource_ref(
-                "vpc".to_string(),
-                "id".to_string(),
-                vec![],
-            )),
+            Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
         );
     assert!(matches!(resource.get_attr("name"), Some(Value::String(_))));
     assert!(matches!(
@@ -687,81 +637,11 @@ fn resource_attributes_use_expr_type() {
 }
 
 #[test]
-fn expr_serde_round_trip() {
-    let exprs = vec![
-        Expr(Value::String("hello".to_string())),
-        Expr(Value::Int(42)),
-        Expr(Value::resource_ref(
-            "vpc".to_string(),
-            "id".to_string(),
-            vec![],
-        )),
-        Expr(Value::Interpolation(vec![
-            InterpolationPart::Literal("prefix-".to_string()),
-            InterpolationPart::Expr(Value::resource_ref(
-                "vpc".to_string(),
-                "id".to_string(),
-                vec![],
-            )),
-        ])),
-        Expr(Value::FunctionCall {
-            name: "join".to_string(),
-            args: vec![
-                Value::String("-".to_string()),
-                Value::List(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string()),
-                ]),
-            ],
-        }),
-    ];
-
-    for expr in exprs {
-        let json = serde_json::to_string(&expr).unwrap();
-        let deserialized: Expr = serde_json::from_str(&json).unwrap();
-        assert_eq!(expr, deserialized, "Round-trip failed for {:?}", expr);
-    }
-}
-
-#[test]
-fn expr_is_resolved_for_plain_values() {
-    assert!(Expr(Value::String("hello".to_string())).is_resolved());
-    assert!(Expr(Value::Int(42)).is_resolved());
-    assert!(Expr(Value::Bool(true)).is_resolved());
-}
-
-#[test]
-fn expr_is_not_resolved_for_refs() {
-    assert!(
-        !Expr(Value::resource_ref(
-            "vpc".to_string(),
-            "id".to_string(),
-            vec![]
-        ))
-        .is_resolved()
-    );
-}
-
-#[test]
-fn expr_deref_to_value() {
-    let expr = Expr(Value::String("hello".to_string()));
-    let val: &Value = &expr;
-    assert!(matches!(val, Value::String(s) if s == "hello"));
-}
-
-#[test]
-fn expr_from_value() {
-    let value = Value::Int(42);
-    let expr: Expr = value.into();
-    assert_eq!(expr.0, Value::Int(42));
-}
-
-#[test]
-fn expr_resolve_map() {
+fn attrs_to_hashmap_clones_values() {
     let mut attrs = IndexMap::new();
-    attrs.insert("name".to_string(), Expr(Value::String("test".to_string())));
-    attrs.insert("count".to_string(), Expr(Value::Int(5)));
-    let resolved = Expr::resolve_map(&attrs);
+    attrs.insert("name".to_string(), Value::String("test".to_string()));
+    attrs.insert("count".to_string(), Value::Int(5));
+    let resolved = attrs_to_hashmap(&attrs);
     assert_eq!(
         resolved.get("name"),
         Some(&Value::String("test".to_string()))

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1709,7 +1709,7 @@ pub fn resolve_block_names(
             };
             match &attr_schema.attr_type {
                 AttributeType::Struct { fields, .. } => {
-                    if let Value::Map(inner_map) = &mut **value {
+                    if let Value::Map(inner_map) = value {
                         resolve_block_names_in_map(
                             inner_map,
                             fields,
@@ -1720,7 +1720,7 @@ pub fn resolve_block_names(
                 }
                 AttributeType::List { inner, .. } => {
                     if let AttributeType::Struct { fields, .. } = inner.as_ref()
-                        && let Value::List(items) = &mut **value
+                        && let Value::List(items) = value
                     {
                         for item in items.iter_mut() {
                             if let Value::Map(item_map) = item {

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -198,7 +198,7 @@ pub fn check_upstream_state_field_references(
         // `ResourceContext::Deferred` branch to mention the for header so
         // users can tell body errors from top-level ones.
         for (ctx, resource) in parsed.iter_all_resources() {
-            for (attr_name, expr) in resource.attributes.iter() {
+            for (attr_name, value) in resource.attributes.iter() {
                 let location = match ctx {
                     ResourceContext::Direct => {
                         format!("{} attribute `{}`", resource.id, attr_name)
@@ -208,7 +208,7 @@ pub fn check_upstream_state_field_references(
                         d.header, resource.id, attr_name
                     ),
                 };
-                check(expr.as_value(), &location);
+                check(value, &location);
             }
         }
         for attr in &parsed.attribute_params {
@@ -318,7 +318,7 @@ pub fn check_upstream_state_field_types(
         let Some(schema) = schemas.get(&key) else {
             continue;
         };
-        for (attr_name, expr) in resource.attributes.iter() {
+        for (attr_name, value) in resource.attributes.iter() {
             if attr_name.starts_with('_') {
                 continue;
             }
@@ -333,7 +333,7 @@ pub fn check_upstream_state_field_types(
                 ),
             };
             check_ref_against_type(
-                expr.as_value(),
+                value,
                 &attr_schema.attr_type,
                 exports,
                 &location,

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -96,7 +96,7 @@ pub fn validate_resource_ref_types(
                 continue;
             }
 
-            let (ref_binding, ref_attr) = match attr_value.as_value() {
+            let (ref_binding, ref_attr) = match attr_value {
                 Value::ResourceRef { path } => {
                     (path.binding().to_string(), path.attribute().to_string())
                 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -366,7 +366,7 @@ pub fn redact_secrets_in_resource(
     let attributes = resource
         .attributes
         .iter()
-        .map(|(k, e)| (k.clone(), crate::resource::Expr(redact_secrets_in_value(e))))
+        .map(|(k, e)| (k.clone(), redact_secrets_in_value(e)))
         .collect();
     crate::resource::Resource {
         attributes,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -383,7 +383,7 @@ impl DiagnosticEngine {
                             if matches!(
                                 &attr_schema.attr_type,
                                 carina_core::schema::AttributeType::Struct { .. }
-                            ) && matches!(&**attr_value, Value::List(_))
+                            ) && matches!(attr_value, Value::List(_))
                             {
                                 let search_name =
                                     attr_schema.block_name.as_deref().unwrap_or(attr_name);
@@ -403,7 +403,7 @@ impl DiagnosticEngine {
                                 }
                             }
 
-                            let type_error = match (&attr_schema.attr_type, &**attr_value) {
+                            let type_error = match (&attr_schema.attr_type, attr_value) {
                                 // Bool type should not receive String
                                 (carina_core::schema::AttributeType::Bool, Value::String(s)) => {
                                     Some(format!(

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 
 use carina_core::resource::{
-    Expr, LifecycleConfig, Resource as CoreResource, ResourceId as CoreResourceId,
-    State as CoreState, Value as CoreValue,
+    LifecycleConfig, Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
+    Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -196,7 +196,7 @@ pub fn wit_to_core_resource(resource: &wit::ResourceDef) -> CoreResource {
     core_resource.attributes = resource
         .attributes
         .iter()
-        .map(|(k, v)| (k.clone(), Expr(wit_to_core_value(v))))
+        .map(|(k, v)| (k.clone(), wit_to_core_value(v)))
         .collect();
     core_resource
 }
@@ -591,8 +591,8 @@ mod tests {
     fn test_resource_roundtrip() {
         let mut resource = CoreResource::with_provider("aws", "s3.Bucket", "my-bucket");
         resource.attributes = indexmap::IndexMap::from([
-            ("name".into(), Expr(CoreValue::String("my-bucket".into()))),
-            ("region".into(), Expr(CoreValue::String("us-east-1".into()))),
+            ("name".into(), CoreValue::String("my-bucket".into())),
+            ("region".into(), CoreValue::String("us-east-1".into())),
         ]);
 
         let wit = core_to_wit_resource(&resource);

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -25,7 +25,7 @@ use carina_core::provider::{
     SavedAttrs,
 };
 use carina_core::resource::{
-    Expr, LifecycleConfig, Resource, ResourceId, State, Value, contains_resource_ref,
+    LifecycleConfig, Resource, ResourceId, State, Value, contains_resource_ref,
 };
 use carina_core::schema::{CompletionValue, ResourceSchema};
 
@@ -1510,7 +1510,7 @@ impl ProviderNormalizer for WasmProviderNormalizer {
                         {
                             continue;
                         }
-                        core_res.attributes.insert(key, Expr(value));
+                        core_res.attributes.insert(key, value);
                     }
                 }
             }

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use carina_core::provider::{Provider, ProviderFactory};
-use carina_core::resource::{Expr, Resource, ResourceId, Value};
+use carina_core::resource::{Resource, ResourceId, Value};
 use carina_plugin_host::WasmProviderFactory;
 
 fn wasm_path() -> Option<PathBuf> {
@@ -82,9 +82,9 @@ async fn test_wasm_mock_provider_create_and_read() {
     // Create a resource
     let mut resource = Resource::with_provider("mock", "test.resource", "my-resource");
     resource.attributes = indexmap::IndexMap::from([
-        ("name".into(), Expr(Value::String("my-resource".into()))),
-        ("region".into(), Expr(Value::String("us-east-1".into()))),
-        ("count".into(), Expr(Value::Int(42))),
+        ("name".into(), Value::String("my-resource".into())),
+        ("region".into(), Value::String("us-east-1".into())),
+        ("count".into(), Value::Int(42)),
     ]);
 
     let created = provider
@@ -130,8 +130,8 @@ async fn test_wasm_mock_provider_update_and_delete() {
     // Create first
     let mut resource = Resource::with_provider("mock", "test.resource", "updatable");
     resource.attributes = indexmap::IndexMap::from([
-        ("color".into(), Expr(Value::String("red".into()))),
-        ("size".into(), Expr(Value::Int(10))),
+        ("color".into(), Value::String("red".into())),
+        ("size".into(), Value::Int(10)),
     ]);
 
     let created = provider
@@ -146,8 +146,8 @@ async fn test_wasm_mock_provider_update_and_delete() {
     // Update with new attributes
     let mut updated_resource = Resource::with_provider("mock", "test.resource", "updatable");
     updated_resource.attributes = indexmap::IndexMap::from([
-        ("color".into(), Expr(Value::String("blue".into()))),
-        ("size".into(), Expr(Value::Int(20))),
+        ("color".into(), Value::String("blue".into())),
+        ("size".into(), Value::Int(20)),
     ]);
 
     let updated = provider
@@ -195,8 +195,7 @@ async fn test_wasm_mock_provider_normalizer() {
     // normalize_desired: mock provider returns resources unchanged
     let mut resources = vec![{
         let mut r = Resource::with_provider("mock", "test.resource", "norm-test");
-        r.attributes =
-            indexmap::IndexMap::from([("key".into(), Expr(Value::String("value".into())))]);
+        r.attributes = indexmap::IndexMap::from([("key".into(), Value::String("value".into()))]);
         r
     }];
     let original_attrs = resources[0].resolved_attributes();
@@ -233,11 +232,11 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     resource.attributes = indexmap::IndexMap::from([
         (
             "identity_store_id".into(),
-            Expr(Value::String("d-1234567890".into())),
+            Value::String("d-1234567890".into()),
         ),
         (
             "user_name".into(),
-            Expr(Value::String("alice@example.com".into())),
+            Value::String("alice@example.com".into()),
         ),
     ]);
 


### PR DESCRIPTION
## Summary

Drops the `Expr(Value)` newtype (`carina-core/src/resource/mod.rs`) per option (1) in #2223. The wrapper had no methods, no extra fields, no type-level invariant, and no Span. It introduced noise without protecting any property.

## Decision

Per the issue's "if unsure, (1) now and (2) later when spans are needed", went with **(1) Remove**. Adding `Span` is a separate, larger piece of work that can revisit a typed wrapper when there is a concrete diagnostics consumer to justify it.

## Changes

- `carina-core/src/resource/mod.rs`:
  - Removed `pub struct Expr(pub Value)` and all its impls
  - `Resource.attributes` is now `IndexMap<String, Value>`
  - Replaced `Expr::resolve_map` with a free `pub fn attrs_to_hashmap(...)` helper
  - Dropped the unused `pub type ExprPart = InterpolationPart` legacy alias
- ~50 callsites across `carina-core` / `carina-cli` / `carina-lsp` / `carina-plugin-host` updated to drop `Expr(...)` constructor wrapping and `expr.0` / `as_value()` / `into_value()` accessors

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — pass
- [x] State serialization round-trips: `Expr` was `#[serde(transparent)]`, so the JSON wire format is identical to `Value`. State files written by older binaries still load.

Closes #2223