### PR TITLE
plan: tolerate unresolved upstream_state with display marker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,18 @@ plan-fixtures:
 	@echo "=== upstream_state ==="
 	@$(MAKE) plan-upstream-state
 	@echo "---"
+	@$(MAKE) plan-upstream-state-unresolved
+	@echo "---"
+	@$(MAKE) plan-upstream-state-empty-exports
+	@echo "---"
 	@$(MAKE) plan-deferred-for
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
+plan-upstream-state-unresolved:
+	$(PLAN_FIXTURE) upstream_state_unresolved
+plan-upstream-state-empty-exports:
+	$(PLAN_FIXTURE) upstream_state_empty_exports
 plan-deferred-for:
 	$(PLAN_FIXTURE) deferred_for
 plan-exports:
@@ -130,7 +138,8 @@ plan-exports-multifile:
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
-        plan-upstream-state plan-deferred-for plan-exports plan-exports-multifile \
+        plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
+        plan-deferred-for plan-exports plan-exports-multifile \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -104,6 +104,7 @@ async fn verify_upstream_snapshot(
         base_dir,
         &provider_context,
         &mut cycle_guard,
+        super::plan::UpstreamMissingStatePolicy::Strict,
     )
     .await?;
 
@@ -751,6 +752,7 @@ async fn run_apply_locked(
         base_dir,
         provider_context,
         &mut cycle_guard,
+        super::plan::UpstreamMissingStatePolicy::Strict,
     )
     .await?;
 

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -272,11 +272,13 @@ pub async fn run_plan(
     }
 
     let mut cycle_guard = seed_cycle_guard(base_dir);
+    // #2366: plan tolerates missing upstream state; apply still strict.
     let remote_bindings = load_upstream_states(
         &parsed.upstream_states,
         base_dir,
         provider_context,
         &mut cycle_guard,
+        UpstreamMissingStatePolicy::Lenient,
     )
     .await?;
 
@@ -324,6 +326,14 @@ pub async fn run_plan(
         .collect();
 
     if json {
+        // Refuse to serialize a plan whose attributes contain stamped
+        // unresolved-upstream markers. The marker is plan-display only;
+        // letting it leak into JSON or `--out plan.json` would either
+        // confuse JSON consumers (NUL-prefixed sentinel) or — worse —
+        // round-trip through `apply --plan plan.json` and reach the
+        // provider as a literal string. Force the user to apply the
+        // upstreams first. See #2366.
+        check_no_unresolved_upstream_in_plan(&ctx.plan)?;
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx);
         let json_str = serde_json::to_string_pretty(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
@@ -356,6 +366,10 @@ pub async fn run_plan(
 
     // Save plan to file if --out was specified
     if let Some(out_path) = out {
+        // See `check_no_unresolved_upstream_in_plan` and the matching
+        // gate above the `--json` branch for why an unresolved-upstream
+        // marker must not be persisted (#2366).
+        check_no_unresolved_upstream_in_plan(&ctx.plan)?;
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx);
         let json_out = serde_json::to_string_pretty(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
@@ -539,6 +553,81 @@ pub fn compute_export_diffs(
     changes
 }
 
+/// Refuse to persist a plan whose attributes carry the unresolved-
+/// upstream marker stamped by `resolve_refs_for_plan`. The marker is
+/// plan-display only; serializing it would either confuse JSON consumers
+/// (NUL-prefixed sentinel) or, via `apply --plan plan.json`, hand the
+/// literal sentinel to a provider as if it were a real attribute value.
+/// See #2366.
+fn check_no_unresolved_upstream_in_plan(plan: &carina_core::plan::Plan) -> Result<(), AppError> {
+    let mut offending: Vec<String> = plan
+        .effects()
+        .iter()
+        .filter_map(unresolved_marker_in_effect)
+        .collect();
+    if offending.is_empty() {
+        return Ok(());
+    }
+    offending.sort();
+    offending.dedup();
+    Err(AppError::Config(format!(
+        "Cannot save plan: it depends on upstream values that are not yet \
+         applied ({}). Apply the upstream module(s) first, then re-run \
+         `carina plan --out` (or `--json`).",
+        offending.join(", ")
+    )))
+}
+
+fn unresolved_marker_in_effect(effect: &Effect) -> Option<String> {
+    let mut resources: Vec<&Resource> = Vec::new();
+    match effect {
+        Effect::Read { resource } | Effect::Create(resource) => resources.push(resource),
+        Effect::Update { to, .. } => resources.push(to),
+        Effect::Replace {
+            to,
+            cascading_updates,
+            ..
+        } => {
+            resources.push(to);
+            // `cascading_updates[*].to` carries the dependent resource's
+            // full attribute map verbatim. A cascade-triggered dependent
+            // that itself references an unapplied upstream would
+            // otherwise round-trip the marker through the persisted
+            // plan (#2366 round-5 finding).
+            for cu in cascading_updates {
+                resources.push(&cu.to);
+            }
+        }
+        Effect::Delete { .. }
+        | Effect::Import { .. }
+        | Effect::Remove { .. }
+        | Effect::Move { .. } => return None,
+    }
+    for resource in resources {
+        for value in resource.attributes.values() {
+            if let Some(reference) = first_unresolved_marker(value) {
+                return Some(reference.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn first_unresolved_marker(value: &Value) -> Option<&str> {
+    match value {
+        Value::String(s) => carina_core::parser::decode_unresolved_upstream_marker(s),
+        Value::List(items) => items.iter().find_map(first_unresolved_marker),
+        Value::Map(map) => map.values().find_map(first_unresolved_marker),
+        Value::Interpolation(parts) => parts.iter().find_map(|p| match p {
+            carina_core::resource::InterpolationPart::Expr(v) => first_unresolved_marker(v),
+            _ => None,
+        }),
+        Value::FunctionCall { args, .. } => args.iter().find_map(first_unresolved_marker),
+        Value::Secret(inner) => first_unresolved_marker(inner),
+        _ => None,
+    }
+}
+
 /// Seed a cycle guard with the caller's own base directory so that a chain
 /// ending back at the root is detected as a cycle.
 pub(crate) fn seed_cycle_guard(base_dir: &Path) -> HashSet<PathBuf> {
@@ -549,17 +638,39 @@ pub(crate) fn seed_cycle_guard(base_dir: &Path) -> HashSet<PathBuf> {
     guard
 }
 
+/// How a missing upstream state file is handled while loading upstreams.
+/// `apply` and recursive walks for cycle detection use [`Strict`] (error);
+/// `plan` uses [`Lenient`] so a missing state demotes to a warning and
+/// the upstream binding is recorded with no values (#2366).
+///
+/// [`Strict`]: UpstreamMissingStatePolicy::Strict
+/// [`Lenient`]: UpstreamMissingStatePolicy::Lenient
+#[derive(Clone, Copy)]
+pub(crate) enum UpstreamMissingStatePolicy {
+    Strict,
+    Lenient,
+}
+
 /// Resolve and read each upstream's published exports by parsing its source
 /// directory, deriving its backend, and pulling the state through that backend.
 ///
 /// `cycle_guard` holds canonicalized absolute paths of directories currently
 /// being resolved. An upstream whose source canonicalizes to a path already in
 /// the guard is a cycle (A → B → A) and produces an error naming the path.
+///
+/// `policy` controls only the "state file is missing" case and propagates
+/// through the recursive cycle-walk so a chained upstream (A → B → C) that
+/// is partially unapplied still produces warnings + display markers under
+/// `Lenient` instead of a hard error. Cycle detection, source-path
+/// resolution failures, upstream `.crn` parse errors, and backend I/O
+/// errors remain hard errors regardless — they indicate structural
+/// problems the user must fix before plan output can mean anything.
 pub(crate) async fn load_upstream_states(
     upstream_states: &[UpstreamState],
     base_dir: &Path,
     provider_context: &ProviderContext,
     cycle_guard: &mut HashSet<PathBuf>,
+    policy: UpstreamMissingStatePolicy,
 ) -> Result<HashMap<String, HashMap<String, Value>>, AppError> {
     let mut result = HashMap::new();
 
@@ -581,22 +692,50 @@ pub(crate) async fn load_upstream_states(
             )));
         }
 
-        let load_result =
-            load_upstream_bindings_at(us, &source_abs, provider_context, cycle_guard).await;
+        let backend_result =
+            build_upstream_backend(us, &source_abs, provider_context, cycle_guard, policy).await;
         cycle_guard.remove(&source_abs);
-        let bindings = load_result?;
+        let backend = backend_result?;
+
+        let state_file = backend.read_state().await.map_err(AppError::Backend)?;
+        let bindings = match (state_file, policy) {
+            (Some(sf), _) => sf.build_remote_bindings(),
+            (None, UpstreamMissingStatePolicy::Strict) => {
+                return Err(AppError::Config(format!(
+                    "upstream_state '{}': no state found at {}",
+                    us.binding,
+                    source_abs.display()
+                )));
+            }
+            (None, UpstreamMissingStatePolicy::Lenient) => {
+                let msg = format!(
+                    "Warning: upstream_state '{}': no state found at {}; \
+                     dependent values will display as `(known after upstream apply: ...)`",
+                    us.binding,
+                    source_abs.display()
+                );
+                eprintln!("{}", msg.yellow());
+                HashMap::new()
+            }
+        };
         result.insert(us.binding.clone(), bindings);
     }
 
     Ok(result)
 }
 
-async fn load_upstream_bindings_at(
+/// Resolve an upstream's backend: parse its `.crn`, walk its own upstream
+/// chain (cycle detection), then build the backend honoring local-path
+/// anchoring. Shared between strict and lenient upstream loaders so the
+/// only behavioral difference is how a `None` from `read_state()` is
+/// handled.
+async fn build_upstream_backend(
     us: &UpstreamState,
     source_abs: &Path,
     provider_context: &ProviderContext,
     cycle_guard: &mut HashSet<PathBuf>,
-) -> Result<HashMap<String, Value>, AppError> {
+    policy: UpstreamMissingStatePolicy,
+) -> Result<Box<dyn StateBackend>, AppError> {
     let loaded = load_configuration_with_config(
         &source_abs.to_path_buf(),
         provider_context,
@@ -607,11 +746,14 @@ async fn load_upstream_bindings_at(
     // Walk the upstream's own upstream_state blocks so cycles are detected
     // even when the chain is longer than one hop. The returned bindings are
     // discarded; the downstream only needs this upstream's own exports.
+    // Propagate `policy` so a chained upstream that is itself unapplied
+    // produces a warning under Lenient instead of breaking the plan (#2366).
     Box::pin(load_upstream_states(
         &loaded.parsed.upstream_states,
         source_abs,
         provider_context,
         cycle_guard,
+        policy,
     ))
     .await?;
 
@@ -639,19 +781,7 @@ async fn load_upstream_bindings_at(
         )),
     };
 
-    let state_file = backend
-        .read_state()
-        .await
-        .map_err(AppError::Backend)?
-        .ok_or_else(|| {
-            AppError::Config(format!(
-                "upstream_state '{}': no state found at {}",
-                us.binding,
-                source_abs.display()
-            ))
-        })?;
-
-    Ok(state_file.build_remote_bindings())
+    Ok(backend)
 }
 
 #[cfg(test)]
@@ -692,6 +822,7 @@ mod load_upstream_states_tests {
             base_dir,
             &ProviderContext::default(),
             &mut HashSet::new(),
+            UpstreamMissingStatePolicy::Strict,
         )
         .await
         .unwrap();
@@ -733,6 +864,7 @@ mod load_upstream_states_tests {
             &dir_a,
             &ProviderContext::default(),
             &mut guard,
+            UpstreamMissingStatePolicy::Strict,
         )
         .await
         .unwrap_err();
@@ -750,6 +882,7 @@ mod load_upstream_states_tests {
             Path::new("/"),
             &ProviderContext::default(),
             &mut HashSet::new(),
+            UpstreamMissingStatePolicy::Strict,
         )
         .await
         .unwrap_err();
@@ -757,6 +890,81 @@ mod load_upstream_states_tests {
             err.to_string().contains("orgs"),
             "error should name the binding: {}",
             err
+        );
+    }
+
+    /// Strict policy with a parseable upstream that has *no* `carina.state.json`
+    /// must error with `"no state found at <path>"` — this is the contract
+    /// `apply` relies on (#2366).
+    #[tokio::test]
+    async fn load_upstream_states_strict_errors_when_state_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("main.crn"),
+            r#"backend local { path = "carina.state.json" }"#,
+        )
+        .unwrap();
+        // Intentionally do NOT write carina.state.json.
+
+        let upstream_states = vec![UpstreamState {
+            binding: "orgs".to_string(),
+            source: dir.path().to_path_buf(),
+        }];
+        let base_dir = dir.path().parent().unwrap();
+        let err = load_upstream_states(
+            &upstream_states,
+            base_dir,
+            &ProviderContext::default(),
+            &mut HashSet::new(),
+            UpstreamMissingStatePolicy::Strict,
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no state found at"),
+            "expected `no state found at`, got: {}",
+            msg
+        );
+        assert!(
+            msg.contains("orgs"),
+            "error should name the binding: {}",
+            msg
+        );
+    }
+
+    /// Lenient policy with the same setup must NOT error — it warns and
+    /// returns an empty binding so downstream display can stamp the marker.
+    #[tokio::test]
+    async fn load_upstream_states_lenient_returns_empty_when_state_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("main.crn"),
+            r#"backend local { path = "carina.state.json" }"#,
+        )
+        .unwrap();
+
+        let upstream_states = vec![UpstreamState {
+            binding: "orgs".to_string(),
+            source: dir.path().to_path_buf(),
+        }];
+        let base_dir = dir.path().parent().unwrap();
+        let result = load_upstream_states(
+            &upstream_states,
+            base_dir,
+            &ProviderContext::default(),
+            &mut HashSet::new(),
+            UpstreamMissingStatePolicy::Lenient,
+        )
+        .await
+        .expect("lenient must not error");
+        assert!(
+            result.contains_key("orgs"),
+            "binding name must be present so display can stamp the marker"
+        );
+        assert!(
+            result["orgs"].is_empty(),
+            "no exports available, so the inner map must be empty"
         );
     }
 }
@@ -831,6 +1039,7 @@ exports { region: String = "ap-northeast-1" }"#,
             &dir_b,
             &ProviderContext::default(),
             &mut guard,
+            UpstreamMissingStatePolicy::Strict,
         )
         .await
         .expect("upstream bindings");
@@ -838,6 +1047,99 @@ exports { region: String = "ap-northeast-1" }"#,
             bindings["a"]["region"],
             Value::String("ap-northeast-1".to_string())
         );
+    }
+}
+
+#[cfg(test)]
+mod unresolved_marker_persistence_tests {
+    use super::*;
+    use carina_core::effect::Effect;
+    use carina_core::parser::encode_unresolved_upstream_marker;
+    use carina_core::plan::Plan;
+    use carina_core::resource::Resource;
+
+    fn make_plan_with(attrs: Vec<(&str, Value)>) -> Plan {
+        let mut r = Resource::new("test.resource", "name");
+        for (k, v) in attrs {
+            r.attributes.insert(k.to_string(), v);
+        }
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(r));
+        plan
+    }
+
+    #[test]
+    fn check_no_unresolved_upstream_in_plan_passes_when_clean() {
+        let plan = make_plan_with(vec![("vpc_id", Value::String("vpc-123".to_string()))]);
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_ok());
+    }
+
+    #[test]
+    fn check_no_unresolved_upstream_in_plan_errors_on_top_level_marker() {
+        let plan = make_plan_with(vec![(
+            "vpc_id",
+            Value::String(encode_unresolved_upstream_marker("network.vpc.vpc_id")),
+        )]);
+        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("network.vpc.vpc_id"), "got: {}", msg);
+        assert!(msg.contains("upstream"), "got: {}", msg);
+    }
+
+    #[test]
+    fn check_no_unresolved_upstream_in_plan_recurses_into_lists_and_maps() {
+        let inner = Value::String(encode_unresolved_upstream_marker("network.public_sg"));
+        let plan = make_plan_with(vec![(
+            "security_group_ids",
+            Value::List(vec![Value::String("sg-1".to_string()), inner]),
+        )]);
+        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
+        assert!(
+            err.to_string().contains("network.public_sg"),
+            "got: {}",
+            err
+        );
+    }
+
+    /// `Effect::Replace::cascading_updates[*].to` carries the dependent
+    /// resource's full attribute map. A cascade dependent that references
+    /// an unapplied upstream must also block plan persistence (#2366).
+    #[test]
+    fn check_no_unresolved_upstream_in_plan_scans_replace_cascading_updates() {
+        use carina_core::effect::CascadingUpdate;
+        use carina_core::resource::{LifecycleConfig, State};
+
+        let mut top = Resource::new("test.resource", "primary");
+        top.attributes
+            .insert("name".to_string(), Value::String("clean".to_string()));
+        let top_id = top.id.clone();
+
+        let mut dep = Resource::new("test.resource", "dependent");
+        dep.attributes.insert(
+            "vpc_id".to_string(),
+            Value::String(encode_unresolved_upstream_marker("network.vpc_id")),
+        );
+        let dep_id = dep.id.clone();
+        let cascade = CascadingUpdate {
+            id: dep_id.clone(),
+            from: Box::new(State::not_found(dep_id)),
+            to: dep,
+        };
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Replace {
+            id: top_id.clone(),
+            from: Box::new(State::not_found(top_id)),
+            to: top,
+            lifecycle: LifecycleConfig::default(),
+            changed_create_only: Vec::new(),
+            cascading_updates: vec![cascade],
+            temporary_name: None,
+            cascade_ref_hints: Vec::new(),
+        });
+
+        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
+        assert!(err.to_string().contains("network.vpc_id"), "got: {}", err);
     }
 }
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -11,7 +11,7 @@ use carina_core::config_loader::{get_base_dir, load_configuration};
 use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::plan::Plan;
-use carina_core::resolver::resolve_refs_with_state_and_remote;
+use carina_core::resolver::resolve_refs_for_plan;
 use carina_core::resource::{ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 use carina_state::{StateFile, check_and_migrate};
@@ -100,6 +100,10 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         }
     }
 
+    // Insert every upstream binding — even when the state file is
+    // unreadable — so `resolve_refs_for_plan` knows the binding name
+    // and can stamp surviving refs as `(known after upstream apply: <ref>)`
+    // instead of leaving the raw dot-form (#2366).
     let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
     for us in &parsed.upstream_states {
         let dir = if us.source.is_absolute() {
@@ -108,15 +112,20 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
             base_dir.join(&us.source)
         };
         let state_path = dir.join(carina_state::LocalBackend::DEFAULT_STATE_FILE);
-        if let Ok(content) = std::fs::read_to_string(&state_path)
-            && let Ok(sf) = check_and_migrate(&content)
-        {
-            remote_bindings.insert(us.binding.clone(), sf.build_remote_bindings());
-        }
+        let bindings = std::fs::read_to_string(&state_path)
+            .ok()
+            .and_then(|content| check_and_migrate(&content).ok())
+            .map(|sf| sf.build_remote_bindings())
+            .unwrap_or_default();
+        remote_bindings.insert(us.binding.clone(), bindings);
     }
 
+    // Plan-only resolution: stamps surviving upstream refs for display
+    // as `(known after upstream apply: <ref>)` (#2366). The fixture
+    // loader is already lenient about missing upstream state files (see
+    // the loop above that silently skips them).
     let mut resources = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(&mut resources, &current_states, &remote_bindings)
+    resolve_refs_for_plan(&mut resources, &current_states, &remote_bindings)
         .expect("Failed to resolve refs with state");
 
     normalize_desired_with_ctx(&wiring, &mut resources);

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -528,6 +528,57 @@ fn plan_snapshot_upstream_state() {
     insta::assert_snapshot!(strip_ansi(&output));
 }
 
+/// When an upstream_state's state file is missing, the plan must render
+/// the unresolved attribute as `(known after upstream apply: <ref>)`
+/// instead of leaving the raw dot-form (`network.vpc.vpc_id`) which
+/// looks like a string literal. See issue #2366.
+#[test]
+fn plan_snapshot_upstream_state_unresolved() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("upstream_state_unresolved");
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+    );
+    let stripped = strip_ansi(&output);
+    assert!(
+        stripped.contains("(known after upstream apply: network.vpc.vpc_id)"),
+        "expected unresolved upstream ref to render as `(known after upstream apply: ...)`, got:\n{}",
+        stripped
+    );
+    insta::assert_snapshot!(stripped);
+}
+
+/// Companion to `plan_snapshot_upstream_state_unresolved`: state file is
+/// present but `exports` is empty (upstream module declared but not yet
+/// applied). The same `(known after upstream apply: <ref>)` rendering
+/// must apply, with no warning since the state file was readable. See
+/// issue #2366.
+#[test]
+fn plan_snapshot_upstream_state_empty_exports() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("upstream_state_empty_exports");
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+    );
+    let stripped = strip_ansi(&output);
+    assert!(
+        stripped.contains("(known after upstream apply: network.vpc.vpc_id)"),
+        "expected empty-exports upstream ref to render as `(known after upstream apply: ...)`, got:\n{}",
+        stripped
+    );
+    insta::assert_snapshot!(stripped);
+}
+
 #[test]
 fn plan_snapshot_exports() {
     use crate::commands::plan::ExportChange;

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_empty_exports.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_empty_exports.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: stripped
+---
+Execution Plan:
+
+  + awscc.ec2.SecurityGroup 
+      group_description: "Web security group"
+      tags:
+        Name: "web-sg"
+      vpc_id: (known after upstream apply: network.vpc.vpc_id)
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_unresolved.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_unresolved.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: stripped
+---
+Execution Plan:
+
+  + awscc.ec2.SecurityGroup 
+      group_description: "Web security group"
+      tags:
+        Name: "web-sg"
+      vpc_id: (known after upstream apply: network.vpc.vpc_id)
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -20,7 +20,7 @@ use carina_core::provider::{
     self as provider_mod, Provider, ProviderError, ProviderFactory, ProviderNormalizer,
     ProviderRouter,
 };
-use carina_core::resolver::resolve_refs_with_state_and_remote;
+use carina_core::resolver::{resolve_refs_for_plan, resolve_refs_with_state_and_remote};
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::{SchemaRegistry, resolve_block_names};
 use carina_core::utils;
@@ -1044,9 +1044,13 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         HashMap::new()
     };
 
-    // Resolve ResourceRef values and enum identifiers using AWS state
+    // Resolve ResourceRef values and enum identifiers using AWS state.
+    // Plan-only: surviving upstream refs are stamped for display as
+    // `(known after upstream apply: <ref>)` (#2366). `apply` calls
+    // `resolve_refs_with_state_and_remote` and still errors on
+    // unresolved upstream references.
     let mut resources = sorted_resources.clone();
-    resolve_refs_with_state_and_remote(&mut resources, &current_states, remote_bindings)?;
+    resolve_refs_for_plan(&mut resources, &current_states, remote_bindings)?;
 
     // Run the normalization pipeline: normalize_desired → normalize_state →
     // merge_default_tags → resolve_enum_aliases (order matters).

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/main.crn
@@ -1,0 +1,21 @@
+# Test upstream_state when the state file is present but the referenced
+# export value is absent (e.g. upstream module declared but not yet
+# applied). Plan must render the dependent attribute as
+# `(known after upstream apply: <ref>)` instead of the raw dot-form.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let network = upstream_state {
+  source = "./network"
+}
+
+awscc.ec2.SecurityGroup {
+  group_description = 'Web security group'
+  vpc_id            = network.vpc.vpc_id
+
+  tags = {
+    Name = 'web-sg'
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/network/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/network/carina.state.json
@@ -1,0 +1,8 @@
+{
+  "version": 5,
+  "serial": 0,
+  "lineage": "empty-exports-fixture",
+  "carina_version": "0.4.0",
+  "resources": [],
+  "exports": {}
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/network/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_empty_exports/network/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+exports {
+  vpc: struct = {
+    vpc_id = "vpc-abc123"
+    cidr_block = "10.0.0.0/16"
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_unresolved/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_unresolved/main.crn
@@ -1,0 +1,19 @@
+# Test upstream_state when the upstream value cannot be resolved
+# (state file missing, or state present but the export value is empty).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let network = upstream_state {
+  source = "./network"
+}
+
+awscc.ec2.SecurityGroup {
+  group_description = 'Web security group'
+  vpc_id            = network.vpc.vpc_id
+
+  tags = {
+    Name = 'web-sg'
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_unresolved/network/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_unresolved/network/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+exports {
+  vpc: struct = {
+    vpc_id = "vpc-abc123"
+    cidr_block = "10.0.0.0/16"
+  }
+}

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -13,6 +13,55 @@ use std::collections::{HashMap, HashSet};
 
 /// Placeholder text for values that depend on an upstream apply.
 pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
+/// Internal marker stamped onto an `upstream_state` reference that survived
+/// resolution (state file missing, or export value absent). Plan display
+/// detects this prefix and renders the value as
+/// `(known after upstream apply: <ref>)`. The leading NUL byte keeps the
+/// marker disjoint from any user-authored string and from
+/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` / `DEFERRED_UPSTREAM_INDEX_PLACEHOLDER`,
+/// which share the human-readable `(known after upstream apply: ...)`
+/// shape. Use [`encode_unresolved_upstream_marker`] /
+/// [`decode_unresolved_upstream_marker`] instead of inlining the prefix.
+/// See issue #2366.
+pub(crate) const UPSTREAM_UNRESOLVED_MARKER_PREFIX: &str = "\0upstream_unresolved:";
+
+/// Encode `<ref>` (e.g. `network.vpc.vpc_id`) into the marker string
+/// stamped into a `Value::String` by `resolver::resolve_refs_for_plan`.
+pub fn encode_unresolved_upstream_marker(reference: &str) -> String {
+    format!("{}{}", UPSTREAM_UNRESOLVED_MARKER_PREFIX, reference)
+}
+
+/// If `s` carries the unresolved-upstream marker, return the original
+/// `<ref>` payload; otherwise `None`. Used by plan display to detect
+/// stamped values without inlining the prefix.
+pub fn decode_unresolved_upstream_marker(s: &str) -> Option<&str> {
+    s.strip_prefix(UPSTREAM_UNRESOLVED_MARKER_PREFIX)
+}
+
+#[cfg(test)]
+mod marker_tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let encoded = encode_unresolved_upstream_marker("network.vpc.vpc_id");
+        assert_eq!(
+            decode_unresolved_upstream_marker(&encoded),
+            Some("network.vpc.vpc_id")
+        );
+    }
+
+    #[test]
+    fn decode_returns_none_for_user_strings() {
+        assert_eq!(decode_unresolved_upstream_marker(""), None);
+        assert_eq!(decode_unresolved_upstream_marker("vpc-abc123"), None);
+        assert_eq!(
+            decode_unresolved_upstream_marker("(known after upstream apply: key)"),
+            None,
+            "must not collide with DEFERRED_UPSTREAM_KEY_PLACEHOLDER"
+        );
+    }
+}
 /// Placeholder reserved for map-binding key variables. Distinct from the
 /// value-var placeholder so expansion can substitute each correctly.
 pub(crate) const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -22,6 +22,7 @@ pub use ast::{
     InferredFile, ModuleCall, ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock,
     ResourceContext, ResourceTypePath, StateBlock, TypeExpr, UpstreamState, UseStatement,
     UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
+    decode_unresolved_upstream_marker, encode_unresolved_upstream_marker,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub use entry::{parse, parse_and_resolve};

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -38,6 +38,31 @@ pub fn resolve_refs_with_state_and_remote(
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
 ) -> Result<(), String> {
+    resolve_refs_inner(resources, current_states, remote_bindings, false)
+}
+
+/// Plan-only counterpart used when an upstream's state file is missing or
+/// its export is absent. Behaves like
+/// [`resolve_refs_with_state_and_remote`], but any surviving
+/// `Value::ResourceRef` whose root binding is named in `remote_bindings`
+/// is replaced with a marker `Value::String` (built via
+/// `crate::parser::encode_unresolved_upstream_marker`) so plan display
+/// can render it as `(known after upstream apply: <ref>)` instead of the
+/// raw dot-form. `apply` continues to call the strict variant. See #2366.
+pub fn resolve_refs_for_plan(
+    resources: &mut [Resource],
+    current_states: &HashMap<ResourceId, State>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+) -> Result<(), String> {
+    resolve_refs_inner(resources, current_states, remote_bindings, true)
+}
+
+fn resolve_refs_inner(
+    resources: &mut [Resource],
+    current_states: &HashMap<ResourceId, State>,
+    remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    mark_unresolved_upstream: bool,
+) -> Result<(), String> {
     // Save dependency bindings before resolution destroys ResourceRef values.
     // This metadata is used by plan tree building to recover parent-child
     // relationships (see build_plan_tree in display.rs and app.rs).
@@ -51,17 +76,84 @@ pub fn resolve_refs_with_state_and_remote(
     let bindings =
         ResolvedBindings::from_resources_with_state(resources, current_states, remote_bindings);
 
+    let upstream_binding_names: std::collections::HashSet<&str> = if mark_unresolved_upstream {
+        remote_bindings.keys().map(String::as_str).collect()
+    } else {
+        std::collections::HashSet::new()
+    };
+
     // Resolve ResourceRef values in all resources. Stay in `IndexMap`
     // so the user's authored attribute order survives resolution
     // (#2222).
     for resource in resources.iter_mut() {
         let mut resolved_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
         for (key, value) in &resource.attributes {
-            resolved_attrs.insert(key.clone(), resolve_ref_value(value, &bindings)?);
+            let resolved = resolve_ref_value(value, &bindings)?;
+            let final_value = if mark_unresolved_upstream {
+                stamp_unresolved_upstream(resolved, &upstream_binding_names)
+            } else {
+                resolved
+            };
+            resolved_attrs.insert(key.clone(), final_value);
         }
         resource.attributes = resolved_attrs;
     }
     Ok(())
+}
+
+/// Replace any `Value::ResourceRef` whose root binding is in
+/// `upstream_binding_names` with the unresolved-upstream marker string.
+/// Recurses through `List` / `Map` / `Interpolation` / `FunctionCall` /
+/// `Secret` so nested upstream refs (e.g. inside a `tags` map) are also
+/// stamped. Subtrees containing no upstream refs are returned by move
+/// without rebuilding.
+fn stamp_unresolved_upstream(
+    value: Value,
+    upstream_binding_names: &std::collections::HashSet<&str>,
+) -> Value {
+    match value {
+        Value::ResourceRef { ref path } if upstream_binding_names.contains(path.binding()) => {
+            Value::String(crate::parser::encode_unresolved_upstream_marker(
+                &path.to_dot_string(),
+            ))
+        }
+        Value::List(items) => Value::List(
+            items
+                .into_iter()
+                .map(|v| stamp_unresolved_upstream(v, upstream_binding_names))
+                .collect(),
+        ),
+        Value::Map(map) => {
+            let mut out: IndexMap<String, Value> = IndexMap::new();
+            for (k, v) in map {
+                out.insert(k, stamp_unresolved_upstream(v, upstream_binding_names));
+            }
+            Value::Map(out)
+        }
+        Value::Interpolation(parts) => Value::Interpolation(
+            parts
+                .into_iter()
+                .map(|p| match p {
+                    InterpolationPart::Expr(v) => InterpolationPart::Expr(
+                        stamp_unresolved_upstream(v, upstream_binding_names),
+                    ),
+                    other => other,
+                })
+                .collect(),
+        ),
+        Value::FunctionCall { name, args } => Value::FunctionCall {
+            name,
+            args: args
+                .into_iter()
+                .map(|a| stamp_unresolved_upstream(a, upstream_binding_names))
+                .collect(),
+        },
+        Value::Secret(inner) => Value::Secret(Box::new(stamp_unresolved_upstream(
+            *inner,
+            upstream_binding_names,
+        ))),
+        other => other,
+    }
 }
 
 /// Recursively resolve a single Value, replacing ResourceRef with the referenced value.
@@ -741,5 +833,197 @@ mod tests {
             resources[0].get_attr("vpc_id"),
             Some(Value::ResourceRef { .. })
         ));
+    }
+
+    /// `resolve_refs_for_plan` stamps any surviving `ResourceRef` whose
+    /// root binding is in `remote_bindings.keys()` with the unresolved-
+    /// upstream marker. Plan display detects the marker via
+    /// `parser::decode_unresolved_upstream_marker`.
+    #[test]
+    fn test_resolve_refs_for_plan_stamps_top_level_unresolved_upstream() {
+        let mut resources = vec![make_resource(
+            "web-sg",
+            None,
+            vec![(
+                "vpc_id",
+                Value::resource_ref(
+                    "network".to_string(),
+                    "vpc".to_string(),
+                    vec!["vpc_id".to_string()],
+                ),
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("network".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        match resources[0].get_attr("vpc_id") {
+            Some(Value::String(s)) => {
+                let payload = crate::parser::decode_unresolved_upstream_marker(s)
+                    .expect("expected marker prefix");
+                assert_eq!(payload, "network.vpc.vpc_id");
+            }
+            other => panic!("expected marker String, got {:?}", other),
+        }
+    }
+
+    /// The apply-side `resolve_refs_with_state_and_remote` must leave a
+    /// surviving upstream `ResourceRef` intact (no marker String). Apply
+    /// still requires every upstream value to be resolved at apply time;
+    /// the resolver-level guarantee is "no stamping unless `for_plan`".
+    #[test]
+    fn test_resolve_refs_with_state_and_remote_leaves_unresolved_ref_intact() {
+        let mut resources = vec![make_resource(
+            "web-sg",
+            None,
+            vec![(
+                "vpc_id",
+                Value::resource_ref(
+                    "network".to_string(),
+                    "vpc".to_string(),
+                    vec!["vpc_id".to_string()],
+                ),
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("network".to_string(), HashMap::new());
+
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            .unwrap();
+
+        assert!(matches!(
+            resources[0].get_attr("vpc_id"),
+            Some(Value::ResourceRef { .. })
+        ));
+    }
+
+    /// Refs to non-upstream bindings must not be marked, so existing
+    /// diagnostics for in-DSL `let` typos keep working.
+    #[test]
+    fn test_resolve_refs_for_plan_leaves_non_upstream_refs() {
+        let mut resources = vec![make_resource(
+            "web-sg",
+            None,
+            vec![(
+                "vpc_id",
+                Value::resource_ref("main".to_string(), "vpc_id".to_string(), Vec::new()),
+            )],
+        )];
+        let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        assert!(matches!(
+            resources[0].get_attr("vpc_id"),
+            Some(Value::ResourceRef { .. })
+        ));
+    }
+
+    /// Upstream refs nested inside a `List` must be reached too — e.g.
+    /// `security_group_ids = [network.public_sg, network.private_sg]`.
+    #[test]
+    fn test_resolve_refs_for_plan_stamps_inside_list() {
+        let mut resources = vec![make_resource(
+            "instance",
+            None,
+            vec![(
+                "security_group_ids",
+                Value::List(vec![
+                    Value::resource_ref("network".to_string(), "public_sg".to_string(), Vec::new()),
+                    Value::resource_ref(
+                        "network".to_string(),
+                        "private_sg".to_string(),
+                        Vec::new(),
+                    ),
+                ]),
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("network".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        match resources[0].get_attr("security_group_ids") {
+            Some(Value::List(items)) => {
+                assert_eq!(items.len(), 2);
+                for (idx, item) in items.iter().enumerate() {
+                    match item {
+                        Value::String(s) => assert!(
+                            crate::parser::decode_unresolved_upstream_marker(s).is_some(),
+                            "list[{}] should be marker String, got {:?}",
+                            idx,
+                            s
+                        ),
+                        other => panic!("list[{}] should be marker String, got {:?}", idx, other),
+                    }
+                }
+            }
+            other => panic!("expected List, got {:?}", other),
+        }
+    }
+
+    /// Stamping must not destroy the `dependency_bindings` saved by the
+    /// resolver before stamping. Plan-tree building and `Delete` effect
+    /// linkage rely on this metadata; without it, a deleted resource that
+    /// referenced an unresolved upstream would lose the parent-child link.
+    #[test]
+    fn test_resolve_refs_for_plan_preserves_dependency_bindings() {
+        let mut resources = vec![make_resource(
+            "web-sg",
+            None,
+            vec![(
+                "vpc_id",
+                Value::resource_ref(
+                    "network".to_string(),
+                    "vpc".to_string(),
+                    vec!["vpc_id".to_string()],
+                ),
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("network".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        assert!(
+            resources[0].dependency_bindings.contains("network"),
+            "dependency_bindings must record the upstream binding even after stamping"
+        );
+    }
+
+    /// Upstream refs nested inside `Map` must be reached — a
+    /// `tags = { id = network.vpc.vpc_id }` attribute would otherwise
+    /// render the raw dot-form when only the top level gets stamped.
+    #[test]
+    fn test_resolve_refs_for_plan_recurses_into_collections() {
+        let inner = Value::resource_ref(
+            "network".to_string(),
+            "vpc".to_string(),
+            vec!["vpc_id".to_string()],
+        );
+        let mut tag_map: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+        tag_map.insert("VpcId".to_string(), inner);
+        let mut resources = vec![make_resource(
+            "web-sg",
+            None,
+            vec![("tags", Value::Map(tag_map))],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("network".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        match resources[0].get_attr("tags") {
+            Some(Value::Map(m)) => match m.get("VpcId") {
+                Some(Value::String(s)) => assert!(
+                    crate::parser::decode_unresolved_upstream_marker(s).is_some(),
+                    "expected marker prefix, got {:?}",
+                    s
+                ),
+                other => panic!("nested entry should be marker String, got {:?}", other),
+            },
+            other => panic!("expected Map, got {:?}", other),
+        }
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -188,6 +188,12 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             if s.starts_with(SECRET_PREFIX) {
                 return "(secret)".to_string();
             }
+            // Unresolved upstream_state references stamped by
+            // `resolve_refs_for_plan` — render unquoted as
+            // `(known after upstream apply: <ref>)`.
+            if let Some(rest) = crate::parser::decode_unresolved_upstream_marker(s) {
+                return format!("(known after upstream apply: {})", rest);
+            }
             // DSL enum format (namespaced identifiers) - resolve to provider value
             if is_dsl_enum_format(s) {
                 let resolved = convert_enum_value(s);
@@ -728,6 +734,21 @@ mod tests {
     fn test_format_value_resource_ref() {
         let v = Value::resource_ref("vpc", "id", vec![]);
         assert_eq!(format_value(&v), "vpc.id");
+    }
+
+    /// `Value::String` carrying the upstream-unresolved marker prefix
+    /// renders unquoted as `(known after upstream apply: <ref>)`. The
+    /// marker is stamped by `resolve_refs_for_plan` and detected here by
+    /// `format_value_with_key` (#2366).
+    #[test]
+    fn test_format_value_unresolved_upstream_marker() {
+        let v = Value::String(crate::parser::encode_unresolved_upstream_marker(
+            "network.vpc.vpc_id",
+        ));
+        assert_eq!(
+            format_value(&v),
+            "(known after upstream apply: network.vpc.vpc_id)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2366

## Summary

- `carina plan` now warns (not errors) when an `upstream_state`'s state file is missing or the referenced export value is absent, and renders the dependent attribute as `(known after upstream apply: <ref>)` instead of leaving the raw `network.vpc.vpc_id` form.
- `carina apply` keeps current strict behavior — every upstream value must still resolve at apply time.
- `plan --json` and `plan --out plan.json` refuse to persist a plan that carries the unresolved-upstream marker, so the plan-only display sentinel cannot leak into JSON consumers or, via `apply --plan plan.json`, reach providers as a literal string.

## Design

- **Resolver split**: new `resolver::resolve_refs_for_plan` shares logic with the existing strict resolver via `resolve_refs_inner` (`mark_unresolved_upstream: bool`). Stamping happens in the same pass as resolution — no second walk, no duplicated `upstream_binding_names` construction.
- **Marker shape**: `\0upstream_unresolved:<ref>` — a NUL-prefixed `Value::String`, encapsulated by `parser::{encode,decode}_unresolved_upstream_marker`. Mirrors the existing `SECRET_PREFIX` pattern; cannot collide with user strings or with the `DEFERRED_UPSTREAM_*_PLACEHOLDER` family.
- **Display**: `value::format_value_with_key` checks the marker via the decode helper and renders unquoted `(known after upstream apply: <ref>)`.
- **Loader unification**: `UpstreamMissingStatePolicy::{Strict, Lenient}` enum threads through the recursive cycle-walk, so chained upstreams (A → B → C) where C is unapplied still complete plan with warnings rather than erroring.
- **Persistence guard**: `check_no_unresolved_upstream_in_plan` walks `Effect::{Read, Create, Update, Replace}` (including `Replace::cascading_updates[*].to`) and refuses to serialize when the marker is present.

## Test plan

- [x] `cargo nextest run --workspace` (2598 tests pass)
- [x] `cargo test --workspace --doc` (passes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] All `scripts/check-*.sh` invariants pass
- [x] Real-infra smoke test against `~/tmp/carina-upstream-state/web` for both state-missing and empty-exports scenarios
- [x] Existing `plan_snapshot_upstream_state` snapshot unchanged (resolved upstream values still display fully)
- [x] New snapshot tests `plan_snapshot_upstream_state_unresolved` and `plan_snapshot_upstream_state_empty_exports`
- [x] Marker codec, both resolver variants, all four collection walk arms, dependency-bindings preservation, both loader policies under state-missing, persistence-guard across Effect kinds (including `Replace::cascading_updates`)

## Out of scope (follow-up candidates)

- Suppress duplicate "upstream X is unapplied" warnings when chained upstreams emit the same warning multiple times.
- Suppress warnings for upstreams reached only by recursive cycle-walk (not directly referenced by the current config).
- Integration test exercising the full `run_plan(json=true)` error path.