### PR TITLE
refactor(core, lsp): unify Struct validation via path-tagged collector

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -135,6 +135,82 @@ pub enum AttributeType {
     Union(Vec<AttributeType>),
 }
 
+/// One step in a [`FieldPath`]. Either a struct field name or a list
+/// index — what the path needs to express to point a downstream tool
+/// (e.g. the LSP) at the offending location in the source DSL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldPathStep {
+    Field(String),
+    Index(usize),
+}
+
+impl fmt::Display for FieldPathStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldPathStep::Field(name) => write!(f, "{}", name),
+            FieldPathStep::Index(i) => write!(f, "[{}]", i),
+        }
+    }
+}
+
+/// Path from the validated value's root to the location that produced
+/// a particular [`TypeError`]. Used by [`AttributeType::validate_collect`]
+/// so the LSP can map errors back to source positions without
+/// re-running validation itself (#2214).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FieldPath {
+    steps: Vec<FieldPathStep>,
+}
+
+impl FieldPath {
+    pub fn new() -> Self {
+        Self { steps: Vec::new() }
+    }
+
+    pub fn steps(&self) -> &[FieldPathStep] {
+        &self.steps
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    /// Append a struct-field step and return a new path. Cheap clone
+    /// because validation paths are tiny (depth-of-struct, typically
+    /// < 5).
+    pub fn push_field(&self, name: impl Into<String>) -> Self {
+        let mut next = self.clone();
+        next.steps.push(FieldPathStep::Field(name.into()));
+        next
+    }
+
+    /// Append a list-index step and return a new path.
+    pub fn push_index(&self, index: usize) -> Self {
+        let mut next = self.clone();
+        next.steps.push(FieldPathStep::Index(index));
+        next
+    }
+}
+
+impl fmt::Display for FieldPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for step in &self.steps {
+            match step {
+                FieldPathStep::Field(name) => {
+                    if !first {
+                        write!(f, ".")?;
+                    }
+                    write!(f, "{}", name)?;
+                }
+                FieldPathStep::Index(i) => write!(f, "[{}]", i)?,
+            }
+            first = false;
+        }
+        Ok(())
+    }
+}
+
 impl AttributeType {
     /// Create a List type with default ordering (ordered=true, matching CloudFormation default).
     pub fn list(inner: AttributeType) -> Self {
@@ -227,6 +303,159 @@ impl AttributeType {
             | AttributeType::Int
             | AttributeType::Float
             | AttributeType::Bool => self.validate_primitive(value),
+        }
+    }
+
+    /// Validate a value and collect every error along with the
+    /// [`FieldPath`] from the value's root to the offending location
+    /// (#2214).
+    ///
+    /// This is the path-tagged sibling of [`Self::validate`]: where
+    /// `validate` returns the first error wrapped in
+    /// `StructFieldError` / `ListItemError` / `MapValueError` enclosure
+    /// and stops, `validate_collect` keeps walking through every
+    /// field of every nested struct (and every item of a list-of-struct)
+    /// so a downstream tool like the LSP can surface every problem at
+    /// once with positional information.
+    ///
+    /// For non-Struct, non-List<Struct> shapes the result is exactly
+    /// one error (or none) — there is no nested context to descend
+    /// into, so this method is no slower than `validate` for primitives.
+    pub fn validate_collect(&self, value: &Value) -> Vec<(FieldPath, TypeError)> {
+        let mut out = Vec::new();
+        self.collect_into(&FieldPath::new(), value, &mut out);
+        out
+    }
+
+    fn collect_into(&self, path: &FieldPath, value: &Value, out: &mut Vec<(FieldPath, TypeError)>) {
+        // FunctionCall and Secret resolve at runtime — same skip rule
+        // as `validate`.
+        if matches!(value, Value::FunctionCall { .. } | Value::Secret(_)) {
+            return;
+        }
+
+        match self {
+            AttributeType::Struct { name, fields } => {
+                self.collect_struct(path, name, fields, value, out);
+            }
+            AttributeType::List { inner, .. } => {
+                self.collect_list(path, inner, value, out);
+            }
+            // For everything else the existing single-shot validator is
+            // already correct: it returns at most one error and there
+            // is no nested structure to recurse into. Forward the error
+            // (if any) under the current path.
+            _ => {
+                if let Err(e) = self.validate(value) {
+                    out.push((path.clone(), e));
+                }
+            }
+        }
+    }
+
+    fn collect_struct(
+        &self,
+        path: &FieldPath,
+        name: &str,
+        fields: &[StructField],
+        value: &Value,
+        out: &mut Vec<(FieldPath, TypeError)>,
+    ) {
+        // Block syntax → Value::List([Value::Map(...)])  for List<Struct>;
+        // bare Struct rejects List with `BlockSyntaxNotAllowed`.
+        if matches!(value, Value::List(_)) {
+            out.push((
+                path.clone(),
+                TypeError::BlockSyntaxNotAllowed {
+                    attribute: name.to_string(),
+                },
+            ));
+            return;
+        }
+        let Value::Map(map) = value else {
+            out.push((
+                path.clone(),
+                TypeError::TypeMismatch {
+                    expected: self.type_name(),
+                    got: value.type_name(),
+                },
+            ));
+            return;
+        };
+
+        // Map every accepted name (canonical + block_name alias) to the
+        // canonical `StructField`. Pre-#2214 the LSP did this alias
+        // resolution itself; now the core validator is the single
+        // source of truth and `validate_struct` shares the same map
+        // (#2214 reconciliation).
+        let accepted = build_accepted_field_map(fields);
+        let canonical_field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+
+        // Required-field check.
+        for f in fields {
+            if f.required && !map.contains_key(&f.name) {
+                let field_path = path.push_field(f.name.clone());
+                out.push((
+                    field_path,
+                    TypeError::MissingRequired {
+                        name: f.name.clone(),
+                    },
+                ));
+            }
+        }
+
+        // Each present field — descend (for nested struct/list of
+        // struct) or run the leaf validator.
+        for (k, v) in map {
+            match accepted.get(k.as_str()) {
+                Some(field) => {
+                    let next_path = path.push_field(k.clone());
+                    // ResourceRef / Interpolation values are placeholders
+                    // resolved at apply time — skip type checking but
+                    // still descend into ResourceRef-free shapes.
+                    if matches!(v, Value::ResourceRef { .. }) {
+                        continue;
+                    }
+                    field.field_type.collect_into(&next_path, v, out);
+                }
+                None => {
+                    let suggestion = suggest_similar_name(k, &canonical_field_names);
+                    out.push((
+                        path.push_field(k.clone()),
+                        TypeError::UnknownStructField {
+                            struct_name: name.to_string(),
+                            field: k.clone(),
+                            suggestion,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+
+    fn collect_list(
+        &self,
+        path: &FieldPath,
+        inner: &AttributeType,
+        value: &Value,
+        out: &mut Vec<(FieldPath, TypeError)>,
+    ) {
+        let Value::List(items) = value else {
+            out.push((
+                path.clone(),
+                TypeError::TypeMismatch {
+                    expected: self.type_name(),
+                    got: value.type_name(),
+                },
+            ));
+            return;
+        };
+        // For List<Struct> we want per-item descent so each item's
+        // errors carry a `[i]` step in the path. For plain List<T>
+        // this still works — each item runs the leaf validator under
+        // the indexed path.
+        for (i, item) in items.iter().enumerate() {
+            inner.collect_into(&path.push_index(i), item, out);
         }
     }
 
@@ -481,12 +710,14 @@ impl AttributeType {
                 });
             }
         }
-        // Type-check each field value
-        let field_map: std::collections::HashMap<&str, &StructField> =
-            fields.iter().map(|f| (f.name.as_str(), f)).collect();
-        let field_names: Vec<&str> = field_map.keys().copied().collect();
+        // Type-check each field value. Use the same accepted-name map
+        // (canonical + block_name alias) the path-tagged validator
+        // builds; before #2214 this branch only knew canonical names
+        // and silently rejected aliases that the LSP happily accepted.
+        let accepted = build_accepted_field_map(fields);
+        let canonical_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
         for (k, v) in map {
-            if let Some(field) = field_map.get(k.as_str()) {
+            if let Some(field) = accepted.get(k.as_str()) {
                 field
                     .field_type
                     .validate(v)
@@ -495,7 +726,7 @@ impl AttributeType {
                         inner: Box::new(e),
                     })?;
             } else {
-                let suggestion = suggest_similar_name(k, &field_names);
+                let suggestion = suggest_similar_name(k, &canonical_names);
                 return Err(TypeError::UnknownStructField {
                     struct_name: name.clone(),
                     field: k.clone(),
@@ -676,6 +907,25 @@ impl AttributeType {
             (a, b) => a.type_name() == b.type_name(),
         }
     }
+}
+
+/// Map every accepted field name to its canonical [`StructField`].
+/// Both the canonical `name` and any `block_name` alias resolve to the
+/// same field, so users can write either form interchangeably.
+///
+/// Used by both [`AttributeType::validate`] (single-shot) and
+/// [`AttributeType::validate_collect`] (path-tagged) so the two paths
+/// agree on which keys are accepted (#2214 — the LSP previously did
+/// this alias resolution itself, which let the two validators drift).
+fn build_accepted_field_map(fields: &[StructField]) -> HashMap<&str, &StructField> {
+    let mut accepted: HashMap<&str, &StructField> = HashMap::new();
+    for f in fields {
+        accepted.insert(f.name.as_str(), f);
+        if let Some(block) = f.block_name.as_deref() {
+            accepted.insert(block, f);
+        }
+    }
+    accepted
 }
 
 /// Source length is contained in sink length (narrow ⊆ wide).

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2571,3 +2571,181 @@ fn validate_email_type() {
     // Wrong type
     assert!(t.validate(&Value::Int(42)).is_err());
 }
+
+#[cfg(test)]
+mod validate_collect_tests {
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn struct_type(name: &str, fields: Vec<StructField>) -> AttributeType {
+        AttributeType::Struct {
+            name: name.to_string(),
+            fields,
+        }
+    }
+
+    fn map_value(entries: Vec<(&str, Value)>) -> Value {
+        let mut map = IndexMap::new();
+        for (k, v) in entries {
+            map.insert(k.to_string(), v);
+        }
+        Value::Map(map)
+    }
+
+    #[test]
+    fn collect_empty_on_valid_value() {
+        let ty = struct_type(
+            "Versioning",
+            vec![
+                StructField::new("status", AttributeType::String).required(),
+                StructField::new("mfa_delete", AttributeType::Bool),
+            ],
+        );
+        let v = map_value(vec![
+            ("status", Value::String("Enabled".to_string())),
+            ("mfa_delete", Value::Bool(false)),
+        ]);
+        let errors = ty.validate_collect(&v);
+        assert!(
+            errors.is_empty(),
+            "valid struct must produce no errors, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn collect_reports_all_unknown_fields_with_path() {
+        // Two unknown fields in one struct — `validate_collect` must
+        // surface both, while the legacy `validate()` would stop at the
+        // first.
+        let ty = struct_type(
+            "Versioning",
+            vec![StructField::new("status", AttributeType::String)],
+        );
+        let v = map_value(vec![
+            ("statuus", Value::String("Enabled".to_string())),
+            ("mfa", Value::Bool(false)),
+        ]);
+        let errors = ty.validate_collect(&v);
+        assert_eq!(
+            errors.len(),
+            2,
+            "expected two unknown-field errors, got {errors:?}"
+        );
+        let names: Vec<String> = errors.iter().map(|(p, _)| p.to_string()).collect();
+        let names: Vec<&str> = names.iter().map(String::as_str).collect();
+        assert!(names.contains(&"statuus"), "got {names:?}");
+        assert!(names.contains(&"mfa"), "got {names:?}");
+    }
+
+    #[test]
+    fn collect_descends_into_nested_struct_with_field_path() {
+        // Inner struct has a type error — the path must record the
+        // outer field name then the inner field name so the LSP can
+        // walk back to the source position.
+        let inner = struct_type(
+            "Inner",
+            vec![StructField::new("count", AttributeType::Int).required()],
+        );
+        let outer = struct_type("Outer", vec![StructField::new("nested", inner).required()]);
+        let v = map_value(vec![(
+            "nested",
+            map_value(vec![("count", Value::String("not an int".to_string()))]),
+        )]);
+        let errors = outer.validate_collect(&v);
+        assert_eq!(errors.len(), 1, "got {errors:?}");
+        let (path, _err) = &errors[0];
+        let steps: Vec<String> = path.steps().iter().map(|s| s.to_string()).collect();
+        assert_eq!(steps, vec!["nested".to_string(), "count".to_string()]);
+    }
+
+    #[test]
+    fn collect_descends_into_list_of_struct_with_index_path() {
+        // List<Struct> errors must include the list index in the path
+        // so the LSP can locate the offending block.
+        let inner = struct_type(
+            "Item",
+            vec![StructField::new("name", AttributeType::String).required()],
+        );
+        let outer_attr = AttributeType::List {
+            inner: Box::new(inner),
+            ordered: true,
+        };
+
+        // Two list items, second one has wrong type for `name`
+        let v = Value::List(vec![
+            map_value(vec![("name", Value::String("ok".to_string()))]),
+            map_value(vec![("name", Value::Int(42))]),
+        ]);
+        let errors = outer_attr.validate_collect(&v);
+        assert_eq!(errors.len(), 1, "got {errors:?}");
+        let path = &errors[0].0;
+        let steps: Vec<String> = path.steps().iter().map(|s| s.to_string()).collect();
+        assert_eq!(steps, vec!["[1]".to_string(), "name".to_string()]);
+    }
+
+    #[test]
+    fn collect_resolves_block_name_alias() {
+        // `block_name` is an alias users can type instead of `name` in
+        // the DSL (e.g. `transition` for the canonical `transitions`).
+        // The unified validator must recognise the alias rather than
+        // flagging it as an unknown field — the LSP used to do this
+        // alias lookup itself, but that responsibility now belongs to
+        // the core validator.
+        let ty = struct_type(
+            "Lifecycle",
+            vec![
+                StructField::new("transitions", AttributeType::String)
+                    .with_block_name("transition"),
+            ],
+        );
+        let v = map_value(vec![("transition", Value::String("ok".to_string()))]);
+        let errors = ty.validate_collect(&v);
+        assert!(
+            errors.is_empty(),
+            "block_name alias must not flag the field as unknown, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn collect_skips_resource_ref_in_struct_field() {
+        // ResourceRef values are placeholders that resolve at apply
+        // time. Skipping them avoids spurious "wrong type" errors for
+        // fields whose value is `vpc.id` etc.
+        let ty = struct_type(
+            "Subnet",
+            vec![StructField::new("vpc_id", AttributeType::Int)],
+        );
+        let v = map_value(vec![(
+            "vpc_id",
+            Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
+        )]);
+        let errors = ty.validate_collect(&v);
+        assert!(
+            errors.is_empty(),
+            "ResourceRef in struct field must not produce an error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn collect_yields_unknown_struct_field_with_suggestion() {
+        // The existing `validate()` already produces a
+        // `UnknownStructField { suggestion }` for typos. The
+        // collected variant must preserve this — the LSP previously
+        // emitted a plain "Unknown field" message and lost the
+        // suggestion, which #2214 fixes.
+        let ty = struct_type(
+            "Versioning",
+            vec![StructField::new("status", AttributeType::String)],
+        );
+        let v = map_value(vec![("statuus", Value::String("x".to_string()))]);
+        let errors = ty.validate_collect(&v);
+        assert_eq!(errors.len(), 1);
+        match &errors[0].1 {
+            TypeError::UnknownStructField {
+                suggestion: Some(s),
+                ..
+            } => assert_eq!(s, "status"),
+            other => panic!("expected UnknownStructField with suggestion, got {other:?}"),
+        }
+    }
+}

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -566,27 +566,26 @@ impl DiagnosticEngine {
                                 ));
                             }
 
-                            // Struct field validation
-                            let struct_fields = match &attr_schema.attr_type {
-                                carina_core::schema::AttributeType::Struct { fields, .. } => {
-                                    Some(fields)
-                                }
-                                carina_core::schema::AttributeType::List { inner, .. } => {
-                                    match inner.as_ref() {
-                                        carina_core::schema::AttributeType::Struct {
-                                            fields,
-                                            ..
-                                        } => Some(fields),
-                                        _ => None,
-                                    }
-                                }
-                                _ => None,
+                            // Struct field validation. The wrapper borrows
+                            // the schema's `AttributeType` directly so we
+                            // don't deep-clone the field set on every
+                            // keystroke (LSP `analyze_with_filename` is on
+                            // the per-keystroke hot path).
+                            let is_struct_shape = match &attr_schema.attr_type {
+                                carina_core::schema::AttributeType::Struct { .. } => true,
+                                carina_core::schema::AttributeType::List { inner, .. } => matches!(
+                                    inner.as_ref(),
+                                    carina_core::schema::AttributeType::Struct { .. }
+                                ),
+                                _ => false,
                             };
-
-                            if let Some(fields) = struct_fields {
-                                diagnostics.extend(
-                                    self.validate_struct_value(doc, attr_name, attr_value, fields),
-                                );
+                            if is_struct_shape {
+                                diagnostics.extend(self.validate_struct_value(
+                                    doc,
+                                    attr_name,
+                                    attr_value,
+                                    &attr_schema.attr_type,
+                                ));
                             }
                         }
                     }

--- a/carina-lsp/src/diagnostics/validation.rs
+++ b/carina-lsp/src/diagnostics/validation.rs
@@ -1,118 +1,118 @@
-//! Struct and block syntax validation for resource attributes.
+//! LSP adapter that runs core's path-tagged validator
+//! ([`AttributeType::validate_collect`]) and anchors each error at
+//! its source position. The recursive struct/list-of-struct walk
+//! lives entirely in `carina-core` after #2214; this module just
+//! translates `(FieldPath, TypeError)` to LSP diagnostics.
 
-use std::collections::{HashMap, HashSet};
-
-use indexmap::IndexMap;
+use std::collections::HashMap;
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
 
 use crate::document::Document;
 use crate::position;
 use carina_core::resource::Value;
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::{AttributeType, FieldPath, FieldPathStep, ResourceSchema};
 
 use super::{DiagnosticEngine, carina_diagnostic};
 
 impl DiagnosticEngine {
+    /// Run [`AttributeType::validate_collect`] against the resource
+    /// attribute's schema and translate each `(FieldPath, TypeError)`
+    /// into an LSP `Diagnostic` anchored at the offending source
+    /// position. The LSP no longer recurses into nested struct shapes
+    /// — that responsibility belongs to the core validator (#2214).
+    ///
+    /// Takes `&AttributeType` (rather than `&[StructField]`) so the
+    /// per-keystroke diagnostic pass borrows the schema instead of
+    /// deep-cloning every `StructField` (which itself contains
+    /// recursive `AttributeType` sub-trees).
     pub(super) fn validate_struct_value(
         &self,
         doc: &Document,
         attr_name: &str,
         value: &Value,
-        fields: &[carina_core::schema::StructField],
+        ty: &AttributeType,
     ) -> Vec<Diagnostic> {
+        let errors = ty.validate_collect(value);
         let mut diagnostics = Vec::new();
-
-        let maps: Vec<&IndexMap<String, Value>> = match value {
-            Value::Map(map) => vec![map],
-            Value::List(items) => items
-                .iter()
-                .filter_map(|item| {
-                    if let Value::Map(map) = item {
-                        Some(map)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            _ => return diagnostics,
-        };
-
-        let field_names: HashSet<&str> = fields.iter().map(|f| f.name.as_str()).collect();
-        // Also include block_names as valid field names
-        let block_name_to_canonical: HashMap<&str, &str> = fields
-            .iter()
-            .filter_map(|f| f.block_name.as_deref().map(|bn| (bn, f.name.as_str())))
-            .collect();
-        let field_map: HashMap<&str, &carina_core::schema::StructField> =
-            fields.iter().map(|f| (f.name.as_str(), f)).collect();
-
-        for (map_index, map) in maps.iter().enumerate() {
-            for (key, val) in *map {
-                let all_positions = self.find_all_nested_field_positions(doc, attr_name, key);
-                if let Some(Some((line, col))) = all_positions.get(map_index) {
-                    let (line, col) = (*line, *col);
-                    // Resolve block_name to canonical name
-                    let canonical_key = block_name_to_canonical
-                        .get(key.as_str())
-                        .copied()
-                        .unwrap_or(key.as_str());
-
-                    // Check for unknown fields
-                    if !field_names.contains(canonical_key) {
-                        diagnostics.push(carina_diagnostic(
-                            line,
-                            col,
-                            col + key.len() as u32,
-                            DiagnosticSeverity::WARNING,
-                            format!("Unknown field '{}' in '{}'", key, attr_name),
-                        ));
-                        continue;
-                    }
-
-                    // Type validation for known fields
-                    if let Some(field) = field_map.get(canonical_key) {
-                        // Skip validation for ResourceRef values (resolved at runtime)
-                        let type_error = if matches!(val, Value::ResourceRef { .. }) {
-                            None
-                        } else {
-                            field.field_type.validate(val).err().map(|e| e.to_string())
-                        };
-
-                        if let Some(message) = type_error {
-                            diagnostics.push(carina_diagnostic(
-                                line,
-                                col,
-                                col + key.len() as u32,
-                                DiagnosticSeverity::WARNING,
-                                message,
-                            ));
-                        }
-
-                        // Recurse into nested Struct / List<Struct> fields
-                        let nested_fields = match &field.field_type {
-                            carina_core::schema::AttributeType::Struct { fields, .. } => {
-                                Some(fields)
-                            }
-                            carina_core::schema::AttributeType::List { inner, .. } => {
-                                match inner.as_ref() {
-                                    carina_core::schema::AttributeType::Struct {
-                                        fields, ..
-                                    } => Some(fields),
-                                    _ => None,
-                                }
-                            }
-                            _ => None,
-                        };
-                        if let Some(nested) = nested_fields {
-                            diagnostics.extend(self.validate_struct_value(doc, key, val, nested));
-                        }
-                    }
-                }
+        for (path, err) in errors {
+            if let Some((line, col, end_col)) = self.range_for_path(doc, attr_name, &path) {
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    end_col,
+                    DiagnosticSeverity::WARNING,
+                    err.to_string(),
+                ));
             }
         }
-
         diagnostics
+    }
+
+    /// Walk a [`FieldPath`] across the source `doc` and return the
+    /// `(line, col, end_col)` triple to underline. Returns `None` when
+    /// the path cannot be located — better to drop the diagnostic
+    /// than to attach it to the wrong line.
+    fn range_for_path(
+        &self,
+        doc: &Document,
+        attr_name: &str,
+        path: &FieldPath,
+    ) -> Option<(u32, u32, u32)> {
+        let steps = path.steps();
+        if steps.is_empty() {
+            return None;
+        }
+
+        // For a List<Struct> at the top level (block syntax `attr {
+        // ... } attr { ... }`), the first step is a `[i]` index that
+        // selects which block to walk into; the *next* step is the
+        // first field name to find inside that block.
+        let (block_index, name_steps): (usize, &[FieldPathStep]) = match &steps[0] {
+            FieldPathStep::Index(i) => (*i, &steps[1..]),
+            FieldPathStep::Field(_) => (0, steps),
+        };
+
+        let Some(FieldPathStep::Field(first_name)) = name_steps.first() else {
+            // Path ends with an index — anchor on the block header itself.
+            let positions = self.find_all_block_positions(doc, attr_name);
+            return positions
+                .get(block_index)
+                .map(|(line, col)| (*line, *col, *col + attr_name.len() as u32));
+        };
+
+        // The first name lookup goes through the LSP's existing
+        // nested-block scanner, which already handles repeated blocks
+        // and assignment-style `attr = { ... }`.
+        let positions = self.find_all_nested_field_positions(doc, attr_name, first_name);
+        let Some(Some((mut line, mut col))) = positions.get(block_index).copied() else {
+            return None;
+        };
+
+        // For deeper paths (struct nested inside struct), descend by
+        // re-using the same scanner with the previous field name as
+        // the block name. This is approximate — LSP-side struct path
+        // resolution is best-effort — but matches what the legacy
+        // `validate_struct_value` was already doing.
+        let mut current_block = first_name.as_str();
+        for step in name_steps.iter().skip(1) {
+            if let FieldPathStep::Field(child) = step {
+                let nested_positions =
+                    self.find_all_nested_field_positions(doc, current_block, child);
+                if let Some(Some((nl, nc))) = nested_positions.first().copied() {
+                    line = nl;
+                    col = nc;
+                }
+                current_block = child.as_str();
+            }
+            // `Index` steps inside a nested struct (List<Struct> field
+            // of a struct) keep the `current_block` cursor where it
+            // is; the existing scanner walks all matching blocks and
+            // we already pinned the outer index above.
+        }
+
+        let end_col = col + current_block.len() as u32;
+        Some((line, col, end_col))
     }
 
     /// Find the start positions of ALL blocks with the given name.


### PR DESCRIPTION
## Summary

Eliminates the long-standing duplication between `carina-core::schema::AttributeType::validate` and `carina-lsp::diagnostics::validation::validate_struct_value`. The LSP no longer re-implements struct/list-of-struct recursion; the core validator gains a path-tagged sibling that lets the LSP look up source positions for each error.

## Design

The issue listed two viable shapes (path-tagged Vec vs visitor trait). **Path-tagged Vec** chosen — same shape as `ResolvedBindings::from_resources_with_state` (#2299) and the LSP's use case is "collect everything, then iterate to build diagnostics", which is more natural with a Vec than a visitor.

### New types in `carina-core::schema`

```rust
pub enum FieldPathStep { Field(String), Index(usize) }
pub struct FieldPath { steps: Vec<FieldPathStep> }   // Display: "tags.entries[3].name"

impl AttributeType {
    pub fn validate_collect(&self, value: &Value) -> Vec<(FieldPath, TypeError)>;
}
```

`validate_collect` is the path-tagged sibling of the existing `validate`: it walks the entire struct / list-of-struct shape and collects every error with the path from the value's root. Primitives and Custom/Union/StringEnum/Map types fall through to the legacy `validate` since there's no nested context to descend into.

### Drift reconciliation (bonus)

Both `validate` and `validate_collect` now share a single `build_accepted_field_map` helper. Previously the LSP recognised `block_name` aliases for struct fields but the core validator did not; that drift is closed — both paths accept the same set of names.

### LSP wrapper

`validate_struct_value` shrinks from ~100 lines of recursive logic to "call `validate_collect`, map each `(path, error)` to a `Diagnostic` via `range_for_path`". The wrapper takes `&AttributeType` directly (not `&[StructField]`) so the per-keystroke diagnostic pass borrows the schema instead of deep-cloning every `StructField` sub-tree.

## Acceptance criteria

- [x] `carina-lsp/src/diagnostics/validation.rs` no longer recurses into Struct/List<Struct>.
- [x] All existing LSP diagnostic tests still pass (357/357).
- [x] Adding a new validation rule (e.g. min/max length on a struct field) requires changing only the core, and the LSP picks it up automatically with positions.

## Test plan

- [x] `cargo nextest run --workspace` — 2399 / 2399 passed.
- [x] `cargo test --workspace --doc` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — 5/5 passed.
- [x] 7 new unit tests on `validate_collect` cover: valid value (empty errors), multiple unknown fields collected in one pass, nested struct path tagging, list-of-struct index path tagging, `block_name` alias acceptance, ResourceRef skip, `UnknownStructField.suggestion` preservation.

Closes #2214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)