### PR TITLE
fix: bridge WASM-plugin Custom validators into schema validation

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -290,7 +290,7 @@ pub fn validate_and_resolve_errors_with_factories(
     }
 
     if !skip_resource_validation {
-        errors.extend(validate_resources_with_ctx(&ctx, parsed));
+        errors.extend(validate_resources_with_ctx(&ctx, parsed, &enriched_context));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -180,7 +180,11 @@ fn lift_validation_result(res: Result<(), String>) -> Vec<AppError> {
         .collect()
 }
 
-pub fn validate_resources_with_ctx(ctx: &WiringContext, parsed: &ParsedFile) -> Vec<AppError> {
+pub fn validate_resources_with_ctx(
+    ctx: &WiringContext,
+    parsed: &ParsedFile,
+    provider_context: &carina_core::parser::ProviderContext,
+) -> Vec<AppError> {
     let known_providers: HashSet<String> = ctx
         .factories()
         .iter()
@@ -190,6 +194,7 @@ pub fn validate_resources_with_ctx(ctx: &WiringContext, parsed: &ParsedFile) -> 
         parsed,
         ctx.schemas(),
         &known_providers,
+        provider_context,
     ))
 }
 
@@ -1404,7 +1409,11 @@ pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
         resources: resources.to_vec(),
         ..ParsedFile::default()
     };
-    errors_to_legacy_result(validate_resources_with_ctx(&ctx, &parsed))
+    errors_to_legacy_result(validate_resources_with_ctx(
+        &ctx,
+        &parsed,
+        &carina_core::parser::ProviderContext::default(),
+    ))
 }
 
 #[cfg(test)]

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -493,7 +493,8 @@ fn validate_resources_with_ctx_returns_each_error_as_app_error() {
         ..ParsedFile::default()
     };
 
-    let errors = validate_resources_with_ctx(&ctx, &parsed);
+    let provider_ctx = carina_core::parser::ProviderContext::default();
+    let errors = validate_resources_with_ctx(&ctx, &parsed, &provider_ctx);
     assert_eq!(errors.len(), 2, "got {errors:?}");
     for err in &errors {
         assert!(matches!(err, AppError::Validation(_)), "got {err:?}");

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -28,6 +28,7 @@ use carina_core::provider::{
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, SchemaRegistry, StructField, legacy_validator,
+    noop_validator,
 };
 use carina_lsp::diagnostics::DiagnosticEngine;
 use carina_lsp::document::Document;
@@ -742,6 +743,243 @@ test.r.renamed_block {
     assert!(
         any(&|s| cli_messages_contain(&cli_diags, s)),
         "CLI must diagnose rule.days int mismatch, got {:?}",
+        cli_diags,
+    );
+}
+
+// ============================================================================
+// Scenario: WASM-plugin Custom validator bridge (#2354)
+//
+// A schema produced via the WASM plugin path carries `validate: noop_validator()`
+// on every `AttributeType::Custom`, with the real validator behind the
+// factory's `validate_custom_type`. The validation pipeline must reach
+// through `ProviderContext.custom_type_validator` so a bad `vpc_id`
+// value is rejected.
+// ============================================================================
+
+struct WasmStyleProviderFactory {
+    name: String,
+    schemas: Vec<ResourceSchema>,
+}
+
+impl ProviderFactory for WasmStyleProviderFactory {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn display_name(&self) -> &str {
+        "WASM-style test provider"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+        // Mirror awscc's `prefixed` validator family: vpc_id must start
+        // with "vpc-".
+        if type_name == "vpc_id" && !value.starts_with("vpc-") {
+            return Err(format!(
+                "Invalid vpc_id '{}': must start with 'vpc-'",
+                value
+            ));
+        }
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn Provider>> {
+        Box::pin(async { Box::new(NoopProvider) as Box<dyn Provider> })
+    }
+    fn create_normalizer(
+        &self,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        self.schemas.clone()
+    }
+}
+
+fn wasm_style_vpc_schema() -> ResourceSchema {
+    let vpc_id_type = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+    ResourceSchema::new("ec2.security_group")
+        .attribute(AttributeSchema::new(
+            "group_description",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_type))
+}
+
+fn wasm_style_schemas() -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awsccmock", wasm_style_vpc_schema());
+    schemas
+}
+
+fn wasm_style_factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(WasmStyleProviderFactory {
+        name: "awsccmock".to_string(),
+        schemas: vec![wasm_style_vpc_schema()],
+    }) as Box<dyn ProviderFactory>]
+}
+
+fn wasm_style_engine() -> DiagnosticEngine {
+    let schemas = wasm_style_schemas();
+    let factories: Vec<Box<dyn ProviderFactory>> = wasm_style_factories();
+    let provider_names = vec!["awsccmock".to_string()];
+    DiagnosticEngine::new(Arc::new(schemas), provider_names, Arc::new(factories))
+}
+
+#[test]
+fn wasm_plugin_custom_validator_rejects_invalid_vpc_id_parity() {
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awsccmock.ec2.security_group {
+    group_description = "web sg"
+    vpc_id            = "test"
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&wasm_style_engine(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(wasm_style_factories(), &fixture);
+
+    assert!(
+        lsp_messages_contain(&lsp_diags, "vpc_id") || lsp_messages_contain(&lsp_diags, "vpc-"),
+        "LSP must diagnose invalid vpc_id, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        cli_messages_contain(&cli_diags, "vpc_id") || cli_messages_contain(&cli_diags, "vpc-"),
+        "CLI must diagnose invalid vpc_id, got {:?}",
+        cli_diags,
+    );
+}
+
+#[test]
+fn wasm_plugin_custom_validator_accepts_valid_vpc_id_parity() {
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awsccmock.ec2.security_group {
+    group_description = "web sg"
+    vpc_id            = "vpc-12345678"
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&wasm_style_engine(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(wasm_style_factories(), &fixture);
+
+    assert!(
+        !lsp_messages_contain(&lsp_diags, "vpc-"),
+        "LSP must not diagnose a valid vpc_id, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        !cli_messages_contain(&cli_diags, "vpc-"),
+        "CLI must not diagnose a valid vpc_id, got {:?}",
+        cli_diags,
+    );
+}
+
+fn wasm_style_subnet_schema() -> ResourceSchema {
+    let vpc_id_type = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+    ResourceSchema::new("ec2.subnet").attribute(AttributeSchema::new(
+        "vpc_ids",
+        AttributeType::list(vpc_id_type),
+    ))
+}
+
+fn wasm_style_subnet_schemas() -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awsccmock", wasm_style_subnet_schema());
+    schemas
+}
+
+fn wasm_style_subnet_factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(WasmStyleProviderFactory {
+        name: "awsccmock".to_string(),
+        schemas: vec![wasm_style_subnet_schema()],
+    }) as Box<dyn ProviderFactory>]
+}
+
+#[test]
+fn wasm_plugin_custom_validator_rejects_invalid_vpc_id_inside_list_parity() {
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awsccmock.ec2.subnet {
+    vpc_ids = ["vpc-good", "bogus"]
+}
+"#,
+    )]);
+    let schemas = wasm_style_subnet_schemas();
+    let provider_names = vec!["awsccmock".to_string()];
+    let engine = DiagnosticEngine::new(
+        Arc::new(schemas),
+        provider_names,
+        Arc::new(wasm_style_subnet_factories()),
+    );
+
+    let lsp_diags = lsp_diagnostics(&engine, &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(wasm_style_subnet_factories(), &fixture);
+
+    assert!(
+        cli_messages_contain(&cli_diags, "bogus") || cli_messages_contain(&cli_diags, "vpc-"),
+        "CLI must diagnose invalid vpc_id inside list, got {:?}",
+        cli_diags,
+    );
+    assert!(
+        lsp_messages_contain(&lsp_diags, "bogus") || lsp_messages_contain(&lsp_diags, "vpc-"),
+        "LSP must diagnose invalid vpc_id inside list, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn wasm_plugin_custom_validator_reports_every_bad_item_in_list() {
+    // Multi-item failure case: walk_custom_lookup should accumulate one
+    // diagnostic per bad item instead of stopping at the first.
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awsccmock.ec2.subnet {
+    vpc_ids = ["bad-1", "bad-2"]
+}
+"#,
+    )]);
+    let cli_diags = cli_diagnostics(wasm_style_subnet_factories(), &fixture);
+    let bad_count = cli_diags
+        .iter()
+        .filter(|m| m.contains("bad-1") || m.contains("bad-2"))
+        .count();
+    assert_eq!(
+        bad_count, 2,
+        "CLI must report a diagnostic per bad list item, got {:?}",
         cli_diags,
     );
 }

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -193,6 +193,22 @@ pub(super) fn prepare_user_function_call<'cfg>(
     Ok((child_ctx, substitutions))
 }
 
+/// Adapter that turns a [`ProviderContext`] into the
+/// [`crate::schema::CustomTypeLookup`] shape consumed by the schema-walk
+/// validator. PascalCase semantic names (e.g. `VpcId`) are normalized to
+/// snake_case (`vpc_id`) before lookup, then [`validate_custom_type`]
+/// runs the registered validator chain. The returned closure may be
+/// hoisted out of any per-resource loop — it borrows the context only.
+pub fn provider_context_lookup(
+    ctx: &ProviderContext,
+) -> impl Fn(&str, &Value) -> Result<(), crate::schema::TypeError> + use<'_> {
+    move |type_name, value| {
+        let key = pascal_to_snake(type_name);
+        validate_custom_type(&key, value, ctx)
+            .map_err(|message| crate::schema::TypeError::ValidationFailed { message })
+    }
+}
+
 /// Validate a value against a custom type (ipv4_cidr, ipv4_address, etc.).
 /// Returns Ok(()) if the value passes validation or cannot be validated statically
 /// (e.g., ResourceRef, FunctionCall, Interpolation are deferred).

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -27,7 +27,7 @@ pub use entry::{parse, parse_and_resolve};
 pub(crate) use entry::{parse_expression, parse_expression_eval};
 pub use error::{ParseError, ParseWarning};
 pub(crate) use functions::evaluate_user_function;
-pub use functions::validate_custom_type;
+pub use functions::{provider_context_lookup, validate_custom_type};
 pub use resolve::{
     check_identifier_scope, collect_known_bindings_merged, resolve_resource_refs,
     resolve_resource_refs_with_config,

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -52,6 +52,108 @@ pub fn noop_validator() -> CustomValidator {
     validator(|_| Ok(()))
 }
 
+/// External validator looked up by `AttributeType::Custom.semantic_name`
+/// at validation time. Used to bridge to provider-supplied validators
+/// (the `ProviderContext.validators` map and WASM factory's
+/// `validate_custom_type`) that the schema itself cannot carry across
+/// the WASM boundary — see #2354.
+///
+/// Implementors normalize the type name as needed (typically PascalCase
+/// → snake_case via `parser::pascal_to_snake`) before looking up the
+/// real validator.
+pub type CustomTypeLookup<'a> =
+    &'a (dyn Fn(&str, &Value) -> Result<(), TypeError> + Send + Sync + 'a);
+
+/// A [`CustomTypeLookup`] that approves every value. Pass to
+/// `validate_with_origins_and_lookup` from contexts that have no
+/// `ProviderContext` (snapshot tests, schema unit tests). The
+/// schema-attached `validate` closure still runs for built-in
+/// validators registered directly on the type.
+pub fn no_lookup() -> CustomTypeLookup<'static> {
+    &|_name, _value| Ok(())
+}
+
+/// Walk an [`AttributeType`] and apply `lookup` to every `Custom` node
+/// reached. Pushes any returned error into `errors`, tagged with
+/// `attr_name` so it points back at the user-visible attribute. Used
+/// by `ResourceSchema::validate_inner` to bridge provider-supplied
+/// validators that the schema's own closure cannot carry (e.g. WASM
+/// plugins, where the schema arrives with `noop_validator()` and the
+/// real validator lives behind the factory's `validate_custom_type`).
+fn walk_custom_lookup(
+    attr_type: &AttributeType,
+    value: &Value,
+    attr_name: &str,
+    lookup: CustomTypeLookup<'_>,
+    errors: &mut Vec<TypeError>,
+) {
+    // Values that resolve at runtime are skipped — the same convention
+    // the schema-attached `validate` closure follows.
+    if matches!(
+        value,
+        Value::FunctionCall { .. }
+            | Value::Secret(_)
+            | Value::ResourceRef { .. }
+            | Value::Interpolation(_)
+    ) {
+        return;
+    }
+    match attr_type {
+        AttributeType::Custom { semantic_name, .. } => {
+            if let Some(name) = semantic_name
+                && let Err(e) = lookup(name, value)
+            {
+                // Re-wrap as `ResourceValidationFailed` so the attribute
+                // slot survives. `with_attribute` only enriches the two
+                // enum-variant errors; bare `ValidationFailed` would
+                // arrive at the LSP without a position hint and get
+                // filtered out by the resource-level dedup.
+                let message = match e {
+                    TypeError::ValidationFailed { message } => message,
+                    other => other.to_string(),
+                };
+                errors.push(TypeError::ResourceValidationFailed {
+                    message,
+                    attribute: Some(attr_name.to_string()),
+                });
+            }
+        }
+        AttributeType::List { inner, .. } => {
+            if let Value::List(items) = value {
+                for item in items {
+                    walk_custom_lookup(inner, item, attr_name, lookup, errors);
+                }
+            }
+        }
+        AttributeType::Map { value: inner, .. } => {
+            if let Value::Map(map) = value {
+                for v in map.values() {
+                    walk_custom_lookup(inner, v, attr_name, lookup, errors);
+                }
+            }
+        }
+        AttributeType::Struct { fields, .. } => {
+            if let Value::Map(map) = value {
+                for f in fields {
+                    if let Some(v) = map.get(&f.name) {
+                        walk_custom_lookup(&f.field_type, v, attr_name, lookup, errors);
+                    }
+                }
+            }
+        }
+        AttributeType::Union(members) => {
+            for member in members {
+                walk_custom_lookup(member, value, attr_name, lookup, errors);
+            }
+        }
+        AttributeType::String
+        | AttributeType::Int
+        | AttributeType::Float
+        | AttributeType::Bool
+        | AttributeType::StringEnum { .. } => {}
+    }
+}
+
 pub type StringEnumParts<'a> = (
     &'a str,
     &'a [String],
@@ -1952,7 +2054,7 @@ impl ResourceSchema {
     /// knows which attributes were written as quoted string literals
     /// (see #2094).
     pub fn validate(&self, attributes: &HashMap<String, Value>) -> Result<(), Vec<TypeError>> {
-        self.validate_inner(attributes, &|_attr_name| false)
+        self.validate_inner(attributes, &|_attr_name| false, no_lookup())
     }
 
     /// Validate resource attributes, reshaping enum-variant errors into
@@ -1970,13 +2072,27 @@ impl ResourceSchema {
         attributes: &HashMap<String, Value>,
         is_string_literal: &dyn Fn(&str) -> bool,
     ) -> Result<(), Vec<TypeError>> {
-        self.validate_inner(attributes, is_string_literal)
+        self.validate_inner(attributes, is_string_literal, no_lookup())
+    }
+
+    /// As [`validate_with_origins`], but also runs `lookup` on every
+    /// `AttributeType::Custom` value reached during traversal so
+    /// provider-supplied validators that the schema itself cannot
+    /// carry (WASM plugin path) still get to reject bad values.
+    pub fn validate_with_origins_and_lookup(
+        &self,
+        attributes: &HashMap<String, Value>,
+        is_string_literal: &dyn Fn(&str) -> bool,
+        lookup: CustomTypeLookup<'_>,
+    ) -> Result<(), Vec<TypeError>> {
+        self.validate_inner(attributes, is_string_literal, lookup)
     }
 
     fn validate_inner(
         &self,
         attributes: &HashMap<String, Value>,
         is_string_literal: &dyn Fn(&str) -> bool,
+        lookup: CustomTypeLookup<'_>,
     ) -> Result<(), Vec<TypeError>> {
         let mut errors = Vec::new();
 
@@ -2022,6 +2138,7 @@ impl ResourceSchema {
                     };
                     errors.push(reshaped);
                 }
+                walk_custom_lookup(&schema.attr_type, value, name, lookup, &mut errors);
             } else {
                 let suggestion = suggest_similar_name(name, &known);
                 errors.push(TypeError::UnknownAttribute {

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -20,8 +20,10 @@ pub fn validate_resources(
     parsed: &ParsedFile,
     registry: &SchemaRegistry,
     known_providers: &HashSet<String>,
+    provider_context: &ProviderContext,
 ) -> Result<(), String> {
     let mut all_errors = Vec::new();
+    let lookup = crate::parser::provider_context_lookup(provider_context);
 
     for (_ctx, resource) in parsed.iter_all_resources() {
         // Skip virtual resources (module attribute containers)
@@ -32,9 +34,11 @@ pub fn validate_resources(
         match registry.get_for(resource) {
             Some(schema) => {
                 let is_string_literal = |attr: &str| resource.quoted_string_attrs.contains(attr);
-                if let Err(errors) = schema
-                    .validate_with_origins(&resource.resolved_attributes(), &is_string_literal)
-                {
+                if let Err(errors) = schema.validate_with_origins_and_lookup(
+                    &resource.resolved_attributes(),
+                    &is_string_literal,
+                    &lookup,
+                ) {
                     for error in errors {
                         all_errors.push(format!("{}: {}", resource.id, error));
                     }

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1670,7 +1670,8 @@ fn validate_resources_rejects_missing_exclusive_required() {
 
     let mut parsed = empty_parsed();
     parsed.resources.push(vpc); // allow: direct — fixture test inspection
-    let err = validate_resources(&parsed, &schemas, &known).unwrap_err();
+    let err =
+        validate_resources(&parsed, &schemas, &known, &ProviderContext::default()).unwrap_err();
     assert!(
         err.contains("Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified"),
         "expected exclusive_required error, got: {err}"
@@ -1715,7 +1716,7 @@ fn enum_membership_violation_in_for_body_is_flagged() {
     let mut known = HashSet::new();
     known.insert("test".to_string());
 
-    let result = validate_resources(&parsed, &schemas, &known);
+    let result = validate_resources(&parsed, &schemas, &known, &ProviderContext::default());
     assert!(result.is_err(), "expected enum-mismatch error in for body");
     let err = result.unwrap_err();
     assert!(
@@ -1770,7 +1771,13 @@ fn quoted_literal_enum_value_yields_string_literal_diagnostic() {
         }
         "#,
     );
-    let err = validate_resources(&parsed, &mode_schema(), &mode_known()).unwrap_err();
+    let err = validate_resources(
+        &parsed,
+        &mode_schema(),
+        &mode_known(),
+        &ProviderContext::default(),
+    )
+    .unwrap_err();
     assert!(
         err.contains("got a string literal"),
         "quoted literal must emit the shape-mismatch diagnostic, got: {err}"
@@ -1797,7 +1804,13 @@ fn bare_invalid_enum_value_keeps_invalid_variant_diagnostic() {
         }
         "#,
     );
-    let err = validate_resources(&parsed, &mode_schema(), &mode_known()).unwrap_err();
+    let err = validate_resources(
+        &parsed,
+        &mode_schema(),
+        &mode_known(),
+        &ProviderContext::default(),
+    )
+    .unwrap_err();
     assert!(
         !err.contains("got a string literal"),
         "bare identifier must NOT get the shape-mismatch diagnostic, got: {err}"
@@ -1820,7 +1833,13 @@ fn bare_valid_enum_value_passes() {
         "#,
     );
     assert!(
-        validate_resources(&parsed, &mode_schema(), &mode_known()).is_ok(),
+        validate_resources(
+            &parsed,
+            &mode_schema(),
+            &mode_known(),
+            &ProviderContext::default()
+        )
+        .is_ok(),
         "bare valid identifier must pass"
     );
 }
@@ -1837,7 +1856,13 @@ fn fully_qualified_enum_value_passes() {
         "#,
     );
     assert!(
-        validate_resources(&parsed, &mode_schema(), &mode_known()).is_ok(),
+        validate_resources(
+            &parsed,
+            &mode_schema(),
+            &mode_known(),
+            &ProviderContext::default()
+        )
+        .is_ok(),
         "fully-qualified identifier must pass"
     );
 }
@@ -1869,7 +1894,8 @@ fn read_against_managed_only_type_is_rejected() {
     let mut known = HashSet::new();
     known.insert("awscc".to_string());
 
-    let err = validate_resources(&parsed, &schemas, &known).unwrap_err();
+    let err =
+        validate_resources(&parsed, &schemas, &known, &ProviderContext::default()).unwrap_err();
     assert!(
         err.contains("is a managed resource, not a data source"),
         "expected managed-only diagnostic, got: {err}"

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -494,8 +494,20 @@ impl DiagnosticEngine {
                                         namespace.as_deref(),
                                     );
 
-                                    // Use schema's validate function for all Custom types
-                                    validate(&resolved_value).err().map(|inner_err| {
+                                    // Run the schema-attached validator first; for WASM-plugin
+                                    // types it is a noop, so fall back to the provider-context
+                                    // lookup which reaches the factory's `validate_custom_type`.
+                                    let lookup = carina_core::parser::provider_context_lookup(
+                                        &self.provider_context,
+                                    );
+                                    validate(&resolved_value)
+                                        .err()
+                                        .or_else(|| {
+                                            (!name.is_empty())
+                                                .then(|| lookup(name, &resolved_value).err())
+                                                .flatten()
+                                        })
+                                        .map(|inner_err| {
                                         // For namespaced Custom types (enum-like), mirror
                                         // the CLI shape-mismatch diagnostic when the user
                                         // wrote a quoted string literal. The validator
@@ -613,7 +625,15 @@ impl DiagnosticEngine {
 
                     // Run resource-level validator (e.g., mutually exclusive required fields)
                     let resolved_attrs = resource.resolved_attributes();
-                    if let Err(errors) = schema.validate(&resolved_attrs) {
+                    let lookup =
+                        carina_core::parser::provider_context_lookup(&self.provider_context);
+                    let is_string_literal =
+                        |attr: &str| resource.quoted_string_attrs.contains(attr);
+                    if let Err(errors) = schema.validate_with_origins_and_lookup(
+                        &resolved_attrs,
+                        &is_string_literal,
+                        &lookup,
+                    ) {
                         for error in errors {
                             // Skip errors that are already reported with precise positions
                             // by the attribute-level checks above.


### PR DESCRIPTION
Closes #2354

## Summary

Custom-type validators defined in a WASM provider plugin (e.g. awscc's `vpc_id` requires a `vpc-` prefix) were silently dropped at the host boundary. `wasm_convert.rs` rebuilds the schema with `noop_validator()` because function pointers cannot cross the WASM boundary, and the schema-validation path called only the schema-attached closure — never consulting `ProviderContext.validators` or the factory's `validate_custom_type`. Result: `vpc_id = "test"` passed `carina validate`.

## Approach (option D)

Thread `&ProviderContext` into `validate_resources`, `ResourceSchema::validate_with_origins_and_lookup`, and the LSP diagnostics counterpart. Inside `validate_inner`, walk the attribute type tree once per attribute (`walk_custom_lookup`) and call a lookup closure on every `Custom` node reached. The lookup closure is built by the new `parser::provider_context_lookup` helper, which reuses the existing `validate_custom_type` chain (built-ins → validators map → factory fallback) so the dispatch rules stay in one place.

Errors from the lookup are wrapped as `ResourceValidationFailed` with the attribute slot populated; the LSP resource-level dedup filter preserves them.

See [the decision comment on #2354](https://github.com/carina-rs/carina/issues/2354#issuecomment-4365617791) for the A/B/C/D trade-off discussion.

## Tests

Parity tests in `carina-cli/tests/e2e_typecheck_parity.rs` exercise both CLI and LSP paths against a `WasmStyleProviderFactory` that mirrors the awscc WASM bridge (schema with `noop_validator`, real validator behind `validate_custom_type`):

- top-level `Custom` rejects `vpc_id = "test"`
- top-level `Custom` accepts `vpc_id = "vpc-12345678"`
- nested `List<Custom>` rejects bad items
- multi-bad-item list reports one diagnostic per item

## Test plan

- [x] `cargo nextest run --workspace` (2517 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] Smoke test against real awscc plugin once a release with PascalCase resource names ships (current 0.4.0 doesn't recognize `awscc.ec2.SecurityGroup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)