### PR TITLE
fix(cli): apply --plan must use the upstream snapshot from carina plan

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -78,6 +78,151 @@ pub async fn execute_effects(
     result
 }
 
+/// Re-load each upstream declared in the saved plan and verify its
+/// attribute map matches the snapshot the plan was computed against
+/// (#2303). Fails on the first drifted binding so the user gets an
+/// actionable message naming what changed; pretending the apply will
+/// succeed and silently mixing plan-time and apply-time values
+/// produces incorrect cascade re-resolution.
+async fn verify_upstream_snapshot(
+    sources: &[crate::commands::plan::UpstreamSource],
+    snapshot: &HashMap<String, HashMap<String, Value>>,
+    base_dir: &std::path::Path,
+) -> Result<(), AppError> {
+    use carina_core::parser::UpstreamState;
+    let upstream_states: Vec<UpstreamState> = sources
+        .iter()
+        .map(|s| UpstreamState {
+            binding: s.binding.clone(),
+            source: s.source.clone(),
+        })
+        .collect();
+    let provider_context = ProviderContext::default();
+    let mut cycle_guard = super::plan::seed_cycle_guard(base_dir);
+    let current = super::plan::load_upstream_states(
+        &upstream_states,
+        base_dir,
+        &provider_context,
+        &mut cycle_guard,
+    )
+    .await?;
+
+    diff_upstream_snapshot(snapshot, &current).map_err(AppError::Config)
+}
+
+/// Pure comparison between a planned snapshot and a freshly-loaded
+/// upstream view. Returns the user-facing error message naming the
+/// first binding that disagrees, or `Ok(())` when the two views are
+/// equal.
+///
+/// Split out so it can be unit-tested without a real upstream backend.
+fn diff_upstream_snapshot(
+    snapshot: &HashMap<String, HashMap<String, Value>>,
+    current: &HashMap<String, HashMap<String, Value>>,
+) -> Result<(), String> {
+    for (binding, planned_attrs) in snapshot {
+        match current.get(binding) {
+            None => {
+                return Err(format!(
+                    "upstream_state '{}' was present at plan time but is missing now. \
+                     Re-run 'carina plan' to capture the current upstream view.",
+                    binding
+                ));
+            }
+            Some(current_attrs) if current_attrs != planned_attrs => {
+                return Err(format!(
+                    "upstream_state '{}' has drifted since the plan was created. \
+                     Re-run 'carina plan' so the apply uses the values it was computed against.",
+                    binding
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    for binding in current.keys() {
+        if !snapshot.contains_key(binding) {
+            return Err(format!(
+                "upstream_state '{}' was added since the plan was created. \
+                 Re-run 'carina plan' so the apply sees the new upstream binding.",
+                binding
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod upstream_snapshot_tests {
+    use super::*;
+
+    fn binding(name: &str, attrs: &[(&str, &str)]) -> (String, HashMap<String, Value>) {
+        let map = attrs
+            .iter()
+            .map(|(k, v)| (k.to_string(), Value::String(v.to_string())))
+            .collect();
+        (name.to_string(), map)
+    }
+
+    #[test]
+    fn matching_snapshot_passes() {
+        let snapshot: HashMap<String, HashMap<String, Value>> =
+            vec![binding("network", &[("vpc_id", "vpc-A")])]
+                .into_iter()
+                .collect();
+        let current = snapshot.clone();
+        assert!(diff_upstream_snapshot(&snapshot, &current).is_ok());
+    }
+
+    #[test]
+    fn drifted_attribute_fails() {
+        // Same binding name, but the attribute value changed underneath.
+        // This is the original bug: cascade re-resolution would silently
+        // see "vpc-B" while the static plan was built around "vpc-A".
+        let snapshot: HashMap<String, HashMap<String, Value>> =
+            vec![binding("network", &[("vpc_id", "vpc-A")])]
+                .into_iter()
+                .collect();
+        let current: HashMap<String, HashMap<String, Value>> =
+            vec![binding("network", &[("vpc_id", "vpc-B")])]
+                .into_iter()
+                .collect();
+        let err = diff_upstream_snapshot(&snapshot, &current).expect_err("must fail");
+        assert!(
+            err.contains("network"),
+            "error must name the binding: {err}"
+        );
+        assert!(err.contains("drifted"), "error must say drifted: {err}");
+    }
+
+    #[test]
+    fn binding_disappeared_fails() {
+        let snapshot: HashMap<String, HashMap<String, Value>> =
+            vec![binding("network", &[("vpc_id", "vpc-A")])]
+                .into_iter()
+                .collect();
+        let current: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let err = diff_upstream_snapshot(&snapshot, &current).expect_err("must fail");
+        assert!(err.contains("missing now"), "got: {err}");
+    }
+
+    #[test]
+    fn binding_appeared_fails() {
+        let snapshot: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        let current: HashMap<String, HashMap<String, Value>> =
+            vec![binding("network", &[("vpc_id", "vpc-A")])]
+                .into_iter()
+                .collect();
+        let err = diff_upstream_snapshot(&snapshot, &current).expect_err("must fail");
+        assert!(err.contains("added since"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_both_sides_passes() {
+        let empty: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        assert!(diff_upstream_snapshot(&empty, &empty).is_ok());
+    }
+}
+
 /// Refresh states for resources whose operations failed.
 ///
 /// This is kept for use by tests in `tests.rs`. The core executor has its own
@@ -1001,10 +1146,15 @@ pub async fn run_apply_from_plan(
     let plan_file: PlanFile =
         serde_json::from_str(&content).map_err(|e| format!("Failed to parse plan file: {}", e))?;
 
-    // Validate version compatibility
-    if plan_file.version != 1 {
+    // Validate version compatibility. Plan-file version 2 added the
+    // upstream-state snapshot (#2303); older plans cannot guarantee the
+    // upstream values used during cascade re-resolution match what the
+    // plan was computed against, so they are rejected outright per the
+    // repo's no-backward-compat policy.
+    if plan_file.version != 2 {
         return Err(AppError::Config(format!(
-            "Unsupported plan file version: {} (expected 1)",
+            "Unsupported plan file version: {} (expected 2). \
+             Re-run 'carina plan' to produce a plan in the current format.",
             plan_file.version
         )));
     }
@@ -1214,11 +1364,19 @@ async fn run_apply_from_plan_locked(
         return Ok(());
     }
 
-    // Build initial bindings for reference resolution
+    // Verify upstream-state bindings have not drifted since `carina
+    // plan` ran (#2303). Re-load each upstream the plan declared and
+    // compare against the persisted snapshot; if any binding's
+    // attribute map disagrees, fail rather than silently mixing
+    // plan-time and apply-time values during cascade re-resolution.
+    let upstream_snapshot = plan_file.upstream_snapshot.clone();
+    if !plan_file.upstream_sources.is_empty() {
+        verify_upstream_snapshot(&plan_file.upstream_sources, &upstream_snapshot, base_dir).await?;
+    }
     let mut bindings = ResolvedBindings::from_resources_with_state(
         sorted_resources,
         &current_states,
-        &HashMap::new(),
+        &upstream_snapshot,
     );
 
     println!("{}", "Applying changes...".cyan().bold());

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -53,6 +53,33 @@ pub struct PlanFile {
     pub sorted_resources: Vec<Resource>,
     /// Current states (for binding_map + state saving)
     pub current_states: Vec<CurrentStateEntry>,
+    /// `upstream_state` bindings as resolved at plan time (#2303).
+    ///
+    /// Persisted so `apply --plan` can verify the upstream values have
+    /// not drifted between plan and apply. If any binding here disagrees
+    /// with the freshly-loaded upstream view at apply time, the apply
+    /// fails with a structured error rather than silently mixing
+    /// plan-time and apply-time values during cascade re-resolution.
+    ///
+    /// Empty when the configuration declares no `upstream_state` blocks.
+    pub upstream_snapshot: HashMap<String, HashMap<String, Value>>,
+    /// `upstream_state` block sources (binding name → directory) as
+    /// declared in the original `.crn` config (#2303). Persisted so
+    /// `apply --plan` can re-load each upstream and compare against
+    /// `upstream_snapshot`.
+    pub upstream_sources: Vec<UpstreamSource>,
+}
+
+/// Serializable representation of an `upstream_state` declaration's
+/// source directory — needed because `parser::ast::UpstreamState` is
+/// not `Serialize`/`Deserialize` and pulling a `serde` derive into
+/// `carina-core::parser::ast` would have wider blast radius than this
+/// PR wants. Constructed once at plan time and consumed at
+/// apply-from-plan time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpstreamSource {
+    pub binding: String,
+    pub source: std::path::PathBuf,
 }
 
 /// Entry for serializing current resource states
@@ -69,7 +96,7 @@ fn build_plan_file(
     ctx: &crate::wiring::PlanContext,
 ) -> PlanFile {
     PlanFile {
-        version: 1,
+        version: 2,
         carina_version: env!("CARGO_PKG_VERSION").to_string(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         source_path: path.display().to_string(),
@@ -89,6 +116,15 @@ fn build_plan_file(
             .map(|(id, state)| CurrentStateEntry {
                 id: id.clone(),
                 state: redact_secrets_in_state(state),
+            })
+            .collect(),
+        upstream_snapshot: ctx.upstream_snapshot.clone(),
+        upstream_sources: parsed
+            .upstream_states
+            .iter()
+            .map(|us| UpstreamSource {
+                binding: us.binding.clone(),
+                source: us.source.clone(),
             })
             .collect(),
     }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -277,7 +277,7 @@ fn plan_file_serde_round_trip() {
     }];
 
     let plan_file = PlanFile {
-        version: 1,
+        version: 2,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -307,12 +307,14 @@ fn plan_file_serde_round_trip() {
         plan,
         sorted_resources,
         current_states,
+        upstream_snapshot: HashMap::new(),
+        upstream_sources: Vec::new(),
     };
 
     let json = serde_json::to_string_pretty(&plan_file).unwrap();
     let deserialized: PlanFile = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.version, 1);
+    assert_eq!(deserialized.version, 2);
     assert_eq!(deserialized.carina_version, "0.1.0");
     assert_eq!(deserialized.source_path, "example.crn");
     assert_eq!(deserialized.state_lineage, Some("test-lineage".to_string()));
@@ -2604,7 +2606,7 @@ fn plan_file_serialization_redacts_secrets() {
 
     // Redact before building PlanFile (same as production code does)
     let plan_file = PlanFile {
-        version: 1,
+        version: 2,
         carina_version: "0.1.0".to_string(),
         timestamp: "2025-01-01T00:00:00Z".to_string(),
         source_path: "example.crn".to_string(),
@@ -2618,6 +2620,8 @@ fn plan_file_serialization_redacts_secrets() {
             id: ResourceId::with_provider("awscc", "rds.db_instance", "my-db"),
             state: redact_secrets_in_state(&state_with_secret),
         }],
+        upstream_snapshot: HashMap::new(),
+        upstream_sources: Vec::new(),
     };
 
     let json = serde_json::to_string_pretty(&plan_file).unwrap();

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -39,6 +39,12 @@ pub struct PlanContext {
     /// Maps moved-to resource IDs to their original (moved-from) IDs.
     /// Used by display to show "(moved from: ...)" annotations on Update/Replace effects.
     pub moved_origins: HashMap<ResourceId, ResourceId>,
+    /// Snapshot of `upstream_state` bindings as resolved at plan time.
+    /// Persisted to the plan file (#2303) so apply-from-plan can verify
+    /// the upstream values have not drifted before re-using them for
+    /// cascade re-resolution. Empty when the configuration declares no
+    /// `upstream_state` blocks.
+    pub upstream_snapshot: HashMap<String, HashMap<String, carina_core::resource::Value>>,
 }
 
 /// Cached provider factories and schemas, constructed once per CLI invocation.
@@ -1089,6 +1095,7 @@ pub async fn create_plan_from_parsed_with_upstream(
         sorted_resources,
         current_states,
         moved_origins,
+        upstream_snapshot: remote_bindings.clone(),
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing apply-from-plan bug discovered while reviewing PR #2304 (#2300). The apply-from-plan path passed an empty `remote_bindings` to `ResolvedBindings::from_resources_with_state`, so when `executor::phased.rs` or `executor::replace.rs` re-resolved attributes during cascade flows, raw `ResourceRef`s leaked through to the provider instead of upstream-state values.

Naive fix (re-load upstream at apply time) breaks the plan-file contract: a saved plan promises the change set the plan command predicted, and re-loading lets cascade re-resolution see a value the static effects in the plan were not built around. So this PR snapshots the upstream view at plan time and verifies it before apply uses it.

## Changes

- `PlanContext` and `PlanFile` gain `upstream_snapshot` (the resolved upstream attribute maps) and `upstream_sources` (the binding-name and source-directory pairs needed to re-load).
- Plan-file version 1 → 2. Old version-1 plans are rejected at apply time with a "re-run carina plan" message rather than silently treated as having an empty snapshot.
- `apply --plan` builds `ResolvedBindings` with the persisted snapshot (cascade re-resolution now sees upstream values), but only after `verify_upstream_snapshot` confirms the freshly-loaded upstream matches.
- Drift comparison is split into a pure `diff_upstream_snapshot` helper for testability.

## Test plan

- [x] `cargo nextest run --workspace` — 2392 / 2392 passed.
- [x] `cargo test --workspace --doc` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — 5/5 passed.
- [x] 5 new unit tests on `diff_upstream_snapshot` cover: matching snapshot passes, drifted attribute fails, binding disappeared fails, binding appeared fails, empty-on-both passes.

End-to-end "real upstream backend with real drift" tests are not included — they need a stub upstream backend that goes beyond this PR's scope. The bug-trigger path (cascade re-resolution against an empty upstream view) is now structurally impossible: `apply --plan` either fails at `verify_upstream_snapshot` or uses the equal snapshot, so there is no in-between state where the values disagree.

Closes #2303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)