### PR TITLE
docs: drop redundant cargo build from local verify protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build and Test Commands
 
 ```bash
-# Build
-cargo build
+# Compile-only sanity check (faster than `cargo build`; does not link binaries)
+cargo check
 
-# Run all tests
+# Run all tests (also compiles; do NOT run `cargo build` separately first)
 cargo test
 
 # Run tests for a specific crate
@@ -26,6 +26,35 @@ cargo run -- apply .
 # With AWS credentials (using aws-vault)
 aws-vault exec <profile> -- cargo run -- plan .
 ```
+
+### Verify Protocol — Do Not Run Redundant Builds
+
+The verify cycle is the slowest thing about working on this repo. Most of
+that cost is cargo work, and the single biggest waste is running
+`cargo build` immediately before `cargo test`: the test step compiles
+the same artifacts the build step just produced, doubling the wait.
+
+**Rules:**
+
+- **Do not run `cargo build`** as a separate verification step. `cargo test`
+  already compiles everything it needs. Running both is pure duplication.
+- For a faster compile-only sanity check during iteration, use
+  `cargo check -p <crate>` (skips linking, ~30–50% faster than `cargo build`).
+- The only legitimate use of `cargo build` in the verify cycle is
+  `cargo build --release` immediately before opening a PR, to catch
+  release-only issues that debug builds miss. Skip it for refactors,
+  bug fixes, or anything that has not changed `Cargo.toml` / unsafe code /
+  the `release` profile config.
+- Order your verify cycle as: `cargo test -p <crate>` → broaden to
+  `cargo test --workspace` only when the change spans crates → then
+  `cargo clippy --workspace --all-targets -- -D warnings` →
+  `bash scripts/check-*.sh`.
+
+CI's `Test` job runs `cargo build -p carina-provider-mock --target wasm32-wasip2`
+*before* `cargo test`, but that build targets a different platform
+(`wasm32-wasip2`) than the test step (host), so it is not redundant —
+it produces the WASM fixture that `carina-plugin-host`'s integration
+tests load. Do not generalize from that step to local development.
 
 ### Plan Display Testing
 
@@ -63,20 +92,20 @@ If snapshots are not updated after a display change, CI will fail on the `Test` 
 When working on a specific crate, always use crate-specific commands to avoid unnecessary compilation:
 
 ```bash
-# Prefer crate-specific builds over full workspace builds
-cargo build -p carina-core          # Instead of `cargo build`
-cargo test -p carina-core           # Instead of `cargo test`
+# Prefer crate-scoped check/test over full workspace runs
+cargo check -p carina-core          # Fastest sanity check while iterating
+cargo test -p carina-core           # Compiles + runs the crate's tests
 
-# Only use full workspace build/test when changes span multiple crates
-cargo build
+# Only use full workspace test when changes span multiple crates,
+# or as the final pre-PR sweep
 cargo test
 ```
 
 Key rules:
-- After modifying a single crate, build/test only that crate with `-p <crate-name>`
-- Use full workspace `cargo build` / `cargo test` only when changes affect multiple crates or before creating a PR
-- For `cargo check`, prefer `cargo check -p <crate-name>` as well
-- Provider crates (aws, awscc) are in separate repositories — changes here may require updating those repos
+- After modifying a single crate, test only that crate with `cargo test -p <crate-name>`. Do **not** run `cargo build -p <crate-name>` first — `cargo test` does the build.
+- Use full workspace `cargo test` only when changes affect multiple crates or before creating a PR.
+- For the fastest iteration loop, `cargo check -p <crate-name>` skips linking and is ~30–50% faster than `cargo build -p <crate-name>`.
+- Provider crates (aws, awscc) are in separate repositories — changes here may require updating those repos.
 
 ### Build Cache Setup (sccache + shared target)
 


### PR DESCRIPTION
## Summary

Updates `CLAUDE.md` so the verify protocol no longer prescribes `cargo build` as a separate step before `cargo test`. `cargo test` already compiles everything; running both is pure duplication and roughly doubles the wait on a cold cache.

## Scope

This PR is **CLAUDE.md only**. No CI workflow changes.

The parent issue (#2286) called out CI as a possible target, but the only `cargo build` step in `.github/workflows/ci.yml` is in the `Test` job:

```yaml
- run: cargo build -p carina-provider-mock --target wasm32-wasip2
- run: cargo test --all-features
```

That build targets `wasm32-wasip2` while `cargo test` targets the host. Different platform → different artifacts → not redundant. It produces the WASM fixture that `carina-plugin-host`'s integration tests load. Removing it would silently turn `wasm_integration_test` into a no-op. Documented in the new section so future readers do not generalize from CI to local development.

## Changes

- `Build and Test Commands` section: lead with `cargo check` (fast sanity) and `cargo test` (compile + run); annotate that `cargo build` should not be a separate verification step.
- New `Verify Protocol — Do Not Run Redundant Builds` section: pins the rule, names the one legitimate `cargo build --release` exception (pre-PR final check on changes that touch `Cargo.toml` / unsafe / release profile), and disambiguates the CI WASM build.
- `Incremental Build Strategy` section: rewrite so crate-scoped iteration is `cargo check -p <crate>` / `cargo test -p <crate>`, with no preceding `cargo build -p <crate>`.

## Measurement

From the parent issue's observed breakdown on a recent small refactor (#2226):

| Step | Time |
| --- | ---: |
| `cargo build` (workspace) | ~4 min |
| `cargo test --workspace` | ~5 min |

`cargo test --workspace` alone covers the compile that `cargo build` was doing, so dropping the separate `cargo build` step saves **~4 min per verify cycle** on a cold cache.

This is a guidance change, so the win materializes only when agents follow the new protocol. The remaining sub-issues under #2286 (per-worktree target-dir #2290, nextest #2291, crate-scoped verify #2292) attack the rest of the cycle time.

## Test plan

- [x] `bash scripts/check-docs-use-new-spellings.sh` — pass
- [x] No code changes; pre-commit hook skipped Rust checks ("No Rust-affecting changes detected")

Closes #2289
Refs #2286
