### PR TITLE
refactor(core): closure-capable, structured-error Custom validator

### DIFF
--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -26,7 +26,9 @@ use carina_core::provider::{
     BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer,
 };
 use carina_core::resource::{Resource, ResourceId, State, Value};
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+};
 use carina_lsp::diagnostics::DiagnosticEngine;
 use carina_lsp::document::Document;
 use indexmap::IndexMap;
@@ -321,7 +323,7 @@ fn region_schemas() -> HashMap<String, ResourceSchema> {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_region,
+        validate: legacy_validator(validate_region),
         namespace: Some("test".to_string()),
         to_dsl: Some(to_dsl),
     };

--- a/carina-cli/tests/enum_error_display_snapshot.rs
+++ b/carina-cli/tests/enum_error_display_snapshot.rs
@@ -20,7 +20,7 @@
 use std::collections::HashMap;
 
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
 fn render_first_error(
     schema: &ResourceSchema,
@@ -123,7 +123,7 @@ fn string_literal_expected_enum_custom_namespaced_display() {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: validate_mode,
+                validate: legacy_validator(validate_mode),
                 namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::schema::noop_validator;
 use indexmap::IndexMap;
 
 #[test]
@@ -95,7 +96,7 @@ fn type_aware_custom_delegates_to_base() {
         base: Box::new(AttributeType::Float),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -316,7 +317,7 @@ fn type_aware_struct_ignores_default_custom_type() {
                     base: Box::new(AttributeType::Int),
                     pattern: None,
                     length: None,
-                    validate: |_| Ok(()),
+                    validate: noop_validator(),
                     namespace: None,
                     to_dsl: None,
                 },

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -569,8 +569,11 @@ fn collect_validators_from_type(
         } => {
             let snake_name = crate::parser::pascal_to_snake(name);
             validators.entry(snake_name).or_insert_with(|| {
-                let validate_fn = *validate;
-                Box::new(move |s: &str| validate_fn(&crate::resource::Value::String(s.to_string())))
+                let validate_fn = validate.clone();
+                Box::new(move |s: &str| {
+                    validate_fn(&crate::resource::Value::String(s.to_string()))
+                        .map_err(|e| e.to_string())
+                })
             });
         }
         AttributeType::Custom {

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 
@@ -14,6 +15,43 @@ use crate::value::format_value_with_key;
 
 /// Type alias for resource validator functions
 pub type ResourceValidator = fn(&HashMap<String, Value>) -> Result<(), Vec<TypeError>>;
+
+/// Validator stored on `AttributeType::Custom`. Boxed as `Arc<dyn Fn>` so it
+/// can capture provider-side state (region, account ID, schema handles) and
+/// return a structured `TypeError` directly — both of which a bare `fn`
+/// pointer cannot do. See #2217.
+pub type CustomValidator = Arc<dyn Fn(&Value) -> Result<(), TypeError> + Send + Sync>;
+
+/// Build a [`CustomValidator`] from any closure that returns a structured
+/// [`TypeError`]. This is the preferred constructor: validators that emit
+/// `TypeError::InvalidEnumVariant` (or other structured variants) flow
+/// straight into the LSP's quick-fix path.
+pub fn validator<F>(f: F) -> CustomValidator
+where
+    F: Fn(&Value) -> Result<(), TypeError> + Send + Sync + 'static,
+{
+    Arc::new(f)
+}
+
+/// Build a [`CustomValidator`] from a closure that still uses the legacy
+/// `Result<(), String>` shape. The returned message is wrapped in
+/// `TypeError::ValidationFailed`. Use this for builtins that haven't yet
+/// been migrated to structured errors.
+pub fn legacy_validator<F>(f: F) -> CustomValidator
+where
+    F: Fn(&Value) -> Result<(), String> + Send + Sync + 'static,
+{
+    Arc::new(move |v| f(v).map_err(|message| TypeError::ValidationFailed { message }))
+}
+
+/// A [`CustomValidator`] that accepts every value. Useful for tests and
+/// for placeholder Custom types whose validation is delegated elsewhere
+/// (e.g. plugin-loaded providers route validation through
+/// `ProviderContext.validators`).
+pub fn noop_validator() -> CustomValidator {
+    validator(|_| Ok(()))
+}
+
 pub type StringEnumParts<'a> = (
     &'a str,
     &'a [String],
@@ -73,7 +111,7 @@ impl StructField {
 }
 
 /// Attribute type
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum AttributeType {
     /// String
     String,
@@ -101,7 +139,7 @@ pub enum AttributeType {
         pattern: Option<String>,
         /// Optional length bounds (min, max).
         length: Option<(Option<u64>, Option<u64>)>,
-        validate: fn(&Value) -> Result<(), String>,
+        validate: CustomValidator,
         /// Namespace for resolving shorthand enum values (e.g., "aws.vpc")
         /// When set, allows `dedicated` to be resolved to `aws.vpc.InstanceTenancy.dedicated`
         namespace: Option<String>,
@@ -133,6 +171,66 @@ pub enum AttributeType {
     },
     /// Union of multiple types (value is valid if it matches any member)
     Union(Vec<AttributeType>),
+}
+
+impl fmt::Debug for AttributeType {
+    // Hand-written so that `Custom.validate` (an `Arc<dyn Fn>`, which does
+    // not implement `Debug`) can be rendered as a placeholder. Every other
+    // variant matches what `#[derive(Debug)]` would produce.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AttributeType::String => f.write_str("String"),
+            AttributeType::Int => f.write_str("Int"),
+            AttributeType::Float => f.write_str("Float"),
+            AttributeType::Bool => f.write_str("Bool"),
+            AttributeType::StringEnum {
+                name,
+                values,
+                namespace,
+                to_dsl,
+            } => f
+                .debug_struct("StringEnum")
+                .field("name", name)
+                .field("values", values)
+                .field("namespace", namespace)
+                .field("to_dsl", to_dsl)
+                .finish(),
+            AttributeType::Custom {
+                semantic_name,
+                base,
+                pattern,
+                length,
+                namespace,
+                to_dsl,
+                validate: _,
+            } => f
+                .debug_struct("Custom")
+                .field("semantic_name", semantic_name)
+                .field("base", base)
+                .field("pattern", pattern)
+                .field("length", length)
+                .field("namespace", namespace)
+                .field("to_dsl", to_dsl)
+                .field("validate", &"<closure>")
+                .finish(),
+            AttributeType::List { inner, ordered } => f
+                .debug_struct("List")
+                .field("inner", inner)
+                .field("ordered", ordered)
+                .finish(),
+            AttributeType::Map { key, value } => f
+                .debug_struct("Map")
+                .field("key", key)
+                .field("value", value)
+                .finish(),
+            AttributeType::Struct { name, fields } => f
+                .debug_struct("Struct")
+                .field("name", name)
+                .field("fields", fields)
+                .finish(),
+            AttributeType::Union(types) => f.debug_tuple("Union").field(types).finish(),
+        }
+    }
 }
 
 /// One step in a [`FieldPath`]. Either a struct field name or a list
@@ -619,7 +717,7 @@ impl AttributeType {
         let name_for_resolve = semantic_name.as_deref().unwrap_or("");
         let resolved_value =
             Self::resolve_enum_input(name_for_resolve, namespace.as_deref(), value);
-        validate(&resolved_value).map_err(|msg| TypeError::ValidationFailed { message: msg })
+        validate(&resolved_value)
     }
 
     /// Validate a `List` variant by validating each item with the inner type.
@@ -1214,7 +1312,7 @@ pub struct ExpectedEnumVariant {
 impl ExpectedEnumVariant {
     /// `namespace` head becomes `provider`; the rest become `segments`.
     /// `None` produces a bare-form variant.
-    fn from_namespaced(
+    pub fn from_namespaced(
         namespace: Option<&str>,
         type_name: &str,
         value: &str,
@@ -2183,7 +2281,7 @@ pub mod types {
             base: Box::new(AttributeType::Int),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::Int(n) = value {
                     if *n > 0 {
                         Ok(())
@@ -2193,7 +2291,7 @@ pub mod types {
                 } else {
                     Err("Expected integer".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }
@@ -2206,13 +2304,13 @@ pub mod types {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::String(s) = value {
                     validate_ipv4_cidr(s)
                 } else {
                     Err("Expected string".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }
@@ -2225,13 +2323,13 @@ pub mod types {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::String(s) = value {
                     validate_ipv4_address(s)
                 } else {
                     Err("Expected string".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }
@@ -2244,13 +2342,13 @@ pub mod types {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::String(s) = value {
                     validate_ipv6_address(s)
                 } else {
                     Err("Expected string".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }
@@ -2263,13 +2361,13 @@ pub mod types {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::String(s) = value {
                     validate_ipv6_cidr(s)
                 } else {
                     Err("Expected string".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }
@@ -2291,13 +2389,13 @@ pub mod types {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |value| {
+            validate: legacy_validator(|value| {
                 if let Value::String(s) = value {
                     validate_email(s)
                 } else {
                     Err("Expected string".to_string())
                 }
-            },
+            }),
             namespace: None,
             to_dsl: None,
         }

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -464,7 +464,7 @@ fn schema_validate_with_origins_reshapes_custom_namespaced_type() {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: validate_mode,
+                validate: legacy_validator(validate_mode),
                 namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },
@@ -1337,7 +1337,7 @@ fn validate_union_type() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 if s.starts_with("a-") {
                     Ok(())
@@ -1347,7 +1347,7 @@ fn validate_union_type() {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     };
@@ -1356,7 +1356,7 @@ fn validate_union_type() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |value| {
+        validate: legacy_validator(|value| {
             if let Value::String(s) = value {
                 if s.starts_with("b-") {
                     Ok(())
@@ -1366,7 +1366,7 @@ fn validate_union_type() {
             } else {
                 Err("Expected string".to_string())
             }
-        },
+        }),
         namespace: None,
         to_dsl: None,
     };
@@ -1442,7 +1442,7 @@ fn union_type_name() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1451,7 +1451,7 @@ fn union_type_name() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1467,7 +1467,7 @@ fn union_accepts_type_name() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1476,7 +1476,7 @@ fn union_accepts_type_name() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2158,7 +2158,7 @@ fn make_custom(name: &str, base: AttributeType) -> AttributeType {
         base: Box::new(base),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     }
@@ -2170,7 +2170,7 @@ fn make_custom_anon_pattern(pattern: &str) -> AttributeType {
         base: Box::new(AttributeType::String),
         pattern: Some(pattern.to_string()),
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     }
@@ -2182,7 +2182,7 @@ fn make_custom_anon_len(min: u64, max: u64) -> AttributeType {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: Some((Some(min), Some(max))),
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     }
@@ -2220,7 +2220,7 @@ fn assignable_narrow_to_anonymous_unconstrained_sink() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2273,7 +2273,7 @@ fn assignable_union_source_requires_all_members_assignable() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2299,7 +2299,7 @@ fn semantic_custom_assigns_to_anonymous_unconstrained_sink() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2339,7 +2339,7 @@ fn make_custom_anon_pattern_and_len(
         base: Box::new(AttributeType::String),
         pattern: pattern.map(str::to_string),
         length,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     }
@@ -2450,7 +2450,7 @@ fn custom_carries_semantic_name_pattern_length() {
         base: Box::new(AttributeType::String),
         pattern: Some("^vpc-[a-f0-9]+$".to_string()),
         length: Some((Some(8), Some(21))),
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2476,7 +2476,7 @@ fn custom_type_name_anonymous_pattern_only() {
         base: Box::new(AttributeType::String),
         pattern: Some("^foo$".to_string()),
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2490,7 +2490,7 @@ fn custom_type_name_anonymous_length_only() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: Some((Some(1), Some(64))),
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2504,7 +2504,7 @@ fn custom_type_name_anonymous_pattern_and_length() {
         base: Box::new(AttributeType::String),
         pattern: Some("^.*$".to_string()),
         length: Some((Some(1), Some(64))),
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -2879,7 +2879,7 @@ fn custom_namespaced_string_literal_routes_validator_text_to_extra_message() {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: validate_mode,
+                validate: legacy_validator(validate_mode),
                 namespace: Some("test.r".to_string()),
                 to_dsl: None,
             },
@@ -3038,7 +3038,7 @@ fn union_string_vs_custom_picks_custom_error_for_string_input() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: must_be_arn,
+            validate: legacy_validator(must_be_arn),
             namespace: None,
             to_dsl: None,
         },
@@ -3099,7 +3099,7 @@ fn union_custom_with_int_base_picks_custom_error_for_int_input() {
             base: Box::new(AttributeType::Int),
             pattern: None,
             length: None,
-            validate: must_be_positive,
+            validate: legacy_validator(must_be_positive),
             namespace: None,
             to_dsl: None,
         },
@@ -3142,4 +3142,93 @@ fn union_struct_member_still_wins_for_map_input_regression() {
         msg.contains("typo") && msg.contains("Principal"),
         "Struct member must still win for Map input, got: {msg}"
     );
+}
+
+#[test]
+fn custom_validator_can_capture_external_state() {
+    // The validator closes over `allowed_region`, captured from the
+    // surrounding scope. A `fn` pointer cannot do this; only a
+    // closure-capable validator can. This is the core acceptance for
+    // #2217 (closure-capable Custom validator).
+    let allowed_region = "ap-northeast-1".to_string();
+    let attr = AttributeType::Custom {
+        semantic_name: Some("Region".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validator(move |v| match v {
+            Value::String(s) if s == &allowed_region => Ok(()),
+            Value::String(s) => Err(TypeError::ValidationFailed {
+                message: format!("expected region {}, got {}", allowed_region, s),
+            }),
+            other => Err(TypeError::TypeMismatch {
+                expected: "String".to_string(),
+                got: other.type_name(),
+            }),
+        }),
+        namespace: None,
+        to_dsl: None,
+    };
+    assert!(
+        attr.validate(&Value::String("ap-northeast-1".to_string()))
+            .is_ok()
+    );
+    let err = attr
+        .validate(&Value::String("us-east-1".to_string()))
+        .unwrap_err();
+    match err {
+        TypeError::ValidationFailed { message } => {
+            assert!(message.contains("ap-northeast-1") && message.contains("us-east-1"));
+        }
+        other => panic!("expected ValidationFailed, got: {other:?}"),
+    }
+}
+
+#[test]
+fn custom_validator_returns_structured_type_error_directly() {
+    // The validator returns `TypeError::InvalidEnumVariant` directly,
+    // bypassing the legacy `String -> ValidationFailed` round-trip.
+    // This is what unlocks LSP code-action quick-fixes for Custom-typed
+    // attributes (see #2220 / #2309 for the structured-error path).
+    let attr = AttributeType::Custom {
+        semantic_name: Some("Mode".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: validator(|v| match v {
+            Value::String(s) if s == "fast" || s == "slow" => Ok(()),
+            Value::String(s) => Err(TypeError::InvalidEnumVariant {
+                value: s.clone(),
+                attribute: None,
+                type_name: Some("Mode".to_string()),
+                expected: vec![
+                    ExpectedEnumVariant::from_namespaced(None, "Mode", "fast", false),
+                    ExpectedEnumVariant::from_namespaced(None, "Mode", "slow", false),
+                ],
+            }),
+            other => Err(TypeError::TypeMismatch {
+                expected: "String".to_string(),
+                got: other.type_name(),
+            }),
+        }),
+        namespace: None,
+        to_dsl: None,
+    };
+    let err = attr
+        .validate(&Value::String("medium".to_string()))
+        .unwrap_err();
+    match err {
+        TypeError::InvalidEnumVariant {
+            value,
+            type_name,
+            expected,
+            ..
+        } => {
+            assert_eq!(value, "medium");
+            assert_eq!(type_name.as_deref(), Some("Mode"));
+            let values: Vec<&str> = expected.iter().map(|e| e.value.as_str()).collect();
+            assert_eq!(values, vec!["fast", "slow"]);
+        }
+        other => panic!("expected InvalidEnumVariant, got: {other:?}"),
+    }
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -1029,10 +1029,7 @@ mod tests {
         // Consumer attribute is `Custom { name: "KmsKeyArn", base: Arn }`;
         // export declares plain `TypeExpr::Simple("arn")`. The type checker
         // walks Custom's base chain, so `arn` accepts `KmsKeyArn`.
-        use crate::schema::AttributeType;
-        fn noop_validate(_v: &crate::resource::Value) -> Result<(), String> {
-            Ok(())
-        }
+        use crate::schema::{AttributeType, noop_validator};
         let parsed = parse_project_with_provider(
             r#"
                 let orgs = upstream_state { source = "../organizations" }
@@ -1051,13 +1048,13 @@ mod tests {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: noop_validate,
+                validate: noop_validator(),
                 namespace: None,
                 to_dsl: None,
             }),
             pattern: None,
             length: None,
-            validate: noop_validate,
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         };

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::parser::{ParsedFile, ProviderContext};
 use crate::resource::Resource;
+use crate::schema::noop_validator;
 
 fn empty_parsed() -> ParsedFile {
     ParsedFile {
@@ -1301,7 +1302,7 @@ fn attribute_param_ref_type_mismatch_detected() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         },
@@ -1454,13 +1455,13 @@ fn type_compat_subtype_accepted() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         }),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1480,13 +1481,13 @@ fn type_compat_sibling_rejected() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         }),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1506,13 +1507,13 @@ fn type_compat_resource_id_subtype() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         }),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1532,13 +1533,13 @@ fn type_compat_resource_id_siblings_rejected() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: |_| Ok(()),
+            validate: noop_validator(),
             namespace: None,
             to_dsl: None,
         }),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };
@@ -1555,7 +1556,7 @@ fn type_compat_exact_match() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |_| Ok(()),
+        validate: noop_validator(),
         namespace: None,
         to_dsl: None,
     };

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2509,7 +2509,7 @@ exports {
 /// the issue spec.
 #[test]
 fn exports_map_value_offers_matching_resource_refs() {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
     use std::collections::HashMap;
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
@@ -2519,7 +2519,7 @@ fn exports_map_value_offers_matching_resource_refs() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_noop,
+        validate: legacy_validator(validate_noop),
         namespace: None,
         to_dsl: None,
     };
@@ -2594,7 +2594,7 @@ fn exports_list_value_position_filters_by_element_type() {
 /// expect matching resource-ref refs.
 #[test]
 fn exports_map_value_multiple_entries_returns_refs() {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
     use std::collections::HashMap;
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
@@ -2604,7 +2604,7 @@ fn exports_map_value_multiple_entries_returns_refs() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_noop,
+        validate: legacy_validator(validate_noop),
         namespace: None,
         to_dsl: None,
     };
@@ -2652,7 +2652,7 @@ exports {
 /// scanning sibling `.crn` files, not just the current buffer.
 #[test]
 fn exports_map_value_includes_bindings_from_sibling_files() {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
     use std::collections::HashMap;
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
@@ -2662,7 +2662,7 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_noop,
+        validate: legacy_validator(validate_noop),
         namespace: None,
         to_dsl: None,
     };
@@ -2710,7 +2710,7 @@ exports {
 /// `registry_prod.account_id`.
 #[test]
 fn custom_type_value_ref_includes_sibling_file_bindings() {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
     use std::collections::HashMap;
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
@@ -2720,7 +2720,7 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_noop,
+        validate: legacy_validator(validate_noop),
         namespace: None,
         to_dsl: None,
     };
@@ -2814,7 +2814,7 @@ let b = awscc.s3.Bucket {
 /// `main.crn`.
 #[test]
 fn binding_dot_completion_resolves_sibling_file_binding() {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
     use std::collections::HashMap;
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
@@ -2824,7 +2824,7 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_noop,
+        validate: legacy_validator(validate_noop),
         namespace: None,
         to_dsl: None,
     };

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -4,7 +4,9 @@ use super::*;
 use crate::document::Document;
 use carina_core::parser::ProviderContext;
 use carina_core::provider::ProviderFactory;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+};
 
 mod basic;
 mod extended;
@@ -218,7 +220,7 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: noop_validate,
+        validate: legacy_validator(noop_validate),
         namespace: None,
         to_dsl: None,
     };

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::{
 
 use carina_core::builtins;
 use carina_core::parser::snake_to_pascal;
-use carina_core::schema::AttributeType;
+use carina_core::schema::{AttributeType, legacy_validator};
 
 use super::{CompletionProvider, DslSource};
 
@@ -1385,7 +1385,7 @@ fn parse_exports_type_text(text: &str) -> Option<AttributeType> {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: noop_validate,
+                validate: legacy_validator(noop_validate),
                 namespace: None,
                 to_dsl: None,
             })

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -501,13 +501,13 @@ impl DiagnosticEngine {
                                     );
 
                                     // Use schema's validate function for all Custom types
-                                    validate(&resolved_value).err().map(|inner_msg| {
+                                    validate(&resolved_value).err().map(|inner_err| {
                                         // For namespaced Custom types (enum-like), mirror
                                         // the CLI shape-mismatch diagnostic when the user
-                                        // wrote a quoted string literal. The Custom
-                                        // validator itself returns a free-form string, so
-                                        // we wrap its message rather than reshape a
-                                        // TypeError. See #2094.
+                                        // wrote a quoted string literal. The validator
+                                        // returns a structured `TypeError`; render it as a
+                                        // string when wrapping for the LSP message. See #2094.
+                                        let inner_msg = inner_err.to_string();
                                         if namespace.is_some()
                                             && matches!(value, Value::String(s) if !s.contains('.'))
                                             && resource.quoted_string_attrs.contains(attr_name)

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1282,7 +1282,7 @@ attributes {
 fn resource_ref_type_check_helper_regression() {
     // Regression test for refactoring: all three ResourceRef type-checking paths
     // (Union, StringEnum, Custom) must produce consistent "Type mismatch" diagnostics.
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
     fn dummy_validate(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
@@ -1301,7 +1301,7 @@ fn resource_ref_type_check_helper_regression() {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: dummy_validate,
+                validate: legacy_validator(dummy_validate),
                 namespace: Some("test".to_string()),
                 to_dsl: None,
             },
@@ -1329,7 +1329,7 @@ fn resource_ref_type_check_helper_regression() {
                 base: Box::new(AttributeType::String),
                 pattern: None,
                 length: None,
-                validate: dummy_validate,
+                validate: legacy_validator(dummy_validate),
                 namespace: Some("test".to_string()),
                 to_dsl: None,
             },
@@ -1738,7 +1738,7 @@ fn distinct_semantic_customs_are_rejected() {
     // (AwsAccountId vs TargetId) are NOT assignable. The previous permissive
     // rule (#1795) collapsed all String-based Customs into one compatibility
     // class, which silently accepted `target_id = sso.identity_store_id`.
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
     fn validate_account_id(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
@@ -1762,7 +1762,7 @@ fn distinct_semantic_customs_are_rejected() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: validate_account_id,
+            validate: legacy_validator(validate_account_id),
             namespace: Some("aws".to_string()),
             to_dsl: None,
         },
@@ -1776,7 +1776,7 @@ fn distinct_semantic_customs_are_rejected() {
             base: Box::new(AttributeType::String),
             pattern: None,
             length: None,
-            validate: validate_target_id,
+            validate: legacy_validator(validate_target_id),
             namespace: Some("awscc".to_string()),
             to_dsl: None,
         },
@@ -1820,14 +1820,14 @@ fn exports_cross_file_ref_no_false_positive() {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: |v| match v {
+        validate: carina_core::schema::legacy_validator(|v| match v {
             Value::String(s) if s.len() == 12 && s.chars().all(|c| c.is_ascii_digit()) => Ok(()),
             Value::String(s) => Err(format!(
                 "must be exactly 12 digits, got {} characters",
                 s.len()
             )),
             _ => Err("expected string".to_string()),
-        },
+        }),
         namespace: None,
         to_dsl: None,
     };

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -112,7 +112,7 @@ pub(super) fn test_engine_with_namespaced_enum_attr() -> DiagnosticEngine {
 /// Engine whose `mode` attribute is a `Custom` type with a namespace — the
 /// other shape #2094 wants to treat as "expects an enum identifier".
 pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
-    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
     fn validate_mode(v: &carina_core::resource::Value) -> Result<(), String> {
         match v {
@@ -133,7 +133,7 @@ pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_mode,
+        validate: legacy_validator(validate_mode),
         namespace: Some("test.r".to_string()),
         to_dsl: None,
     };

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -17,7 +17,9 @@ mod support;
 
 use std::collections::HashMap;
 
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+};
 use support::fixture::{analyze, engine_with_schemas, single_schema_map, write_fixture};
 
 fn count_with(diags: &[tower_lsp::lsp_types::Diagnostic], substring: &str) -> usize {
@@ -137,7 +139,7 @@ fn region_schemas() -> HashMap<String, ResourceSchema> {
         base: Box::new(AttributeType::String),
         pattern: None,
         length: None,
-        validate: validate_region,
+        validate: legacy_validator(validate_region),
         namespace: Some("test".to_string()),
         to_dsl: Some(to_dsl),
     };

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -8,7 +8,7 @@ use carina_core::resource::{
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
-    ResourceSchema as CoreResourceSchema, StructField as CoreStructField,
+    ResourceSchema as CoreResourceSchema, StructField as CoreStructField, noop_validator,
 };
 
 use carina_provider_protocol::types as proto;
@@ -386,7 +386,7 @@ fn proto_attr_type_to_core(t: &proto::AttributeType) -> CoreAttributeType {
             base: Box::new(proto_attr_type_to_core(base)),
             pattern: None,
             length: None,
-            validate: |_| Ok(()), // Validation is handled via ProviderContext.validators
+            validate: noop_validator(), // Validation is handled via ProviderContext.validators
             namespace: namespace.clone(),
             to_dsl: None,
         },


### PR DESCRIPTION
## Summary

- Changes `AttributeType::Custom.validate` from `fn(&Value) -> Result<(), String>` to `Arc<dyn Fn(&Value) -> Result<(), TypeError> + Send + Sync>` — validators can now capture provider-side state and return structured `TypeError` directly.
- Adds three helpers in `carina-core::schema`: `validator()` (structured-error), `legacy_validator()` (wraps `Result<(), String>` into `ValidationFailed`), `noop_validator()` (accepts everything).
- The 6 builtin validators in `schema::types` (`positive_int`, `ipv4_cidr`, `ipv4_address`, `ipv6_cidr`, `ipv6_address`, `email`) keep their existing string messages via `legacy_validator(...)`. Migrating them to structured errors is intentionally deferred.

This unlocks the LSP code-action / quick-fix path established by #2220 and #2309 for `Custom`-typed attributes — previously the `String` round-trip dropped all structure, so e.g. `InvalidEnumVariant`-shaped errors couldn't reach the editor.

This is **PR 1 of a 3-PR train** for #2217. Provider repos (carina-provider-aws, carina-provider-awscc) consume the new type and will land in follow-up PRs that wrap their existing builtin validators with `legacy_validator(...)`. ``Refs #2217`` (not ``Closes``) — full acceptance lands when all three PRs are merged.

## Test plan

- [x] `cargo nextest run --workspace` — 2461 tests pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `scripts/check-*.sh` — clean
- [x] Two new acceptance tests in `carina-core/src/schema/tests.rs`:
  - `custom_validator_can_capture_external_state` — closure captures `allowed_region` from outer scope
  - `custom_validator_returns_structured_type_error_directly` — validator returns `InvalidEnumVariant` with structured `expected` variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)