### PR TITLE
docs: gold-themed sidebar / code frames / search / tables (round 4)

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -218,3 +218,134 @@ table td, table th { border-color: var(--sl-color-hairline-light); }
   stroke-linecap: round;
   stroke-linejoin: round;
 }
+
+/* ============================================================
+   Round 4 — Sidebar / Code frames / Search / Tables
+   ============================================================ */
+
+/* ---------- A. Sidebar group labels & active marker ---------- */
+.sidebar-pane .sidebar-content > ul > li > details > summary,
+.sidebar-pane .sidebar-content > ul > li > .group-label,
+.sidebar-pane .sidebar-content > ul > li > span.large {
+  font-family: var(--sl-font-system-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #fbbf24;
+  opacity: 0.9;
+  border-bottom: 1px solid rgba(251, 191, 36, 0.25);
+  padding-bottom: 0.4rem;
+  margin-top: 1.1rem;
+}
+
+/* Active link gets a gold left bar */
+.sidebar-pane a[aria-current="page"] {
+  position: relative;
+  color: #fbbf24 !important;
+  font-weight: 500;
+}
+.sidebar-pane a[aria-current="page"]::before {
+  content: '';
+  position: absolute;
+  left: -0.75rem;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  width: 2px;
+  background: #fbbf24;
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(251, 191, 36, 0.6);
+}
+
+/* ---------- B. Expressive Code title bars (terminal style) ---------- */
+.expressive-code .frame .header {
+  display: flex !important;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem !important;
+  background: #162032 !important;
+  border-bottom: 1px solid #334155 !important;
+}
+
+/* Add traffic-light dots before the filename */
+.expressive-code .frame .header::before {
+  content: '';
+  display: inline-flex;
+  width: 2.5rem;
+  height: 0.5rem;
+  background-image:
+    radial-gradient(circle at 0.25rem center, #f43f5e 0.25rem, transparent 0.26rem),
+    radial-gradient(circle at 1.125rem center, #f59e0b 0.25rem, transparent 0.26rem),
+    radial-gradient(circle at 2rem center, #10b981 0.25rem, transparent 0.26rem);
+  background-repeat: no-repeat;
+}
+
+/* Make the filename gold + mono */
+.expressive-code .frame .header .title,
+.expressive-code .frame .header > span:not(.copy) {
+  font-family: var(--sl-font-system-mono) !important;
+  color: #fbbf24 !important;
+  font-size: 0.75rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0 !important;
+}
+
+/* ---------- C. Search box & Pagefind results ---------- */
+site-search button[data-open-modal],
+site-search .pagefind-ui__search-input,
+input.pagefind-ui__search-input {
+  border: 1px solid rgba(251, 191, 36, 0.35) !important;
+  background: #1e293b !important;
+  color: #cbd5e1 !important;
+  border-radius: 0.375rem !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+site-search button[data-open-modal]:hover,
+site-search button[data-open-modal]:focus,
+input.pagefind-ui__search-input:focus {
+  border-color: #fbbf24 !important;
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.2) !important;
+  outline: none !important;
+}
+
+/* Highlight matched terms in results */
+.pagefind-ui__result mark,
+.pagefind-ui__result-excerpt mark {
+  background: rgba(251, 191, 36, 0.3) !important;
+  color: #fbbf24 !important;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+.pagefind-ui__result-link {
+  color: #f1f5f9 !important;
+}
+.pagefind-ui__result-link:hover {
+  color: #fbbf24 !important;
+}
+
+/* ---------- D. Tables ---------- */
+.sl-markdown-content table {
+  border-collapse: collapse;
+}
+.sl-markdown-content table thead th {
+  font-family: var(--sl-font-system-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.08);
+  border-bottom: 1px solid rgba(251, 191, 36, 0.3);
+  padding: 0.5rem 0.625rem;
+  text-align: left;
+}
+.sl-markdown-content table tbody tr {
+  transition: background-color 0.15s ease;
+}
+.sl-markdown-content table tbody tr:hover td {
+  background: rgba(251, 191, 36, 0.05);
+}
+.sl-markdown-content table tbody td {
+  padding: 0.5rem 0.625rem;
+  border-bottom: 1px solid #334155;
+}

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -257,7 +257,12 @@ table td, table th { border-color: var(--sl-color-hairline-light); }
   box-shadow: 0 0 6px rgba(251, 191, 36, 0.6);
 }
 
-/* ---------- B. Expressive Code title bars (terminal style) ---------- */
+/* ---------- B. Expressive Code title bars ----------
+   - All titled blocks: gold mono filename + slate bar
+   - Terminal blocks (bash/sh/zsh/console/shell, or title containing
+     "terminal"): also show the three traffic-light dots
+*/
+
 .expressive-code .frame .header {
   display: flex !important;
   align-items: center;
@@ -267,8 +272,22 @@ table td, table th { border-color: var(--sl-color-hairline-light); }
   border-bottom: 1px solid #334155 !important;
 }
 
-/* Add traffic-light dots before the filename */
-.expressive-code .frame .header::before {
+.expressive-code .frame .header .title,
+.expressive-code .frame .header > span:not(.copy) {
+  font-family: var(--sl-font-system-mono) !important;
+  color: #fbbf24 !important;
+  font-size: 0.75rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0 !important;
+}
+
+/* Traffic-light dots — only on terminal-flavoured frames */
+.expressive-code .frame.is-terminal .header::before,
+.expressive-code .frame[data-language="bash"] .header::before,
+.expressive-code .frame[data-language="sh"] .header::before,
+.expressive-code .frame[data-language="zsh"] .header::before,
+.expressive-code .frame[data-language="shell"] .header::before,
+.expressive-code .frame[data-language="console"] .header::before {
   content: '';
   display: inline-flex;
   width: 2.5rem;
@@ -278,16 +297,7 @@ table td, table th { border-color: var(--sl-color-hairline-light); }
     radial-gradient(circle at 1.125rem center, #f59e0b 0.25rem, transparent 0.26rem),
     radial-gradient(circle at 2rem center, #10b981 0.25rem, transparent 0.26rem);
   background-repeat: no-repeat;
-}
-
-/* Make the filename gold + mono */
-.expressive-code .frame .header .title,
-.expressive-code .frame .header > span:not(.copy) {
-  font-family: var(--sl-font-system-mono) !important;
-  color: #fbbf24 !important;
-  font-size: 0.75rem !important;
-  font-weight: 600 !important;
-  letter-spacing: 0 !important;
+  margin-right: 0.25rem;
 }
 
 /* ---------- C. Search box & Pagefind results ---------- */


### PR DESCRIPTION
## Summary
- **Sidebar**: group labels rendered as gold mono uppercase eyebrows with a faint underline; the current page link gets a glowing gold left bar.
- **Expressive Code frames**: title bars styled like terminal headers — traffic-light dots (red/amber/green) before a gold mono filename.
- **Search**: built-in `<site-search>` button and Pagefind input get a gold border and focus ring; matched terms in results highlighted in amber.
- **Tables**: markdown tables in `.sl-markdown-content` get gold mono uppercase headers and a faint gold row hover.

## Test plan
- [x] `npm run dev` in `docs/`
- [x] CSS served at `/src/styles/custom.css` contains all four Round 4 blocks
- [x] `/getting-started/quick-start/` — `Getting Started` group label is wrapped by `<details><summary><div class="group-label"><span class="large">…` and `a[aria-current="page"]` is present (selectors match)
- [x] Frame headers exist as `<figcaption class="header"><span class="title">main.crn</span></figcaption>` inside `.expressive-code .frame …`
- [ ] Visual confirmation in a browser of: sidebar gold bar + code-block traffic lights + search focus ring + table gold headers (please verify in the browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)