### PR TITLE
feat(lsp): code action to insert enum identifier from structured TypeError::expected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,7 @@ dependencies = [
  "log",
  "pest",
  "ropey",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1120,7 +1120,11 @@ fn format_invalid_enum(
 /// impl re-renders the same form the user should type — fully-qualified
 /// (`awscc.sso.Assignment.TargetType.AWS_ACCOUNT`) when `provider` is set,
 /// bare (`fast`) otherwise. See #2220.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializes via `serde` so the LSP can ferry the structured data
+/// through `Diagnostic.data` for `textDocument/codeAction` consumption
+/// (#2309).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExpectedEnumVariant {
     /// Provider segment of the namespace (`"awscc"` for
     /// `awscc.sso.Assignment.TargetType.AWS_ACCOUNT`). `None` for

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2924,3 +2924,33 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
         "Display must keep the shape-mismatch wording, got: {rendered}"
     );
 }
+
+#[test]
+fn expected_enum_variant_serde_round_trip() {
+    // The LSP carries `Vec<ExpectedEnumVariant>` through
+    // `Diagnostic.data` (an opaque JSON value) and reads it back on
+    // `textDocument/codeAction` requests. Lock the serde shape so a
+    // refactor that renames a field cannot silently break the LSP
+    // payload contract. See #2309.
+    let original = ExpectedEnumVariant {
+        provider: Some("awscc".to_string()),
+        segments: vec!["sso".to_string(), "Assignment".to_string()],
+        type_name: "TargetType".to_string(),
+        value: "AWS_ACCOUNT".to_string(),
+        is_alias: false,
+    };
+    let json = serde_json::to_value(&original).expect("serialize");
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "provider": "awscc",
+            "segments": ["sso", "Assignment"],
+            "type_name": "TargetType",
+            "value": "AWS_ACCOUNT",
+            "is_alias": false,
+        }),
+        "JSON shape changed — LSP payload contract is at risk"
+    );
+    let round: ExpectedEnumVariant = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(round, original);
+}

--- a/carina-lsp/Cargo.toml
+++ b/carina-lsp/Cargo.toml
@@ -29,6 +29,7 @@ ropey = "1"
 pest = "2"
 log = "0.4"
 env_logger = "0.11"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -374,6 +374,18 @@ impl LanguageServer for Backend {
                     ),
                 ),
                 document_formatting_provider: Some(OneOf::Left(true)),
+                // Declare `code_action_kinds` explicitly so editors that
+                // gate on `only` (`CodeActionContext.only`) can avoid
+                // probing this server for kinds it never emits. Carina
+                // only ships QUICKFIX actions for #2309 today; add more
+                // kinds here when other features start emitting actions.
+                code_action_provider: Some(CodeActionProviderCapability::Options(
+                    CodeActionOptions {
+                        code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                        resolve_provider: None,
+                        work_done_progress_options: Default::default(),
+                    },
+                )),
                 ..Default::default()
             },
             ..Default::default()
@@ -572,6 +584,28 @@ impl LanguageServer for Backend {
             }
         }
         Ok(None)
+    }
+
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        // The handler is purely diagnostic-driven: the editor passes the
+        // diagnostics it currently shows in `params.context.diagnostics`,
+        // each one carrying its `Diagnostic.data` payload unchanged. We
+        // read the structured `EnumDiagnosticData` off matching
+        // diagnostics and emit one `CodeAction` per remaining candidate.
+        // Diagnostics without an enum payload (or from other features)
+        // produce no actions here.
+        let uri = &params.text_document.uri;
+        let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+        for diag in &params.context.diagnostics {
+            for action in crate::code_action::code_actions_for_diagnostic(uri, diag) {
+                actions.push(CodeActionOrCommand::CodeAction(action));
+            }
+        }
+        if actions.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(actions))
+        }
     }
 }
 

--- a/carina-lsp/src/code_action.rs
+++ b/carina-lsp/src/code_action.rs
@@ -1,0 +1,288 @@
+//! Code-action support for enum-mismatch diagnostics. See #2309.
+//!
+//! Diagnostics produced for `TypeError::InvalidEnumVariant` and
+//! `TypeError::StringLiteralExpectedEnum` carry a serialized
+//! [`EnumDiagnosticData`] payload on `Diagnostic.data`. The LSP's
+//! `textDocument/codeAction` handler reads that payload back, dedupes
+//! the candidate list, and returns one `CodeAction` per remaining
+//! candidate that replaces the offending range with the canonical
+//! identifier form.
+//!
+//! The kind tag distinguishes the two diagnostic shapes:
+//!
+//! - [`EnumDiagnosticKind::BareInvalid`] — the user typed a bare or
+//!   namespaced identifier that didn't match any variant. The
+//!   replacement is the new identifier alone (no quotes); the
+//!   diagnostic range covers the value text.
+//! - [`EnumDiagnosticKind::StringLiteral`] — the user wrote a quoted
+//!   string literal on an enum-typed attribute. The diagnostic range
+//!   covers the literal *including* both quote characters; the
+//!   replacement is the canonical identifier form (no quotes), so
+//!   applying the action drops the quotes too.
+
+use carina_core::schema::ExpectedEnumVariant;
+use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types::{CodeAction, CodeActionKind, Diagnostic, TextEdit, Url, WorkspaceEdit};
+
+/// Whether the diagnostic was emitted for a bare-identifier mismatch
+/// or a quoted string literal in enum position. Determines how the
+/// code-action `WorkspaceEdit` overwrites the offending range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnumDiagnosticKind {
+    /// The user typed an identifier (bare or namespaced) that didn't
+    /// match any variant. Replace with the canonical identifier.
+    BareInvalid,
+    /// The user wrote a quoted string literal where an enum identifier
+    /// was expected. Replace including the surrounding quotes.
+    StringLiteral,
+}
+
+/// Payload attached to enum-mismatch `Diagnostic.data`. Round-trips
+/// through JSON so the LSP client can hand it back unchanged on a
+/// `textDocument/codeAction` request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnumDiagnosticData {
+    /// Marker discriminator so future payloads on `Diagnostic.data`
+    /// (e.g. for `UnknownAttribute` quick-fixes) won't be mistaken
+    /// for an enum payload after deserialization.
+    pub tag: EnumDiagnosticTag,
+    pub kind: EnumDiagnosticKind,
+    pub expected: Vec<ExpectedEnumVariant>,
+}
+
+/// Static tag value used as a structural marker. `serde` rejects
+/// anything else when deserializing, so a stray `Diagnostic.data`
+/// from another source can't masquerade as an enum payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EnumDiagnosticTag {
+    #[serde(rename = "carina_enum_mismatch")]
+    EnumMismatch,
+}
+
+impl EnumDiagnosticData {
+    pub fn new(kind: EnumDiagnosticKind, expected: Vec<ExpectedEnumVariant>) -> Self {
+        Self {
+            tag: EnumDiagnosticTag::EnumMismatch,
+            kind,
+            expected,
+        }
+    }
+
+    /// Try to read an enum-mismatch payload off a `Diagnostic`.
+    /// Returns `None` when `data` is missing, was emitted by a
+    /// different feature, or fails to deserialize.
+    pub fn from_diagnostic(diag: &Diagnostic) -> Option<Self> {
+        let data = diag.data.as_ref()?;
+        serde_json::from_value(data.clone()).ok()
+    }
+}
+
+/// Build the `CodeAction` list for one diagnostic. Returns an empty
+/// vec when the payload is absent or no candidates apply.
+pub fn code_actions_for_diagnostic(uri: &Url, diag: &Diagnostic) -> Vec<CodeAction> {
+    let Some(payload) = EnumDiagnosticData::from_diagnostic(diag) else {
+        return Vec::new();
+    };
+
+    // Drop alias entries when at least one canonical entry is present.
+    // The issue's spec: "skipping `is_alias = true` unless no canonical
+    // entry exists". Aliases (e.g. `enabled` for `Enabled`) are valid
+    // forms but the canonical name is the preferred fix.
+    let has_canonical = payload.expected.iter().any(|e| !e.is_alias);
+    let candidates: Vec<&ExpectedEnumVariant> = if has_canonical {
+        payload.expected.iter().filter(|e| !e.is_alias).collect()
+    } else {
+        payload.expected.iter().collect()
+    };
+
+    candidates
+        .into_iter()
+        .map(|variant| {
+            let new_text = variant.to_string();
+            let title = format!("Replace with `{}`", new_text);
+            let edit = TextEdit {
+                range: diag.range,
+                new_text,
+            };
+            let mut changes = std::collections::HashMap::new();
+            changes.insert(uri.clone(), vec![edit]);
+            CodeAction {
+                title,
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(vec![diag.clone()]),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    ..Default::default()
+                }),
+                is_preferred: Some(!variant.is_alias),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::lsp_types::{Position, Range};
+
+    /// Build a versioning-bucket fixture variant — keep the `aws.s3.Bucket
+    /// .VersioningStatus` shape stable across these tests so `Display`
+    /// renders `aws.s3.Bucket.VersioningStatus.<value>` and the
+    /// snapshot assertions stay readable.
+    fn s3_versioning_variant(
+        provider: Option<&str>,
+        value: &str,
+        is_alias: bool,
+    ) -> ExpectedEnumVariant {
+        ExpectedEnumVariant {
+            provider: provider.map(String::from),
+            segments: provider
+                .map(|_| vec!["s3".to_string(), "Bucket".to_string()])
+                .unwrap_or_default(),
+            type_name: "VersioningStatus".to_string(),
+            value: value.to_string(),
+            is_alias,
+        }
+    }
+
+    fn diag_with_payload(payload: EnumDiagnosticData) -> Diagnostic {
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 5,
+                },
+                end: Position {
+                    line: 0,
+                    character: 12,
+                },
+            },
+            data: Some(serde_json::to_value(payload).unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn dummy_uri() -> Url {
+        Url::parse("file:///tmp/main.crn").unwrap()
+    }
+
+    #[test]
+    fn payload_round_trips_via_diagnostic_data() {
+        let original = EnumDiagnosticData::new(
+            EnumDiagnosticKind::BareInvalid,
+            vec![s3_versioning_variant(Some("aws"), "Enabled", false)],
+        );
+        let diag = diag_with_payload(original.clone());
+        let read = EnumDiagnosticData::from_diagnostic(&diag).expect("payload present");
+        assert_eq!(read, original);
+    }
+
+    #[test]
+    fn from_diagnostic_returns_none_when_data_is_absent() {
+        let diag = Diagnostic::default();
+        assert!(EnumDiagnosticData::from_diagnostic(&diag).is_none());
+    }
+
+    #[test]
+    fn from_diagnostic_returns_none_for_unrelated_payload() {
+        // A diagnostic from another feature (or a future tag) must not
+        // be mistakenly routed to the enum code-action handler.
+        let diag = Diagnostic {
+            data: Some(serde_json::json!({ "tag": "something_else" })),
+            ..Default::default()
+        };
+        assert!(EnumDiagnosticData::from_diagnostic(&diag).is_none());
+    }
+
+    #[test]
+    fn aliases_are_skipped_when_canonical_entry_exists() {
+        let payload = EnumDiagnosticData::new(
+            EnumDiagnosticKind::BareInvalid,
+            vec![
+                s3_versioning_variant(Some("aws"), "Enabled", false),
+                s3_versioning_variant(Some("aws"), "enabled", true),
+                s3_versioning_variant(Some("aws"), "Suspended", false),
+                s3_versioning_variant(Some("aws"), "suspended", true),
+            ],
+        );
+        let diag = diag_with_payload(payload);
+        let actions = code_actions_for_diagnostic(&dummy_uri(), &diag);
+        let titles: Vec<String> = actions.iter().map(|a| a.title.clone()).collect();
+        assert_eq!(
+            titles,
+            vec![
+                "Replace with `aws.s3.Bucket.VersioningStatus.Enabled`",
+                "Replace with `aws.s3.Bucket.VersioningStatus.Suspended`",
+            ],
+            "alias entries should be filtered out when canonicals are present"
+        );
+    }
+
+    #[test]
+    fn aliases_are_kept_when_no_canonical_entry_exists() {
+        // Defensive: if a malformed payload contains only aliases, the
+        // user should still get *something* actionable.
+        let payload = EnumDiagnosticData::new(
+            EnumDiagnosticKind::BareInvalid,
+            vec![s3_versioning_variant(Some("aws"), "enabled", true)],
+        );
+        let diag = diag_with_payload(payload);
+        let actions = code_actions_for_diagnostic(&dummy_uri(), &diag);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            actions[0].title,
+            "Replace with `aws.s3.Bucket.VersioningStatus.enabled`"
+        );
+    }
+
+    #[test]
+    fn workspace_edit_replaces_diagnostic_range_with_new_text() {
+        // The applied edit's `new_text` is the variant's `Display`
+        // form — for `StringLiteral` kind the diagnostic range
+        // already covers the surrounding quotes, so writing the bare
+        // identifier in that range drops the quotes too.
+        let payload = EnumDiagnosticData::new(
+            EnumDiagnosticKind::StringLiteral,
+            vec![s3_versioning_variant(Some("aws"), "Enabled", false)],
+        );
+        let diag = diag_with_payload(payload);
+        let actions = code_actions_for_diagnostic(&dummy_uri(), &diag);
+        let action = &actions[0];
+        let edit = action.edit.as_ref().unwrap();
+        let changes = edit.changes.as_ref().unwrap();
+        let edits = changes.get(&dummy_uri()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range, diag.range);
+        assert_eq!(edits[0].new_text, "aws.s3.Bucket.VersioningStatus.Enabled");
+    }
+
+    #[test]
+    fn non_namespaced_variant_renders_bare_value() {
+        let payload = EnumDiagnosticData::new(
+            EnumDiagnosticKind::BareInvalid,
+            vec![ExpectedEnumVariant {
+                provider: None,
+                segments: Vec::new(),
+                type_name: "Mode".to_string(),
+                value: "fast".to_string(),
+                is_alias: false,
+            }],
+        );
+        let diag = diag_with_payload(payload);
+        let actions = code_actions_for_diagnostic(&dummy_uri(), &diag);
+        assert_eq!(actions[0].title, "Replace with `fast`");
+    }
+
+    #[test]
+    fn canonical_action_is_marked_preferred() {
+        let payload = EnumDiagnosticData::new(
+            EnumDiagnosticKind::BareInvalid,
+            vec![s3_versioning_variant(Some("aws"), "Enabled", false)],
+        );
+        let diag = diag_with_payload(payload);
+        let actions = code_actions_for_diagnostic(&dummy_uri(), &diag);
+        assert_eq!(actions[0].is_preferred, Some(true));
+    }
+}

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -403,6 +403,29 @@ impl DiagnosticEngine {
                                 }
                             }
 
+                            // #2309: when the attribute schema is a StringEnum and
+                            // validation fails, emit a Diagnostic with the structured
+                            // candidate list on `Diagnostic.data` and a range that
+                            // covers the offending value text — both prerequisites
+                            // for the `textDocument/codeAction` quick-fix. Falls
+                            // through to the generic match below for everything
+                            // else (and when the StringEnum branch can't locate a
+                            // value range).
+                            if let carina_core::schema::AttributeType::StringEnum { .. } =
+                                &attr_schema.attr_type
+                                && let Some(diag) = build_string_enum_diagnostic(
+                                    &attr_schema.attr_type,
+                                    attr_value,
+                                    attr_name,
+                                    resource.quoted_string_attrs.contains(attr_name),
+                                    self.find_attribute_value_range(doc, attr_name, scope),
+                                )
+                            {
+                                diagnostics.push(diag);
+                                // Continue past the generic match: this attribute
+                                // is already reported with the richer diagnostic.
+                                continue;
+                            }
                             let type_error = match (&attr_schema.attr_type, attr_value) {
                                 // Bool type should not receive String
                                 (carina_core::schema::AttributeType::Bool, Value::String(s)) => {
@@ -437,15 +460,19 @@ impl DiagnosticEngine {
                                     path.binding(),
                                     path.attribute(),
                                 ),
-                                // Custom type validation (all Custom types use their validate fn)
+                                // StringEnum: the structured-payload path
+                                // above handles `InvalidEnumVariant` /
+                                // `StringLiteralExpectedEnum` and
+                                // `continue`s past this match. We only
+                                // reach this arm when that path declined
+                                // (e.g. `TypeMismatch` from a non-string
+                                // value, or `ValidationFailed` from the
+                                // namespace-shape fallback) — surface the
+                                // plain message so the user still sees a
+                                // diagnostic, just without the quick-fix.
                                 (carina_core::schema::AttributeType::StringEnum { .. }, value) => {
                                     attr_schema.attr_type.validate(value).err().map(|e| {
                                         let tagged = e.with_attribute(attr_name);
-                                        // Mirror PR 2 (#2112) diagnostic parity in the LSP:
-                                        // if the parser tagged this attribute as a quoted
-                                        // string literal, reshape the enum-variant error
-                                        // into the shape-mismatch variant so editor hovers
-                                        // match CLI output. See #2094.
                                         let reshaped =
                                             if resource.quoted_string_attrs.contains(attr_name) {
                                                 tagged.into_string_literal_diagnostic()
@@ -896,6 +923,129 @@ impl DiagnosticEngine {
         }
         None
     }
+
+    /// Locate the value side of `attr_name = <value>` and return the
+    /// `Range` covering the value token. For a quoted string literal
+    /// the range covers both surrounding quote characters; for a
+    /// dotted identifier the range covers the whole identifier
+    /// (including any `.` separators) up to the first whitespace or
+    /// line-terminator.
+    ///
+    /// Used by code-action diagnostics so the editor's quick-fix
+    /// `WorkspaceEdit` overwrites just the offending value, not the
+    /// whole line.
+    ///
+    /// Returns `None` for value shapes the LSP code action does not
+    /// support: block-syntax `attr = { ... }`, multi-line lists, or
+    /// missing-value lines.
+    fn find_attribute_value_range(
+        &self,
+        doc: &Document,
+        attr_name: &str,
+        scope: Option<(u32, u32)>,
+    ) -> Option<tower_lsp::lsp_types::Range> {
+        use tower_lsp::lsp_types::{Position, Range};
+        let text = doc.text();
+        let (start, end) = scope.unwrap_or((0, u32::MAX));
+
+        for (line_idx, line) in text.lines().enumerate() {
+            let line_idx_u32 = line_idx as u32;
+            if line_idx_u32 < start {
+                continue;
+            }
+            if line_idx_u32 >= end {
+                break;
+            }
+            let leading = position::leading_whitespace_chars(line) as usize;
+            let trimmed = &line[leading..];
+            if !trimmed.starts_with(attr_name) {
+                continue;
+            }
+            let after_attr = &trimmed[attr_name.len()..];
+            if !after_attr.starts_with(' ')
+                && !after_attr.starts_with('\t')
+                && !after_attr.starts_with('=')
+            {
+                continue;
+            }
+            // Skip past `name`, optional whitespace, `=`, optional whitespace.
+            // Carina's formatter standardizes spaces, but accept tabs too so
+            // a hand-formatted buffer (e.g. mid-edit) still surfaces the
+            // quick-fix instead of silently dropping it.
+            let mut col = leading + attr_name.len();
+            let bytes = line.as_bytes();
+            while col < bytes.len() && (bytes[col] == b' ' || bytes[col] == b'\t') {
+                col += 1;
+            }
+            if col >= bytes.len() || bytes[col] != b'=' {
+                return None;
+            }
+            col += 1; // past `=`
+            while col < bytes.len() && (bytes[col] == b' ' || bytes[col] == b'\t') {
+                col += 1;
+            }
+            if col >= bytes.len() {
+                return None;
+            }
+            let value_start = col;
+            let value_end = if bytes[col] == b'"' {
+                // Quoted string literal: include both quotes. Bail
+                // (return None) if the closing quote is missing rather
+                // than guess at a range.
+                let mut i = col + 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    // Skip a backslash-escaped char so an inner `\"`
+                    // doesn't terminate the literal early.
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+                if i >= bytes.len() {
+                    return None;
+                }
+                i + 1
+            } else if bytes[col] == b'{' || bytes[col] == b'[' {
+                // Block-syntax / list-syntax values are out of scope
+                // for this code action — there's no single offending
+                // identifier to replace.
+                return None;
+            } else {
+                // Bare identifier (possibly dotted, e.g.
+                // `aws.s3.Bucket.VersioningStatus.Enabled`). Read up
+                // to whitespace or a comment.
+                let mut i = col;
+                while i < bytes.len()
+                    && bytes[i] != b' '
+                    && bytes[i] != b'\t'
+                    && bytes[i] != b'#'
+                    && bytes[i] != b','
+                {
+                    i += 1;
+                }
+                i
+            };
+            // LSP `Position.character` is a UTF-16/codepoint offset, not
+            // a byte offset. The byte-walk above is safe up to
+            // `value_start` (only ASCII attr-name / whitespace / `=`
+            // precede it on the line) but the value itself can contain
+            // multi-byte chars (e.g. `attr = "あ"`), so convert both
+            // ends through `byte_offset_to_char_offset` before handing
+            // them to the LSP client.
+            return Some(Range {
+                start: Position {
+                    line: line_idx_u32,
+                    character: position::byte_offset_to_char_offset(line, value_start),
+                },
+                end: Position {
+                    line: line_idx_u32,
+                    character: position::byte_offset_to_char_offset(line, value_end),
+                },
+            });
+        }
+        None
+    }
 }
 
 /// Derive the source line range (0-indexed, half-open) of a resource block.
@@ -982,6 +1132,57 @@ fn strip_line_comment(line: &str) -> &str {
         i += 1;
     }
     line
+}
+
+/// Build a `Diagnostic` for a failed `StringEnum` attribute validation,
+/// carrying the structured candidate list on `Diagnostic.data` and a
+/// range over the offending value text. Returns `None` when validation
+/// passed, when the value range can't be located (block-syntax,
+/// missing value), or when the failing error isn't an enum-variant
+/// shape (e.g. a `TypeMismatch` from a non-string `Value`).
+///
+/// See #2309. The structured payload is consumed by
+/// [`crate::code_action::code_actions_for_diagnostic`].
+fn build_string_enum_diagnostic(
+    attr_type: &carina_core::schema::AttributeType,
+    attr_value: &Value,
+    attr_name: &str,
+    is_quoted_literal: bool,
+    value_range: Option<tower_lsp::lsp_types::Range>,
+) -> Option<Diagnostic> {
+    use crate::code_action::{EnumDiagnosticData, EnumDiagnosticKind};
+    let err = attr_type.validate(attr_value).err()?;
+    let tagged = err.with_attribute(attr_name);
+    // Reshape into the shape-mismatch diagnostic when the value came
+    // from a quoted string literal — mirrors CLI behavior (#2094).
+    let reshaped = if is_quoted_literal {
+        tagged.into_string_literal_diagnostic()
+    } else {
+        tagged
+    };
+    let (kind, expected_variants) = match &reshaped {
+        carina_core::schema::TypeError::InvalidEnumVariant { expected, .. } => {
+            (EnumDiagnosticKind::BareInvalid, expected.clone())
+        }
+        carina_core::schema::TypeError::StringLiteralExpectedEnum { expected, .. } => {
+            (EnumDiagnosticKind::StringLiteral, expected.clone())
+        }
+        // The error wasn't an enum-variant mismatch (e.g. TypeMismatch
+        // when a non-string Value was passed to StringEnum). Skip the
+        // structured payload — the generic match below will surface a
+        // plain message instead.
+        _ => return None,
+    };
+    let range = value_range?;
+    let data = EnumDiagnosticData::new(kind, expected_variants);
+    Some(Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::WARNING),
+        source: Some("carina".to_string()),
+        message: reshaped.to_string(),
+        data: Some(serde_json::to_value(data).expect("EnumDiagnosticData serialize")),
+        ..Default::default()
+    })
 }
 
 /// Check whether a ResourceRef value is type-compatible with the expected attribute type.

--- a/carina-lsp/src/diagnostics/tests/basic.rs
+++ b/carina-lsp/src/diagnostics/tests/basic.rs
@@ -713,3 +713,125 @@ awscc.ec2.SecurityGroup {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2309 — find_attribute_value_range coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn value_range_covers_dotted_identifier() {
+    let engine = super::test_engine();
+    let doc = super::create_document(
+        "let _ = aws.s3.Bucket {\n  versioning = aws.s3.VersioningStatus.NotReal\n}\n",
+    );
+    let range = engine
+        .find_attribute_value_range(&doc, "versioning", None)
+        .expect("range located");
+    assert_eq!(range.start.line, 1);
+    // Compute expected columns from the line text directly so the
+    // assertion stays robust to incidental indentation tweaks.
+    let text = doc.text();
+    let line = text.lines().nth(1).unwrap();
+    let value_start = line.find("aws.s3.VersioningStatus.NotReal").unwrap() as u32;
+    let value_end = value_start + "aws.s3.VersioningStatus.NotReal".len() as u32;
+    assert_eq!(range.start.character, value_start);
+    assert_eq!(range.end.character, value_end);
+}
+
+#[test]
+fn value_range_includes_quotes_for_string_literal() {
+    // Code action for `StringLiteralExpectedEnum` replaces the quoted
+    // literal *with* its surrounding quotes — applying the fix drops
+    // the quotes and writes the bare identifier.
+    let engine = super::test_engine();
+    let doc =
+        super::create_document("awscc.sso.Assignment {\n  target_type = \"AWS_ACCOUNT\"\n}\n");
+    let range = engine
+        .find_attribute_value_range(&doc, "target_type", None)
+        .expect("range located");
+    let text = doc.text();
+    let line = text.lines().nth(1).unwrap();
+    let value_start = line.find('"').unwrap() as u32;
+    let value_end = (line.rfind('"').unwrap() + 1) as u32;
+    assert_eq!(range.start.line, 1);
+    assert_eq!(range.start.character, value_start);
+    assert_eq!(range.end.character, value_end);
+}
+
+#[test]
+fn value_range_returns_none_for_block_syntax_value() {
+    // `attr = { ... }` has no single offending identifier — the code
+    // action declines to fix it (no range, hence no quick-fix).
+    let engine = super::test_engine();
+    let doc = super::create_document("aws.s3.Bucket {\n  tags = { Env = \"prod\" }\n}\n");
+    assert!(
+        engine
+            .find_attribute_value_range(&doc, "tags", None)
+            .is_none()
+    );
+}
+
+#[test]
+fn value_range_uses_character_offsets_for_multibyte_literal() {
+    // LSP `Position.character` is a UTF-16/codepoint offset, not a byte
+    // offset. Quoted-literal values that contain multi-byte chars
+    // (e.g. `"あ"`) must still produce a `Range` whose `end.character`
+    // equals the codepoint count, not the UTF-8 byte length — otherwise
+    // an editor applying the quick-fix would corrupt surrounding text.
+    let engine = super::test_engine();
+    let doc = super::create_document("aws.s3.Bucket {\n  versioning = \"あ\"\n}\n");
+    let range = engine
+        .find_attribute_value_range(&doc, "versioning", None)
+        .expect("range located");
+    let text = doc.text();
+    let line = text.lines().nth(1).unwrap();
+    // The literal `"あ"` is 3 codepoints: `"`, `あ`, `"`.
+    let value_start_chars = line.chars().take_while(|c| *c != '"').count() as u32;
+    assert_eq!(range.start.line, 1);
+    assert_eq!(range.start.character, value_start_chars);
+    assert_eq!(range.end.character, value_start_chars + 3);
+}
+
+#[test]
+fn string_enum_with_non_string_value_still_emits_diagnostic() {
+    // Regression: when #2309 routed StringEnum through
+    // `build_string_enum_diagnostic`, the fall-back match arm for
+    // StringEnum was removed. That hid `TypeError::TypeMismatch`
+    // diagnostics when the user typed a non-string value (e.g. an
+    // integer) against an enum-typed attribute. The fall-through
+    // generic-message arm restored it; this test pins the behavior.
+    let engine = super::test_engine_with_enum_attr();
+    let doc = super::create_document("test.r.mode_holder {\n  name = \"a\"\n  mode = 42\n}\n");
+    let diagnostics = engine.analyze(&doc, None);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.message.to_ascii_lowercase().contains("type mismatch")
+                || d.message.to_ascii_lowercase().contains("expected")),
+        "non-string value against StringEnum must still produce a diagnostic, got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn value_range_locates_value_separated_by_tabs() {
+    // Round 4 widened the separator handling in `find_attribute_value_range`
+    // from spaces-only to spaces *or* tabs so a hand-formatted buffer
+    // (or one mid-edit, before the formatter has run) still surfaces
+    // the quick-fix. Pin the behavior so a future tightening can't
+    // silently regress it.
+    let engine = super::test_engine();
+    let doc = super::create_document(
+        "let _ = aws.s3.Bucket {\n\tversioning\t=\taws.s3.VersioningStatus.NotReal\n}\n",
+    );
+    let range = engine
+        .find_attribute_value_range(&doc, "versioning", None)
+        .expect("range located even with tab separators");
+    assert_eq!(range.start.line, 1);
+    let text = doc.text();
+    let line = text.lines().nth(1).unwrap();
+    let value_start = line.find("aws.s3.VersioningStatus.NotReal").unwrap() as u32;
+    let value_end = value_start + "aws.s3.VersioningStatus.NotReal".len() as u32;
+    assert_eq!(range.start.character, value_start);
+    assert_eq!(range.end.character, value_end);
+}

--- a/carina-lsp/src/lib.rs
+++ b/carina-lsp/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backend;
+pub mod code_action;
 pub mod completion;
 pub mod diagnostics;
 pub mod document;

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -13,67 +13,12 @@
 //! provider plugin that is not built in this repo. These LSP-side tests
 //! still pin the parse → resolve → validate pipeline end-to-end.
 
+mod support;
+
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
-use carina_lsp::diagnostics::DiagnosticEngine;
-use carina_lsp::document::Document;
-use tempfile::TempDir;
-
-/// Lay a multi-file fixture mirroring `infra/aws/management/<dir>/`:
-/// `main.crn`, `exports.crn`, `providers.crn`. Returns the temp dir
-/// (kept alive by the caller) plus the absolute path it sits at.
-fn write_fixture(files: &[(&str, &str)]) -> TempDir {
-    let dir = tempfile::tempdir().expect("tempdir");
-    for (name, body) in files {
-        std::fs::write(dir.path().join(name), body).expect("write fixture file");
-    }
-    dir
-}
-
-/// Build a `Document` from one file inside the fixture and feed it through
-/// the engine with `base_path` set so directory-scoped checks see the
-/// sibling files.
-fn analyze(
-    engine: &DiagnosticEngine,
-    fixture: &TempDir,
-    file_name: &str,
-) -> Vec<tower_lsp::lsp_types::Diagnostic> {
-    let path = fixture.path().join(file_name);
-    let text = std::fs::read_to_string(&path).expect("read fixture file");
-    let doc = Document::new(
-        text,
-        Arc::new(carina_core::parser::ProviderContext::default()),
-    );
-    engine.analyze_with_filename(&doc, Some(file_name), Some(fixture.path()))
-}
-
-// Mirrors `custom_engine` in `carina-lsp/src/diagnostics/tests/mod.rs`. The
-// in-crate test helpers there are `pub(super)` and not reachable from
-// `tests/`, so an integration test has to redefine this. Keep the two
-// shapes in sync if either one grows fields.
-fn engine_with_schemas(schemas: HashMap<String, ResourceSchema>) -> DiagnosticEngine {
-    let provider_names: Vec<String> = schemas
-        .keys()
-        .filter_map(|k| k.split('.').next())
-        .collect::<std::collections::HashSet<_>>()
-        .into_iter()
-        .map(String::from)
-        .collect();
-    DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(vec![]))
-}
-
-/// Wrap one `ResourceSchema` in a `HashMap` keyed by its `resource_type`,
-/// so each scenario only has to spell `"test.r.<thing>"` once. The
-/// double-spelling is a real footgun: an off-by-one between the key and
-/// `ResourceSchema::new` argument silently makes the engine treat the
-/// resource as unknown.
-fn single_schema_map(schema: ResourceSchema) -> HashMap<String, ResourceSchema> {
-    let mut schemas = HashMap::new();
-    schemas.insert(schema.resource_type.clone(), schema);
-    schemas
-}
+use support::fixture::{analyze, engine_with_schemas, single_schema_map, write_fixture};
 
 fn count_with(diags: &[tower_lsp::lsp_types::Diagnostic], substring: &str) -> usize {
     diags

--- a/carina-lsp/tests/lsp_enum_code_action.rs
+++ b/carina-lsp/tests/lsp_enum_code_action.rs
@@ -1,0 +1,212 @@
+//! Integration coverage for #2309: enum-mismatch diagnostics carry a
+//! structured payload on `Diagnostic.data` and the
+//! `textDocument/codeAction` handler turns that payload into one
+//! quick-fix per candidate.
+//!
+//! Each scenario builds a directory-shaped fixture (`main.crn` plus a
+//! sibling file) under `tempfile::tempdir()`, runs the
+//! `DiagnosticEngine` to produce diagnostics, then exercises the
+//! `code_actions_for_diagnostic` consumer directly. Going through the
+//! engine + the public consumer (rather than the tower-lsp socket)
+//! keeps the test focused on the contract under #2309: structured
+//! payload in, `WorkspaceEdit` out. Editor-side wiring is out of
+//! scope per the issue.
+
+mod support;
+
+use std::collections::HashMap;
+
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_lsp::code_action::{
+    EnumDiagnosticData, EnumDiagnosticKind, code_actions_for_diagnostic,
+};
+use support::fixture::{analyze, engine_with_schemas, write_fixture};
+use tower_lsp::lsp_types::{Diagnostic, Url};
+
+fn versioning_schema() -> HashMap<String, ResourceSchema> {
+    fn lower(v: &str) -> String {
+        v.to_ascii_lowercase()
+    }
+    let versioning = AttributeType::StringEnum {
+        name: "VersioningStatus".to_string(),
+        values: vec!["Enabled".to_string(), "Suspended".to_string()],
+        namespace: Some("aws.s3.Bucket".to_string()),
+        to_dsl: Some(lower),
+    };
+    let mut schemas = HashMap::new();
+    schemas.insert(
+        "aws.s3.bucket".to_string(),
+        ResourceSchema::new("aws.s3.bucket")
+            .attribute(AttributeSchema::new("name", AttributeType::String))
+            .attribute(AttributeSchema::new("versioning", versioning)),
+    );
+    schemas
+}
+
+fn first_enum_diagnostic(diags: &[Diagnostic]) -> &Diagnostic {
+    diags
+        .iter()
+        .find(|d| EnumDiagnosticData::from_diagnostic(d).is_some())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected at least one diagnostic with EnumDiagnosticData, got: {:#?}",
+                diags
+            )
+        })
+}
+
+fn dummy_uri() -> Url {
+    Url::parse("file:///tmp/main.crn").unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: bare-identifier mismatch on a namespaced StringEnum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_identifier_invalid_emits_payload_and_quick_fix() {
+    let engine = engine_with_schemas(versioning_schema());
+    // Multi-file fixture per the directory-scoped invariant: providers.crn
+    // sits next to main.crn so the engine sees the directory shape.
+    let fixture = write_fixture(&[
+        (
+            "main.crn",
+            "aws.s3.bucket {\n  name = \"b1\"\n  versioning = aws.s3.Bucket.VersioningStatus.Bogus\n}\n",
+        ),
+        ("providers.crn", "provider aws {}\n"),
+    ]);
+    let diags = analyze(&engine, &fixture, "main.crn");
+    let diag = first_enum_diagnostic(&diags);
+
+    let payload = EnumDiagnosticData::from_diagnostic(diag).expect("payload present");
+    assert_eq!(payload.kind, EnumDiagnosticKind::BareInvalid);
+    // Canonical entries first; aliases (`enabled`, `suspended` from the
+    // `to_dsl` lowercase mapping) follow.
+    let canonicals: Vec<_> = payload
+        .expected
+        .iter()
+        .filter(|e| !e.is_alias)
+        .map(|e| e.value.clone())
+        .collect();
+    assert_eq!(
+        canonicals,
+        vec!["Enabled".to_string(), "Suspended".to_string()]
+    );
+
+    let actions = code_actions_for_diagnostic(&dummy_uri(), diag);
+    let titles: Vec<_> = actions.iter().map(|a| a.title.clone()).collect();
+    assert_eq!(
+        titles,
+        vec![
+            "Replace with `aws.s3.Bucket.VersioningStatus.Enabled`".to_string(),
+            "Replace with `aws.s3.Bucket.VersioningStatus.Suspended`".to_string(),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: quoted string literal on a StringEnum (StringLiteral kind)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_literal_emits_string_literal_kind_and_replaces_quotes() {
+    let engine = engine_with_schemas(versioning_schema());
+    let fixture = write_fixture(&[
+        (
+            "main.crn",
+            "aws.s3.bucket {\n  name = \"b1\"\n  versioning = \"Bogus\"\n}\n",
+        ),
+        ("providers.crn", "provider aws {}\n"),
+    ]);
+    let diags = analyze(&engine, &fixture, "main.crn");
+    let diag = first_enum_diagnostic(&diags);
+    let payload = EnumDiagnosticData::from_diagnostic(diag).expect("payload present");
+    assert_eq!(payload.kind, EnumDiagnosticKind::StringLiteral);
+
+    // The diagnostic range must cover both quote characters so the
+    // applied edit drops them when writing the bare identifier.
+    let text = std::fs::read_to_string(fixture.path().join("main.crn")).expect("read fixture file");
+    let line = text.lines().nth(2).expect("third line");
+    let open = line.find('"').expect("opening quote") as u32;
+    let close = (line.rfind('"').expect("closing quote") + 1) as u32;
+    assert_eq!(diag.range.start.character, open);
+    assert_eq!(diag.range.end.character, close);
+
+    let actions = code_actions_for_diagnostic(&dummy_uri(), diag);
+    assert!(
+        !actions.is_empty(),
+        "code action should be offered for string-literal enum diagnostic"
+    );
+    // The first action's edit replaces `"Bogus"` (incl. quotes) with the
+    // bare identifier — applying it must produce a buffer that
+    // re-validates.
+    let edit = actions[0].edit.as_ref().unwrap();
+    let edits = edit.changes.as_ref().unwrap().get(&dummy_uri()).unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].range, diag.range);
+    assert_eq!(
+        edits[0].new_text, "aws.s3.Bucket.VersioningStatus.Enabled",
+        "first canonical candidate replaces the quoted literal"
+    );
+
+    // Sanity: applying that edit to the source line should yield a
+    // line that is now valid input syntactically — i.e. the literal
+    // form was replaced and there are no orphan quotes.
+    let mut applied = String::new();
+    applied.push_str(&line[..open as usize]);
+    applied.push_str(&edits[0].new_text);
+    applied.push_str(&line[close as usize..]);
+    assert!(
+        !applied.contains('"'),
+        "applied edit must drop both quotes, got: {applied}"
+    );
+    assert!(
+        applied.contains("aws.s3.Bucket.VersioningStatus.Enabled"),
+        "applied edit must contain the canonical identifier, got: {applied}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: non-namespaced StringEnum
+// ---------------------------------------------------------------------------
+
+fn bare_mode_schema() -> HashMap<String, ResourceSchema> {
+    let mode = AttributeType::StringEnum {
+        name: "Mode".to_string(),
+        values: vec!["fast".to_string(), "slow".to_string()],
+        namespace: None,
+        to_dsl: None,
+    };
+    let mut schemas = HashMap::new();
+    schemas.insert(
+        "test.r.mode_holder".to_string(),
+        ResourceSchema::new("test.r.mode_holder")
+            .attribute(AttributeSchema::new("name", AttributeType::String))
+            .attribute(AttributeSchema::new("mode", mode)),
+    );
+    schemas
+}
+
+#[test]
+fn non_namespaced_enum_quick_fix_uses_bare_value() {
+    let engine = engine_with_schemas(bare_mode_schema());
+    let fixture = write_fixture(&[
+        (
+            "main.crn",
+            "test.r.mode_holder {\n  name = \"a\"\n  mode = bogus\n}\n",
+        ),
+        ("providers.crn", "provider test {}\n"),
+    ]);
+    let diags = analyze(&engine, &fixture, "main.crn");
+    let diag = first_enum_diagnostic(&diags);
+    let actions = code_actions_for_diagnostic(&dummy_uri(), diag);
+    let titles: Vec<_> = actions.iter().map(|a| a.title.clone()).collect();
+    assert_eq!(
+        titles,
+        vec![
+            "Replace with `fast`".to_string(),
+            "Replace with `slow`".to_string()
+        ],
+        "non-namespaced enums replace with bare values, no provider prefix"
+    );
+}

--- a/carina-lsp/tests/support/fixture.rs
+++ b/carina-lsp/tests/support/fixture.rs
@@ -1,0 +1,61 @@
+//! Multi-file `.crn` fixture helpers shared by integration tests that
+//! exercise `DiagnosticEngine::analyze_with_filename` against the
+//! directory-shaped layout the project's invariant requires
+//! (`main.crn` + sibling files like `providers.crn`, `exports.crn`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use carina_core::schema::ResourceSchema;
+use carina_lsp::diagnostics::DiagnosticEngine;
+use carina_lsp::document::Document;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::Diagnostic;
+
+/// Lay a multi-file fixture under `tempfile::tempdir()` and return the
+/// owning `TempDir`. Caller keeps it alive for the duration of the test.
+#[allow(dead_code)]
+pub fn write_fixture(files: &[(&str, &str)]) -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (name, body) in files {
+        std::fs::write(dir.path().join(name), body).expect("write fixture file");
+    }
+    dir
+}
+
+/// Read one file inside the fixture and feed it through `analyze` with
+/// `base_path` set so the engine sees sibling files.
+#[allow(dead_code)]
+pub fn analyze(engine: &DiagnosticEngine, fixture: &TempDir, file_name: &str) -> Vec<Diagnostic> {
+    let path = fixture.path().join(file_name);
+    let text = std::fs::read_to_string(&path).expect("read fixture file");
+    let doc = Document::new(
+        text,
+        Arc::new(carina_core::parser::ProviderContext::default()),
+    );
+    engine.analyze_with_filename(&doc, Some(file_name), Some(fixture.path()))
+}
+
+/// Build a `DiagnosticEngine` from in-memory schemas. Provider names
+/// are derived from the `<provider>.<...>` keys so the engine can
+/// recognise the synthetic providers used in tests.
+#[allow(dead_code)]
+pub fn engine_with_schemas(schemas: HashMap<String, ResourceSchema>) -> DiagnosticEngine {
+    let provider_names: Vec<String> = schemas
+        .keys()
+        .filter_map(|k| k.split('.').next())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .map(String::from)
+        .collect();
+    DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(vec![]))
+}
+
+/// Wrap one `ResourceSchema` in a `HashMap` keyed by its
+/// `resource_type`. Convenience for single-resource scenarios.
+#[allow(dead_code)]
+pub fn single_schema_map(schema: ResourceSchema) -> HashMap<String, ResourceSchema> {
+    let mut schemas = HashMap::new();
+    schemas.insert(schema.resource_type.clone(), schema);
+    schemas
+}

--- a/carina-lsp/tests/support/mod.rs
+++ b/carina-lsp/tests/support/mod.rs
@@ -4,6 +4,7 @@
 //! `mod support;` — the standard Cargo convention for cross-test code.
 
 pub mod byte_helpers;
+pub mod fixture;
 pub mod test_client;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

Wire the structured `Vec<ExpectedEnumVariant>` from #2220 into a `textDocument/codeAction` quick-fix.

Enum-mismatch diagnostics (`InvalidEnumVariant` / `StringLiteralExpectedEnum`) now carry a serialized `EnumDiagnosticData` payload on `Diagnostic.data` and a range that covers the offending value text. The new handler reads the payload back and returns one `CodeAction` per non-alias candidate; alias entries (from `to_dsl`, e.g. `enabled` for `Enabled`) are skipped unless no canonical entry exists.

- **`BareInvalid`** kind: replace the bare identifier (e.g. `aws.s3.Bucket.VersioningStatus.Bogus` → `aws.s3.Bucket.VersioningStatus.Enabled`).
- **`StringLiteral`** kind: range covers both quote characters so applying the action drops them and writes the bare identifier.

Custom-namespaced reshape paths emit no payload (the validator does not enumerate variants), so those diagnostics still surface but offer no quick-fix — within scope of #2309.

## Changes

- `ExpectedEnumVariant` gains `Serialize` / `Deserialize` so the LSP can ferry it through `Diagnostic.data` JSON.
- New `carina-lsp/src/code_action.rs` with `EnumDiagnosticData`, `EnumDiagnosticKind`, `EnumDiagnosticTag` (structural marker so foreign payloads can't masquerade as enum data), and `code_actions_for_diagnostic`.
- New `find_attribute_value_range` helper returns LSP UTF-16 character offsets and tolerates both space and tab separators between attribute, `=`, and value.
- New `build_string_enum_diagnostic` free fn constructs the structured-payload diagnostic; the existing match below catches non-enum-shape errors (`TypeMismatch`, `ValidationFailed`) so non-enum-shape validation against a `StringEnum` (e.g. `mode = 42`) still produces a diagnostic — pinned by a regression test.
- `code_action_provider: Some(CodeActionProviderCapability::Options { code_action_kinds: Some(vec![QUICKFIX]), .. })` in `initialize`.
- `tests/support/fixture.rs` factors out the directory-fixture helpers that were duplicated between `e2e_typecheck.rs` and the new integration test.

## Out of scope (per the issue)

- Code actions for non-enum diagnostics (`UnknownAttribute`, `MissingRequired`, etc.) — separate follow-ups.
- Editor-side wiring beyond what is exercised by the in-process integration tests.

## Test plan

- [x] `cargo nextest run --workspace` (2439 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] New unit tests in `carina-lsp::code_action::tests` (8 tests covering payload round-trip, alias filtering, kind dispatch, foreign-payload rejection, `is_preferred` flag).
- [x] New `find_attribute_value_range` tests (5 tests covering dotted identifiers, quoted literals, block-syntax rejection, multi-byte UTF-16 offsets, tab separators).
- [x] New `lsp_enum_code_action.rs` integration tests with multi-file directory fixtures (`main.crn` + `providers.crn`) for namespaced bare invalid, string-literal, and non-namespaced bare invalid.
- [x] Regression test for non-enum-shape `StringEnum` errors (`mode = 42`).
- [x] `expected_enum_variant_serde_round_trip` locks the JSON wire format.

Closes #2309
Refs #2220