### PR TITLE
docs: drop redundant "." from carina plan example in landing hero

### DIFF
--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -17,7 +17,7 @@ const codeHtml = `<span class="kw">provider</span> <span class="id">awscc</span>
   <span class="attr">cidr_block =</span> <span class="str">'10.0.1.0/24'</span>
 }`;
 
-const planHtml = `<span class="prompt">$</span> carina plan .
+const planHtml = `<span class="prompt">$</span> carina plan
 <span class="muted">Planning...</span>
 
 <span class="add">+</span> <span class="id">awscc.ec2.Vpc</span>


### PR DESCRIPTION
## Summary
- The landing page hero showed `$ carina plan .` as the example terminal output.
- `[PATH]` is optional in `carina plan` and defaults to the current directory, so the trailing `.` adds no information and just looks like noise.
- Drop it so the hero matches the cleanest invocation form.

## Test plan
- [ ] Visual check on the rendered landing page hero — the terminal pane shows `$ carina plan` (no trailing dot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)