### PR TITLE
DSL: subscript-after-field-access in upstream_state refs

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -391,16 +391,20 @@ pub fn validate_and_resolve_errors_with_factories(
                 parsed,
                 &upstream_exports,
             );
+        let subscript_errors = carina_core::upstream_exports::check_upstream_state_subscript_shapes(
+            parsed,
+            &upstream_exports,
+        );
         errors.extend(
             resolve_errors
                 .iter()
                 .map(|e| AppError::Validation(e.to_string())),
         );
-        // The four upstream-ref checks return distinct concrete types
+        // The five upstream-ref checks return distinct concrete types
         // but share `UpstreamRefDiagnostic`. Chain them through the
         // trait (`Display` supertrait gives the canonical
         // `"location: message"` form — the per-type `Display` impl is
-        // the single source of truth) so adding a fifth check is one
+        // the single source of truth) so adding a sixth check is one
         // extra `chain(...)`.
         errors.extend(
             field_errors
@@ -410,6 +414,11 @@ pub fn validate_and_resolve_errors_with_factories(
                 .chain(shape_errors.iter().map(|e| e as &dyn UpstreamRefDiagnostic))
                 .chain(
                     attribute_access_errors
+                        .iter()
+                        .map(|e| e as &dyn UpstreamRefDiagnostic),
+                )
+                .chain(
+                    subscript_errors
                         .iter()
                         .map(|e| e as &dyn UpstreamRefDiagnostic),
                 )

--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -220,6 +220,12 @@ identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 // Namespaced identifier: aws.s3_bucket, aws.Region.ap_northeast_1, Type.ipsec.1
 namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
 
+// Namespaced identifier with trailing `[index]` subscripts:
+// `orgs.accounts[0]`, `orgs.account.children["alpha"]`. Mirrors the
+// canonical parser's `subscripted_id` so post-field index access
+// formats round-trip.
+subscripted_id = { namespaced_id ~ (trivia* ~ index_access)+ }
+
 // Expression
 expression = { pipe_expr }
 
@@ -258,6 +264,7 @@ primary = {
   | function_call
   | list
   | map
+  | subscripted_id      // Must come before namespaced_id so "a.b[0]" doesn't bottom out as "a.b"
   | namespaced_id
   | boolean
   | float

--- a/carina-core/src/formatter/cst.rs
+++ b/carina-core/src/formatter/cst.rs
@@ -93,6 +93,7 @@ pub enum NodeKind {
     FunctionCall,
     VariableRef,
     NamespacedId,
+    SubscriptedId,
     Identifier,
     String,
     Number,

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -228,6 +228,9 @@ impl<'a> CstBuilder<'a> {
             Rule::variable_ref => {
                 Some(CstChild::Node(self.build_node(NodeKind::VariableRef, pair)))
             }
+            Rule::subscripted_id => Some(CstChild::Node(
+                self.build_node(NodeKind::SubscriptedId, pair),
+            )),
 
             // Atoms - these become tokens
             Rule::namespaced_id => {

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -197,6 +197,7 @@ impl Formatter {
             NodeKind::ComposeExpr => self.format_compose_expr(node),
             NodeKind::FunctionCall => self.format_function_call(node),
             NodeKind::VariableRef => self.format_variable_ref(node),
+            NodeKind::SubscriptedId => self.format_subscripted_id(node),
             NodeKind::List => self.format_list(node),
             NodeKind::Map => self.format_map(node),
             NodeKind::MapEntry => self.format_map_entry(node),

--- a/carina-core/src/formatter/rules/expressions.rs
+++ b/carina-core/src/formatter/rules/expressions.rs
@@ -263,6 +263,23 @@ impl Formatter {
         }
     }
 
+    pub(in crate::formatter) fn format_subscripted_id(&mut self, node: &CstNode) {
+        // `binding.field[idx]…` — the namespaced_id portion is a single
+        // token (the `@{ }` rule produces no inner pairs), and each
+        // `index_access` child carries its own `[` / expression / `]`.
+        for child in &node.children {
+            match child {
+                CstChild::Token(token) => {
+                    self.write_token(&token.text);
+                }
+                CstChild::Node(n) if n.kind == NodeKind::IndexAccess => {
+                    self.format_index_access(n);
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn format_field_access(&mut self, node: &CstNode) {
         self.write(".");
         for child in &node.children {

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -268,11 +268,14 @@ pub(super) fn rewrite_intra_module_refs(
 ) -> Value {
     match value {
         Value::ResourceRef { path } if intra_module_bindings.contains(path.binding()) => {
-            Value::resource_ref(
-                format!("{}.{}", instance_prefix, path.binding()),
-                path.attribute().to_string(),
-                path.field_path().to_vec(),
-            )
+            Value::ResourceRef {
+                path: crate::resource::AccessPath::with_fields_and_subscripts(
+                    format!("{}.{}", instance_prefix, path.binding()),
+                    path.attribute().to_string(),
+                    path.field_path().to_vec(),
+                    path.subscripts().to_vec(),
+                ),
+            }
         }
         Value::List(items) => Value::List(
             items
@@ -526,11 +529,14 @@ fn rewrite_ref_prefixes(
                 && let Some(&target) = remap.get(&(module.to_string(), simhash))
             {
                 let new_binding = format!("{}_{:016x}.{}", module, target, rest);
-                return Value::resource_ref(
-                    new_binding,
-                    path.attribute().to_string(),
-                    path.field_path().to_vec(),
-                );
+                return Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        new_binding,
+                        path.attribute().to_string(),
+                        path.field_path().to_vec(),
+                        path.subscripts().to_vec(),
+                    ),
+                };
             }
             value.clone()
         }

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -187,6 +187,13 @@ identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 // Segments after the first dot can also be digit-only (e.g., "Type.ipsec.1")
 namespaced_id = @{ identifier ~ ("." ~ (identifier | ASCII_DIGIT+))+ }
 
+// Namespaced identifier followed by one or more `[index]` subscripts:
+// `orgs.accounts[0]`, `orgs.account.children["alpha"]`. Captured as a
+// distinct rule so the namespaced_id arm doesn't have to introspect for
+// trailing subscripts and so the grammar matches the issue-#2318
+// surface (post-field index access) explicitly.
+subscripted_id = { namespaced_id ~ index_access+ }
+
 // Expression
 expression = { coalesce_expr }
 
@@ -217,6 +224,7 @@ primary = {
   | function_call        // Must come before variable_ref so "func(...)" is parsed as function call
   | list
   | map
+  | subscripted_id      // Must come before namespaced_id so "a.b[0]" doesn't bottom out as "a.b"
   | namespaced_id
   | boolean
   | float

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -12,8 +12,90 @@ use crate::parser::{
     ParseContext, ParseError, Rule, evaluate_user_function, extract_key_string, first_inner,
     is_static_value, next_pair, parse_block_contents, parse_expression, parse_expression_eval,
 };
-use crate::resource::Value;
+use crate::resource::{AccessPath, Subscript, Value};
 use indexmap::IndexMap;
+
+/// Convert an index-expression value into a `Subscript`. Only
+/// non-negative integer and string keys are legal subscripts; anything
+/// else is a parse error. Negative integers are rejected here rather
+/// than at validate time because the DSL has no `[-1]` "from end"
+/// semantic — accepting them would let the validator pass and the
+/// resolver silently fall back to the unresolved ref.
+fn subscript_from_value(value: Value) -> Result<Subscript, ParseError> {
+    match value {
+        Value::Int(n) if n < 0 => Err(ParseError::InvalidExpression {
+            line: 0,
+            message: format!("index access key must be non-negative, got {}", n),
+        }),
+        Value::Int(n) => Ok(Subscript::Int { index: n }),
+        Value::String(s) => Ok(Subscript::Str { key: s }),
+        other => Err(ParseError::InvalidExpression {
+            line: 0,
+            message: format!(
+                "index access key must be an integer or string, got {:?}",
+                other
+            ),
+        }),
+    }
+}
+
+/// Lower a `namespaced_id` pair to its `EvalValue`, attaching any
+/// trailing subscripts collected by the caller (the `subscripted_id`
+/// arm). String-form enum shorthands like `aws.Region.ap_northeast_1`
+/// have no `AccessPath` to host subscripts — those reject outright.
+fn parse_namespaced_id_value(
+    pair: pest::iterators::Pair<Rule>,
+    ctx: &ParseContext,
+    subscripts: Vec<Subscript>,
+) -> Result<EvalValue, ParseError> {
+    let full_str = pair.as_str();
+    let parts: Vec<&str> = full_str.split('.').collect();
+    // Pest's `namespaced_id = @{ identifier ~ ("." ~ ...)+ }` rule
+    // guarantees ≥2 parts; a future grammar tweak that loosened it
+    // would silently start panicking on `parts[1]` below.
+    debug_assert!(
+        parts.len() >= 2,
+        "namespaced_id parsed without a `.` segment: {:?}",
+        full_str
+    );
+
+    if ctx.is_resource_binding(parts[0]) {
+        let attribute = parts[1].to_string();
+        let field_path = parts[2..].iter().map(|s| s.to_string()).collect();
+        let path = AccessPath::with_fields_and_subscripts(
+            parts[0].to_string(),
+            attribute,
+            field_path,
+            subscripts,
+        );
+        return Ok(EvalValue::from_value(Value::ResourceRef { path }));
+    }
+
+    if !subscripts.is_empty() {
+        return Err(ParseError::InvalidExpression {
+            line: 0,
+            message: format!(
+                "cannot subscript `{}` — it is not a known resource binding",
+                full_str
+            ),
+        });
+    }
+
+    if parts.len() == 2
+        && ctx.get_variable(parts[0]).is_some()
+        && !ctx.is_resource_binding(parts[0])
+    {
+        return Err(ParseError::InvalidExpression {
+            line: 0,
+            message: format!(
+                "'{}' is not a resource, cannot access attribute '{}'",
+                parts[0], parts[1]
+            ),
+        });
+    }
+
+    Ok(EvalValue::from_value(Value::String(full_str.to_string())))
+}
 
 pub(crate) fn parse_primary_eval(
     pair: pest::iterators::Pair<Rule>,
@@ -76,51 +158,25 @@ pub(crate) fn parse_primary_eval(
             }
             Ok(EvalValue::from_value(Value::Map(map)))
         }
-        Rule::namespaced_id => {
-            // Namespaced identifier (e.g., aws.Region.ap_northeast_1)
-            // or resource reference (e.g., bucket.name)
-            // or arguments reference in module context (e.g., arguments.vpc_id)
-            let full_str = inner.as_str();
-            let parts: Vec<&str> = full_str.split('.').collect();
-
-            if parts.len() == 2 {
-                // Two-part identifier: could be resource reference or variable access
-                if ctx.get_variable(parts[0]).is_some() && !ctx.is_resource_binding(parts[0]) {
-                    // Variable exists but trying to access attribute on non-resource
-                    Err(ParseError::InvalidExpression {
-                        line: 0,
-                        message: format!(
-                            "'{}' is not a resource, cannot access attribute '{}'",
-                            parts[0], parts[1]
-                        ),
-                    })
-                } else if ctx.is_resource_binding(parts[0]) {
-                    // Known resource binding: treat as resource reference
-                    Ok(EvalValue::from_value(Value::resource_ref(
-                        parts[0].to_string(),
-                        parts[1].to_string(),
-                        vec![],
-                    )))
-                } else {
-                    // Unknown 2-part identifier: could be TypeName.value enum shorthand
-                    // Will be resolved during schema validation
-                    Ok(EvalValue::from_value(Value::String(format!(
-                        "{}.{}",
-                        parts[0], parts[1]
-                    ))))
+        Rule::namespaced_id => parse_namespaced_id_value(inner, ctx, Vec::new()),
+        Rule::subscripted_id => {
+            // `binding.field[idx]` / `binding.field.subfield[idx]…` —
+            // the namespaced_id portion behaves like a plain
+            // namespaced_id (identifier shorthand or resource ref), and
+            // any trailing `[idx]` subscripts are folded onto the
+            // resulting `AccessPath`.
+            let mut parts = inner.into_inner();
+            let head = next_pair(&mut parts, "namespaced_id", "subscripted_id")?;
+            let mut subscripts: Vec<Subscript> = Vec::new();
+            for index_pair in parts {
+                if !matches!(index_pair.as_rule(), Rule::index_access) {
+                    continue;
                 }
-            } else if ctx.is_resource_binding(parts[0]) {
-                // 3+ part identifier where first part is a resource binding:
-                // chained field access (e.g., web.network.vpc_id)
-                Ok(EvalValue::from_value(Value::resource_ref(
-                    parts[0].to_string(),
-                    parts[1].to_string(),
-                    parts[2..].iter().map(|s| s.to_string()).collect(),
-                )))
-            } else {
-                // 3+ part identifier is a namespaced type (aws.Region.ap_northeast_1)
-                Ok(EvalValue::from_value(Value::String(full_str.to_string())))
+                let index_expr_pair = first_inner(index_pair, "index expression", "index access")?;
+                let index_value = parse_expression(index_expr_pair, ctx)?;
+                subscripts.push(subscript_from_value(index_value)?);
             }
+            parse_namespaced_id_value(head, ctx, subscripts)
         }
         Rule::boolean => {
             let b = inner.as_str() == "true";
@@ -225,49 +281,63 @@ pub(crate) fn parse_primary_eval(
                     ))),
                 }
             } else {
-                // Build binding_name, attribute_name, and field_path from access steps.
-                // Index access (e.g., [0] or ["key"]) composes the binding name.
-                // Field access after the binding gives attribute_name and field_path.
+                // Build binding_name, attribute_name, field_path, and
+                // post-field subscripts from the access steps. There are
+                // two index phases:
+                //
+                //   * **pre-field** — index access *before* any field
+                //     access. The legacy convention folds these into the
+                //     binding name string (`subnets[0]`,
+                //     `networks.prod`), preserved here unchanged so
+                //     `for`-iteration addresses round-trip.
+                //   * **post-field** — index access *after* field access
+                //     (`orgs.accounts[0]`, `orgs.account.children[0]`).
+                //     Captured structurally on `AccessPath::subscripts`
+                //     so cross-directory shape checks can tell `[0]`
+                //     from `.0` (#2318).
+                //
+                // The two never interleave: once a field segment is
+                // seen, every later index becomes post-field. A second
+                // field after a post-field subscript (e.g.
+                // `a.b[0].c`) is rejected — runtime list-indexing of
+                // arbitrary structs isn't representable today.
                 let mut binding_name = first_ident.to_string();
                 let mut field_names: Vec<String> = Vec::new();
+                let mut subscripts: Vec<Subscript> = Vec::new();
                 let mut in_field_phase = false;
 
                 for step in access_steps {
                     match step.as_rule() {
                         Rule::index_access => {
-                            if in_field_phase {
-                                // Index access after field access is not yet supported
-                                // (e.g., a.b[0] — would need runtime list indexing)
-                                return Err(ParseError::InvalidExpression {
-                                    line: 0,
-                                    message: "index access after field access is not supported"
-                                        .to_string(),
-                                });
-                            }
-                            // Parse the index expression
                             let index_expr_pair =
                                 first_inner(step, "index expression", "index access")?;
                             let index_value = parse_expression(index_expr_pair, ctx)?;
-                            // Compose the binding name: name[0] or name["key"]
-                            match &index_value {
-                                Value::Int(n) => {
-                                    binding_name = format!("{}[{}]", binding_name, n);
-                                }
-                                Value::String(s) => {
-                                    binding_name = crate::utils::map_key_address(&binding_name, s);
-                                }
-                                other => {
-                                    return Err(ParseError::InvalidExpression {
-                                        line: 0,
-                                        message: format!(
-                                            "index access key must be an integer or string, got {:?}",
-                                            other
-                                        ),
-                                    });
-                                }
+                            let subscript = subscript_from_value(index_value)?;
+                            if in_field_phase {
+                                subscripts.push(subscript);
+                            } else {
+                                // Pre-field index — fold into the
+                                // binding name string per the legacy
+                                // convention so `for`-iteration
+                                // addresses round-trip.
+                                binding_name = match subscript {
+                                    Subscript::Int { index } => {
+                                        format!("{}[{}]", binding_name, index)
+                                    }
+                                    Subscript::Str { key } => {
+                                        crate::utils::map_key_address(&binding_name, &key)
+                                    }
+                                };
                             }
                         }
                         Rule::field_access => {
+                            if !subscripts.is_empty() {
+                                return Err(ParseError::InvalidExpression {
+                                    line: 0,
+                                    message: "field access after index access is not supported"
+                                        .to_string(),
+                                });
+                            }
                             in_field_phase = true;
                             let field_ident =
                                 first_inner(step, "field identifier", "field access")?;
@@ -278,27 +348,27 @@ pub(crate) fn parse_primary_eval(
                 }
 
                 if field_names.is_empty() {
-                    // Index access only, no field access (e.g., subnets[0])
-                    // Check if the composed binding name is a known variable
+                    // No field access: subscripts is empty by
+                    // construction (the post-field bucket only fills
+                    // after a field). Pre-field subscripts have already
+                    // been folded into binding_name above.
                     match ctx.get_variable(&binding_name) {
                         Some(val) => Ok(val.clone()),
-                        None => {
-                            // Return as ResourceRef with empty attribute_name
-                            // (will be resolved later)
-                            Ok(EvalValue::from_value(Value::resource_ref(
-                                binding_name,
-                                String::new(),
-                                vec![],
-                            )))
-                        }
+                        None => Ok(EvalValue::from_value(Value::resource_ref(
+                            binding_name,
+                            String::new(),
+                            vec![],
+                        ))),
                     }
                 } else {
                     let attribute_name = field_names.remove(0);
-                    Ok(EvalValue::from_value(Value::resource_ref(
+                    let path = AccessPath::with_fields_and_subscripts(
                         binding_name,
                         attribute_name,
                         field_names,
-                    )))
+                        subscripts,
+                    );
+                    Ok(EvalValue::from_value(Value::ResourceRef { path }))
                 }
             }
         }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -3229,6 +3229,176 @@ fn parse_index_access_with_chained_fields() {
 }
 
 #[test]
+fn parse_subscript_after_field_access_with_integer() {
+    // `orgs.accounts[0]` — subscript after `binding.field`. Issue #2318.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.accounts[0]
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert!(path.field_path().is_empty());
+            assert_eq!(
+                path.subscripts(),
+                [crate::resource::Subscript::Int { index: 0 }]
+            );
+            assert_eq!(path.to_dot_string(), "orgs.accounts[0]");
+        }
+        other => panic!("Expected ResourceRef with subscript, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_subscript_after_field_access_with_string_key() {
+    // `orgs.accounts["alpha"]` — subscript after `binding.field`. Issue #2318.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.accounts["alpha"]
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert!(path.field_path().is_empty());
+            assert_eq!(
+                path.subscripts(),
+                [crate::resource::Subscript::Str {
+                    key: "alpha".to_string()
+                }]
+            );
+            assert_eq!(path.to_dot_string(), "orgs.accounts[\"alpha\"]");
+        }
+        other => panic!("Expected ResourceRef with subscript, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_chained_subscripts_after_field_access() {
+    // `orgs.matrix[0][1]` — multiple subscripts after field access.
+    // The shape check relies on the AST exposing them in source order.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.matrix[0][1]
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "matrix");
+            assert!(path.field_path().is_empty());
+            assert_eq!(
+                path.subscripts(),
+                [
+                    crate::resource::Subscript::Int { index: 0 },
+                    crate::resource::Subscript::Int { index: 1 },
+                ]
+            );
+        }
+        other => panic!("Expected ResourceRef, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_negative_subscript_is_rejected() {
+    // `orgs.accounts[-1]` — the DSL has no `[-1]` "from end" semantic.
+    // Rejecting at parse time avoids the validator passing and the
+    // resolver silently falling back to an unresolved ref.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.accounts[-1]
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("non-negative"),
+        "expected non-negative rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_field_after_subscript_after_field_is_rejected() {
+    // `a.b[0].c` — once a subscript appears after a field, no more
+    // fields are allowed. Runtime list-indexing of arbitrary structs
+    // isn't representable today.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.accounts[0].id
+        }
+    "#;
+    let err = parse(input, &ProviderContext::default()).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("field access after index access")
+            || msg.contains("field_access after index_access")
+            || msg.contains("InvalidExpression")
+            || msg.contains("Syntax"),
+        "expected rejection of `a.b[0].c`, got: {msg}"
+    );
+}
+
+#[test]
+fn parse_subscript_after_nested_field_access() {
+    // `orgs.account.accounts[0]` — subscript after a multi-level field
+    // chain. Should populate both `field_path` and `subscripts`.
+    let input = r#"
+        let orgs = upstream_state { source = "../organizations" }
+
+        awscc.ec2.Subnet {
+            name = "test"
+            cidr_block = orgs.account.accounts[0]
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).unwrap();
+    let subnet = result.resources.last().expect("subnet");
+    let value = subnet.get_attr("cidr_block").expect("cidr_block");
+    match value {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "account");
+            assert_eq!(path.field_path(), vec!["accounts"]);
+            assert_eq!(
+                path.subscripts(),
+                [crate::resource::Subscript::Int { index: 0 }]
+            );
+        }
+        other => panic!("Expected ResourceRef, got {:?}", other),
+    }
+}
+
+#[test]
 fn parse_import_block() {
     let input = r#"
         import {

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -98,6 +98,39 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                     }
                 }
 
+                // Descend into the resolved value by each post-field
+                // subscript (`orgs.accounts[0]`, `orgs.matrix[0][1]`).
+                // The validate-time shape check
+                // (`check_upstream_state_subscript_shapes`) already
+                // rejects kind mismatches against typed exports, so by
+                // the time we get here the subscripts should fit the
+                // shape — but the resolver still has to handle the
+                // happy path and bail out cleanly when an out-of-range
+                // index or missing key is encountered (e.g. resources
+                // produced by `for` whose count differs from the
+                // upstream's declared length).
+                use crate::resource::Subscript;
+                for sub in path.subscripts() {
+                    match (resolved, sub) {
+                        (Value::List(items), Subscript::Int { index }) => {
+                            let idx = usize::try_from(*index).ok().filter(|i| *i < items.len());
+                            match idx {
+                                Some(i) => {
+                                    resolved = resolve_ref_value(&items[i], bindings)?;
+                                }
+                                None => return Ok(value.clone()),
+                            }
+                        }
+                        (Value::Map(map), Subscript::Str { key }) => match map.get(key) {
+                            Some(nested) => {
+                                resolved = resolve_ref_value(nested, bindings)?;
+                            }
+                            None => return Ok(value.clone()),
+                        },
+                        _ => return Ok(value.clone()),
+                    }
+                }
+
                 return Ok(resolved);
             }
             // Keep as-is if not found
@@ -204,6 +237,76 @@ mod tests {
             })
             .collect();
         ResolvedBindings::from_resources_with_state(&resources, &HashMap::new(), &HashMap::new())
+    }
+
+    #[test]
+    fn test_resolve_subscript_descends_into_list() {
+        // `orgs.accounts[0]` against `accounts: [a, b]` resolves to `a`.
+        let bindings = bindings_from(vec![(
+            "orgs",
+            vec![(
+                "accounts",
+                Value::List(vec![
+                    Value::String("alpha".to_string()),
+                    Value::String("beta".to_string()),
+                ]),
+            )],
+        )]);
+        let path = crate::resource::AccessPath::with_fields_and_subscripts(
+            "orgs",
+            "accounts",
+            Vec::new(),
+            vec![crate::resource::Subscript::Int { index: 0 }],
+        );
+        let ref_value = Value::ResourceRef { path };
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(resolved, Value::String("alpha".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_subscript_descends_into_map() {
+        // `orgs.accounts["alpha"]` against `accounts: { alpha = "1", beta = "2" }`
+        // resolves to `"1"`.
+        let map: indexmap::IndexMap<String, Value> = vec![
+            ("alpha".to_string(), Value::String("1".to_string())),
+            ("beta".to_string(), Value::String("2".to_string())),
+        ]
+        .into_iter()
+        .collect();
+        let bindings = bindings_from(vec![("orgs", vec![("accounts", Value::Map(map))])]);
+        let path = crate::resource::AccessPath::with_fields_and_subscripts(
+            "orgs",
+            "accounts",
+            Vec::new(),
+            vec![crate::resource::Subscript::Str {
+                key: "alpha".to_string(),
+            }],
+        );
+        let ref_value = Value::ResourceRef { path };
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(resolved, Value::String("1".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_subscript_out_of_range_keeps_ref() {
+        // `orgs.accounts[5]` against a 2-element list — out of range,
+        // keep as-is so the planner can surface the unresolved ref.
+        let bindings = bindings_from(vec![(
+            "orgs",
+            vec![(
+                "accounts",
+                Value::List(vec![Value::String("a".to_string())]),
+            )],
+        )]);
+        let path = crate::resource::AccessPath::with_fields_and_subscripts(
+            "orgs",
+            "accounts",
+            Vec::new(),
+            vec![crate::resource::Subscript::Int { index: 5 }],
+        );
+        let ref_value = Value::ResourceRef { path: path.clone() };
+        let resolved = resolve_ref_value(&ref_value, &bindings).unwrap();
+        assert_eq!(resolved, ref_value);
     }
 
     #[test]

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -156,18 +156,61 @@ impl std::fmt::Display for ResourceId {
     }
 }
 
+/// A `[index]` subscript appended to an `AccessPath`'s field chain.
+///
+/// `binding.field[0]` and `binding.field["k"]` parse into the same
+/// `binding` + `attribute` + `field_path` as `binding.field`, plus a
+/// trailing `Subscript` capturing the `[…]` form. Distinguishing
+/// integer from string at this layer lets cross-directory shape checks
+/// reject `[0]` against a `map(_)` export and `["k"]` against a
+/// `list(_)` export with type-aware diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Subscript {
+    /// Integer subscript: `[0]`. Valid against `list(_)` exports.
+    Int { index: i64 },
+    /// String subscript: `["k"]`. Valid against `map(_)` exports.
+    Str { key: String },
+}
+
+impl Subscript {
+    /// Append this subscript to `out` in source-form: `[0]` or `["k"]`.
+    /// String keys go through `{:?}` so embedded quotes/backslashes
+    /// round-trip as valid DSL source — the same form is used by
+    /// diagnostic messages so escapes matter there too.
+    pub fn append_to_dot_string(&self, out: &mut String) {
+        use std::fmt::Write as _;
+        match self {
+            Subscript::Int { index } => {
+                let _ = write!(out, "[{}]", index);
+            }
+            Subscript::Str { key } => {
+                let _ = write!(out, "[{:?}]", key);
+            }
+        }
+    }
+}
+
 /// A typed access path representing a `ResourceRef` target.
 ///
-/// The path always carries a binding name and an attribute name; nested field
-/// access (e.g., `web.network.vpc_id`) is captured in `field_path`. The
-/// "binding + attribute is mandatory" invariant is enforced by the type system
-/// — there is no way to construct an `AccessPath` without both.
+/// The path always carries a binding name and an attribute name; nested
+/// field access (e.g., `web.network.vpc_id`) is captured in
+/// `field_path`, and any trailing `[index]` subscripts in `subscripts`.
+/// The grammar accepts only `binding.field[…]…`, never `binding[…].field`,
+/// so the two chains never interleave — pre-field index access is folded
+/// into the binding name string by the parser as before.
+///
+/// The "binding + attribute is mandatory" invariant is enforced by the
+/// type system — there is no way to construct an `AccessPath` without
+/// both.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct AccessPath {
     binding: String,
     attribute: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     field_path: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    subscripts: Vec<Subscript>,
 }
 
 impl AccessPath {
@@ -177,6 +220,7 @@ impl AccessPath {
             binding: binding.into(),
             attribute: attribute.into(),
             field_path: Vec::new(),
+            subscripts: Vec::new(),
         }
     }
 
@@ -190,6 +234,24 @@ impl AccessPath {
             binding: binding.into(),
             attribute: attribute.into(),
             field_path,
+            subscripts: Vec::new(),
+        }
+    }
+
+    /// Create an `AccessPath` with both a field chain and trailing
+    /// `[index]` subscripts. Used by the parser when source contains
+    /// `binding.field[idx]` or `binding.field.subfield[idx]…`.
+    pub fn with_fields_and_subscripts(
+        binding: impl Into<String>,
+        attribute: impl Into<String>,
+        field_path: Vec<String>,
+        subscripts: Vec<Subscript>,
+    ) -> Self {
+        Self {
+            binding: binding.into(),
+            attribute: attribute.into(),
+            field_path,
+            subscripts,
         }
     }
 
@@ -209,7 +271,14 @@ impl AccessPath {
         &self.field_path
     }
 
-    /// Returns the path as `binding.attribute[.field...]`.
+    /// Returns the trailing `[index]` subscripts (empty if the
+    /// reference doesn't subscript past the field chain).
+    pub fn subscripts(&self) -> &[Subscript] {
+        &self.subscripts
+    }
+
+    /// Returns the path in source-form: `binding.attribute` followed by
+    /// `.field…[idx]…` segments as written.
     pub fn to_dot_string(&self) -> String {
         let mut out = String::with_capacity(
             self.binding.len()
@@ -223,6 +292,9 @@ impl AccessPath {
         for field in &self.field_path {
             out.push('.');
             out.push_str(field);
+        }
+        for sub in &self.subscripts {
+            sub.append_to_dot_string(&mut out);
         }
         out
     }

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -674,6 +674,35 @@ fn resource_module_source_typed_field() {
 }
 
 #[test]
+fn access_path_subscripts_render_with_escapes() {
+    use crate::resource::{AccessPath, Subscript};
+
+    // Integer subscript renders as `[N]`.
+    let int_path = AccessPath::with_fields_and_subscripts(
+        "orgs",
+        "accounts",
+        Vec::new(),
+        vec![Subscript::Int { index: 0 }],
+    );
+    assert_eq!(int_path.to_dot_string(), "orgs.accounts[0]");
+
+    // String subscript with embedded quote escapes through {:?}.
+    let str_path = AccessPath::with_fields_and_subscripts(
+        "orgs",
+        "accounts",
+        Vec::new(),
+        vec![Subscript::Str {
+            key: "a\"b".to_string(),
+        }],
+    );
+    let rendered = str_path.to_dot_string();
+    assert!(
+        rendered.contains("\\\""),
+        "embedded quote must escape, got: {rendered}"
+    );
+}
+
+#[test]
 fn access_path_new() {
     let path = AccessPath::new("vpc", "id");
     assert_eq!(path.binding(), "vpc");

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 use crate::config_loader::{find_crn_files_in_dir, parse_directory};
 use crate::parser::{ParsedFile, ProviderContext, ResourceContext, TypeExpr, UpstreamState};
-use crate::resource::Value;
+use crate::resource::{Subscript, Value};
 use crate::schema::{AttributeType, ResourceSchema, suggest_similar_name};
 
 /// Exports declared by each `upstream_state` binding: binding name →
@@ -33,13 +33,14 @@ pub type UpstreamExports = HashMap<String, HashMap<String, Option<TypeExpr>>>;
 /// A diagnostic about a `binding.field` reference whose downstream usage
 /// doesn't fit the upstream's exports.
 ///
-/// Four error types share this shape — name-not-exported
+/// Five error types share this shape — name-not-exported
 /// ([`UpstreamFieldError`]), top-level type mismatch
 /// ([`UpstreamTypeError`]), `for`-iterable shape mismatch
-/// ([`UpstreamForIterableShapeError`]), and attribute-access shape
-/// mismatch ([`UpstreamAttributeAccessShapeError`]). They share their CLI
-/// and LSP wirings through this trait so adding a fifth check is one
-/// `impl`, not three identical extends/loops.
+/// ([`UpstreamForIterableShapeError`]), attribute-access shape
+/// mismatch ([`UpstreamAttributeAccessShapeError`]), and subscript
+/// shape mismatch ([`UpstreamSubscriptShapeError`]). They share their
+/// CLI and LSP wirings through this trait so adding a sixth check is
+/// one `impl`, not three identical extends/loops.
 ///
 /// Excludes [`UpstreamResolveError`] on purpose: a resolve failure
 /// doesn't have a `(binding, field)` pair (the upstream source itself
@@ -826,7 +827,7 @@ fn visit_attribute_access(
         let Some(Some(export_type)) = fields.get(attribute) else {
             return;
         };
-        if let Some((mismatched_at, bad_segment)) = walk_type_expr_path(export_type, field_path) {
+        if let Err((mismatched_at, bad_segment)) = walk_type_expr_path(export_type, field_path) {
             errors.push(UpstreamAttributeAccessShapeError {
                 location: location.to_string(),
                 binding: binding.to_string(),
@@ -839,9 +840,12 @@ fn visit_attribute_access(
     });
 }
 
-/// Walk `field_path` against `start`. Return
-/// `Some((mismatched_type, bad_segment))` for the first segment that
-/// can't be resolved; return `None` when the entire path resolves cleanly.
+/// Walk `field_path` against `start`. Return `Ok(tail_type)` on a
+/// clean walk and `Err((mismatched_type, bad_segment))` for the first
+/// segment that can't be resolved. Lists, maps, and scalars never host
+/// `.field` access — the parent type they reach is the right anchor
+/// for the diagnostic builder's "use iteration / subscript / nothing"
+/// suggestion.
 ///
 /// Walks by reference so deep struct paths don't pay an O(depth) clone
 /// chain — the caller clones once at the return site if it needs an
@@ -849,7 +853,7 @@ fn visit_attribute_access(
 fn walk_type_expr_path<'a, 'b>(
     start: &'a TypeExpr,
     field_path: &'b [String],
-) -> Option<(&'a TypeExpr, &'b str)> {
+) -> Result<&'a TypeExpr, (&'a TypeExpr, &'b str)> {
     let mut current = start;
     for segment in field_path {
         match current {
@@ -857,17 +861,186 @@ fn walk_type_expr_path<'a, 'b>(
                 Some((_, ty)) => {
                     current = ty;
                 }
-                None => return Some((current, segment.as_str())),
+                None => return Err((current, segment.as_str())),
             },
-            // Lists, maps, and scalars don't host `.field` access at all.
-            // The caller wants iteration / subscript / nothing,
-            // respectively. The mismatched type is the parent that was
-            // reached; the diagnostic builder turns that into the right
-            // suggestion.
-            _ => return Some((current, segment.as_str())),
+            _ => return Err((current, segment.as_str())),
         }
     }
-    None
+    Ok(current)
+}
+
+/// A `[index]` subscript reads an `upstream_state` export at a depth
+/// where the declared `TypeExpr` doesn't permit that subscript shape:
+/// integer subscript against `map(_)` / `Struct{...}` / scalar, or
+/// string subscript against `list(_)` / `Struct{...}` / scalar.
+#[derive(Debug, Clone)]
+pub struct UpstreamSubscriptShapeError {
+    pub location: String,
+    pub binding: String,
+    pub field: String,
+    /// Field-chain segments between `binding.field` and the offending
+    /// subscript. Empty when the subscript sits directly on the
+    /// top-level export (`orgs.accounts[0]`).
+    pub field_path: Vec<String>,
+    /// What the upstream declared at the position the bad subscript
+    /// reads. For `orgs.accounts[0]` against `accounts: map(_)` this
+    /// is the `map(_)`; for `orgs.region[0]` it's the scalar.
+    pub mismatched_at: TypeExpr,
+    /// The literal subscript the user wrote — preserved so the
+    /// diagnostic echoes their own syntax (`[0]` / `["alpha"]`)
+    /// rather than a placeholder.
+    pub bad_subscript: Subscript,
+}
+
+impl UpstreamSubscriptShapeError {
+    pub fn diagnostic_message(&self) -> String {
+        let mut access = format!("{}.{}", self.binding, self.field);
+        for seg in &self.field_path {
+            access.push('.');
+            access.push_str(seg);
+        }
+        let mut bad = String::new();
+        self.bad_subscript.append_to_dot_string(&mut bad);
+        let suggestion = match (&self.mismatched_at, &self.bad_subscript) {
+            (TypeExpr::List(_), Subscript::Str { .. }) => {
+                "; integer subscript `[i]` reads list elements"
+            }
+            (TypeExpr::Map(_), Subscript::Int { .. }) => {
+                "; string subscript `[\"k\"]` reads map entries"
+            }
+            // Struct/scalar don't host any subscript form, so the
+            // "use the other syntax" hint would be misleading. Stay
+            // silent and let the caller show the declared type.
+            _ => "",
+        };
+        format!(
+            "upstream_state `{}` is declared as `{}`; `{}{}` does not fit{}",
+            access, self.mismatched_at, access, bad, suggestion,
+        )
+    }
+}
+
+impl std::fmt::Display for UpstreamSubscriptShapeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.location, self.diagnostic_message())
+    }
+}
+
+impl std::error::Error for UpstreamSubscriptShapeError {}
+
+impl UpstreamRefDiagnostic for UpstreamSubscriptShapeError {
+    fn location(&self) -> &str {
+        &self.location
+    }
+    fn binding(&self) -> &str {
+        &self.binding
+    }
+    fn field(&self) -> &str {
+        &self.field
+    }
+    fn diagnostic_message(&self) -> String {
+        UpstreamSubscriptShapeError::diagnostic_message(self)
+    }
+}
+
+/// Walk every `Value::ResourceRef` whose root is an `upstream_state`
+/// binding and whose `subscripts` chain is non-empty, and emit an error
+/// whenever a subscript's kind (integer vs string) doesn't fit the
+/// declared upstream `TypeExpr` at that depth.
+///
+/// Skipped silently when:
+/// - the binding isn't in `exports` (already surfaced by
+///   `check_upstream_state_field_references` if it should be);
+/// - the field isn't exported (same — duplicate diagnostics hurt);
+/// - the export has no declared type (`accounts` without `: T`) — there's
+///   no upstream type to compare the subscript against;
+/// - the leading `field_path` already mismatches the declared shape
+///   (already handled by `check_upstream_state_attribute_access_shapes`)
+///   — in that case the field-walk diagnostic is enough.
+pub fn check_upstream_state_subscript_shapes(
+    parsed: &ParsedFile,
+    exports: &UpstreamExports,
+) -> Vec<UpstreamSubscriptShapeError> {
+    let mut errors: Vec<UpstreamSubscriptShapeError> = Vec::new();
+    for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
+        visit_subscript_access(
+            value,
+            exports,
+            &resource_attr_location(ctx, resource, attr_name),
+            &mut errors,
+        );
+    });
+    for_each_non_resource_value(
+        parsed,
+        NonResourceScope::ExportsAndModules,
+        |value, location| {
+            visit_subscript_access(value, exports, location, &mut errors);
+        },
+    );
+    errors.sort_by(|a, b| {
+        (a.location.as_str(), a.binding.as_str(), a.field.as_str()).cmp(&(
+            b.location.as_str(),
+            b.binding.as_str(),
+            b.field.as_str(),
+        ))
+    });
+    errors
+}
+
+/// Walk a Value tree, find every `ResourceRef` with a non-empty
+/// `subscripts` chain, and check each subscript's kind against the
+/// upstream's declared `TypeExpr` at that depth.
+fn visit_subscript_access(
+    value: &Value,
+    exports: &UpstreamExports,
+    location: &str,
+    errors: &mut Vec<UpstreamSubscriptShapeError>,
+) {
+    value.visit_refs(&mut |path| {
+        let subscripts = path.subscripts();
+        if subscripts.is_empty() {
+            return;
+        }
+        let binding = path.binding();
+        let attribute = path.attribute();
+        let Some(fields) = exports.get(binding) else {
+            return;
+        };
+        let Some(Some(export_type)) = fields.get(attribute) else {
+            return;
+        };
+        // If the field path itself doesn't resolve, the
+        // attribute-access check will already report it. Skip here so
+        // we don't double-fire.
+        let field_path = path.field_path();
+        let Ok(at_field_end) = walk_type_expr_path(export_type, field_path) else {
+            return;
+        };
+        // Step through each subscript, descending into the element
+        // type when it fits and emitting at the first kind mismatch.
+        let mut current = at_field_end;
+        for sub in subscripts {
+            match (current, sub) {
+                (TypeExpr::List(inner), Subscript::Int { .. }) => {
+                    current = inner.as_ref();
+                }
+                (TypeExpr::Map(inner), Subscript::Str { .. }) => {
+                    current = inner.as_ref();
+                }
+                (mismatched_at, bad) => {
+                    errors.push(UpstreamSubscriptShapeError {
+                        location: location.to_string(),
+                        binding: binding.to_string(),
+                        field: attribute.to_string(),
+                        field_path: field_path.to_vec(),
+                        mismatched_at: mismatched_at.clone(),
+                        bad_subscript: bad.clone(),
+                    });
+                    return;
+                }
+            }
+        }
+    });
 }
 
 #[cfg(test)]
@@ -2390,11 +2563,327 @@ mod tests {
     }
 
     // ================================================================
+    // #2318: subscript-after-field shape compatibility
+    // (`check_upstream_state_subscript_shapes`)
+    // ================================================================
+
+    #[test]
+    fn subscript_int_against_list_export_is_ok() {
+        // `orgs.accounts[0]` against `accounts: list(String)` — integer
+        // subscripts read list elements; shape check stays silent.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("accounts", TypeExpr::List(Box::new(TypeExpr::String)))],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(errs.is_empty(), "[int] on list(_) must pass, got: {errs:?}");
+    }
+
+    #[test]
+    fn subscript_str_against_map_export_is_ok() {
+        // `orgs.accounts["alpha"]` against `accounts: map(String)` —
+        // string subscripts read map entries; shape check stays silent.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts["alpha"]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("accounts", TypeExpr::Map(Box::new(TypeExpr::String)))],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(
+            errs.is_empty(),
+            "[\"k\"] on map(_) must pass, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_int_against_map_export_flags_mismatch() {
+        // `orgs.accounts[0]` against `accounts: map(String)` — wrong
+        // syntax; should fire with a hint to use `["k"]`.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("accounts", TypeExpr::Map(Box::new(TypeExpr::String)))],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert_eq!(errs.len(), 1, "[int] on map must fail, got: {errs:?}");
+        assert_eq!(errs[0].binding, "orgs");
+        assert_eq!(errs[0].field, "accounts");
+        assert!(matches!(errs[0].bad_subscript, Subscript::Int { index: 0 }));
+        let msg = errs[0].diagnostic_message();
+        assert!(msg.contains("map"), "message must mention map shape: {msg}");
+        assert!(
+            msg.contains("[0]"),
+            "message must echo the user's literal subscript, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn subscript_str_against_list_export_flags_mismatch() {
+        // `orgs.accounts["alpha"]` against `accounts: list(String)` —
+        // wrong syntax; should fire with a hint to use `[i]`.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts["alpha"]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("accounts", TypeExpr::List(Box::new(TypeExpr::String)))],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert_eq!(errs.len(), 1, "[\"k\"] on list must fail, got: {errs:?}");
+        assert!(matches!(errs[0].bad_subscript, Subscript::Str { .. }));
+        let msg = errs[0].diagnostic_message();
+        assert!(
+            msg.contains("list"),
+            "message must mention list shape: {msg}"
+        );
+    }
+
+    #[test]
+    fn subscript_against_struct_export_flags_mismatch() {
+        // `orgs.account[0]` against `account: struct {...}` — structs
+        // don't host any subscript form. The diagnostic stays silent on
+        // the "use the other syntax" hint because neither would help.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.account[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "account",
+                TypeExpr::Struct {
+                    fields: vec![("id".to_string(), TypeExpr::String)],
+                },
+            )],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert_eq!(
+            errs.len(),
+            1,
+            "subscript on struct must fail, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_against_scalar_export_flags_mismatch() {
+        // `orgs.region[0]` against `region: String` — scalars are not
+        // subscriptable.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.region[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[("orgs", &[("region", TypeExpr::String)])]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert_eq!(
+            errs.len(),
+            1,
+            "subscript on scalar must fail, got: {errs:?}"
+        );
+        let msg = errs[0].diagnostic_message();
+        assert!(
+            msg.contains("String"),
+            "message must show scalar export type: {msg}"
+        );
+    }
+
+    #[test]
+    fn subscript_after_struct_field_walks_path() {
+        // `orgs.account.children[0]` against
+        // `account: struct { children: list(String) }` — the walker
+        // must descend through the struct field before checking the
+        // subscript.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.account.children[0]
+                }
+            "#,
+            "test",
+        );
+        let outer = TypeExpr::Struct {
+            fields: vec![(
+                "children".to_string(),
+                TypeExpr::List(Box::new(TypeExpr::String)),
+            )],
+        };
+        let exports = mk_typed_exports(&[("orgs", &[("account", outer)])]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(
+            errs.is_empty(),
+            "subscript after struct field walks path, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_skipped_when_export_has_no_declared_type() {
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts[0]
+                }
+            "#,
+            "test",
+        );
+        let mut exports = UpstreamExports::new();
+        let mut fields = HashMap::new();
+        fields.insert("accounts".to_string(), None);
+        exports.insert("orgs".to_string(), fields);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(errs.is_empty(), "no annotation → silent, got: {errs:?}");
+    }
+
+    #[test]
+    fn subscript_skipped_when_binding_unknown() {
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(errs.is_empty(), "missing binding → silent, got: {errs:?}");
+    }
+
+    #[test]
+    fn subscript_skipped_when_field_path_mismatches() {
+        // `orgs.account.bad[0]` — the `.bad` already mismatches the
+        // declared struct type. Don't double-fire on the subscript;
+        // the attribute-access check owns that diagnostic.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.account.bad[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "account",
+                TypeExpr::Struct {
+                    fields: vec![("id".to_string(), TypeExpr::String)],
+                },
+            )],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(
+            errs.is_empty(),
+            "field-path mismatch is the attribute-access check's job, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_chained_descends_into_inner_type() {
+        // `orgs.matrix[0][1]` against `matrix: list(list(String))` —
+        // each integer subscript peels one `list(_)` layer.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.matrix[0][1]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "matrix",
+                TypeExpr::List(Box::new(TypeExpr::List(Box::new(TypeExpr::String)))),
+            )],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert!(
+            errs.is_empty(),
+            "list(list(_))[0][1] must pass, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn subscript_chained_flags_inner_mismatch() {
+        // `orgs.matrix[0]["k"]` against `matrix: list(list(String))` —
+        // first `[0]` peels to `list(String)`; second `["k"]` then
+        // mismatches.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.matrix[0]["k"]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "matrix",
+                TypeExpr::List(Box::new(TypeExpr::List(Box::new(TypeExpr::String)))),
+            )],
+        )]);
+        let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
+        assert_eq!(
+            errs.len(),
+            1,
+            "second subscript mismatch must fire, got: {errs:?}"
+        );
+        assert!(matches!(errs[0].bad_subscript, Subscript::Str { .. }));
+    }
+
+    // ================================================================
     // #2319: UpstreamRefDiagnostic trait
     // ================================================================
 
     #[test]
-    fn upstream_ref_diagnostic_trait_covers_all_four_error_types() {
+    fn upstream_ref_diagnostic_trait_covers_all_five_error_types() {
         // Building a `Vec<&dyn UpstreamRefDiagnostic>` proves each type
         // implements the trait and that the LSP/CLI can iterate them
         // uniformly. The CLI/LSP wirings rely on this being possible.
@@ -2428,6 +2917,14 @@ mod tests {
             },
             bad_segment: "bad".to_string(),
         };
+        let subscript_err = UpstreamSubscriptShapeError {
+            location: "loc-e".to_string(),
+            binding: "orgs".to_string(),
+            field: "accounts".to_string(),
+            field_path: vec![],
+            mismatched_at: TypeExpr::Map(Box::new(TypeExpr::String)),
+            bad_subscript: Subscript::Int { index: 0 },
+        };
         // Tuples of (dyn-trait reference, expected location, expected
         // binding, expected field, expected diagnostic_message). Looping
         // catches a future struct that silently desyncs trait impls
@@ -2460,6 +2957,13 @@ mod tests {
                 "orgs",
                 "account",
                 attr_err.diagnostic_message(),
+            ),
+            (
+                &subscript_err,
+                "loc-e",
+                "orgs",
+                "accounts",
+                subscript_err.diagnostic_message(),
             ),
         ];
         for (d, expected_location, expected_binding, expected_field, expected_message) in cases {

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -479,11 +479,13 @@ impl DiagnosticEngine {
             carina_core::upstream_exports::check_upstream_state_attribute_access_shapes(
                 merged, &exports,
             );
+        let subscript_errors =
+            carina_core::upstream_exports::check_upstream_state_subscript_shapes(merged, &exports);
         let mut seen_count: std::collections::HashMap<String, usize> =
             std::collections::HashMap::new();
-        // The four upstream-ref checks return distinct concrete types
+        // The five upstream-ref checks return distinct concrete types
         // but share `UpstreamRefDiagnostic`; chain them through the
-        // trait so adding a fifth check is one extra `chain(...)`.
+        // trait so adding a sixth check is one extra `chain(...)`.
         self.push_upstream_ref_diagnostics(
             doc,
             &mut seen_count,
@@ -495,6 +497,11 @@ impl DiagnosticEngine {
                 .chain(shape_errors.iter().map(|e| e as &dyn UpstreamRefDiagnostic))
                 .chain(
                     attribute_access_errors
+                        .iter()
+                        .map(|e| e as &dyn UpstreamRefDiagnostic),
+                )
+                .chain(
+                    subscript_errors
                         .iter()
                         .map(|e| e as &dyn UpstreamRefDiagnostic),
                 )


### PR DESCRIPTION
## Summary
- Parser accepts `binding.field[idx]` / `binding.field.subfield["k"]…` (was a hard-coded parse error).
- `AccessPath` carries `subscripts: Vec<Subscript>` alongside the existing `field_path`. `to_dot_string` round-trips the `[…]` form (string keys escape via `{:?}`).
- Resolver descends `List`/`Map` values by integer/string subscripts; out-of-range or missing keys leave the ref unresolved so the planner can surface it.
- Module expander preserves `subscripts` when rewriting intra-module refs and when remapping synthetic instance prefixes.
- New cross-directory shape check `check_upstream_state_subscript_shapes` rejects `[int]` against `map(_)` / `Struct{...}` / scalar and `[\"k\"]` against `list(_)` / `Struct{...}` / scalar before apply. Wired into CLI and LSP next to the four existing upstream-ref checks.
- `walk_type_expr_path` unified into a single `Result<&TypeExpr, (&TypeExpr, &str)>` walker shared by attribute-access and subscript checks.
- Negative subscripts (`[-1]`) rejected at parse time; the DSL has no Python-style from-end semantic.

Closes #2318

## Test plan
- [x] `cargo nextest run --workspace` (2508 tests pass, was 2501)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (docs / examples / no-direct-resources / plan-fixtures / provider-boundaries)
- [x] Parser tests: `parse_subscript_after_field_access_with_integer`, `…_with_string_key`, `parse_subscript_after_nested_field_access`, `parse_chained_subscripts_after_field_access`, `parse_field_after_subscript_after_field_is_rejected`, `parse_negative_subscript_is_rejected`
- [x] Resolver tests: list-descent, map-descent, out-of-range fall-through
- [x] Shape-check tests: 11 cases covering int/str × list/map/struct/scalar, nested struct path, no-annotation skip, unknown-binding skip, field-path-mismatch silent skip, chained `[0][1]`, chained inner mismatch
- [x] `UpstreamRefDiagnostic` trait parity test extended to 5 error types
- [x] Format round-trip on `orgs.accounts[0]` / `orgs.accounts[\"alpha\"]` / `orgs.account.children[0]` / `orgs.matrix[0][1]`