### PR TITLE
docs: Carina-branded footer / OG card / 404 page + sidebar contrast fix

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,9 +15,11 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Carina',
+      disable404Route: true,
       components: {
         Hero: './src/components/Hero.astro',
         Head: './src/components/Head.astro',
+        Footer: './src/components/Footer.astro',
       },
       favicon: '/favicon.png',
       head: [],

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,0 +1,88 @@
+---
+// Carina-branded page footer.
+// Renders at the bottom of every page.
+---
+
+<footer class="carina-footer">
+  <div class="carina-footer-star" aria-hidden="true"></div>
+  <p class="carina-footer-quote">
+    Named after the keel of <span class="accent">Argo Navis</span> — the structural backbone of the ship.
+  </p>
+  <div class="carina-footer-meta">
+    <a href="https://github.com/carina-rs/carina">GitHub</a>
+    <span class="sep">·</span>
+    <a href="https://crates.io/crates/carina">crates.io</a>
+    <span class="sep">·</span>
+    <span>MIT License</span>
+    <span class="sep">·</span>
+    <span>Built with Astro &amp; Starlight</span>
+  </div>
+</footer>
+
+<style>
+  .carina-footer {
+    position: relative;
+    margin-top: 4rem;
+    padding: 2.25rem 1rem 1.75rem;
+    text-align: center;
+  }
+
+  .carina-footer::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 15%;
+    right: 15%;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      #0891b2 50%,
+      transparent 100%
+    );
+    opacity: 0.5;
+  }
+
+  .carina-footer-star {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #fef3c7;
+    box-shadow: 0 0 8px #fde68a, 0 0 22px rgba(253, 230, 138, 0.35);
+    margin: 0 auto 0.75rem;
+  }
+
+  .carina-footer-quote {
+    font-family: var(--carina-font-display, var(--sl-font));
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--sl-color-gray-3);
+    margin: 0 0 1rem;
+    letter-spacing: 0.005em;
+  }
+
+  .carina-footer-quote .accent {
+    color: #fbbf24;
+    font-style: normal;
+    font-weight: 600;
+  }
+
+  .carina-footer-meta {
+    display: flex;
+    justify-content: center;
+    gap: 1.125rem;
+    font-size: 0.75rem;
+    color: var(--sl-color-gray-4);
+    flex-wrap: wrap;
+  }
+
+  .carina-footer-meta a {
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+
+  .carina-footer-meta a:hover { color: #fbbf24; }
+
+  .carina-footer-meta .sep { color: var(--sl-color-gray-5); }
+</style>

--- a/docs/src/ogp/templates.ts
+++ b/docs/src/ogp/templates.ts
@@ -6,112 +6,143 @@ type SatoriNode = {
 };
 
 const COLORS = {
+  bg: "#0b1220",
   gold: "#fbbf24",
-  white: "#f1f5f9",
+  goldSoft: "#fde68a",
   cyan: "#0891b2",
+  fg1: "#f1f5f9",
+  fg2: "#cbd5e1",
+  fg3: "#94a3b8",
+  // legacy aliases (kept for any external imports)
+  white: "#f1f5f9",
   slate: "#94a3b8",
   navyDark: "#0f172a",
   navyLight: "#1e293b",
 } as const;
 
-function regularPageTemplate(
-  pageTitle: string,
-  logoBase64: string,
-): SatoriNode {
+const TAGLINE = "Strongly Typed Infrastructure as Code";
+
+function cardFrame(children: SatoriNode[]): SatoriNode {
   return {
     type: "div",
     props: {
       style: {
-        display: "flex",
         width: 1200,
         height: 630,
-        backgroundImage: `linear-gradient(135deg, ${COLORS.navyDark}, ${COLORS.navyLight})`,
+        display: "flex",
+        flexDirection: "column",
+        padding: "70px 80px",
+        backgroundColor: COLORS.bg,
+        backgroundImage: [
+          "radial-gradient(ellipse 70% 60% at 30% 30%, rgba(251,191,36,0.10) 0%, transparent 60%)",
+          "radial-gradient(ellipse 50% 50% at 80% 80%, rgba(8,145,178,0.10) 0%, transparent 60%)",
+        ].join(", "),
+        position: "relative",
+        fontFamily: "Inter",
+      },
+      children,
+    },
+  };
+}
+
+function topHorizon(): SatoriNode {
+  return {
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        top: 50,
+        left: 80,
+        right: 80,
+        height: 1,
+        backgroundImage: `linear-gradient(90deg, transparent 0%, ${COLORS.gold} 50%, transparent 100%)`,
+        opacity: 0.55,
+      },
+    },
+  };
+}
+
+function bottomHorizon(): SatoriNode {
+  return {
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        bottom: 50,
+        left: 80,
+        right: 80,
+        height: 1,
+        backgroundImage: `linear-gradient(90deg, transparent 0%, ${COLORS.cyan} 50%, transparent 100%)`,
+        opacity: 0.55,
+      },
+    },
+  };
+}
+
+function canopusStar(marginBottom: number): SatoriNode {
+  return {
+    type: "div",
+    props: {
+      style: {
+        width: 14,
+        height: 14,
+        borderRadius: 7,
+        backgroundColor: COLORS.goldSoft,
+        boxShadow: `0 0 24px ${COLORS.goldSoft}, 0 0 60px rgba(253,230,138,0.4)`,
+        marginBottom,
+      },
+    },
+  };
+}
+
+function wordmark(): SatoriNode {
+  return {
+    type: "div",
+    props: {
+      style: {
+        fontSize: 22,
+        fontWeight: 700,
+        color: COLORS.gold,
+        letterSpacing: 6.16,
+        marginBottom: 20,
+      },
+      children: "CARINA",
+    },
+  };
+}
+
+function metaRow(url: string): SatoriNode {
+  return {
+    type: "div",
+    props: {
+      style: {
+        position: "absolute",
+        bottom: 70,
+        left: 80,
+        right: 80,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        fontSize: 18,
+        color: COLORS.fg3,
       },
       children: [
         {
           type: "div",
           props: {
-            style: {
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: 420,
-              height: 630,
-              backgroundImage:
-                "radial-gradient(circle at center, rgba(8,145,178,0.08) 0%, transparent 70%)",
-              borderRight: "1px solid rgba(8,145,178,0.2)",
-            },
-            children: [
-              {
-                type: "img",
-                props: {
-                  src: logoBase64,
-                  style: { width: 200, height: 200 },
-                },
-              },
-            ],
+            style: { color: COLORS.gold },
+            children: url,
           },
         },
         {
           type: "div",
           props: {
             style: {
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              width: 780,
-              height: 630,
-              paddingLeft: 60,
-              paddingRight: 60,
+              letterSpacing: 3.24,
+              textTransform: "uppercase",
+              fontWeight: 600,
             },
-            children: [
-              {
-                type: "div",
-                props: {
-                  style: {
-                    color: COLORS.gold,
-                    fontSize: 20,
-                    textTransform: "uppercase",
-                    letterSpacing: 3,
-                  },
-                  children: "CARINA",
-                },
-              },
-              {
-                type: "div",
-                props: {
-                  style: {
-                    color: COLORS.white,
-                    fontSize: 48,
-                    fontWeight: 700,
-                    marginTop: 16,
-                  },
-                  children: pageTitle,
-                },
-              },
-              {
-                type: "div",
-                props: {
-                  style: {
-                    width: 80,
-                    height: 3,
-                    backgroundColor: COLORS.cyan,
-                    marginTop: 24,
-                  },
-                },
-              },
-              {
-                type: "div",
-                props: {
-                  style: {
-                    color: COLORS.slate,
-                    fontSize: 20,
-                    marginTop: 24,
-                  },
-                  children: "Strongly Typed Infrastructure as Code",
-                },
-              },
-            ],
+            children: "Strongly typed IaC",
           },
         },
       ],
@@ -119,80 +150,81 @@ function regularPageTemplate(
   };
 }
 
-function topPageTemplate(logoBase64: string): SatoriNode {
-  return {
-    type: "div",
-    props: {
-      style: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        width: 1200,
-        height: 630,
-        backgroundImage: `linear-gradient(160deg, ${COLORS.navyDark}, ${COLORS.navyLight}, ${COLORS.navyDark})`,
+function regularPageTemplate(
+  pageTitle: string,
+  _logoBase64: string,
+): SatoriNode {
+  void _logoBase64;
+  return cardFrame([
+    topHorizon(),
+    bottomHorizon(),
+    canopusStar(36),
+    wordmark(),
+    {
+      type: "div",
+      props: {
+        style: {
+          fontSize: 96,
+          fontWeight: 700,
+          color: COLORS.gold,
+          letterSpacing: -2.4,
+          lineHeight: 1.05,
+          marginBottom: 28,
+        },
+        children: pageTitle,
       },
-      children: [
-        {
-          type: "div",
-          props: {
-            style: {
-              position: "absolute",
-              top: 0,
-              left: "10%",
-              right: "10%",
-              height: 3,
-              backgroundImage: `linear-gradient(90deg, transparent, ${COLORS.gold}, transparent)`,
-            },
-          },
-        },
-        {
-          type: "img",
-          props: {
-            src: logoBase64,
-            style: { width: 160, height: 160 },
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              color: COLORS.gold,
-              fontSize: 28,
-              textTransform: "uppercase",
-              letterSpacing: 4,
-              marginTop: 24,
-            },
-            children: "CARINA",
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              color: COLORS.slate,
-              fontSize: 22,
-              marginTop: 16,
-            },
-            children: "Strongly Typed Infrastructure as Code",
-          },
-        },
-        {
-          type: "div",
-          props: {
-            style: {
-              position: "absolute",
-              bottom: 0,
-              left: "10%",
-              right: "10%",
-              height: 3,
-              backgroundImage: `linear-gradient(90deg, transparent, ${COLORS.cyan}, transparent)`,
-            },
-          },
-        },
-      ],
     },
-  };
+    {
+      type: "div",
+      props: {
+        style: {
+          fontSize: 32,
+          color: COLORS.fg2,
+          lineHeight: 1.4,
+          maxWidth: 880,
+        },
+        children: TAGLINE,
+      },
+    },
+    metaRow("carina-rs.dev"),
+  ]);
+}
+
+function topPageTemplate(_logoBase64: string): SatoriNode {
+  void _logoBase64;
+  return cardFrame([
+    topHorizon(),
+    bottomHorizon(),
+    canopusStar(36),
+    wordmark(),
+    {
+      type: "div",
+      props: {
+        style: {
+          fontSize: 96,
+          fontWeight: 700,
+          color: COLORS.gold,
+          letterSpacing: -2.4,
+          lineHeight: 1.05,
+          marginBottom: 28,
+        },
+        children: "Carina",
+      },
+    },
+    {
+      type: "div",
+      props: {
+        style: {
+          fontSize: 32,
+          color: COLORS.fg2,
+          lineHeight: 1.4,
+          maxWidth: 880,
+        },
+        children: TAGLINE,
+      },
+    },
+    metaRow("carina-rs.dev"),
+  ]);
 }
 
 export { regularPageTemplate, topPageTemplate, COLORS };

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,0 +1,141 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: '404 — Off the chart',
+    template: 'splash',
+    pagefind: false,
+  }}
+>
+  <div class="lost-stage">
+    <span class="nav-star" style="top:8%; left:12%;"></span>
+    <span class="nav-star" style="top:14%; left:78%;"></span>
+    <span class="nav-star bright" style="top:22%; left:30%;"></span>
+    <span class="nav-star" style="top:28%; left:64%;"></span>
+    <span class="nav-star" style="top:42%; left:8%;"></span>
+    <span class="nav-star bright" style="top:48%; left:88%;"></span>
+    <span class="nav-star" style="top:60%; left:18%;"></span>
+    <span class="nav-star" style="top:68%; left:72%;"></span>
+    <span class="nav-star bright" style="top:78%; left:42%;"></span>
+    <span class="nav-star" style="top:84%; left:26%;"></span>
+    <span class="nav-star" style="top:88%; left:82%;"></span>
+    <span class="nav-star" style="top:18%; left:48%;"></span>
+    <span class="nav-star" style="top:90%; left:14%;"></span>
+    <span class="nav-star" style="top:6%; left:62%;"></span>
+
+    <p class="lost-eyebrow">Lost in the constellation</p>
+    <h1 class="lost-title">404 — Off the chart</h1>
+    <p class="lost-sub">This star is not on our map. Maybe it drifted, or maybe it never existed.</p>
+
+    <div class="lost-actions">
+      <a href="/" class="lost-btn primary">Back to Carina</a>
+      <a href="https://github.com/carina-rs/carina/issues" class="lost-btn secondary">Report it</a>
+    </div>
+
+    <p class="lost-mono">CARINA · α <span class="accent">CANOPUS</span> · MAG -0.74</p>
+  </div>
+</StarlightPage>
+
+<style>
+  .lost-stage {
+    position: relative;
+    min-height: 60vh;
+    padding: 4rem 1.5rem;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background:
+      radial-gradient(ellipse 60% 50% at 50% 35%, rgba(251, 191, 36, 0.08) 0%, transparent 60%),
+      radial-gradient(ellipse 80% 60% at 50% 100%, rgba(8, 145, 178, 0.06) 0%, transparent 70%);
+  }
+
+  .nav-star {
+    position: absolute;
+    width: 2px;
+    height: 2px;
+    border-radius: 50%;
+    background: var(--sl-color-gray-5);
+    pointer-events: none;
+  }
+  .nav-star.bright {
+    width: 3px;
+    height: 3px;
+    background: #fde68a;
+    box-shadow: 0 0 6px #fde68a;
+  }
+
+  .lost-eyebrow {
+    font-family: var(--carina-font-display, var(--sl-font));
+    font-size: var(--sl-text-xs);
+    font-weight: 700;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: #fbbf24;
+    margin: 0 0 1rem;
+    z-index: 1;
+  }
+
+  .lost-title {
+    font-family: var(--carina-font-display, var(--sl-font));
+    font-size: clamp(2rem, 6vw, 3.5rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--sl-color-white);
+    margin: 0 0 0.875rem;
+    z-index: 1;
+  }
+
+  .lost-sub {
+    font-size: var(--sl-text-base);
+    color: var(--sl-color-gray-3);
+    margin: 0 0 1.75rem;
+    max-width: 32rem;
+    z-index: 1;
+  }
+
+  .lost-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    z-index: 1;
+  }
+
+  .lost-btn {
+    padding: 0.5rem 1.125rem;
+    border-radius: 0.375rem;
+    font-size: var(--sl-text-sm);
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  }
+
+  .lost-btn.primary {
+    background: #fbbf24;
+    color: #0f172a;
+  }
+  .lost-btn.primary:hover { background: #fde68a; }
+
+  .lost-btn.secondary {
+    border: 1px solid #475569;
+    color: var(--sl-color-gray-3);
+  }
+  .lost-btn.secondary:hover {
+    border-color: #64748b;
+    color: var(--sl-color-white);
+  }
+
+  .lost-mono {
+    margin-top: 1.75rem;
+    font-family: var(--__sl-font-mono);
+    font-size: 0.6875rem;
+    color: var(--sl-color-gray-5);
+    letter-spacing: 0.1em;
+    z-index: 1;
+  }
+  .lost-mono .accent { color: #fbbf24; }
+</style>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -541,3 +541,16 @@ input.pagefind-ui__search-input:focus {
   --carina-aside-accent: #f87171;
   --carina-aside-bg: color-mix(in oklab, #f87171 9%, var(--sl-color-bg));
 }
+
+/* ============================================================
+   Sidebar — active item contrast fix
+   The active sidebar link uses a gold background; text must
+   be dark navy for readability instead of white.
+   ============================================================ */
+
+.sidebar-pane a[aria-current="page"],
+.sidebar-pane a[aria-current="page"]:hover,
+.sidebar-pane a[aria-current="page"]:focus {
+  color: #0f172a !important;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- **Footer**: replace Starlight's default page footer with `<carina-footer>` (Canopus star, "Argo Navis" italic quote with gold accent, GitHub · crates.io · MIT License · Built with Astro & Starlight meta row, hover-on-gold). Wired via `components.Footer` in `astro.config.mjs`.
- **OG card**: rewrite both `regularPageTemplate` and `topPageTemplate` to render the new layout — deep navy background with gold/cyan radial glows, gold + cyan horizons, Canopus star, `CARINA` wordmark, gigantic gold title, slate tagline, `carina-rs.dev` / `STRONGLY TYPED IAC` meta row. Existing exports/signatures preserved; Space Grotesk / JetBrains Mono fall back to Inter.
- **404 page**: add `src/pages/404.astro` ("Off the chart" splash with scattered nav stars, gold eyebrow "Lost in the constellation", "404 — Off the chart" headline, two action buttons, `CARINA · α CANOPUS · MAG -0.74` mono caption). Set `disable404Route: true` so Starlight's default 404 stops shadowing it (also clears the Astro route-collision warning).
- **Sidebar contrast fix**: the active sidebar link now uses dark navy text on its gold background instead of white, restoring readability.

## Test plan
- [x] `npm run dev` in `docs/`
- [x] Footer renders on every page; old Starlight default footer no longer appears.
- [x] `/this-does-not-exist` returns 404 with my "Off the chart" splash; route-collision warning gone.
- [x] Sidebar active item uses dark navy text on gold background.
- [ ] OG card visual verification deferred to CI build (templates compile, but PNG output not inspected locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)