### PR TITLE
LSP: suggest upstream_state exports in attribute value position

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2862,3 +2862,179 @@ let attach = awscc.organizations.policy_target_attachment {
         labels
     );
 }
+
+/// Issue #2353: in attribute value position, an `upstream_state` binding's
+/// typed `exports { ... }` field whose type matches the target attribute
+/// must surface as `<binding>.<export>` — symmetric with the existing
+/// resource-binding Custom-type matching path.
+#[test]
+fn upstream_state_export_suggested_in_value_position() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("foo.bar")
+        .attribute(AttributeSchema::new("attr", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("network")).unwrap();
+    std::fs::create_dir_all(root.join("web")).unwrap();
+    std::fs::write(
+        root.join("network/main.crn"),
+        "exports {\n  vpc_id: String = 'vpc-abc'\n}\n",
+    )
+    .unwrap();
+    let main_src = "\
+let network = upstream_state {
+  source = '../network'
+}
+
+test.foo.bar {
+  attr =
+}
+";
+    std::fs::write(root.join("web/main.crn"), main_src).unwrap();
+
+    let doc = create_document(main_src);
+    let position = Position {
+        line: 5,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&root.join("web")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"network.vpc_id"),
+        "upstream_state export with matching type must be offered as '<binding>.<export>'. Got: {:?}",
+        labels
+    );
+}
+
+/// Issue #2353: an `upstream_state` export whose declared type does not
+/// match the target attribute must NOT be offered. Mirrors the
+/// type-filtering behavior of the existing Custom-type matching path
+/// for resource bindings.
+#[test]
+fn upstream_state_export_filtered_by_attribute_type() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("foo.bar")
+        .attribute(AttributeSchema::new("attr", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("network")).unwrap();
+    std::fs::create_dir_all(root.join("web")).unwrap();
+    std::fs::write(
+        root.join("network/main.crn"),
+        "exports {\n  vpc_id: String = 'vpc-abc'\n  count: Int = 3\n}\n",
+    )
+    .unwrap();
+    let main_src = "\
+let network = upstream_state {
+  source = '../network'
+}
+
+test.foo.bar {
+  attr =
+}
+";
+    std::fs::write(root.join("web/main.crn"), main_src).unwrap();
+
+    let doc = create_document(main_src);
+    let position = Position {
+        line: 5,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&root.join("web")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    // Positive companion: prove the upstream pass actually ran by asserting
+    // the matching-type export is offered. Otherwise the negative assertion
+    // could pass for the wrong reason (pass never executed at all).
+    assert!(
+        labels.contains(&"network.vpc_id"),
+        "matching-type export must be offered (sanity: confirms the upstream pass ran). Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"network.count"),
+        "upstream_state export with non-matching type must not be offered. Got: {:?}",
+        labels
+    );
+}
+
+/// Issue #2353: exercise the directory-scoped path that matters in real
+/// `infra/` projects — exports declared in a sibling `exports.crn`, not
+/// `main.crn` — and confirm two distinct `upstream_state` bindings each
+/// surface their own typed exports independently. Without this fixture
+/// a future regression that swapped `parse_directory` for a single-file
+/// read would silently break production while the prior tests stayed
+/// green.
+#[test]
+fn upstream_state_export_multiple_bindings_and_sibling_exports_file() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("foo.bar")
+        .attribute(AttributeSchema::new("attr", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("test", schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["test".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("network")).unwrap();
+    std::fs::create_dir_all(root.join("shared")).unwrap();
+    std::fs::create_dir_all(root.join("web")).unwrap();
+    // network: exports split into a sibling `exports.crn`, `main.crn` empty.
+    std::fs::write(root.join("network/main.crn"), "").unwrap();
+    std::fs::write(
+        root.join("network/exports.crn"),
+        "exports {\n  vpc_id: String = 'vpc-abc'\n}\n",
+    )
+    .unwrap();
+    // shared: exports in `main.crn`.
+    std::fs::write(
+        root.join("shared/main.crn"),
+        "exports {\n  hosted_zone_id: String = 'Z123'\n}\n",
+    )
+    .unwrap();
+    let main_src = "\
+let network = upstream_state {
+  source = '../network'
+}
+
+let shared = upstream_state {
+  source = '../shared'
+}
+
+test.foo.bar {
+  attr =
+}
+";
+    std::fs::write(root.join("web/main.crn"), main_src).unwrap();
+
+    let doc = create_document(main_src);
+    let position = Position {
+        line: 9,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&root.join("web")));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"network.vpc_id"),
+        "exports declared in sibling `exports.crn` must be discovered. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"shared.hosted_zone_id"),
+        "second upstream_state binding must surface its exports independently. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -126,24 +126,57 @@ impl CompletionProvider {
             );
         }
 
-        // Type-based resource reference completions:
-        // Look up the attribute's type from the schema. If it's a Custom type,
-        // find bindings whose resource schema has an attribute with the same Custom type name.
+        // Cache resolved upstream `exports` maps for the lifetime of this
+        // call. The upstream-binding REFERENCE pass below and the
+        // for-binding type-inference pass further down both call
+        // `resolve_upstream_exports`, which re-parses the upstream
+        // directory on each invocation — sharing one cache holds the
+        // cost to a single parse per upstream binding per keystroke.
+        let upstream_sources = super::collect_upstream_state_bindings(src);
+        let mut exports_cache: std::collections::HashMap<
+            String,
+            std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+        > = std::collections::HashMap::new();
+
+        // Type-based reference completions: walk every binding in scope and
+        // emit `<binding>.<field>` candidates whose type matches the target
+        // attribute. Two binding sources contribute, sharing the same
+        // schema lookup but using different matching strategies:
+        //
+        //   - Resource bindings: each binding's resource schema is queried
+        //     directly. A field is offered when its `Custom`-type name
+        //     equals the target attribute's `Custom`-type name. This is a
+        //     string compare — adequate because both ends sit inside the
+        //     compiled provider schema and share a closed type vocabulary.
+        //
+        //   - `upstream_state` bindings (#2353): exports are declared by
+        //     the user with a `TypeExpr` that lives in a different type
+        //     system than the schema's `AttributeType`, so name equality
+        //     does not apply. `is_type_expr_compatible_with_schema`
+        //     bridges the two — it walks `Custom` base chains and accepts
+        //     structural shapes (list/map/struct), so e.g. an export
+        //     declared `: String` matches a schema attribute typed
+        //     `Custom { semantic_name: "Arn", base: String, .. }`.
+        //
+        // Resource bindings skip self-references (`current_binding`) because
+        // their own attributes are accessible by bare attribute name within
+        // the block. Upstream bindings have no such bare-name shortcut — the
+        // only way to reference an export is `<binding>.<export>` — and a
+        // resource block being edited can never be an `upstream_state`
+        // block (the dispatcher routes those through
+        // `InsideUpstreamStateBlock`), so the self-skip is unreachable
+        // for upstream bindings and intentionally omitted.
         if let Some(schema) = self.lookup_schema(resource_type)
             && let Some(attr_schema) = schema.attributes.get(attr_name)
         {
-            let target_type_name = Self::extract_custom_type_name(&attr_schema.attr_type);
-            if let Some(target_name) = target_type_name {
+            if let Some(target_name) = Self::extract_custom_type_name(&attr_schema.attr_type) {
                 for (binding_name, binding_resource_type) in &self.extract_resource_bindings(src) {
                     if binding_resource_type.is_empty() {
                         continue;
                     }
-                    // Skip self-references: don't suggest the current resource's own binding
                     if current_binding.is_some_and(|cb| cb == binding_name) {
                         continue;
                     }
-                    // Look up the binding's resource schema and find attributes
-                    // with matching Custom type name
                     if let Some(binding_schema) = self.lookup_schema(binding_resource_type) {
                         for binding_attr in binding_schema.attributes.values() {
                             if let Some(binding_type_name) =
@@ -169,6 +202,37 @@ impl CompletionProvider {
                             }
                         }
                     }
+                }
+            }
+
+            for (binding, source) in &upstream_sources {
+                let exports =
+                    resolve_upstream_exports_cached(binding, source, base_path, &mut exports_cache);
+                for (export_name, export_type) in exports {
+                    let Some(export_type) = export_type else {
+                        continue;
+                    };
+                    if !carina_core::validation::is_type_expr_compatible_with_schema(
+                        export_type,
+                        &attr_schema.attr_type,
+                    ) {
+                        continue;
+                    }
+                    let full_ref = format!("{}.{}", binding, export_name);
+                    completions.push(CompletionItem {
+                        label: full_ref.clone(),
+                        kind: Some(CompletionItemKind::REFERENCE),
+                        detail: Some(format!(
+                            "export from upstream_state `{}` ({})",
+                            binding,
+                            self.format_type_expr(export_type)
+                        )),
+                        text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                            range: ref_edit_range,
+                            new_text: full_ref,
+                        })),
+                        ..Default::default()
+                    });
                 }
             }
         }
@@ -199,19 +263,6 @@ impl CompletionProvider {
             .and_then(|s| s.attributes.get(attr_name))
             .map(|a| &a.attr_type);
         let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
-        // Cache the resolved exports per upstream. Without this, each
-        // for-binding re-parses the upstream project every keystroke.
-        // The sibling scan itself reuses the already-resolved `src`.
-        let upstream_sources: std::collections::HashMap<String, String> =
-            if for_bindings.iter().any(|b| b.iterable.is_some()) {
-                super::collect_upstream_state_bindings(src)
-            } else {
-                std::collections::HashMap::new()
-            };
-        let mut exports_cache: std::collections::HashMap<
-            String,
-            std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
-        > = std::collections::HashMap::new();
         for binding in &for_bindings {
             if let Some(attr_type) = attr_type_for_for_filter
                 && let Some(element_type) = infer_for_binding_type(
@@ -1201,6 +1252,10 @@ impl CompletionProvider {
 /// directory has no export entry for `binding`. Both depth-1 and
 /// depth-2 dot completion build on this — they only differ in how
 /// they consume the resulting map.
+///
+/// Use [`resolve_upstream_exports_cached`] instead when calling from
+/// `value_completions_for_attr`, which has multiple consumers and pays
+/// for re-parsing without a shared cache.
 fn resolve_upstream_export_keys(
     binding: &str,
     source: &str,
@@ -1217,6 +1272,33 @@ fn resolve_upstream_export_keys(
         &Default::default(),
     );
     exports.remove(binding)
+}
+
+/// Cached variant of [`resolve_upstream_export_keys`] for use inside a
+/// single `value_completions_for_attr` call. Differences from the
+/// non-cached form:
+///
+/// - **Returns `&HashMap`, never `None`.** A failed resolution (missing
+///   `base_path`, missing source directory, parse error) is collapsed
+///   to an empty map so callers can iterate uniformly with the
+///   resolved-but-empty case. Callers that need to distinguish failure
+///   from "resolved with zero exports" must use [`resolve_upstream_export_keys`].
+/// - **Caches per binding name.** A failed lookup poisons the cache
+///   entry to an empty map for the lifetime of the call, which is
+///   intentional — every keystroke creates a fresh cache, and re-trying
+///   the same failing parse mid-call would be wasted work.
+fn resolve_upstream_exports_cached<'a>(
+    binding: &str,
+    source: &str,
+    base_path: Option<&Path>,
+    cache: &'a mut std::collections::HashMap<
+        String,
+        std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+    >,
+) -> &'a std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>> {
+    cache.entry(binding.to_string()).or_insert_with(|| {
+        resolve_upstream_export_keys(binding, source, base_path).unwrap_or_default()
+    })
 }
 
 /// Infer the static type of a for-loop binding by resolving its iterable


### PR DESCRIPTION
Closes #2353

## Summary

- Symmetric LSP completion: in attribute value position (`vpc_id = |`), the popup now offers `<binding>.<export>` REFERENCE candidates from `upstream_state` bindings whose `exports`-declared `TypeExpr` is compatible with the target attribute's schema type — same shape the resource-binding Custom-type matching path has always produced for local resources.
- Hoisted `exports_cache` to the top of `value_completions_for_attr` so the new pass and the existing for-binding type-inference pass share one cache (one parse per upstream binding per keystroke instead of one per consumer).
- New helper `resolve_upstream_exports_cached` wraps the or-insert logic; the non-cached `resolve_upstream_export_keys` is kept for the dot-suffix paths that need to distinguish "missing" from "resolved with zero exports".

## Test plan

- [x] `cargo nextest run -p carina-lsp` (382 passed)
- [x] `cargo test --workspace --doc` (passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [x] `bash scripts/check-*.sh` (all green)
- [x] Three new tempdir fixtures in `carina-lsp/src/completion/tests/extended.rs`:
  - `upstream_state_export_suggested_in_value_position` — positive case
  - `upstream_state_export_filtered_by_attribute_type` — non-matching type filtered, with positive companion to confirm the pass actually ran
  - `upstream_state_export_multiple_bindings_and_sibling_exports_file` — two upstream bindings + exports declared in a sibling `exports.crn` (guards against regression to single-file parsing)
- [ ] Manual check in VSCode against `~/tmp/carina-upstream-state/web` — recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
