### PR TITLE
Drop Option<TypeExpr> from ExportParameter (#2360 stage 2)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -335,7 +335,7 @@ pub(crate) async fn persist_exports_only(
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     state_file: Option<StateFile>,
-    export_params: &[carina_core::parser::ExportParameter],
+    export_params: &[carina_core::parser::InferredExportParam],
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
     let exports = resolve_exports(export_params, &state);
@@ -463,7 +463,11 @@ pub async fn run_apply(
     reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let loaded = load_configuration_with_config(path, provider_context)?;
+    let loaded = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
     let mut parsed = loaded.parsed;
     let backend_file = loaded.backend_file;
 
@@ -621,7 +625,12 @@ pub async fn run_apply(
                     );
 
                     // Re-parse the updated configuration to include the new resource
-                    parsed = load_configuration_with_config(path, provider_context)?.parsed;
+                    parsed = load_configuration_with_config(
+                        path,
+                        provider_context,
+                        &carina_core::schema::SchemaRegistry::new(),
+                    )?
+                    .parsed;
                     if let Err(e) = module_resolver::resolve_modules_with_config(
                         &mut parsed,
                         get_base_dir(path),
@@ -706,7 +715,7 @@ pub async fn run_apply(
 
 async fn run_apply_locked(
     ctx: &WiringContext,
-    parsed: &mut carina_core::parser::ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     auto_approve: bool,
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -436,7 +436,7 @@ fn format_duration_zero() {
 
 #[test]
 fn resolve_exports_resolves_cross_file_dot_notation_strings() {
-    use carina_core::parser::ExportParameter;
+    use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
     use carina_core::resource::Value;
     use carina_state::StateFile;
 
@@ -469,7 +469,7 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
     // the let binding in main.crn, so the parser emits a plain string)
     let export_params = vec![ExportParameter {
         name: "account_id".to_string(),
-        type_expr: None,
+        type_expr: TypeExpr::Unknown,
         value: Some(Value::String("registry_prod.account_id".to_string())),
     }];
 

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -48,7 +48,12 @@ pub async fn run_destroy(
     reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let mut parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
@@ -127,7 +132,7 @@ pub async fn run_destroy(
 
 #[allow(clippy::too_many_arguments)]
 async fn run_destroy_locked(
-    parsed: &mut carina_core::parser::ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     auto_approve: bool,
     backend: &dyn StateBackend,
     protected_bucket: Option<String>,

--- a/carina-cli/src/commands/export.rs
+++ b/carina-cli/src/commands/export.rs
@@ -26,7 +26,12 @@ pub async fn run_export(
     format: OutputFormat,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
         .await

--- a/carina-cli/src/commands/init.rs
+++ b/carina-cli/src/commands/init.rs
@@ -23,8 +23,12 @@ pub fn run_init(path: &Path, upgrade: bool, locked: bool) -> Result<(), String> 
     let path_buf = path.to_path_buf();
 
     let provider_context = ProviderContext::default();
-    let loaded = load_configuration_with_config(&path_buf, &provider_context)
-        .map_err(|e| format!("Failed to load configuration: {e}"))?;
+    let loaded = load_configuration_with_config(
+        &path_buf,
+        &provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )
+    .map_err(|e| format!("Failed to load configuration: {e}"))?;
 
     let missing_source: Vec<String> = loaded
         .parsed

--- a/carina-cli/src/commands/lint.rs
+++ b/carina-cli/src/commands/lint.rs
@@ -26,7 +26,12 @@ struct LintWarning {
 }
 
 pub fn run_lint(path: &PathBuf, provider_context: &ProviderContext) -> Result<(), AppError> {
-    let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let mut parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let base_dir = get_base_dir(path);
 
@@ -202,8 +207,8 @@ pub fn run_lint(path: &PathBuf, provider_context: &ProviderContext) -> Result<()
 /// `import net = './modules/network'` uses alias `net` but dir `network`).
 /// Modules are directory-scoped (#1997), so only directory imports that are
 /// actually called from the root config are scanned.
-fn collect_tag_keys_from_modules(
-    parsed: &carina_core::parser::ParsedFile,
+fn collect_tag_keys_from_modules<E>(
+    parsed: &carina_core::parser::File<E>,
     base_dir: &std::path::Path,
 ) -> Vec<(PathBuf, TagKeyEntry)> {
     let aliases_used: HashSet<&str> = parsed

--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use carina_core::module_resolver;
-use carina_core::parser::{BackendConfig, ParsedFile, ProviderContext};
+use carina_core::parser::{BackendConfig, ProviderContext};
 use carina_core::upstream_exports::UpstreamRefDiagnostic;
 use carina_state::BackendLock;
 use carina_state::backend::BackendConfig as StateBackendConfig;
@@ -127,7 +127,7 @@ pub fn ensure_backend_lock(
 /// name resolution and identifier computation without full schema validation.
 #[allow(dead_code)] // Used by snapshot tests
 pub fn validate_and_resolve(
-    parsed: &mut ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     base_dir: &Path,
     skip_resource_validation: bool,
 ) -> Result<(), AppError> {
@@ -174,7 +174,7 @@ pub(crate) fn collapse_errors(errors: Vec<AppError>) -> AppError {
 }
 
 pub fn validate_and_resolve_with_config(
-    parsed: &mut ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     base_dir: &Path,
     skip_resource_validation: bool,
 ) -> Result<(), AppError> {
@@ -190,7 +190,7 @@ pub fn validate_and_resolve_with_config(
 /// uses it to fold findings into its own accumulator; the `Result`-returning
 /// wrapper above flushes through `collapse_errors` for the rest of the CLI.
 pub fn validate_and_resolve_errors(
-    parsed: &mut ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     base_dir: &Path,
     skip_resource_validation: bool,
 ) -> Vec<AppError> {
@@ -215,7 +215,7 @@ pub fn validate_and_resolve_errors(
 /// non-injecting wrapper above; this entry point is not used outside
 /// tests.
 pub fn validate_and_resolve_errors_with_factories(
-    parsed: &mut ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     base_dir: &Path,
     skip_resource_validation: bool,
     factories: Vec<Box<dyn carina_core::provider::ProviderFactory>>,
@@ -323,7 +323,6 @@ pub fn validate_and_resolve_errors_with_factories(
         if let Err(msg) = carina_core::validation::validate_export_param_ref_types(
             &parsed.export_params,
             &parsed.resources,
-            &parsed.upstream_states,
             ctx.schemas(),
         ) {
             errors.extend(split_validation_message(&msg));
@@ -443,7 +442,7 @@ mod tests {
     use carina_core::parser::ProviderConfig;
     use carina_core::resource::Value;
     use indexmap::IndexMap;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     fn s3_backend_config(bucket: &str, region: &str) -> BackendConfig {
         let mut attributes = HashMap::new();
@@ -544,25 +543,8 @@ mod tests {
         assert!(result2.is_ok());
     }
 
-    fn empty_parsed_file() -> ParsedFile {
-        ParsedFile {
-            providers: vec![],
-            resources: vec![],
-            variables: IndexMap::new(),
-            uses: vec![],
-            module_calls: vec![],
-            arguments: vec![],
-            attribute_params: vec![],
-            export_params: vec![],
-            backend: None,
-            state_blocks: vec![],
-            user_functions: HashMap::new(),
-            upstream_states: vec![],
-            requires: vec![],
-            structural_bindings: HashSet::new(),
-            warnings: vec![],
-            deferred_for_expressions: vec![],
-        }
+    fn empty_parsed_file() -> carina_core::parser::InferredFile {
+        carina_core::parser::InferredFile::default()
     }
 
     #[test]
@@ -655,6 +637,7 @@ exports {
         let loaded = carina_core::config_loader::load_configuration_with_config(
             &base,
             &ProviderContext::default(),
+            &carina_core::schema::SchemaRegistry::new(),
         )
         .expect("load");
         let mut parsed = loaded.parsed;

--- a/carina-cli/src/commands/module.rs
+++ b/carina-cli/src/commands/module.rs
@@ -36,8 +36,11 @@ pub fn run_module_command(
 }
 
 fn run_module_list(path: &Path, provider_context: &ProviderContext) -> Result<(), AppError> {
-    let config =
-        config_loader::load_configuration_with_config(&path.to_path_buf(), provider_context)?;
+    let config = config_loader::load_configuration_with_config(
+        &path.to_path_buf(),
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
     let output = format_module_list(&config.parsed.uses);
     print!("{output}");
     Ok(())

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -89,9 +89,9 @@ pub struct CurrentStateEntry {
     pub state: State,
 }
 
-fn build_plan_file(
+fn build_plan_file<E>(
     path: &Path,
-    parsed: &carina_core::parser::ParsedFile,
+    parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     ctx: &crate::wiring::PlanContext,
 ) -> PlanFile {
@@ -141,7 +141,12 @@ pub async fn run_plan(
     reconfigure: bool,
     provider_context: &ProviderContext,
 ) -> Result<bool, AppError> {
-    let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let mut parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, false)?;
@@ -384,10 +389,10 @@ pub async fn run_plan(
 /// and values are `Value::Map` of that resource's attributes.
 /// Resolve export value expressions for plan display.
 pub(crate) fn resolve_export_values_for_display(
-    export_params: &[carina_core::parser::ExportParameter],
+    export_params: &[carina_core::parser::InferredExportParam],
     resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
-) -> Vec<carina_core::parser::ExportParameter> {
+) -> Vec<carina_core::parser::InferredExportParam> {
     let bindings = carina_core::binding_index::ResolvedBindings::from_resources_with_state(
         resources,
         current_states,
@@ -401,7 +406,7 @@ pub(crate) fn resolve_export_values_for_display(
                 .value
                 .as_ref()
                 .map(|v| resolve_export_value(v, &bindings));
-            carina_core::parser::ExportParameter {
+            carina_core::parser::InferredExportParam {
                 name: param.name.clone(),
                 type_expr: param.type_expr.clone(),
                 value: resolved_value,
@@ -486,7 +491,7 @@ impl ExportChange {
 /// current resource states. `current_exports` is the JSON-serialized map
 /// from `StateFile.exports`.
 pub fn compute_export_diffs(
-    resolved_params: &[carina_core::parser::ExportParameter],
+    resolved_params: &[carina_core::parser::InferredExportParam],
     current_exports: &HashMap<String, serde_json::Value>,
 ) -> Vec<ExportChange> {
     let mut changes = Vec::new();
@@ -497,11 +502,15 @@ pub fn compute_export_diffs(
         let Some(ref value) = param.value else {
             continue;
         };
+        // Unknown sentinels carry no usable type information for the
+        // plan display; surface as `None` so the diff prints without
+        // a type tag.
+        let type_expr = param.type_expr.clone().into_known();
         let new_json = crate::commands::shared::state_writeback::dsl_value_to_json(value);
         match (current_exports.get(&param.name), new_json) {
             (None, _) => changes.push(ExportChange::Added {
                 name: param.name.clone(),
-                type_expr: param.type_expr.clone(),
+                type_expr: type_expr.clone(),
                 new_value: value.clone(),
             }),
             (Some(old), Some(new)) if old == &new => {
@@ -509,7 +518,7 @@ pub fn compute_export_diffs(
             }
             (Some(old), _) => changes.push(ExportChange::Modified {
                 name: param.name.clone(),
-                type_expr: param.type_expr.clone(),
+                type_expr,
                 old_json: old.clone(),
                 new_value: value.clone(),
             }),
@@ -588,8 +597,12 @@ async fn load_upstream_bindings_at(
     provider_context: &ProviderContext,
     cycle_guard: &mut HashSet<PathBuf>,
 ) -> Result<HashMap<String, Value>, AppError> {
-    let loaded = load_configuration_with_config(&source_abs.to_path_buf(), provider_context)
-        .map_err(|e| AppError::Config(format!("upstream_state '{}': {}", us.binding, e)))?;
+    let loaded = load_configuration_with_config(
+        &source_abs.to_path_buf(),
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )
+    .map_err(|e| AppError::Config(format!("upstream_state '{}': {}", us.binding, e)))?;
 
     // Walk the upstream's own upstream_state blocks so cycles are detected
     // even when the chain is longer than one hop. The returned bindings are
@@ -808,6 +821,7 @@ exports { region: String = "ap-northeast-1" }"#,
         let parsed = carina_core::config_loader::load_configuration_with_config(
             &dir_b,
             &ProviderContext::default(),
+            &carina_core::schema::SchemaRegistry::new(),
         )
         .expect("load config")
         .parsed;
@@ -830,12 +844,12 @@ exports { region: String = "ap-northeast-1" }"#,
 #[cfg(test)]
 mod export_diff_tests {
     use super::*;
-    use carina_core::parser::ExportParameter;
+    use carina_core::parser::{InferredExportParam, TypeExpr};
 
-    fn param(name: &str, value: Value) -> ExportParameter {
-        ExportParameter {
+    fn param(name: &str, value: Value) -> InferredExportParam {
+        InferredExportParam {
             name: name.to_string(),
-            type_expr: None,
+            type_expr: TypeExpr::Unknown,
             value: Some(value),
         }
     }

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -70,12 +70,12 @@ pub(crate) struct FinalizeApplyInput<'a> {
     pub backend: &'a dyn StateBackend,
     pub lock: Option<&'a LockInfo>,
     pub schemas: &'a SchemaRegistry,
-    pub export_params: &'a [carina_core::parser::ExportParameter],
+    pub export_params: &'a [carina_core::parser::InferredExportParam],
 }
 
 /// Resolve export expressions using bindings built from applied state.
 pub(crate) fn resolve_exports(
-    export_params: &[carina_core::parser::ExportParameter],
+    export_params: &[carina_core::parser::InferredExportParam],
     state: &StateFile,
 ) -> HashMap<String, serde_json::Value> {
     use carina_core::binding_index::{BindingValueSource, ResolvedBindings};

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -207,7 +207,12 @@ pub async fn run_force_unlock(
     path: &PathBuf,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
         .await
@@ -238,7 +243,11 @@ async fn load_state_file(
     path: &PathBuf,
     provider_context: &ProviderContext,
 ) -> Result<StateFile, AppError> {
-    let loaded = load_configuration_with_config(path, provider_context)?;
+    let loaded = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
     let parsed = loaded.parsed;
 
     let backend: Box<dyn StateBackend> = resolve_backend(parsed.backend.as_ref())
@@ -451,7 +460,12 @@ async fn run_state_bucket_delete(
     path: &PathBuf,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
 
     let backend_config = parsed
         .backend
@@ -563,7 +577,11 @@ pub async fn run_state_refresh(
     lock: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let loaded = load_configuration_with_config(path, provider_context)?;
+    let loaded = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
     let mut parsed = loaded.parsed;
 
     let base_dir = get_base_dir(path);
@@ -617,7 +635,7 @@ pub async fn run_state_refresh(
 }
 
 pub(crate) async fn run_state_refresh_locked(
-    parsed: &mut carina_core::parser::ParsedFile,
+    parsed: &mut carina_core::parser::InferredFile,
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     base_dir: &std::path::Path,
@@ -910,7 +928,12 @@ async fn run_state_migrate(
     auto_approve: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let mut parsed = load_configuration_with_config(path, provider_context)?.parsed;
+    let mut parsed = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?
+    .parsed;
     let base_dir = get_base_dir(path);
     validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
 

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -53,7 +53,11 @@ pub fn validate_with_factories(
     factories: Vec<Box<dyn carina_core::provider::ProviderFactory>>,
 ) -> Vec<String> {
     let provider_context = ProviderContext::default();
-    let loaded = match load_configuration_with_config(path, &provider_context) {
+    let loaded = match load_configuration_with_config(
+        path,
+        &provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    ) {
         Ok(l) => l,
         Err(e) => return vec![e.to_string()],
     };
@@ -67,6 +71,11 @@ pub fn validate_with_factories(
             .iter()
             .map(ToString::to_string),
     );
+    // Surface inference failures from `apply_inference` (#2360 stage 2).
+    // Each `Unknown` sentinel in `parsed.export_params` has a paired
+    // entry here; reporting the underlying reason gives the user the
+    // actionable "type annotation required" guidance.
+    error_reports.extend(format_inference_errors(&loaded.inference_errors));
 
     error_reports.extend(
         super::validate_and_resolve_errors_with_factories(
@@ -83,12 +92,29 @@ pub fn validate_with_factories(
     error_reports
 }
 
+/// Format `LoadedConfig.inference_errors` into "export '<name>': type
+/// annotation required: <reason>" strings via the shared
+/// `inference::format_inference_error` helper so the CLI and LSP keep
+/// emitting the same wording.
+fn format_inference_errors(
+    errors: &[(String, carina_core::validation::inference::InferenceError)],
+) -> Vec<String> {
+    errors
+        .iter()
+        .map(|(name, err)| carina_core::validation::inference::format_inference_error(name, err))
+        .collect()
+}
+
 pub fn run_validate(
     path: &PathBuf,
     json: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
-    let loaded = load_configuration_with_config(path, provider_context)?;
+    let loaded = load_configuration_with_config(
+        path,
+        provider_context,
+        &carina_core::schema::SchemaRegistry::new(),
+    )?;
     let mut parsed = loaded.parsed;
 
     let base_dir = get_base_dir(path);
@@ -103,6 +129,7 @@ pub fn run_validate(
             .iter()
             .map(ToString::to_string),
     );
+    error_reports.extend(format_inference_errors(&loaded.inference_errors));
     if let Err(AppError::Validation(msg)) =
         check_upstream_state_sources(base_dir, &parsed.upstream_states)
     {

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -33,7 +33,7 @@ pub struct FixturePlan {
     pub schemas: SchemaRegistry,
     pub moved_origins: HashMap<ResourceId, ResourceId>,
     pub deferred_for_expressions: Vec<carina_core::parser::DeferredForExpression>,
-    pub export_params: Vec<carina_core::parser::ExportParameter>,
+    pub export_params: Vec<carina_core::parser::InferredExportParam>,
 }
 
 /// Build a plan from a fixture directory name (e.g. "all_create"). Resolves

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1965,26 +1965,12 @@ async fn state_refresh_removes_orphaned_resource_deleted_externally() {
     let backend = RefreshTestBackend::new(state);
 
     // Config only has "keep-bucket" -- "orphan-bucket" was removed from .crn
-    let mut parsed = ParsedFile {
-        providers: vec![],
-        backend: None,
+    let mut parsed = carina_core::parser::InferredFile {
         resources: vec![
             Resource::new("s3.Bucket", "keep-bucket")
                 .with_attribute("bucket", Value::String("keep-bucket".to_string())),
         ],
-        variables: IndexMap::new(),
-        uses: vec![],
-        module_calls: vec![],
-        arguments: vec![],
-        attribute_params: vec![],
-        export_params: vec![],
-        state_blocks: vec![],
-        user_functions: HashMap::new(),
-        upstream_states: vec![],
-        requires: vec![],
-        structural_bindings: HashSet::new(),
-        warnings: vec![],
-        deferred_for_expressions: vec![],
+        ..carina_core::parser::InferredFile::default()
     };
 
     // MockProvider returns not_found for both resources (simulates external deletion)
@@ -2728,7 +2714,7 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
 
 #[tokio::test]
 async fn persist_exports_only_writes_state_with_new_exports() {
-    use carina_core::parser::ExportParameter;
+    use carina_core::parser::{InferredExportParam, TypeExpr};
     use carina_core::resource::Value;
 
     let captured = Arc::new(Mutex::new(None));
@@ -2737,9 +2723,9 @@ async fn persist_exports_only_writes_state_with_new_exports() {
     };
     let lock = LockInfo::new("apply");
 
-    let export_params = vec![ExportParameter {
+    let export_params = vec![InferredExportParam {
         name: "account_id".to_string(),
-        type_expr: None,
+        type_expr: TypeExpr::Unknown,
         value: Some(Value::String("123456789012".to_string())),
     }];
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -14,7 +14,7 @@ use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::identifier::{self, AnonymousIdStateInfo, PrefixStateInfo};
 use carina_core::module_resolver;
-use carina_core::parser::{ParsedFile, ProviderConfig, StateBlock};
+use carina_core::parser::{ProviderConfig, StateBlock};
 use carina_core::plan::Plan;
 use carina_core::provider::{
     self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
@@ -180,9 +180,9 @@ fn lift_validation_result(res: Result<(), String>) -> Vec<AppError> {
         .collect()
 }
 
-pub fn validate_resources_with_ctx(
+pub fn validate_resources_with_ctx<E>(
     ctx: &WiringContext,
-    parsed: &ParsedFile,
+    parsed: &carina_core::parser::File<E>,
     provider_context: &carina_core::parser::ProviderContext,
 ) -> Vec<AppError> {
     let known_providers: HashSet<String> = ctx
@@ -198,9 +198,9 @@ pub fn validate_resources_with_ctx(
     ))
 }
 
-pub fn validate_resource_ref_types_with_ctx(
+pub fn validate_resource_ref_types_with_ctx<E>(
     ctx: &WiringContext,
-    parsed: &ParsedFile,
+    parsed: &carina_core::parser::File<E>,
     argument_names: &HashSet<String>,
 ) -> Vec<AppError> {
     lift_validation_result(validation::validate_resource_ref_types(
@@ -566,13 +566,15 @@ fn resolve_value_alias(
     }
 }
 
-pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
+pub fn check_unused_bindings<E: carina_core::parser::ExportParamLike>(
+    parsed: &carina_core::parser::File<E>,
+) -> Vec<String> {
     validation::check_unused_bindings(parsed)
 }
 
-pub fn validate_provider_region_with_ctx(
+pub fn validate_provider_region_with_ctx<E>(
     ctx: &WiringContext,
-    parsed: &ParsedFile,
+    parsed: &carina_core::parser::File<E>,
 ) -> Vec<AppError> {
     lift_validation_result(validation::validate_provider_config(
         parsed,
@@ -580,8 +582,8 @@ pub fn validate_provider_region_with_ctx(
     ))
 }
 
-pub fn validate_module_calls(
-    parsed: &ParsedFile,
+pub fn validate_module_calls<E>(
+    parsed: &carina_core::parser::File<E>,
     base_dir: &Path,
     config: &carina_core::parser::ProviderContext,
 ) -> Vec<AppError> {
@@ -600,9 +602,9 @@ pub fn validate_module_calls(
     ))
 }
 
-pub fn validate_module_attribute_param_types(
+pub fn validate_module_attribute_param_types<E>(
     ctx: &WiringContext,
-    parsed: &ParsedFile,
+    parsed: &carina_core::parser::File<E>,
     base_dir: &Path,
 ) -> Vec<AppError> {
     let mut errors = Vec::new();
@@ -633,9 +635,9 @@ pub fn validate_module_attribute_param_types(
     errors
 }
 
-pub async fn get_provider_with_ctx(
+pub async fn get_provider_with_ctx<E>(
     ctx: &WiringContext,
-    parsed: &ParsedFile,
+    parsed: &carina_core::parser::File<E>,
     base_dir: &Path,
 ) -> ProviderRouter {
     let mut router = ProviderRouter::new();
@@ -780,8 +782,8 @@ pub async fn create_providers_from_configs(
 /// This is a convenience wrapper around `create_plan_from_parsed_with_upstream`
 /// for callers that don't use upstream_state blocks.
 #[allow(dead_code)]
-pub async fn create_plan_from_parsed(
-    parsed: &ParsedFile,
+pub async fn create_plan_from_parsed<E>(
+    parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     refresh: bool,
     base_dir: &Path,
@@ -790,8 +792,8 @@ pub async fn create_plan_from_parsed(
         .await
 }
 
-pub async fn create_plan_from_parsed_with_upstream(
-    parsed: &ParsedFile,
+pub async fn create_plan_from_parsed_with_upstream<E>(
+    parsed: &carina_core::parser::File<E>,
     state_file: &Option<StateFile>,
     refresh: bool,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
@@ -1404,6 +1406,7 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
 /// which is acceptable in test code where the overhead is negligible.
 #[cfg(test)]
 pub fn validate_resources(resources: &[Resource]) -> Result<(), AppError> {
+    use carina_core::parser::ParsedFile;
     let ctx = WiringContext::new(vec![]);
     let parsed = ParsedFile {
         resources: resources.to_vec(),

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use carina_core::parser::ParsedFile;
 
 #[test]
 #[ignore = "requires provider binary for enum alias resolution"]

--- a/carina-core/src/binding_index.rs
+++ b/carina-core/src/binding_index.rs
@@ -39,7 +39,6 @@
 //! }
 //! ```
 
-use crate::parser::ParsedFile;
 use crate::resource::{Resource, ResourceId, State, Value};
 use crate::schema::{ResourceSchema, SchemaRegistry};
 use std::collections::HashMap;
@@ -77,7 +76,10 @@ impl<'a> BindingIndex<'a> {
     /// skipped — callers (validation / LSP) treat unknown resource types
     /// as a separate diagnostic, so reporting them again here would
     /// double-count.
-    pub fn from_parsed(parsed: &'a ParsedFile, registry: &'a SchemaRegistry) -> Self {
+    pub fn from_parsed<E>(
+        parsed: &'a crate::parser::File<E>,
+        registry: &'a SchemaRegistry,
+    ) -> Self {
         let mut entries = HashMap::new();
         let mut known_names = std::collections::HashSet::new();
         // Walk top-level resources only. The parser auto-generates a
@@ -210,7 +212,7 @@ impl BindingNameSet {
     /// — keeps `Variable` last because `parsed.variables` is the
     /// catch-all "any `let`-RHS placeholder lives here" map, while the
     /// preceding sources are narrower declaration forms.
-    pub fn from_parsed(parsed: &ParsedFile) -> Self {
+    pub fn from_parsed<E>(parsed: &crate::parser::File<E>) -> Self {
         let mut by_name: HashMap<String, BindingNameKind> = HashMap::new();
 
         for resource in &parsed.resources {
@@ -910,7 +912,7 @@ mod resolved_bindings_tests {
 #[cfg(test)]
 mod binding_name_set_tests {
     use super::*;
-    use crate::parser::parse;
+    use crate::parser::{ParsedFile, parse};
 
     fn parsed_with(src: &str) -> ParsedFile {
         parse(src, &Default::default()).expect("parse")

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::parser::{self, ParsedFile, ProviderContext};
+use crate::parser::{self, InferredFile, ParsedFile, ProviderContext};
+use crate::schema::SchemaRegistry;
+use crate::validation::inference::InferenceError;
 
 /// Result of loading configuration, includes the file path containing backend block.
 ///
@@ -14,10 +16,15 @@ use crate::parser::{self, ParsedFile, ProviderContext};
 /// findings (#2102). Blocking errors (bad parse, missing modules) still
 /// come back as `Err` from the loader.
 pub struct LoadedConfig {
-    pub parsed: ParsedFile,
+    /// Post-inference file: every export carries a bare `TypeExpr`
+    /// (possibly the `TypeExpr::Unknown` sentinel for failed inference,
+    /// in which case a matching entry appears in `inference_errors`).
+    pub parsed: InferredFile,
     /// Resources before reference resolution, for unused binding detection.
     /// After `resolve_resource_refs`, intermediate `ResourceRef` values are resolved away,
     /// so this preserves the original references for accurate unused binding analysis.
+    /// Stays as `ParsedFile` because nothing downstream of this field
+    /// reads `export_params.type_expr`.
     pub unresolved_parsed: ParsedFile,
     pub backend_file: Option<PathBuf>,
     /// Identifier-scope errors surfaced by [`parser::check_identifier_scope`]
@@ -27,11 +34,18 @@ pub struct LoadedConfig {
     /// directory-wide binding set. The loader does not short-circuit on
     /// these so that later validators can also run in a single pass.
     pub identifier_scope_errors: Vec<parser::ParseError>,
+    /// Inference errors collected by `apply_inference` (#2360 stage 2):
+    /// one entry per `exports { ... }` declaration whose type could not
+    /// be statically resolved. The corresponding entry in `parsed.export_params`
+    /// carries `TypeExpr::Unknown` so downstream consumers can keep
+    /// looking the export up by name without spawning cascading
+    /// "missing export" diagnostics.
+    pub inference_errors: Vec<(String, InferenceError)>,
 }
 
 /// Load configuration from a directory containing .crn files
 pub fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
-    load_configuration_with_config(path, &ProviderContext::default())
+    load_configuration_with_config(path, &ProviderContext::default(), &SchemaRegistry::new())
 }
 
 /// Load configuration from a directory containing .crn files.
@@ -40,6 +54,7 @@ pub fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
 pub fn load_configuration_with_config(
     path: &PathBuf,
     config: &ProviderContext,
+    schemas: &SchemaRegistry,
 ) -> Result<LoadedConfig, String> {
     if path.is_file() {
         Err(format!("expected directory, got file: {}", path.display()))
@@ -169,11 +184,18 @@ pub fn load_configuration_with_config(
         // static error in one pass (#2102, #2126, #2138).
         let identifier_scope_errors = parser::check_identifier_scope(&merged);
 
+        // Phase transition: post-resolve, run rhs-driven inference over
+        // every `exports { ... }` declaration so downstream consumers
+        // see a definitive `TypeExpr` per export (#2360 stage 2).
+        let (inferred, inference_errors) =
+            crate::validation::inference::apply_inference(merged, schemas);
+
         Ok(LoadedConfig {
-            parsed: merged,
+            parsed: inferred,
             unresolved_parsed: unresolved_merged,
             backend_file,
             identifier_scope_errors,
+            inference_errors,
         })
     } else {
         Err(format!("Path not found: {}", path.display()))
@@ -543,6 +565,58 @@ mod tests {
     }
 
     // ========== load_configuration tests ==========
+
+    #[test]
+    fn load_configuration_runs_inference_and_surfaces_errors() {
+        // Stage 2 (#2360): an unannotated dynamic-rhs export
+        // (`lookup` returns Any) becomes a sentinel + an inference
+        // error rather than slipping through unchecked.
+        let dir = create_temp_dir("load_inference_failure");
+        fs::write(
+            dir.join("main.crn"),
+            "exports {\n  zone_id = lookup({a = \"1\"}, \"a\", \"default\")\n}\n",
+        )
+        .unwrap();
+
+        let loaded = load_configuration_with_config(
+            &dir,
+            &ProviderContext::default(),
+            &SchemaRegistry::new(),
+        )
+        .unwrap();
+        cleanup(&dir);
+        assert_eq!(loaded.parsed.export_params.len(), 1);
+        assert_eq!(
+            loaded.parsed.export_params[0].type_expr,
+            crate::parser::TypeExpr::Unknown,
+        );
+        assert_eq!(loaded.inference_errors.len(), 1);
+    }
+
+    #[test]
+    fn load_configuration_keeps_inferable_export_typed() {
+        // String-literal rhs is statically inferable; no annotation
+        // required, no inference error.
+        let dir = create_temp_dir("load_inferable_literal");
+        fs::write(dir.join("main.crn"), "exports {\n  name = \"carina\"\n}\n").unwrap();
+
+        let loaded = load_configuration_with_config(
+            &dir,
+            &ProviderContext::default(),
+            &SchemaRegistry::new(),
+        )
+        .unwrap();
+        cleanup(&dir);
+        assert!(
+            loaded.inference_errors.is_empty(),
+            "no inference errors expected, got {:?}",
+            loaded.inference_errors,
+        );
+        assert_eq!(
+            loaded.parsed.export_params[0].type_expr,
+            crate::parser::TypeExpr::String,
+        );
+    }
 
     #[test]
     fn load_configuration_directory_with_provider() {
@@ -943,8 +1017,12 @@ awscc.ec2.SecurityGroup {
 "#,
         )
         .unwrap();
-        let loaded = load_configuration_with_config(&dir2, &ProviderContext::default())
-            .expect("load_configuration should not short-circuit on identifier-scope errors");
+        let loaded = load_configuration_with_config(
+            &dir2,
+            &ProviderContext::default(),
+            &SchemaRegistry::new(),
+        )
+        .expect("load_configuration should not short-circuit on identifier-scope errors");
         cleanup(&dir2);
         assert_eq!(
             loaded.identifier_scope_errors.len(),
@@ -981,8 +1059,12 @@ awscc.ec2.SecurityGroup {
         )
         .unwrap();
 
-        let loaded = load_configuration_with_config(&dir, &ProviderContext::default())
-            .expect("directory with cross-file ResourceRef must load without error");
+        let loaded = load_configuration_with_config(
+            &dir,
+            &ProviderContext::default(),
+            &SchemaRegistry::new(),
+        )
+        .expect("directory with cross-file ResourceRef must load without error");
         cleanup(&dir);
         assert!(
             loaded.identifier_scope_errors.is_empty(),

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -4,7 +4,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::parser::{ParsedFile, ResourceTypePath, TypeExpr};
+use crate::parser::{ResourceTypePath, TypeExpr};
 use crate::resource::Value;
 
 /// Dependency between resources
@@ -334,7 +334,7 @@ pub struct ModuleCallInfo {
 
 impl RootConfigSignature {
     /// Build a root config signature from a parsed file
-    pub fn from_parsed_file(parsed: &ParsedFile, file_name: &str) -> Self {
+    pub fn from_parsed_file<E>(parsed: &crate::parser::File<E>, file_name: &str) -> Self {
         // Build imports
         let imports: Vec<ImportInfo> = parsed
             .uses
@@ -666,7 +666,7 @@ impl FileSignature {
     /// Create from a parsed file
     /// For directory-based modules (files with top-level arguments/attributes blocks),
     /// the module name is derived from the directory name or file name.
-    pub fn from_parsed_file(parsed: &ParsedFile, file_name: &str) -> Self {
+    pub fn from_parsed_file<E>(parsed: &crate::parser::File<E>, file_name: &str) -> Self {
         // Check for directory-based module (has top-level arguments or attribute_params)
         if !parsed.arguments.is_empty() || !parsed.attribute_params.is_empty() {
             return FileSignature::Module(ModuleSignature::from_directory_module(
@@ -680,7 +680,10 @@ impl FileSignature {
 
     /// Create from a parsed file with a specific module name
     /// Use this when you know the module name (e.g., from directory structure)
-    pub fn from_parsed_file_with_name(parsed: &ParsedFile, module_name: &str) -> Self {
+    pub fn from_parsed_file_with_name<E>(
+        parsed: &crate::parser::File<E>,
+        module_name: &str,
+    ) -> Self {
         // Check for directory-based module (has top-level arguments or attribute_params)
         if !parsed.arguments.is_empty() || !parsed.attribute_params.is_empty() {
             return FileSignature::Module(ModuleSignature::from_directory_module(
@@ -719,7 +722,7 @@ pub struct ModuleSignature {
 
 impl ModuleSignature {
     /// Build a module signature from a directory-based module (ParsedFile with top-level arguments/attributes)
-    pub fn from_directory_module(parsed: &ParsedFile, module_name: &str) -> Self {
+    pub fn from_directory_module<E>(parsed: &crate::parser::File<E>, module_name: &str) -> Self {
         // Build requires (typed inputs)
         let requires: Vec<TypedArgument> = parsed
             .arguments

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -208,8 +208,12 @@ pub fn resolve_modules(parsed: &mut ParsedFile, base_dir: &Path) -> Result<(), M
 }
 
 /// Resolve all modules in a parsed file with the given parser configuration.
-pub fn resolve_modules_with_config(
-    parsed: &mut ParsedFile,
+///
+/// Generic over the export-parameter shape so callers can pass either
+/// `ParsedFile` (parser phase) or `InferredFile` (post-loader phase) —
+/// the resolver only touches `uses`, `module_calls`, and `resources`.
+pub fn resolve_modules_with_config<E>(
+    parsed: &mut crate::parser::File<E>,
     base_dir: &Path,
     config: &ProviderContext,
 ) -> Result<(), ModuleError> {

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -143,5 +143,9 @@ pub(super) fn check_type_match(
             }
             TypeCheckResult::Ok
         }
+        // Sentinel for failed inference (#2360 stage 2). Module signatures
+        // are user-declared and should never carry Unknown — reaching this
+        // arm is a defensive fallthrough, treated as a mismatch.
+        TypeExpr::Unknown => TypeCheckResult::Mismatch,
     }
 }

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -136,6 +136,28 @@ pub enum TypeExpr {
     Struct {
         fields: Vec<(String, TypeExpr)>,
     },
+    /// Sentinel for inference failure: an unannotated export whose
+    /// rhs could not be statically typed. Produced *only* by
+    /// `apply_inference`, never by the parser. Type-comparison
+    /// predicates reject `Unknown` against any concrete receiver, so
+    /// the `inference_errors` channel surfaces the actionable
+    /// "type annotation required" message instead of a cascade of
+    /// "missing export" diagnostics. See #2360 stage 2.
+    Unknown,
+}
+
+impl TypeExpr {
+    /// Project away the [`TypeExpr::Unknown`] sentinel: returns
+    /// `Some(self)` for any concrete type, `None` for `Unknown`. Used
+    /// when a downstream consumer has no use for sentinel-bearing
+    /// entries (plan display, upstream-export forwarding) and prefers
+    /// the legacy "no static type" `None` shape.
+    pub fn into_known(self) -> Option<TypeExpr> {
+        match self {
+            TypeExpr::Unknown => None,
+            other => Some(other),
+        }
+    }
 }
 
 impl std::fmt::Display for TypeExpr {
@@ -168,6 +190,7 @@ impl std::fmt::Display for TypeExpr {
                     write!(f, " }}")
                 }
             }
+            TypeExpr::Unknown => write!(f, "<unknown>"),
         }
     }
 }
@@ -243,13 +266,42 @@ pub struct AttributeParameter {
     pub value: Option<Value>,
 }
 
-/// An export parameter in an `exports { }` block.
-/// Publishes a named value for `upstream_state` consumers.
+/// An export parameter in an `exports { }` block, as produced by the
+/// parser before any inference runs.
+///
+/// `type_expr` is `Option<TypeExpr>` here because the user may have
+/// omitted the annotation. The loader then runs `apply_inference`
+/// (#2360 stage 2) to resolve the effective type and emits
+/// [`InferredExportParam`] downstream.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ExportParameter {
+pub struct ParsedExportParam {
     pub name: String,
     pub type_expr: Option<TypeExpr>,
     pub value: Option<Value>,
+}
+
+/// Alias kept so the parser's own construct sites (which always
+/// produce the parser-phase shape) read naturally as
+/// `ExportParameter`; downstream consumers should use the explicit
+/// [`ParsedExportParam`] / [`InferredExportParam`] names.
+pub type ExportParameter = ParsedExportParam;
+
+/// Phase-agnostic accessor over an export parameter. Implemented by both
+/// [`ParsedExportParam`] (parser phase) and [`InferredExportParam`]
+/// (post-loader phase) so helpers like `check_unused_bindings` work
+/// uniformly across both shapes.
+pub trait ExportParamLike {
+    fn name(&self) -> &str;
+    fn value(&self) -> Option<&Value>;
+}
+
+impl ExportParamLike for ParsedExportParam {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn value(&self) -> Option<&Value> {
+        self.value.as_ref()
+    }
 }
 
 /// State manipulation block (import, removed, moved)
@@ -373,9 +425,39 @@ pub struct UpstreamState {
     pub source: std::path::PathBuf,
 }
 
-/// Parse result
-#[derive(Debug, Clone, Default)]
-pub struct ParsedFile {
+/// An export parameter as seen post-inference (#2360 stage 2).
+///
+/// `type_expr` is bare `TypeExpr` because every export carries a
+/// definitive type by construction: the loader runs `apply_inference`
+/// after parse + resolve, which fills in either the user's annotation,
+/// the rhs-inferred type, or the [`TypeExpr::Unknown`] sentinel for
+/// failed inference (paired with an entry in `LoadedConfig.inference_errors`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct InferredExportParam {
+    pub name: String,
+    pub type_expr: TypeExpr,
+    pub value: Option<Value>,
+}
+
+impl ExportParamLike for InferredExportParam {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn value(&self) -> Option<&Value> {
+        self.value.as_ref()
+    }
+}
+
+/// Parse result, generic over the export-parameter shape.
+///
+/// Two phases share this struct via aliases (see [`ParsedFile`] and
+/// [`InferredFile`]): the parser produces `File<ParsedExportParam>`
+/// where `type_expr` is `Option<TypeExpr>`; the loader runs
+/// `apply_inference` and yields `File<InferredExportParam>` where every
+/// export's `type_expr` is bare. Every other field is identical between
+/// phases. See `docs/specs/2026-05-03-typeexpr-stage2-design.md`.
+#[derive(Debug, Clone)]
+pub struct File<E> {
     pub providers: Vec<ProviderConfig>,
     pub resources: Vec<Resource>,
     pub variables: IndexMap<String, Value>,
@@ -387,8 +469,9 @@ pub struct ParsedFile {
     pub arguments: Vec<ArgumentParameter>,
     /// Top-level attribute parameters (directory-based module style)
     pub attribute_params: Vec<AttributeParameter>,
-    /// Top-level export parameters (published to upstream_state consumers)
-    pub export_params: Vec<ExportParameter>,
+    /// Top-level export parameters (published to upstream_state consumers).
+    /// Element type varies by phase — see [`ParsedExportParam`] / [`InferredExportParam`].
+    pub export_params: Vec<E>,
     /// Backend configuration for state storage
     pub backend: Option<BackendConfig>,
     /// State manipulation blocks (import, removed, moved)
@@ -408,7 +491,37 @@ pub struct ParsedFile {
     pub deferred_for_expressions: Vec<DeferredForExpression>,
 }
 
-impl ParsedFile {
+/// Parse-phase file: exports retain their `Option<TypeExpr>` shape.
+pub type ParsedFile = File<ParsedExportParam>;
+
+/// Post-inference file: every export carries a bare [`TypeExpr`]
+/// (possibly [`TypeExpr::Unknown`] for inference failures).
+pub type InferredFile = File<InferredExportParam>;
+
+impl<E> Default for File<E> {
+    fn default() -> Self {
+        Self {
+            providers: Vec::new(),
+            resources: Vec::new(),
+            variables: IndexMap::new(),
+            uses: Vec::new(),
+            module_calls: Vec::new(),
+            arguments: Vec::new(),
+            attribute_params: Vec::new(),
+            export_params: Vec::new(),
+            backend: None,
+            state_blocks: Vec::new(),
+            user_functions: HashMap::new(),
+            upstream_states: Vec::new(),
+            requires: Vec::new(),
+            structural_bindings: HashSet::new(),
+            warnings: Vec::new(),
+            deferred_for_expressions: Vec::new(),
+        }
+    }
+}
+
+impl<E> File<E> {
     /// Iterate every resource reachable from the parsed file — both
     /// top-level `resources` and the `template_resource` of each deferred
     /// for-expression — tagged with its origin context.

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -324,6 +324,8 @@ fn check_fn_arg_type(
             }
         }
         TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        // Inference sentinel: never matches a concrete value.
+        TypeExpr::Unknown => false,
     };
     if !type_matches {
         let actual_type = value_type_name(value);
@@ -387,6 +389,8 @@ fn check_fn_return_type(
             }
         }
         TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        // Inference sentinel: never matches a concrete value.
+        TypeExpr::Unknown => false,
     };
     if !type_matches {
         let actual_type = value_type_name(value);

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -18,9 +18,10 @@ mod util;
 
 pub use ast::{
     ArgumentParameter, AttributeParameter, BackendConfig, DEFERRED_UPSTREAM_PLACEHOLDER,
-    DeferredForExpression, ExportParameter, FnParam, ModuleCall, ParsedFile, ProviderConfig,
-    RequireBlock, ResourceContext, ResourceTypePath, StateBlock, TypeExpr, UpstreamState,
-    UseStatement, UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
+    DeferredForExpression, ExportParamLike, ExportParameter, File, FnParam, InferredExportParam,
+    InferredFile, ModuleCall, ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock,
+    ResourceContext, ResourceTypePath, StateBlock, TypeExpr, UpstreamState, UseStatement,
+    UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub use entry::{parse, parse_and_resolve};

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -7638,3 +7638,51 @@ fn nested_block_value_map_preserves_insertion_order() {
         "nested block Value::Map must preserve source key order; got {keys:?}"
     );
 }
+
+#[test]
+fn type_expr_unknown_displays_as_unknown_marker() {
+    let u = TypeExpr::Unknown;
+    assert_eq!(format!("{}", u), "<unknown>");
+}
+
+#[test]
+fn type_expr_unknown_serde_round_trips() {
+    let u = TypeExpr::Unknown;
+    let json = serde_json::to_string(&u).unwrap();
+    let back: TypeExpr = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, u);
+}
+
+#[test]
+fn parsed_export_param_keeps_optional_type_expr() {
+    let p = ParsedExportParam {
+        name: "vpc_id".to_string(),
+        type_expr: None,
+        value: None,
+    };
+    assert!(p.type_expr.is_none());
+}
+
+#[test]
+fn parsed_file_is_file_of_parsed_export_param() {
+    fn _coerce(p: ParsedFile) -> File<ParsedExportParam> {
+        p
+    }
+    fn _back(f: File<ParsedExportParam>) -> ParsedFile {
+        f
+    }
+}
+
+#[test]
+fn inferred_file_holds_inferred_export_param() {
+    let one = InferredExportParam {
+        name: "vpc_id".to_string(),
+        type_expr: TypeExpr::String,
+        value: None,
+    };
+    let f: InferredFile = InferredFile {
+        export_params: vec![one],
+        ..Default::default()
+    };
+    assert_eq!(f.export_params[0].type_expr, TypeExpr::String);
+}

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::config_loader::{find_crn_files_in_dir, parse_directory};
-use crate::parser::{ParsedFile, ProviderContext, ResourceContext, TypeExpr, UpstreamState};
+use crate::parser::{ProviderContext, ResourceContext, TypeExpr, UpstreamState};
 use crate::resource::{Subscript, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
@@ -189,37 +189,37 @@ pub fn resolve_upstream_exports_with_schemas(
         }
         match parse_directory(&source_abs, config) {
             Ok(parsed) => {
-                // Infer-on-failure semantics here are deliberate: any
-                // inference error is silently dropped to `e.type_expr`
-                // (often `None` itself). The downstream consumer's
-                // typecheck is what surfaces a "type annotation
-                // required" diagnostic — the upstream's own validate
-                // run (via `validate_export_param_ref_types`) already
-                // gates the upstream side, so re-emitting the same
-                // error from this resolver would double-report.
-                let bindings =
-                    schemas.map(|_| crate::validation::inference::bindings_from_parsed(&parsed));
-                let keys: HashMap<String, Option<TypeExpr>> = parsed
-                    .export_params
-                    .iter()
-                    .map(|e| {
-                        let inferred = match (schemas, bindings.as_ref()) {
-                            (Some(s), Some(b)) => crate::validation::inference::infer_type_expr(
-                                e.type_expr.as_ref(),
-                                e.value.as_ref(),
-                                b,
-                                s,
-                            )
-                            .ok()
-                            .flatten()
-                            .or_else(|| e.type_expr.clone()),
-                            // `schemas` is None (legacy entry point) —
-                            // forward the declared type unchanged.
-                            _ => e.type_expr.clone(),
-                        };
-                        (e.name.clone(), inferred)
-                    })
-                    .collect();
+                // When schemas are available, hoist the upstream parse
+                // through `apply_inference` so every export carries a
+                // bare `TypeExpr` (possibly the `Unknown` sentinel for
+                // failures) — the same pipeline the loader runs on the
+                // current directory (#2360 stage 2). Inference errors
+                // are silently dropped here: the upstream's own
+                // validate run reports them, and re-emitting from this
+                // resolver would double-report.
+                let keys: HashMap<String, Option<TypeExpr>> = match schemas {
+                    Some(s) => {
+                        let (inferred, _errors) =
+                            crate::validation::inference::apply_inference(parsed, s);
+                        inferred
+                            .export_params
+                            .into_iter()
+                            // Preserve the legacy "no static type"
+                            // surface for sentinels — Unknown carries
+                            // nothing worth forwarding to the consumer.
+                            .map(|e| (e.name, e.type_expr.into_known()))
+                            .collect()
+                    }
+                    // `schemas` is None (legacy entry point) — forward
+                    // the declared type unchanged. Note that without
+                    // schemas there is no way to run inference, so
+                    // unannotated exports stay `None`.
+                    None => parsed
+                        .export_params
+                        .into_iter()
+                        .map(|e| (e.name, e.type_expr))
+                        .collect(),
+                };
                 out.insert(us.binding.clone(), keys);
             }
             Err(reason) => {
@@ -257,7 +257,7 @@ fn resource_attr_location(
 /// for each non-internal attribute (skips `_*` keys). Used by all three
 /// upstream-ref checks; centralized so the iter_all_resources walk and
 /// the `_*` skip are written once.
-fn for_each_resource_attr<F>(parsed: &ParsedFile, mut f: F)
+fn for_each_resource_attr<E, F>(parsed: &crate::parser::File<E>, mut f: F)
 where
     F: FnMut(ResourceContext<'_>, &crate::resource::Resource, &str, &Value),
 {
@@ -281,8 +281,12 @@ where
 /// `scope` controls which subset is walked, mirroring what each
 /// existing caller walks today. See [`NonResourceScope`] for the two
 /// shapes.
-fn for_each_non_resource_value<F>(parsed: &ParsedFile, scope: NonResourceScope, mut f: F)
-where
+fn for_each_non_resource_value<E, F>(
+    parsed: &crate::parser::File<E>,
+    scope: NonResourceScope,
+    mut f: F,
+) where
+    E: crate::parser::ExportParamLike,
     F: FnMut(&Value, &str),
 {
     if matches!(scope, NonResourceScope::All) {
@@ -296,8 +300,8 @@ where
         }
     }
     for export in &parsed.export_params {
-        if let Some(value) = &export.value {
-            f(value, &format!("exports.{}", export.name));
+        if let Some(value) = export.value() {
+            f(value, &format!("exports.{}", export.name()));
         }
     }
     for call in &parsed.module_calls {
@@ -335,8 +339,8 @@ enum NonResourceScope {
 ///
 /// Bindings absent from `exports` are skipped — the caller decides what to
 /// do about unresolved upstreams.
-pub fn check_upstream_state_field_references(
-    parsed: &ParsedFile,
+pub fn check_upstream_state_field_references<E: crate::parser::ExportParamLike>(
+    parsed: &crate::parser::File<E>,
     exports: &UpstreamExports,
 ) -> Vec<UpstreamFieldError> {
     let mut errors: Vec<UpstreamFieldError> = Vec::new();
@@ -479,8 +483,8 @@ impl UpstreamRefDiagnostic for UpstreamTypeError {
 ///
 /// Exports without a declared type (no `: T` annotation) are skipped —
 /// there's nothing to compare.
-pub fn check_upstream_state_field_types(
-    parsed: &ParsedFile,
+pub fn check_upstream_state_field_types<E>(
+    parsed: &crate::parser::File<E>,
     exports: &UpstreamExports,
     registry: &SchemaRegistry,
 ) -> Vec<UpstreamTypeError> {
@@ -659,8 +663,8 @@ impl UpstreamRefDiagnostic for UpstreamForIterableShapeError {
 /// Both flag `(ForBinding × shape)` mismatches; this one fires at
 /// validate time off the upstream's *declared* type, the parser-side
 /// one fires at expansion time off the *resolved* `Value`.
-pub fn check_upstream_state_for_iterable_shapes(
-    parsed: &ParsedFile,
+pub fn check_upstream_state_for_iterable_shapes<E>(
+    parsed: &crate::parser::File<E>,
     exports: &UpstreamExports,
 ) -> Vec<UpstreamForIterableShapeError> {
     let mut errors: Vec<UpstreamForIterableShapeError> = Vec::new();
@@ -811,8 +815,8 @@ impl UpstreamRefDiagnostic for UpstreamAttributeAccessShapeError {
 /// Sibling of [`check_upstream_state_for_iterable_shapes`] from #2317;
 /// both surface "downstream usage doesn't fit upstream's declared
 /// shape" before apply.
-pub fn check_upstream_state_attribute_access_shapes(
-    parsed: &ParsedFile,
+pub fn check_upstream_state_attribute_access_shapes<E: crate::parser::ExportParamLike>(
+    parsed: &crate::parser::File<E>,
     exports: &UpstreamExports,
 ) -> Vec<UpstreamAttributeAccessShapeError> {
     let mut errors: Vec<UpstreamAttributeAccessShapeError> = Vec::new();
@@ -997,8 +1001,8 @@ impl UpstreamRefDiagnostic for UpstreamSubscriptShapeError {
 /// - the leading `field_path` already mismatches the declared shape
 ///   (already handled by `check_upstream_state_attribute_access_shapes`)
 ///   — in that case the field-walk diagnostic is enough.
-pub fn check_upstream_state_subscript_shapes(
-    parsed: &ParsedFile,
+pub fn check_upstream_state_subscript_shapes<E: crate::parser::ExportParamLike>(
+    parsed: &crate::parser::File<E>,
     exports: &UpstreamExports,
 ) -> Vec<UpstreamSubscriptShapeError> {
     let mut errors: Vec<UpstreamSubscriptShapeError> = Vec::new();
@@ -1086,6 +1090,7 @@ fn visit_subscript_access(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::ParsedFile;
     use std::fs;
     use std::path::PathBuf;
 
@@ -3005,5 +3010,35 @@ mod tests {
                 format!("{}: {}", d.location(), d.diagnostic_message())
             );
         }
+    }
+
+    #[test]
+    fn resolve_upstream_exports_with_schemas_uses_inference_for_unannotated() {
+        // Stage 2 (#2360): the resolver hoists the upstream parse
+        // through `apply_inference`, so an unannotated literal export
+        // surfaces as a typed entry to consumers without the user
+        // having to write `: String`.
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("upstream");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "main.crn",
+            "exports {\n  region = \"us-east-1\"\n}\n",
+        );
+
+        let upstream_state = upstream("ups", "upstream");
+        let (exports, _errors) = resolve_upstream_exports_with_schemas(
+            tmp.path(),
+            &[upstream_state],
+            &ctx(),
+            Some(&crate::schema::SchemaRegistry::new()),
+        );
+        let region_type = exports
+            .get("ups")
+            .and_then(|m| m.get("region"))
+            .and_then(|t| t.as_ref())
+            .expect("region should be inferred");
+        assert_eq!(region_type, &TypeExpr::String);
     }
 }

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -1081,7 +1081,7 @@ mod tests {
         let mut parsed = crate::parser::ParsedFile::default();
         let res = crate::resource::Resource::with_provider("awscc", "ec2.Vpc", "main")
             .with_binding("main");
-        parsed.resources.push(res);
+        parsed.resources.push(res); // allow: direct — fixture test inspection
         parsed.export_params.push(crate::parser::ParsedExportParam {
             name: "vpc_id".to_string(),
             type_expr: None,

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -1,15 +1,16 @@
-//! Rhs-driven type inference for `exports { }` and `attributes { }`
-//! declarations whose `type_expr` annotation is omitted.
+//! Rhs-driven type inference for `exports { }` declarations whose
+//! `type_expr` annotation is omitted.
 //!
-//! Stage 1 of #2360 (issue #2361). Until this lands, an unannotated
-//! declaration sits in the AST as `type_expr: None` and every
-//! type-checking predicate skips it via `if let Some(type_expr) = ...`,
-//! reopening the same downcast hole #2358 closed for the annotated
-//! direction. This module synthesizes a `TypeExpr` from the rhs `Value`
-//! whenever it can, so callers downstream of resolution always see a
-//! typed declaration (or a hard parse-style error if inference fails).
+//! [`apply_inference`] is the bridge from `ParsedFile` (where exports
+//! carry `Option<TypeExpr>`) to `InferredFile` (where every export
+//! carries a bare `TypeExpr`, possibly the [`TypeExpr::Unknown`]
+//! sentinel for a failure paired with a `(name, InferenceError)` entry
+//! on the side). The loader runs this once per directory load so
+//! downstream consumers (CLI validate, LSP diagnostics, LSP
+//! completion) see a definitive type per export instead of having to
+//! re-derive it. See `docs/specs/2026-05-03-typeexpr-stage2-design.md`.
 //!
-//! Inference rules — from #2360 / #2361 decisions:
+//! Inference rules:
 //!
 //! - `Value::String/Int/Bool/Float` → corresponding `TypeExpr` primitive.
 //! - `Value::List(items)` → `List(T)` where `T` is the unified element
@@ -51,7 +52,7 @@ pub enum InferenceError {
     /// Binding is known but inference can't proceed through it —
     /// today this is only `upstream_state` bindings (the export's
     /// type lives in the upstream's `parsed.export_params`, which the
-    /// inferer doesn't recursively resolve in stage 1). Distinct from
+    /// inferer doesn't recursively resolve today, see #2357). Distinct from
     /// `UnknownBinding` so callers can swallow this case (the
     /// downstream consumer's typecheck will still gate the use)
     /// while a true typo bubbles up as a hard error.
@@ -90,7 +91,7 @@ impl std::fmt::Display for InferenceError {
 /// One entry in the binding map. Resource bindings (`let <name> = <provider>.<resource> { ... }`)
 /// carry the provider/resource type and are inferred through; `upstream_state`
 /// bindings are recognized by name but cannot be projected to a `TypeExpr`
-/// in stage 1 (the export's type lives in the upstream's `parsed.export_params`,
+/// today (the export's type lives in the upstream's `parsed.export_params`,
 /// which the inferer doesn't recursively resolve here). Distinguishing the
 /// two lets the inferer turn a true typo (`mian.vpc_id`) into a hard error
 /// while still passing through `upstream_state`-derived references.
@@ -472,6 +473,90 @@ fn infer_function_call(name: &str) -> Result<TypeExpr, InferenceError> {
     }
 }
 
+/// Phase transition (#2360 stage 2): walk every `ParsedExportParam` in
+/// `parsed`, resolve its effective `TypeExpr` (annotation wins;
+/// otherwise infer from rhs), and emit an `InferredFile` with bare
+/// `TypeExpr` on every export. Failed inferences are *not* dropped —
+/// they are kept with `type_expr: TypeExpr::Unknown` and accompanied
+/// by an entry in the returned `Vec<InferenceError>`. The
+/// sentinel-over-exclude shape prevents cascading "missing export"
+/// diagnostics; the inference error is the single point of truth for
+/// "this needs an annotation".
+pub fn apply_inference(
+    parsed: crate::parser::ParsedFile,
+    schemas: &SchemaRegistry,
+) -> (crate::parser::InferredFile, Vec<(String, InferenceError)>) {
+    let (inferred_exports, errors) = infer_export_params(&parsed, schemas);
+    (
+        crate::parser::InferredFile {
+            providers: parsed.providers,
+            resources: parsed.resources,
+            variables: parsed.variables,
+            uses: parsed.uses,
+            module_calls: parsed.module_calls,
+            arguments: parsed.arguments,
+            attribute_params: parsed.attribute_params,
+            export_params: inferred_exports,
+            backend: parsed.backend,
+            state_blocks: parsed.state_blocks,
+            user_functions: parsed.user_functions,
+            upstream_states: parsed.upstream_states,
+            requires: parsed.requires,
+            structural_bindings: parsed.structural_bindings,
+            warnings: parsed.warnings,
+            deferred_for_expressions: parsed.deferred_for_expressions,
+        },
+        errors,
+    )
+}
+
+/// Borrowing variant of [`apply_inference`] that returns just the
+/// inferred export parameters and any inference errors. The full
+/// `InferredFile` reconstruction in `apply_inference` clones every
+/// non-export field; consumers that only need the export-side typecheck
+/// (LSP diagnostics, in particular) should use this instead to avoid
+/// the per-keystroke deep-clone.
+pub fn infer_export_params(
+    parsed: &crate::parser::ParsedFile,
+    schemas: &SchemaRegistry,
+) -> (
+    Vec<crate::parser::InferredExportParam>,
+    Vec<(String, InferenceError)>,
+) {
+    let bindings = bindings_from_parts(&parsed.resources, &parsed.upstream_states);
+    let mut errors = Vec::new();
+    let inferred_exports: Vec<crate::parser::InferredExportParam> = parsed
+        .export_params
+        .iter()
+        .map(|p| {
+            let type_expr =
+                match infer_type_expr(p.type_expr.as_ref(), p.value.as_ref(), &bindings, schemas) {
+                    Ok(Some(ty)) => ty,
+                    Ok(None) => TypeExpr::Unknown,
+                    Err(e) => {
+                        errors.push((p.name.clone(), e));
+                        TypeExpr::Unknown
+                    }
+                };
+            crate::parser::InferredExportParam {
+                name: p.name.clone(),
+                type_expr,
+                value: p.value.clone(),
+            }
+        })
+        .collect();
+    (inferred_exports, errors)
+}
+
+/// Format an inference error pointing at the offending export. The CLI
+/// (`carina-cli/src/commands/validate.rs`) and the LSP
+/// (`carina-lsp/src/diagnostics/checks.rs`) both surface this same
+/// "type annotation required" wording so editor and command line stay
+/// in parity (the existing e2e parity tests pin this).
+pub fn format_inference_error(name: &str, err: &InferenceError) -> String {
+    format!("export '{}': type annotation required: {}", name, err)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -805,8 +890,8 @@ mod tests {
     #[test]
     fn resource_ref_through_upstream_state_binding_returns_non_inferable() {
         // `network.vpc_id` where `network` is a `let network = upstream_state { ... }`
-        // — known binding but stage 1 cannot project upstream exports
-        // recursively. Distinct from `UnknownBinding` (typo) so the
+        // — known binding but the inferer cannot project upstream
+        // exports recursively (see #2357). Distinct from `UnknownBinding` (typo) so the
         // outer `infer_type_expr` can pass through cleanly while a real
         // typo bubbles up.
         let mut bindings = InferenceBindings::new();
@@ -989,5 +1074,85 @@ mod tests {
             &SchemaRegistry::new(),
         );
         assert!(matches!(r, Err(InferenceError::UnknownType { .. })));
+    }
+
+    #[test]
+    fn apply_inference_fills_inferable_export_with_inferred_type() {
+        let mut parsed = crate::parser::ParsedFile::default();
+        let res = crate::resource::Resource::with_provider("awscc", "ec2.Vpc", "main")
+            .with_binding("main");
+        parsed.resources.push(res);
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "vpc_id".to_string(),
+            type_expr: None,
+            value: Some(Value::resource_ref(
+                "main".to_string(),
+                "vpc_id".to_string(),
+                vec![],
+            )),
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &schemas_with_vpc());
+        assert!(errors.is_empty(), "no errors expected, got {:?}", errors);
+        assert_eq!(inferred.export_params.len(), 1);
+        assert_eq!(
+            inferred.export_params[0].type_expr,
+            TypeExpr::Simple("vpc_id".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_inference_substitutes_unknown_for_failed_inference() {
+        let mut parsed = crate::parser::ParsedFile::default();
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "zone_id".to_string(),
+            type_expr: None,
+            // `lookup` returns Any: inference fails, sentinel produced.
+            value: Some(Value::FunctionCall {
+                name: "lookup".to_string(),
+                args: vec![],
+            }),
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
+        assert_eq!(inferred.export_params.len(), 1);
+        assert_eq!(inferred.export_params[0].type_expr, TypeExpr::Unknown);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].0, "zone_id");
+        assert!(matches!(errors[0].1, InferenceError::UnknownType { .. }));
+    }
+
+    #[test]
+    fn apply_inference_preserves_explicit_annotation() {
+        let mut parsed = crate::parser::ParsedFile::default();
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "vpc_id".to_string(),
+            type_expr: Some(TypeExpr::Simple("vpc_id".to_string())),
+            value: Some(Value::String("vpc-abc".to_string())),
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
+        assert!(errors.is_empty(), "no errors expected, got {:?}", errors);
+        assert_eq!(
+            inferred.export_params[0].type_expr,
+            TypeExpr::Simple("vpc_id".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_inference_substitutes_unknown_for_export_without_value() {
+        // Export with no value and no annotation: nothing to infer from
+        // → Unknown sentinel, no error (the value-less shape is the
+        // parser-tombstoned state, not an inference failure).
+        let mut parsed = crate::parser::ParsedFile::default();
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "vpc_id".to_string(),
+            type_expr: None,
+            value: None,
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
+        assert!(errors.is_empty());
+        assert_eq!(inferred.export_params[0].type_expr, TypeExpr::Unknown);
     }
 }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::binding_index::BindingIndex;
-use crate::parser::{ModuleCall, ParsedFile, ProviderContext, TypeExpr, validate_custom_type};
+use crate::parser::{ModuleCall, ProviderContext, TypeExpr, validate_custom_type};
 use crate::provider::ProviderFactory;
 use crate::resource::{Resource, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
@@ -16,8 +16,8 @@ use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 /// and a non-`read` resource requires a `Managed` registry entry. If the
 /// wrong-kind entry is present (e.g. `read` against a managed-only type),
 /// emit a kind-specific error explaining the mismatch.
-pub fn validate_resources(
-    parsed: &ParsedFile,
+pub fn validate_resources<E>(
+    parsed: &crate::parser::File<E>,
     registry: &SchemaRegistry,
     known_providers: &HashSet<String>,
     provider_context: &ProviderContext,
@@ -91,8 +91,8 @@ pub fn validate_resources(
 ///
 /// For example, if `ipv4_ipam_pool_id` expects `IpamPoolId` type,
 /// a reference like `vpc.vpc_id` (which is `AwsResourceId`) should be an error.
-pub fn validate_resource_ref_types(
-    parsed: &ParsedFile,
+pub fn validate_resource_ref_types<E>(
+    parsed: &crate::parser::File<E>,
     registry: &SchemaRegistry,
     argument_names: &HashSet<String>,
 ) -> Result<(), String> {
@@ -266,9 +266,8 @@ pub fn validate_attribute_param_ref_types(
 /// This catches mismatches like `exports { x: list(bool) = [vpc.vpc_id] }` where
 /// `vpc_id` is a string attribute but the export declares `bool`.
 pub fn validate_export_param_ref_types(
-    export_params: &[crate::parser::ExportParameter],
+    export_params: &[crate::parser::InferredExportParam],
     resources: &[Resource],
-    upstream_states: &[crate::parser::UpstreamState],
     registry: &SchemaRegistry,
 ) -> Result<(), String> {
     let mut binding_map: HashMap<String, &Resource> = HashMap::new();
@@ -277,12 +276,6 @@ pub fn validate_export_param_ref_types(
             binding_map.insert(binding_name.clone(), resource);
         }
     }
-    // The inference helper consults both resource bindings and
-    // `upstream_state` bindings — the latter tagged so the inferer
-    // can distinguish "known but non-inferable" from a typo. Their
-    // export's type is resolved by the consumer-side typecheck
-    // instead of here.
-    let inference_bindings = inference::bindings_from_parts(resources, upstream_states);
 
     let mut errors = Vec::new();
 
@@ -290,30 +283,15 @@ pub fn validate_export_param_ref_types(
         let Some(ref value) = param.value else {
             continue;
         };
-
-        // Resolve the effective type — explicit annotation wins; if
-        // omitted, infer from rhs. Inference failure surfaces as a
-        // "type annotation required" error so the unannotated +
-        // un-inferable shape can no longer slip through (#2361).
-        let effective_type = match inference::infer_type_expr(
-            param.type_expr.as_ref(),
-            param.value.as_ref(),
-            &inference_bindings,
-            registry,
-        ) {
-            Ok(Some(t)) => t,
-            Ok(None) => continue,
-            Err(reason) => {
-                errors.push(format!(
-                    "export '{}': type annotation required: {}",
-                    param.name, reason
-                ));
-                continue;
-            }
-        };
+        // Skip the `Unknown` sentinel — the loader's `inference_errors`
+        // channel already reports the missing annotation; emitting a
+        // "type mismatch" here would be a duplicate.
+        if matches!(&param.type_expr, crate::parser::TypeExpr::Unknown) {
+            continue;
+        }
 
         collect_ref_type_errors(
-            &effective_type,
+            &param.type_expr,
             value,
             &param.name,
             &binding_map,
@@ -483,6 +461,10 @@ pub fn is_type_expr_compatible_with_schema(
                 .all(|(_, ty)| is_type_expr_compatible_with_schema(ty, schema_inner)),
             _ => false,
         },
+        // Sentinel for failed inference (#2360 stage 2). Never matches a
+        // concrete receiver — the inference_errors channel reports the
+        // underlying "type annotation required" instead.
+        TypeExpr::Unknown => false,
         _ => true, // Ref, SchemaType — conservatively accept
     }
 }
@@ -541,7 +523,7 @@ fn attr_type_demands_specific_custom(attr_type: &AttributeType) -> bool {
 /// the user is validating in isolation. We only flag the misplaced block
 /// when a `backend` or `provider` block is also present, since both are
 /// root-only constructs and unambiguously identify a root configuration.
-pub fn validate_no_arguments_in_root(parsed: &ParsedFile) -> Result<(), String> {
+pub fn validate_no_arguments_in_root<E>(parsed: &crate::parser::File<E>) -> Result<(), String> {
     let is_root = parsed.backend.is_some() || !parsed.providers.is_empty();
     if !parsed.arguments.is_empty() && is_root {
         return Err(
@@ -555,7 +537,7 @@ pub fn validate_no_arguments_in_root(parsed: &ParsedFile) -> Result<(), String> 
 ///
 /// Provider configuration should only be defined at the root configuration level,
 /// not inside modules (files with `arguments` or `attributes` blocks).
-pub fn validate_no_provider_in_module(parsed: &ParsedFile) -> Result<(), String> {
+pub fn validate_no_provider_in_module<E>(parsed: &crate::parser::File<E>) -> Result<(), String> {
     let is_module = !parsed.arguments.is_empty() || !parsed.attribute_params.is_empty();
     if is_module && !parsed.providers.is_empty() {
         return Err(
@@ -573,8 +555,8 @@ pub fn validate_no_provider_in_module(parsed: &ParsedFile) -> Result<(), String>
 /// provider-specific semantic checks. Keeping format validation
 /// (namespace structure, enum membership) on the host side means fixes
 /// in `carina-core` take effect without rebuilding provider binaries.
-pub fn validate_provider_config(
-    parsed: &ParsedFile,
+pub fn validate_provider_config<E>(
+    parsed: &crate::parser::File<E>,
     factories: &[Box<dyn ProviderFactory>],
 ) -> Result<(), String> {
     for provider in &parsed.providers {
@@ -636,15 +618,23 @@ pub fn validate_module_calls(
 ///
 /// For each export with both a `type_expr` and a `value`, validates the value
 /// using `validate_type_expr_value`. Accumulates all errors.
+///
+/// Accepts post-inference [`InferredExportParam`]s (#2360 stage 2):
+/// `type_expr` is bare. Sentinel-bearing exports
+/// (`TypeExpr::Unknown`) are skipped — the loader's `inference_errors`
+/// channel surfaces those, and re-checking would double-report.
 pub fn validate_export_params(
-    export_params: &[crate::parser::ExportParameter],
+    export_params: &[crate::parser::InferredExportParam],
     config: &ProviderContext,
 ) -> Result<(), String> {
     let mut errors = Vec::new();
 
     for param in export_params {
-        if let (Some(type_expr), Some(value)) = (&param.type_expr, &param.value)
-            && let Some(error) = validate_type_expr_value(type_expr, value, config)
+        if matches!(&param.type_expr, crate::parser::TypeExpr::Unknown) {
+            continue;
+        }
+        if let Some(value) = &param.value
+            && let Some(error) = validate_type_expr_value(&param.type_expr, value, config)
         {
             errors.push(format!("export '{}': {}", param.name, error));
         }
@@ -661,7 +651,13 @@ pub fn validate_export_params(
 ///
 /// A binding is unused if its name never appears as a `ResourceRef.binding_name`
 /// in any resource attribute, module call argument, or attribute parameter value.
-pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
+///
+/// Generic over the export-parameter shape so both `ParsedFile` (parser
+/// phase) and `InferredFile` (post-loader phase) can drive it without
+/// duplicating the binding walk.
+pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
+    parsed: &crate::parser::File<E>,
+) -> Vec<String> {
     // Collect all defined binding names (skip discard pattern `_`).
     // Walk top-level and for-body resources so bindings declared inside a
     // `for` template are also tracked.
@@ -713,7 +709,7 @@ pub fn check_unused_bindings(parsed: &ParsedFile) -> Vec<String> {
         }
     }
     for export_param in &parsed.export_params {
-        if let Some(value) = &export_param.value {
+        if let Some(value) = export_param.value() {
             collect_resource_refs(value, &mut referenced);
             // Cross-file: when exports.crn is parsed without the binding context,
             // "vpc.vpc_id" becomes String("vpc.vpc_id") instead of ResourceRef.

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1241,6 +1241,46 @@ fn is_type_expr_compatible_struct_rejects_map_with_wrong_element_type() {
 // `String` constraint cannot prove it satisfies the more specific
 // invariants the receiver demands.
 #[test]
+fn is_type_expr_compatible_unknown_rejects_all_concrete_receivers() {
+    // Sentinel for failed inference (#2360 stage 2): never matches any
+    // concrete receiver — the inference_errors channel surfaces the
+    // actionable "type annotation required" instead.
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Unknown,
+        &AttributeType::String,
+    ));
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Unknown,
+        &AttributeType::Int,
+    ));
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Unknown,
+        &AttributeType::Bool,
+    ));
+}
+
+#[test]
+fn is_type_expr_compatible_unknown_rejects_custom_receiver() {
+    use crate::schema::legacy_validator;
+    fn noop(_v: &crate::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let custom = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: legacy_validator(noop),
+        namespace: None,
+        to_dsl: None,
+    };
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Unknown,
+        &custom,
+    ));
+}
+
+#[test]
 fn is_type_expr_compatible_string_rejects_custom_with_semantic_name() {
     use crate::schema::legacy_validator;
     fn noop(_v: &crate::resource::Value) -> Result<(), String> {
@@ -1491,12 +1531,12 @@ fn attribute_param_ref_type_mismatch_detected() {
 
 #[test]
 fn validate_export_params_rejects_invalid_custom_type() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let config = context_with_iam_policy_arn_validator();
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "policy".to_string(),
-        type_expr: Some(TypeExpr::Simple("iam_policy_arn".to_string())),
+        type_expr: TypeExpr::Simple("iam_policy_arn".to_string()),
         value: Some(Value::String("not-an-arn".to_string())),
     }];
     let result = validate_export_params(&exports, &config);
@@ -1508,14 +1548,12 @@ fn validate_export_params_rejects_invalid_custom_type() {
 
 #[test]
 fn validate_export_params_rejects_invalid_list_element() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let config = context_with_iam_policy_arn_validator();
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "policies".to_string(),
-        type_expr: Some(TypeExpr::List(Box::new(TypeExpr::Simple(
-            "iam_policy_arn".to_string(),
-        )))),
+        type_expr: TypeExpr::List(Box::new(TypeExpr::Simple("iam_policy_arn".to_string()))),
         value: Some(Value::List(vec![
             Value::String("arn:aws:iam::123456789012:policy/valid".to_string()),
             Value::String("garbage".to_string()),
@@ -1530,12 +1568,12 @@ fn validate_export_params_rejects_invalid_list_element() {
 
 #[test]
 fn validate_export_params_accepts_valid_values() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let config = context_with_iam_policy_arn_validator();
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "policy".to_string(),
-        type_expr: Some(TypeExpr::Simple("iam_policy_arn".to_string())),
+        type_expr: TypeExpr::Simple("iam_policy_arn".to_string()),
         value: Some(Value::String(
             "arn:aws:iam::123456789012:policy/admin".to_string(),
         )),
@@ -1545,13 +1583,16 @@ fn validate_export_params_accepts_valid_values() {
 }
 
 #[test]
-fn validate_export_params_skips_no_type_annotation() {
-    use crate::parser::ExportParameter;
+fn validate_export_params_skips_unknown_sentinel() {
+    use crate::parser::InferredExportParam;
 
+    // Stage 2 (#2360): exports with `TypeExpr::Unknown` are skipped —
+    // the loader's `inference_errors` channel reports the missing
+    // annotation, so re-checking here would double-report.
     let config = ProviderContext::default();
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "raw".to_string(),
-        type_expr: None,
+        type_expr: TypeExpr::Unknown,
         value: Some(Value::String("anything".to_string())),
     }];
     let result = validate_export_params(&exports, &config);
@@ -1560,12 +1601,12 @@ fn validate_export_params_skips_no_type_annotation() {
 
 #[test]
 fn validate_export_params_rejects_type_mismatch() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let config = ProviderContext::default();
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "flag".to_string(),
-        type_expr: Some(TypeExpr::Bool),
+        type_expr: TypeExpr::Bool,
         value: Some(Value::String("not-a-bool".to_string())),
     }];
     let result = validate_export_params(&exports, &config);
@@ -1707,7 +1748,7 @@ fn type_compat_plain_string_rejected_for_simple() {
 
 #[test]
 fn validate_export_param_ref_types_map_accepts_compatible_types() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -1732,14 +1773,14 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
         ),
     );
 
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "accounts".to_string(),
         // declared as map(string), and values are String-typed — should pass
-        type_expr: Some(TypeExpr::Map(Box::new(TypeExpr::String))),
+        type_expr: TypeExpr::Map(Box::new(TypeExpr::String)),
         value: Some(Value::Map(map_value)),
     }];
 
-    let result = validate_export_param_ref_types(&exports, &[registry_prod], &[], &schemas);
+    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
     assert!(
         result.is_ok(),
         "map(String) = {{ prod = registry_prod.account_id (String) }} should pass, got: {:?}",
@@ -1749,7 +1790,7 @@ fn validate_export_param_ref_types_map_accepts_compatible_types() {
 
 #[test]
 fn validate_export_param_ref_types_map_rejects_type_mismatch() {
-    use crate::parser::ExportParameter;
+    use crate::parser::InferredExportParam;
 
     let mut schemas = SchemaRegistry::new();
     schemas.insert(
@@ -1774,14 +1815,14 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         ),
     );
 
-    let exports = vec![ExportParameter {
+    let exports = vec![InferredExportParam {
         name: "accounts".to_string(),
         // declared as map(bool) — values should be rejected as they are strings
-        type_expr: Some(TypeExpr::Map(Box::new(TypeExpr::Bool))),
+        type_expr: TypeExpr::Map(Box::new(TypeExpr::Bool)),
         value: Some(Value::Map(map_value)),
     }];
 
-    let result = validate_export_param_ref_types(&exports, &[registry_prod], &[], &schemas);
+    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
     assert!(
         result.is_err(),
         "map(Bool) = {{ prod = registry_prod.account_id }} (String) should be flagged as type mismatch"
@@ -1791,6 +1832,62 @@ fn validate_export_param_ref_types_map_rejects_type_mismatch() {
         err.contains("accounts") && err.contains("type mismatch"),
         "error should mention the export name and type mismatch, got: {err}"
     );
+}
+
+#[test]
+fn validate_export_param_ref_types_skips_unknown_sentinel() {
+    use crate::parser::InferredExportParam;
+
+    // Sentinel-bearing exports are surfaced via `inference_errors`,
+    // so the ref-type validator must skip them silently — emitting a
+    // duplicate diagnostic here would double-report the same issue.
+    let exports = vec![InferredExportParam {
+        name: "zone_id".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::String("ignored".to_string())),
+    }];
+
+    let result = validate_export_param_ref_types(&exports, &[], &SchemaRegistry::new());
+    assert!(
+        result.is_ok(),
+        "Unknown sentinel must be skipped, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn validate_export_param_ref_types_against_inferred_inputs() {
+    use crate::parser::{InferredExportParam, UpstreamState};
+
+    // Smoke test: a happy-path post-inference shape (bare TypeExpr,
+    // matching attribute type) typechecks cleanly through the new
+    // signature.
+    let registry_prod = Resource::with_provider("awscc", "organizations.account", "prod")
+        .with_binding("registry_prod")
+        .with_attribute("account_id", Value::String("111".to_string()));
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "awscc",
+        make_schema(
+            "organizations.account",
+            vec![("account_id", AttributeType::String)],
+        ),
+    );
+
+    let exports = vec![InferredExportParam {
+        name: "id".to_string(),
+        type_expr: TypeExpr::String,
+        value: Some(Value::resource_ref(
+            "registry_prod".to_string(),
+            "account_id".to_string(),
+            vec![],
+        )),
+    }];
+
+    let _: &[UpstreamState] = &[]; // signature no longer takes upstream_states; doc only.
+    let result = validate_export_param_ref_types(&exports, &[registry_prod], &schemas);
+    assert!(result.is_ok(), "got {:?}", result);
 }
 
 /// `validate_resources` must reject a resource whose schema declares an

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -386,6 +386,7 @@ impl CompletionProvider {
             }
             schema_type @ parser::TypeExpr::SchemaType { .. } => schema_type.to_string(),
             struct_type @ parser::TypeExpr::Struct { .. } => struct_type.to_string(),
+            parser::TypeExpr::Unknown => "<unknown>".to_string(),
         }
     }
 

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1270,12 +1270,30 @@ impl DiagnosticEngine {
             }
         }
 
-        // Schema-level ref type checking for ResourceRef values in exports
+        // Schema-level ref type checking for ResourceRef values in exports.
+        // `infer_export_params` borrows `parsed` (avoiding the per-keystroke
+        // deep clone the full `apply_inference` would force) so the LSP
+        // can derive the post-inference shape without rebuilding the
+        // whole `InferredFile`.
         let resources = all_resources.unwrap_or(&parsed.resources);
+        let (inferred_export_params, inference_errors) =
+            carina_core::validation::inference::infer_export_params(parsed, &self.schemas);
+        // Surface inference failures as "type annotation required"
+        // diagnostics, anchored at the export name.
+        for (name, err) in &inference_errors {
+            if let Some((line, col)) = self.find_exports_param_position(doc, name) {
+                diagnostics.push(carina_diagnostic(
+                    line,
+                    col,
+                    col + name.len() as u32,
+                    DiagnosticSeverity::WARNING,
+                    carina_core::validation::inference::format_inference_error(name, err),
+                ));
+            }
+        }
         if let Err(ref_errors) = carina_core::validation::validate_export_param_ref_types(
-            &parsed.export_params,
+            &inferred_export_params,
             resources,
-            &parsed.upstream_states,
             &self.schemas,
         ) {
             for error_msg in ref_errors.split('\n') {


### PR DESCRIPTION
Closes #2360.

## Summary

Generic `File<E>` AST splits the export-parameter shape between the parser phase (`ParsedExportParam`, `Option<TypeExpr>`) and the post-loader phase (`InferredExportParam`, bare `TypeExpr`). The loader runs `apply_inference` once after resolve, filling in either the user's annotation, a rhs-inferred type, or the new `TypeExpr::Unknown` sentinel for failed inference. Stage 1 (#2361 / #2362) ran inference inline at the typecheck sites; stage 2 hoists it to the loader so the AST itself encodes the post-inference invariant — `Option<TypeExpr>` is unrepresentable on a post-load export.

## Changes

- **`TypeExpr::Unknown` sentinel** — never produced by the parser; type-comparison predicates reject it against every concrete receiver, so an unannotated `lookup()` or other `Any`-returning builtin can no longer slip through unchecked.
- **`File<E>` generic + `ParsedFile` / `InferredFile` aliases** in `carina-core/src/parser/ast.rs`. Helpers that don't touch `export_params` were generic-ized over `&File<E>` (e.g. `validate_resources`, `check_unused_bindings`, the upstream-state checks) so both `loaded.unresolved_parsed: ParsedFile` and `loaded.parsed: InferredFile` flow through them. `ExportParamLike` trait gives `name`/`value` accessors when generic helpers need them.
- **`apply_inference(ParsedFile, &SchemaRegistry) -> (InferredFile, Vec<(String, InferenceError)>)`** plus a borrowing variant `infer_export_params` so the LSP per-keystroke path can avoid the deep-clone.
- **`LoadedConfig.parsed: InferredFile`** + new `inference_errors: Vec<(String, InferenceError)>` field. CLI's `validate.rs` and LSP's `diagnostics/checks.rs` both surface inference failures via the shared `inference::format_inference_error` helper so the parity tests stay honest.
- **Stage-1 inline inference removed** from `validate_export_param_ref_types` and `validate_export_params` — the loader is now the single source of truth.

## Acceptance

- ✅ `grep -n 'Option<TypeExpr>' carina-core/src/parser/ast.rs` returns no hits on `ExportParameter`'s field. The remaining hits are `AttributeParameter` / `TypedAttributeParam` / `FnParam` (stage 3 scope, deliberately untouched).
- ✅ `cargo nextest run --workspace` — 2578 tests pass, including the existing stage-1 e2e parity tests (`unannotated_export_of_dynamic_lookup_demands_annotation`, `unannotated_export_of_literal_inferred_as_primitive`).
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- ✅ All `bash scripts/check-*.sh` scripts pass.

## Out of scope

- `AttributeParameter` / `TypedAttributeParam` cleanup — tracked as the stage-3 follow-up the design doc anticipates.
- Recursive inference through `upstream_state` bindings — #2357.
- Schema-ing `Any`-returning builtins (`lookup`, `min`, `max`, `map`) — #2360 long-term direction.

## Test plan

- [x] cargo nextest run --workspace
- [x] cargo test --workspace --doc
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] scripts/check-*.sh
- [ ] Real-infra smoke against `~/tmp/carina-upstream-state/` (requires AWS creds; defer to apply-time review)

## Related

- Design: `docs/specs/2026-05-03-typeexpr-stage2-design.md`
- Plan: `docs/specs/2026-05-03-typeexpr-stage2-plan.md`
- Stage 1: PR #2362 (issue #2361)
- Soundness predecessor: PR #2359 (issue #2358)

🤖 Generated with [Claude Code](https://claude.com/claude-code)