### PR TITLE
refactor(core,protocol): rename data_source: bool to SchemaKind enum, ResourceKind::Real to Managed

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -278,7 +278,7 @@ pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceI
     Resource {
         id: id.clone(),
         attributes: attributes.into_iter().collect(),
-        kind: carina_core::resource::ResourceKind::Real,
+        kind: carina_core::resource::ResourceKind::Managed,
         lifecycle: rs.lifecycle.clone(),
         prefixes: rs.prefixes.clone(),
         binding: rs.binding.clone(),

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -339,7 +339,7 @@ pub fn create_plan(
                     // matter (it only feeds the dependency walker), so
                     // a plain clone-through `wrap_map` is fine.
                     attributes: state.attributes.clone().into_iter().collect(),
-                    kind: ResourceKind::Real,
+                    kind: ResourceKind::Managed,
                     lifecycle: lifecycle.clone(),
                     prefixes: HashMap::new(),
                     binding: None,

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -33,7 +33,7 @@ fn create_test_module() -> ParsedFile {
                 );
                 attrs.into_iter().collect()
             },
-            kind: ResourceKind::Real,
+            kind: ResourceKind::Managed,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: None,
@@ -161,7 +161,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                     );
                     attrs.into_iter().collect()
                 },
-                kind: ResourceKind::Real,
+                kind: ResourceKind::Managed,
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: Some("vpc".to_string()),
@@ -179,7 +179,7 @@ fn create_module_with_intra_refs() -> ParsedFile {
                     );
                     attrs.into_iter().collect()
                 },
-                kind: ResourceKind::Real,
+                kind: ResourceKind::Managed,
                 lifecycle: LifecycleConfig::default(),
                 prefixes: HashMap::new(),
                 binding: Some("subnet".to_string()),
@@ -306,7 +306,7 @@ fn create_module_with_attributes() -> ParsedFile {
                 );
                 attrs.into_iter().collect()
             },
-            kind: ResourceKind::Real,
+            kind: ResourceKind::Managed,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: Some("sg".to_string()),
@@ -1107,7 +1107,7 @@ fn create_module_with_interpolation() -> ParsedFile {
                 );
                 attrs.into_iter().collect()
             },
-            kind: ResourceKind::Real,
+            kind: ResourceKind::Managed,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: Some("vpc".to_string()),

--- a/carina-core/src/parser/blocks/resource.rs
+++ b/carina-core/src/parser/blocks/resource.rs
@@ -54,7 +54,7 @@ pub(in crate::parser) fn parse_anonymous_resource(
     Ok(Resource {
         id,
         attributes: attributes.into_iter().collect(),
-        kind: ResourceKind::Real,
+        kind: ResourceKind::Managed,
         lifecycle,
         prefixes: HashMap::new(),
         binding: None,
@@ -215,7 +215,7 @@ pub(crate) fn parse_resource_expr(
     Ok(Resource {
         id,
         attributes: attributes.into_iter().collect(),
-        kind: ResourceKind::Real,
+        kind: ResourceKind::Managed,
         lifecycle,
         prefixes: HashMap::new(),
         binding: Some(binding_name.to_string()),

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -929,9 +929,9 @@ impl ModuleSource {
 /// Classification of a resource in the IR
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ResourceKind {
-    /// A real infrastructure resource managed by a provider
+    /// A managed infrastructure resource with full CRUD lifecycle.
     #[default]
-    Real,
+    Managed,
     /// A virtual resource created by the module resolver to expose module attributes.
     /// Virtual resources are not sent to providers; they exist only in the IR.
     Virtual {
@@ -953,7 +953,7 @@ pub struct Resource {
     /// re-renders attributes — diagnostic messages, formatter output,
     /// plan display, snapshot tests — depends on this stability (#2222).
     pub attributes: IndexMap<String, Value>,
-    /// Classification of this resource (real, virtual, or data source)
+    /// Classification of this resource (managed, virtual, or data source)
     #[serde(default)]
     pub kind: ResourceKind,
     /// Lifecycle meta-argument configuration
@@ -1000,7 +1000,7 @@ impl Resource {
         Self {
             id: ResourceId::new(resource_type, name),
             attributes: IndexMap::new(),
-            kind: ResourceKind::Real,
+            kind: ResourceKind::Managed,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: None,
@@ -1018,7 +1018,7 @@ impl Resource {
         Self {
             id: ResourceId::with_provider(provider, resource_type, name),
             attributes: IndexMap::new(),
-            kind: ResourceKind::Real,
+            kind: ResourceKind::Managed,
             lifecycle: LifecycleConfig::default(),
             prefixes: HashMap::new(),
             binding: None,

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -583,9 +583,9 @@ fn resource_default_metadata_fields() {
 }
 
 #[test]
-fn resource_kind_enum_real_by_default() {
+fn resource_kind_enum_managed_by_default() {
     let resource = Resource::new("s3.Bucket", "my-bucket");
-    assert_eq!(resource.kind, ResourceKind::Real);
+    assert_eq!(resource.kind, ResourceKind::Managed);
     assert!(!resource.is_virtual());
     assert!(!resource.is_data_source());
 }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1747,6 +1747,16 @@ pub struct OperationConfig {
     pub create_max_retries: Option<u32>,
 }
 
+/// Classification of a resource schema: managed (full CRUD lifecycle) vs
+/// data source (read-only lookup of existing infrastructure).
+///
+/// See `docs/specs/2026-05-02-resource-vs-data-source-design.md` (Decision 1-1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaKind {
+    Managed,
+    DataSource,
+}
+
 /// Resource schema
 #[derive(Debug, Clone)]
 pub struct ResourceSchema {
@@ -1756,8 +1766,9 @@ pub struct ResourceSchema {
     /// Optional validator function for cross-attribute validation
     /// (e.g., mutually exclusive required fields)
     pub validator: Option<ResourceValidator>,
-    /// If true, this resource type is a data source and must be used with `read`
-    pub data_source: bool,
+    /// Whether this is a managed resource or a data source.
+    /// Data sources must be used with the `read` keyword.
+    pub kind: SchemaKind,
     /// The attribute that serves as the unique name for this resource type.
     /// Used for automatic unique name generation during create-before-destroy replacement.
     /// (e.g., "bucket_name" for s3.bucket, "log_group_name" for logs.log_group)
@@ -1784,7 +1795,7 @@ impl ResourceSchema {
             attributes: HashMap::new(),
             description: None,
             validator: None,
-            data_source: false,
+            kind: SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,
@@ -1822,8 +1833,12 @@ impl ResourceSchema {
     }
 
     pub fn as_data_source(mut self) -> Self {
-        self.data_source = true;
+        self.kind = SchemaKind::DataSource;
         self
+    }
+
+    pub fn is_data_source(&self) -> bool {
+        matches!(self.kind, SchemaKind::DataSource)
     }
 
     pub fn with_name_attribute(mut self, attr: impl Into<String>) -> Self {

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -13,15 +13,17 @@ fn attribute_schema_write_only_builder() {
 }
 
 #[test]
-fn resource_schema_data_source_default_false() {
+fn resource_schema_kind_default_managed() {
     let schema = ResourceSchema::new("test.resource");
-    assert!(!schema.data_source);
+    assert_eq!(schema.kind, SchemaKind::Managed);
+    assert!(!schema.is_data_source());
 }
 
 #[test]
-fn resource_schema_as_data_source_sets_flag() {
+fn resource_schema_as_data_source_sets_kind() {
     let schema = ResourceSchema::new("test.resource").as_data_source();
-    assert!(schema.data_source);
+    assert_eq!(schema.kind, SchemaKind::DataSource);
+    assert!(schema.is_data_source());
 }
 
 #[test]

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -32,7 +32,7 @@ pub fn validate_resources(
 
         match schemas.get(&schema_key) {
             Some(schema) => {
-                if schema.data_source && !resource.is_data_source() {
+                if schema.is_data_source() && !resource.is_data_source() {
                     all_errors.push(format!(
                         "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
                         schema.resource_type, schema.resource_type

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -407,7 +407,7 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
         attributes,
         description: None,
         validator: None,
-        data_source: false,
+        kind: crate::schema::SchemaKind::Managed,
         name_attribute: None,
         force_replace: false,
         operation_config: None,

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -285,7 +285,7 @@ impl DiagnosticEngine {
                 let schema = self.schemas.get(&full_resource_type).cloned();
                 if let Some(schema) = &schema {
                     // Check data source without `read` keyword
-                    if schema.data_source
+                    if schema.is_data_source()
                         && !resource.is_data_source()
                         && let Some((line, col)) = self.find_resource_type_position(
                             doc,

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -271,7 +271,10 @@ fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
             .collect(),
         description: s.description.clone(),
         validator: build_validator_from_types(&s.validators),
-        data_source: s.data_source,
+        kind: match s.kind {
+            proto::SchemaKind::Managed => carina_core::schema::SchemaKind::Managed,
+            proto::SchemaKind::DataSource => carina_core::schema::SchemaKind::DataSource,
+        },
         name_attribute: s.name_attribute.clone(),
         force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| {
@@ -670,7 +673,6 @@ mod tests {
           {
             "resource_type": "ec2.SecurityGroup",
             "description": "EC2 Security Group",
-            "data_source": false,
             "name_attribute": "group_name",
             "force_replace": true,
             "attributes": {
@@ -754,7 +756,7 @@ mod tests {
         let schema = &schemas[0];
         assert_eq!(schema.resource_type, "ec2.SecurityGroup");
         assert_eq!(schema.description.as_deref(), Some("EC2 Security Group"));
-        assert!(!schema.data_source);
+        assert!(!schema.is_data_source());
         assert_eq!(schema.name_attribute.as_deref(), Some("group_name"));
         assert!(schema.force_replace);
 
@@ -881,7 +883,7 @@ mod tests {
             resource_type: "awscc.s3.Bucket".to_string(),
             attributes: HashMap::new(),
             description: None,
-            data_source: false,
+            kind: proto::SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,
@@ -898,7 +900,7 @@ mod tests {
             resource_type: "awscc.s3.Bucket".to_string(),
             attributes: HashMap::new(),
             description: None,
-            data_source: false,
+            kind: proto::SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,
@@ -917,7 +919,7 @@ mod tests {
             resource_type: "awscc.ec2.Vpc".to_string(),
             attributes: HashMap::new(),
             description: None,
-            data_source: false,
+            kind: proto::SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,
@@ -955,7 +957,7 @@ mod tests {
             resource_type: "awscc.ec2.Vpc".to_string(),
             attributes: HashMap::new(),
             description: None,
-            data_source: false,
+            kind: proto::SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,
@@ -977,7 +979,7 @@ mod tests {
             resource_type: "awscc.s3.Bucket".to_string(),
             attributes: HashMap::new(),
             description: None,
-            data_source: false,
+            kind: proto::SchemaKind::Managed,
             name_attribute: None,
             force_replace: false,
             operation_config: None,

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -163,6 +163,24 @@ pub enum ValidatorType {
     TagsKeyValueCheck,
 }
 
+/// Classification of a schema in the provider protocol: managed (full CRUD
+/// lifecycle) vs data source (read-only lookup of existing infrastructure).
+///
+/// Mirror of `carina_core::schema::SchemaKind`. Defined here independently to
+/// keep `carina-provider-protocol` free of a dependency on `carina-core`
+/// (the protocol crate is the lightweight contract layer that providers
+/// link against).
+///
+/// `Default` is derived to back `#[serde(default)]` on `ResourceSchema::kind`,
+/// so JSON payloads from older or minimal producers omit the field and
+/// fall back to `Managed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum SchemaKind {
+    #[default]
+    Managed,
+    DataSource,
+}
+
 /// Schema types for resource validation and completion.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceSchema {
@@ -171,7 +189,7 @@ pub struct ResourceSchema {
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
-    pub data_source: bool,
+    pub kind: SchemaKind,
     #[serde(default)]
     pub name_attribute: Option<String>,
     #[serde(default)]

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -175,6 +175,7 @@ pub enum ValidatorType {
 /// so JSON payloads from older or minimal producers omit the field and
 /// fall back to `Managed`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SchemaKind {
     #[default]
     Managed,


### PR DESCRIPTION
Closes #2327

## Summary

Pure mechanical rename per ADR #2326 (Decision 1-1). No behavioural change.

- `ResourceSchema::data_source: bool` → `kind: SchemaKind { Managed, DataSource }` (new 2-value enum). Added `is_data_source()` helper mirroring `Resource::is_data_source()`.
- `ResourceKind::Real` → `Managed`. Variants stay at three (`Managed`, `DataSource`, `Virtual`).
- `carina-provider-protocol` defines its own independent mirror `SchemaKind` with `Default` backing `#[serde(default)]`, so the protocol crate keeps zero dependency on `carina-core`.
- `carina-plugin-host` bridges `proto::SchemaKind` → `core::SchemaKind` via an exhaustive match (future variants will fail to compile, which is the desired behaviour).
- `carina-lsp` validation diagnostic now goes through `schema.is_data_source()`.

## Verify

- `cargo nextest run --workspace`: **2508 tests pass**
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- All `scripts/check-*.sh`: pass

## Review

5 self-review rounds, all clean. No new issues introduced after simplify.

## Downstream impact (follow-up PRs needed)

The provider repos depend on this crate's renamed types:

- **carina-provider-aws**: any codegen template that emits `data_source: false` / `data_source: true` literals must switch to `kind: proto::SchemaKind::Managed` / `kind: proto::SchemaKind::DataSource` (or rely on `#[serde(default)]` for the Managed case). Any pattern match on `ResourceKind::Real` must be updated to `Managed`.
- **carina-provider-awscc**: same.

These are mechanical and follow the same pattern shown in this PR's diff (see `carina-plugin-host/src/wasm_convert.rs` for both shapes).

## Backward compatibility

Per project policy, no backward-compat shim. Existing `carina.state.json` files that contain `"kind": "Real"` will fail to deserialize and need to be regenerated.

## Test plan

- [x] All workspace tests pass
- [x] Doctests pass
- [x] Clippy clean with `-D warnings`
- [x] Repo-invariant scripts pass
- [ ] After merge, open follow-up PRs in `carina-provider-aws` and `carina-provider-awscc` to regenerate codegen output
