### PR TITLE
feat(lsp): depth-2 dot completion for upstream_state struct exports

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -56,6 +56,15 @@ impl CompletionProvider {
     ) -> Vec<CompletionItem> {
         let text = doc.text();
 
+        // `<binding>.<key>.<partial>` (depth-2) is checked first because
+        // its prefix shape also matches the depth-1 walker's tail (which
+        // would treat `<key>` as the binding and decline). #2041.
+        if let Some(m) = detect_upstream_state_depth2_dot(&text, position, base_path) {
+            return self.upstream_state_depth2_dot_completions(
+                &m.binding, &m.key, &m.partial, &m.source, position, base_path,
+            );
+        }
+
         // `<binding>.<partial>` where `<binding>` is an `upstream_state` is
         // matched ahead of the block-context walk: the same prefix would
         // otherwise be interpreted as `AfterEquals` (dot-after-binding inside
@@ -830,33 +839,118 @@ fn detect_upstream_state_dot(
     let current_line = text.lines().nth(line_idx)?;
     let col = position.character as usize;
     let prefix: String = current_line.chars().take(col).collect();
-    let dot_rel = prefix.rfind('.')?;
-    let before_dot = &prefix[..dot_rel];
-    let after_dot = &prefix[dot_rel + 1..];
-    if !after_dot
+    let segs = parse_trailing_dotted_segments(&prefix, 2)?;
+    let [binding, partial] = segs.as_slice() else {
+        unreachable!("parse_trailing_dotted_segments returns exactly the requested count");
+    };
+    let source = resolve_upstream_state_source(text, base_path, binding)?;
+    Some((binding.to_string(), partial.to_string(), source))
+}
+
+/// Match on `<binding>.<key>.<partial>` (depth-2), where `<binding>` is
+/// an `upstream_state` and `<key>` is one of its declared exports. The
+/// caller uses the export's `TypeExpr` to descend (struct fields,
+/// future map-key recursion, etc.). See #2041.
+///
+/// Returns `None` when the prefix isn't depth-2 shape or when
+/// `<binding>` isn't a known upstream-state — in which case the
+/// dispatcher falls through to the depth-1 detector or further down.
+fn detect_upstream_state_depth2_dot(
+    text: &str,
+    position: Position,
+    base_path: Option<&std::path::Path>,
+) -> Option<UpstreamDepth2Match> {
+    let line_idx = position.line as usize;
+    let current_line = text.lines().nth(line_idx)?;
+    let col = position.character as usize;
+    let prefix: String = current_line.chars().take(col).collect();
+    let segs = parse_trailing_dotted_segments(&prefix, 3)?;
+    let [binding, key, partial] = segs.as_slice() else {
+        unreachable!("parse_trailing_dotted_segments returns exactly the requested count");
+    };
+    let source = resolve_upstream_state_source(text, base_path, binding)?;
+    Some(UpstreamDepth2Match {
+        binding: binding.to_string(),
+        key: key.to_string(),
+        partial: partial.to_string(),
+        source,
+    })
+}
+
+/// Result of [`detect_upstream_state_depth2_dot`]. Named fields keep
+/// the four positional `String`s from being reordered at call sites.
+struct UpstreamDepth2Match {
+    binding: String,
+    key: String,
+    partial: String,
+    source: String,
+}
+
+/// Walk back from the end of `prefix` collecting the trailing run of
+/// `<id>(.<id>)*<.partial>` (where `partial` may be empty after a
+/// trailing `.`). Returns exactly `n` segments — earliest first — or
+/// `None` if the run is too short, contains non-identifier characters,
+/// or any non-trailing segment is empty / starts with a digit. The
+/// trailing segment (`partial`) is allowed to be empty so completion
+/// fires the moment the user types the dot.
+fn parse_trailing_dotted_segments(prefix: &str, n: usize) -> Option<Vec<&str>> {
+    debug_assert!(n >= 2, "trailing-dot parse needs at least one dot");
+    // Walk back across `n - 1` dots, validating identifier chars between
+    // them. The trailing segment is allowed to be empty.
+    let last_dot = prefix.rfind('.')?;
+    let trailing = &prefix[last_dot + 1..];
+    if !trailing
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_')
     {
         return None;
     }
-    let binding_start = before_dot
+    let mut segments_rev: Vec<&str> = vec![trailing];
+    let mut cursor = &prefix[..last_dot];
+    while segments_rev.len() < n - 1 {
+        let dot = cursor.rfind('.')?;
+        let seg = &cursor[dot + 1..];
+        if !is_identifier(seg) {
+            return None;
+        }
+        segments_rev.push(seg);
+        cursor = &cursor[..dot];
+    }
+    // The first segment is whatever non-identifier-bounded run sits at
+    // the tail of `cursor` — the binding name. Its leading char must
+    // start an identifier; any non-identifier before it is fine.
+    let first_start = cursor
         .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
         .map(|i| i + 1)
         .unwrap_or(0);
-    let binding = &before_dot[binding_start..];
-    if binding.is_empty()
-        || !binding
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-    {
+    let first = &cursor[first_start..];
+    if !is_identifier(first) {
         return None;
     }
+    segments_rev.push(first);
+    segments_rev.reverse();
+    Some(segments_rev)
+}
+
+fn is_identifier(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Look up the `source = '...'` path for `binding` declared in any
+/// sibling `.crn` file under `base_path`. Returns `None` when the
+/// binding isn't declared as an `upstream_state` anywhere visible.
+fn resolve_upstream_state_source(
+    text: &str,
+    base_path: Option<&std::path::Path>,
+    binding: &str,
+) -> Option<String> {
     let mut src_buf = String::new();
     let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
-    let bindings = collect_upstream_state_bindings(src);
-    let source = bindings.get(binding)?.clone();
-    Some((binding.to_string(), after_dot.to_string(), source))
+    collect_upstream_state_bindings(src).get(binding).cloned()
 }
 
 /// Return every `let <name> = upstream_state { source = '...' }` declared

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -1908,6 +1908,162 @@ fn upstream_state_dot_completion_detail_shows_type_expr() {
 }
 
 // =====================================================================
+// upstream_state depth-2 completion: dot after the export key (#2041)
+// =====================================================================
+// `orgs.config.<HERE>` — the export's declared `TypeExpr::Struct` lets
+// us recurse into its named fields. `TypeExpr::Map(_)` / `List(_)` /
+// scalars have no named children at this depth and produce no
+// completions (deferred per #2041 umbrella discussion).
+
+#[test]
+fn upstream_state_depth2_dot_completion_lists_struct_fields() {
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  config: struct { name: String, region: String } = { name = \"x\", region = \"ap-northeast-1\" }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.config.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.config.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"name") && labels.contains(&"region"),
+        "expected struct fields `name` and `region` in completions, got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_detail_shows_field_type() {
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  config: struct { region: String, replicas: Int } = { region = \"x\", replicas = 1 }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.config.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.config.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let region = completions
+        .iter()
+        .find(|c| c.label == "region")
+        .expect("expected `region` field");
+    let detail = region.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("String"),
+        "field detail must surface the field's TypeExpr, got: {:?}",
+        detail
+    );
+    let replicas = completions
+        .iter()
+        .find(|c| c.label == "replicas")
+        .expect("expected `replicas` field");
+    let detail = replicas.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("Int"),
+        "Int field detail must surface as `Int`, got: {:?}",
+        detail
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_text_edit_replaces_partial() {
+    // `orgs.config.na<cursor>` — the TextEdit must replace just the
+    // `na` partial so accepting `name` lands as `orgs.config.name`,
+    // not `orgs.config.naname`.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  config: struct { name: String } = { name = \"x\" }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.config.na\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.config.na".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let name = completions
+        .iter()
+        .find(|c| c.label == "name")
+        .expect("expected `name` completion");
+    match name.text_edit.as_ref() {
+        Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(edit)) => {
+            assert_eq!(edit.new_text, "name");
+            // `let x = orgs.config.` occupies cols 0..20; `na` at col 20.
+            let line_one = "let x = orgs.config.";
+            let prefix_len = line_one.chars().count() as u32;
+            assert_eq!(edit.range.start.line, 1);
+            assert_eq!(edit.range.start.character, prefix_len);
+            assert_eq!(edit.range.end.character, prefix_len + 2);
+        }
+        other => panic!("expected TextEdit::Edit, got {:?}", other),
+    }
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_skips_map_typed_export() {
+    // `accounts: map(string)` — depth-2 completion has no named keys to
+    // suggest (the map's runtime keys aren't part of the type). Falling
+    // through to no-op is the documented behavior, deferred per #2041.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.accounts.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.accounts.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    assert!(
+        completions.is_empty(),
+        "depth-2 completion on a map(_) export must yield nothing, got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_unknown_key_returns_empty() {
+    // `orgs.unknown.<HERE>` where `unknown` is not declared in
+    // `exports { }`. The depth-2 detector should decline (no key →
+    // no type to descend into) and fall through to nothing useful;
+    // we assert no spurious top-level keywords leak out.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  config: struct { name: String } = { name = \"x\" }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.unknown.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.unknown.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"name"),
+        "unknown key must not bleed in fields from an unrelated export, got: {:?}",
+        labels
+    );
+}
+
+// =====================================================================
 // exports block: type-aware value-position completion (#1993)
 // =====================================================================
 

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -614,19 +614,7 @@ impl CompletionProvider {
         position: Position,
         base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
-        let Some(base) = base_path else {
-            return Vec::new();
-        };
-        let upstream = carina_core::parser::UpstreamState {
-            binding: binding.to_string(),
-            source: std::path::PathBuf::from(source),
-        };
-        let (exports, _errors) = carina_core::upstream_exports::resolve_upstream_exports(
-            base,
-            &[upstream],
-            &Default::default(),
-        );
-        let Some(keys) = exports.get(binding) else {
+        let Some(keys) = resolve_upstream_export_keys(binding, source, base_path) else {
             return Vec::new();
         };
 
@@ -659,6 +647,64 @@ impl CompletionProvider {
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range,
                     new_text: key.clone(),
+                })),
+                ..Default::default()
+            })
+            .collect();
+        items.sort_by(|a, b| a.label.cmp(&b.label));
+        items
+    }
+
+    /// Completions for `<binding>.<key>.<partial>` — depth-2 descent
+    /// into an `upstream_state` export's declared `TypeExpr`.
+    ///
+    /// When the export's type is `TypeExpr::Struct`, every field name
+    /// is offered with the field type rendered into `detail`. Other
+    /// type variants (`Map`, `List`, scalars, `Simple`, `Ref`,
+    /// `SchemaType`) have no named child positions at this depth and
+    /// produce an empty list. Map-key recursion via the runtime
+    /// `Value` is intentionally deferred per #2041.
+    pub(super) fn upstream_state_depth2_dot_completions(
+        &self,
+        binding: &str,
+        key: &str,
+        partial: &str,
+        source: &str,
+        position: Position,
+        base_path: Option<&Path>,
+    ) -> Vec<CompletionItem> {
+        let Some(keys) = resolve_upstream_export_keys(binding, source, base_path) else {
+            return Vec::new();
+        };
+        let Some(Some(type_expr)) = keys.get(key) else {
+            // Untyped or unknown key: we have no fields to descend into.
+            return Vec::new();
+        };
+        let carina_core::parser::TypeExpr::Struct { fields } = type_expr else {
+            // Map / List / scalars: depth-2 names are runtime values, not
+            // part of the type. Suggest nothing rather than something
+            // potentially invalid (#2041).
+            return Vec::new();
+        };
+
+        let partial_chars = partial.chars().count() as u32;
+        let range = Range {
+            start: Position {
+                line: position.line,
+                character: position.character.saturating_sub(partial_chars),
+            },
+            end: position,
+        };
+
+        let mut items: Vec<CompletionItem> = fields
+            .iter()
+            .map(|(name, field_type)| CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::FIELD),
+                detail: Some(format!("{}: {}", name, field_type)),
+                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: name.clone(),
                 })),
                 ..Default::default()
             })
@@ -1145,6 +1191,29 @@ impl CompletionProvider {
                 .collect(),
         }
     }
+}
+
+/// Resolve the export name → `TypeExpr` map for an `upstream_state`
+/// binding. Returns `None` when `base_path` is missing or the upstream
+/// directory has no export entry for `binding`. Both depth-1 and
+/// depth-2 dot completion build on this — they only differ in how
+/// they consume the resulting map.
+fn resolve_upstream_export_keys(
+    binding: &str,
+    source: &str,
+    base_path: Option<&Path>,
+) -> Option<std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>> {
+    let base = base_path?;
+    let upstream = carina_core::parser::UpstreamState {
+        binding: binding.to_string(),
+        source: std::path::PathBuf::from(source),
+    };
+    let (mut exports, _errors) = carina_core::upstream_exports::resolve_upstream_exports(
+        base,
+        &[upstream],
+        &Default::default(),
+    );
+    exports.remove(binding)
 }
 
 /// Infer the static type of a for-loop binding by resolving its iterable


### PR DESCRIPTION
## Summary

Close the last open slice of the **#2041 umbrella**. When the user types `<binding>.<key>.<HERE>` in a downstream project and `<key>` is an `upstream_state` export declared with a `TypeExpr::Struct`, the LSP now lists the struct's fields with each field's type rendered into `detail`.

```crn
let orgs = upstream_state { source = '../organizations' }
let x = orgs.config.<HERE>   # ← name, region (with `region: String` etc. in popup)
```

`Map(_)` / `List(_)` / scalar / `Ref` / `SchemaType` exports produce no completions at depth 2 — they have no named children at the type level. Map-key recursion via the runtime `Value` is intentionally deferred per the umbrella discussion (would create two overlapping paths once a fixed-record struct shape exists, which #2140 added).

## Changes

- **New `detect_upstream_state_depth2_dot`** parses `<binding>.<key>.<partial>` and returns a named `UpstreamDepth2Match` struct. Dispatcher routes depth-2 ahead of depth-1 (depth-2 prefix shape would otherwise be misinterpreted by depth-1 as binding=`<key>`).
- **New `upstream_state_depth2_dot_completions`** resolves the export's `TypeExpr` and emits one `CompletionItem` per `Struct { fields }` field.
- **Refactor (no behavior change for depth-1)**: shared `parse_trailing_dotted_segments(prefix, n)` walks back N identifier-and-dot segments; `is_identifier`, `resolve_upstream_state_source`, and `resolve_upstream_export_keys` capture the validation, binding lookup, and `resolve_upstream_exports` setup respectively.

## Out of scope (potential follow-ups)

- **UTF-16 column encoding**: 4 completion handlers (depth-1 / depth-2 / for-iterable / etc.) compute `Position.character` via `chars().count()` (codepoints), but the LSP default is UTF-16 code units. Multi-byte characters in identifiers cause column drift. Pre-existing across all four sites — worth a single follow-up issue.
- **Hover for upstream-state fields**: `HoverProvider` doesn't surface field types. Natural follow-up.

## Umbrella status

| Sub-task | Status |
| --- | --- |
| #1996 depth-1 completion | closed |
| #2128 depth-1 detail with TypeExpr | closed |
| #2129 for-loop binding dot completion | closed |
| #2140 `TypeExpr::Struct` added | closed |
| #1992 upstream_state static type-check | closed |
| **depth-2 descent (this PR)** | **shipping** |

After merge, **#2041 can close**.

## Test plan

- [x] `cargo nextest run -p carina-lsp` (379 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] 5 new integration tests in `carina-lsp/src/completion/tests/extended.rs`, all multi-file directory fixtures (per "directory-scoped, never single-file" rule):
  - `upstream_state_depth2_dot_completion_lists_struct_fields` — `name`/`region` appear
  - `upstream_state_depth2_dot_completion_detail_shows_field_type` — `String`/`Int` rendered in `detail`
  - `upstream_state_depth2_dot_completion_text_edit_replaces_partial` — partial replacement
  - `upstream_state_depth2_dot_completion_skips_map_typed_export` — `map(_)` returns empty
  - `upstream_state_depth2_dot_completion_unknown_key_returns_empty` — guard against export-name leakage

Closes #2041
Refs #2128 #2129 #2140