### PR TITLE
docs: tint inline code with Carina gold accent

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -459,3 +459,29 @@ input.pagefind-ui__search-input:focus {
   padding: 1px 6px;
   border-radius: 3px;
 }
+
+/* ============================================================
+   Inline code — Carina brand tint
+   Applies to <code> in body text (markdown backticks).
+   Excludes code blocks (which are styled by Expressive Code).
+   ============================================================ */
+:root {
+  --carina-inline-code-color: #fbbf24;
+  --carina-inline-code-bg: rgba(251, 191, 36, 0.07);
+}
+
+.sl-markdown-content :not(pre) > code {
+  font-family: var(--__sl-font-mono);
+  font-size: 0.88em;
+  color: var(--carina-inline-code-color);
+  background: var(--carina-inline-code-bg);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 0;
+}
+
+/* Ensure links containing inline code keep the underline/link color
+   on the surrounding link, not the code itself. */
+.sl-markdown-content a > code {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- Style markdown backtick `<code>` in body text with a gold foreground on a faint gold tint, no border, mono font.
- Excludes fenced code blocks (`<pre> > <code>`), which remain Expressive Code's responsibility.
- Inline code inside a link inherits the link color so links don't lose their underline/color.

## Test plan
- [x] `npm run dev` in `docs/`
- [x] `/reference/providers/awscc/ec2/vpc/` and `/getting-started/core-concepts/` — body backticks render in gold on a faint gold tint, no border
- [x] Fenced code blocks unchanged (Expressive Code styling intact)
- [x] Inline code inside `<a>` keeps the surrounding link color (verified via the `color: inherit` rule on `a > code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)