### PR TITLE
feat(core,state): canonical map-key resource address — drop quote asymmetry

### DIFF
--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -514,7 +514,7 @@ impl ParsedFile {
                     keys.sort();
                     for key in keys {
                         let val = &map[key];
-                        let address = format!("{}[\"{}\"]", deferred.binding_name, key);
+                        let address = crate::utils::map_key_address(&deferred.binding_name, key);
                         let mut resource = deferred.template_resource.clone();
                         resource.id.set_name(address.clone());
                         resource.binding = Some(address);

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -206,7 +206,7 @@ pub(crate) fn parse_for_expr(
             keys.sort();
             for key in keys {
                 let val = &map[key];
-                let address = format!("{}[\"{}\"]", binding_name, key);
+                let address = crate::utils::map_key_address(binding_name, key);
                 let mut iter_ctx = ctx.clone();
                 bind(&mut iter_ctx, key_var, Value::String(key.clone()));
                 bind(&mut iter_ctx, val_var, val.clone());

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -254,7 +254,7 @@ pub(crate) fn parse_primary_eval(
                                     binding_name = format!("{}[{}]", binding_name, n);
                                 }
                                 Value::String(s) => {
-                                    binding_name = format!("{}[\"{}\"]", binding_name, s);
+                                    binding_name = crate::utils::map_key_address(&binding_name, s);
                                 }
                                 other => {
                                     return Err(ParseError::InvalidExpression {

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2931,14 +2931,15 @@ fn parse_for_expression_over_map() {
     let result = parse(input, &ProviderContext::default()).unwrap();
     assert_eq!(result.resources.len(), 2);
 
-    // Map iteration produces map-keyed addresses
+    // Map iteration produces map-keyed addresses in canonical dot
+    // form (#1903) — both keys here are identifier-safe.
     let names: Vec<&str> = result
         .resources
         .iter()
         .map(|r| r.id.name.as_str())
         .collect();
-    assert!(names.contains(&r#"networks["prod"]"#));
-    assert!(names.contains(&r#"networks["staging"]"#));
+    assert!(names.contains(&"networks.prod"));
+    assert!(names.contains(&"networks.staging"));
 }
 
 #[test]
@@ -2985,14 +2986,15 @@ fn parse_for_expression_with_module_call() {
     // for expression with module call should produce module calls, not resources
     assert_eq!(result.module_calls.len(), 2);
 
-    // Module calls should have binding names like webs["prod"] and webs["staging"]
+    // Module calls have canonical dot-form binding names (#1903) —
+    // both keys here are identifier-safe.
     let binding_names: Vec<&str> = result
         .module_calls
         .iter()
         .map(|c| c.binding_name.as_deref().unwrap())
         .collect();
-    assert!(binding_names.contains(&r#"webs["prod"]"#));
-    assert!(binding_names.contains(&r#"webs["staging"]"#));
+    assert!(binding_names.contains(&"webs.prod"));
+    assert!(binding_names.contains(&"webs.staging"));
 
     // Each module call should have the loop variable substituted in arguments
     for call in &result.module_calls {
@@ -3004,7 +3006,7 @@ fn parse_for_expression_with_module_call() {
     let prod_call = result
         .module_calls
         .iter()
-        .find(|c| c.binding_name.as_deref() == Some(r#"webs["prod"]"#))
+        .find(|c| c.binding_name.as_deref() == Some("webs.prod"))
         .unwrap();
     assert_eq!(
         prod_call.arguments.get("vpc_cidr"),
@@ -3014,7 +3016,7 @@ fn parse_for_expression_with_module_call() {
     let staging_call = result
         .module_calls
         .iter()
-        .find(|c| c.binding_name.as_deref() == Some(r#"webs["staging"]"#))
+        .find(|c| c.binding_name.as_deref() == Some("webs.staging"))
         .unwrap();
     assert_eq!(
         staging_call.arguments.get("vpc_cidr"),
@@ -3151,7 +3153,10 @@ fn parse_index_access_with_integer() {
 
 #[test]
 fn parse_index_access_with_string_key() {
-    // networks["prod"].vpc_id should parse as ResourceRef with binding_name=r#networks["prod"]#
+    // `networks["prod"].vpc_id` parses as a ResourceRef whose binding
+    // name is the canonical dot form `networks.prod` (#1903) — the
+    // index-access syntax with an identifier-safe string key
+    // collapses to the same address that `for`-iteration emits.
     let input = r#"
         let cidrs = {
             prod    = "10.0.0.0/16"
@@ -3178,7 +3183,7 @@ fn parse_index_access_with_string_key() {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
-            assert_eq!(binding_name, r#"networks["prod"]"#);
+            assert_eq!(binding_name, "networks.prod");
             assert_eq!(attribute_name, "vpc_id");
             assert!(field_path.is_empty());
         }
@@ -3215,7 +3220,7 @@ fn parse_index_access_with_chained_fields() {
             let binding_name = path.binding();
             let attribute_name = path.attribute();
             let field_path = path.field_path();
-            assert_eq!(binding_name, r#"webs["prod"]"#);
+            assert_eq!(binding_name, "webs.prod");
             assert_eq!(attribute_name, "security_group");
             assert_eq!(field_path, vec!["id"]);
         }
@@ -3287,6 +3292,102 @@ fn parse_moved_block() {
         }
         other => panic!("Expected Moved, got {:?}", other),
     }
+}
+
+#[test]
+fn moved_block_accepts_three_map_key_address_forms() {
+    // #1903: a `moved` block addresses a map-keyed resource. All three
+    // input shapes — bare dot, single-quoted bracket, double-quoted
+    // bracket — must collapse to the canonical form so existing state
+    // (which may have been written under any historical shape) still
+    // resolves.
+    // The DSL has two string-literal forms. We pair each input shape
+    // with the outer quoting that lets the inner shape sit unescaped:
+    // - dot form: any outer
+    // - `['key']`: outer `"`-delimited
+    // - `["key"]`: outer `'`-delimited
+    let cases = [
+        (
+            "dot",
+            r#"to = awscc.sso.Assignment "_accounts.registry_prod""#,
+        ),
+        (
+            "single-quote bracket",
+            r#"to = awscc.sso.Assignment "_accounts['registry_prod']""#,
+        ),
+        (
+            "double-quote bracket",
+            r#"to = awscc.sso.Assignment '_accounts["registry_prod"]'"#,
+        ),
+    ];
+    for (label, to_clause) in cases {
+        let input = format!(
+            r#"
+                moved {{
+                    from = awscc.sso.Assignment "_accounts[0]"
+                    {}
+                }}
+            "#,
+            to_clause
+        );
+        let result = parse(&input, &ProviderContext::default())
+            .unwrap_or_else(|e| panic!("parse failed for {label}: {e:?}"));
+        assert_eq!(result.state_blocks.len(), 1);
+        match &result.state_blocks[0] {
+            StateBlock::Moved { to, .. } => {
+                assert_eq!(
+                    to.name_str(),
+                    "_accounts.registry_prod",
+                    "input shape {label} must canonicalize to dot form",
+                );
+            }
+            other => panic!("Expected Moved, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn moved_block_keeps_non_identifier_safe_key_in_quoted_form() {
+    // Keys with hyphens, spaces, or leading digits are not
+    // identifier-safe — the canonical form keeps them in single-quoted
+    // brackets. Both legacy `["..."]` and `['...']` collapse to
+    // single-quoted.
+    let input = r#"
+        moved {
+            from = awscc.sso.Assignment "_accounts[0]"
+            to   = awscc.sso.Assignment '_envs["prod-east"]'
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    match &result.state_blocks[0] {
+        StateBlock::Moved { to, .. } => {
+            assert_eq!(to.name_str(), "_envs['prod-east']");
+        }
+        other => panic!("Expected Moved, got {:?}", other),
+    }
+}
+
+#[test]
+fn for_expression_over_map_uses_canonical_dot_form() {
+    // The emit side mirrors the canonicalizer: a map iteration where
+    // every key is identifier-safe must produce `binding.key` addresses
+    // — no embedded quotes — so `moved`/`removed` blocks targeting
+    // those resources can stay quote-free.
+    let input = r#"
+        let envs = {
+            prod = "p"
+            dev  = "d"
+        }
+
+        let resources = for key, val in envs {
+            awscc.ec2.Subnet {
+                name = key
+            }
+        }
+    "#;
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let names: Vec<&str> = result.resources.iter().map(|r| r.id.name_str()).collect();
+    assert_eq!(names, vec!["resources.dev", "resources.prod"]);
 }
 
 #[test]

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -92,7 +92,11 @@ pub(crate) fn parse_resource_address(
         .to_string();
     let name_pair = next_pair(&mut inner, "resource name", "resource address")?;
     // The name is a string literal - extract value from quotes
-    let name = parse_string_literal(name_pair)?;
+    let raw_name = parse_string_literal(name_pair)?;
+    // Normalize map-key trailing segment so all three input shapes
+    // (`binding.key`, `binding['key']`, `binding["key"]`) collapse
+    // to the canonical form before state lookup. See #1903.
+    let name = crate::utils::canonicalize_map_key_address(&raw_name);
 
     // Split namespaced id into provider and resource_type
     let (provider, resource_type) = split_namespaced_id(&namespaced);

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -533,6 +533,88 @@ pub fn convert_region_value(value: &str) -> String {
     value.to_string()
 }
 
+/// Build the canonical address for a map-iteration key — used at every
+/// `for ... in <map>` emit site. Identifier-safe keys produce
+/// `binding.key`; everything else is single-quoted so the outer
+/// `moved` / `removed` string can stay double-quoted without escape
+/// juggling. See #1903.
+pub fn map_key_address(binding: &str, key: &str) -> String {
+    if is_identifier_safe(key) {
+        format!("{}.{}", binding, key)
+    } else {
+        format!("{}['{}']", binding, key)
+    }
+}
+
+/// Canonicalize the trailing map-key segment of a resource address so
+/// `for`-expression iteration over a map and the user-written address
+/// in `moved` / `removed` blocks share one shape. See #1903.
+///
+/// Rules:
+/// - `binding["key"]` / `binding['key']` with an identifier-safe key
+///   (`[A-Za-z_][A-Za-z0-9_]*`) → `binding.key`.
+/// - `binding["key with space"]` (or any non-identifier-safe key) →
+///   `binding['key with space']` (single quotes preferred to match the
+///   DSL string convention).
+/// - `binding[N]` for an integer `N` → unchanged (list index).
+/// - Inputs without a trailing `[...]` segment → returned unchanged.
+///
+/// Only the *last* `[...]` segment is canonicalized — the parser
+/// itself only emits a single trailing key per `for`-iteration, so a
+/// single-pass rewrite is sufficient.
+pub fn canonicalize_map_key_address(name: &str) -> String {
+    // Find the final `[`. Nothing to do when the trailing segment isn't
+    // a bracket form.
+    let Some(open) = name.rfind('[') else {
+        return name.to_string();
+    };
+    if !name.ends_with(']') {
+        return name.to_string();
+    }
+    let prefix = &name[..open];
+    let inside = &name[open + 1..name.len() - 1];
+
+    // Numeric index — list iteration. Leave alone.
+    if !inside.is_empty() && inside.bytes().all(|b| b.is_ascii_digit()) {
+        return name.to_string();
+    }
+
+    // Strip surrounding quotes when present so legacy `["key"]` and
+    // `['key']` collapse to the same canonical form. The `len < 2`
+    // guard keeps `&inside[1..inside.len() - 1]` from panicking when
+    // `inside` is a single quote char (e.g. a malformed `binding["]`)
+    // — `'"'` satisfies both starts_with and ends_with checks.
+    let key = if (inside.starts_with('"') && inside.ends_with('"'))
+        || (inside.starts_with('\'') && inside.ends_with('\''))
+    {
+        if inside.len() < 2 {
+            return name.to_string();
+        }
+        &inside[1..inside.len() - 1]
+    } else {
+        inside
+    };
+
+    if is_identifier_safe(key) {
+        format!("{}.{}", prefix, key)
+    } else {
+        format!("{}['{}']", prefix, key)
+    }
+}
+
+/// True when `s` is a valid Carina identifier: starts with `[A-Za-z_]`
+/// and continues with `[A-Za-z0-9_]*`. The same rule the parser uses
+/// for `let` bindings, struct field names, and (after #1903) map keys
+/// that can be embedded in a resource address without quoting.
+pub fn is_identifier_safe(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1139,5 +1221,69 @@ mod tests {
             let actual = expand_enum_shorthand(input, name, *ns);
             assert_eq!(actual, *expected, "input={input:?} name={name:?} ns={ns:?}",);
         }
+    }
+
+    #[test]
+    fn canonicalize_drops_quotes_for_identifier_safe_key() {
+        // The legacy emit form `["key"]` and the alt form `['key']`
+        // both collapse to `binding.key` — see #1903.
+        assert_eq!(
+            canonicalize_map_key_address("_accounts[\"registry_prod\"]"),
+            "_accounts.registry_prod"
+        );
+        assert_eq!(
+            canonicalize_map_key_address("_accounts['registry_prod']"),
+            "_accounts.registry_prod"
+        );
+    }
+
+    #[test]
+    fn canonicalize_keeps_already_canonical_dot_form() {
+        assert_eq!(
+            canonicalize_map_key_address("_accounts.registry_prod"),
+            "_accounts.registry_prod"
+        );
+    }
+
+    #[test]
+    fn canonicalize_uses_single_quotes_for_non_identifier_safe_key() {
+        // Hyphen, space, leading digit, and dot are all non-safe — the
+        // canonical form keeps them in single-quoted brackets so the
+        // outer `moved`/`removed` string can stay double-quoted without
+        // escape juggling.
+        assert_eq!(
+            canonicalize_map_key_address("_envs[\"prod-east\"]"),
+            "_envs['prod-east']"
+        );
+        assert_eq!(
+            canonicalize_map_key_address("_envs[\"key with space\"]"),
+            "_envs['key with space']"
+        );
+        assert_eq!(
+            canonicalize_map_key_address("_envs[\"3rd-region\"]"),
+            "_envs['3rd-region']"
+        );
+        assert_eq!(
+            canonicalize_map_key_address("_envs[\"a.b\"]"),
+            "_envs['a.b']"
+        );
+    }
+
+    #[test]
+    fn canonicalize_leaves_numeric_list_index_unchanged() {
+        assert_eq!(canonicalize_map_key_address("_accounts[0]"), "_accounts[0]");
+        assert_eq!(
+            canonicalize_map_key_address("_accounts[42]"),
+            "_accounts[42]"
+        );
+    }
+
+    #[test]
+    fn canonicalize_returns_input_when_no_trailing_bracket() {
+        assert_eq!(canonicalize_map_key_address("my_bucket"), "my_bucket");
+        assert_eq!(
+            canonicalize_map_key_address("explicit-name-with-hyphens"),
+            "explicit-name-with-hyphens"
+        );
     }
 }

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -933,11 +933,7 @@ fn parse_trailing_dotted_segments(prefix: &str, n: usize) -> Option<Vec<&str>> {
 }
 
 fn is_identifier(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    carina_core::utils::is_identifier_safe(s)
 }
 
 /// Look up the `source = '...'` path for `binding` declared in any

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -270,6 +270,27 @@ impl StateFile {
             .collect()
     }
 
+    /// Rewrite every map-key address in the state to its canonical
+    /// shape (#1903). State files written by older Carina builds may
+    /// store `binding["key"]`; new emissions use `binding.key` (or
+    /// `binding['key']` for non-identifier-safe keys). Running this on
+    /// load lets old state resolve against new desired-state addresses
+    /// without a `moved` block.
+    pub fn canonicalize_addresses(&mut self) {
+        use carina_core::utils::canonicalize_map_key_address;
+        for r in &mut self.resources {
+            r.name = canonicalize_map_key_address(&r.name);
+            if let Some(b) = r.binding.as_ref() {
+                r.binding = Some(canonicalize_map_key_address(b));
+            }
+            r.dependency_bindings = r
+                .dependency_bindings
+                .iter()
+                .map(|d| canonicalize_map_key_address(d))
+                .collect();
+        }
+    }
+
     /// Remove a resource from the state
     pub fn remove_resource(
         &mut self,
@@ -313,14 +334,17 @@ pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
     let check: VersionCheck = serde_json::from_str(content)
         .map_err(|e| BackendError::InvalidState(format!("Failed to parse state version: {}", e)))?;
 
-    match check.version {
-        v if v == StateFile::CURRENT_VERSION => serde_json::from_str(content)
-            .map_err(|e| BackendError::InvalidState(format!("Failed to parse state file: {}", e))),
-        v if v > StateFile::CURRENT_VERSION => Err(BackendError::InvalidState(format!(
-            "State file version {} is newer than supported version {}. Please upgrade Carina.",
-            v,
-            StateFile::CURRENT_VERSION
-        ))),
+    let mut state: StateFile = match check.version {
+        v if v == StateFile::CURRENT_VERSION => serde_json::from_str(content).map_err(|e| {
+            BackendError::InvalidState(format!("Failed to parse state file: {}", e))
+        })?,
+        v if v > StateFile::CURRENT_VERSION => {
+            return Err(BackendError::InvalidState(format!(
+                "State file version {} is newer than supported version {}. Please upgrade Carina.",
+                v,
+                StateFile::CURRENT_VERSION
+            )));
+        }
         v => {
             // Older version — for now, try to deserialize with serde defaults.
             // In the future, add explicit migration functions here.
@@ -336,9 +360,14 @@ pub fn check_and_migrate(content: &str) -> Result<StateFile, BackendError> {
                 ))
             })?;
             state.version = StateFile::CURRENT_VERSION;
-            Ok(state)
+            state
         }
-    }
+    };
+    // Map-key addresses written under the legacy `["..."]` shape are
+    // rewritten to the canonical form on read so existing state files
+    // resolve cleanly against new emissions. See #1903.
+    state.canonicalize_addresses();
+    Ok(state)
 }
 
 /// Deserialize a state file from a byte slice, checking the version and

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -1025,3 +1025,40 @@ fn build_remote_bindings_ignores_resource_bindings() {
         "resource bindings should not be exposed"
     );
 }
+
+#[test]
+fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
+    // State files written by older Carina builds embed the map key in
+    // `binding["key"]` form. After #1903 the canonical address is the
+    // dot form for identifier-safe keys; non-identifier-safe keys move
+    // from double quotes to single. The `check_and_migrate` load path
+    // rewrites these so existing state resolves against new emissions
+    // without a `moved` block.
+    let json = format!(
+        r#"{{
+            "version": {ver},
+            "serial": 1,
+            "lineage": "abc",
+            "carina_version": "test",
+            "resources": [
+                {{
+                    "resource_type": "sso.Assignment",
+                    "name": "_accounts[\"registry_prod\"]",
+                    "provider": "awscc",
+                    "identifier": "x",
+                    "attributes": {{}},
+                    "binding": "_accounts[\"registry_prod\"]",
+                    "dependency_bindings": ["other[\"a\"]", "_envs[\"prod-east\"]"]
+                }}
+            ]
+        }}"#,
+        ver = StateFile::CURRENT_VERSION,
+    );
+    let state = check_and_migrate(&json).expect("load state");
+    let r = &state.resources[0];
+    assert_eq!(r.name, "_accounts.registry_prod");
+    assert_eq!(r.binding.as_deref(), Some("_accounts.registry_prod"));
+    let deps: Vec<&str> = r.dependency_bindings.iter().map(String::as_str).collect();
+    assert!(deps.contains(&"other.a"));
+    assert!(deps.contains(&"_envs['prod-east']"));
+}


### PR DESCRIPTION
## Summary

`for`-expression iteration over a map used to embed double quotes around the key (`_accounts["registry_prod"]`), forcing users to quote-juggle in `moved`/`removed` blocks while list iteration emits a clean `_accounts[0]`. After this PR:

- **Identifier-safe key** (`[A-Za-z_][A-Za-z0-9_]*`): canonical = `binding.key` (e.g. `_accounts.registry_prod`)
- **Otherwise**: canonical = `binding['key']` (single quotes; e.g. `_envs['prod-east']`) so the surrounding `moved` string stays double-quoted without escape juggling
- **List index**: `binding[N]` unchanged
- **Input** to `moved` / `removed` / `import` blocks: all three forms (`binding.key`, `binding['key']`, `binding["key"]`) collapse to canonical before state lookup
- **Migration**: state files written by older Carina builds are normalized on read — no `moved` block required

## Changes

- `carina-core/src/utils.rs`: new `pub fn map_key_address(binding, key)` (emit-side) and `pub fn canonicalize_map_key_address(name)` (input-side rewriter). `pub fn is_identifier_safe(s)` — the Carina identifier predicate, also used by carina-lsp.
- 3 emit sites switched to `map_key_address`: deferred for-expansion (`parser/ast.rs`), synchronous for-expansion (`parser/expressions/for_expr.rs`), index-access (`parser/expressions/primary.rs`).
- `parser/util.rs::parse_resource_address` runs `canonicalize_map_key_address` on the parsed string-literal name (catches all input forms in `moved`/`removed`/`import`).
- `carina-state/src/state/mod.rs`: new `StateFile::canonicalize_addresses(&mut self)` rewrites every `name` / `binding` / `dependency_bindings` entry. `check_and_migrate` calls it post-deserialize so legacy state resolves cleanly.
- `carina-lsp/src/completion/mod.rs::is_identifier`: now delegates to `carina_core::utils::is_identifier_safe` (was hand-rolled in #2041, now unified).

## Out of scope (potential follow-ups surfaced by review)

- **`carina state lookup` query parser** mis-segments canonical names like `_accounts.registry_prod` (first-dot split). Pre-existing for index-access dot forms; surfaced more visibly by this PR. Suggest longest-match against known resource names.
- **`parse_string_literal` doesn't unescape `\"`** in double-quoted string literals (only `parse_string_value` does). Discovered while writing tests. Pre-existing and unrelated. Worked around in this PR's tests by using single-quoted outer wrappers.

## Test plan

- [x] `cargo nextest run --workspace` (2453 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] 5 new unit tests for `canonicalize_map_key_address` (id-safe / non-id-safe / numeric / no bracket / dot already canonical)
- [x] 3 new parser tests:
  - `moved_block_accepts_three_map_key_address_forms` — all input shapes collapse to canonical
  - `moved_block_keeps_non_identifier_safe_key_in_quoted_form` — hyphen key stays bracketed
  - `for_expression_over_map_uses_canonical_dot_form` — emit side
- [x] 1 new state test: legacy `["..."]` collapses on `check_and_migrate` for `name` / `binding` / `dependency_bindings`
- [x] 4 existing tests updated (`parse_for_expression_over_map`, `parse_for_expression_with_module_call`, `parse_index_access_with_string_key`, `parse_index_access_with_chained_fields`) to assert the new dot form

Closes #1903