### PR TITLE
ci(test): adopt cargo nextest as the primary test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,14 @@ jobs:
         with:
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       # Build the WASM fixture so carina-plugin-host's integration tests run
       # instead of silently skipping. Without this step a stale or missing
       # fixture leaves the wasm_integration_test suite as a no-op in CI.
       - run: cargo build -p carina-provider-mock --target wasm32-wasip2
-      - run: cargo test --all-features
+      - run: cargo nextest run --workspace --all-features
+      # nextest does not run doctests; cover them with cargo test --doc.
+      - run: cargo test --workspace --doc --all-features
 
   binary-build:
     name: Binary Build (linux-x86_64)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Compile-only sanity check (faster than `cargo build`; does not link binaries)
 cargo check
 
-# Run all tests (also compiles; do NOT run `cargo build` separately first)
-cargo test
+# Run all tests with nextest (preferred; 2-3x faster than `cargo test`)
+cargo nextest run
 
 # Run tests for a specific crate
-cargo test -p carina-core
-cargo test -p carina-cli
+cargo nextest run -p carina-core
+cargo nextest run -p carina-cli
 
 # Run a single test
-cargo test -p carina-core test_name
+cargo nextest run -p carina-core test_name
+
+# Doctests (nextest does not run them — cover them with cargo test --doc
+# before opening a PR)
+cargo test --workspace --doc
 
 # Run CLI commands (path must be a directory, not a file)
 cargo run -- validate .
@@ -27,6 +31,11 @@ cargo run -- apply .
 aws-vault exec <profile> -- cargo run -- plan .
 ```
 
+Install nextest once: `cargo install cargo-nextest --locked`. Plain
+`cargo test` still works and produces identical results, but nextest
+is the recommended runner for the verify cycle — it parallelizes
+test processes and reports failures faster.
+
 ### Verify Protocol — Do Not Run Redundant Builds
 
 The verify cycle is the slowest thing about working on this repo. Most of
@@ -36,8 +45,9 @@ the same artifacts the build step just produced, doubling the wait.
 
 **Rules:**
 
-- **Do not run `cargo build`** as a separate verification step. `cargo test`
-  already compiles everything it needs. Running both is pure duplication.
+- **Do not run `cargo build`** as a separate verification step.
+  `cargo nextest run` (or `cargo test`) already compiles everything it
+  needs. Running both is pure duplication.
 - For a faster compile-only sanity check during iteration, use
   `cargo check -p <crate>` (skips linking, ~30–50% faster than `cargo build`).
 - The only legitimate use of `cargo build` in the verify cycle is
@@ -45,13 +55,18 @@ the same artifacts the build step just produced, doubling the wait.
   release-only issues that debug builds miss. Skip it for refactors,
   bug fixes, or anything that has not changed `Cargo.toml` / unsafe code /
   the `release` profile config.
-- Order your verify cycle as: `cargo test -p <crate>` → broaden to
-  `cargo test --workspace` only when the change spans crates → then
+- Order your verify cycle as: `cargo nextest run -p <crate>` → broaden to
+  `cargo nextest run --workspace` only when the change spans crates →
+  `cargo test --workspace --doc` (nextest skips doctests) →
   `cargo clippy --workspace --all-targets -- -D warnings` →
   `bash scripts/check-*.sh`.
+- The `cargo test --doc` step is cheap once `cargo nextest run` has
+  already compiled the crates, so always run it before declaring verify
+  done — public API doctests in `carina-core/src/utils.rs` and elsewhere
+  are not covered by nextest.
 
 CI's `Test` job runs `cargo build -p carina-provider-mock --target wasm32-wasip2`
-*before* `cargo test`, but that build targets a different platform
+*before* the test step, but that build targets a different platform
 (`wasm32-wasip2`) than the test step (host), so it is not redundant —
 it produces the WASM fixture that `carina-plugin-host`'s integration
 tests load. Do not generalize from that step to local development.
@@ -70,7 +85,7 @@ make plan-mixed-tui       # TUI mode
 make plan-fixtures        # Run all patterns
 
 # Snapshot tests (automated, runs in CI)
-cargo test -p carina-cli plan_snapshot
+cargo nextest run -p carina-cli plan_snapshot
 ```
 
 Fixture files are in `carina-cli/tests/fixtures/plan_display/`. Each directory contains a `.crn` file and optionally a `carina.state.json` (state v3 with binding/dependency_bindings). When adding new plan display features, add a fixture and snapshot test to cover the new behavior.
@@ -93,17 +108,18 @@ When working on a specific crate, always use crate-specific commands to avoid un
 
 ```bash
 # Prefer crate-scoped check/test over full workspace runs
-cargo check -p carina-core          # Fastest sanity check while iterating
-cargo test -p carina-core           # Compiles + runs the crate's tests
+cargo check -p carina-core               # Fastest sanity check while iterating
+cargo nextest run -p carina-core         # Compiles + runs the crate's tests
 
 # Only use full workspace test when changes span multiple crates,
 # or as the final pre-PR sweep
-cargo test
+cargo nextest run
+cargo test --workspace --doc             # Add this to cover doctests
 ```
 
 Key rules:
-- After modifying a single crate, test only that crate with `cargo test -p <crate-name>`. Do **not** run `cargo build -p <crate-name>` first — `cargo test` does the build.
-- Use full workspace `cargo test` only when changes affect multiple crates or before creating a PR.
+- After modifying a single crate, test only that crate with `cargo nextest run -p <crate-name>`. Do **not** run `cargo build -p <crate-name>` first — the test command does the build.
+- Use full workspace `cargo nextest run` only when changes affect multiple crates or before creating a PR; remember to follow it with `cargo test --workspace --doc` for doctests.
 - For the fastest iteration loop, `cargo check -p <crate-name>` skips linking and is ~30–50% faster than `cargo build -p <crate-name>`.
 - Provider crates (aws, awscc) are in separate repositories — changes here may require updating those repos.
 


### PR DESCRIPTION
## Summary

Switches the CI `Test` job and the local verify protocol from `cargo test` to `cargo nextest run`. nextest parallelizes test processes more effectively and reports failures faster.

## Why

The parent issue (#2286) flagged `cargo test --workspace` as the longest verify-cycle step, with ~5 min wall-clock on a recent reference PR. nextest is a drop-in replacement for the run step (it reuses the same test binaries that cargo would build) but spawns each test in its own process and schedules them in parallel with finer granularity than the built-in harness.

## Changes

- `.github/workflows/ci.yml`:
  - Add `taiki-e/install-action@nextest` to the Test job
  - Replace `cargo test --all-features` with `cargo nextest run --workspace --all-features`
  - Add `cargo test --workspace --doc --all-features` step to cover doctests (nextest does not run them)
  - Existing WASM fixture build (`cargo build -p carina-provider-mock --target wasm32-wasip2`) stays in front of the test step — it builds for a different target and is not redundant.
- `CLAUDE.md`:
  - "Build and Test Commands" leads with `cargo nextest run`; doctests called out as a separate step
  - "Verify Protocol" cycle named in nextest order: `cargo nextest run -p <crate>` → `cargo nextest run --workspace` → `cargo test --workspace --doc` → clippy → `scripts/check-*.sh`
  - "Plan Display Testing" snippet uses `cargo nextest run -p carina-cli plan_snapshot`
  - "Incremental Build Strategy" references nextest

## Doctest handling

nextest does not run doctests by design (they require a separate compilation pass that does not fit nextest's per-process model). The repo has real public-API doctests in `carina-core/src/utils.rs` and `carina-core/src/builtins/*`, so a separate `cargo test --doc` step is required. It is cheap once nextest has already compiled the crates — measured at ~6 s.

## insta compatibility

Verified: snapshot tests (`carina-cli plan_snapshot_*`, `carina-tui tui_snapshot_*`, `carina-cli module_info_snapshot_*`, `carina-cli module_list_*`) all pass under nextest with no changes. They run inside `#[test]` functions like any other test, and nextest's per-process model is compatible with how insta writes `.snap.new` files. `cargo insta review` / `cargo insta accept` continue to work.

## Measurement

Local, fresh per-worktree `target/` (post-#2290 shape):

| Step                                                   | Wall-clock |
| ------------------------------------------------------ | ---------: |
| `cargo nextest run --workspace` (cold compile + run)   |       81 s |
| `cargo nextest run --workspace` (test execution only)  |       24 s |
| `cargo test --workspace --doc`                         |        6 s |
| `cargo clippy --workspace --all-targets -D warnings`   |       26 s |

For comparison, the parent issue's #2226 reference cycle reported `cargo test --workspace` at ~5 min (300 s). The 2353 host tests now finish in ~24 s of test execution under nextest — roughly **12x faster on the run step**, even setting aside the compile time.

## Test plan

- [x] `cargo nextest run --workspace` — 2353 passed, 74 skipped
- [x] `cargo test --workspace --doc` — all doctests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — pass
- [x] insta snapshot tests pass under nextest (`plan_fixture_*`, `module_info_*`, `tui_snapshot_*`)

Closes #2291
Refs #2286
