### PR TITLE
refactor(core): introduce SchemaRegistry; allow same type as Managed and DataSource (#2328)

### DIFF
--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use std::time::Duration;
 
 #[test]
@@ -8,12 +8,12 @@ fn build_state_after_apply_finds_write_only_with_provider_prefix() {
     // but the buggy code used resource.id.resource_type (e.g., "ec2.Vpc") for lookup.
     // This test verifies that write-only attributes are found when the schema key
     // includes the provider prefix.
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     let schema = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
         .attribute(AttributeSchema::new("ipv4_netmask_length", AttributeType::Int).write_only());
     // Schema is registered with provider-prefixed key
-    schemas.insert("awscc.ec2.Vpc".to_string(), schema);
+    schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "my-vpc");
     resource.set_attr(
@@ -75,7 +75,7 @@ fn build_state_after_apply_preserves_block_name_attribute() {
     // This is the scenario in issue #1499 (iam_role/with_policy).
     use carina_core::schema::StructField;
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
         .attribute(
@@ -91,7 +91,7 @@ fn build_state_after_apply_preserves_block_name_attribute() {
             )
             .with_block_name("policy"),
         );
-    schemas.insert("awscc.iam.role".to_string(), schema);
+    schemas.insert("awscc", schema);
 
     // Resource with resolved block name (policy -> policies)
     let mut resource = Resource::with_provider("awscc", "iam.role", "test-role");
@@ -301,7 +301,7 @@ fn block_name_attribute_state_roundtrip() {
     // from issue #1499.
     use carina_core::schema::StructField;
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     let schema = ResourceSchema::new("ec2.ipam")
         .attribute(
             AttributeSchema::new(
@@ -314,7 +314,7 @@ fn block_name_attribute_state_roundtrip() {
             .with_block_name("operating_region"),
         )
         .attribute(AttributeSchema::new("description", AttributeType::String));
-    schemas.insert("awscc.ec2.ipam".to_string(), schema);
+    schemas.insert("awscc", schema);
 
     // Resource with resolved block name
     let mut resource = Resource::with_provider("awscc", "ec2.ipam", "test-ipam");

--- a/carina-cli/src/commands/lint.rs
+++ b/carina-cli/src/commands/lint.rs
@@ -14,7 +14,6 @@ use carina_core::lint::{
 };
 use carina_core::module_resolver;
 use carina_core::parser::ProviderContext;
-use carina_core::provider::{self as provider_mod};
 
 use crate::error::AppError;
 use crate::wiring::{WiringContext, build_factories_from_providers};
@@ -37,7 +36,6 @@ pub fn run_lint(path: &PathBuf, provider_context: &ProviderContext) -> Result<()
 
     let (provider_factories, _) = build_factories_from_providers(&parsed.providers, base_dir);
     let ctx = WiringContext::new(provider_factories);
-    let factories = ctx.factories();
     let schemas = ctx.schemas();
 
     // Collect source texts for each .crn file
@@ -57,8 +55,7 @@ pub fn run_lint(path: &PathBuf, provider_context: &ProviderContext) -> Result<()
     let mut all_list_struct_attrs: HashSet<String> = HashSet::new();
     let mut block_name_suggestions: HashMap<String, String> = HashMap::new();
     for resource in &parsed.resources {
-        let schema_key = provider_mod::schema_key_for_resource(factories, resource);
-        if let Some(schema) = schemas.get(&schema_key) {
+        if let Some(schema) = schemas.get_for(resource) {
             all_list_struct_attrs.extend(list_struct_attr_names(schema));
             for (attr_name, attr_schema) in &schema.attributes {
                 if let Some(bn) = &attr_schema.block_name {

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -137,7 +137,7 @@ pub fn validate_and_resolve(
 /// Create a `ProviderContext` with custom type validators extracted from
 /// the already-collected schema map and factory-based validation for WASM providers.
 fn enrich_provider_context(
-    schemas: &std::collections::HashMap<String, carina_core::schema::ResourceSchema>,
+    schemas: &carina_core::schema::SchemaRegistry,
     factories: Arc<Vec<Box<dyn carina_core::provider::ProviderFactory>>>,
 ) -> ProviderContext {
     ProviderContext {
@@ -324,9 +324,6 @@ pub fn validate_and_resolve_errors_with_factories(
             &parsed.export_params,
             &parsed.resources,
             ctx.schemas(),
-            &|r: &carina_core::resource::Resource| {
-                carina_core::provider::schema_key_for_resource(ctx.factories(), r)
-            },
         ) {
             errors.extend(split_validation_message(&msg));
         }
@@ -371,9 +368,6 @@ pub fn validate_and_resolve_errors_with_factories(
             parsed,
             &upstream_exports,
             ctx.schemas(),
-            &|r: &carina_core::resource::Resource| {
-                carina_core::provider::schema_key_for_resource(ctx.factories(), r)
-            },
         );
         // #1894 (option 2): cross-directory `for`-iterable shape check.
         // Surfaces pending `list ↔ map` migrations in the upstream's

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -10,7 +10,7 @@ use carina_core::effect::Effect;
 use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
 use carina_core::resource::{Resource, ResourceId, State, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 use carina_state::{LockInfo, ResourceState, StateBackend, StateFile};
 
 use crate::error::AppError;
@@ -69,7 +69,7 @@ pub(crate) struct FinalizeApplyInput<'a> {
     pub plan: &'a Plan,
     pub backend: &'a dyn StateBackend,
     pub lock: Option<&'a LockInfo>,
-    pub schemas: &'a HashMap<String, ResourceSchema>,
+    pub schemas: &'a SchemaRegistry,
     pub export_params: &'a [carina_core::parser::ExportParameter],
 }
 
@@ -142,7 +142,7 @@ pub(crate) struct ApplyStateSave<'a> {
     pub plan: &'a Plan,
     pub successfully_deleted: &'a HashSet<ResourceId>,
     pub failed_refreshes: &'a HashSet<ResourceId>,
-    pub schemas: &'a HashMap<String, ResourceSchema>,
+    pub schemas: &'a SchemaRegistry,
 }
 
 pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateFile, AppError> {
@@ -166,15 +166,8 @@ pub(crate) fn build_state_after_apply(save: ApplyStateSave<'_>) -> Result<StateF
             resource.id.name_str(),
         );
         // Collect write-only attribute names from the schema for this resource type.
-        // Schema keys include the provider prefix (e.g., "awscc.ec2.Vpc"), so we must
-        // construct the key the same way as schema_key_for_resource().
-        let schema_key = if resource.id.provider.is_empty() {
-            resource.id.resource_type.clone()
-        } else {
-            format!("{}.{}", resource.id.provider, resource.id.resource_type)
-        };
         let write_only_keys: Vec<String> = schemas
-            .get(&schema_key)
+            .get_for(resource)
             .map(|schema| {
                 schema
                     .attributes

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -422,7 +422,7 @@ async fn run_state_show(
 
     if tui {
         let plan = build_plan_from_state(&state);
-        carina_tui::run(&plan, &HashMap::new())
+        carina_tui::run(&plan, &carina_core::schema::SchemaRegistry::new())
             .map_err(|e| AppError::Config(format!("TUI error: {}", e)))?;
     } else {
         let output = format_state_show(&state);

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -19,7 +19,7 @@ use carina_core::plan_tree::{
     build_dependency_graph, build_single_parent_tree, extract_compact_hint,
 };
 use carina_core::resource::{ResourceId, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 #[cfg(test)]
 use carina_core::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
@@ -185,7 +185,7 @@ pub fn print_plan(
     plan: &Plan,
     detail: DetailLevel,
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
-    schemas: Option<&HashMap<String, ResourceSchema>>,
+    schemas: Option<&SchemaRegistry>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
@@ -212,7 +212,7 @@ pub fn format_plan(
     plan: &Plan,
     detail: DetailLevel,
     delete_attributes: &HashMap<ResourceId, HashMap<String, Value>>,
-    schemas: Option<&HashMap<String, ResourceSchema>>,
+    schemas: Option<&SchemaRegistry>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
@@ -373,7 +373,7 @@ struct TreeRenderContext<'a> {
     dependents: HashMap<usize, Vec<usize>>,
     detail: DetailLevel,
     delete_attributes: Option<&'a HashMap<ResourceId, HashMap<String, Value>>>,
-    schemas: Option<&'a HashMap<String, ResourceSchema>>,
+    schemas: Option<&'a SchemaRegistry>,
     moved_origins: &'a HashMap<ResourceId, ResourceId>,
     /// ResourceIds that are targets of Update or Replace effects.
     /// Used to skip Move line display when the move is already shown via annotation.
@@ -731,7 +731,7 @@ fn format_plan_tree(
     plan: &Plan,
     detail: DetailLevel,
     delete_attributes: Option<&HashMap<ResourceId, HashMap<String, Value>>>,
-    schemas: Option<&HashMap<String, ResourceSchema>>,
+    schemas: Option<&SchemaRegistry>,
     moved_origins: &HashMap<ResourceId, ResourceId>,
 ) -> String {
     // Build dependency graph from effects

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -13,7 +13,7 @@ use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::plan::Plan;
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{ResourceId, State, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 use carina_state::{StateFile, check_and_migrate};
 
 use crate::commands::validate_and_resolve;
@@ -30,7 +30,7 @@ const FIXTURE_SUBPATH: &str = "tests/fixtures/plan_display";
 pub struct FixturePlan {
     pub plan: Plan,
     pub current_states: HashMap<ResourceId, State>,
-    pub schemas: HashMap<String, ResourceSchema>,
+    pub schemas: SchemaRegistry,
     pub moved_origins: HashMap<ResourceId, ResourceId>,
     pub deferred_for_expressions: Vec<carina_core::parser::DeferredForExpression>,
     pub export_params: Vec<carina_core::parser::ExportParameter>,

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use carina_core::config_loader::load_configuration;
 use carina_core::resource::{ResourceId, State};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 
 use crate::DetailLevel;
 use crate::display::{format_destroy_plan, format_plan};
@@ -26,7 +26,7 @@ fn build_plan_from_fixture(
     fixture_dir: &str,
 ) -> (
     carina_core::plan::Plan,
-    HashMap<String, ResourceSchema>,
+    SchemaRegistry,
     HashMap<ResourceId, ResourceId>,
 ) {
     let fp = build_plan_from_fixture_name(fixture_dir);
@@ -39,7 +39,7 @@ fn build_plan_and_states_from_fixture(
 ) -> (
     carina_core::plan::Plan,
     HashMap<ResourceId, State>,
-    HashMap<String, ResourceSchema>,
+    SchemaRegistry,
     HashMap<ResourceId, ResourceId>,
 ) {
     let fp = build_plan_from_fixture_name(fixture_dir);

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -11,7 +11,7 @@ use carina_core::parser::{ParsedFile, ProviderConfig};
 use carina_core::plan::Plan;
 use carina_core::provider::{BoxFuture, ProviderError, ProviderResult};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_state::{BackendError, LockInfo, ResourceState, StateBackend, StateFile};
 
 use crate::commands::apply::{
@@ -143,7 +143,7 @@ async fn refresh_pending_states_updates_saved_state_from_provider_read() {
         plan: &Plan::new(),
         successfully_deleted: &HashSet::new(),
         failed_refreshes: &failed_refreshes,
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
     })
     .unwrap();
 
@@ -191,7 +191,7 @@ async fn refresh_pending_states_removes_not_found_resource_from_saved_state() {
         plan: &Plan::new(),
         successfully_deleted: &HashSet::new(),
         failed_refreshes: &failed_refreshes,
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
     })
     .unwrap();
 
@@ -238,7 +238,7 @@ async fn refresh_pending_states_does_not_overwrite_with_stale_snapshot_when_refr
         plan: &Plan::new(),
         successfully_deleted: &HashSet::new(),
         failed_refreshes: &failed_refreshes,
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
     })
     .unwrap();
 
@@ -1260,7 +1260,7 @@ fn orphaned_state_resource_produces_delete_effect() {
         &desired,
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &saved_attrs,
         &prev_desired_keys,
         &HashMap::new(),
@@ -1390,7 +1390,7 @@ async fn lock_released_on_write_state_failure() {
         plan: &Plan::new(),
         backend: &backend,
         lock: Some(&lock),
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
         export_params: &[],
     })
     .await;
@@ -1523,7 +1523,7 @@ async fn finalize_apply_uses_write_state_locked() {
         plan: &Plan::new(),
         backend: &backend,
         lock: Some(&lock),
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
         export_params: &[],
     })
     .await;
@@ -2063,7 +2063,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         plan: &Plan::new(),
         backend: &backend,
         lock: None, // No lock
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
         export_params: &[],
     })
     .await;
@@ -2163,7 +2163,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
         &desired,
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &saved_attrs,
         &prev_desired_keys,
         &HashMap::new(),
@@ -2245,7 +2245,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
         &desired,
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &saved_attrs,
         &prev_desired_keys,
         &HashMap::new(),
@@ -2291,7 +2291,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
         &desired,
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &saved_attrs,
         &prev_desired_keys,
         &HashMap::new(),
@@ -2335,7 +2335,7 @@ fn refresh_false_without_state_file_treats_resources_as_new() {
         &desired,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -2400,7 +2400,7 @@ fn import_effect_preserves_resource_metadata_in_state() {
         plan: &plan,
         successfully_deleted: &HashSet::new(),
         failed_refreshes: &HashSet::new(),
-        schemas: &HashMap::new(),
+        schemas: &SchemaRegistry::new(),
     })
     .unwrap();
 
@@ -2465,9 +2465,9 @@ fn build_state_after_apply_persists_write_only_attributes() {
 
     // Build schema with write-only attribute.
     // Schema keys include the provider prefix (e.g., "awscc.ec2.Vpc").
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "awscc.ec2.Vpc".to_string(),
+        "awscc",
         ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
             .attribute(
@@ -2547,9 +2547,9 @@ fn build_state_after_apply_write_only_detects_value_change() {
     old_rs.write_only_attributes = vec!["ipv4_netmask_length".to_string()];
     existing_state.upsert_resource(old_rs);
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "awscc.ec2.Vpc".to_string(),
+        "awscc",
         ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
             .attribute(

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -22,7 +22,7 @@ use carina_core::provider::{
 };
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{Resource, ResourceId, State, Value};
-use carina_core::schema::{ResourceSchema, resolve_block_names};
+use carina_core::schema::{SchemaRegistry, resolve_block_names};
 use carina_core::utils;
 use carina_core::validation;
 use carina_provider_mock::MockProvider;
@@ -54,7 +54,7 @@ pub struct PlanContext {
 /// `WiringContext` and pass it through the command execution path.
 pub struct WiringContext {
     factories: Arc<Vec<Box<dyn ProviderFactory>>>,
-    schemas: HashMap<String, ResourceSchema>,
+    schemas: SchemaRegistry,
 }
 
 impl WiringContext {
@@ -74,7 +74,7 @@ impl WiringContext {
         Arc::clone(&self.factories)
     }
 
-    pub fn schemas(&self) -> &HashMap<String, ResourceSchema> {
+    pub fn schemas(&self) -> &SchemaRegistry {
         &self.schemas
     }
 }
@@ -189,7 +189,6 @@ pub fn validate_resources_with_ctx(ctx: &WiringContext, parsed: &ParsedFile) -> 
     lift_validation_result(validation::validate_resources(
         parsed,
         ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &known_providers,
     ))
 }
@@ -202,7 +201,6 @@ pub fn validate_resource_ref_types_with_ctx(
     lift_validation_result(validation::validate_resource_ref_types(
         parsed,
         ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         argument_names,
     ))
 }
@@ -216,15 +214,12 @@ pub fn validate_attribute_param_ref_types_with_ctx(
         attribute_params,
         resources,
         ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
     ))
 }
 
 /// Resolve block name aliases and attribute prefixes in one step.
 pub fn resolve_names_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) -> Vec<AppError> {
-    let mut errors = lift_validation_result(resolve_block_names(resources, ctx.schemas(), |r| {
-        provider_mod::schema_key_for_resource(ctx.factories(), r)
-    }));
+    let mut errors = lift_validation_result(resolve_block_names(resources, ctx.schemas()));
     errors.extend(resolve_attr_prefixes_with_ctx(ctx, resources));
     errors
 }
@@ -233,11 +228,7 @@ pub fn resolve_attr_prefixes_with_ctx(
     ctx: &WiringContext,
     resources: &mut [Resource],
 ) -> Vec<AppError> {
-    lift_validation_result(identifier::resolve_attr_prefixes(
-        resources,
-        ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
-    ))
+    lift_validation_result(identifier::resolve_attr_prefixes(resources, ctx.schemas()))
 }
 
 pub fn reconcile_prefixed_names(resources: &mut [Resource], state_file: &Option<StateFile>) {
@@ -293,12 +284,14 @@ pub fn apply_anonymous_to_named_renames(
     let renames = identifier::detect_anonymous_to_named_renames(
         resources,
         ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &|provider, resource_type| {
-            let schema_key = format!("{}.{}", provider, resource_type);
             let create_only_attrs = ctx
                 .schemas()
-                .get(&schema_key)
+                .get(
+                    provider,
+                    resource_type,
+                    carina_core::schema::SchemaKind::Managed,
+                )
                 .map(|s| s.create_only_attributes())
                 .unwrap_or_default();
             sf.resources_by_type(provider, resource_type)
@@ -348,12 +341,14 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
     identifier::reconcile_anonymous_identifiers(
         resources,
         ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         &|provider, resource_type| {
-            let schema_key = format!("{}.{}", provider, resource_type);
             let create_only_attrs = ctx
                 .schemas()
-                .get(&schema_key)
+                .get(
+                    provider,
+                    resource_type,
+                    carina_core::schema::SchemaKind::Managed,
+                )
                 .map(|s| s.create_only_attributes())
                 .unwrap_or_default();
 
@@ -385,13 +380,9 @@ pub fn compute_anonymous_identifiers_with_ctx(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
 ) -> Vec<AppError> {
-    match identifier::compute_anonymous_identifiers(
-        resources,
-        providers,
-        ctx.schemas(),
-        &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
-        &|name| identity_attributes_for_provider(ctx, name),
-    ) {
+    match identifier::compute_anonymous_identifiers(resources, providers, ctx.schemas(), &|name| {
+        identity_attributes_for_provider(ctx, name)
+    }) {
         Ok(()) => Vec::new(),
         Err(msg) => vec![AppError::Config(msg)],
     }
@@ -622,7 +613,6 @@ pub fn validate_module_attribute_param_types(
             &module_parsed.attribute_params,
             &module_parsed.resources,
             ctx.schemas(),
-            &|r| provider_mod::schema_key_for_resource(ctx.factories(), r),
         ) {
             // Preserve the module-path prefix the legacy wrapper emitted
             // so diagnostics point at which imported module failed.
@@ -1172,7 +1162,7 @@ pub fn add_state_block_effects(
     state_blocks: &[StateBlock],
     state_file: &Option<StateFile>,
     moved_pairs: &[(ResourceId, ResourceId)],
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) {
     // Collect resource IDs that are covered by removed blocks
     // to suppress orphan Delete effects
@@ -1190,7 +1180,7 @@ pub fn add_state_block_effects(
                 // resources via the schema's name_attribute. This lets users write
                 // `to = awscc.s3.Bucket 'carina-rs-state'` without needing the
                 // auto-generated hash name.
-                let effective_to = resolve_import_target(to, plan, state_file, schemas);
+                let effective_to = resolve_import_target(to, plan, state_file, registry);
 
                 // Skip if resource already exists in state
                 let already_in_state = state_file.as_ref().is_some_and(|sf| {
@@ -1269,10 +1259,14 @@ fn resolve_import_target(
     to: &ResourceId,
     plan: &Plan,
     state_file: &Option<StateFile>,
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) -> ResourceId {
-    let name_attr = schemas
-        .get(&to.display_type())
+    let name_attr = registry
+        .get(
+            &to.provider,
+            &to.resource_type,
+            carina_core::schema::SchemaKind::Managed,
+        )
         .and_then(|s| s.name_attribute.as_deref());
 
     // Single pass: prefer exact id match, otherwise remember the first name_attribute match.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -142,7 +142,6 @@ fn test_resolve_enum_aliases_in_struct_field() {
 fn test_normalize_state_prevents_false_enum_diff() {
     use carina_core::differ::create_plan;
     use carina_core::resource::LifecycleConfig;
-    use carina_core::schema::ResourceSchema;
 
     let ctx = WiringContext::new(vec![]);
 
@@ -167,7 +166,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     // Without normalize_state, the differ would see a false diff
     let resources_without = vec![resource.clone()];
     let lifecycles: HashMap<ResourceId, LifecycleConfig> = HashMap::new();
-    let schemas: HashMap<String, ResourceSchema> = HashMap::new();
+    let schemas = SchemaRegistry::new();
     let saved_attrs = HashMap::new();
     let prev_desired_keys = HashMap::new();
     let orphan_deps = HashMap::new();
@@ -222,12 +221,12 @@ fn test_merge_default_tags_prevents_false_diff() {
 
     // Build a minimal schema that has a "tags" attribute.
     // merge_default_tags checks for the presence of "tags" in the schema.
-    let schema = ResourceSchema::new("awscc.s3.Bucket").attribute(AttributeSchema::new(
+    let schema = ResourceSchema::new("s3.Bucket").attribute(AttributeSchema::new(
         "tags",
         AttributeType::map(AttributeType::String),
     ));
-    let mut schemas: HashMap<String, ResourceSchema> = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     // Desired resource without explicit tags
     let resource = Resource::with_provider("awscc", "s3.Bucket", "test-bucket");
@@ -340,9 +339,9 @@ fn import_fallback_matches_anonymous_resource_by_name_attribute() {
     use carina_core::schema::ResourceSchema;
 
     // Schema with name_attribute = "bucket_name"
-    let bucket_schema = ResourceSchema::new("awscc.s3.Bucket").with_name_attribute("bucket_name");
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), bucket_schema);
+    let bucket_schema = ResourceSchema::new("s3.Bucket").with_name_attribute("bucket_name");
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", bucket_schema);
 
     // Anonymous resource with hash name but bucket_name = "carina-rs-state"
     let mut resource = Resource::with_provider("awscc", "s3.Bucket", "s3_bucket_1d43a664");
@@ -388,9 +387,9 @@ fn import_fallback_skips_when_already_in_state_by_name_attribute() {
     use carina_core::schema::ResourceSchema;
     use carina_state::state::{ResourceState, StateFile};
 
-    let bucket_schema = ResourceSchema::new("awscc.s3.Bucket").with_name_attribute("bucket_name");
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), bucket_schema);
+    let bucket_schema = ResourceSchema::new("s3.Bucket").with_name_attribute("bucket_name");
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", bucket_schema);
 
     // State has the resource under its anonymous hash name
     let mut state_file = StateFile::new();

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -27,7 +27,7 @@ use carina_core::provider::{
 };
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+    AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField, legacy_validator,
 };
 use carina_lsp::diagnostics::DiagnosticEngine;
 use carina_lsp::document::Document;
@@ -46,30 +46,29 @@ fn write_fixture(files: &[(&str, &str)]) -> TempDir {
     dir
 }
 
-fn engine_with_schemas(schemas: HashMap<String, ResourceSchema>) -> DiagnosticEngine {
+fn engine_with_schemas(schemas: SchemaRegistry) -> DiagnosticEngine {
     let provider_names: Vec<String> = schemas
-        .keys()
-        .filter_map(|k| k.split('.').next())
+        .iter()
+        .map(|(provider, _, _, _)| provider.to_string())
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
-        .map(String::from)
         .collect();
     DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(vec![]))
 }
 
-fn single_schema_map(schema: ResourceSchema) -> HashMap<String, ResourceSchema> {
-    let mut schemas = HashMap::new();
-    schemas.insert(schema.resource_type.clone(), schema);
+fn single_schema_map(schema: ResourceSchema) -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
     schemas
 }
 
 /// Build a `ProviderFactory` set covering every provider name implied by
 /// the schemas. The CLI pipeline keys schemas by provider, so each
 /// distinct prefix (`test`, `aws`, ...) needs its own factory entry.
-fn factories_for(schemas: &HashMap<String, ResourceSchema>) -> Vec<Box<dyn ProviderFactory>> {
+fn factories_for(schemas: &SchemaRegistry) -> Vec<Box<dyn ProviderFactory>> {
     let mut by_provider: HashMap<String, Vec<ResourceSchema>> = HashMap::new();
-    for (key, schema) in schemas {
-        let provider = key.split('.').next().unwrap_or("test").to_string();
+    for (provider, _resource_type, _kind, schema) in schemas.iter() {
+        let provider = provider.to_string();
         by_provider
             .entry(provider)
             .or_default()
@@ -218,7 +217,7 @@ impl Provider for NoopProvider {
 // Scenario 1: StringEnum bare / TypeQualified / fully-qualified all pass
 // ============================================================================
 
-fn enum_schemas() -> HashMap<String, ResourceSchema> {
+fn enum_schemas() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
@@ -226,7 +225,7 @@ fn enum_schemas() -> HashMap<String, ResourceSchema> {
         to_dsl: None,
     };
     single_schema_map(
-        ResourceSchema::new("test.r.mode_holder")
+        ResourceSchema::new("r.mode_holder")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("mode", mode)),
     )
@@ -302,7 +301,7 @@ test.r.mode_holder {
 // Scenario 2: Custom type with `to_dsl` normalization (Region-like)
 // ============================================================================
 
-fn region_schemas() -> HashMap<String, ResourceSchema> {
+fn region_schemas() -> SchemaRegistry {
     fn validate_region(v: &Value) -> Result<(), String> {
         const VALID: &[&str] = &["ap-northeast-1", "us-west-2"];
         if let Value::String(s) = v {
@@ -329,7 +328,7 @@ fn region_schemas() -> HashMap<String, ResourceSchema> {
     };
 
     single_schema_map(
-        ResourceSchema::new("test.r.region_holder")
+        ResourceSchema::new("r.region_holder")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("region", region_custom)),
     )
@@ -433,7 +432,7 @@ test.r.region_holder {
 // Scenario 3: nested-Struct field type mismatch
 // ============================================================================
 
-fn nested_struct_schemas() -> HashMap<String, ResourceSchema> {
+fn nested_struct_schemas() -> SchemaRegistry {
     let inner = AttributeType::Struct {
         name: "Inner".to_string(),
         fields: vec![StructField::new("leaf", AttributeType::Int)],
@@ -447,7 +446,7 @@ fn nested_struct_schemas() -> HashMap<String, ResourceSchema> {
     };
 
     single_schema_map(
-        ResourceSchema::new("test.r.nested")
+        ResourceSchema::new("r.nested")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("outer", outer)),
     )
@@ -485,10 +484,10 @@ test.r.nested {
 // Scenario 4: Union with multiple member candidates
 // ============================================================================
 
-fn union_schemas() -> HashMap<String, ResourceSchema> {
+fn union_schemas() -> SchemaRegistry {
     let union = AttributeType::Union(vec![AttributeType::Int, AttributeType::String]);
     single_schema_map(
-        ResourceSchema::new("test.r.union")
+        ResourceSchema::new("r.union")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("value", union)),
     )
@@ -553,16 +552,16 @@ test.r.union {
 // Scenario 5: ResourceRef across sibling files
 // ============================================================================
 
-fn resource_ref_schemas() -> HashMap<String, ResourceSchema> {
-    let producer = ResourceSchema::new("test.r.producer")
+fn resource_ref_schemas() -> SchemaRegistry {
+    let producer = ResourceSchema::new("r.producer")
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new("id", AttributeType::String).read_only());
-    let consumer = ResourceSchema::new("test.r.consumer")
+    let consumer = ResourceSchema::new("r.consumer")
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new("target_id", AttributeType::String));
-    let mut schemas = HashMap::new();
-    schemas.insert(producer.resource_type.clone(), producer);
-    schemas.insert(consumer.resource_type.clone(), consumer);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", producer);
+    schemas.insert("test", consumer);
     schemas
 }
 
@@ -618,7 +617,7 @@ let upstream = test.r.producer {
 #[test]
 fn unknown_attribute_emits_suggestion_parity() {
     let schemas = single_schema_map(
-        ResourceSchema::new("test.r.suggester")
+        ResourceSchema::new("r.suggester")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("description", AttributeType::String)),
     );
@@ -650,7 +649,7 @@ test.r.suggester {
 // Scenario 3b: List<Struct> with nested-Struct field error (#2249)
 // ============================================================================
 
-fn list_struct_schemas() -> HashMap<String, ResourceSchema> {
+fn list_struct_schemas() -> SchemaRegistry {
     let inner = AttributeType::Struct {
         name: "Inner".to_string(),
         fields: vec![StructField::new("leaf", AttributeType::Int)],
@@ -663,7 +662,7 @@ fn list_struct_schemas() -> HashMap<String, ResourceSchema> {
         ],
     });
     single_schema_map(
-        ResourceSchema::new("test.r.list_nested")
+        ResourceSchema::new("r.list_nested")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("outer", outer).with_block_name("outer")),
     )
@@ -703,13 +702,13 @@ test.r.list_nested {
     );
 }
 
-fn list_struct_renamed_block_schemas() -> HashMap<String, ResourceSchema> {
+fn list_struct_renamed_block_schemas() -> SchemaRegistry {
     let rule = AttributeType::list(AttributeType::Struct {
         name: "Rule".to_string(),
         fields: vec![StructField::new("days", AttributeType::Int)],
     });
     single_schema_map(
-        ResourceSchema::new("test.r.renamed_block")
+        ResourceSchema::new("r.renamed_block")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("rules", rule).with_block_name("rule")),
     )

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -33,7 +33,7 @@
 //! type/enum diagnostics fire); only the binding-name table is scoped.
 //!
 //! ```ignore
-//! let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_fn);
+//! let index = BindingIndex::from_parsed(&parsed, &registry);
 //! if let Some(entry) = index.get("vpc") {
 //!     // entry.resource and entry.schema are both available
 //! }
@@ -41,7 +41,7 @@
 
 use crate::parser::ParsedFile;
 use crate::resource::{Resource, ResourceId, State, Value};
-use crate::schema::ResourceSchema;
+use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
 
 /// One entry in the binding index. Both fields are non-`Option` because the
@@ -68,20 +68,16 @@ pub struct BindingIndex<'a> {
 }
 
 impl<'a> BindingIndex<'a> {
-    /// Build the index from a parsed file and a schema map. `schema_key_fn`
-    /// converts a `Resource` to the key under which its schema is stored
-    /// (e.g. `"aws.s3.Bucket" -> "s3.Bucket"`); validation and the LSP both
-    /// already pass such a function around, so the contract here mirrors
-    /// theirs.
+    /// Build the index from a parsed file and a [`SchemaRegistry`]. The
+    /// registry handles the `(provider, resource_type, kind) -> schema`
+    /// lookup, including the kind-aware split between managed resources
+    /// and data sources.
     ///
-    /// Bindings whose schema is missing from `schemas` are silently skipped
-    /// — callers (validation / LSP) treat unknown resource types as a
-    /// separate diagnostic, so reporting them again here would double-count.
-    pub fn from_parsed(
-        parsed: &'a ParsedFile,
-        schemas: &'a HashMap<String, ResourceSchema>,
-        schema_key_fn: &dyn Fn(&Resource) -> String,
-    ) -> Self {
+    /// Bindings whose schema is missing from the registry are silently
+    /// skipped — callers (validation / LSP) treat unknown resource types
+    /// as a separate diagnostic, so reporting them again here would
+    /// double-count.
+    pub fn from_parsed(parsed: &'a ParsedFile, registry: &'a SchemaRegistry) -> Self {
         let mut entries = HashMap::new();
         let mut known_names = std::collections::HashSet::new();
         // Walk top-level resources only. The parser auto-generates a
@@ -98,7 +94,7 @@ impl<'a> BindingIndex<'a> {
                 continue;
             };
             known_names.insert(binding_name.clone());
-            let Some(schema) = schemas.get(&schema_key_fn(resource)) else {
+            let Some(schema) = registry.get_for(resource) else {
                 continue;
             };
             entries.insert(binding_name.clone(), BindingEntry { resource, schema });
@@ -453,14 +449,16 @@ mod tests {
     use crate::parser::parse;
     use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
-    fn schema_key_aws(r: &Resource) -> String {
-        format!("{}.{}", r.id.provider, r.id.resource_type)
-    }
-
     fn vpc_schema() -> ResourceSchema {
-        ResourceSchema::new("aws.ec2.Vpc")
+        ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+    }
+
+    fn registry_with_vpc() -> SchemaRegistry {
+        let mut r = SchemaRegistry::new();
+        r.insert("aws", vpc_schema());
+        r
     }
 
     #[test]
@@ -472,12 +470,11 @@ let vpc = aws.ec2.Vpc {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let mut schemas = HashMap::new();
-        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+        let registry = registry_with_vpc();
 
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let index = BindingIndex::from_parsed(&parsed, &registry);
         let entry = index.get("vpc").expect("vpc binding present");
-        assert_eq!(entry.schema.resource_type, "aws.ec2.Vpc");
+        assert_eq!(entry.schema.resource_type, "ec2.Vpc");
         assert_eq!(entry.resource.binding.as_deref(), Some("vpc"));
         assert_eq!(index.len(), 1);
     }
@@ -493,10 +490,9 @@ aws.ec2.Vpc {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let mut schemas = HashMap::new();
-        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+        let registry = registry_with_vpc();
 
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let index = BindingIndex::from_parsed(&parsed, &registry);
         assert!(index.is_empty());
     }
 
@@ -513,9 +509,9 @@ let vpc = aws.ec2.Vpc {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let schemas: HashMap<String, ResourceSchema> = HashMap::new();
+        let registry = SchemaRegistry::new();
 
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let index = BindingIndex::from_parsed(&parsed, &registry);
         assert!(index.get("vpc").is_none());
         assert!(
             index.is_declared("vpc"),
@@ -543,10 +539,9 @@ for _, n in some_iterable {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let mut schemas = HashMap::new();
-        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
+        let registry = registry_with_vpc();
 
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let index = BindingIndex::from_parsed(&parsed, &registry);
         assert!(index.get("net").is_some(), "named let binding indexed");
         assert!(
             !index.is_declared("n"),
@@ -568,13 +563,12 @@ let vpc = aws.ec2.Vpc {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let mut schemas = HashMap::new();
-        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let registry = registry_with_vpc();
+        let index = BindingIndex::from_parsed(&parsed, &registry);
 
         let by_name = index.schemas_by_name();
         let schema = by_name.get("vpc").expect("vpc projection present");
-        assert_eq!(schema.resource_type, "aws.ec2.Vpc");
+        assert_eq!(schema.resource_type, "ec2.Vpc");
         // The projection borrows from the index — pointer-equal to
         // `index.get(...).schema`, which is the whole point.
         assert!(std::ptr::eq(*schema, index.get("vpc").unwrap().schema));
@@ -589,9 +583,8 @@ let vpc = aws.ec2.Vpc {
 }
 "#;
         let parsed = parse(src, &Default::default()).expect("parse");
-        let mut schemas = HashMap::new();
-        schemas.insert("aws.ec2.Vpc".to_string(), vpc_schema());
-        let index = BindingIndex::from_parsed(&parsed, &schemas, &schema_key_aws);
+        let registry = registry_with_vpc();
+        let index = BindingIndex::from_parsed(&parsed, &registry);
         assert!(index.get("missing").is_none());
     }
 }

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -11,7 +11,7 @@ use indexmap::IndexMap;
 use crate::diff_helpers::{compute_map_diff, compute_unchanged_count};
 use crate::effect::Effect;
 use crate::resource::{ResourceId, Value};
-use crate::schema::ResourceSchema;
+use crate::schema::SchemaRegistry;
 use crate::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
 /// Controls how much detail is shown in plan output.
@@ -210,7 +210,7 @@ pub struct CascadingUpdateAttr {
 /// with appropriate formatting (colors, prefixes, etc.).
 pub fn build_detail_rows(
     effect: &Effect,
-    schemas: Option<&HashMap<String, ResourceSchema>>,
+    registry: Option<&SchemaRegistry>,
     detail: DetailLevel,
     delete_attributes: Option<&HashMap<ResourceId, HashMap<String, Value>>>,
 ) -> Vec<DetailRow> {
@@ -219,7 +219,7 @@ pub fn build_detail_rows(
     }
 
     match effect {
-        Effect::Create(r) => build_create_rows(r, schemas, detail),
+        Effect::Create(r) => build_create_rows(r, registry, detail),
         Effect::Update {
             from,
             to,
@@ -244,7 +244,7 @@ pub fn build_detail_rows(
             detail,
         ),
         Effect::Delete { id, .. } => build_delete_rows(id, delete_attributes),
-        Effect::Read { resource } => build_create_rows(resource, schemas, detail),
+        Effect::Read { resource } => build_create_rows(resource, registry, detail),
         Effect::Import { identifier, .. } => {
             vec![DetailRow::Attribute {
                 key: "id".to_string(),
@@ -259,7 +259,7 @@ pub fn build_detail_rows(
 
 fn build_create_rows(
     r: &crate::resource::Resource,
-    schemas: Option<&HashMap<String, ResourceSchema>>,
+    registry: Option<&SchemaRegistry>,
     detail: DetailLevel,
 ) -> Vec<DetailRow> {
     let mut rows = Vec::new();
@@ -319,22 +319,20 @@ fn build_create_rows(
 
     // In Full mode, show defaults and read-only attributes
     if detail == DetailLevel::Full
-        && let Some(schema_map) = schemas
+        && let Some(registry) = registry
+        && let Some(schema) = registry.get_for(r)
     {
-        let schema_key = r.id.display_type();
-        if let Some(schema) = schema_map.get(&schema_key) {
-            let user_keys: HashSet<&str> = keys.iter().map(|k| k.as_str()).collect();
+        let user_keys: HashSet<&str> = keys.iter().map(|k| k.as_str()).collect();
 
-            for (attr, formatted) in schema.compute_default_attrs(&user_keys) {
-                rows.push(DetailRow::Default {
-                    key: attr,
-                    value: formatted,
-                });
-            }
+        for (attr, formatted) in schema.compute_default_attrs(&user_keys) {
+            rows.push(DetailRow::Default {
+                key: attr,
+                value: formatted,
+            });
+        }
 
-            for attr in schema.compute_read_only_attrs(&user_keys) {
-                rows.push(DetailRow::ReadOnly { key: attr });
-            }
+        for attr in schema.compute_read_only_attrs(&user_keys) {
+            rows.push(DetailRow::ReadOnly { key: attr });
         }
     }
 

--- a/carina-core/src/differ/cascade_tests.rs
+++ b/carina-core/src/differ/cascade_tests.rs
@@ -65,7 +65,7 @@ fn cascade_dependent_updates_adds_update_for_dependent() {
     });
 
     // Apply cascade
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
     cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
 
     // Verify the Replace effect now has a cascading update for the subnet
@@ -157,7 +157,7 @@ fn cascade_skips_resources_already_in_plan() {
         changed_attributes: vec!["cidr_block".to_string()],
     });
 
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
     cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
 
     // The Replace should have NO cascading updates since subnet already has an Update
@@ -216,7 +216,7 @@ fn cascade_no_op_without_create_before_destroy() {
         cascade_ref_hints: vec![],
     });
 
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
     cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
 
     if let Effect::Replace {
@@ -302,7 +302,7 @@ fn cascade_transitive_dependencies() {
         cascade_ref_hints: vec![],
     });
 
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
     cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
 
     // Only subnet directly depends on VPC, so only subnet gets cascading update
@@ -372,7 +372,7 @@ fn cascade_anonymous_resource_dependent() {
         cascade_ref_hints: vec![],
     });
 
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
     cascade_dependent_updates(&mut plan, &unresolved_resources, &current_states, &schemas);
 
     if let Effect::Replace {
@@ -451,8 +451,8 @@ fn cascade_generates_replace_when_dependent_attribute_is_create_only() {
         )
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", subnet_schema);
 
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
@@ -605,8 +605,8 @@ fn cascade_merges_with_existing_replace_direct_change_plus_cascade() {
         )
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", subnet_schema);
 
     // Build a plan:
     // - VPC Replace (create_before_destroy) due to cidr_block change
@@ -739,9 +739,9 @@ fn auto_detect_create_before_destroy_when_resource_has_dependents() {
         )
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Vpc".to_string(), vpc_schema);
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", vpc_schema);
+    schemas.insert("", subnet_schema);
 
     // Build a plan with Replace for VPC using DEFAULT lifecycle (no explicit CBD)
     let mut plan = Plan::new();
@@ -845,8 +845,8 @@ fn cascade_upgrades_update_to_replace_when_ref_is_create_only() {
         .attribute(AttributeSchema::new("tags", AttributeType::String))
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", subnet_schema);
 
     // Build a plan:
     // - VPC Replace (create_before_destroy) due to cidr_block change
@@ -960,8 +960,8 @@ fn cascade_prevent_destroy_blocks_promotion_to_replace() {
         )
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", subnet_schema);
 
     // Build a plan with Replace for VPC (create_before_destroy)
     let mut plan = Plan::new();
@@ -1070,8 +1070,8 @@ fn cascade_prevent_destroy_blocks_merge_upgrade_to_replace() {
         .attribute(AttributeSchema::new("tags", AttributeType::String))
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required());
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Subnet".to_string(), subnet_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", subnet_schema);
 
     // Build a plan with Replace for VPC and Update for subnet (tags changed)
     let mut plan = Plan::new();

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -69,7 +69,7 @@ fn create_plan_from_resources() {
         &resources,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -94,7 +94,7 @@ fn create_plan_with_read_only_resource() {
         &resources,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -174,7 +174,7 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
         &desired,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -220,7 +220,7 @@ fn read_only_resource_always_generates_read_effect() {
         &resources,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -277,9 +277,9 @@ fn replace_when_create_only_attr_changed() {
     );
 
     // Build schema with cidr_block marked as create-only
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         crate::schema::ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
@@ -323,9 +323,9 @@ fn normal_update_when_non_create_only_attr_changed() {
     );
 
     // cidr_block is create-only, but enable_dns_support is not
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         crate::schema::ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only())
             .attribute(AttributeSchema::new(
@@ -384,9 +384,9 @@ fn replace_when_schema_force_replace() {
     );
 
     // Schema has force_replace=true (no create-only attributes)
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.internet_gateway".to_string(),
+        "",
         crate::schema::ResourceSchema::new("ec2.internet_gateway")
             .attribute(crate::schema::AttributeSchema::new(
                 "tags",
@@ -435,9 +435,9 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         crate::schema::ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only())
             .attribute(AttributeSchema::new(
@@ -489,9 +489,9 @@ fn replace_carries_create_before_destroy_lifecycle() {
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         crate::schema::ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
@@ -582,11 +582,11 @@ fn replace_with_provider_prefixed_schema_key() {
         ),
     );
 
-    // Schema keyed with provider prefix (as in production)
-    let mut schemas = HashMap::new();
+    // Schema registered under provider "awscc"
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "awscc.ec2.Vpc".to_string(),
-        crate::schema::ResourceSchema::new("awscc.ec2.Vpc")
+        "awscc",
+        crate::schema::ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
 
@@ -862,7 +862,7 @@ fn orphan_delete_preserves_binding_and_dependencies() {
         &desired,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -21,7 +21,7 @@ use crate::plan::Plan;
 #[cfg(test)]
 use crate::resource::LifecycleConfig;
 #[cfg(test)]
-use crate::schema::AttributeType;
+use crate::schema::{AttributeType, SchemaRegistry};
 #[cfg(test)]
 use comparison::find_changed_attributes;
 #[cfg(test)]

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -7,7 +7,7 @@ use crate::effect::{CascadingUpdate, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
 use crate::plan::{Plan, PlanError};
 use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, State, Value};
-use crate::schema::ResourceSchema;
+use crate::schema::{ResourceSchema, SchemaKind, SchemaRegistry};
 
 use super::{Diff, diff};
 
@@ -24,9 +24,9 @@ fn find_changed_create_only(
     provider: &str,
     resource_type: &str,
     changed_attributes: &[String],
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) -> Vec<String> {
-    let Some(schema) = find_schema(provider, resource_type, schemas) else {
+    let Some(schema) = registry.get(provider, resource_type, SchemaKind::Managed) else {
         return Vec::new();
     };
 
@@ -47,9 +47,9 @@ fn filter_non_removable_removals(
     resource_type: &str,
     to: &Resource,
     changed_attributes: Vec<String>,
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) -> Vec<String> {
-    let Some(schema) = find_schema(provider, resource_type, schemas) else {
+    let Some(schema) = registry.get(provider, resource_type, SchemaKind::Managed) else {
         // No schema available — keep all changes (conservative)
         return changed_attributes;
     };
@@ -67,21 +67,6 @@ fn filter_non_removable_removals(
             removable_attrs.contains(&attr.as_str())
         })
         .collect()
-}
-
-/// Look up the schema for a resource, trying both direct and provider-prefixed keys.
-fn find_schema<'a>(
-    provider: &str,
-    resource_type: &str,
-    schemas: &'a HashMap<String, ResourceSchema>,
-) -> Option<&'a ResourceSchema> {
-    schemas.get(resource_type).or_else(|| {
-        if !provider.is_empty() {
-            schemas.get(&format!("{}.{}", provider, resource_type))
-        } else {
-            None
-        }
-    })
 }
 
 /// Generate a temporary name for create-before-destroy replacement.
@@ -153,7 +138,7 @@ pub fn create_plan(
     desired: &[Resource],
     current_states: &HashMap<ResourceId, State>,
     lifecycles: &HashMap<ResourceId, LifecycleConfig>,
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
     saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     prev_desired_keys: &HashMap<ResourceId, Vec<String>>,
     orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
@@ -184,7 +169,11 @@ pub fn create_plan(
 
         let saved = saved_attrs.get(&resource.id);
         let prev_keys = prev_desired_keys.get(&resource.id);
-        let schema = find_schema(&resource.id.provider, &resource.id.resource_type, schemas);
+        let schema = registry.get(
+            &resource.id.provider,
+            &resource.id.resource_type,
+            SchemaKind::Managed,
+        );
         let d = diff(
             resource,
             &current,
@@ -209,7 +198,7 @@ pub fn create_plan(
                     &resource.id.resource_type,
                     &to,
                     changed_attributes,
-                    schemas,
+                    registry,
                 );
 
                 if changed_attributes.is_empty() {
@@ -222,13 +211,17 @@ pub fn create_plan(
                     &resource.id.provider,
                     &resource.id.resource_type,
                     &changed_attributes,
-                    schemas,
+                    registry,
                 );
 
                 // Check if the resource type forces replacement (no update support)
-                let schema_force_replace =
-                    find_schema(&resource.id.provider, &resource.id.resource_type, schemas)
-                        .is_some_and(|s| s.force_replace);
+                let schema_force_replace = registry
+                    .get(
+                        &resource.id.provider,
+                        &resource.id.resource_type,
+                        SchemaKind::Managed,
+                    )
+                    .is_some_and(|s| s.force_replace);
 
                 if changed_create_only.is_empty() && !schema_force_replace {
                     plan.add(Effect::Update {
@@ -250,7 +243,12 @@ pub fn create_plan(
                     }
                     let lifecycle = resource.lifecycle.clone();
                     let temporary_name = if lifecycle.create_before_destroy {
-                        find_schema(&resource.id.provider, &resource.id.resource_type, schemas)
+                        registry
+                            .get(
+                                &resource.id.provider,
+                                &resource.id.resource_type,
+                                SchemaKind::Managed,
+                            )
                             .and_then(|schema| generate_temporary_name(&to, &from, schema))
                     } else {
                         None
@@ -370,18 +368,18 @@ pub fn create_plan(
 ///
 /// 1. Finds all Replace effects with create_before_destroy = true
 /// 2. Identifies dependent resources that reference the replaced resource's binding
-/// 3. If the referencing attribute is create-only on the dependent (per `schemas`),
+/// 3. If the referencing attribute is create-only on the dependent (per the registry),
 ///    promotes the dependent to its own Replace effect in the plan
 /// 4. Otherwise, adds a CascadingUpdate entry to the parent Replace effect
 ///
 /// `unresolved_resources` should be the resources BEFORE ref resolution (still containing
 /// ResourceRef values). `current_states` provides the `from` state for each dependent.
-/// `schemas` provides attribute metadata to detect create-only attributes.
+/// `registry` provides attribute metadata to detect create-only attributes.
 pub fn cascade_dependent_updates(
     plan: &mut Plan,
     unresolved_resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) {
     // Build binding/key -> unresolved resource mapping.
     // Uses the same key logic as the dependent lookup below so anonymous resources
@@ -518,7 +516,7 @@ pub fn cascade_dependent_updates(
                 &resource.id.provider,
                 &resource.id.resource_type,
                 &ref_attrs,
-                schemas,
+                registry,
             );
 
             if !create_only_refs.is_empty() {
@@ -597,7 +595,7 @@ pub fn cascade_dependent_updates(
                     &unresolved.id.provider,
                     &unresolved.id.resource_type,
                     &ref_attrs,
-                    schemas,
+                    registry,
                 );
 
                 if create_only_refs.is_empty() {

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -27,9 +27,9 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only())
             .attribute(
@@ -105,9 +105,9 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
         State::existing(ResourceId::new("logs.LogGroup", "my-log-group"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "logs.LogGroup".to_string(),
+        "",
         ResourceSchema::new("logs.LogGroup")
             .attribute(
                 // log_group_name is NOT create-only in this test (can be renamed)
@@ -163,9 +163,9 @@ fn no_temporary_name_without_create_before_destroy() {
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only())
             .attribute(
@@ -223,9 +223,9 @@ fn no_temporary_name_when_name_prefix_is_used() {
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only())
             .attribute(
@@ -277,9 +277,9 @@ fn no_temporary_name_without_name_attribute_in_schema() {
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
         // No name_attribute set
@@ -332,9 +332,9 @@ fn no_temporary_name_when_name_attribute_changes() {
         State::existing(ResourceId::new("s3.Bucket", "my-bucket"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only())
             .attribute(
@@ -506,7 +506,7 @@ fn create_plan_detects_attribute_removal() {
         &resources,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &prev_desired_keys,
         &HashMap::new(),
@@ -556,9 +556,9 @@ fn create_plan_filters_non_removable_attribute_removal() {
 
     // Schema: tags is auto-removable (optional, not create-only),
     // region is explicitly non-removable (provider-inherited)
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("region", AttributeType::String).non_removable())
             .attribute(AttributeSchema::new(
@@ -624,9 +624,9 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
     );
 
     // Schema: region is explicitly non-removable, bucket is required
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket")
             .attribute(AttributeSchema::new("bucket", AttributeType::String).required())
             .attribute(AttributeSchema::new("region", AttributeType::String).non_removable()),
@@ -707,7 +707,7 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
         &[], // no desired resources
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -757,9 +757,9 @@ fn prevent_destroy_blocks_replace() {
         State::existing(ResourceId::new("ec2.Vpc", "my-vpc"), attrs),
     );
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "",
         ResourceSchema::new("ec2.Vpc")
             .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only()),
     );
@@ -819,7 +819,7 @@ fn prevent_destroy_does_not_block_update() {
         &resources,
         &current_states,
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -854,7 +854,7 @@ fn prevent_destroy_does_not_block_create() {
         &resources,
         &HashMap::new(), // no current states (resource doesn't exist)
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -893,7 +893,7 @@ fn without_prevent_destroy_delete_works_normally() {
         &[], // no desired resources
         &current_states,
         &HashMap::new(), // no lifecycles (default = prevent_destroy: false)
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -954,7 +954,7 @@ fn prevent_destroy_collects_multiple_errors() {
         &[],
         &current_states,
         &lifecycles,
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
@@ -990,7 +990,7 @@ fn virtual_resources_are_skipped_in_plan() {
         &resources,
         &HashMap::new(),
         &HashMap::new(),
-        &HashMap::new(),
+        &SchemaRegistry::new(),
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::parser::ProviderConfig;
 use crate::resource::{Resource, ResourceId, Value};
-use crate::schema::ResourceSchema;
+use crate::schema::SchemaRegistry;
 use crate::validation::is_string_compatible_type;
 
 /// Generate a random 8-character lowercase hex suffix using UUID v4.
@@ -28,15 +28,12 @@ pub fn generate_random_suffix() -> String {
 /// Errors if both `<attr>_prefix` and `<attr>` are specified, or if prefix is empty.
 pub fn resolve_attr_prefixes(
     resources: &mut [Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
     for resource in resources.iter_mut() {
-        let schema_key = schema_key_fn(resource);
-
-        let schema = match schemas.get(&schema_key) {
+        let schema = match registry.get_for(resource) {
             Some(s) => s,
             None => continue, // Unknown resource type; validate_resources will catch this
         };
@@ -366,8 +363,7 @@ fn compute_resource_simhash(
 pub fn compute_anonymous_identifiers(
     resources: &mut [Resource],
     providers: &[ProviderConfig],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
 ) -> Result<(), String> {
     use std::collections::BTreeMap;
@@ -386,9 +382,8 @@ pub fn compute_anonymous_identifiers(
             continue;
         }
         let provider_name = &resource.id.provider;
-        let schema_key = schema_key_fn(resource);
 
-        let Some(schema) = schemas.get(&schema_key) else {
+        let Some(schema) = registry.get_for(resource) else {
             continue;
         };
 
@@ -516,8 +511,7 @@ pub struct AnonymousIdStateInfo {
 /// entries for that resource type with their create-only attribute values.
 pub fn reconcile_anonymous_identifiers(
     resources: &mut [Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
 ) {
     for resource in resources.iter_mut() {
@@ -532,8 +526,7 @@ pub fn reconcile_anonymous_identifiers(
             continue;
         }
 
-        let schema_key = schema_key_fn(resource);
-        let Some(schema) = schemas.get(&schema_key) else {
+        let Some(schema) = registry.get_for(resource) else {
             continue;
         };
 
@@ -658,8 +651,7 @@ pub fn reconcile_anonymous_identifiers(
 /// resource (so it would otherwise appear as a Delete in the plan).
 pub fn detect_anonymous_to_named_renames(
     resources: &[Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
     providers: &[ProviderConfig],
     identity_attributes_fn: &dyn Fn(&str) -> Vec<String>,
@@ -686,8 +678,7 @@ pub fn detect_anonymous_to_named_renames(
             continue;
         }
 
-        let schema_key = schema_key_fn(resource);
-        let Some(schema) = schemas.get(&schema_key) else {
+        let Some(schema) = registry.get_for(resource) else {
             continue;
         };
 

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -1,20 +1,17 @@
 use super::*;
 use crate::resource::Resource;
-use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use crate::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use indexmap::IndexMap;
 
-fn make_s3_bucket_schema() -> (String, ResourceSchema) {
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
-        .attribute(AttributeSchema::new("bucket_name", AttributeType::String));
-    ("awscc.s3.Bucket".to_string(), schema)
+fn make_s3_bucket_schema() -> ResourceSchema {
+    ResourceSchema::new("s3.Bucket")
+        .attribute(AttributeSchema::new("bucket_name", AttributeType::String))
 }
 
-fn schema_key_fn(resource: &Resource) -> String {
-    if resource.id.provider.is_empty() {
-        resource.id.resource_type.clone()
-    } else {
-        format!("{}.{}", resource.id.provider, resource.id.resource_type)
-    }
+fn registry_with_s3_bucket() -> SchemaRegistry {
+    let mut r = SchemaRegistry::new();
+    r.insert("awscc", make_s3_bucket_schema());
+    r
 }
 
 #[test]
@@ -32,10 +29,9 @@ fn test_resolve_attr_prefixes_extracts_prefix_and_generates_name() {
         Value::String("my-app-".to_string()),
     );
 
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![make_s3_bucket_schema()].into_iter().collect();
+    let schemas = registry_with_s3_bucket();
     let mut resources = vec![resource];
-    resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn).unwrap();
+    resolve_attr_prefixes(&mut resources, &schemas).unwrap();
 
     // bucket_name_prefix should be removed
     assert!(!resources[0].attributes.contains_key("bucket_name_prefix"));
@@ -63,10 +59,9 @@ fn test_resolve_attr_prefixes_leaves_non_matching_prefix_alone() {
         Value::String("some-value".to_string()),
     );
 
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![make_s3_bucket_schema()].into_iter().collect();
+    let schemas = registry_with_s3_bucket();
     let mut resources = vec![resource];
-    resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn).unwrap();
+    resolve_attr_prefixes(&mut resources, &schemas).unwrap();
 
     // nonexistent_attr_prefix should remain untouched
     assert!(
@@ -89,10 +84,9 @@ fn test_resolve_attr_prefixes_errors_when_both_prefix_and_attr_specified() {
         Value::String("my-actual-bucket".to_string()),
     );
 
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![make_s3_bucket_schema()].into_iter().collect();
+    let schemas = registry_with_s3_bucket();
     let mut resources = vec![resource];
-    let result = resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn);
+    let result = resolve_attr_prefixes(&mut resources, &schemas);
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("cannot specify both"));
 }
@@ -105,10 +99,9 @@ fn test_resolve_attr_prefixes_errors_on_empty_prefix() {
         Value::String("".to_string()),
     );
 
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![make_s3_bucket_schema()].into_iter().collect();
+    let schemas = registry_with_s3_bucket();
     let mut resources = vec![resource];
-    let result = resolve_attr_prefixes(&mut resources, &schemas, &schema_key_fn);
+    let result = resolve_attr_prefixes(&mut resources, &schemas);
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("cannot be empty"));
 }
@@ -201,12 +194,11 @@ fn test_reconcile_prefixed_names_keeps_generated_name_when_no_state() {
 fn test_reconcile_anonymous_id_partial_create_only_match() {
     // When one create-only property changes but another stays the same,
     // reconciliation should restore the state's identifier.
-    let schema = ResourceSchema::new("awscc.iam.role")
+    let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("path", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.iam.role".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -225,14 +217,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     );
     r1.set_attr("path".to_string(), Value::String("/".to_string()));
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(
-        &mut resources1,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with path="/carina/" (changed create-only)
@@ -243,14 +228,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
     );
     r2.set_attr("path".to_string(), Value::String("/carina/".to_string()));
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(
-        &mut resources2,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
     let step2_id = resources2[0].id.name_str().to_string();
 
     // Hash includes path, so identifiers differ
@@ -266,12 +244,9 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources2,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // After reconciliation, step2 resource should have step1's identifier
     assert_eq!(resources2[0].id.name_str(), step1_id);
@@ -280,12 +255,11 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
 #[test]
 fn test_reconcile_anonymous_id_no_match_when_all_differ() {
     // When ALL create-only properties differ, no reconciliation (truly new resource)
-    let schema = ResourceSchema::new("awscc.iam.role")
+    let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("path", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.iam.role".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
     resource.set_attr(
@@ -307,12 +281,9 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Identifier should remain unchanged
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -322,12 +293,11 @@ fn test_reconcile_anonymous_id_no_match_when_all_differ() {
 fn test_reconcile_anonymous_id_no_match_when_all_same() {
     // When ALL create-only properties match, the hash should also match,
     // so no reconciliation is needed (same identifier)
-    let schema = ResourceSchema::new("awscc.iam.role")
+    let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("path", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.iam.role".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
     resource.set_attr(
@@ -350,12 +320,9 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
         .into_iter()
         .collect(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Identifier should remain unchanged (all values match = no partial match)
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -365,11 +332,10 @@ fn test_reconcile_anonymous_id_no_match_when_all_same() {
 fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     // With only one create-only property, changing it means ALL changed,
     // so no reconciliation (matched=0 or mismatched=0)
-    let schema = ResourceSchema::new("awscc.ec2.Vpc")
+    let schema = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.Vpc".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "ec2_vpc_aabbccdd");
     resource.set_attr(
@@ -386,12 +352,9 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
             .into_iter()
             .collect(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // No reconciliation: only one create-only prop and it changed
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -400,15 +363,14 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
 #[test]
 fn test_anonymous_resource_no_create_only_properties() {
     // Resources with no create-only properties should still work as anonymous resources
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new(
             "tags",
             AttributeType::map(AttributeType::String),
         ));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: vec![(
@@ -428,14 +390,7 @@ fn test_anonymous_resource_no_create_only_properties() {
     r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
 
     let mut resources = vec![r];
-    compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
     // Should have computed an identifier
     assert!(!resources[0].id.name_str().is_empty());
@@ -445,11 +400,10 @@ fn test_anonymous_resource_no_create_only_properties() {
 #[test]
 fn test_anonymous_resource_no_create_only_deterministic() {
     // Same attributes should produce the same identifier
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: vec![(
@@ -473,22 +427,8 @@ fn test_anonymous_resource_no_create_only_deterministic() {
 
     let mut resources1 = vec![make_resource()];
     let mut resources2 = vec![make_resource()];
-    compute_anonymous_identifiers(
-        &mut resources1,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
-    compute_anonymous_identifiers(
-        &mut resources2,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
 
     assert_eq!(resources1[0].id.name_str(), resources2[0].id.name_str());
 }
@@ -496,11 +436,10 @@ fn test_anonymous_resource_no_create_only_deterministic() {
 #[test]
 fn test_anonymous_resource_no_create_only_collision() {
     // Two identical anonymous resources with no create-only properties should collide
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -518,13 +457,7 @@ fn test_anonymous_resource_no_create_only_collision() {
     r2.set_attr("domain".to_string(), Value::String("vpc".to_string()));
 
     let mut resources = vec![r1, r2];
-    let result = compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    );
+    let result = compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn);
 
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("collision"));
@@ -536,7 +469,7 @@ fn test_identity_attribute_prevents_collision() {
     // but different identity attrs should NOT collide.
     // This simulates route53.record_set where `name` is create-only (same)
     // but `type` is identity (A vs AAAA).
-    let schema = ResourceSchema::new("awscc.route53.record_set")
+    let schema = ResourceSchema::new("route53.record_set")
         .attribute(AttributeSchema::new("name", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("hosted_zone_id", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("type", AttributeType::String).identity())
@@ -545,10 +478,8 @@ fn test_identity_attribute_prevents_collision() {
             "resource_records",
             AttributeType::list(AttributeType::String),
         ));
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![("awscc.route53.record_set".to_string(), schema)]
-            .into_iter()
-            .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -582,14 +513,8 @@ fn test_identity_attribute_prevents_collision() {
     r2.set_attr("type".to_string(), Value::String("AAAA".to_string()));
 
     let mut resources = vec![r1, r2];
-    compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .expect("should not collide when identity attrs differ");
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn)
+        .expect("should not collide when identity attrs differ");
 
     // Both should have identifiers assigned
     assert!(!resources[0].id.name_str().is_empty());
@@ -666,13 +591,12 @@ fn test_extract_hash_from_identifier() {
 fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     // When schema has no create-only properties and an attribute changes,
     // Hamming distance reconciliation should match with the closest state entry.
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new("tag_name", AttributeType::String))
         .attribute(AttributeSchema::new("tag_env", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: vec![(
@@ -697,14 +621,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         Value::String("production".to_string()),
     );
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(
-        &mut resources1,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
     let old_id = resources1[0].id.name_str().to_string();
 
     // Step 2: compute identifier with tag_env="staging" (one attribute changed)
@@ -713,14 +630,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
     r2.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
     r2.set_attr("tag_env".to_string(), Value::String("staging".to_string()));
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(
-        &mut resources2,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
     let new_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different attributes)
@@ -731,12 +641,9 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         name: old_id.clone(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources2,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // After reconciliation, should have the old identifier (Hamming distance match)
     assert_eq!(resources2[0].id.name_str(), old_id);
@@ -745,11 +652,10 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
 #[test]
 fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
     // Completely different resources should not reconcile
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     // Resource with a computed identifier
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
@@ -763,12 +669,9 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
         name: "ec2_eip_5544332266778899".to_string(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Identifier should remain unchanged (too distant)
     assert_eq!(resources[0].id.name_str(), original_id);
@@ -778,12 +681,11 @@ fn test_reconcile_anonymous_id_no_create_only_no_match_when_distant() {
 fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     // Case A: Schema has create-only properties, but user didn't set any.
     // Should use SimHash-based Hamming distance reconciliation.
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new("public_ipv4_pool", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -798,14 +700,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
     let mut r1 = Resource::with_provider("awscc", "ec2.eip", "");
     r1.set_attr("domain".to_string(), Value::String("vpc".to_string()));
     let mut resources = vec![r1];
-    compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
     // Should have computed an identifier (not errored)
     assert!(!resources[0].id.name_str().is_empty());
@@ -818,12 +713,9 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         name: state_id,
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Same identifier in state, no change needed
     assert_eq!(resources[0].id.name_str(), current_id);
@@ -968,14 +860,13 @@ fn test_simhash_all_attributes_changed_large_distance() {
 #[test]
 fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
     // When multiple state entries exist, reconciliation should pick the closest one
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new("tag_name", AttributeType::String))
         .attribute(AttributeSchema::new("tag_env", AttributeType::String))
         .attribute(AttributeSchema::new("tag_team", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -998,38 +889,19 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 
     // Original: env=prod, team=infra
     let mut resources_orig = vec![make_resource("production", "infra")];
-    compute_anonymous_identifiers(
-        &mut resources_orig,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources_orig, &providers, &schemas, &identity_fn).unwrap();
     let orig_id = resources_orig[0].id.name_str().to_string();
 
     // Distant: env=dev, team=frontend (2 attrs changed)
     let mut resources_distant = vec![make_resource("development", "frontend")];
-    compute_anonymous_identifiers(
-        &mut resources_distant,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources_distant, &providers, &schemas, &identity_fn)
+        .unwrap();
     let distant_id = resources_distant[0].id.name_str().to_string();
 
     // Current: env=staging, team=infra (1 attr changed from orig)
     let mut resources_current = vec![make_resource("staging", "infra")];
-    compute_anonymous_identifiers(
-        &mut resources_current,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources_current, &providers, &schemas, &identity_fn)
+        .unwrap();
 
     // State has both orig and distant entries
     let state_entries = vec![
@@ -1043,12 +915,9 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         },
     ];
 
-    reconcile_anonymous_identifiers(
-        &mut resources_current,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources_current, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Should match orig (closer: 1 attr changed) rather than distant (2 attrs changed)
     // Note: This depends on SimHash producing closer hashes for more similar inputs.
@@ -1077,11 +946,10 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
 #[test]
 fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     // If state already has the same identifier, no reconciliation needed
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -1095,14 +963,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
     let mut r = Resource::with_provider("awscc", "ec2.eip", "");
     r.set_attr("domain".to_string(), Value::String("vpc".to_string()));
     let mut resources = vec![r];
-    compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
     let id = resources[0].id.name_str().to_string();
 
     // State has the exact same identifier
@@ -1110,12 +971,9 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         name: id.clone(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Should remain unchanged
     assert_eq!(resources[0].id.name_str(), id);
@@ -1124,23 +982,17 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
 #[test]
 fn test_reconcile_no_create_only_empty_state() {
     // No state entries = no reconciliation
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let mut resource = Resource::with_provider("awscc", "ec2.eip", "ec2_eip_aabbccdd11223344");
     resource.set_attr("domain".to_string(), Value::String("vpc".to_string()));
     let original_id = resource.id.name_str().to_string();
     let mut resources = vec![resource];
 
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| vec![],
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| vec![]);
 
     assert_eq!(resources[0].id.name_str(), original_id);
 }
@@ -1148,14 +1000,12 @@ fn test_reconcile_no_create_only_empty_state() {
 #[test]
 fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
     // Verify that changing one attribute produces a different but nearby identifier
-    let schema = ResourceSchema::new("awscc.ec2.internet_gateway")
+    let schema = ResourceSchema::new("ec2.internet_gateway")
         .attribute(AttributeSchema::new("tag_name", AttributeType::String))
         .attribute(AttributeSchema::new("tag_env", AttributeType::String))
         .attribute(AttributeSchema::new("tag_team", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![("awscc.ec2.internet_gateway".to_string(), schema)]
-            .into_iter()
-            .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -1179,10 +1029,8 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
 
     let mut r1 = vec![make_resource("production")];
     let mut r2 = vec![make_resource("staging")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Different identifiers
     assert_ne!(r1[0].id.name_str(), r2[0].id.name_str());
@@ -1203,18 +1051,15 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
 fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     // Resources with create-only properties use standard hash,
     // resources without use SimHash. Verify both work side by side.
-    let schema_with_co = ResourceSchema::new("awscc.ec2.Vpc")
+    let schema_with_co = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("tag_name", AttributeType::String));
-    let schema_without_co = ResourceSchema::new("awscc.ec2.eip")
+    let schema_without_co = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new("tag_name", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![
-        ("awscc.ec2.Vpc".to_string(), schema_with_co),
-        ("awscc.ec2.eip".to_string(), schema_without_co),
-    ]
-    .into_iter()
-    .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema_with_co);
+    schemas.insert("awscc", schema_without_co);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -1237,14 +1082,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     eip.set_attr("tag_name".to_string(), Value::String("my-eip".to_string()));
 
     let mut resources = vec![vpc, eip];
-    compute_anonymous_identifiers(
-        &mut resources,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
     // Both should have identifiers computed
     assert!(resources[0].id.name_str().starts_with("ec2_vpc_"));
@@ -1261,12 +1099,11 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
 fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
     // Verify that resources WITH create-only properties still use the
     // existing partial-match reconciliation, not Hamming distance.
-    let schema = ResourceSchema::new("awscc.iam.role")
+    let schema = ResourceSchema::new("iam.role")
         .attribute(AttributeSchema::new("role_name", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("path", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.iam.role".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     // Resource with both create-only props set
     let mut resource = Resource::with_provider("awscc", "iam.role", "iam_role_aabbccdd");
@@ -1290,12 +1127,9 @@ fn test_reconcile_create_only_path_unaffected_by_simhash_changes() {
         .collect(),
     }];
 
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Should reconcile via partial create-only match (not Hamming distance)
     assert_eq!(resources[0].id.name_str(), "iam_role_11223344");
@@ -1307,11 +1141,10 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
     // When a create-only attribute has a prefix (e.g., bucket_name_prefix),
     // the anonymous identifier should be based on the prefix, not the
     // randomly generated name. This ensures the hash is stable across runs.
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
+    let schema = ResourceSchema::new("s3.Bucket")
         .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.s3.Bucket".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -1336,10 +1169,8 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 
     let mut r1 = vec![make_resource("my-app-abc12345")];
     let mut r2 = vec![make_resource("my-app-xyz98765")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Same prefix should produce the same anonymous identifier
     assert_eq!(
@@ -1352,11 +1183,10 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
 #[test]
 fn test_compute_anonymous_id_different_prefix_produces_different_id() {
     // Different prefixes should produce different anonymous identifiers
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
+    let schema = ResourceSchema::new("s3.Bucket")
         .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.s3.Bucket".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: IndexMap::new(),
@@ -1380,10 +1210,8 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
 
     let mut r1 = vec![make_resource("app-a-", "app-a-abc12345")];
     let mut r2 = vec![make_resource("app-b-", "app-b-xyz98765")];
-    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
-    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &schema_key_fn, &identity_fn)
-        .unwrap();
+    compute_anonymous_identifiers(&mut r1, &providers, &schemas, &identity_fn).unwrap();
+    compute_anonymous_identifiers(&mut r2, &providers, &schemas, &identity_fn).unwrap();
 
     // Different prefixes should produce different identifiers
     assert_ne!(
@@ -1397,14 +1225,12 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
 fn test_reconcile_skips_let_bound_resources() {
     // Let-bound (named) resources should never be reconciled, even if their
     // name doesn't exist in state. The _binding attribute marks them as named.
-    let schema = ResourceSchema::new("aws.ec2.security_group_ingress")
+    let schema = ResourceSchema::new("ec2.security_group_ingress")
         .attribute(AttributeSchema::new("cidr_ip", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("ip_protocol", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("description", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![("aws.ec2.security_group_ingress".to_string(), schema)]
-            .into_iter()
-            .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
 
     // A let-bound resource whose name does NOT exist in state
     let mut ingress_new =
@@ -1435,12 +1261,9 @@ fn test_reconcile_skips_let_bound_resources() {
         .collect(),
     }];
 
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Named resource must keep its original name
     assert_eq!(
@@ -1455,14 +1278,12 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
     // When multiple state entries partially match an anonymous resource,
     // reconciliation should skip rather than picking the first match.
     // This prevents a new SG rule from hijacking an unrelated state entry.
-    let schema = ResourceSchema::new("aws.ec2.security_group_ingress")
+    let schema = ResourceSchema::new("ec2.security_group_ingress")
         .attribute(AttributeSchema::new("cidr_ip", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("ip_protocol", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("description", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![("aws.ec2.security_group_ingress".to_string(), schema)]
-            .into_iter()
-            .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
 
     // Anonymous resource with a new hash-derived identifier
     let mut new_rule = Resource::with_provider(
@@ -1508,12 +1329,9 @@ fn test_reconcile_skips_when_multiple_partial_matches() {
         },
     ];
 
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // With multiple partial matches, reconciliation should be skipped
     assert_eq!(
@@ -1529,7 +1347,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     // (address, ipam_pool_id, etc.) but user didn't set any. Only tags changed.
     // SimHash reconciliation should match the resource as an in-place update,
     // not a replace (delete+create).
-    let schema = ResourceSchema::new("awscc.ec2.eip")
+    let schema = ResourceSchema::new("ec2.eip")
         .attribute(AttributeSchema::new("domain", AttributeType::String))
         .attribute(AttributeSchema::new("address", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("ipam_pool_id", AttributeType::String).create_only())
@@ -1541,9 +1359,8 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
             "tags",
             AttributeType::map(AttributeType::String),
         ));
-    let schemas: HashMap<String, ResourceSchema> = vec![("awscc.ec2.eip".to_string(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let providers = vec![ProviderConfig {
         name: "awscc".to_string(),
         attributes: vec![(
@@ -1574,14 +1391,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     r1.set_attr("tags".to_string(), Value::Map(tags1));
 
     let mut resources1 = vec![r1];
-    compute_anonymous_identifiers(
-        &mut resources1,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources1, &providers, &schemas, &identity_fn).unwrap();
     let step1_id = resources1[0].id.name_str().to_string();
 
     // Step 2: Change tag Environment=staging (only tags changed)
@@ -1599,14 +1409,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
     r2.set_attr("tags".to_string(), Value::Map(tags2));
 
     let mut resources2 = vec![r2];
-    compute_anonymous_identifiers(
-        &mut resources2,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut resources2, &providers, &schemas, &identity_fn).unwrap();
     let step2_id = resources2[0].id.name_str().to_string();
 
     // Identifiers should differ (different tag values)
@@ -1617,12 +1420,9 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         name: step1_id.clone(),
         create_only_values: HashMap::new(), // No create-only values in state either
     }];
-    reconcile_anonymous_identifiers(
-        &mut resources2,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // After reconciliation, step2 should have step1's identifier (in-place update)
     assert_eq!(
@@ -1640,14 +1440,12 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
     //
     // Both resources are named (let-bound) and already match state entries by name.
     // Reconciliation should leave them unchanged.
-    let schema = ResourceSchema::new("aws.ec2.security_group_ingress")
+    let schema = ResourceSchema::new("ec2.security_group_ingress")
         .attribute(AttributeSchema::new("cidr_ip", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("ip_protocol", AttributeType::String).create_only())
         .attribute(AttributeSchema::new("description", AttributeType::String).create_only());
-    let schemas: HashMap<String, ResourceSchema> =
-        vec![("aws.ec2.security_group_ingress".to_string(), schema)]
-            .into_iter()
-            .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
 
     // Two named ingress resources with overlapping create-only attributes
     let mut ingress_http =
@@ -1700,12 +1498,9 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
         },
     ];
 
-    reconcile_anonymous_identifiers(
-        &mut resources,
-        &schemas,
-        &schema_key_fn,
-        &|_provider, _rt| state_entries.clone(),
-    );
+    reconcile_anonymous_identifiers(&mut resources, &schemas, &|_provider, _rt| {
+        state_entries.clone()
+    });
 
     // Names must remain unchanged - no swapping
     assert_eq!(
@@ -1720,10 +1515,12 @@ fn test_reconcile_does_not_swap_named_resources_with_overlapping_create_only() {
     );
 }
 
-fn make_sso_instance_schema() -> (String, ResourceSchema) {
-    let schema = ResourceSchema::new("awscc.sso.Instance")
+fn make_sso_instance_registry() -> SchemaRegistry {
+    let schema = ResourceSchema::new("sso.Instance")
         .attribute(AttributeSchema::new("name", AttributeType::String).create_only());
-    ("awscc.sso.Instance".to_string(), schema)
+    let mut r = SchemaRegistry::new();
+    r.insert("awscc", schema);
+    r
 }
 
 #[test]
@@ -1732,8 +1529,7 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     // DSL now defines it as a let-bound resource with the same name.
     // detect_anonymous_to_named_renames should emit a rename from the
     // anonymous hash name to the binding name.
-    let (key, schema) = make_sso_instance_schema();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry();
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
@@ -1750,7 +1546,6 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &[],
         &|_provider| Vec::new(),
@@ -1764,8 +1559,7 @@ fn test_detect_rename_unique_match_by_create_only_attrs() {
 #[test]
 fn test_detect_rename_skips_when_binding_already_in_state() {
     // If state already has an entry for the binding name, nothing to rename.
-    let (key, schema) = make_sso_instance_schema();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry();
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
@@ -1782,7 +1576,6 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &[],
         &|_provider| Vec::new(),
@@ -1793,8 +1586,7 @@ fn test_detect_rename_skips_when_binding_already_in_state() {
 #[test]
 fn test_detect_rename_ignores_anonymous_resources() {
     // Anonymous resources (binding=None) are not candidates for this rename.
-    let (key, schema) = make_sso_instance_schema();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry();
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso_instance_new");
     // No binding set
@@ -1811,7 +1603,6 @@ fn test_detect_rename_ignores_anonymous_resources() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &[],
         &|_provider| Vec::new(),
@@ -1822,8 +1613,7 @@ fn test_detect_rename_ignores_anonymous_resources() {
 #[test]
 fn test_detect_rename_skips_ambiguous_matches() {
     // Two orphan state entries match — skip to avoid rebinding the wrong one.
-    let (key, schema) = make_sso_instance_schema();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry();
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
@@ -1848,7 +1638,6 @@ fn test_detect_rename_skips_ambiguous_matches() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &[],
         &|_provider| Vec::new(),
@@ -1860,8 +1649,7 @@ fn test_detect_rename_skips_ambiguous_matches() {
 fn test_detect_rename_ignores_non_hash_state_names() {
     // A state entry with a non-hash name (e.g., another let binding) is not
     // treated as an anonymous candidate and must not be silently renamed.
-    let (key, schema) = make_sso_instance_schema();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry();
 
     let mut resource = Resource::with_provider("awscc", "sso.Instance", "sso");
     resource.binding = Some("sso".to_string());
@@ -1878,7 +1666,6 @@ fn test_detect_rename_ignores_non_hash_state_names() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &[],
         &|_provider| Vec::new(),
@@ -1886,11 +1673,13 @@ fn test_detect_rename_ignores_non_hash_state_names() {
     assert!(renames.is_empty());
 }
 
-/// Schema with NO create-only attributes — like `awscc.sso.Instance`.
-fn make_sso_instance_schema_no_create_only() -> (String, ResourceSchema) {
-    let schema = ResourceSchema::new("awscc.sso.Instance")
+/// Registry with NO create-only attributes — like `awscc.sso.Instance`.
+fn make_sso_instance_registry_no_create_only() -> SchemaRegistry {
+    let schema = ResourceSchema::new("sso.Instance")
         .attribute(AttributeSchema::new("name", AttributeType::String));
-    ("awscc.sso.Instance".to_string(), schema)
+    let mut r = SchemaRegistry::new();
+    r.insert("awscc", schema);
+    r
 }
 
 #[test]
@@ -1900,8 +1689,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     // anonymous → let-bound rename must still be detected so `carina plan`
     // shows a Move rather than Delete+Create, which would destroy the
     // Identity Center instance and all of its users/groups.
-    let (key, schema) = make_sso_instance_schema_no_create_only();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry_no_create_only();
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
@@ -1910,14 +1698,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
     anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(
-        &mut anon_vec,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
     assert!(
         anonymous_name.starts_with("sso_instance_"),
@@ -1940,7 +1721,6 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &providers,
         &identity_fn,
@@ -1957,8 +1737,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     // Hamming threshold from any orphan, no rename is emitted and the
     // user falls back to delete+create (or a `moved` block if they want
     // to preserve state).
-    let (key, schema) = make_sso_instance_schema_no_create_only();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry_no_create_only();
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
@@ -1970,14 +1749,7 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     tags.insert("k2".to_string(), Value::String("v2".to_string()));
     anon.set_attr("tags".to_string(), Value::Map(tags));
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(
-        &mut anon_vec,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Let-bound resource with wildly different attributes.
@@ -2002,7 +1774,6 @@ fn test_detect_rename_no_create_only_skips_when_attributes_differ_too_much() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &providers,
         &identity_fn,
@@ -2019,8 +1790,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     // Two orphans: one is an exact SimHash match, the other is off by a
     // few bits but still within the Hamming threshold. The exact match
     // must win — this exercises the `distance < d` branch of the picker.
-    let (key, schema) = make_sso_instance_schema_no_create_only();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry_no_create_only();
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
@@ -2028,14 +1798,7 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
     anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(
-        &mut anon_vec,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let exact_name = anon_vec[0].id.name_str().to_string();
 
     // Construct a "close but not equal" orphan by flipping the last hex
@@ -2068,7 +1831,6 @@ fn test_detect_rename_no_create_only_picks_closest_among_multiple_candidates() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &providers,
         &identity_fn,
@@ -2087,8 +1849,7 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
     // An 8-hex state entry (from the create-only hash path) must not
     // match against a 16-hex SimHash — the hashes use different schemes
     // and comparing them by Hamming distance is meaningless.
-    let (key, schema) = make_sso_instance_schema_no_create_only();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry_no_create_only();
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
@@ -2106,7 +1867,6 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &providers,
         &identity_fn,
@@ -2122,8 +1882,7 @@ fn test_detect_rename_no_create_only_skips_8_char_hash_entries() {
 fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     // Two orphans both within the Hamming threshold with identical distance
     // to the let-bound resource — ambiguous, must skip.
-    let (key, schema) = make_sso_instance_schema_no_create_only();
-    let schemas: HashMap<String, ResourceSchema> = vec![(key, schema)].into_iter().collect();
+    let schemas = make_sso_instance_registry_no_create_only();
     let providers: Vec<ProviderConfig> = Vec::new();
     let identity_fn = |_: &str| -> Vec<String> { Vec::new() };
 
@@ -2131,14 +1890,7 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     let mut anon = Resource::with_provider("awscc", "sso.Instance", "");
     anon.set_attr("name".to_string(), Value::String("carina-rs".to_string()));
     let mut anon_vec = vec![anon];
-    compute_anonymous_identifiers(
-        &mut anon_vec,
-        &providers,
-        &schemas,
-        &schema_key_fn,
-        &identity_fn,
-    )
-    .unwrap();
+    compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
 
     // Two state entries with the exact same name hash → same distance (0).
@@ -2161,7 +1913,6 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
     let renames = detect_anonymous_to_named_renames(
         &resources,
         &schemas,
-        &schema_key_fn,
         &|_provider, _rt| state_entries.clone(),
         &providers,
         &identity_fn,

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use crate::schema::ResourceSchema;
+use crate::schema::SchemaRegistry;
 
 /// Error type for Provider operations
 #[derive(Debug)]
@@ -190,7 +190,7 @@ pub trait ProviderNormalizer: Send + Sync {
         &self,
         _resources: &mut [Resource],
         _default_tags: &IndexMap<String, Value>,
-        _schemas: &HashMap<String, ResourceSchema>,
+        _registry: &SchemaRegistry,
     ) {
     }
 }
@@ -212,7 +212,7 @@ pub fn merge_default_tags_for_provider(
     provider_name: &str,
     resources: &mut [Resource],
     default_tags: &IndexMap<String, Value>,
-    schemas: &HashMap<String, ResourceSchema>,
+    registry: &SchemaRegistry,
 ) {
     if default_tags.is_empty() {
         return;
@@ -224,9 +224,8 @@ pub fn merge_default_tags_for_provider(
         }
 
         // Check if the resource schema has a `tags` attribute
-        let schema_key = format!("{}.{}", provider_name, resource.id.resource_type);
-        let has_tags = schemas
-            .get(&schema_key)
+        let has_tags = registry
+            .get_for(resource)
             .is_some_and(|s| s.attributes.contains_key("tags"));
 
         if !has_tags {
@@ -387,10 +386,10 @@ impl ProviderNormalizer for ProviderRouter {
         &self,
         resources: &mut [Resource],
         default_tags: &IndexMap<String, Value>,
-        schemas: &HashMap<String, ResourceSchema>,
+        registry: &SchemaRegistry,
     ) {
         for ext in &self.normalizers {
-            ext.merge_default_tags(resources, default_tags, schemas);
+            ext.merge_default_tags(resources, default_tags, registry);
         }
     }
 }
@@ -454,12 +453,6 @@ pub trait ProviderFactory: Send + Sync {
     /// Get all resource schemas for this provider.
     fn schemas(&self) -> Vec<crate::schema::ResourceSchema>;
 
-    /// Format a schema lookup key from a resource type.
-    /// Default: prepends provider name (e.g., "awscc" + "ec2_vpc" → "awscc.ec2_vpc").
-    fn format_schema_key(&self, resource_type: &str) -> String {
-        format!("{}.{}", self.name(), resource_type)
-    }
-
     /// Attribute names (beyond schema create-only properties) that contribute
     /// to anonymous resource identity. For example, AWS providers return
     /// `["region"]` because the same resource type in different regions must
@@ -504,30 +497,32 @@ pub fn find_factory<'a>(
         .map(|f| f.as_ref())
 }
 
-/// Collect all resource schemas from the given factories into a single map.
-pub fn collect_schemas(
-    factories: &[Box<dyn ProviderFactory>],
-) -> HashMap<String, crate::schema::ResourceSchema> {
-    let mut all_schemas = HashMap::new();
+/// Collect all resource schemas from the given factories into a [`SchemaRegistry`].
+///
+/// Each schema is inserted under the factory's `name()` plus `schema.kind`,
+/// so a given `(provider, resource_type)` pair may have both a `Managed`
+/// and a `DataSource` entry registered side by side.
+pub fn collect_schemas(factories: &[Box<dyn ProviderFactory>]) -> SchemaRegistry {
+    let mut registry = SchemaRegistry::new();
     for factory in factories {
         for schema in factory.schemas() {
-            all_schemas.insert(schema.resource_type.clone(), schema);
+            registry.insert(factory.name(), schema);
         }
     }
-    all_schemas
+    registry
 }
 
-/// Extract custom type validators from collected schemas.
+/// Extract custom type validators from a registry.
 ///
-/// Walks all `AttributeType::Custom` types in the schema map and returns
-/// a map of (snake_case type name → validator function) suitable for
-/// populating `ProviderContext.validators`.
+/// Walks all `AttributeType::Custom` types in every registered schema and
+/// returns a map of (snake_case type name → validator function) suitable
+/// for populating `ProviderContext.validators`.
 pub fn collect_custom_type_validators(
-    schemas: &HashMap<String, crate::schema::ResourceSchema>,
+    registry: &SchemaRegistry,
 ) -> HashMap<String, crate::parser::ValidatorFn> {
     let mut validators: HashMap<String, crate::parser::ValidatorFn> = HashMap::new();
 
-    for schema in schemas.values() {
+    for (_provider, _resource_type, _kind, schema) in registry.iter() {
         for attr_schema in schema.attributes.values() {
             collect_validators_from_type(&attr_schema.attr_type, &mut validators);
         }
@@ -536,16 +531,14 @@ pub fn collect_custom_type_validators(
     validators
 }
 
-/// Collect custom type names from schemas without allocating validators.
+/// Collect custom type names from a registry without allocating validators.
 ///
 /// Cheaper than `collect_custom_type_validators` when only the type names
 /// are needed (e.g., for LSP completions).
-pub fn collect_custom_type_names(
-    schemas: &HashMap<String, crate::schema::ResourceSchema>,
-) -> Vec<String> {
+pub fn collect_custom_type_names(registry: &SchemaRegistry) -> Vec<String> {
     let mut names = std::collections::HashSet::new();
 
-    for schema in schemas.values() {
+    for (_provider, _resource_type, _kind, schema) in registry.iter() {
         for attr_schema in schema.attributes.values() {
             collect_type_names_from_type(&attr_schema.attr_type, &mut names);
         }
@@ -637,21 +630,6 @@ fn collect_type_names_from_type(
             }
         }
         _ => {}
-    }
-}
-
-/// Determine the schema lookup key for a resource based on its provider.
-pub fn schema_key_for_resource(
-    factories: &[Box<dyn ProviderFactory>],
-    resource: &Resource,
-) -> String {
-    if resource.id.provider.is_empty() {
-        return resource.id.resource_type.clone();
-    }
-    if let Some(factory) = find_factory(factories, &resource.id.provider) {
-        factory.format_schema_key(&resource.id.resource_type)
-    } else {
-        resource.id.resource_type.clone()
     }
 }
 
@@ -1018,42 +996,6 @@ mod tests {
         );
     }
 
-    // Mock ProviderFactory for testing schema_key_for_resource
-    struct MockProviderFactory;
-
-    impl ProviderFactory for MockProviderFactory {
-        fn name(&self) -> &str {
-            "mock"
-        }
-
-        fn display_name(&self) -> &str {
-            "Mock provider"
-        }
-
-        fn provider_config_attribute_types(&self) -> HashMap<String, crate::schema::AttributeType> {
-            HashMap::new()
-        }
-
-        fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
-            Ok(())
-        }
-
-        fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
-            "us-east-1".to_string()
-        }
-
-        fn create_provider(
-            &self,
-            _attributes: &IndexMap<String, Value>,
-        ) -> BoxFuture<'_, Box<dyn Provider>> {
-            Box::pin(async { Box::new(MockProvider) as Box<dyn Provider> })
-        }
-
-        fn schemas(&self) -> Vec<crate::schema::ResourceSchema> {
-            vec![]
-        }
-    }
-
     #[test]
     fn provider_normalizer_separate_from_runtime() {
         // Verify that ProviderNormalizer can be implemented independently from Provider.
@@ -1201,17 +1143,5 @@ mod tests {
             resources[0].get_attr("key"),
             Some(&Value::String("norm:val".to_string()))
         );
-    }
-
-    #[test]
-    fn schema_key_for_resource_uses_id_provider_not_attribute() {
-        let factories: Vec<Box<dyn ProviderFactory>> = vec![Box::new(MockProviderFactory)];
-
-        // Resource with id.provider set but NO _provider attribute
-        let resource = Resource::with_provider("mock", "s3.Bucket", "my-bucket");
-        assert!(!resource.attributes.contains_key("_provider"));
-
-        let key = schema_key_for_resource(&factories, &resource);
-        assert_eq!(key, "mock.s3.Bucket");
     }
 }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -2057,11 +2057,9 @@ impl ResourceSchema {
 /// Collect all attribute_name -> block_name mappings from all schemas.
 /// This includes both top-level attributes and nested struct fields.
 /// Used by the formatter to convert `= [{...}]` to block syntax.
-pub fn collect_all_block_names(
-    schemas: &HashMap<String, ResourceSchema>,
-) -> HashMap<String, String> {
+pub fn collect_all_block_names(registry: &SchemaRegistry) -> HashMap<String, String> {
     let mut result = HashMap::new();
-    for schema in schemas.values() {
+    for (_provider, _resource_type, _kind, schema) in registry.iter() {
         for (attr_name, attr_schema) in &schema.attributes {
             if let Some(bn) = &attr_schema.block_name {
                 result.insert(attr_name.clone(), bn.clone());
@@ -2183,18 +2181,14 @@ fn resolve_block_names_in_map(
 /// (singular) and the canonical attribute name (plural) are present.
 ///
 /// Also recursively resolves block names in nested struct values.
-///
-/// The `schema_key_fn` closure computes the schema lookup key for a resource.
 pub fn resolve_block_names(
     resources: &mut [Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: impl Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
 
     for resource in resources.iter_mut() {
-        let schema_key = schema_key_fn(resource);
-        let schema = match schemas.get(&schema_key) {
+        let schema = match registry.get_for(resource) {
             Some(s) => s,
             None => continue,
         };
@@ -2673,6 +2667,98 @@ fn validate_ipv6_group(group: &str, addr: &str) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+// --- SchemaRegistry ---
+
+/// A registry that holds resource schemas keyed by `(provider, resource_type)`
+/// and `SchemaKind`. The same `(provider, resource_type)` may have **two
+/// independent entries** — a `Managed` one and a `DataSource` one — so that
+/// a type like `aws.s3.Bucket` can be used both for new-resource creation
+/// and for `read`-keyword lookup of existing infrastructure.
+///
+/// See `docs/specs/2026-05-02-resource-vs-data-source-design.md` (Decision 1-2).
+#[derive(Debug, Clone, Default)]
+pub struct SchemaRegistry {
+    managed: HashMap<(String, String), ResourceSchema>,
+    data_sources: HashMap<(String, String), ResourceSchema>,
+}
+
+impl SchemaRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a schema under the given provider. The `kind` field on the
+    /// schema decides which sub-map it goes into.
+    pub fn insert(&mut self, provider: impl Into<String>, schema: ResourceSchema) {
+        let key = (provider.into(), schema.resource_type.clone());
+        match schema.kind {
+            SchemaKind::Managed => {
+                self.managed.insert(key, schema);
+            }
+            SchemaKind::DataSource => {
+                self.data_sources.insert(key, schema);
+            }
+        }
+    }
+
+    /// Look up a schema by explicit `(provider, resource_type, kind)`.
+    pub fn get(
+        &self,
+        provider: &str,
+        resource_type: &str,
+        kind: SchemaKind,
+    ) -> Option<&ResourceSchema> {
+        let key = (provider.to_string(), resource_type.to_string());
+        match kind {
+            SchemaKind::Managed => self.managed.get(&key),
+            SchemaKind::DataSource => self.data_sources.get(&key),
+        }
+    }
+
+    /// Look up the schema appropriate for a given `Resource`. Picks the
+    /// `Managed` entry for normal resources and the `DataSource` entry for
+    /// `read`-keyword resources (`ResourceKind::DataSource`).
+    pub fn get_for(&self, resource: &crate::resource::Resource) -> Option<&ResourceSchema> {
+        let kind = if resource.is_data_source() {
+            SchemaKind::DataSource
+        } else {
+            SchemaKind::Managed
+        };
+        self.get(&resource.id.provider, &resource.id.resource_type, kind)
+    }
+
+    pub fn has_managed(&self, provider: &str, resource_type: &str) -> bool {
+        self.get(provider, resource_type, SchemaKind::Managed)
+            .is_some()
+    }
+
+    pub fn has_data_source(&self, provider: &str, resource_type: &str) -> bool {
+        self.get(provider, resource_type, SchemaKind::DataSource)
+            .is_some()
+    }
+
+    /// Iterate every schema in the registry, yielding `(provider,
+    /// resource_type, kind, &ResourceSchema)`.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, SchemaKind, &ResourceSchema)> + '_ {
+        self.managed
+            .iter()
+            .map(|((p, t), s)| (p.as_str(), t.as_str(), SchemaKind::Managed, s))
+            .chain(
+                self.data_sources
+                    .iter()
+                    .map(|((p, t), s)| (p.as_str(), t.as_str(), SchemaKind::DataSource, s)),
+            )
+    }
+
+    pub fn len(&self) -> usize {
+        self.managed.len() + self.data_sources.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.managed.is_empty() && self.data_sources.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -1549,16 +1549,16 @@ fn resolve_block_names_renames_key() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.ipam".to_string(),
+        "",
         ResourceSchema::new("ec2.ipam").attribute(
             AttributeSchema::new("operating_regions", AttributeType::String)
                 .with_block_name("operating_region"),
         ),
     );
 
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     assert!(resources[0].attributes.contains_key("operating_regions"));
     assert!(!resources[0].attributes.contains_key("operating_region"));
@@ -1572,14 +1572,14 @@ fn resolve_block_names_noop_when_no_match() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.ipam".to_string(),
+        "",
         ResourceSchema::new("ec2.ipam")
             .attribute(AttributeSchema::new("name", AttributeType::String)),
     );
 
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     assert!(resources[0].attributes.contains_key("name"));
 }
@@ -1615,16 +1615,16 @@ fn resolve_block_names_errors_on_mixed_syntax() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.ipam".to_string(),
+        "",
         ResourceSchema::new("ec2.ipam").attribute(
             AttributeSchema::new("operating_regions", AttributeType::String)
                 .with_block_name("operating_region"),
         ),
     );
 
-    let result = resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone());
+    let result = resolve_block_names(&mut resources, &schemas);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.contains("operating_region"));
@@ -1642,10 +1642,10 @@ fn resolve_block_names_skips_unknown_schema() {
         r
     }];
 
-    let schemas = HashMap::new();
+    let schemas = SchemaRegistry::new();
 
     // Should not error for unknown resource types
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     // Key should remain unchanged
     assert!(resources[0].attributes.contains_key("operating_region"));
@@ -1687,9 +1687,9 @@ fn resolve_block_names_nested_struct() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket").attribute(AttributeSchema::new(
             "lifecycle_configuration",
             AttributeType::Struct {
@@ -1708,7 +1708,7 @@ fn resolve_block_names_nested_struct() {
         )),
     );
 
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     // The nested "transition" key should be renamed to "transitions"
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
@@ -1752,9 +1752,9 @@ fn resolve_block_names_singular_field_not_renamed_when_assigned() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket").attribute(AttributeSchema::new(
             "lifecycle_configuration",
             AttributeType::Struct {
@@ -1780,7 +1780,7 @@ fn resolve_block_names_singular_field_not_renamed_when_assigned() {
         )),
     );
 
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
         Some(Value::Map(m)) => m,
@@ -1821,9 +1821,9 @@ fn resolve_block_names_block_syntax_renamed_when_singular_field_exists() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "s3.Bucket".to_string(),
+        "",
         ResourceSchema::new("s3.Bucket").attribute(AttributeSchema::new(
             "lifecycle_configuration",
             AttributeType::Struct {
@@ -1849,7 +1849,7 @@ fn resolve_block_names_block_syntax_renamed_when_singular_field_exists() {
         )),
     );
 
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     let lifecycle = match resources[0].get_attr("lifecycle_configuration") {
         Some(Value::Map(m)) => m,
@@ -1885,9 +1885,9 @@ fn resolve_block_names_same_block_and_canonical_name() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.SecurityGroup".to_string(),
+        "",
         ResourceSchema::new("ec2.SecurityGroup").attribute(
             AttributeSchema::new(
                 "ingress",
@@ -1901,7 +1901,7 @@ fn resolve_block_names_same_block_and_canonical_name() {
     );
 
     // Should succeed without errors (block_name == canonical name, no rename needed)
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     // Key should remain as "ingress"
     assert!(resources[0].attributes.contains_key("ingress"));
@@ -1938,9 +1938,9 @@ fn resolve_block_names_same_block_and_canonical_name_multiple_items() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.SecurityGroup".to_string(),
+        "",
         ResourceSchema::new("ec2.SecurityGroup").attribute(
             AttributeSchema::new(
                 "ingress",
@@ -1954,7 +1954,7 @@ fn resolve_block_names_same_block_and_canonical_name_multiple_items() {
     );
 
     // Should succeed; block_name == canonical name means no conflict possible
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     assert!(resources[0].attributes.contains_key("ingress"));
     match resources[0].get_attr("ingress") {
@@ -1984,9 +1984,9 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
         r
     }];
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "test.resource".to_string(),
+        "",
         ResourceSchema::new("test.resource").attribute(AttributeSchema::new(
             "config",
             AttributeType::Struct {
@@ -2009,7 +2009,7 @@ fn resolve_block_names_nested_same_block_and_canonical_name() {
     );
 
     // Should succeed without errors
-    resolve_block_names(&mut resources, &schemas, |r| r.id.resource_type.clone()).unwrap();
+    resolve_block_names(&mut resources, &schemas).unwrap();
 
     let config = match resources[0].get_attr("config") {
         Some(Value::Map(m)) => m,
@@ -3233,4 +3233,71 @@ fn custom_validator_returns_structured_type_error_directly() {
         }
         other => panic!("expected InvalidEnumVariant, got: {other:?}"),
     }
+}
+
+// --- SchemaRegistry tests (#2328) ---
+
+#[test]
+fn schema_registry_new_is_empty() {
+    let registry = SchemaRegistry::new();
+    assert_eq!(registry.len(), 0);
+    assert!(registry.is_empty());
+}
+
+#[test]
+fn schema_registry_inserts_managed_and_data_source_for_same_type() {
+    let mut registry = SchemaRegistry::new();
+    let managed = ResourceSchema::new("s3.Bucket");
+    let data_source = ResourceSchema::new("s3.Bucket").as_data_source();
+
+    registry.insert("aws", managed);
+    registry.insert("aws", data_source);
+
+    assert_eq!(registry.len(), 2);
+    assert!(registry.has_managed("aws", "s3.Bucket"));
+    assert!(registry.has_data_source("aws", "s3.Bucket"));
+}
+
+#[test]
+fn schema_registry_get_picks_kind_from_resource() {
+    use crate::resource::Resource;
+
+    let mut registry = SchemaRegistry::new();
+    registry.insert("aws", ResourceSchema::new("s3.Bucket"));
+    registry.insert("aws", ResourceSchema::new("s3.Bucket").as_data_source());
+
+    let managed_res = Resource::with_provider("aws", "s3.Bucket", "new");
+    let data_res = Resource::with_provider("aws", "s3.Bucket", "existing")
+        .with_kind(crate::resource::ResourceKind::DataSource);
+
+    let m = registry
+        .get_for(&managed_res)
+        .expect("managed schema present");
+    assert_eq!(m.kind, SchemaKind::Managed);
+
+    let d = registry
+        .get_for(&data_res)
+        .expect("data source schema present");
+    assert_eq!(d.kind, SchemaKind::DataSource);
+}
+
+#[test]
+fn schema_registry_missing_returns_none() {
+    let registry = SchemaRegistry::new();
+    assert!(
+        registry
+            .get("aws", "s3.Bucket", SchemaKind::Managed)
+            .is_none()
+    );
+    assert!(!registry.has_managed("aws", "s3.Bucket"));
+    assert!(!registry.has_data_source("aws", "s3.Bucket"));
+}
+
+#[test]
+fn schema_registry_has_managed_only_does_not_imply_data_source() {
+    let mut registry = SchemaRegistry::new();
+    registry.insert("aws", ResourceSchema::new("s3.Bucket"));
+
+    assert!(registry.has_managed("aws", "s3.Bucket"));
+    assert!(!registry.has_data_source("aws", "s3.Bucket"));
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use crate::config_loader::{find_crn_files_in_dir, parse_directory};
 use crate::parser::{ParsedFile, ProviderContext, ResourceContext, TypeExpr, UpstreamState};
 use crate::resource::{Subscript, Value};
-use crate::schema::{AttributeType, ResourceSchema, suggest_similar_name};
+use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
 /// Exports declared by each `upstream_state` binding: binding name →
 /// (export name → declared type, or `None` if the export has no annotation).
@@ -440,13 +440,11 @@ impl UpstreamRefDiagnostic for UpstreamTypeError {
 pub fn check_upstream_state_field_types(
     parsed: &ParsedFile,
     exports: &UpstreamExports,
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&crate::resource::Resource) -> String,
+    registry: &SchemaRegistry,
 ) -> Vec<UpstreamTypeError> {
     let mut errors: Vec<UpstreamTypeError> = Vec::new();
     for_each_resource_attr(parsed, |ctx, resource, attr_name, value| {
-        let key = schema_key_fn(resource);
-        let Some(schema) = schemas.get(&key) else {
+        let Some(schema) = registry.get_for(resource) else {
             return;
         };
         let Some(attr_schema) = schema.attributes.get(attr_name) else {
@@ -1511,17 +1509,17 @@ mod tests {
     }
 
     /// Minimal schema registry for test resources: `test.r.res` with a single
-    /// typed attribute.
+    /// typed attribute, registered under provider `test`.
     fn schema_with_attr(
         attr_name: &str,
         attr_type: crate::schema::AttributeType,
-    ) -> HashMap<String, crate::schema::ResourceSchema> {
+    ) -> SchemaRegistry {
         use crate::schema::{AttributeSchema, ResourceSchema};
         let schema =
-            ResourceSchema::new("test.r.res").attribute(AttributeSchema::new(attr_name, attr_type));
-        let mut map = HashMap::new();
-        map.insert("test.r.res".to_string(), schema);
-        map
+            ResourceSchema::new("r.res").attribute(AttributeSchema::new(attr_name, attr_type));
+        let mut registry = SchemaRegistry::new();
+        registry.insert("test", schema);
+        registry
     }
 
     fn parse_project_with_provider(source: &str, provider_name: &str) -> ParsedFile {
@@ -1548,9 +1546,7 @@ mod tests {
         );
         let exports = mk_typed_exports(&[("orgs", &[("count", TypeExpr::Int)])]);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert_eq!(errs.len(), 1, "unexpected: {errs:?}");
         assert_eq!(errs[0].binding, "orgs");
         assert_eq!(errs[0].field, "count");
@@ -1575,9 +1571,7 @@ mod tests {
         );
         let exports = mk_typed_exports(&[("orgs", &[("region", TypeExpr::String)])]);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert!(errs.is_empty(), "unexpected errors: {errs:?}");
     }
 
@@ -1599,9 +1593,7 @@ mod tests {
         fields.insert("count".to_string(), None);
         exports.insert("orgs".to_string(), fields);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert!(errs.is_empty(), "unexpected errors: {errs:?}");
     }
 
@@ -1620,9 +1612,7 @@ mod tests {
         );
         let exports = mk_typed_exports(&[("orgs", &[("count", TypeExpr::Int)])]);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert!(errs.is_empty(), "unexpected errors: {errs:?}");
     }
 
@@ -1646,9 +1636,7 @@ mod tests {
             "name",
             crate::schema::AttributeType::list(crate::schema::AttributeType::String),
         );
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert_eq!(errs.len(), 1, "unexpected: {errs:?}");
     }
 
@@ -1673,9 +1661,7 @@ mod tests {
             ],
         )]);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert_eq!(
             errs.len(),
             1,
@@ -1719,9 +1705,7 @@ mod tests {
             to_dsl: None,
         };
         let schemas = schema_with_attr("name", kms_arn);
-        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas, &|r| {
-            format!("{}.{}", r.id.provider, r.id.resource_type)
-        });
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
         assert!(
             errs.is_empty(),
             "Custom type chain must accept base ancestor, got: {errs:?}"

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -8,16 +8,17 @@ use crate::binding_index::BindingIndex;
 use crate::parser::{ModuleCall, ParsedFile, ProviderContext, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
 use crate::resource::{Resource, Value};
-use crate::schema::{AttributeType, ResourceSchema, suggest_similar_name};
+use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
 /// Validate resources against their schemas.
 ///
-/// Checks that each resource's type is known, data sources use the `read` keyword,
-/// and all attributes pass schema validation.
+/// Two-sided check: a `read` resource requires a `DataSource` registry entry,
+/// and a non-`read` resource requires a `Managed` registry entry. If the
+/// wrong-kind entry is present (e.g. `read` against a managed-only type),
+/// emit a kind-specific error explaining the mismatch.
 pub fn validate_resources(
     parsed: &ParsedFile,
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     known_providers: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
@@ -28,16 +29,8 @@ pub fn validate_resources(
             continue;
         }
 
-        let schema_key = schema_key_fn(resource);
-
-        match schemas.get(&schema_key) {
+        match registry.get_for(resource) {
             Some(schema) => {
-                if schema.is_data_source() && !resource.is_data_source() {
-                    all_errors.push(format!(
-                        "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
-                        schema.resource_type, schema.resource_type
-                    ));
-                }
                 let is_string_literal = |attr: &str| resource.quoted_string_attrs.contains(attr);
                 if let Err(errors) = schema
                     .validate_with_origins(&resource.resolved_attributes(), &is_string_literal)
@@ -48,14 +41,37 @@ pub fn validate_resources(
                 }
             }
             None => {
-                // If no factory is registered for this provider, skip validation
-                // (schemas are simply not available)
-                if !resource.id.provider.is_empty()
-                    && !known_providers.contains(&resource.id.provider)
-                {
+                let provider = resource.id.provider.as_str();
+                let resource_type = resource.id.resource_type.as_str();
+
+                // No matching-kind entry. Skip if provider is not loaded —
+                // schemas are simply not available, not a configuration error.
+                if !provider.is_empty() && !known_providers.contains(provider) {
                     continue;
                 }
-                all_errors.push(format!("Unknown resource type: {}", schema_key));
+                let has_managed = registry.has_managed(provider, resource_type);
+                let has_data_source = registry.has_data_source(provider, resource_type);
+                let kind_label = if provider.is_empty() {
+                    resource_type.to_string()
+                } else {
+                    format!("{}.{}", provider, resource_type)
+                };
+
+                if resource.is_data_source() && has_managed {
+                    // `read` used against a managed-only type
+                    all_errors.push(format!(
+                        "{} is a managed resource, not a data source. Remove the `read` keyword:\n  let <name> = {} {{ }}",
+                        kind_label, kind_label
+                    ));
+                } else if !resource.is_data_source() && has_data_source {
+                    // No `read` against a data-source-only type
+                    all_errors.push(format!(
+                        "{} is a data source and must be used with the `read` keyword:\n  let <name> = read {} {{ }}",
+                        kind_label, kind_label
+                    ));
+                } else {
+                    all_errors.push(format!("Unknown resource type: {}", kind_label));
+                }
             }
         }
     }
@@ -73,8 +89,7 @@ pub fn validate_resources(
 /// a reference like `vpc.vpc_id` (which is `AwsResourceId`) should be an error.
 pub fn validate_resource_ref_types(
     parsed: &ParsedFile,
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     argument_names: &HashSet<String>,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
@@ -82,12 +97,10 @@ pub fn validate_resource_ref_types(
     // Single source of truth for `binding_name → (resource, schema)` —
     // shared with the LSP via `BindingIndex` so the two paths cannot drift
     // (#2231).
-    let bindings = BindingIndex::from_parsed(parsed, schemas, schema_key_fn);
+    let bindings = BindingIndex::from_parsed(parsed, registry);
 
     for (_ctx, resource) in parsed.iter_all_resources() {
-        let schema_key = schema_key_fn(resource);
-
-        let Some(schema) = schemas.get(&schema_key) else {
+        let Some(schema) = registry.get_for(resource) else {
             continue;
         };
 
@@ -180,8 +193,7 @@ pub fn validate_resource_ref_types(
 pub fn validate_attribute_param_ref_types(
     attribute_params: &[crate::parser::AttributeParameter],
     resources: &[Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut binding_map: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
@@ -217,8 +229,7 @@ pub fn validate_attribute_param_ref_types(
         let Some(ref_resource) = binding_map.get(&ref_binding) else {
             continue;
         };
-        let ref_schema_key = schema_key_fn(ref_resource);
-        let Some(ref_schema) = schemas.get(&ref_schema_key) else {
+        let Some(ref_schema) = registry.get_for(ref_resource) else {
             continue;
         };
         let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr.as_str()) else {
@@ -253,8 +264,7 @@ pub fn validate_attribute_param_ref_types(
 pub fn validate_export_param_ref_types(
     export_params: &[crate::parser::ExportParameter],
     resources: &[Resource],
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut binding_map: HashMap<String, &Resource> = HashMap::new();
     for resource in resources {
@@ -278,8 +288,7 @@ pub fn validate_export_param_ref_types(
             value,
             &param.name,
             &binding_map,
-            schemas,
-            schema_key_fn,
+            registry,
             &mut errors,
         );
     }
@@ -297,8 +306,7 @@ fn collect_ref_type_errors(
     value: &Value,
     param_name: &str,
     binding_map: &HashMap<String, &Resource>,
-    schemas: &HashMap<String, ResourceSchema>,
-    schema_key_fn: &dyn Fn(&Resource) -> String,
+    registry: &SchemaRegistry,
     errors: &mut Vec<String>,
 ) {
     use crate::parser::TypeExpr;
@@ -311,8 +319,7 @@ fn collect_ref_type_errors(
             let Some(ref_resource) = binding_map.get(ref_binding) else {
                 return;
             };
-            let ref_schema_key = schema_key_fn(ref_resource);
-            let Some(ref_schema) = schemas.get(&ref_schema_key) else {
+            let Some(ref_schema) = registry.get_for(ref_resource) else {
                 return;
             };
             let Some(ref_attr_schema) = ref_schema.attributes.get(ref_attr) else {
@@ -330,28 +337,12 @@ fn collect_ref_type_errors(
         }
         (TypeExpr::List(inner), Value::List(items)) => {
             for item in items {
-                collect_ref_type_errors(
-                    inner,
-                    item,
-                    param_name,
-                    binding_map,
-                    schemas,
-                    schema_key_fn,
-                    errors,
-                );
+                collect_ref_type_errors(inner, item, param_name, binding_map, registry, errors);
             }
         }
         (TypeExpr::Map(inner), Value::Map(map)) => {
             for value in map.values() {
-                collect_ref_type_errors(
-                    inner,
-                    value,
-                    param_name,
-                    binding_map,
-                    schemas,
-                    schema_key_fn,
-                    errors,
-                );
+                collect_ref_type_errors(inner, value, param_name, binding_map, registry, errors);
             }
         }
         (TypeExpr::Struct { fields }, Value::Map(map)) => {
@@ -362,8 +353,7 @@ fn collect_ref_type_errors(
                         value,
                         param_name,
                         binding_map,
-                        schemas,
-                        schema_key_fn,
+                        registry,
                         errors,
                     );
                 }

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::parser::{ParsedFile, ProviderContext};
 use crate::resource::Resource;
-use crate::schema::noop_validator;
+use crate::schema::{ResourceSchema, SchemaRegistry, noop_validator};
 
 fn empty_parsed() -> ParsedFile {
     ParsedFile {
@@ -415,15 +415,11 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
     }
 }
 
-fn test_schema_key_fn(r: &Resource) -> String {
-    r.id.resource_type.clone()
-}
-
 #[test]
 fn unknown_binding_reference_reports_error() {
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Subnet".to_string(),
+        "awscc",
         make_schema("ec2.Subnet", vec![("vpc_id", AttributeType::String)]),
     );
 
@@ -435,8 +431,7 @@ fn unknown_binding_reference_reports_error() {
 
     let mut parsed = empty_parsed();
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result =
-        validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
     assert_eq!(
         result.unwrap_err(),
         "awscc.ec2.Subnet.web-subnet: unknown binding 'vpc' in reference vpc.vpc_id"
@@ -445,13 +440,13 @@ fn unknown_binding_reference_reports_error() {
 
 #[test]
 fn unknown_attribute_reference_reports_error() {
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "awscc",
         make_schema("ec2.Vpc", vec![("cidr_block", AttributeType::String)]),
     );
     schemas.insert(
-        "ec2.Subnet".to_string(),
+        "awscc",
         make_schema("ec2.Subnet", vec![("vpc_id", AttributeType::String)]),
     );
 
@@ -469,8 +464,7 @@ fn unknown_attribute_reference_reports_error() {
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result =
-        validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
     assert_eq!(
         result.unwrap_err(),
         "awscc.ec2.Subnet.web-subnet: unknown attribute 'nonexistent_attr' on 'vpc' in reference vpc.nonexistent_attr"
@@ -479,16 +473,16 @@ fn unknown_attribute_reference_reports_error() {
 
 #[test]
 fn unknown_attribute_reference_suggests_similar_name() {
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.internet_gateway".to_string(),
+        "awscc",
         make_schema(
             "ec2.internet_gateway",
             vec![("internet_gateway_id", AttributeType::String)],
         ),
     );
     schemas.insert(
-        "ec2.route".to_string(),
+        "awscc",
         make_schema(
             "ec2.route",
             vec![
@@ -513,8 +507,7 @@ fn unknown_attribute_reference_suggests_similar_name() {
     let mut parsed = empty_parsed();
     parsed.resources.push(igw); // allow: direct — fixture test inspection
     parsed.resources.push(route); // allow: direct — fixture test inspection
-    let result =
-        validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
     let err = result.unwrap_err();
     assert!(
         err.contains("Did you mean 'internet_gateway_id'?"),
@@ -525,13 +518,13 @@ fn unknown_attribute_reference_suggests_similar_name() {
 
 #[test]
 fn unknown_attribute_reference_no_suggestion_when_too_different() {
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "ec2.Vpc".to_string(),
+        "awscc",
         make_schema("ec2.Vpc", vec![("cidr_block", AttributeType::String)]),
     );
     schemas.insert(
-        "ec2.Subnet".to_string(),
+        "awscc",
         make_schema("ec2.Subnet", vec![("vpc_id", AttributeType::String)]),
     );
 
@@ -550,8 +543,7 @@ fn unknown_attribute_reference_no_suggestion_when_too_different() {
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
     parsed.resources.push(subnet); // allow: direct — fixture test inspection
-    let result =
-        validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
     let err = result.unwrap_err();
     assert!(
         !err.contains("Did you mean"),
@@ -579,20 +571,19 @@ fn ref_type_mismatch_inside_for_body_is_rejected() {
     "#;
     let parsed = crate::parser::parse(src, &ProviderContext::default()).unwrap();
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     // test.r.vpc exposes `vpc_id: Int`
     schemas.insert(
-        "r.vpc".to_string(),
+        "test",
         make_schema("r.vpc", vec![("vpc_id", AttributeType::Int)]),
     );
     // test.r.pool_user requires `pool_id: Bool` — incompatible with Int.
     schemas.insert(
-        "r.pool_user".to_string(),
+        "test",
         make_schema("r.pool_user", vec![("pool_id", AttributeType::Bool)]),
     );
 
-    let result =
-        validate_resource_ref_types(&parsed, &schemas, &test_schema_key_fn, &HashSet::new());
+    let result = validate_resource_ref_types(&parsed, &schemas, &HashSet::new());
     assert!(result.is_err(), "expected type-mismatch error in for body");
     let msg = result.unwrap_err();
     assert!(
@@ -1308,8 +1299,8 @@ fn attribute_param_ref_type_mismatch_detected() {
         },
     ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("iam.role".to_string(), role_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", role_schema);
 
     let resources = vec![role];
 
@@ -1324,12 +1315,7 @@ fn attribute_param_ref_type_mismatch_detected() {
         )),
     }];
 
-    let result = validate_attribute_param_ref_types(
-        &params_mismatch,
-        &resources,
-        &schemas,
-        &|r: &Resource| r.id.resource_type.clone(),
-    );
+    let result = validate_attribute_param_ref_types(&params_mismatch, &resources, &schemas);
     assert!(
         result.is_err(),
         "Should reject String assigned to iam_role_arn"
@@ -1349,10 +1335,7 @@ fn attribute_param_ref_type_mismatch_detected() {
         )),
     }];
 
-    let result =
-        validate_attribute_param_ref_types(&params_match, &resources, &schemas, &|r: &Resource| {
-            r.id.resource_type.clone()
-        });
+    let result = validate_attribute_param_ref_types(&params_match, &resources, &schemas);
     assert!(
         result.is_ok(),
         "Should accept IamRoleArn assigned to iam_role_arn"
@@ -1579,9 +1562,9 @@ fn type_compat_plain_string_rejected_for_simple() {
 fn validate_export_param_ref_types_map_accepts_compatible_types() {
     use crate::parser::ExportParameter;
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "organizations.account".to_string(),
+        "awscc",
         make_schema(
             "organizations.account",
             vec![("account_id", AttributeType::String)],
@@ -1609,8 +1592,7 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         value: Some(Value::Map(map_value)),
     }];
 
-    let result =
-        validate_export_param_ref_types(&exports, &[registry_prod], &schemas, &test_schema_key_fn);
+    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
     assert!(
         result.is_ok(),
         "map(String) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
@@ -1622,9 +1604,9 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
 fn validate_export_param_ref_types_map_rejects_type_mismatch() {
     use crate::parser::ExportParameter;
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "organizations.account".to_string(),
+        "awscc",
         make_schema(
             "organizations.account",
             vec![("account_id", AttributeType::String)],
@@ -1652,8 +1634,7 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         value: Some(Value::Map(map_value)),
     }];
 
-    let result =
-        validate_export_param_ref_types(&exports, &[registry_prod], &schemas, &test_schema_key_fn);
+    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
     assert!(
         result.is_err(),
         "map(Bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
@@ -1679,8 +1660,8 @@ fn validate_resources_rejects_missing_exclusive_required() {
     )
     .exclusive_required(&["cidr_block", "ipv4_ipam_pool_id"]);
 
-    let mut schemas = HashMap::new();
-    schemas.insert("ec2.Vpc".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let vpc = Resource::with_provider("awscc", "ec2.Vpc", "main-vpc");
 
@@ -1689,7 +1670,7 @@ fn validate_resources_rejects_missing_exclusive_required() {
 
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
-    let err = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known).unwrap_err();
+    let err = validate_resources(&parsed, &schemas, &known).unwrap_err();
     assert!(
         err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),
         "expected exclusive_required error, got: {err}"
@@ -1714,9 +1695,9 @@ fn enum_membership_violation_in_for_body_is_flagged() {
     "#;
     let parsed = crate::parser::parse(src, &ProviderContext::default()).unwrap();
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "r.mode_holder".to_string(),
+        "test",
         make_schema(
             "r.mode_holder",
             vec![(
@@ -1734,7 +1715,7 @@ fn enum_membership_violation_in_for_body_is_flagged() {
     let mut known = HashSet::new();
     known.insert("test".to_string());
 
-    let result = validate_resources(&parsed, &schemas, &test_schema_key_fn, &known);
+    let result = validate_resources(&parsed, &schemas, &known);
     assert!(result.is_err(), "expected enum-mismatch error in for body");
     let err = result.unwrap_err();
     assert!(
@@ -1748,10 +1729,10 @@ fn enum_membership_violation_in_for_body_is_flagged() {
 ///   2. `mode = aaa`   (bare invalid)     → InvalidEnumVariant (unchanged)
 ///   3. `mode = fast`  (bare valid)       → pass (unchanged)
 ///   4. fully-qualified form              → pass (unchanged)
-fn mode_schema() -> HashMap<String, ResourceSchema> {
-    let mut schemas = HashMap::new();
+fn mode_schema() -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "r.mode_holder".to_string(),
+        "test",
         make_schema(
             "r.mode_holder",
             vec![(
@@ -1789,8 +1770,7 @@ fn quoted_literal_enum_value_yields_string_literal_diagnostic() {
         }
         "#,
     );
-    let err = validate_resources(&parsed, &mode_schema(), &test_schema_key_fn, &mode_known())
-        .unwrap_err();
+    let err = validate_resources(&parsed, &mode_schema(), &mode_known()).unwrap_err();
     assert!(
         err.contains("got a string literal"),
         "quoted literal must emit the shape-mismatch diagnostic, got: {err}"
@@ -1817,8 +1797,7 @@ fn bare_invalid_enum_value_keeps_invalid_variant_diagnostic() {
         }
         "#,
     );
-    let err = validate_resources(&parsed, &mode_schema(), &test_schema_key_fn, &mode_known())
-        .unwrap_err();
+    let err = validate_resources(&parsed, &mode_schema(), &mode_known()).unwrap_err();
     assert!(
         !err.contains("got a string literal"),
         "bare identifier must NOT get the shape-mismatch diagnostic, got: {err}"
@@ -1841,7 +1820,7 @@ fn bare_valid_enum_value_passes() {
         "#,
     );
     assert!(
-        validate_resources(&parsed, &mode_schema(), &test_schema_key_fn, &mode_known()).is_ok(),
+        validate_resources(&parsed, &mode_schema(), &mode_known()).is_ok(),
         "bare valid identifier must pass"
     );
 }
@@ -1858,7 +1837,45 @@ fn fully_qualified_enum_value_passes() {
         "#,
     );
     assert!(
-        validate_resources(&parsed, &mode_schema(), &test_schema_key_fn, &mode_known()).is_ok(),
+        validate_resources(&parsed, &mode_schema(), &mode_known()).is_ok(),
         "fully-qualified identifier must pass"
+    );
+}
+
+/// `read` against a managed-only resource type emits a kind-specific error
+/// pointing the user at the fix (drop the `read` keyword).
+///
+/// Companion to the inverse direction — non-`read` against a data-source-only
+/// type — which the existing "is a data source and must be used with the
+/// `read` keyword" tests already cover.
+#[test]
+fn read_against_managed_only_type_is_rejected() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "awscc",
+        make_schema("ec2.Vpc", vec![("cidr_block", AttributeType::String)]),
+    );
+
+    let parsed = crate::parser::parse(
+        r#"
+        let v = read awscc.ec2.Vpc {
+            cidr_block = "10.0.0.0/16"
+        }
+        "#,
+        &ProviderContext::default(),
+    )
+    .unwrap();
+
+    let mut known = HashSet::new();
+    known.insert("awscc".to_string());
+
+    let err = validate_resources(&parsed, &schemas, &known).unwrap_err();
+    assert!(
+        err.contains("is a managed resource, not a data source"),
+        "expected managed-only diagnostic, got: {err}"
+    );
+    assert!(
+        err.contains("Remove the `read` keyword"),
+        "expected fix hint, got: {err}"
     );
 }

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -9,20 +9,22 @@ mod tests;
 
 pub(crate) use dsl_source::DslSource;
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Command, CompletionItem, CompletionItemKind, Position};
 
 use crate::document::Document;
-use carina_core::schema::{AttributeType, CompletionValue, ResourceSchema, StructField};
+use carina_core::schema::{
+    AttributeType, CompletionValue, ResourceSchema, SchemaKind, SchemaRegistry, StructField,
+};
 
 pub struct CompletionProvider {
-    schemas: Arc<HashMap<String, ResourceSchema>>,
+    schemas: Arc<SchemaRegistry>,
     provider_names: Vec<String>,
     region_completions_data: Vec<CompletionValue>,
-    /// Resource type patterns sorted longest-first for matching
+    /// Resource type patterns sorted longest-first for matching.
+    /// Each pattern is `"<provider>.<resource_type>"` for both Managed and DataSource entries.
     resource_type_patterns: Vec<String>,
     /// Custom type names from provider validators (e.g., "arn", "vpc_id")
     custom_type_names: Vec<String>,
@@ -30,13 +32,24 @@ pub struct CompletionProvider {
 
 impl CompletionProvider {
     pub fn new(
-        schemas: Arc<HashMap<String, ResourceSchema>>,
+        schemas: Arc<SchemaRegistry>,
         provider_names: Vec<String>,
         region_completions_data: Vec<CompletionValue>,
         custom_type_names: Vec<String>,
     ) -> Self {
-        // Build sorted resource type patterns from schema keys (longest first)
-        let mut resource_type_patterns: Vec<String> = schemas.keys().cloned().collect();
+        // Build sorted resource type patterns from registry entries (longest first).
+        let mut resource_type_patterns: Vec<String> = schemas
+            .iter()
+            .map(|(provider, resource_type, _kind, _schema)| {
+                if provider.is_empty() {
+                    resource_type.to_string()
+                } else {
+                    format!("{}.{}", provider, resource_type)
+                }
+            })
+            .collect();
+        resource_type_patterns.sort();
+        resource_type_patterns.dedup();
         resource_type_patterns.sort_by_key(|b| std::cmp::Reverse(b.len()));
 
         Self {
@@ -46,6 +59,20 @@ impl CompletionProvider {
             resource_type_patterns,
             custom_type_names,
         }
+    }
+
+    /// Look up a schema by `"<provider>.<resource_type>"` key, trying Managed first.
+    pub(super) fn lookup_schema(&self, key: &str) -> Option<&ResourceSchema> {
+        let (provider, resource_type) = match key.split_once('.') {
+            Some(parts) => parts,
+            None => return self.schemas.get("", key, SchemaKind::Managed),
+        };
+        self.schemas
+            .get(provider, resource_type, SchemaKind::Managed)
+            .or_else(|| {
+                self.schemas
+                    .get(provider, resource_type, SchemaKind::DataSource)
+            })
     }
 
     pub fn complete(
@@ -598,7 +625,7 @@ impl CompletionProvider {
             arguments: None,
         };
 
-        if let Some(schema) = self.schemas.get(resource_type) {
+        if let Some(schema) = self.lookup_schema(resource_type) {
             // Try struct field completions first
             if let Some(fields) = self.resolve_struct_fields_for_path(schema, attr_path) {
                 return fields
@@ -680,7 +707,7 @@ impl CompletionProvider {
         attr_path: &[String],
         field_name: &str,
     ) -> Vec<CompletionItem> {
-        if let Some(schema) = self.schemas.get(resource_type)
+        if let Some(schema) = self.lookup_schema(resource_type)
             && let Some(fields) = self.resolve_struct_fields_for_path(schema, attr_path)
             && let Some(field) = fields.iter().find(|f| f.name == field_name)
         {

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1116,10 +1116,10 @@ fn unknown_attribute_fallback_has_no_type_pollution() {
     use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema};
     use std::sync::Arc;
 
-    let schema = ResourceSchema::new("test.foo.bar")
+    let schema = ResourceSchema::new("foo.bar")
         .attribute(AttributeSchema::new("known_attr", AttributeType::String));
-    let mut schemas = HashMap::new();
-    schemas.insert("test.foo.bar".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
     let regions = vec![CompletionValue {
         value: "aws.Region.ap_northeast_1".to_string(),
         description: "Tokyo".to_string(),

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -156,11 +156,11 @@ fn list_string_enum_completions() {
         to_dsl: None,
     });
 
-    let schema = ResourceSchema::new("test.list.resource")
+    let schema = ResourceSchema::new("list.resource")
         .attribute(AttributeSchema::new("protocols", list_enum));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.list.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![]);
@@ -312,14 +312,14 @@ fn no_completions_for_unknown_resource_type_in_block() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
     // Create a provider with two schemas
-    let schema_a = ResourceSchema::new("test.a.resource")
+    let schema_a = ResourceSchema::new("a.resource")
         .attribute(AttributeSchema::new("attr_a", AttributeType::String));
-    let schema_b = ResourceSchema::new("test.b.resource")
+    let schema_b = ResourceSchema::new("b.resource")
         .attribute(AttributeSchema::new("attr_b", AttributeType::String));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.a.resource".to_string(), schema_a);
-    schemas.insert("test.b.resource".to_string(), schema_b);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema_a);
+    schemas.insert("test", schema_b);
 
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![]);
@@ -1009,7 +1009,7 @@ outer =
 #[test]
 fn map_key_completions_from_string_enum_key_type() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
+
     use std::sync::Arc;
 
     // Create a schema with a Map attribute whose key is StringEnum
@@ -1028,10 +1028,10 @@ fn map_key_completions_from_string_enum_key_type() {
         AttributeType::map(AttributeType::String),
     );
     let schema =
-        ResourceSchema::new("test.resource").attribute(AttributeSchema::new("condition", map_type));
+        ResourceSchema::new("resource").attribute(AttributeSchema::new("condition", map_type));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let provider = super::super::CompletionProvider::new(Arc::new(schemas), vec![], vec![], vec![]);
 
@@ -1068,7 +1068,7 @@ fn map_key_completions_from_string_enum_key_type() {
 #[test]
 fn union_struct_field_completions() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
-    use std::collections::HashMap;
+
     use std::sync::Arc;
 
     // principal: Union([Struct { fields: [service, aws, federated] }, String])
@@ -1089,11 +1089,11 @@ fn union_struct_field_completions() {
         fields: vec![StructField::new("principal", principal_type)],
     };
 
-    let schema = ResourceSchema::new("test.resource")
+    let schema = ResourceSchema::new("resource")
         .attribute(AttributeSchema::new("statement", statement_type));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let provider = super::super::CompletionProvider::new(Arc::new(schemas), vec![], vec![], vec![]);
 
@@ -2510,7 +2510,7 @@ exports {
 #[test]
 fn exports_map_value_offers_matching_resource_refs() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-    use std::collections::HashMap;
+
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
@@ -2523,10 +2523,10 @@ fn exports_map_value_offers_matching_resource_refs() {
         namespace: None,
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 
@@ -2595,7 +2595,7 @@ fn exports_list_value_position_filters_by_element_type() {
 #[test]
 fn exports_map_value_multiple_entries_returns_refs() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-    use std::collections::HashMap;
+
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
@@ -2608,10 +2608,10 @@ fn exports_map_value_multiple_entries_returns_refs() {
         namespace: None,
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 
@@ -2653,7 +2653,7 @@ exports {
 #[test]
 fn exports_map_value_includes_bindings_from_sibling_files() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-    use std::collections::HashMap;
+
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
@@ -2666,10 +2666,10 @@ fn exports_map_value_includes_bindings_from_sibling_files() {
         namespace: None,
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.organizations.account".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 
@@ -2711,7 +2711,7 @@ exports {
 #[test]
 fn custom_type_value_ref_includes_sibling_file_bindings() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-    use std::collections::HashMap;
+
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
@@ -2724,16 +2724,13 @@ fn custom_type_value_ref_includes_sibling_file_bindings() {
         namespace: None,
         to_dsl: None,
     };
-    let account_schema = ResourceSchema::new("awscc.organizations.account")
+    let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
-    let consumer_schema = ResourceSchema::new("awscc.organizations.policy_target_attachment")
+    let consumer_schema = ResourceSchema::new("organizations.policy_target_attachment")
         .attribute(AttributeSchema::new("target_id", account_id));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.organizations.account".to_string(), account_schema);
-    schemas.insert(
-        "awscc.organizations.policy_target_attachment".to_string(),
-        consumer_schema,
-    );
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", account_schema);
+    schemas.insert("awscc", consumer_schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 
@@ -2772,11 +2769,11 @@ let attach = awscc.organizations.policy_target_attachment {
 #[test]
 fn argument_parameters_include_sibling_file_args() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
+
+    let schema = ResourceSchema::new("s3.Bucket")
         .attribute(AttributeSchema::new("name", AttributeType::String));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 
@@ -2815,7 +2812,7 @@ let b = awscc.s3.Bucket {
 #[test]
 fn binding_dot_completion_resolves_sibling_file_binding() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
-    use std::collections::HashMap;
+
     fn validate_noop(_v: &carina_core::resource::Value) -> Result<(), String> {
         Ok(())
     }
@@ -2828,16 +2825,13 @@ fn binding_dot_completion_resolves_sibling_file_binding() {
         namespace: None,
         to_dsl: None,
     };
-    let account_schema = ResourceSchema::new("awscc.organizations.account")
+    let account_schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", account_id.clone()));
-    let consumer_schema = ResourceSchema::new("awscc.organizations.policy_target_attachment")
+    let consumer_schema = ResourceSchema::new("organizations.policy_target_attachment")
         .attribute(AttributeSchema::new("target_id", account_id));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.organizations.account".to_string(), account_schema);
-    schemas.insert(
-        "awscc.organizations.policy_target_attachment".to_string(),
-        consumer_schema,
-    );
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", account_schema);
+    schemas.insert("awscc", consumer_schema);
     let provider =
         CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
 

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -98,11 +98,11 @@ pub(super) fn test_provider_with_block_name_nested() -> CompletionProvider {
         ],
     };
 
-    let schema = ResourceSchema::new("test.block.resource")
+    let schema = ResourceSchema::new("block.resource")
         .attribute(AttributeSchema::new("config", config_struct));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.block.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![])
 }
@@ -124,11 +124,11 @@ pub(super) fn test_provider_with_nested_structs() -> CompletionProvider {
         ],
     };
 
-    let schema = ResourceSchema::new("test.nested.resource")
+    let schema = ResourceSchema::new("nested.resource")
         .attribute(AttributeSchema::new("outer", outer_struct));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.nested.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![])
 }
@@ -137,10 +137,10 @@ pub(super) fn test_provider_with_nested_structs() -> CompletionProvider {
 /// `attr` string attribute. Enough to exercise value-position completions
 /// without needing real provider schemas.
 pub(super) fn test_provider_single_attr() -> CompletionProvider {
-    let schema = ResourceSchema::new("test.foo.bar")
+    let schema = ResourceSchema::new("foo.bar")
         .attribute(AttributeSchema::new("attr", AttributeType::String));
-    let mut schemas = HashMap::new();
-    schemas.insert("test.foo.bar".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
     CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![])
 }
 
@@ -154,10 +154,10 @@ pub(super) fn test_provider_with_enum_and_regions() -> CompletionProvider {
         namespace: None,
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
+    let schema = ResourceSchema::new("s3.Bucket")
         .attribute(AttributeSchema::new("versioning_status", status_enum));
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     let region_completions: Vec<CompletionValue> = vec![
         CompletionValue {
@@ -194,15 +194,15 @@ pub(super) fn test_provider_with_nameless_enum() -> CompletionProvider {
         fields: vec![StructField::new("status", status_enum.clone())],
     };
 
-    let schema = ResourceSchema::new("awscc.s3.Bucket")
+    let schema = ResourceSchema::new("s3.Bucket")
         .attribute(AttributeSchema::new("versioning_status", status_enum))
         .attribute(AttributeSchema::new(
             "versioning_configuration",
             versioning_struct,
         ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.s3.Bucket".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
 
     CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
 }
@@ -230,11 +230,11 @@ pub(super) fn test_provider_with_custom_semantic_attr() -> CompletionProvider {
         namespace: Some("awscc.sso.Assignment".to_string()),
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.sso.Assignment")
+    let schema = ResourceSchema::new("sso.Assignment")
         .attribute(AttributeSchema::new("principal_type", principal_type))
         .attribute(AttributeSchema::new("target_id", account_id));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("awscc.sso.Assignment".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
 }

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -203,7 +203,12 @@ impl CompletionProvider {
         }
 
         // Generate resource type completions from schemas
-        for (resource_type, schema) in self.schemas.iter() {
+        for (provider, resource_type, _kind, schema) in self.schemas.iter() {
+            let key = if provider.is_empty() {
+                resource_type.to_string()
+            } else {
+                format!("{}.{}", provider, resource_type)
+            };
             let description = schema
                 .description
                 .as_deref()
@@ -211,7 +216,7 @@ impl CompletionProvider {
                 .to_string();
 
             // Build snippet with required attributes
-            let mut snippet = format!("{} {{\n", resource_type);
+            let mut snippet = format!("{} {{\n", key);
             let mut tab_stop = 1;
             for attr in schema.attributes.values() {
                 if attr.required {
@@ -222,7 +227,7 @@ impl CompletionProvider {
             snippet.push('}');
 
             completions.push(CompletionItem {
-                label: resource_type.clone(),
+                label: key.clone(),
                 kind: Some(CompletionItemKind::CLASS),
                 text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                     range: replacement_range,

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -51,7 +51,7 @@ impl CompletionProvider {
         };
 
         // Get schema for specific resource type
-        if let Some(schema) = self.schemas.get(resource_type) {
+        if let Some(schema) = self.lookup_schema(resource_type) {
             for attr in schema.attributes.values().filter(|a| !a.read_only) {
                 let detail = attr.description.clone();
                 let required_marker = if attr.required { " (required)" } else { "" };
@@ -129,7 +129,7 @@ impl CompletionProvider {
         // Type-based resource reference completions:
         // Look up the attribute's type from the schema. If it's a Custom type,
         // find bindings whose resource schema has an attribute with the same Custom type name.
-        if let Some(schema) = self.schemas.get(resource_type)
+        if let Some(schema) = self.lookup_schema(resource_type)
             && let Some(attr_schema) = schema.attributes.get(attr_name)
         {
             let target_type_name = Self::extract_custom_type_name(&attr_schema.attr_type);
@@ -144,7 +144,7 @@ impl CompletionProvider {
                     }
                     // Look up the binding's resource schema and find attributes
                     // with matching Custom type name
-                    if let Some(binding_schema) = self.schemas.get(binding_resource_type) {
+                    if let Some(binding_schema) = self.lookup_schema(binding_resource_type) {
                         for binding_attr in binding_schema.attributes.values() {
                             if let Some(binding_type_name) =
                                 Self::extract_custom_type_name(&binding_attr.attr_type)
@@ -195,8 +195,7 @@ impl CompletionProvider {
         // unconditional suggest so the user still gets autocomplete on
         // the bare name.
         let attr_type_for_for_filter = self
-            .schemas
-            .get(resource_type)
+            .lookup_schema(resource_type)
             .and_then(|s| s.attributes.get(attr_name))
             .map(|a| &a.attr_type);
         let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
@@ -238,7 +237,7 @@ impl CompletionProvider {
         }
 
         // Look up the attribute type from schema
-        if let Some(schema) = self.schemas.get(resource_type)
+        if let Some(schema) = self.lookup_schema(resource_type)
             && let Some(attr_schema) = schema.attributes.get(attr_name)
         {
             // Struct types: offer `{ }` snippet only, no built-in functions
@@ -350,7 +349,7 @@ impl CompletionProvider {
         edit_range: Range,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
-        if let Some(schema) = self.schemas.get(binding_resource_type) {
+        if let Some(schema) = self.lookup_schema(binding_resource_type) {
             for attr in schema.attributes.values() {
                 let full_ref = format!("{}.{}", binding_name, attr.name);
                 completions.push(CompletionItem {
@@ -867,7 +866,7 @@ impl CompletionProvider {
             if resource_type.is_empty() {
                 continue;
             }
-            let Some(schema) = self.schemas.get(&resource_type) else {
+            let Some(schema) = self.lookup_schema(&resource_type) else {
                 continue;
             };
             for attr in schema.attributes.values() {
@@ -1079,17 +1078,21 @@ impl CompletionProvider {
             .collect();
 
         // Resource types from schemas
-        let resource = self.schemas.iter().map(move |(resource_type, schema)| {
-            let description = schema
-                .description
-                .as_deref()
-                .unwrap_or("Resource reference");
-            type_completion_item(
-                resource_type.clone(),
-                format!("{} reference", description),
-                replacement_range,
-            )
-        });
+        let resource = self
+            .schemas
+            .iter()
+            .map(move |(provider, resource_type, _kind, schema)| {
+                let key = if provider.is_empty() {
+                    resource_type.to_string()
+                } else {
+                    format!("{}.{}", provider, resource_type)
+                };
+                let description = schema
+                    .description
+                    .as_deref()
+                    .unwrap_or("Resource reference");
+                type_completion_item(key, format!("{} reference", description), replacement_range)
+            });
 
         basic.chain(generic).chain(custom).chain(resource).collect()
     }

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -461,9 +461,6 @@ impl DiagnosticEngine {
             merged,
             &exports,
             &self.schemas,
-            &|r: &carina_core::resource::Resource| {
-                carina_core::provider::schema_key_for_resource(&self.factories, r)
-            },
         );
         // #1894 (option 2): cross-directory `for`-iterable shape check.
         // Anchored at the same `binding.field` ref occurrence so the
@@ -1009,15 +1006,7 @@ impl DiagnosticEngine {
         let ref_resource = resources
             .iter()
             .find(|r| r.binding.as_deref() == Some(ref_binding))?;
-        let schema_key = format!(
-            "{}.{}",
-            ref_resource.id.provider, ref_resource.id.resource_type
-        );
-        // Try without provider prefix too (different providers use different key formats)
-        let ref_schema = self
-            .schemas
-            .get(&schema_key)
-            .or_else(|| self.schemas.get(&ref_resource.id.resource_type))?;
+        let ref_schema = self.schemas.get_for(ref_resource)?;
         let ref_attr_schema = ref_schema.attributes.get(ref_attr)?;
         let ref_type_name = ref_attr_schema.attr_type.type_name();
         let ref_type_snake = carina_core::parser::pascal_to_snake(&ref_type_name);
@@ -1068,7 +1057,19 @@ impl DiagnosticEngine {
                 // Look up resource type from sibling bindings
                 if let Some(resource_type) = sibling_bindings.get(binding) {
                     // Look up attribute schema type
-                    if let Some(schema) = self.schemas.get(resource_type)
+                    let (provider, rt) = resource_type
+                        .split_once('.')
+                        .unwrap_or(("", resource_type.as_str()));
+                    if let Some(schema) = self
+                        .schemas
+                        .get(provider, rt, carina_core::schema::SchemaKind::Managed)
+                        .or_else(|| {
+                            self.schemas.get(
+                                provider,
+                                rt,
+                                carina_core::schema::SchemaKind::DataSource,
+                            )
+                        })
                         && let Some(attr_schema) = schema.attributes.get(attr)
                     {
                         let ref_type = &attr_schema.attr_type;
@@ -1269,12 +1270,10 @@ impl DiagnosticEngine {
 
         // Schema-level ref type checking for ResourceRef values in exports
         let resources = all_resources.unwrap_or(&parsed.resources);
-        let schema_key_fn = |r: &Resource| format!("{}.{}", r.id.provider, r.id.resource_type);
         if let Err(ref_errors) = carina_core::validation::validate_export_param_ref_types(
             &parsed.export_params,
             resources,
             &self.schemas,
-            &schema_key_fn,
         ) {
             for error_msg in ref_errors.split('\n') {
                 if let Some((line, col)) = self.find_ref_error_position(doc, error_msg) {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -15,7 +15,7 @@ use crate::position;
 use carina_core::parser::{ParseError, ParsedFile};
 use carina_core::provider::ProviderFactory;
 use carina_core::resource::Value;
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::{ResourceSchema, SchemaRegistry};
 
 /// Create a `Diagnostic` on a single line with the standard "carina" source.
 pub(crate) fn carina_diagnostic(
@@ -59,7 +59,7 @@ pub(crate) fn carina_diagnostic_range(
 }
 
 pub struct DiagnosticEngine {
-    schemas: Arc<HashMap<String, ResourceSchema>>,
+    schemas: Arc<SchemaRegistry>,
     provider_names: Vec<String>,
     factories: Arc<Vec<Box<dyn ProviderFactory>>>,
     /// Providers that failed to load: name -> error reason.
@@ -70,7 +70,7 @@ pub struct DiagnosticEngine {
 
 impl DiagnosticEngine {
     pub fn new(
-        schemas: Arc<HashMap<String, ResourceSchema>>,
+        schemas: Arc<SchemaRegistry>,
         provider_names: Vec<String>,
         factories: Arc<Vec<Box<dyn ProviderFactory>>>,
     ) -> Self {
@@ -191,14 +191,8 @@ impl DiagnosticEngine {
             // reference-checking helpers below consume a borrow-valued
             // map, so no per-keystroke `ResourceSchema::clone()` is
             // needed.
-            let schema_key_fn = |r: &carina_core::resource::Resource| {
-                format!("{}.{}", r.id.provider, r.id.resource_type)
-            };
-            let binding_index = carina_core::binding_index::BindingIndex::from_parsed(
-                parsed,
-                &self.schemas,
-                &schema_key_fn,
-            );
+            let binding_index =
+                carina_core::binding_index::BindingIndex::from_parsed(parsed, &self.schemas);
             let binding_schema_map = binding_index.schemas_by_name();
 
             // Check resource types — include for-body template resources so
@@ -211,7 +205,7 @@ impl DiagnosticEngine {
                 // anchor on the first top-level `mode =` in the file.
                 let scope = resource_source_range(doc, ctx, provider, &resource.id.resource_type);
 
-                if !self.schemas.contains_key(&full_resource_type) {
+                if self.schemas.get_for(resource).is_none() {
                     let provider_loaded = self.provider_names.contains(&provider.to_string());
 
                     if let Some(reason) = self.provider_errors.get(provider) {
@@ -282,7 +276,7 @@ impl DiagnosticEngine {
                 }
 
                 // Semantic validation using schema
-                let schema = self.schemas.get(&full_resource_type).cloned();
+                let schema = self.schemas.get_for(resource).cloned();
                 if let Some(schema) = &schema {
                     // Check data source without `read` keyword
                     if schema.is_data_source()

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -271,11 +271,11 @@ fn list_item_type_validation() {
         to_dsl: None,
     });
 
-    let schema = ResourceSchema::new("test.list.resource")
+    let schema = ResourceSchema::new("list.resource")
         .attribute(AttributeSchema::new("protocols", list_enum));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.list.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let engine = DiagnosticEngine::new(
         Arc::new(schemas),
@@ -355,8 +355,8 @@ fn union_static_value_validated() {
             ]),
         ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let engine = custom_engine(schemas);
     let doc = create_document(
@@ -408,8 +408,8 @@ fn union_valid_static_value_no_warning() {
             ]),
         ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let engine = custom_engine(schemas);
     let doc = create_document(
@@ -454,8 +454,8 @@ fn union_valid_int_value_no_warning() {
             ]),
         ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let engine = custom_engine(schemas);
     let doc = create_document(
@@ -1292,7 +1292,7 @@ fn resource_ref_type_check_helper_regression() {
     }
 
     // Source resource: has a String attribute "name" and a Custom "my_id"
-    let source_schema = ResourceSchema::new("test.source")
+    let source_schema = ResourceSchema::new("source")
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new(
             "my_id",
@@ -1308,7 +1308,7 @@ fn resource_ref_type_check_helper_regression() {
         ));
 
     // Target resource: has Union, StringEnum, and Custom attributes
-    let target_schema = ResourceSchema::new("test.target")
+    let target_schema = ResourceSchema::new("target")
         .attribute(AttributeSchema::new(
             "union_attr",
             AttributeType::Union(vec![AttributeType::Int, AttributeType::Bool]),
@@ -1335,9 +1335,9 @@ fn resource_ref_type_check_helper_regression() {
             },
         ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.source".to_string(), source_schema);
-    schemas.insert("test.target".to_string(), target_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", source_schema);
+    schemas.insert("test", target_schema);
     let engine = custom_engine(schemas);
 
     // Case 1: Union attr with incompatible ResourceRef (MyId != Int|Bool) -> mismatch
@@ -1449,9 +1449,8 @@ attributes {
 #[test]
 fn resource_validation_failed_with_attribute_points_to_attribute_line() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, TypeError};
-    use std::collections::HashMap;
 
-    let schema = ResourceSchema::new("mock.test.resource")
+    let schema = ResourceSchema::new("test.resource")
         .attribute(AttributeSchema::new("name", AttributeType::String).required())
         .attribute(AttributeSchema::new(
             "tags",
@@ -1471,8 +1470,8 @@ fn resource_validation_failed_with_attribute_points_to_attribute_line() {
             Ok(())
         });
 
-    let mut schemas = HashMap::new();
-    schemas.insert("mock.test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("mock", schema);
     let engine = custom_engine(schemas);
 
     let doc = create_document(
@@ -1503,7 +1502,7 @@ fn warning_when_provider_loaded_but_schema_missing() {
     // Provider is loaded but doesn't have a schema for this resource type.
     // Should show WARNING (not ERROR), not "Unknown resource type".
     let engine = DiagnosticEngine::new(
-        Arc::new(HashMap::new()),
+        Arc::new(SchemaRegistry::new()),
         vec!["awscc".to_string()],
         Arc::new(vec![]),
     );
@@ -1545,7 +1544,7 @@ fn error_when_provider_not_loaded_at_all() {
     // Message should point at the missing download, not a generic "Unknown
     // resource type" (which misleads the user into searching for typos in a
     // name that is actually correct — see issue #2005).
-    let engine = DiagnosticEngine::new(Arc::new(HashMap::new()), vec![], Arc::new(vec![]));
+    let engine = DiagnosticEngine::new(Arc::new(SchemaRegistry::new()), vec![], Arc::new(vec![]));
     let doc = create_document(
         r#"awscc.iam.role {
   role_name = 'test'
@@ -1585,7 +1584,7 @@ fn no_undefined_resource_for_namespaced_enum_value() {
     // provider_names includes "awscc", so awscc.xxx.yyy.EnumType.VALUE
     // should NOT be flagged as "Undefined resource"
     let engine = DiagnosticEngine::new(
-        Arc::new(HashMap::new()),
+        Arc::new(SchemaRegistry::new()),
         vec!["awscc".to_string()],
         Arc::new(vec![]),
     );
@@ -1617,7 +1616,7 @@ fn no_undefined_resource_for_declared_but_uninstalled_provider() {
     // awscc = aws...'` — which is both wrong (awscc is a namespace, not a let
     // binding) and actively misleading (following the fix breaks valid DSL).
     let engine = DiagnosticEngine::new(
-        Arc::new(HashMap::new()),
+        Arc::new(SchemaRegistry::new()),
         vec![], // nothing installed — simulates missing .carina/
         Arc::new(vec![]),
     );
@@ -1646,7 +1645,7 @@ fn undefined_resource_still_fires_when_identifier_is_not_a_declared_provider() {
     // binding diagnostics. When the root identifier is not a declared provider
     // and not a defined binding, the existing "Undefined resource" message
     // should still fire.
-    let engine = DiagnosticEngine::new(Arc::new(HashMap::new()), vec![], Arc::new(vec![]));
+    let engine = DiagnosticEngine::new(Arc::new(SchemaRegistry::new()), vec![], Arc::new(vec![]));
     let doc = create_document(
         r#"provider awscc {
   region = totally_unknown.some_attr
@@ -1698,8 +1697,8 @@ fn map_key_validation_warns_on_invalid_key() {
         },
     ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.test.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     let engine = DiagnosticEngine::new(
         Arc::new(schemas),
@@ -1754,19 +1753,21 @@ fn distinct_semantic_customs_are_rejected() {
         }
     }
 
-    // Source resource: has an AwsAccountId attribute
-    let source_schema = ResourceSchema::new("sts.caller_identity").attribute(AttributeSchema::new(
-        "account_id",
-        AttributeType::Custom {
-            semantic_name: Some("AwsAccountId".to_string()),
-            base: Box::new(AttributeType::String),
-            pattern: None,
-            length: None,
-            validate: legacy_validator(validate_account_id),
-            namespace: Some("aws".to_string()),
-            to_dsl: None,
-        },
-    ));
+    // Source resource: data source with an AwsAccountId attribute
+    let source_schema = ResourceSchema::new("sts.caller_identity")
+        .as_data_source()
+        .attribute(AttributeSchema::new(
+            "account_id",
+            AttributeType::Custom {
+                semantic_name: Some("AwsAccountId".to_string()),
+                base: Box::new(AttributeType::String),
+                pattern: None,
+                length: None,
+                validate: legacy_validator(validate_account_id),
+                namespace: Some("aws".to_string()),
+                to_dsl: None,
+            },
+        ));
 
     // Target resource: has a TargetId attribute (also String-based Custom)
     let target_schema = ResourceSchema::new("sso.Assignment").attribute(AttributeSchema::new(
@@ -1782,9 +1783,9 @@ fn distinct_semantic_customs_are_rejected() {
         },
     ));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("aws.sts.caller_identity".to_string(), source_schema);
-    schemas.insert("awscc.sso.Assignment".to_string(), target_schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", source_schema);
+    schemas.insert("awscc", target_schema);
     let engine = custom_engine(schemas);
 
     let doc = create_document(
@@ -1813,7 +1814,6 @@ fn exports_cross_file_ref_no_false_positive() {
     // skip these dot-notation strings to avoid false positives.
     use carina_core::resource::Value;
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
 
     let aws_account_id_type = AttributeType::Custom {
         semantic_name: Some("AwsAccountId".to_string()),
@@ -1831,11 +1831,10 @@ fn exports_cross_file_ref_no_false_positive() {
         namespace: None,
         to_dsl: None,
     };
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", aws_account_id_type));
-    let schemas: HashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let engine = custom_engine(schemas);
 
     // exports.crn parsed alone: "registry_prod.account_id" stays as String
@@ -1896,13 +1895,11 @@ fn exports_type_warning_survives_formatter_round_trip() {
 fn exports_ref_type_warning_survives_formatter_round_trip() {
     use carina_core::formatter::{FormatConfig, format};
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
 
-    let schema = ResourceSchema::new("test.sample.resource")
+    let schema = ResourceSchema::new("sample.resource")
         .attribute(AttributeSchema::new("enabled", AttributeType::Bool));
-    let schemas: HashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
     let engine = custom_engine(schemas);
 
     let original = r#"let item = test.sample.resource {
@@ -1944,13 +1941,11 @@ exports {
 fn exports_ref_type_warning_survives_document_reparse_after_format_edit() {
     use carina_core::formatter::{FormatConfig, format};
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
 
-    let schema = ResourceSchema::new("test.sample.resource")
+    let schema = ResourceSchema::new("sample.resource")
         .attribute(AttributeSchema::new("enabled", AttributeType::Bool));
-    let schemas: HashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
     let engine = custom_engine(schemas);
 
     let original = r#"let item = test.sample.resource {
@@ -2083,14 +2078,12 @@ fn exports_type_warning_multiline_vs_oneline() {
 #[test]
 fn exports_map_type_warning_for_cross_file_ref() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap;
 
     // Schema: registry_prod.account_id is String — incompatible with map(bool)
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", AttributeType::String));
-    let schemas: HashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let engine = custom_engine(schemas);
 
     let tmp = tempfile::tempdir().unwrap();
@@ -2119,7 +2112,7 @@ fn exports_map_type_warning_for_cross_file_ref() {
 #[test]
 fn no_undefined_resource_for_sibling_binding_in_exports() {
     let engine = DiagnosticEngine::new(
-        Arc::new(HashMap::new()),
+        Arc::new(SchemaRegistry::new()),
         vec!["awscc".to_string()],
         Arc::new(vec![]),
     );
@@ -3149,14 +3142,12 @@ fn unreferenced_binding_is_still_flagged_unused() {
 #[test]
 fn exports_type_check_resolves_resource_binding_from_sibling_file() {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-    use std::collections::HashMap as StdHashMap;
 
     // Schema: registry_prod.account_id is String.
-    let schema = ResourceSchema::new("awscc.organizations.account")
+    let schema = ResourceSchema::new("organizations.account")
         .attribute(AttributeSchema::new("account_id", AttributeType::String));
-    let schemas: StdHashMap<String, ResourceSchema> = vec![(schema.resource_type.clone(), schema)]
-        .into_iter()
-        .collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
     let engine = custom_engine(schemas);
 
     let tmp = tempfile::tempdir().unwrap();

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::*;
 use crate::document::Document;
 use carina_core::parser::ProviderContext;
 use carina_core::provider::{self as provider_mod, ProviderFactory};
+use carina_core::schema::SchemaRegistry;
 
 mod basic;
 mod extended;
@@ -46,11 +46,11 @@ pub(super) fn test_engine_with_nested_structs() -> DiagnosticEngine {
         ],
     });
 
-    let schema = ResourceSchema::new("test.nested.resource")
+    let schema = ResourceSchema::new("nested.resource")
         .attribute(AttributeSchema::new("outer", outer_struct));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.nested.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     DiagnosticEngine::new(
         Arc::new(schemas),
@@ -69,11 +69,11 @@ pub(super) fn test_engine_with_enum_attr() -> DiagnosticEngine {
         to_dsl: None,
     };
 
-    let schema = ResourceSchema::new("test.r.mode_holder")
-        .attribute(AttributeSchema::new("mode", mode_enum));
+    let schema =
+        ResourceSchema::new("r.mode_holder").attribute(AttributeSchema::new("mode", mode_enum));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.r.mode_holder".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     DiagnosticEngine::new(
         Arc::new(schemas),
@@ -96,11 +96,11 @@ pub(super) fn test_engine_with_namespaced_enum_attr() -> DiagnosticEngine {
         to_dsl: None,
     };
 
-    let schema = ResourceSchema::new("test.r.mode_holder")
-        .attribute(AttributeSchema::new("mode", mode_enum));
+    let schema =
+        ResourceSchema::new("r.mode_holder").attribute(AttributeSchema::new("mode", mode_enum));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.r.mode_holder".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     DiagnosticEngine::new(
         Arc::new(schemas),
@@ -138,11 +138,11 @@ pub(super) fn test_engine_with_custom_namespaced_attr() -> DiagnosticEngine {
         to_dsl: None,
     };
 
-    let schema = ResourceSchema::new("test.r.mode_holder")
-        .attribute(AttributeSchema::new("mode", mode_custom));
+    let schema =
+        ResourceSchema::new("r.mode_holder").attribute(AttributeSchema::new("mode", mode_custom));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.r.mode_holder".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     DiagnosticEngine::new(
         Arc::new(schemas),
@@ -171,11 +171,11 @@ pub(super) fn test_engine_with_block_name_nested() -> DiagnosticEngine {
         ],
     };
 
-    let schema = ResourceSchema::new("test.block.resource")
+    let schema = ResourceSchema::new("block.resource")
         .attribute(AttributeSchema::new("config", config_struct));
 
-    let mut schemas = HashMap::new();
-    schemas.insert("test.block.resource".to_string(), schema);
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
 
     DiagnosticEngine::new(
         Arc::new(schemas),
@@ -184,15 +184,12 @@ pub(super) fn test_engine_with_block_name_nested() -> DiagnosticEngine {
     )
 }
 
-pub(super) fn custom_engine(
-    schemas: HashMap<String, carina_core::schema::ResourceSchema>,
-) -> DiagnosticEngine {
+pub(super) fn custom_engine(schemas: SchemaRegistry) -> DiagnosticEngine {
     let provider_names: Vec<String> = schemas
-        .keys()
-        .filter_map(|k| k.split('.').next())
+        .iter()
+        .map(|(provider, _, _, _)| provider.to_string())
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
-        .map(|s| s.to_string())
         .collect();
     DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(vec![]))
 }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -8,7 +7,7 @@ use crate::document::Document;
 use carina_core::builtins;
 use carina_core::parser::ArgumentParameter;
 use carina_core::resource::Value;
-use carina_core::schema::{CompletionValue, ResourceSchema};
+use carina_core::schema::{CompletionValue, ResourceSchema, SchemaRegistry};
 
 /// Format a Value for hover display
 fn format_value_for_hover(value: &Value) -> String {
@@ -94,15 +93,12 @@ fn convert_markdown_links_to_plain_text(text: &str) -> String {
 }
 
 pub struct HoverProvider {
-    schemas: Arc<HashMap<String, ResourceSchema>>,
+    schemas: Arc<SchemaRegistry>,
     region_completions: Vec<CompletionValue>,
 }
 
 impl HoverProvider {
-    pub fn new(
-        schemas: Arc<HashMap<String, ResourceSchema>>,
-        region_completions: Vec<CompletionValue>,
-    ) -> Self {
+    pub fn new(schemas: Arc<SchemaRegistry>, region_completions: Vec<CompletionValue>) -> Self {
         Self {
             schemas,
             region_completions,
@@ -215,14 +211,27 @@ impl HoverProvider {
                         // Found opening brace, check if it's a module call
                         // Module calls: identifier { (not "let x = ..." or "provider." prefix)
                         // Check if any provider name prefix matches
+                        // Iterate registry entries but skip empty-provider ones —
+                        // the synthetic `format!("{}.", "")` would match every line
+                        // and block the resource-block path entirely.
                         let provider_prefixes: Vec<&str> = self
                             .schemas
-                            .keys()
-                            .filter_map(|k| k.split('.').next())
+                            .iter()
+                            .map(|(provider, _, _, _)| provider)
+                            .filter(|p| !p.is_empty())
                             .collect();
+                        // Treat schemas registered without a provider (e.g.
+                        // test fixtures with `ResourceSchema::new("ec2.X")` and
+                        // `insert("", ...)`) as ordinary resource lines too.
+                        let starts_with_known_resource_type = self
+                            .schemas
+                            .iter()
+                            .filter(|(p, _, _, _)| p.is_empty())
+                            .any(|(_, rt, _, _)| trimmed.starts_with(&format!("{} ", rt)));
                         let starts_with_provider = provider_prefixes
                             .iter()
-                            .any(|p| trimmed.starts_with(&format!("{}.", p)));
+                            .any(|p| trimmed.starts_with(&format!("{}.", p)))
+                            || starts_with_known_resource_type;
 
                         if !trimmed.starts_with("let ")
                             && !starts_with_provider
@@ -380,14 +389,27 @@ impl HoverProvider {
                         brace_depth -= 1;
                     } else {
                         // Found opening brace. Check if it's a module call.
+                        // Iterate registry entries but skip empty-provider ones —
+                        // the synthetic `format!("{}.", "")` would match every line
+                        // and block the resource-block path entirely.
                         let provider_prefixes: Vec<&str> = self
                             .schemas
-                            .keys()
-                            .filter_map(|k| k.split('.').next())
+                            .iter()
+                            .map(|(provider, _, _, _)| provider)
+                            .filter(|p| !p.is_empty())
                             .collect();
+                        // Treat schemas registered without a provider (e.g.
+                        // test fixtures with `ResourceSchema::new("ec2.X")` and
+                        // `insert("", ...)`) as ordinary resource lines too.
+                        let starts_with_known_resource_type = self
+                            .schemas
+                            .iter()
+                            .filter(|(p, _, _, _)| p.is_empty())
+                            .any(|(_, rt, _, _)| trimmed.starts_with(&format!("{} ", rt)));
                         let starts_with_provider = provider_prefixes
                             .iter()
-                            .any(|p| trimmed.starts_with(&format!("{}.", p)));
+                            .any(|p| trimmed.starts_with(&format!("{}.", p)))
+                            || starts_with_known_resource_type;
 
                         if !trimmed.starts_with("let ")
                             && !starts_with_provider
@@ -410,16 +432,19 @@ impl HoverProvider {
     }
 
     fn resource_type_hover(&self, word: &str) -> Option<Hover> {
-        // Check against all schema keys
-        for (resource_type, schema) in self.schemas.iter() {
-            if word == resource_type || word.contains(resource_type.as_str()) {
+        // Check against all schema keys (provider.resource_type)
+        for (provider, resource_type, _kind, schema) in self.schemas.iter() {
+            let key = if provider.is_empty() {
+                resource_type.to_string()
+            } else {
+                format!("{}.{}", provider, resource_type)
+            };
+            if word == key || word.contains(key.as_str()) {
                 // Avoid matching substrings like "vpc_id" for "vpc"
-                if word.contains(&format!("{}_", resource_type))
-                    || word.contains(&format!("_{}", resource_type))
-                {
+                if word.contains(&format!("{}_", key)) || word.contains(&format!("_{}", key)) {
                     continue;
                 }
-                return self.schema_hover(resource_type, schema);
+                return self.schema_hover(&key, schema);
             }
         }
         None
@@ -491,7 +516,19 @@ impl HoverProvider {
         let current_line = position.line as usize;
 
         // Build a list of schema keys sorted longest-first for correct matching
-        let mut schema_keys: Vec<&str> = self.schemas.keys().map(|s| s.as_str()).collect();
+        let mut schema_keys: Vec<String> = self
+            .schemas
+            .iter()
+            .map(|(provider, resource_type, _kind, _schema)| {
+                if provider.is_empty() {
+                    resource_type.to_string()
+                } else {
+                    format!("{}.{}", provider, resource_type)
+                }
+            })
+            .collect();
+        schema_keys.sort();
+        schema_keys.dedup();
         schema_keys.sort_by_key(|k| std::cmp::Reverse(k.len()));
 
         let mut brace_depth: i32 = 0;
@@ -529,17 +566,34 @@ impl HoverProvider {
         // Falling back to a global scan would return a lookalike attribute from
         // an unrelated schema (nondeterministic via HashMap iteration order) —
         // see #1988.
-        if let Some(resource_type) = enclosing_resource {
-            return self
-                .schemas
-                .get(resource_type)
-                .and_then(|schema| schema.attributes.get(word))
-                .and_then(|attr| self.build_attribute_hover(attr));
-        }
-
-        // No enclosing-resource context (e.g., bare identifier at top level):
-        // we have nothing to anchor the lookup to, so do not guess.
-        None
+        let key = enclosing_resource?;
+        // Try splitting on the first dot first (`provider.resource_type`); if that
+        // doesn't resolve, fall back to treating the whole key as the resource type
+        // under the empty provider — some test fixtures register schemas that way.
+        let lookup = |provider: &str, resource_type: &str| {
+            self.schemas
+                .get(
+                    provider,
+                    resource_type,
+                    carina_core::schema::SchemaKind::Managed,
+                )
+                .or_else(|| {
+                    self.schemas.get(
+                        provider,
+                        resource_type,
+                        carina_core::schema::SchemaKind::DataSource,
+                    )
+                })
+        };
+        let schema = if let Some((provider, rest)) = key.split_once('.') {
+            lookup(provider, rest).or_else(|| lookup("", key))
+        } else {
+            lookup("", key)
+        }?;
+        schema
+            .attributes
+            .get(word)
+            .and_then(|attr| self.build_attribute_hover(attr))
     }
 
     fn build_attribute_hover(&self, attr: &carina_core::schema::AttributeSchema) -> Option<Hover> {
@@ -700,9 +754,9 @@ mod tests {
         resource_type: &str,
         description: &str,
     ) -> HoverProvider {
-        let mut schemas = HashMap::new();
+        let mut schemas = SchemaRegistry::new();
         let schema = ResourceSchema::new(resource_type).with_description(description);
-        schemas.insert(resource_type.to_string(), schema);
+        schemas.insert("", schema);
         HoverProvider::new(Arc::new(schemas), vec![])
     }
 
@@ -711,12 +765,12 @@ mod tests {
         attr_name: &str,
         attr_description: &str,
     ) -> HoverProvider {
-        let mut schemas = HashMap::new();
+        let mut schemas = SchemaRegistry::new();
         let schema = ResourceSchema::new(resource_type).attribute(
             AttributeSchema::new(attr_name, AttributeType::String)
                 .with_description(attr_description),
         );
-        schemas.insert(resource_type.to_string(), schema);
+        schemas.insert("", schema);
         HoverProvider::new(Arc::new(schemas), vec![])
     }
 
@@ -747,7 +801,10 @@ mod tests {
         let desc = "Specifies a virtual private cloud (VPC). To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html).";
 
         let provider = create_hover_provider_with_description("ec2.Vpc", desc);
-        let schema = provider.schemas.get("ec2.Vpc").unwrap();
+        let schema = provider
+            .schemas
+            .get("", "ec2.Vpc", carina_core::schema::SchemaKind::Managed)
+            .unwrap();
         let hover = provider.schema_hover("ec2.Vpc", schema).unwrap();
 
         let content = match &hover.contents {
@@ -876,24 +933,21 @@ mod tests {
         // Two schemas both have "internet_gateway_id" but with different descriptions.
         // When hovering inside a vpc_gateway_attachment block, the hover should show
         // the description from vpc_gateway_attachment's schema, not internet_gateway's.
-        let mut schemas = HashMap::new();
+        let mut schemas = SchemaRegistry::new();
 
-        let igw_schema = ResourceSchema::new("awscc.ec2.internet_gateway").attribute(
+        let igw_schema = ResourceSchema::new("ec2.internet_gateway").attribute(
             AttributeSchema::new("internet_gateway_id", AttributeType::String)
                 .with_description("The ID of the internet gateway (from internet_gateway schema)."),
         );
-        schemas.insert("awscc.ec2.internet_gateway".to_string(), igw_schema);
+        schemas.insert("awscc", igw_schema);
 
-        let attachment_schema = ResourceSchema::new("awscc.ec2.vpc_gateway_attachment").attribute(
+        let attachment_schema = ResourceSchema::new("ec2.vpc_gateway_attachment").attribute(
             AttributeSchema::new("internet_gateway_id", AttributeType::String)
                 .with_description(
                     "The ID of the internet gateway attached to the VPC (from vpc_gateway_attachment schema).",
                 ),
         );
-        schemas.insert(
-            "awscc.ec2.vpc_gateway_attachment".to_string(),
-            attachment_schema,
-        );
+        schemas.insert("awscc", attachment_schema);
 
         let provider = HoverProvider::new(Arc::new(schemas), vec![]);
 
@@ -942,20 +996,20 @@ awscc.ec2.vpc_gateway_attachment {
         // Regression for #1988: when a word is NOT an attribute of the
         // enclosing resource, hover must return None — not fall back to a
         // lookalike attribute from an unrelated resource schema.
-        let mut schemas = HashMap::new();
+        let mut schemas = SchemaRegistry::new();
 
         // `account_id` lives on organizations.account only.
-        let account_schema = ResourceSchema::new("awscc.organizations.account").attribute(
+        let account_schema = ResourceSchema::new("organizations.account").attribute(
             AttributeSchema::new("account_id", AttributeType::String)
                 .with_description("The unique identifier (ID) of the new account."),
         );
-        schemas.insert("awscc.organizations.account".to_string(), account_schema);
+        schemas.insert("awscc", account_schema);
 
         // `awscc.sso.Assignment` intentionally has NO `account_id`.
-        let assignment_schema = ResourceSchema::new("awscc.sso.Assignment").attribute(
+        let assignment_schema = ResourceSchema::new("sso.Assignment").attribute(
             AttributeSchema::new("target_id", AttributeType::String).with_description("Target id."),
         );
-        schemas.insert("awscc.sso.Assignment".to_string(), assignment_schema);
+        schemas.insert("awscc", assignment_schema);
 
         let provider = HoverProvider::new(Arc::new(schemas), vec![]);
 
@@ -989,7 +1043,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_builtin_function_hover_join() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let doc = Document::new("join".to_string(), Arc::new(ProviderContext::default()));
         let hover = provider
             .hover(&doc, Position::new(0, 1))
@@ -1018,7 +1072,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_builtin_function_hover_cidr_subnet() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let doc = Document::new(
             "cidr_subnet".to_string(),
             Arc::new(ProviderContext::default()),
@@ -1041,7 +1095,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_builtin_function_hover_unknown_returns_none() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let doc = Document::new(
             "not_a_function".to_string(),
             Arc::new(ProviderContext::default()),
@@ -1052,7 +1106,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_all_builtin_functions_have_hover() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let names = [
             "cidr_subnet",
             "concat",
@@ -1089,7 +1143,7 @@ awscc.ec2.vpc_gateway_attachment {
     fn test_module_argument_hover_with_description() {
         use carina_core::parser::{ArgumentParameter, TypeExpr};
 
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let arg = ArgumentParameter {
             name: "vpc".to_string(),
             type_expr: TypeExpr::Ref(carina_core::parser::ResourceTypePath::new(
@@ -1135,7 +1189,7 @@ awscc.ec2.vpc_gateway_attachment {
     fn test_module_argument_hover_with_default() {
         use carina_core::parser::{ArgumentParameter, TypeExpr};
 
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let arg = ArgumentParameter {
             name: "port".to_string(),
             type_expr: TypeExpr::Int,
@@ -1169,7 +1223,7 @@ awscc.ec2.vpc_gateway_attachment {
     fn test_module_argument_hover_without_description() {
         use carina_core::parser::{ArgumentParameter, TypeExpr};
 
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         let arg = ArgumentParameter {
             name: "env".to_string(),
             type_expr: TypeExpr::String,
@@ -1201,7 +1255,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_no_builtin_hover_for_map_in_type_annotation() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         // Line 1 (0-indexed): "  accounts: map(AwsAccountId) = {"
         // Position on "map" → should NOT show function hover
         let doc = Document::new(
@@ -1219,7 +1273,7 @@ awscc.ec2.vpc_gateway_attachment {
 
     #[test]
     fn test_builtin_hover_for_map_in_function_call() {
-        let provider = HoverProvider::new(Arc::new(HashMap::new()), vec![]);
+        let provider = HoverProvider::new(Arc::new(SchemaRegistry::new()), vec![]);
         // Normal function call (no preceding ':') — should show hover
         let doc = Document::new(
             "let x = map(\".id\", items)".to_string(),

--- a/carina-lsp/tests/e2e_typecheck.rs
+++ b/carina-lsp/tests/e2e_typecheck.rs
@@ -15,10 +15,8 @@
 
 mod support;
 
-use std::collections::HashMap;
-
 use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+    AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField, legacy_validator,
 };
 use support::fixture::{analyze, engine_with_schemas, single_schema_map, write_fixture};
 
@@ -40,7 +38,7 @@ fn messages_of(diags: &[tower_lsp::lsp_types::Diagnostic]) -> Vec<&String> {
 // Scenario 1: StringEnum with bare / TypeQualified / fully-qualified
 // ---------------------------------------------------------------
 
-fn enum_schemas() -> HashMap<String, ResourceSchema> {
+fn enum_schemas() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
@@ -48,7 +46,7 @@ fn enum_schemas() -> HashMap<String, ResourceSchema> {
         to_dsl: None,
     };
     single_schema_map(
-        ResourceSchema::new("test.r.mode_holder")
+        ResourceSchema::new("r.mode_holder")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("mode", mode)),
     )
@@ -109,7 +107,7 @@ test.r.mode_holder {
 // Scenario 2: Custom type with `to_dsl` normalization (Region-like)
 // ---------------------------------------------------------------
 
-fn region_schemas() -> HashMap<String, ResourceSchema> {
+fn region_schemas() -> SchemaRegistry {
     // Mirrors the production `aws_region()` shape (#2248): the `Custom`
     // validate path does **not** consult the schema-level `to_dsl`
     // callback — only `StringEnum` validation does, for alias matching.
@@ -145,7 +143,7 @@ fn region_schemas() -> HashMap<String, ResourceSchema> {
     };
 
     single_schema_map(
-        ResourceSchema::new("test.r.region_holder")
+        ResourceSchema::new("r.region_holder")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("region", region_custom)),
     )
@@ -244,7 +242,7 @@ test.r.region_holder {
 // warning and short-circuit the type-check.
 // ---------------------------------------------------------------
 
-fn nested_struct_schemas() -> HashMap<String, ResourceSchema> {
+fn nested_struct_schemas() -> SchemaRegistry {
     // Single Struct holding another single Struct — keeps the fixture in
     // block syntax (no list literals) so the test exercises only the
     // nested-Struct type-check path, not the prefer-block-syntax warning.
@@ -261,7 +259,7 @@ fn nested_struct_schemas() -> HashMap<String, ResourceSchema> {
     };
 
     single_schema_map(
-        ResourceSchema::new("test.r.nested")
+        ResourceSchema::new("r.nested")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("outer", outer)),
     )
@@ -298,10 +296,10 @@ test.r.nested {
 // Scenario 4: Union with multiple member candidates
 // ---------------------------------------------------------------
 
-fn union_schemas() -> HashMap<String, ResourceSchema> {
+fn union_schemas() -> SchemaRegistry {
     let union = AttributeType::Union(vec![AttributeType::Int, AttributeType::String]);
     single_schema_map(
-        ResourceSchema::new("test.r.union")
+        ResourceSchema::new("r.union")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("value", union)),
     )
@@ -361,20 +359,20 @@ test.r.union {
 // Scenario 5: ResourceRef pointing to a binding declared in a sibling file
 // ---------------------------------------------------------------
 
-fn resource_ref_schemas() -> HashMap<String, ResourceSchema> {
+fn resource_ref_schemas() -> SchemaRegistry {
     // Producer: declares a `name` and an `id` attribute marked read-only
     // (provider-computed). Consumers reference it via `<binding>.id`.
-    let producer = ResourceSchema::new("test.r.producer")
+    let producer = ResourceSchema::new("r.producer")
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new("id", AttributeType::String).read_only());
 
     // Consumer: takes a string `target_id`. The fixture below feeds it the
     // producer's computed `id` via a ResourceRef declared in a sibling file.
-    let consumer = ResourceSchema::new("test.r.consumer")
+    let consumer = ResourceSchema::new("r.consumer")
         .attribute(AttributeSchema::new("name", AttributeType::String))
         .attribute(AttributeSchema::new("target_id", AttributeType::String));
 
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(producer.resource_type.clone(), producer);
     schemas.insert(consumer.resource_type.clone(), consumer);
     schemas
@@ -422,7 +420,7 @@ let upstream = test.r.producer {
 #[test]
 fn unknown_attribute_emits_suggestion() {
     let engine = engine_with_schemas(single_schema_map(
-        ResourceSchema::new("test.r.suggester")
+        ResourceSchema::new("r.suggester")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("description", AttributeType::String)),
     ));
@@ -458,7 +456,7 @@ test.r.suggester {
 // to pin.
 // ---------------------------------------------------------------
 
-fn list_struct_schemas() -> HashMap<String, ResourceSchema> {
+fn list_struct_schemas() -> SchemaRegistry {
     let inner = AttributeType::Struct {
         name: "Inner".to_string(),
         fields: vec![StructField::new("leaf", AttributeType::Int)],
@@ -472,7 +470,7 @@ fn list_struct_schemas() -> HashMap<String, ResourceSchema> {
     });
 
     single_schema_map(
-        ResourceSchema::new("test.r.list_nested")
+        ResourceSchema::new("r.list_nested")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("outer", outer).with_block_name("outer")),
     )
@@ -522,14 +520,14 @@ test.r.list_nested {
 // repeated `rule { ... }` blocks). The single-schema-shape test above
 // would silently pass even if the LSP forgot to honour the rename, so a
 // dedicated case is needed.
-fn list_struct_renamed_block_schemas() -> HashMap<String, ResourceSchema> {
+fn list_struct_renamed_block_schemas() -> SchemaRegistry {
     let rule = AttributeType::list(AttributeType::Struct {
         name: "Rule".to_string(),
         fields: vec![StructField::new("days", AttributeType::Int)],
     });
 
     single_schema_map(
-        ResourceSchema::new("test.r.renamed_block")
+        ResourceSchema::new("r.renamed_block")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("rules", rule).with_block_name("rule")),
     )

--- a/carina-lsp/tests/lsp_enum_code_action.rs
+++ b/carina-lsp/tests/lsp_enum_code_action.rs
@@ -14,16 +14,14 @@
 
 mod support;
 
-use std::collections::HashMap;
-
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry};
 use carina_lsp::code_action::{
     EnumDiagnosticData, EnumDiagnosticKind, code_actions_for_diagnostic,
 };
 use support::fixture::{analyze, engine_with_schemas, write_fixture};
 use tower_lsp::lsp_types::{Diagnostic, Url};
 
-fn versioning_schema() -> HashMap<String, ResourceSchema> {
+fn versioning_schema() -> SchemaRegistry {
     fn lower(v: &str) -> String {
         v.to_ascii_lowercase()
     }
@@ -33,10 +31,10 @@ fn versioning_schema() -> HashMap<String, ResourceSchema> {
         namespace: Some("aws.s3.Bucket".to_string()),
         to_dsl: Some(lower),
     };
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "aws.s3.bucket".to_string(),
-        ResourceSchema::new("aws.s3.bucket")
+        "aws",
+        ResourceSchema::new("s3.bucket")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("versioning", versioning)),
     );
@@ -170,17 +168,17 @@ fn string_literal_emits_string_literal_kind_and_replaces_quotes() {
 // Scenario 3: non-namespaced StringEnum
 // ---------------------------------------------------------------------------
 
-fn bare_mode_schema() -> HashMap<String, ResourceSchema> {
+fn bare_mode_schema() -> SchemaRegistry {
     let mode = AttributeType::StringEnum {
         name: "Mode".to_string(),
         values: vec!["fast".to_string(), "slow".to_string()],
         namespace: None,
         to_dsl: None,
     };
-    let mut schemas = HashMap::new();
+    let mut schemas = SchemaRegistry::new();
     schemas.insert(
-        "test.r.mode_holder".to_string(),
-        ResourceSchema::new("test.r.mode_holder")
+        "test",
+        ResourceSchema::new("r.mode_holder")
             .attribute(AttributeSchema::new("name", AttributeType::String))
             .attribute(AttributeSchema::new("mode", mode)),
     );

--- a/carina-lsp/tests/support/fixture.rs
+++ b/carina-lsp/tests/support/fixture.rs
@@ -3,10 +3,9 @@
 //! directory-shaped layout the project's invariant requires
 //! (`main.crn` + sibling files like `providers.crn`, `exports.crn`).
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::{ResourceSchema, SchemaRegistry};
 use carina_lsp::diagnostics::DiagnosticEngine;
 use carina_lsp::document::Document;
 use tempfile::TempDir;
@@ -37,25 +36,25 @@ pub fn analyze(engine: &DiagnosticEngine, fixture: &TempDir, file_name: &str) ->
 }
 
 /// Build a `DiagnosticEngine` from in-memory schemas. Provider names
-/// are derived from the `<provider>.<...>` keys so the engine can
+/// are derived from registered schema entries so the engine can
 /// recognise the synthetic providers used in tests.
 #[allow(dead_code)]
-pub fn engine_with_schemas(schemas: HashMap<String, ResourceSchema>) -> DiagnosticEngine {
+pub fn engine_with_schemas(schemas: SchemaRegistry) -> DiagnosticEngine {
     let provider_names: Vec<String> = schemas
-        .keys()
-        .filter_map(|k| k.split('.').next())
+        .iter()
+        .map(|(provider, _, _, _)| provider.to_string())
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
-        .map(String::from)
         .collect();
     DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(vec![]))
 }
 
-/// Wrap one `ResourceSchema` in a `HashMap` keyed by its
-/// `resource_type`. Convenience for single-resource scenarios.
+/// Wrap one `ResourceSchema` in a `SchemaRegistry` registered under the
+/// `test` provider — the standard provider name for synthetic test fixtures
+/// in this crate.
 #[allow(dead_code)]
-pub fn single_schema_map(schema: ResourceSchema) -> HashMap<String, ResourceSchema> {
-    let mut schemas = HashMap::new();
-    schemas.insert(schema.resource_type.clone(), schema);
-    schemas
+pub fn single_schema_map(schema: ResourceSchema) -> SchemaRegistry {
+    let mut registry = SchemaRegistry::new();
+    registry.insert("test", schema);
+    registry
 }

--- a/carina-tui/src/app/mod.rs
+++ b/carina-tui/src/app/mod.rs
@@ -9,7 +9,7 @@ use carina_core::plan_tree::{
     build_dependency_graph, build_single_parent_tree, extract_compact_hint,
 };
 use carina_core::resource::ResourceId;
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 use ratatui::widgets::ListState;
 
 /// A node in the tree view representing one effect
@@ -93,7 +93,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(plan: &Plan, schemas: &HashMap<String, ResourceSchema>) -> Self {
+    pub fn new(plan: &Plan, schemas: &SchemaRegistry) -> Self {
         let schemas_opt = if schemas.is_empty() {
             None
         } else {
@@ -685,7 +685,7 @@ fn shorten_effect_labels(plan: &Plan, nodes: &mut [TreeNode]) {
     }
 }
 
-fn effect_to_node(effect: &Effect, schemas: Option<&HashMap<String, ResourceSchema>>) -> TreeNode {
+fn effect_to_node(effect: &Effect, schemas: Option<&SchemaRegistry>) -> TreeNode {
     let detail_rows = build_detail_rows(effect, schemas, DetailLevel::Full, None);
 
     match effect {

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -5,7 +5,7 @@ use carina_core::value::format_value;
 #[test]
 fn app_from_empty_plan() {
     let plan = Plan::new();
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.nodes.len(), 0);
     assert_eq!(app.selected, 0);
 }
@@ -22,7 +22,7 @@ fn app_from_plan_with_effects() {
         dependencies: HashSet::new(),
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.nodes.len(), 2);
     assert_eq!(app.nodes[0].symbol, "+");
     assert_eq!(app.nodes[0].kind, EffectKind::Create);
@@ -37,7 +37,7 @@ fn navigation() {
     plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
     plan.add(Effect::Create(Resource::new("s3.Bucket", "c")));
 
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.selected, 0);
 
     app.move_down();
@@ -80,7 +80,7 @@ fn update_effect_has_detail_rows() {
         changed_attributes: vec!["versioning".to_string()],
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.nodes[0].kind, EffectKind::Update);
     // Should have a Changed detail row for versioning
     assert!(
@@ -101,7 +101,7 @@ fn internal_attributes_filtered() {
             .with_module_source(carina_core::resource::ModuleSource::module("web", "web")),
     ));
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     // Only "name" should appear (not _binding or _module)
     let attr_rows: Vec<_> = app.nodes[0]
         .detail_rows
@@ -163,7 +163,7 @@ fn replace_effect_symbols() {
         cascade_ref_hints: vec![],
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.nodes[0].symbol, "+/-");
     assert_eq!(app.nodes[1].symbol, "-/+");
 }
@@ -186,7 +186,7 @@ fn tree_structure_with_dependencies() {
             ),
     ));
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
 
     // VPC should be root (depth 0) with subnet as child
     assert_eq!(app.nodes[0].depth, 0);
@@ -207,7 +207,7 @@ fn selected_node_returns_correct_node() {
             .with_attribute("name", Value::String("test".to_string())),
     ));
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     let node = app.selected_node().unwrap();
     assert_eq!(node.kind, EffectKind::Create);
     // Detail rows should contain the name attribute
@@ -218,7 +218,7 @@ fn selected_node_returns_correct_node() {
 fn toggle_focus_switches_panels() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.focused_panel, FocusedPanel::Tree);
     app.toggle_focus();
@@ -231,7 +231,7 @@ fn toggle_focus_switches_panels() {
 fn detail_scroll_up_down() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     assert_eq!(app.detail_scroll, 0);
     app.detail_scroll_down();
@@ -252,7 +252,7 @@ fn detail_scroll_resets_on_navigation() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
     plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.detail_scroll = 5;
     app.move_down();
@@ -273,7 +273,7 @@ fn tree_scroll_cursor_moves_within_visible_area_before_scrolling() {
             format!("bucket-{}", i),
         )));
     }
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     // Simulate a visible area of 5 items
     app.tree_area_height = 5;
 
@@ -329,7 +329,7 @@ fn tree_scroll_zero_height_does_not_scroll_on_move_down() {
     let mut plan = Plan::new();
     plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
     plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.tree_area_height, 0);
 
     app.move_down();
@@ -362,7 +362,7 @@ fn make_tree_plan() -> Plan {
 #[test]
 fn filter_mode_hides_non_matching_nodes() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     // Before search, all 3 nodes visible
     assert_eq!(app.visible_count(), 3);
@@ -383,7 +383,7 @@ fn filter_mode_hides_non_matching_nodes() {
 #[test]
 fn filter_mode_ancestor_shown_dimmed() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.search_query = "subnet".to_string();
     app.update_search_matches();
@@ -407,7 +407,7 @@ fn filter_mode_ancestor_shown_dimmed() {
 #[test]
 fn filter_mode_clear_query_restores_all() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.search_query = "subnet".to_string();
     app.update_search_matches();
@@ -422,7 +422,7 @@ fn filter_mode_clear_query_restores_all() {
 #[test]
 fn filter_mode_no_matches_shows_all() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.search_query = "zzz_nonexistent".to_string();
     app.update_search_matches();
@@ -434,7 +434,7 @@ fn filter_mode_no_matches_shows_all() {
 #[test]
 fn filter_mode_search_matches_are_non_ancestor_indices() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
 
     app.search_query = "subnet".to_string();
     app.update_search_matches();
@@ -450,7 +450,7 @@ fn filter_mode_search_matches_are_non_ancestor_indices() {
 #[test]
 fn tab_complete_basic() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "sub".to_string();
 
@@ -464,7 +464,7 @@ fn tab_complete_basic() {
 #[test]
 fn tab_complete_cycles_candidates() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "ec2".to_string();
 
@@ -485,7 +485,7 @@ fn tab_complete_cycles_candidates() {
 #[test]
 fn tab_complete_no_match() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "zzz".to_string();
 
@@ -498,7 +498,7 @@ fn tab_complete_no_match() {
 #[test]
 fn tab_complete_empty_query() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = String::new();
 
@@ -511,7 +511,7 @@ fn tab_complete_empty_query() {
 #[test]
 fn tab_complete_case_insensitive() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "SUB".to_string();
 
@@ -525,7 +525,7 @@ fn tab_complete_case_insensitive() {
 #[test]
 fn tab_complete_matches_middle_of_word() {
     let plan = make_tree_plan();
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "net".to_string();
 
@@ -546,7 +546,7 @@ fn tab_complete_with_provider_prefix() {
     plan.add(Effect::Create(
         Resource::with_provider("awscc", "ec2.Subnet", "my-subnet").with_binding("subnet"),
     ));
-    let mut app = App::new(&plan, &HashMap::new());
+    let mut app = App::new(&plan, &SchemaRegistry::new());
     app.search_active = true;
     app.search_query = "ec".to_string();
 
@@ -616,7 +616,7 @@ fn create_effect_attributes_resolve_enum_values() {
             ),
     ));
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     let node = &app.nodes[0];
 
     // Enum value should be resolved in detail rows
@@ -661,7 +661,7 @@ fn move_suppressed_when_update_exists_for_same_target() {
         changed_attributes: vec!["versioning".to_string()],
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     // Move should be suppressed; only the Update node should remain
     assert_eq!(app.nodes.len(), 1);
     assert_eq!(app.nodes[0].kind, EffectKind::Update);
@@ -690,7 +690,7 @@ fn move_suppressed_when_replace_exists_for_same_target() {
         cascade_ref_hints: vec![],
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     assert_eq!(app.nodes.len(), 1);
     assert_eq!(app.nodes[0].symbol, "-/+");
 }
@@ -703,7 +703,7 @@ fn pure_move_not_suppressed() {
         to: ResourceId::new("s3.Bucket", "new-name"),
     });
 
-    let app = App::new(&plan, &HashMap::new());
+    let app = App::new(&plan, &SchemaRegistry::new());
     // Pure move (no Update/Replace for same target) should be kept
     assert_eq!(app.nodes.len(), 1);
     assert_eq!(app.nodes[0].symbol, "->");

--- a/carina-tui/src/lib.rs
+++ b/carina-tui/src/lib.rs
@@ -16,7 +16,6 @@ mod test_utils;
 #[cfg(test)]
 mod tui_snapshot_tests;
 
-use std::collections::HashMap;
 use std::io;
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
@@ -26,7 +25,7 @@ use ratatui::prelude::*;
 
 use carina_core::module::FileSignature;
 use carina_core::plan::Plan;
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 
 pub use app::{App, FocusedPanel};
 pub use module_info_app::ModuleInfoApp;
@@ -187,7 +186,7 @@ pub fn run_module_info(signature: &FileSignature) -> io::Result<()> {
 /// When schemas are provided, the detail panel shows read-only attributes
 /// with `(known after apply)` and default values with `# default`,
 /// matching CLI `--detail full` behavior.
-pub fn run(plan: &Plan, schemas: &HashMap<String, ResourceSchema>) -> io::Result<()> {
+pub fn run(plan: &Plan, schemas: &SchemaRegistry) -> io::Result<()> {
     let mut app = App::new(plan, schemas);
     run_tui(ui::draw, handle_key, &mut app)
 }
@@ -233,7 +232,7 @@ mod tests {
         let mut plan = Plan::new();
         plan.add(Effect::Create(Resource::new("s3.Bucket", "a")));
         plan.add(Effect::Create(Resource::new("s3.Bucket", "b")));
-        App::new(&plan, &HashMap::new())
+        App::new(&plan, &SchemaRegistry::new())
     }
 
     #[test]
@@ -293,7 +292,7 @@ mod tests {
                     ),
                 ),
         ));
-        App::new(&plan, &HashMap::new())
+        App::new(&plan, &SchemaRegistry::new())
     }
 
     #[test]
@@ -492,7 +491,7 @@ mod tests {
         plan.add(Effect::Create(
             Resource::with_provider("awscc", "s3.Bucket", "my-bucket").with_binding("bucket"),
         ));
-        App::new(&plan, &HashMap::new())
+        App::new(&plan, &SchemaRegistry::new())
     }
 
     #[test]

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -3,7 +3,7 @@
 //! Renders the TUI to an in-memory buffer and snapshots the output,
 //! ensuring the plan viewer displays correctly.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
@@ -11,7 +11,7 @@ use ratatui::backend::TestBackend;
 use carina_core::effect::Effect;
 use carina_core::plan::Plan;
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
-use carina_core::schema::ResourceSchema;
+use carina_core::schema::SchemaRegistry;
 
 use crate::app::App;
 use crate::test_utils::buffer_to_string;
@@ -19,13 +19,13 @@ use crate::ui::draw;
 
 /// Render the TUI into a string, optionally selecting a specific node.
 fn render_tui(plan: &Plan, width: u16, height: u16, selection: usize) -> String {
-    render_tui_with_schemas(plan, &HashMap::new(), width, height, selection)
+    render_tui_with_schemas(plan, &SchemaRegistry::new(), width, height, selection)
 }
 
 /// Render the TUI into a string with schemas, optionally selecting a specific node.
 fn render_tui_with_schemas(
     plan: &Plan,
-    schemas: &HashMap<String, ResourceSchema>,
+    schemas: &SchemaRegistry,
     width: u16,
     height: u16,
     selection: usize,
@@ -203,7 +203,7 @@ fn snapshot_create_with_schema() {
             .with_attribute("cidr_block", Value::String("10.0.0.0/16".to_string())),
     ));
 
-    use carina_core::schema::{AttributeSchema, AttributeType};
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 
     let schema = ResourceSchema::new("ec2.Vpc")
         .attribute(AttributeSchema::new("cidr_block", AttributeType::String).required())
@@ -220,8 +220,8 @@ fn snapshot_create_with_schema() {
             AttributeSchema::new("default_security_group_id", AttributeType::String).read_only(),
         );
 
-    let schemas: HashMap<String, ResourceSchema> =
-        [("ec2.Vpc".to_string(), schema)].into_iter().collect();
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("", schema);
 
     let output = render_tui_with_schemas(&plan, &schemas, 120, 40, 0);
     insta::assert_snapshot!(output);
@@ -261,7 +261,7 @@ fn snapshot_detail_panel_third_node() {
 fn render_tui_with_search(plan: &Plan, width: u16, height: u16, query: &str) -> String {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
-    let mut app = App::new(plan, &HashMap::new());
+    let mut app = App::new(plan, &SchemaRegistry::new());
 
     // Simulate typing the search query and confirming with Enter
     app.search_active = true;

--- a/carina-tui/src/ui/tree.rs
+++ b/carina-tui/src/ui/tree.rs
@@ -157,12 +157,13 @@ mod tests {
     use carina_core::effect::Effect;
     use carina_core::plan::Plan;
     use carina_core::resource::{Resource, Value};
+    use carina_core::schema::SchemaRegistry;
 
     #[test]
     fn tree_connector_root_has_no_prefix() {
         let mut plan = Plan::new();
         plan.add(Effect::Create(Resource::new("s3.Bucket", "my-bucket")));
-        let app = App::new(&plan, &std::collections::HashMap::new());
+        let app = App::new(&plan, &SchemaRegistry::new());
         assert_eq!(build_tree_connector(0, &app), "");
     }
 
@@ -182,7 +183,7 @@ mod tests {
                     Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
                 ),
         ));
-        let app = App::new(&plan, &std::collections::HashMap::new());
+        let app = App::new(&plan, &SchemaRegistry::new());
 
         // Subnet is the only (last) child of VPC
         let connector = build_tree_connector(1, &app);
@@ -211,7 +212,7 @@ mod tests {
                     Value::resource_ref("vpc".to_string(), "vpc_id".to_string(), vec![]),
                 ),
         ));
-        let app = App::new(&plan, &std::collections::HashMap::new());
+        let app = App::new(&plan, &SchemaRegistry::new());
 
         // First child gets ├─, last child gets └─
         let children = &app.nodes[0].children;


### PR DESCRIPTION
## Summary

Replaces `HashMap<String, ResourceSchema>` + the `schema_key_fn: &dyn Fn(&Resource) -> String` closure threaded through ~108 call sites with a single `SchemaRegistry` type that owns lookup.

The new registry keys schemas by `(provider, resource_type, SchemaKind)` so the same `(provider, resource_type)` pair can register **two** independent entries — one `Managed`, one `DataSource` — letting a type like `aws.s3.Bucket` be used both for new-resource creation and for `read` keyword lookup. The previous map could only hold one entry per key.

## API

```rust
pub struct SchemaRegistry { /* ... */ }

impl SchemaRegistry {
    pub fn new() -> Self;
    pub fn insert(&mut self, provider: impl Into<String>, schema: ResourceSchema);
    pub fn get(&self, provider: &str, resource_type: &str, kind: SchemaKind) -> Option<&ResourceSchema>;
    pub fn get_for(&self, resource: &Resource) -> Option<&ResourceSchema>;
    pub fn has_managed(&self, provider: &str, resource_type: &str) -> bool;
    pub fn has_data_source(&self, provider: &str, resource_type: &str) -> bool;
    pub fn iter(&self) -> impl Iterator<Item = (&str, &str, SchemaKind, &ResourceSchema)>;
    pub fn len(&self) -> usize;
    pub fn is_empty(&self) -> bool;
}
```

`insert` reads `schema.kind` and routes the schema into the corresponding sub-map. `get_for(resource)` picks `Managed` for normal resources and `DataSource` for `read`-keyword resources, automatically.

## Validation now does a two-sided kind check

- `read` against a managed-only type:
  ```
  awscc.ec2.Vpc is a managed resource, not a data source. Remove the `read` keyword:
    let <name> = awscc.ec2.Vpc { }
  ```
- non-`read` against a data-source-only type (existing wording preserved):
  ```
  awscc.sts.caller_identity is a data source and must be used with the `read` keyword:
    let <name> = read awscc.sts.caller_identity { }
  ```
- neither registered → existing `Unknown resource type:` error.

A new test `read_against_managed_only_type_is_rejected` covers the new direction in `carina-core/src/validation/tests.rs`.

## Removed

- `ProviderFactory::format_schema_key` (trait method)
- `provider::schema_key_for_resource` (free function)
- `schema_key_fn` closure parameter from every call site:
  - `validation/{validate_resources, validate_resource_ref_types, validate_attribute_param_ref_types, validate_export_param_ref_types, collect_ref_type_errors}`
  - `binding_index::BindingIndex::from_parsed`
  - `identifier::{resolve_attr_prefixes, compute_anonymous_identifiers, reconcile_anonymous_identifiers, detect_anonymous_to_named_renames}`
  - `upstream_exports::check_upstream_state_field_types`
  - `differ::plan::{create_plan, cascade_dependent_updates, find_changed_create_only, filter_non_removable_removals}` (and dropped the internal `find_schema` helper)
  - `schema::{resolve_block_names, collect_all_block_names}`
  - `provider::{ProviderNormalizer::merge_default_tags, merge_default_tags_for_provider, collect_schemas, collect_custom_type_validators, collect_custom_type_names}`

`collect_schemas` now returns `SchemaRegistry`. `WiringContext::schemas()` returns `&SchemaRegistry`.

## Verify evidence

- `cargo nextest run --workspace` — 2513 tests pass, 74 skipped, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `bash scripts/check-docs-use-new-spellings.sh` — `docs OK`
- `bash scripts/check-example-warnings.sh` — `All .crn files are warning-free`
- `bash scripts/check-no-direct-resources-access.sh` — pass
- `bash scripts/check-plan-fixtures.sh` — pass
- `bash scripts/check-provider-boundaries.sh` — pass

## Out of scope (follow-ups)

- **`aws.s3.Bucket` dual-registered smoke test** — lives in `carina-rs/carina-provider-aws`. Will file as a sub-issue (add a `DataSourceDef` for `s3.Bucket`, implement `read_data_source`, ship a `.crn` fixture covering both create and `read`).
- **`sidebar.badge` contract finalisation for dual-registered docs** — lives in this repo, coordinates with #1791. Will file as a sub-issue.
- **Provider-crate migration** — `carina-rs/carina-provider-aws` and `carina-rs/carina-provider-awscc` currently construct their own `HashMap<String, ResourceSchema>` and override `format_schema_key`. They need follow-up PRs to switch to `SchemaRegistry::insert(provider, schema)`. Will file one issue per provider repo.

## Test plan

- [x] `read aws.s3.Bucket {...}` rejection (managed-only) — covered by new test
- [x] `aws.s3.Bucket {...}` rejection when only data-source registered — existing test
- [x] `Unknown resource type:` for completely-unknown types — existing test
- [x] All cross-cutting tests (resolution, plan, identifier reconciliation, hover, completion, diagnostics) — covered by full workspace test sweep
- [ ] Once `aws.s3.Bucket` ships dual-registered in `carina-provider-aws`, add a `.crn` fixture exercising both create and `read` of the same type

Closes #2328
