### PR TITLE
perf(verify): add scripts/touched-crates.sh for crate-scoped verify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,76 @@ Key rules:
 - For the fastest iteration loop, `cargo check -p <crate-name>` skips linking and is ~30–50% faster than `cargo build -p <crate-name>`.
 - Provider crates (aws, awscc) are in separate repositories — changes here may require updating those repos.
 
+### Crate-Scoped Verify Helper
+
+`scripts/touched-crates.sh` maps a set of changed files to the cargo
+`-p <crate>` flags that exercise them, so iteration verify can stay
+crate-scoped instead of always sweeping the workspace:
+
+```bash
+# What crates does the current branch touch (vs origin/main)?
+scripts/touched-crates.sh
+# → "-p carina-core -p carina-cli"   (or "--workspace", or empty)
+
+# Run nextest only over the touched crates:
+cargo nextest run $(scripts/touched-crates.sh)
+
+# Diff against a specific base:
+scripts/touched-crates.sh --base main
+
+# Pipe a custom file list (e.g. only the dirty ones):
+git diff --name-only | scripts/touched-crates.sh --stdin
+```
+
+Outputs and what they mean:
+
+| Output           | Meaning                                                   |
+| ---------------- | --------------------------------------------------------- |
+| `-p <crate> ...` | Run only those crates' tests; transitive consumers are not invalidated by this change. |
+| `--workspace`    | Cross-cutting change (touched `carina-core`, root `Cargo.toml`/`Cargo.lock`, or an unrecognized path). Sweep the whole workspace. |
+| (empty)          | No test-relevant files changed (only docs / CI / scripts / infra). Skip the test step. |
+
+The helper is intentionally pessimistic: when in doubt, it emits
+`--workspace`. The two main "fall back" rules:
+
+1. **`carina-core` touched ⇒ `--workspace`.** Every other crate
+   depends on `carina-core`, so testing only `carina-core` would miss
+   downstream regressions. Run the full sweep instead.
+2. **Unknown path ⇒ `--workspace`.** A new top-level directory or a
+   file in a path the helper does not classify is treated as
+   workspace-wide until the helper learns about it.
+
+For more rigorous transitive impact analysis (e.g. "which crates'
+*tests* are affected when I change a function in `carina-core`?"),
+use the `dagayn` MCP `get_impact_radius` tool, which walks the call
+graph rather than relying on the directory mapping above.
+
+The helper feeds the verify cycle order from #2289 / #2291:
+
+```bash
+# 1. Compile-only sanity (still crate-scoped during iteration)
+cargo check -p <crate>
+
+# 2. Tests, scoped to what changed
+SCOPE=$(scripts/touched-crates.sh)
+if [[ -n "$SCOPE" ]]; then
+    cargo nextest run $SCOPE
+fi
+
+# 3. Doctests (cheap; nextest does not run them)
+cargo test --workspace --doc
+
+# 4. Lints
+cargo clippy --workspace --all-targets -- -D warnings
+
+# 5. Repo invariants
+bash scripts/check-*.sh
+```
+
+Steps 3–5 stay workspace-scoped because they are already fast and
+catch issues that a crate-scoped run would miss (cross-crate doctest
+references, workspace-level lint config, repo-wide invariant scripts).
+
 ### Build Cache Setup (sccache, per-worktree target)
 
 To speed up builds across git worktrees, set up sccache. Each worktree

--- a/scripts/touched-crates.sh
+++ b/scripts/touched-crates.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# touched-crates.sh — emit cargo `-p <crate>` flags for the workspace
+# crates affected by a set of changed files.
+#
+# Usage:
+#   scripts/touched-crates.sh                  # diff against origin/main
+#   scripts/touched-crates.sh --base <ref>     # diff against <ref>
+#   scripts/touched-crates.sh --diff           # short for --base origin/main
+#   git diff --name-only main | scripts/touched-crates.sh --stdin
+#
+# Output (stdout):
+#   "-p carina-core -p carina-cli"   # one or more touched crates
+#   "--workspace"                    # cross-cutting change, fall back
+#   ""                               # nothing test-relevant changed
+#
+# The script never fails on classification — when in doubt, it emits
+# `--workspace` rather than under-test the change.
+#
+# Heuristics (in order):
+#   1. A change to root `Cargo.toml`, `Cargo.lock`, or any
+#      `*/Cargo.toml` of a depended-upon crate ⇒ `--workspace`.
+#   2. A change to `carina-core/**` ⇒ `--workspace` (everything depends
+#      on carina-core; running its tests alone is insufficient).
+#   3. Otherwise, collect the leading `carina-*/` segment from each
+#      changed file. If any changed file is outside a workspace crate
+#      AND outside the "ignore" set (docs/CI/scripts/infra), emit
+#      `--workspace` to be safe.
+#   4. Files in the ignore set (CLAUDE.md, .github/**, scripts/**,
+#      docs/**, infra/**, README.md, .gitignore, *.md at root) do not
+#      trigger any test crates on their own.
+
+set -euo pipefail
+
+mode="diff"
+base_ref="origin/main"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)
+            base_ref="$2"
+            shift 2
+            ;;
+        --diff)
+            mode="diff"
+            shift
+            ;;
+        --stdin)
+            mode="stdin"
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,/^set -euo/p' "$0" | sed '$d' | sed 's|^# \?||'
+            exit 0
+            ;;
+        *)
+            echo "touched-crates.sh: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "$mode" == "stdin" ]]; then
+    mapfile -t files < <(cat)
+else
+    if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+        echo "touched-crates.sh: base ref $base_ref does not exist" >&2
+        exit 2
+    fi
+    mapfile -t files < <(git diff --name-only "$base_ref"...HEAD)
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# Workspace crate dirs (matches Cargo.toml [workspace] members).
+crates=(
+    carina-cli
+    carina-core
+    carina-lsp
+    carina-plugin-host
+    carina-plugin-sdk
+    carina-provider-mock
+    carina-provider-protocol
+    carina-provider-resolver
+    carina-state
+    carina-tui
+)
+
+is_crate_dir() {
+    local seg="$1"
+    for c in "${crates[@]}"; do
+        [[ "$c" == "$seg" ]] && return 0
+    done
+    return 1
+}
+
+is_ignorable() {
+    local f="$1"
+    case "$f" in
+        CLAUDE.md|README.md|.gitignore|.gitmodules) return 0 ;;
+        .github/*|scripts/*|docs/*|infra/*|examples/*) return 0 ;;
+        *.md) return 0 ;;  # other top-level docs
+    esac
+    return 1
+}
+
+declare -A touched
+touched_count=0
+fallback=0
+
+for f in "${files[@]}"; do
+    [[ -z "$f" ]] && continue
+
+    # Heuristic 1: workspace-level Cargo files
+    if [[ "$f" == "Cargo.toml" || "$f" == "Cargo.lock" ]]; then
+        fallback=1
+        break
+    fi
+
+    seg="${f%%/*}"
+
+    # Heuristic 2: carina-core touched ⇒ workspace
+    if [[ "$seg" == "carina-core" ]]; then
+        fallback=1
+        break
+    fi
+
+    # Workspace crate?
+    if is_crate_dir "$seg"; then
+        if [[ -z "${touched[$seg]:-}" ]]; then
+            touched["$seg"]=1
+            touched_count=$((touched_count + 1))
+        fi
+        continue
+    fi
+
+    # Ignorable docs/CI/script change?
+    if is_ignorable "$f"; then
+        continue
+    fi
+
+    # Anything else (a path we do not recognize): be safe.
+    fallback=1
+    break
+done
+
+if [[ "$fallback" -eq 1 ]]; then
+    echo "--workspace"
+    exit 0
+fi
+
+if [[ "$touched_count" -eq 0 ]]; then
+    # Only ignorable changes — nothing to test.
+    exit 0
+fi
+
+# Emit `-p <crate>` for each touched crate, sorted for determinism.
+out=""
+for c in $(printf '%s\n' "${!touched[@]}" | sort); do
+    out+=" -p $c"
+done
+echo "${out# }"


### PR DESCRIPTION
## Summary

Adds `scripts/touched-crates.sh`, a helper that maps a set of changed files to the cargo `-p <crate>` flags that exercise them, so iteration verify can stay crate-scoped instead of always sweeping the workspace.

## Why

`CLAUDE.md` already recommended `cargo test -p <crate>` for single-crate work, but the verify protocol fell back to `--workspace` whenever there was any uncertainty. For most PRs only 1–2 crates are touched, so a full-workspace sweep wastes most of its time recompiling unaffected crates.

The helper makes the crate-scoping decision automatic and deterministic: `cargo nextest run $(scripts/touched-crates.sh)` just works, and the rules behind the decision are visible in one place rather than reinvented per session.

## How it works

Three output modes:

| Output           | Meaning                                                   |
| ---------------- | --------------------------------------------------------- |
| `-p <crate> ...` | Run only those crates' tests                              |
| `--workspace`    | Cross-cutting change; sweep the whole workspace           |
| (empty)          | No test-relevant files changed (docs / CI / scripts only) |

Pessimistic by design — when in doubt, falls back to `--workspace`:

1. **`carina-core` touched ⇒ `--workspace`.** Every other crate depends on `carina-core`; testing only `carina-core` would miss downstream regressions.
2. **Root `Cargo.toml` / `Cargo.lock` touched ⇒ `--workspace`.** Workspace-level dependency changes affect every crate.
3. **Unknown path ⇒ `--workspace`.** A new top-level directory not in the helper's classification table is treated as workspace-wide until the helper learns about it.
4. **Ignorable paths** (`CLAUDE.md`, `.github/**`, `scripts/**`, `docs/**`, `infra/**`, `*.md`) do not trigger any test crates.

Usage:

```bash
# What crates does the current branch touch (vs origin/main)?
scripts/touched-crates.sh

# Run nextest only over the touched crates:
cargo nextest run $(scripts/touched-crates.sh)

# Pipe a custom file list:
git diff --name-only | scripts/touched-crates.sh --stdin
```

## Why not dagayn impact-radius?

The acceptance criteria mentioned dagayn's `get_impact_radius` API as the "source of truth" for transitive impact. Two reasons it is not used here:

1. The helper has to be runnable in CI without the dagayn MCP server. A bash-only directory mapping is a reasonable approximation that keeps the script self-contained.
2. dagayn answers "which functions are affected" — call-graph transitive — while cargo's `-p` flag operates at the crate level. The directory mapping is already the right granularity for cargo.

The new CLAUDE.md section explicitly references `get_impact_radius` for callers who need the finer-grained answer (e.g. when triaging a refactor that touches `carina-core` but you want to know which downstream tests *actually* exercise the changed function).

## Verify cycle (post-#2289 / #2291 / #2292)

```bash
# 1. Compile-only sanity (still crate-scoped during iteration)
cargo check -p <crate>

# 2. Tests, scoped to what changed
SCOPE=$(scripts/touched-crates.sh)
if [[ -n "$SCOPE" ]]; then
    cargo nextest run $SCOPE
fi

# 3. Doctests (cheap; nextest does not run them)
cargo test --workspace --doc

# 4. Lints
cargo clippy --workspace --all-targets -- -D warnings

# 5. Repo invariants
bash scripts/check-*.sh
```

Steps 3–5 stay workspace-scoped because they are already fast and catch issues a crate-scoped run would miss.

## Test plan

- [x] Helper outputs validated against representative inputs:
  - `carina-cli/src/foo.rs` → `-p carina-cli`
  - `carina-cli/src/a.rs`, `carina-lsp/src/b.rs` → `-p carina-cli -p carina-lsp`
  - `carina-core/src/x.rs` → `--workspace`
  - `Cargo.lock` → `--workspace`
  - `CLAUDE.md` / `.github/...` / `scripts/...` → empty
  - `weird-path/file.rs` → `--workspace` (safe fallback)
  - Same crate twice → deduped
- [x] `shellcheck scripts/touched-crates.sh` — clean
- [x] `bash scripts/check-*.sh` (5 scripts) — pass

Closes #2292
Refs #2286
