### PR TITLE
validation: reject TypeExpr::String against specific-Custom receiver

### DIFF
--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -105,6 +105,13 @@ fn cli_diagnostics(factories: Vec<Box<dyn ProviderFactory>>, fixture: &TempDir) 
     carina_cli::commands::validate::validate_with_factories(&path, factories)
 }
 
+// NOTE: case-sensitive `contains`. LSP and CLI surfaces sometimes
+// differ in casing (e.g. "Type mismatch" vs "type mismatch") because
+// some diagnostics originate in carina-lsp and others in carina-core.
+// When an assertion needs to bind to both surfaces uniformly use
+// `lsp_messages_contain_ci` / `cli_messages_contain_ci` below — a
+// case-sensitive miss against one surface silently makes the assertion
+// half-empty.
 fn lsp_messages_contain(diags: &[tower_lsp::lsp_types::Diagnostic], substring: &str) -> bool {
     diags.iter().any(|d| d.message.contains(substring))
 }
@@ -122,6 +129,25 @@ fn lsp_messages_count(diags: &[tower_lsp::lsp_types::Diagnostic], substring: &st
 
 fn cli_messages_count(diags: &[String], substring: &str) -> usize {
     diags.iter().filter(|m| m.contains(substring)).count()
+}
+
+// LSP and CLI diagnostic wording differs in casing — LSP says
+// "Type mismatch" (capital T) while CLI says "type mismatch". A
+// case-sensitive `contains` against either spelling silently misses
+// the other side. Use lowercase comparisons when the assertion needs
+// to bind to both surfaces uniformly.
+fn lsp_messages_contain_ci(diags: &[tower_lsp::lsp_types::Diagnostic], substring: &str) -> bool {
+    let needle = substring.to_ascii_lowercase();
+    diags
+        .iter()
+        .any(|d| d.message.to_ascii_lowercase().contains(&needle))
+}
+
+fn cli_messages_contain_ci(diags: &[String], substring: &str) -> bool {
+    let needle = substring.to_ascii_lowercase();
+    diags
+        .iter()
+        .any(|m| m.to_ascii_lowercase().contains(&needle))
 }
 
 // ============================================================================
@@ -980,6 +1006,229 @@ awsccmock.ec2.subnet {
     assert_eq!(
         bad_count, 2,
         "CLI must report a diagnostic per bad list item, got {:?}",
+        cli_diags,
+    );
+}
+
+// ============================================================================
+// Scenario: generic-String → specific Custom downcast (#2358)
+//
+// `vpc_id: String = main.vpc_id` declares a `String`-typed export of a
+// value whose actual type is `Custom { semantic_name: VpcId }`. The
+// declaration drops the specific identity, so any downstream consumer
+// receives `String` and can no longer be type-checked against a
+// `Custom { VpcId }` receiver. Validation, LSP diagnostics, and
+// completion must all reject the unsafe direction (`TypeExpr::String`
+// against a Custom-with-`semantic_name` receiver) while keeping the
+// safe direction (specific Custom export → same Custom receiver) and
+// literal-value assignment (`vpc_id = 'vpc-12345678'`) working.
+// ============================================================================
+
+// `vpc-` prefix validator — mirrors how the awscc plugin attaches its
+// real `prefixed` validators. Used by #2358 fixtures so the literal-
+// assignment test can prove the schema-attached `validate` closure
+// actually runs (a noop validator would let the test pass for the
+// wrong reason).
+fn vpc_id_validate_2358(v: &Value) -> Result<(), String> {
+    match v {
+        Value::String(s) if s.starts_with("vpc-") => Ok(()),
+        Value::String(s) => Err(format!("Invalid vpc_id '{}': must start with 'vpc-'", s)),
+        _ => Ok(()),
+    }
+}
+
+fn vpc_id_custom_type_2358() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(vpc_id_validate_2358),
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+fn vpc_resource_schema_2358() -> ResourceSchema {
+    ResourceSchema::new("ec2.Vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_custom_type_2358()))
+}
+
+fn security_group_schema_2358() -> ResourceSchema {
+    ResourceSchema::new("ec2.SecurityGroup")
+        .attribute(AttributeSchema::new(
+            "group_description",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_custom_type_2358()))
+}
+
+fn schemas_2358() -> SchemaRegistry {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc2358", vpc_resource_schema_2358());
+    schemas.insert("awscc2358", security_group_schema_2358());
+    schemas
+}
+
+fn factories_2358() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(WasmStyleProviderFactory {
+        name: "awscc2358".to_string(),
+        schemas: vec![vpc_resource_schema_2358(), security_group_schema_2358()],
+    }) as Box<dyn ProviderFactory>]
+}
+
+fn engine_2358() -> DiagnosticEngine {
+    DiagnosticEngine::new(
+        Arc::new(schemas_2358()),
+        vec!["awscc2358".to_string()],
+        Arc::new(factories_2358()),
+    )
+}
+
+#[test]
+fn export_string_annotation_of_custom_value_rejected_parity() {
+    // The export declares `: String` but the rhs `main.vpc_id` carries
+    // type `Custom { VpcId }`. The export's narrowed declaration is the
+    // unsafe step — both validate and LSP diagnostics must surface a
+    // type-mismatch error here.
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+let main = awscc2358.ec2.Vpc {
+    cidr_block = "10.0.0.0/16"
+}
+
+exports {
+    vpc_id: String = main.vpc_id
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&engine_2358(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(factories_2358(), &fixture);
+
+    // Pin both that the export name (`vpc_id`) appears in the message
+    // *and* that the carina-core mismatch wording surfaces verbatim
+    // ("expected String, got VpcId"). The two surfaces share the same
+    // format string from carina-core, so case-insensitive `mismatch`
+    // catches both `"type mismatch"` and any future `"Type mismatch"`.
+    assert!(
+        lsp_messages_contain(&lsp_diags, "vpc_id")
+            && lsp_messages_contain_ci(&lsp_diags, "mismatch")
+            && lsp_messages_contain(&lsp_diags, "VpcId"),
+        "LSP must diagnose generic-String export of Custom-typed value, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        cli_messages_contain(&cli_diags, "vpc_id")
+            && cli_messages_contain_ci(&cli_diags, "mismatch")
+            && cli_messages_contain(&cli_diags, "VpcId"),
+        "CLI must diagnose generic-String export of Custom-typed value, got {:?}",
+        cli_diags,
+    );
+}
+
+#[test]
+fn export_vpcid_annotation_of_custom_value_accepted_parity() {
+    // Safe direction: the export declares `: VpcId`, matching the
+    // rhs's actual type. Both validate and LSP must stay quiet.
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+let main = awscc2358.ec2.Vpc {
+    cidr_block = "10.0.0.0/16"
+}
+
+exports {
+    vpc_id: VpcId = main.vpc_id
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&engine_2358(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(factories_2358(), &fixture);
+
+    assert!(
+        !lsp_messages_contain_ci(&lsp_diags, "mismatch"),
+        "LSP must not flag a same-type export as a mismatch, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        !cli_messages_contain_ci(&cli_diags, "mismatch"),
+        "CLI must not flag a same-type export as a mismatch, got {:?}",
+        cli_diags,
+    );
+}
+
+#[test]
+fn literal_valid_string_assignment_to_custom_receiver_still_validates() {
+    // Existing `awscc.ec2.SecurityGroup { vpc_id = 'vpc-12345678' }`
+    // pattern remains valid: a literal string in source becomes
+    // `Value::String(...)`, which validation handles via the schema-
+    // attached `validate` closure on the Custom type — not via
+    // `is_type_expr_compatible_with_schema`. The strictness fix must
+    // not regress this path.
+    //
+    // The fixture's validator requires a `vpc-` prefix; a well-formed
+    // value must pass. Paired with the malformed-literal test below
+    // this proves the `validate` closure is actually being run (a
+    // silent noop validator would let either test pass for the wrong
+    // reason).
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awscc2358.ec2.SecurityGroup {
+    group_description = "web sg"
+    vpc_id            = "vpc-12345678"
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&engine_2358(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(factories_2358(), &fixture);
+
+    assert!(
+        !lsp_messages_contain_ci(&lsp_diags, "vpc_id"),
+        "LSP must not flag a well-formed literal vpc_id, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        !cli_messages_contain_ci(&cli_diags, "vpc_id"),
+        "CLI must not flag a well-formed literal vpc_id, got {:?}",
+        cli_diags,
+    );
+}
+
+#[test]
+fn literal_malformed_string_assignment_still_runs_attached_validator() {
+    // Companion to the well-formed test above. A malformed literal
+    // (`'bad'` — no `vpc-` prefix) must trip the schema-attached
+    // `validate` closure and surface in both surfaces. Together the
+    // pair proves the literal-assignment path is genuinely intact:
+    // the well-formed test is meaningful only because this one shows
+    // the validator can fail.
+    let fixture = write_fixture(&[(
+        "main.crn",
+        r#"
+awscc2358.ec2.SecurityGroup {
+    group_description = "web sg"
+    vpc_id            = "bad"
+}
+"#,
+    )]);
+
+    let lsp_diags = lsp_diagnostics(&engine_2358(), &fixture, "main.crn");
+    let cli_diags = cli_diagnostics(factories_2358(), &fixture);
+
+    assert!(
+        lsp_messages_contain_ci(&lsp_diags, "vpc-"),
+        "LSP must surface the vpc_id validator's prefix complaint, got {:?}",
+        lsp_diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+    assert!(
+        cli_messages_contain_ci(&cli_diags, "vpc-"),
+        "CLI must surface the vpc_id validator's prefix complaint, got {:?}",
         cli_diags,
     );
 }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -375,7 +375,25 @@ pub fn is_type_expr_compatible_with_schema(
     use crate::parser::TypeExpr;
 
     match type_expr {
-        TypeExpr::String => is_string_compatible_type(attr_type),
+        // A bare `TypeExpr::String` must not satisfy a receiver typed as
+        // `Custom { semantic_name: Some(_) }` — the receiver names a
+        // specific identity (e.g. `VpcId`) that a generic `String`
+        // cannot prove. Descends into `Union` members so a polymorphic
+        // receiver like `Union<[String, Custom{VpcId}]>` is rejected
+        // too: every alternative the value might end up satisfying
+        // must be reachable from `String`. The symmetric *narrowing*
+        // case — a specific `: VpcId` export against a less specific
+        // receiver — is handled by the `Simple(name)` arm below: it
+        // walks the receiver's `Custom` base chain looking for a
+        // matching identity, returning `true` only when the receiver
+        // is at least as specific as (or more general than) the
+        // declared type. Issue #2358.
+        TypeExpr::String => {
+            if attr_type_demands_specific_custom(attr_type) {
+                return false;
+            }
+            is_string_compatible_type(attr_type)
+        }
         TypeExpr::Bool => matches!(attr_type, AttributeType::Bool),
         TypeExpr::Int => matches!(attr_type, AttributeType::Int),
         TypeExpr::Float => matches!(attr_type, AttributeType::Float),
@@ -451,6 +469,37 @@ pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
             true
         }
         AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
+        _ => false,
+    }
+}
+
+/// Recursive check used by the `TypeExpr::String` arm of
+/// `is_type_expr_compatible_with_schema`: returns `true` when
+/// `attr_type` carries a `Custom { semantic_name: Some(_) }` either at
+/// the top level or anywhere inside a `Union`. A schema attribute that
+/// names a specific identity (`VpcId`, `Arn`, …) cannot accept a value
+/// known only as `String`. Issue #2358.
+///
+/// Scope:
+/// - Looks at the outer `semantic_name` only — does **not** walk
+///   `Custom.base` chains. Real provider schemas keep `semantic_name`
+///   on the outer wrapper, so an anonymous `Custom` wrapping a
+///   specific `Custom` does not occur in practice. If a future schema
+///   introduces that shape, this helper would need to walk the base
+///   chain too.
+/// - Only `String`-shaped specifics are guarded today. Provider
+///   schemas currently express every named-identity Custom as a
+///   `String`-base wrapper, so `TypeExpr::Int/Bool/Float` arms have
+///   no analogous strictness. If a future schema adds e.g. a
+///   `Custom { semantic_name: "Port", base: Int }`, those arms will
+///   also need to consult this helper (or a sibling).
+fn attr_type_demands_specific_custom(attr_type: &AttributeType) -> bool {
+    match attr_type {
+        AttributeType::Custom {
+            semantic_name: Some(_),
+            ..
+        } => true,
+        AttributeType::Union(types) => types.iter().any(attr_type_demands_specific_custom),
         _ => false,
     }
 }

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1235,6 +1235,153 @@ fn is_type_expr_compatible_struct_rejects_map_with_wrong_element_type() {
     assert!(!is_type_expr_compatible_with_schema(&expr, &schema));
 }
 
+// Issue #2358: a generic `TypeExpr::String` declaration must not satisfy
+// a receiver typed as `Custom { semantic_name: Some(_) }`. The receiver
+// names a specific type (e.g. `VpcId`); a value carrying only the
+// `String` constraint cannot prove it satisfies the more specific
+// invariants the receiver demands.
+#[test]
+fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let schema = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    assert!(
+        !is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
+        "TypeExpr::String must not satisfy Custom{{semantic_name:VpcId}}"
+    );
+}
+
+// Companion: a Custom receiver with no semantic_name (anonymous Custom,
+// e.g. a bare `String` enriched with pattern/length but no semantic
+// label) keeps accepting `TypeExpr::String` — it has no specific
+// identity to demand.
+#[test]
+fn is_type_expr_compatible_string_accepts_custom_without_semantic_name() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let schema = AttributeType::Custom {
+        semantic_name: None,
+        pattern: Some("^.+$".to_string()),
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    assert!(
+        is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
+        "TypeExpr::String must satisfy Custom with no semantic_name"
+    );
+}
+
+// Issue #2358 Union descent: a `TypeExpr::String` declaration must not
+// satisfy a `Union` receiver that contains *any* `Custom { semantic_name }`
+// alternative — the value might end up flowing into the specific
+// branch, and `String` cannot prove that branch's invariants.
+#[test]
+fn is_type_expr_compatible_string_rejects_union_containing_specific_custom() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let schema = AttributeType::Union(vec![
+        AttributeType::String,
+        AttributeType::Custom {
+            semantic_name: Some("VpcId".to_string()),
+            pattern: None,
+            length: None,
+            base: Box::new(AttributeType::String),
+            validate: legacy_validator(noop),
+            namespace: None,
+            to_dsl: None,
+        },
+    ]);
+    assert!(
+        !is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
+        "TypeExpr::String must not satisfy a Union containing Custom{{semantic}}"
+    );
+}
+
+// Companion: a Union of *only* specific Custom alternatives is even
+// more clearly String-incompatible — every branch demands a specific
+// identity that String can't prove.
+#[test]
+fn is_type_expr_compatible_string_rejects_union_of_only_specific_customs() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let mk = |name: &str| AttributeType::Custom {
+        semantic_name: Some(name.to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = AttributeType::Union(vec![mk("VpcId"), mk("SubnetId")]);
+    assert!(
+        !is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
+        "TypeExpr::String must not satisfy a Union of only specific-Custom alternatives"
+    );
+}
+
+// Companion: a Union of only string-shaped, non-specific types must
+// keep accepting `TypeExpr::String` (no specific-Custom alternative
+// exists, so the value can safely flow into any branch).
+#[test]
+fn is_type_expr_compatible_string_accepts_union_of_only_strings() {
+    let schema = AttributeType::Union(vec![
+        AttributeType::String,
+        AttributeType::StringEnum {
+            name: "Mode".to_string(),
+            values: vec!["A".to_string(), "B".to_string()],
+            namespace: None,
+            to_dsl: None,
+        },
+    ]);
+    assert!(
+        is_type_expr_compatible_with_schema(&TypeExpr::String, &schema),
+        "TypeExpr::String must satisfy a Union of only string-shaped non-specific types"
+    );
+}
+
+// Companion: the safe direction — a specific Custom-typed export must
+// continue to satisfy a receiver of the same Custom type. Pin so the
+// strictness fix doesn't accidentally reject the correct direction.
+#[test]
+fn is_type_expr_compatible_simple_vpcid_accepts_custom_vpcid() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let schema = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    // Parser normalizes `: VpcId` to TypeExpr::Simple("vpc_id") (snake).
+    let expr = TypeExpr::Simple("vpc_id".to_string());
+    assert!(is_type_expr_compatible_with_schema(&expr, &schema));
+}
+
 #[test]
 fn validate_module_calls_rejects_custom_type() {
     use crate::parser::ArgumentParameter;

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3038,3 +3038,66 @@ test.foo.bar {
         labels
     );
 }
+
+/// Issue #2358: a `: String` upstream export must NOT be offered as a
+/// candidate at a receiver typed `Custom { semantic_name: Some(_) }`.
+/// Pinned alongside the validation-side fix because completion shares
+/// the same `is_type_expr_compatible_with_schema` predicate — a future
+/// edit that loosens the predicate would silently regress the popup
+/// even if validation still catches the bad code at apply time.
+#[test]
+fn upstream_state_string_export_not_offered_to_specific_custom_receiver() {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+
+    fn noop(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let vpc_id_type = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    let schema = ResourceSchema::new("ec2.SecurityGroup")
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_type));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let provider =
+        CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![]);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("network")).unwrap();
+    std::fs::create_dir_all(root.join("web")).unwrap();
+    std::fs::write(
+        root.join("network/main.crn"),
+        "exports {\n  vpc_id: String = 'vpc-abc'\n}\n",
+    )
+    .unwrap();
+    let main_src = "\
+let network = upstream_state {
+  source = '../network'
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id =
+}
+";
+    std::fs::write(root.join("web/main.crn"), main_src).unwrap();
+
+    let doc = create_document(main_src);
+    let position = Position {
+        line: 5,
+        character: "  vpc_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&root.join("web")));
+    let labels: Vec<String> = completions.iter().map(|c| c.label.clone()).collect();
+    assert!(
+        !labels.iter().any(|l| l == "network.vpc_id"),
+        "generic-String export must not be offered at a specific Custom receiver. Got: {:?}",
+        labels
+    );
+}


### PR DESCRIPTION
Closes #2358

## Summary

Tightens `is_type_expr_compatible_with_schema(TypeExpr::String, ..)` so a generic-`String` declaration no longer satisfies a receiver typed `Custom { semantic_name: Some(_) }`. The receiver names a specific identity (`VpcId`, `Arn`, `IamRoleArn`, …) and a value known only as `String` cannot prove the receiver's invariants — the silent acceptance was an unsafe downcast.

The single-predicate fix flows through three surfaces uniformly:
- `carina validate` now errors on `exports { vpc_id: String = main.vpc_id }` and on the downstream consumption of the same export.
- LSP diagnostics surface the same error in-editor.
- LSP completion stops listing the `: String` export as a candidate for the `Custom { VpcId }` receiver.

The complementary direction (specific export → generic receiver, e.g. `: VpcId` against `String`) is unchanged and continues to work via the existing `Simple(name)` arm. Literal-string assignment (`vpc_id = 'vpc-12345678'`) is unaffected — that path runs the schema-attached `validate` closure, not this predicate.

A small helper `attr_type_demands_specific_custom` recurses into `Union` so polymorphic receivers like `Union<[String, Custom{VpcId}]>` are also rejected (every branch the value might end up satisfying must be reachable from `String`).

## Test plan

- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] **Real-infra smoke** against `~/tmp/carina-upstream-state/`: `carina validate network/` reports `export 'vpc_id': type mismatch for 'main.vpc_id': expected String, got VpcId`; `carina validate web/` reports `awscc.ec2.SecurityGroup.<id> attribute vpc_id: upstream_state network.vpc_id is declared as String but this position expects VpcId`. Both surfaces now catch the bad downcast.
- [x] **6 unit tests** on the predicate in `carina-core/src/validation/tests.rs` cover: outer rejection, anonymous-Custom retention, safe direction (`Simple("vpc_id") → Custom{VpcId}`), Union-with-specific rejection, Union-of-only-specifics rejection, Union-of-only-strings retention.
- [x] **4 e2e CLI/LSP parity tests** in `carina-cli/tests/e2e_typecheck_parity.rs`: export downcast rejected on both surfaces, same-type export accepted on both, well-formed literal assignment accepted on both, malformed literal still trips the schema-attached validator on both.
- [x] **1 LSP completion test** in `carina-lsp/src/completion/tests/extended.rs` pins that the `: String` export is not offered at the `Custom{VpcId}` receiver.
- [x] Two case-insensitive helpers (`lsp_messages_contain_ci`, `cli_messages_contain_ci`) added because LSP says "Type mismatch" while CLI says "type mismatch" — the existing case-sensitive helpers stay and gain a doc-comment warning future authors when to reach for the CI variants.

## Out of scope

- Inferring an unannotated export's type from its rhs `ResourceRef` (would let users skip the redundant `: VpcId` annotation entirely) — tracked in #2357.
- Tightening `Int/Bool/Float` arms for hypothetical non-String semantic types — no current schema needs it; the helper's doc-comment flags the place to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
