### PR TITLE
refactor(core): replace Union error-selection heuristic with member-match scoring

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -739,28 +739,37 @@ impl AttributeType {
 
     /// Validate a `Union` variant: succeed if any member accepts the value.
     ///
-    /// Prefer a `Struct` member's structured error over generic
-    /// `TypeMismatch` when the value is a `Map` — that gives actionable
-    /// feedback (e.g. "unknown field 'aaa'") instead of
-    /// "expected Struct | String, got Map".
+    /// On failure, return the structurally-closest member's error rather
+    /// than a generic `TypeMismatch`. "Closest" is measured by
+    /// [`union_member_score`]: members whose outer constructor matches
+    /// the input's (Map↔Struct, List↔List, String↔StringEnum, scalar↔
+    /// scalar) outscore unrelated members. The first member at the
+    /// maximum score wins — declaration order is preserved by the
+    /// strict `>` comparison below, so the prior Map↔Struct preference
+    /// still holds when multiple Struct members tie. When no member
+    /// shares any structural similarity, fall through to `TypeMismatch`.
+    /// See #2219.
     fn validate_union(&self, value: &Value) -> Result<(), TypeError> {
         let AttributeType::Union(types) = self else {
             unreachable!("validate_union called on non-Union");
         };
-        let mut struct_error = None;
+        let mut best: Option<(u32, TypeError)> = None;
         for member in types {
             match member.validate(value) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    if matches!(value, Value::Map(_))
-                        && matches!(member, AttributeType::Struct { .. })
+                    let score = union_member_score(member, value);
+                    if score > 0
+                        && best
+                            .as_ref()
+                            .is_none_or(|(prev_score, _)| score > *prev_score)
                     {
-                        struct_error = Some(e);
+                        best = Some((score, e));
                     }
                 }
             }
         }
-        Err(struct_error.unwrap_or(TypeError::TypeMismatch {
+        Err(best.map(|(_, e)| e).unwrap_or(TypeError::TypeMismatch {
             expected: self.type_name(),
             got: value.type_name(),
         }))
@@ -906,6 +915,63 @@ impl AttributeType {
             (_non_custom, Custom { .. }) => false,
             (a, b) => a.type_name() == b.type_name(),
         }
+    }
+}
+
+/// Rank a Union member against a runtime value by structural distance:
+/// how close the member's outer constructor is to the input's. Higher
+/// is closer; 0 means no shared structure. Used by `validate_union`
+/// to pick which member's error message to surface on failure (#2219).
+///
+/// Map↔Struct stays the highest (preserves the prior heuristic). The
+/// other constructor pairs — Map↔Map, List↔List, String↔String /
+/// StringEnum, scalar↔scalar — get the next tier. `Custom` defers to
+/// its declared `base`, so a Union of `Int | positive_int()`
+/// validating an `Int` input still surfaces the predicate's message.
+/// `Union` members recurse and take the best inner score so nested
+/// unions still produce a meaningful error.
+///
+/// On a tie, the first member at the maximum wins — `validate_union`
+/// uses strict `>` so declaration order is preserved.
+fn union_member_score(member: &AttributeType, value: &Value) -> u32 {
+    use AttributeType as AT;
+    match (member, value) {
+        // Map↔Struct: the original heuristic. Highest score so a
+        // Struct member's "Unknown field 'x'" wins over a sibling's
+        // generic `TypeMismatch`.
+        (AT::Struct { .. }, Value::Map(_)) => 100,
+        // Same-constructor match — second tier.
+        (AT::Map { .. }, Value::Map(_))
+        | (AT::String, Value::String(_))
+        | (AT::Int, Value::Int(_))
+        | (AT::Float, Value::Float(_))
+        | (AT::Bool, Value::Bool(_))
+        | (AT::StringEnum { .. }, Value::String(_)) => 80,
+        // List↔List: peek at the first element's structural match
+        // against the member's inner type so `List<Struct>` outranks
+        // `List<String>` for an input like `[{...}]`. The inner
+        // contribution is halved so arbitrarily deep nesting can't
+        // exceed the Map↔Struct tier (100). Empty lists fall back to
+        // the bare same-constructor score.
+        (AT::List { inner, .. }, Value::List(items)) => {
+            let inner_bonus = items
+                .first()
+                .map(|first| union_member_score(inner, first) / 2)
+                .unwrap_or(0);
+            80 + inner_bonus
+        }
+        // Custom defers to its `base`. A Custom with a Struct/Int/
+        // String base ranks the same as that base would — its
+        // validator's `ValidationFailed` message is then the one
+        // `validate_union` surfaces on failure.
+        (AT::Custom { base, .. }, v) => union_member_score(base, v),
+        // Nested Union: recurse and take the best inner match.
+        (AT::Union(inner), v) => inner
+            .iter()
+            .map(|m| union_member_score(m, v))
+            .max()
+            .unwrap_or(0),
+        _ => 0,
     }
 }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -2954,3 +2954,192 @@ fn expected_enum_variant_serde_round_trip() {
     let round: ExpectedEnumVariant = serde_json::from_value(json).expect("deserialize");
     assert_eq!(round, original);
 }
+
+// ---------------------------------------------------------------------------
+// #2219 — Union member-match scoring
+// ---------------------------------------------------------------------------
+// On a Union failure, surface the closest-matching member's error rather
+// than a generic TypeMismatch. "Closest" is measured by structural
+// distance: same outer constructor (Map↔Struct, List↔List, String↔
+// StringEnum/Custom) wins over an unrelated member. Tie-broken by
+// declaration order, so the existing Map/Struct case continues to pick
+// the Struct member's error first.
+
+#[test]
+fn union_string_vs_string_enum_picks_enum_error_for_string_input() {
+    // Acceptance #2 from #2219: `Int | StringEnum` with a string input
+    // that doesn't match any enum variant must surface the
+    // `InvalidEnumVariant` error (so the user sees `expected one of:
+    // fast, slow`), not a generic `TypeMismatch`.
+    let union_type = AttributeType::Union(vec![
+        AttributeType::Int,
+        AttributeType::StringEnum {
+            name: "Mode".to_string(),
+            values: vec!["fast".to_string(), "slow".to_string()],
+            namespace: None,
+            to_dsl: None,
+        },
+    ]);
+    let err = union_type
+        .validate(&Value::String("zzz".to_string()))
+        .unwrap_err();
+    match err {
+        TypeError::InvalidEnumVariant { ref expected, .. } => {
+            let rendered: Vec<String> = expected.iter().map(ToString::to_string).collect();
+            assert!(
+                rendered.iter().any(|s| s == "fast"),
+                "expected `fast` in candidate list, got: {rendered:?}"
+            );
+        }
+        other => panic!("expected InvalidEnumVariant from the StringEnum member, got: {other:?}"),
+    }
+}
+
+#[test]
+fn union_list_vs_list_struct_picks_inner_struct_error() {
+    // List<String> | List<Struct{...}>: input is a List of Maps where
+    // one Map has an unknown field. The List<Struct> member's nested
+    // `UnknownStructField { field: "typo", ... }` error should surface
+    // — the user has to know that "typo" isn't a valid field on Item.
+    let union_type = AttributeType::Union(vec![
+        AttributeType::list(AttributeType::String),
+        AttributeType::list(AttributeType::Struct {
+            name: "Item".to_string(),
+            fields: vec![StructField::new("name", AttributeType::String)],
+        }),
+    ]);
+    let mut bad = IndexMap::new();
+    bad.insert("name".to_string(), Value::String("x".to_string()));
+    bad.insert("typo".to_string(), Value::String("y".to_string()));
+    let value = Value::List(vec![Value::Map(bad)]);
+    let err = union_type.validate(&value).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("typo"),
+        "expected the inner Unknown-field error to mention `typo`, got: {msg}"
+    );
+}
+
+#[test]
+fn union_string_vs_custom_picks_custom_error_for_string_input() {
+    // String | Custom { base = String, validate = predicate }:
+    // a string input that fails the Custom predicate should surface
+    // the Custom validator's message, not a generic TypeMismatch.
+    fn must_be_arn(v: &Value) -> Result<(), String> {
+        match v {
+            Value::String(s) if s.starts_with("arn:") => Ok(()),
+            _ => Err("must start with 'arn:'".to_string()),
+        }
+    }
+    let union_type = AttributeType::Union(vec![
+        AttributeType::Int,
+        AttributeType::Custom {
+            semantic_name: Some("Arn".to_string()),
+            base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
+            validate: must_be_arn,
+            namespace: None,
+            to_dsl: None,
+        },
+    ]);
+    let err = union_type
+        .validate(&Value::String("not-an-arn".to_string()))
+        .unwrap_err();
+    match err {
+        TypeError::ValidationFailed { ref message } => {
+            assert!(
+                message.contains("must start with 'arn:'"),
+                "expected the Custom validator's actual message, got: {message}"
+            );
+        }
+        other => {
+            panic!("expected ValidationFailed from the Custom member's predicate, got: {other:?}")
+        }
+    }
+}
+
+#[test]
+fn union_falls_through_to_type_mismatch_when_no_member_matches_shape() {
+    // Int | Bool: input is a Map. Neither member shares a constructor
+    // with Map. The result is a generic TypeMismatch — there's no
+    // "closer" candidate to surface.
+    let union_type = AttributeType::Union(vec![AttributeType::Int, AttributeType::Bool]);
+    let mut map = IndexMap::new();
+    map.insert("k".to_string(), Value::String("v".to_string()));
+    let err = union_type.validate(&Value::Map(map)).unwrap_err();
+    match err {
+        TypeError::TypeMismatch { .. } => {}
+        other => panic!("expected TypeMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn union_custom_with_int_base_picks_custom_error_for_int_input() {
+    // Custom { base = Int, validate = predicate }: a `Custom` Union
+    // member whose declared `base` is `Int` (not `String`) must still
+    // be reachable. With an `Int | positive_int()` Union and a
+    // negative integer input, the Custom validator's
+    // `ValidationFailed` message must surface — not the generic
+    // `TypeMismatch` from the bare `Int` member's success path.
+    fn must_be_positive(v: &Value) -> Result<(), String> {
+        match v {
+            Value::Int(n) if *n > 0 => Ok(()),
+            _ => Err("must be positive".to_string()),
+        }
+    }
+    // Flip the order so the bare `Int` arm doesn't accept the value
+    // first — both members run validate(). Bare `Int::validate`
+    // accepts any `Value::Int`, so we have to keep it second; bind
+    // through a Custom on top so the actual reachable failure path
+    // is the `Custom` one.
+    let union_type = AttributeType::Union(vec![
+        AttributeType::Custom {
+            semantic_name: Some("PositiveInt".to_string()),
+            base: Box::new(AttributeType::Int),
+            pattern: None,
+            length: None,
+            validate: must_be_positive,
+            namespace: None,
+            to_dsl: None,
+        },
+        AttributeType::Bool,
+    ]);
+    let err = union_type.validate(&Value::Int(-5)).unwrap_err();
+    match err {
+        TypeError::ValidationFailed { ref message } => {
+            assert!(
+                message.contains("must be positive"),
+                "expected the Custom validator's actual message, got: {message}"
+            );
+        }
+        other => {
+            panic!("expected ValidationFailed from the Custom-with-Int-base member, got: {other:?}")
+        }
+    }
+}
+
+#[test]
+fn union_struct_member_still_wins_for_map_input_regression() {
+    // Regression for the original heuristic: Map input + Struct member
+    // surfaces the Struct's "Unknown field" error. This test mirrors
+    // `union_struct_unknown_field_shows_specific_error` but is kept
+    // here so a future scoring tweak that drops this case fails
+    // immediately.
+    let union_type = AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "Principal".to_string(),
+            fields: vec![StructField::new("service", AttributeType::String)],
+        },
+        AttributeType::String,
+    ]);
+    let mut map = IndexMap::new();
+    map.insert("service".to_string(), Value::String("x".to_string()));
+    map.insert("typo".to_string(), Value::String("y".to_string()));
+    let err = union_type.validate(&Value::Map(map)).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("typo") && msg.contains("Principal"),
+        "Struct member must still win for Map input, got: {msg}"
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -372,12 +372,19 @@ mode = "invalid_mode"
 
     let diagnostics = engine.analyze(&doc, None);
 
-    let type_error = diagnostics
-        .iter()
-        .find(|d| d.message.contains("Type mismatch"));
+    // After #2219 the Union error surfaces the closest member's
+    // structured error rather than a generic `Type mismatch`. For a
+    // string input that fails `StringEnum | Int`, the StringEnum
+    // member's "Invalid value 'invalid_mode' ... expected one of
+    // active, passive" is the right message.
+    let invalid_value_error = diagnostics.iter().find(|d| {
+        d.message.contains("invalid_mode")
+            && d.message.contains("active")
+            && d.message.contains("passive")
+    });
     assert!(
-        type_error.is_some(),
-        "Should warn about invalid Union value. Got diagnostics: {:?}",
+        invalid_value_error.is_some(),
+        "Should warn about invalid Union value with the StringEnum member's variant list. Got diagnostics: {:?}",
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Summary

When an input fails validation against an `AttributeType::Union`, the old code surfaced a `Struct` member's error only for `Map` inputs and fell back to a generic `TypeMismatch` for everything else. Replace the special-case heuristic with a structural-distance score per member so the closest match's error always surfaces.

## Tier scheme

- `Map↔Struct`: **100** — preserves the prior heuristic
- Same-constructor matches (`Map↔Map`, `List↔List`, `String↔String/StringEnum`, scalar↔scalar): **80**
- `List`: peeks at the first element, adds half of the inner score (bounded so arbitrarily deep nesting can't exceed `Map↔Struct`)
- `Custom { base }`: defers to its base — a `Custom { base = Int }` validator (e.g. `positive_int()`) is now reachable for error surfacing
- `Union`: recurses and takes the best inner score
- Otherwise: 0

The first member at the maximum score wins (strict `>`), preserving declaration order.

## User-visible diff

```
attr: String | Mode  // schema
attr = "bogus"       // input

Before: Type mismatch: expected String | Mode, got String
After:  Invalid value 'bogus' for 'attr' (Mode): expected one of fast, slow
```

The Map↔Struct case is regression-tested and unchanged.

## Test plan

- [x] `cargo nextest run --workspace` (2459 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] 6 new Union scoring tests (carina-core):
  - `union_string_vs_string_enum_picks_enum_error_for_string_input`
  - `union_list_vs_list_struct_picks_inner_struct_error`
  - `union_string_vs_custom_picks_custom_error_for_string_input`
  - `union_custom_with_int_base_picks_custom_error_for_int_input` — verifies the `Custom { base = Int }` reachability fix
  - `union_falls_through_to_type_mismatch_when_no_member_matches_shape`
  - `union_struct_member_still_wins_for_map_input_regression`
- [x] One existing LSP diagnostic test (`union_static_value_validated`) updated to assert the new specific message

Closes #2219