### PR TITLE
refactor(core): structure TypeError::expected as Vec<ExpectedEnumVariant>

### DIFF
--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -1,0 +1,136 @@
+//! Snapshot the user-facing `Display` output of the two enum-mismatch
+//! `TypeError` variants so refactors that touch the structured
+//! `expected: Vec<ExpectedEnumVariant>` cannot accidentally drift the
+//! rendered message. This is the byte-identical guarantee from #2220's
+//! acceptance criteria — the structural change in core must not
+//! perturb what users see.
+//!
+//! Snapshots cover all five user-visible message shapes:
+//!   1. `InvalidEnumVariant`, namespaced StringEnum
+//!   2. `InvalidEnumVariant`, non-namespaced StringEnum (bare variants)
+//!   3. `InvalidEnumVariant`, with `to_dsl` aliases listed alongside
+//!   4. `StringLiteralExpectedEnum` from a quoted-literal on a StringEnum
+//!   5. `StringLiteralExpectedEnum` from a quoted-literal on a Custom
+//!      namespaced type (the `extra_message` path)
+//!
+//! Each schema is built inline so the test does not depend on a
+//! provider plugin binary — the goal is to lock the renderer, not to
+//! exercise the CLI driver.
+
+use std::collections::HashMap;
+
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+fn render_first_error(
+    schema: &ResourceSchema,
+    attrs: HashMap<String, Value>,
+    string_literal: bool,
+) -> String {
+    let result = if string_literal {
+        schema.validate_with_origins(&attrs, &|_| true)
+    } else {
+        schema.validate(&attrs)
+    };
+    let errs = result.expect_err("schema must reject the input under test");
+    errs.first()
+        .expect("at least one error expected")
+        .to_string()
+}
+
+#[test]
+fn invalid_enum_variant_namespaced_display() {
+    let schema = ResourceSchema::new("test.bucket").attribute(
+        AttributeSchema::new(
+            "versioning",
+            AttributeType::StringEnum {
+                name: "VersioningStatus".to_string(),
+                values: vec!["Enabled".to_string(), "Suspended".to_string()],
+                namespace: Some("aws.s3.Bucket".to_string()),
+                to_dsl: None,
+            },
+        )
+        .required(),
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert(
+        "versioning".to_string(),
+        Value::String("aws.s3.Bucket.VersioningStatus.NotReal".to_string()),
+    );
+    insta::assert_snapshot!(render_first_error(&schema, attrs, false));
+}
+
+#[test]
+fn invalid_enum_variant_bare_display() {
+    let t = AttributeType::StringEnum {
+        name: "Mode".to_string(),
+        values: vec!["fast".to_string(), "slow".to_string()],
+        namespace: None,
+        to_dsl: None,
+    };
+    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn invalid_enum_variant_with_to_dsl_aliases_display() {
+    fn lower(v: &str) -> String {
+        v.to_ascii_lowercase()
+    }
+    let t = AttributeType::StringEnum {
+        name: "VersioningStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Suspended".to_string()],
+        namespace: Some("aws.s3.Bucket".to_string()),
+        to_dsl: Some(lower),
+    };
+    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn string_literal_expected_enum_string_enum_display() {
+    let schema = ResourceSchema::new("test.assignment").attribute(
+        AttributeSchema::new(
+            "target_type",
+            AttributeType::StringEnum {
+                name: "TargetType".to_string(),
+                values: vec!["AWS_ACCOUNT".to_string(), "GROUP".to_string()],
+                namespace: Some("awscc.sso.Assignment".to_string()),
+                to_dsl: None,
+            },
+        )
+        .required(),
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("target_type".to_string(), Value::String("aaa".to_string()));
+    insta::assert_snapshot!(render_first_error(&schema, attrs, true));
+}
+
+#[test]
+fn string_literal_expected_enum_custom_namespaced_display() {
+    fn validate_mode(v: &Value) -> Result<(), String> {
+        match v {
+            Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
+            Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+            _ => Err("expected String".to_string()),
+        }
+    }
+    let schema = ResourceSchema::new("test.r.mode_holder").attribute(
+        AttributeSchema::new(
+            "mode",
+            AttributeType::Custom {
+                semantic_name: Some("Mode".to_string()),
+                base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
+                validate: validate_mode,
+                namespace: Some("test.r".to_string()),
+                to_dsl: None,
+            },
+        )
+        .required(),
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+    insta::assert_snapshot!(render_first_error(&schema, attrs, true));
+}

--- a/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_bare_display.snap
+++ b/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_bare_display.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/tests/enum_error_display_snapshot.rs
+expression: err.to_string()
+---
+Invalid value 'zzz' for Mode: expected one of fast, slow

--- a/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_namespaced_display.snap
+++ b/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_namespaced_display.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/tests/enum_error_display_snapshot.rs
+expression: "render_first_error(&schema, attrs, false)"
+---
+Invalid value 'aws.s3.Bucket.VersioningStatus.NotReal' for 'versioning' (VersioningStatus): expected one of aws.s3.Bucket.VersioningStatus.Enabled, aws.s3.Bucket.VersioningStatus.Suspended

--- a/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_with_to_dsl_aliases_display.snap
+++ b/carina-cli/tests/snapshots/enum_error_display_snapshot__invalid_enum_variant_with_to_dsl_aliases_display.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/tests/enum_error_display_snapshot.rs
+expression: err.to_string()
+---
+Invalid value 'zzz' for VersioningStatus: expected one of aws.s3.Bucket.VersioningStatus.Enabled, aws.s3.Bucket.VersioningStatus.Suspended, aws.s3.Bucket.VersioningStatus.enabled, aws.s3.Bucket.VersioningStatus.suspended

--- a/carina-cli/tests/snapshots/enum_error_display_snapshot__string_literal_expected_enum_custom_namespaced_display.snap
+++ b/carina-cli/tests/snapshots/enum_error_display_snapshot__string_literal_expected_enum_custom_namespaced_display.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/tests/enum_error_display_snapshot.rs
+expression: "render_first_error(&schema, attrs, true)"
+---
+'mode' (Mode) expects an enum identifier, got a string literal "aaa". Use one of: invalid Mode 'test.r.Mode.aaa': expected fast

--- a/carina-cli/tests/snapshots/enum_error_display_snapshot__string_literal_expected_enum_string_enum_display.snap
+++ b/carina-cli/tests/snapshots/enum_error_display_snapshot__string_literal_expected_enum_string_enum_display.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/tests/enum_error_display_snapshot.rs
+expression: "render_first_error(&schema, attrs, true)"
+---
+'target_type' (TargetType) expects an enum identifier, got a string literal "aaa". Use one of: awscc.sso.Assignment.TargetType.AWS_ACCOUNT, awscc.sso.Assignment.TargetType.GROUP

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -558,28 +558,28 @@ impl AttributeType {
             if matches_canonical || matches_alias {
                 Ok(())
             } else {
-                // Build the allowed-values list in the form the user
-                // should type — fully-qualified for namespaced enums,
-                // bare otherwise. Also include `to_dsl` aliases so
-                // the message covers every shape validation accepts.
-                let mut expected: Vec<String> = Vec::new();
-                let mut push = |v: &str| {
-                    let rendered = match namespace.as_deref() {
-                        Some(ns) => format!("{}.{}.{}", ns, name, v),
-                        None => v.to_string(),
-                    };
-                    if !expected.contains(&rendered) {
-                        expected.push(rendered);
+                // Aliases produced by `to_dsl` are tagged `is_alias = true`
+                // so LSP code actions can prefer the canonical form.
+                let mut expected: Vec<ExpectedEnumVariant> = Vec::new();
+                let mut push = |variant_value: &str, is_alias: bool| {
+                    let entry = ExpectedEnumVariant::from_namespaced(
+                        namespace.as_deref(),
+                        name,
+                        variant_value,
+                        is_alias,
+                    );
+                    if !expected.contains(&entry) {
+                        expected.push(entry);
                     }
                 };
                 for v in values {
-                    push(v);
+                    push(v, false);
                 }
                 if let Some(f) = to_dsl {
                     for v in values {
                         let alias = f(v);
                         if alias != *v {
-                            push(&alias);
+                            push(&alias, true);
                         }
                     }
                 }
@@ -1029,9 +1029,10 @@ fn reshape_for_string_literal(
     // Namespaced Custom: manually build the shape-mismatch diagnostic from
     // the semantic name. `ValidationFailed` has no attribute slot so
     // `with_attribute` is a no-op; we thread the attribute name in
-    // explicitly. `expected` is left empty — custom validators don't
-    // enumerate variants — but we carry the original validator message in
-    // it so its detail (which often lists valid forms) stays visible.
+    // explicitly. `expected` stays empty — custom validators don't
+    // enumerate variants — and the original validator message rides on
+    // `extra_message` so its detail (which often lists valid forms)
+    // stays visible without polluting the structured candidates list.
     if let AttributeType::Custom {
         semantic_name: Some(name),
         namespace: Some(_),
@@ -1044,27 +1045,45 @@ fn reshape_for_string_literal(
             user_typed: typed.clone(),
             attribute: Some(attr_name.to_string()),
             type_name: name.clone(),
-            expected: vec![message.clone()],
+            expected: Vec::new(),
+            extra_message: Some(message.clone()),
         };
     }
 
     tagged
 }
 
+fn join_expected(expected: &[ExpectedEnumVariant]) -> String {
+    expected
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn format_string_literal_expected_enum(
     user_typed: &str,
     attribute: Option<&str>,
     type_name: &str,
-    expected: &[String],
+    expected: &[ExpectedEnumVariant],
+    extra_message: Option<&str>,
 ) -> String {
     let target = match attribute {
         Some(a) => format!("'{}' ({})", a, type_name),
         None => type_name.to_string(),
     };
-    let joined = expected.join(", ");
+    // When `expected` is empty (Custom-namespaced reshape path) the
+    // validator's own message stands in for the variants list, so the
+    // tail reads "Use one of: <validator message>" — byte-identical to
+    // the pre-#2220 string-vec rendering.
+    let tail = if expected.is_empty() {
+        extra_message.unwrap_or("").to_string()
+    } else {
+        join_expected(expected)
+    };
     format!(
         "{} expects an enum identifier, got a string literal \"{}\". Use one of: {}",
-        target, user_typed, joined
+        target, user_typed, tail
     )
 }
 
@@ -1072,9 +1091,9 @@ fn format_invalid_enum(
     value: &str,
     attribute: Option<&str>,
     type_name: Option<&str>,
-    expected: &[String],
+    expected: &[ExpectedEnumVariant],
 ) -> String {
-    let joined = expected.join(", ");
+    let joined = join_expected(expected);
     let qualifier = match (attribute, type_name) {
         (Some(a), Some(t)) => format!(" for '{}' ({})", a, t),
         (Some(a), None) => format!(" for '{}'", a),
@@ -1091,6 +1110,76 @@ fn format_invalid_enum(
             "Invalid value '{}'{}: expected one of {}",
             value, qualifier, joined
         )
+    }
+}
+
+/// One candidate variant carried by `TypeError::InvalidEnumVariant` and
+/// `TypeError::StringLiteralExpectedEnum`. Splits a fully-qualified enum
+/// identifier into structured pieces so IDE / LSP code actions can
+/// synthesize a fix without re-parsing the rendered string. The `Display`
+/// impl re-renders the same form the user should type — fully-qualified
+/// (`awscc.sso.Assignment.TargetType.AWS_ACCOUNT`) when `provider` is set,
+/// bare (`fast`) otherwise. See #2220.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedEnumVariant {
+    /// Provider segment of the namespace (`"awscc"` for
+    /// `awscc.sso.Assignment.TargetType.AWS_ACCOUNT`). `None` for
+    /// non-namespaced enums whose variants are bare identifiers.
+    pub provider: Option<String>,
+    /// Service / resource segments between the provider and the enum
+    /// type name (`["sso", "Assignment"]` for the example above). Empty
+    /// for non-namespaced enums.
+    pub segments: Vec<String>,
+    /// Name of the enum type (`"TargetType"`).
+    pub type_name: String,
+    /// The variant value as the provider declared it (`"AWS_ACCOUNT"`,
+    /// or `"Enabled"`).
+    pub value: String,
+    /// `true` when this entry came from a `to_dsl` alias rather than the
+    /// canonical provider-side variant. Code actions should prefer the
+    /// canonical form (`is_alias = false`) when offering a fix.
+    pub is_alias: bool,
+}
+
+impl ExpectedEnumVariant {
+    /// `namespace` head becomes `provider`; the rest become `segments`.
+    /// `None` produces a bare-form variant.
+    fn from_namespaced(
+        namespace: Option<&str>,
+        type_name: &str,
+        value: &str,
+        is_alias: bool,
+    ) -> Self {
+        let (provider, segments) = match namespace {
+            Some(ns) => {
+                let mut parts = ns.split('.').map(String::from);
+                let head = parts.next();
+                (head, parts.collect())
+            }
+            None => (None, Vec::new()),
+        };
+        Self {
+            provider,
+            segments,
+            type_name: type_name.to_string(),
+            value: value.to_string(),
+            is_alias,
+        }
+    }
+}
+
+impl fmt::Display for ExpectedEnumVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.provider {
+            Some(provider) => {
+                write!(f, "{}", provider)?;
+                for seg in &self.segments {
+                    write!(f, ".{}", seg)?;
+                }
+                write!(f, ".{}.{}", self.type_name, self.value)
+            }
+            None => write!(f, "{}", self.value),
+        }
     }
 }
 
@@ -1115,10 +1204,12 @@ pub enum TypeError {
         /// tell the reader which enum is expected; None for callers that
         /// build the error by hand without type context.
         type_name: Option<String>,
-        /// Allowed variants in the form the user should type — i.e.
-        /// fully-qualified (`awscc.sso.Assignment.TargetType.AWS_ACCOUNT`)
-        /// for namespaced enums, bare (`fast`, `slow`) otherwise.
-        expected: Vec<String>,
+        /// Allowed variants as structured records. The `Display` impl on
+        /// each entry renders the form the user should type
+        /// (fully-qualified for namespaced enums, bare otherwise);
+        /// programmatic consumers (LSP code actions, `carina explain-error`)
+        /// can read the structured fields directly. See #2220.
+        expected: Vec<ExpectedEnumVariant>,
     },
 
     /// The value was written in the source as a quoted string literal
@@ -1130,7 +1221,7 @@ pub enum TypeError {
     /// See #2094.
     #[error(
         "{}",
-        format_string_literal_expected_enum(user_typed, attribute.as_deref(), type_name, expected)
+        format_string_literal_expected_enum(user_typed, attribute.as_deref(), type_name, expected, extra_message.as_deref())
     )]
     StringLiteralExpectedEnum {
         /// The string the user actually typed between the quotes
@@ -1142,9 +1233,18 @@ pub enum TypeError {
         /// (e.g. `"TargetType"`). Always set for this variant — callers
         /// only build it when they already know the enum type.
         type_name: String,
-        /// Allowed variants in their canonical, user-typeable form
-        /// (fully-qualified for namespaced enums, bare otherwise).
-        expected: Vec<String>,
+        /// Allowed variants as structured records. Same shape as
+        /// `InvalidEnumVariant.expected`. May be empty when the upstream
+        /// schema is `Custom` and the validator does not enumerate
+        /// variants — in that case `extra_message` carries the
+        /// validator's text instead. See #2220.
+        expected: Vec<ExpectedEnumVariant>,
+        /// Free-form text used as the message tail **only when
+        /// `expected` is empty** — i.e. the `Custom` namespaced reshape
+        /// path, where the validator does not enumerate variants. When
+        /// `expected` is non-empty, this field is silently ignored by
+        /// the renderer; callers should not set both at once.
+        extra_message: Option<String>,
     },
 
     #[error("Validation failed: {message}")]
@@ -1241,6 +1341,7 @@ impl TypeError {
                 attribute,
                 type_name,
                 expected,
+                extra_message: None,
             },
             other => other,
         }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -287,7 +287,14 @@ fn string_literal_expected_enum_formats_shape_message() {
         user_typed: "aaa".to_string(),
         attribute: Some("target_type".to_string()),
         type_name: "TargetType".to_string(),
-        expected: vec!["awscc.sso.Assignment.TargetType.AWS_ACCOUNT".to_string()],
+        expected: vec![ExpectedEnumVariant {
+            provider: Some("awscc".to_string()),
+            segments: vec!["sso".to_string(), "Assignment".to_string()],
+            type_name: "TargetType".to_string(),
+            value: "AWS_ACCOUNT".to_string(),
+            is_alias: false,
+        }],
+        extra_message: None,
     };
     let msg = err.to_string();
     assert!(
@@ -317,7 +324,13 @@ fn into_string_literal_diagnostic_reshapes_invalid_enum_variant() {
         value: "aaa".to_string(),
         attribute: Some("target_type".to_string()),
         type_name: Some("TargetType".to_string()),
-        expected: vec!["awscc.sso.Assignment.TargetType.AWS_ACCOUNT".to_string()],
+        expected: vec![ExpectedEnumVariant {
+            provider: Some("awscc".to_string()),
+            segments: vec!["sso".to_string(), "Assignment".to_string()],
+            type_name: "TargetType".to_string(),
+            value: "AWS_ACCOUNT".to_string(),
+            is_alias: false,
+        }],
     };
     let reshaped = original.into_string_literal_diagnostic();
     match reshaped {
@@ -326,14 +339,17 @@ fn into_string_literal_diagnostic_reshapes_invalid_enum_variant() {
             attribute,
             type_name,
             expected,
+            extra_message,
         } => {
             assert_eq!(user_typed, "aaa");
             assert_eq!(attribute.as_deref(), Some("target_type"));
             assert_eq!(type_name, "TargetType");
+            assert_eq!(expected.len(), 1);
             assert_eq!(
-                expected,
-                vec!["awscc.sso.Assignment.TargetType.AWS_ACCOUNT".to_string()]
+                expected[0].to_string(),
+                "awscc.sso.Assignment.TargetType.AWS_ACCOUNT"
             );
+            assert_eq!(extra_message, None);
         }
         other => panic!("expected StringLiteralExpectedEnum, got {other:?}"),
     }
@@ -2748,4 +2764,163 @@ mod validate_collect_tests {
             other => panic!("expected UnknownStructField with suggestion, got {other:?}"),
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// #2220 — ExpectedEnumVariant structured candidates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn expected_enum_variant_display_namespaced_matches_legacy_format() {
+    // The Display impl must reproduce the pre-#2220 rendered string
+    // byte-for-byte so existing CLI / LSP messages stay stable.
+    let v = ExpectedEnumVariant {
+        provider: Some("awscc".to_string()),
+        segments: vec!["sso".to_string(), "Assignment".to_string()],
+        type_name: "TargetType".to_string(),
+        value: "AWS_ACCOUNT".to_string(),
+        is_alias: false,
+    };
+    assert_eq!(v.to_string(), "awscc.sso.Assignment.TargetType.AWS_ACCOUNT");
+}
+
+#[test]
+fn expected_enum_variant_display_bare_when_no_provider() {
+    // Non-namespaced enums (`provider = None`) must render only the
+    // bare value — matching how the legacy formatter pushed `v.to_string()`
+    // when `namespace` was `None`.
+    let v = ExpectedEnumVariant {
+        provider: None,
+        segments: Vec::new(),
+        type_name: "Mode".to_string(),
+        value: "fast".to_string(),
+        is_alias: false,
+    };
+    assert_eq!(v.to_string(), "fast");
+}
+
+#[test]
+fn expected_enum_variant_construction_splits_namespace() {
+    // Namespace head becomes `provider`, the rest become `segments`.
+    let v = ExpectedEnumVariant::from_namespaced(
+        Some("aws.s3.Bucket"),
+        "VersioningStatus",
+        "Enabled",
+        false,
+    );
+    assert_eq!(v.provider.as_deref(), Some("aws"));
+    assert_eq!(v.segments, vec!["s3".to_string(), "Bucket".to_string()]);
+    assert_eq!(v.type_name, "VersioningStatus");
+    assert_eq!(v.value, "Enabled");
+    assert!(!v.is_alias);
+}
+
+#[test]
+fn expected_includes_to_dsl_aliases_with_alias_flag() {
+    // When the schema declares a `to_dsl` mapping, both the canonical
+    // value and the alias appear in `expected`. The alias must be
+    // marked `is_alias = true` so consumers (LSP code action) can
+    // prefer the canonical form.
+    fn lower(v: &str) -> String {
+        v.to_ascii_lowercase()
+    }
+    let t = AttributeType::StringEnum {
+        name: "VersioningStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Suspended".to_string()],
+        namespace: Some("aws.s3.Bucket".to_string()),
+        to_dsl: Some(lower),
+    };
+    let err = t.validate(&Value::String("zzz".to_string())).unwrap_err();
+    let TypeError::InvalidEnumVariant { expected, .. } = err else {
+        panic!("expected InvalidEnumVariant, got {err:?}");
+    };
+    let canonical: Vec<_> = expected.iter().filter(|e| !e.is_alias).collect();
+    let aliases: Vec<_> = expected.iter().filter(|e| e.is_alias).collect();
+    assert_eq!(
+        canonical
+            .iter()
+            .map(|e| e.value.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Enabled", "Suspended"]
+    );
+    assert_eq!(
+        aliases.iter().map(|e| e.value.as_str()).collect::<Vec<_>>(),
+        vec!["enabled", "suspended"],
+        "to_dsl aliases must be present and tagged is_alias=true"
+    );
+    // Every entry round-trips through Display in the legacy form.
+    assert!(
+        canonical
+            .iter()
+            .all(|e| e.to_string().starts_with("aws.s3.Bucket.VersioningStatus."))
+    );
+}
+
+#[test]
+fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
+    // For `AttributeType::Custom` namespaced types the validator
+    // produces an unstructured message. Pre-#2220 it rode in the
+    // `expected: Vec<String>` slot (as a single-element vec). After
+    // #2220 the variants slot is structured, so the validator's text
+    // moves to `extra_message`. The rendered Display output must stay
+    // byte-identical.
+    fn validate_mode(v: &Value) -> Result<(), String> {
+        match v {
+            Value::String(s) if s == "test.r.Mode.fast" => Ok(()),
+            Value::String(s) => Err(format!("invalid Mode '{}': expected fast", s)),
+            _ => Err("expected String".to_string()),
+        }
+    }
+    let schema = ResourceSchema::new("test.r.mode_holder").attribute(
+        AttributeSchema::new(
+            "mode",
+            AttributeType::Custom {
+                semantic_name: Some("Mode".to_string()),
+                base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
+                validate: validate_mode,
+                namespace: Some("test.r".to_string()),
+                to_dsl: None,
+            },
+        )
+        .required(),
+    );
+    let mut attrs = HashMap::new();
+    attrs.insert("mode".to_string(), Value::String("aaa".to_string()));
+    let errs = schema
+        .validate_with_origins(&attrs, &|n| n == "mode")
+        .unwrap_err();
+    let reshaped = errs
+        .into_iter()
+        .find(|e| matches!(e, TypeError::StringLiteralExpectedEnum { .. }))
+        .expect("Custom-namespaced literal must reshape into StringLiteralExpectedEnum");
+    let TypeError::StringLiteralExpectedEnum {
+        expected,
+        extra_message,
+        ..
+    } = &reshaped
+    else {
+        unreachable!();
+    };
+    assert!(
+        expected.is_empty(),
+        "Custom-namespaced reshape leaves structured variants empty"
+    );
+    let msg = extra_message
+        .as_deref()
+        .expect("validator text must be carried on extra_message");
+    assert!(
+        msg.contains("invalid Mode") && msg.contains("expected fast"),
+        "extra_message must carry validator text, got: {msg}"
+    );
+    let rendered = reshaped.to_string();
+    assert!(
+        rendered.contains(msg),
+        "Display must surface extra_message text in tail, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("expects an enum identifier"),
+        "Display must keep the shape-mismatch wording, got: {rendered}"
+    );
 }


### PR DESCRIPTION
## Summary

Replace the rendered-string `expected: Vec<String>` slot on `TypeError::InvalidEnumVariant` and `TypeError::StringLiteralExpectedEnum` with `Vec<ExpectedEnumVariant>` carrying the namespace split into `provider` / `segments`, the enum `type_name`, the `value`, and an `is_alias` flag for `to_dsl`-derived entries.

Programmatic consumers (LSP code actions, future `carina explain-error`) can now read the structured fields directly instead of re-parsing the rendered string. The user-facing `Display` output is **byte-identical** — locked by five new insta snapshots in carina-cli.

`StringLiteralExpectedEnum` gains `extra_message: Option<String>` so the `Custom` namespaced reshape path (validator returns a free-form string instead of enumerated variants) carries that text on a dedicated slot rather than overloading `expected`. This keeps `expected` consistently meaning "structured enum candidates".

LSP code-action implementation that consumes the new fields is split out to follow-up #2309.

## Scope

- **In:** `carina-core` struct + variants, `Display` parity, snapshot guarantee, tests.
- **Out:** LSP `textDocument/codeAction` handler, `Diagnostic.data` payload, `serde` derives — all tracked in #2309.

## Snapshot coverage (carina-cli/tests/snapshots/)

Five user-visible message shapes are locked byte-for-byte:

1. `InvalidEnumVariant`, namespaced `StringEnum`
2. `InvalidEnumVariant`, non-namespaced (bare variants)
3. `InvalidEnumVariant` with `to_dsl` aliases listed
4. `StringLiteralExpectedEnum` from a quoted-literal on a `StringEnum`
5. `StringLiteralExpectedEnum` from a quoted-literal on a `Custom` namespaced type (`extra_message` path)

## Test plan

- [x] `cargo nextest run --workspace` (2421 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] 5 new insta snapshots locked
- [x] 5 new structured-field unit tests in `carina-core::schema::tests`

Closes #2220