### PR TITLE
test(lsp): regression coverage for #2357 unannotated upstream-export inference

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3101,3 +3101,136 @@ awscc.ec2.SecurityGroup {
         labels
     );
 }
+
+/// Build the upstream-state completion fixture used by the #2357
+/// regression tests below. Writes the supplied `network_files`
+/// (typically `[("main.crn", ...)]` or split across `main.crn` +
+/// `exports.crn`) and a fixed `web/main.crn` whose
+/// `awscc.ec2.SecurityGroup` has a `vpc_id =` cursor at line 5.
+/// Returns the cursor `Position` and the `web/` directory.
+fn write_upstream_export_fixture(
+    tmp: &tempfile::TempDir,
+    network_files: &[(&str, &str)],
+) -> (Position, std::path::PathBuf, Document) {
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("network")).unwrap();
+    std::fs::create_dir_all(root.join("web")).unwrap();
+    for (name, body) in network_files {
+        std::fs::write(root.join("network").join(name), body).unwrap();
+    }
+    let main_src = "\
+let network = upstream_state {
+  source = '../network'
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id =
+}
+";
+    std::fs::write(root.join("web/main.crn"), main_src).unwrap();
+
+    (
+        Position {
+            line: 5,
+            character: "  vpc_id = ".chars().count() as u32,
+        },
+        root.join("web"),
+        create_document(main_src),
+    )
+}
+
+/// Issue #2357. An unannotated upstream export whose rhs is a
+/// `ResourceRef` to a typed attribute (`exports { vpc_id = main.vpc_id }`,
+/// where `main` is a `let main = awscc.ec2.Vpc { ... }`) must surface
+/// as a REFERENCE candidate at a downstream `vpc_id =` cursor — the
+/// rhs alone determines the export's type via `apply_inference` so
+/// the user does not have to repeat `: VpcId` redundantly.
+///
+/// This PR is test-only: the inference path was wired into completion
+/// by stage 1 (#2362) and structurally guaranteed by stage 2
+/// (#2360 / #2364). These tests pin the issue's exact scenario as
+/// regression coverage so a future refactor can't silently regress it.
+#[test]
+fn unannotated_upstream_export_with_resource_ref_rhs_is_typed_for_completion() {
+    let provider = test_provider_with_vpc_and_security_group();
+    let tmp = tempfile::tempdir().unwrap();
+    let (position, web_dir, doc) = write_upstream_export_fixture(
+        &tmp,
+        &[(
+            "main.crn",
+            "\
+let main = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+exports {
+  vpc_id = main.vpc_id
+}
+",
+        )],
+    );
+    let completions = provider.complete(&doc, position, Some(&web_dir));
+    let labels: Vec<String> = completions.iter().map(|c| c.label.clone()).collect();
+    assert!(
+        labels.iter().any(|l| l == "network.vpc_id"),
+        "rhs-inferred VpcId export must be offered at the matching SecurityGroup.vpc_id receiver. Got: {:?}",
+        labels
+    );
+}
+
+/// Issue #2357 directory-shape acceptance. The reproduction in the
+/// issue body mentions a `network/exports.crn` sibling-file variant —
+/// the same `let main = awscc.ec2.Vpc` + unannotated `vpc_id = main.vpc_id`
+/// shape, but with the `let` and `exports` blocks split across two
+/// files in the same directory. The merged-directory parse should
+/// reach the same inference outcome and surface the candidate.
+#[test]
+fn unannotated_upstream_export_works_with_split_exports_file() {
+    let provider = test_provider_with_vpc_and_security_group();
+    let tmp = tempfile::tempdir().unwrap();
+    let (position, web_dir, doc) = write_upstream_export_fixture(
+        &tmp,
+        &[
+            (
+                "main.crn",
+                "\
+let main = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+",
+            ),
+            ("exports.crn", "exports {\n  vpc_id = main.vpc_id\n}\n"),
+        ],
+    );
+    let completions = provider.complete(&doc, position, Some(&web_dir));
+    let labels: Vec<String> = completions.iter().map(|c| c.label.clone()).collect();
+    assert!(
+        labels.iter().any(|l| l == "network.vpc_id"),
+        "rhs-inferred VpcId export must be offered even when `let` and `exports` live in sibling files. Got: {:?}",
+        labels
+    );
+}
+
+/// Issue #2357 negative-acceptance. An export whose rhs is a
+/// `Value::FunctionCall` (e.g. `lookup`) cannot be statically typed —
+/// it must stay un-offered, matching the conservative behavior the
+/// stage-1 inference inherited.
+#[test]
+fn unannotated_upstream_export_with_function_call_rhs_is_not_offered() {
+    let provider = test_provider_with_vpc_and_security_group();
+    let tmp = tempfile::tempdir().unwrap();
+    let (position, web_dir, doc) = write_upstream_export_fixture(
+        &tmp,
+        &[(
+            "main.crn",
+            "exports {\n  vpc_id = lookup({a = '1'}, 'a', 'default')\n}\n",
+        )],
+    );
+    let completions = provider.complete(&doc, position, Some(&web_dir));
+    let labels: Vec<String> = completions.iter().map(|c| c.label.clone()).collect();
+    assert!(
+        !labels.iter().any(|l| l == "network.vpc_id"),
+        "Any-returning builtin rhs must not produce a typed candidate. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/mod.rs
+++ b/carina-lsp/src/completion/tests/mod.rs
@@ -207,6 +207,37 @@ pub(super) fn test_provider_with_nameless_enum() -> CompletionProvider {
     CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
 }
 
+/// Provider whose `awscc.ec2.Vpc` schema mirrors the real one as far
+/// as #2357 is concerned: a `vpc_id` attribute typed
+/// `Custom { semantic_name: "VpcId", base: String }`. Pairs with
+/// `awscc.ec2.SecurityGroup`'s `vpc_id` (same `Custom { VpcId }`) so
+/// the upstream-export REFERENCE pass has a typed receiver to match
+/// against.
+pub(super) fn test_provider_with_vpc_and_security_group() -> CompletionProvider {
+    fn noop_validate(_v: &carina_core::resource::Value) -> Result<(), String> {
+        Ok(())
+    }
+    let vpc_id_custom = AttributeType::Custom {
+        semantic_name: Some("VpcId".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: legacy_validator(noop_validate),
+        namespace: None,
+        to_dsl: None,
+    };
+    let vpc = ResourceSchema::new("ec2.Vpc")
+        .attribute(AttributeSchema::new("cidr_block", AttributeType::String))
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_custom.clone()));
+    let security_group = ResourceSchema::new("ec2.SecurityGroup")
+        .attribute(AttributeSchema::new("vpc_id", vpc_id_custom));
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", vpc);
+    schemas.insert("awscc", security_group);
+    CompletionProvider::new(Arc::new(schemas), vec!["awscc".to_string()], vec![], vec![])
+}
+
 /// Provider exposing both a namespaced `StringEnum` (`principal_type`) and a
 /// `Custom` semantic subtype (`target_id` → `aws_account_id`) on the same
 /// resource. Used to reproduce the two value-position completion leaks


### PR DESCRIPTION
Closes #2357.

## Summary

The reported behavior — `exports { vpc_id = main.vpc_id }` should surface `network.vpc_id` as a REFERENCE candidate at a downstream `SecurityGroup.vpc_id =` cursor — was effectively resolved by stage 1 (#2362 wired rhs-driven inference into the LSP completion path) and structurally guaranteed by stage 2 (#2360 / #2364 made `TypeExpr` non-optional on export params).

This PR pins the issue's exact reproduction as regression coverage so a future refactor can't silently regress it.

## Tests added

- `unannotated_upstream_export_with_resource_ref_rhs_is_typed_for_completion` — positive: `vpc_id = main.vpc_id` (no annotation) in single `network/main.crn`, candidate appears at SecurityGroup receiver.
- `unannotated_upstream_export_works_with_split_exports_file` — positive: same shape with `let` and `exports` split across `network/main.crn` + `network/exports.crn` (the sibling-file variant the issue's acceptance criteria explicitly named, also matches CLAUDE.md "Directory-scoped, never single-file" rule).
- `unannotated_upstream_export_with_function_call_rhs_is_not_offered` — negative: `Value::FunctionCall` rhs (`lookup(...)`, `Any`-returning) stays untyped and produces no candidate.

Plus a `write_upstream_export_fixture` helper that dedupes the fixture setup across the three tests, and a `test_provider_with_vpc_and_security_group` that supplies a `Custom { VpcId }` shape shared by both producer and consumer schemas.

## Acceptance

- ✅ All three tests pass: `cargo nextest run -p carina-lsp -E 'test(unannotated_upstream_export)'`
- ✅ `cargo nextest run -p carina-lsp` — 386 tests pass
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean
- ✅ All `bash scripts/check-*.sh` scripts pass

## Test plan

- [x] cargo nextest run -p carina-lsp
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] scripts/check-*.sh
- [ ] Real-infra smoke against `~/tmp/carina-upstream-state/web` (issue's listed acceptance; defer to user)

## Related

- #2362 (PR) — stage 1 of #2360, wired rhs inference into validate / LSP diagnostics / LSP completion.
- #2364 (PR) — stage 2 of #2360, dropped `Option<TypeExpr>` from export params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)