### PR TITLE
docs: fix outdated DSL syntax in aws/awscc provider index pages

### DIFF
--- a/docs/src/content/docs/reference/providers/aws/index.md
+++ b/docs/src/content/docs/reference/providers/aws/index.md
@@ -14,10 +14,10 @@ provider aws {
 
 ## Usage
 
-Resources are defined using the `aws.<resource_type>` syntax:
+Resources are defined using the `aws.<service>.<resource_type>` syntax:
 
 ```crn
-let vpc = aws.ec2_vpc {
+let vpc = aws.ec2.Vpc {
   name       = 'my-vpc'
   cidr_block = '10.0.0.0/16'
   tags = {
@@ -29,7 +29,7 @@ let vpc = aws.ec2_vpc {
 Named resources (using `let`) can be referenced by other resources:
 
 ```crn
-let subnet = aws.ec2_subnet {
+let subnet = aws.ec2.Subnet {
   name              = 'my-subnet'
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
@@ -43,4 +43,4 @@ Some attributes accept enum values. These can be specified in three formats:
 
 - **Bare value**: `instance_tenancy = default`
 - **TypeName.value**: `instance_tenancy = InstanceTenancy.default`
-- **Full namespace**: `instance_tenancy = aws.ec2_vpc.InstanceTenancy.default`
+- **Full namespace**: `instance_tenancy = aws.ec2.Vpc.InstanceTenancy.default`

--- a/docs/src/content/docs/reference/providers/awscc/index.md
+++ b/docs/src/content/docs/reference/providers/awscc/index.md
@@ -17,7 +17,7 @@ provider awscc {
 Resources are defined using the `awscc.<service>.<resource_type>` syntax:
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   name       = 'my-vpc'
   cidr_block = '10.0.0.0/16'
   tags = {
@@ -29,7 +29,7 @@ let vpc = awscc.ec2.vpc {
 Named resources (using `let`) can be referenced by other resources:
 
 ```crn
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   name              = 'my-subnet'
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
@@ -43,4 +43,4 @@ Some attributes accept enum values. These can be specified in three formats:
 
 - **Bare value**: `instance_tenancy = default`
 - **TypeName.value**: `instance_tenancy = InstanceTenancy.default`
-- **Full namespace**: `instance_tenancy = awscc.ec2.vpc.InstanceTenancy.default`
+- **Full namespace**: `instance_tenancy = awscc.ec2.Vpc.InstanceTenancy.default`


### PR DESCRIPTION
## Summary

The aws and awscc provider landing pages
(`docs/src/content/docs/reference/providers/{aws,awscc}/index.md`)
still showed the old pre-PascalCase, pre-dot-notation DSL syntax in
their Quick Example blocks. The generated per-resource reference pages
already use the current syntax (`aws.ec2.Vpc`, `awscc.ec2.Vpc`, ...),
so the index pages were inconsistent with the rest of the reference
docs and would mislead anyone landing there first.

These pages are hand-written, so the recent regenerate-the-docs PRs
(#2339, #2340, #2341) did not touch them.

### awscc/index.md
- `awscc.ec2.vpc` → `awscc.ec2.Vpc`
- `awscc.ec2.subnet` → `awscc.ec2.Subnet`
- `awscc.ec2.vpc.InstanceTenancy.default` → `awscc.ec2.Vpc.InstanceTenancy.default`

### aws/index.md
- `aws.<resource_type>` → `aws.<service>.<resource_type>` (the actual current syntax)
- `aws.ec2_vpc` → `aws.ec2.Vpc`
- `aws.ec2_subnet` → `aws.ec2.Subnet`
- `aws.ec2_vpc.InstanceTenancy.default` → `aws.ec2.Vpc.InstanceTenancy.default`

## Test plan

- [ ] Astro docs site builds without broken-link warnings
- [ ] Quick Example on https://carina-rs.dev/reference/providers/awscc/ matches the per-resource pages
- [ ] Quick Example on https://carina-rs.dev/reference/providers/aws/ matches the per-resource pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)