### PR TITLE
fix(grammars): match PascalCase resource and enum identifiers

### DIFF
--- a/docs/custom-grammars/crn.tmLanguage.json
+++ b/docs/custom-grammars/crn.tmLanguage.json
@@ -110,7 +110,7 @@
       "patterns": [
         {
           "name": "entity.name.type.resource.crn",
-          "match": "\\b(awscc|aws)\\.[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*\\b"
+          "match": "\\b(awscc|aws)\\.[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)*\\b"
         },
         {
           "name": "variable.other.crn",

--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -6,8 +6,8 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#keywords" },
-    { "include": "#resource-types" },
     { "include": "#regions" },
+    { "include": "#resource-types" },
     { "include": "#types" },
     { "include": "#strings" },
     { "include": "#numbers" },
@@ -54,7 +54,7 @@
       "patterns": [
         {
           "name": "support.class.carina",
-          "match": "(aws|awscc|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
+          "match": "\\b(aws|awscc|gcp|azure)\\.[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)*\\b"
         }
       ]
     },

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -6,8 +6,8 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#keywords" },
-    { "include": "#resource-types" },
     { "include": "#regions" },
+    { "include": "#resource-types" },
     { "include": "#types" },
     { "include": "#strings" },
     { "include": "#numbers" },
@@ -54,7 +54,7 @@
       "patterns": [
         {
           "name": "support.class.carina",
-          "match": "(aws|awscc|gcp|azure)\\.[a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*"
+          "match": "\\b(aws|awscc|gcp|azure)\\.[A-Za-z][A-Za-z0-9_]*(\\.[A-Za-z][A-Za-z0-9_]*)*\\b"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- Resource type names and enum values in the DSL are now PascalCase (e.g. `aws.s3.Bucket`, `aws.s3.Bucket.VersioningStatus.Enabled`), but the TextMate grammars only recognized all-lowercase dotted segments. The docs site code blocks and VSCode/TextMate syntax highlighting therefore broke after the casing change — PascalCase tails fell out of the resource scope and either went unstyled (docs grammar) or got picked up only by the generic `entity.name.type` PascalCase fallback (editor grammar).
- Loosened the resource pattern in all three grammar files to accept `[A-Za-z][A-Za-z0-9_]*` segments and made it recursive so long enum paths (`aws.s3.Bucket.VersioningStatus.Enabled`) highlight as one token.
- Reordered `regions` before `resource-types` in the editor grammar so `aws.Region.*` keeps its dedicated `constant.other.region.carina` scope rather than getting absorbed by the more permissive resource pattern.

## Test plan

- [x] `cargo nextest run -p carina-core --test tmlanguage_keyword_parity` — 4/4 pass (keyword parity + byte-identical vscode/tmbundle)
- [x] `npx astro build` in `docs/` — site builds; rendered HTML for `aws.s3.Bucket` and `aws.s3.Bucket.VersioningStatus.Enabled` shows a single highlighted span (`#FFB757`, the `entity.name.type.resource.crn` color)
- [ ] Manual VSCode check on a `.crn` file containing PascalCase identifiers