### PR TITLE
value: add Value::Unknown(UnknownReason) variant (#2371 stage 1)

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -129,6 +129,13 @@ pub(crate) fn dsl_value_to_json(value: &carina_core::resource::Value) -> Option<
                 .collect();
             Some(serde_json::Value::Object(json_map))
         }
+        // RFC #2371: `Value::Unknown` is plan-display only and must
+        // never reach a state file. The wildcard below would silently
+        // drop it (`-> None`), losing the plan/apply boundary contract;
+        // reject explicitly so a stage-2/3 producer bug surfaces here.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         _ => None, // ResourceRef, Null, etc. — skip
     }
 }

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -422,6 +422,9 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
         Value::Secret(_) => "Secret",
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -196,6 +196,9 @@ fn deterministic_value_string(value: &Value) -> String {
         Value::Secret(inner) => {
             format!("Secret({})", deterministic_value_string(inner))
         }
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -175,6 +175,9 @@ fn format_value(value: &Value) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -811,6 +811,13 @@ pub(super) fn substitute_placeholder(
         Value::Secret(inner) => {
             substitute_placeholder(inner, index, key, value);
         }
+        // Stage 3 (RFC #2371) replaces this whole function with an
+        // enum-match on `Value::Unknown(UnknownReason::{ForKey, ForIndex,
+        // ForValue})` instead of the string sentinel above. Until then,
+        // no producer creates `Value::Unknown`, so this arm is dead.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         _ => {}
     }
 }

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -469,6 +469,12 @@ fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -
                 .collect(),
         ),
         Value::Secret(inner) => Value::Secret(Box::new(substitute_fn_params(inner, substitutions))),
+        // RFC #2371: `Value::Unknown` is plan-display only and has no
+        // producer in stage 1. The wildcard below would silently
+        // pass it through; reject explicitly.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         other => other.clone(),
     }
 }

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -18,6 +18,9 @@ pub(crate) fn is_static_value(value: &Value) -> bool {
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
         Value::ResourceRef { .. } | Value::Interpolation(_) => false,
         Value::Secret(inner) => is_static_value(inner),
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -59,6 +59,9 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "string",
         Value::FunctionCall { .. } => "function call",
         Value::Secret(_) => "secret",
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -152,6 +152,13 @@ fn stamp_unresolved_upstream(
             *inner,
             upstream_binding_names,
         ))),
+        // Stage 2 (RFC #2371) replaces this whole function — the
+        // current `Value::String("\0upstream_unresolved:...")` output
+        // becomes `Value::Unknown(UnknownReason::UpstreamRef { ... })`.
+        // Until then no producer creates `Value::Unknown`.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         other => other,
     }
 }
@@ -300,6 +307,11 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
         Value::Secret(inner) => {
             let resolved_inner = resolve_ref_value(inner, bindings)?;
             Ok(Value::Secret(Box::new(resolved_inner)))
+        }
+        // RFC #2371: stage 1 has no producer; stage 2 will route the
+        // `Value::Unknown` cases through this resolver explicitly.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
         }
         _ => Ok(value.clone()),
     }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -338,6 +338,32 @@ pub enum Value {
     /// A secret value. The inner value is sent to the provider but stored as a
     /// SHA256 hash in state. Plan output displays `(secret)` instead of the value.
     Secret(Box<Value>),
+    /// A value not known at plan time. Plan-display only — must never
+    /// reach `apply`, state files, or provider plugins. See RFC #2371.
+    Unknown(UnknownReason),
+}
+
+/// Why a `Value::Unknown` is unknown. Each variant carries only the
+/// information its own consumer needs — no shared "context" field invites
+/// drift across reasons. See RFC #2371.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum UnknownReason {
+    /// Plan-time reference into an `upstream_state` binding that did not
+    /// resolve (state file missing, or the referenced export was absent).
+    /// Renders as `(known after upstream apply: <path.to_dot_string()>)`.
+    /// Holds the original `AccessPath` so display retains subscripts and
+    /// chained field access (`network.accounts[0]`, `vpc.tags["Name"]`).
+    UpstreamRef { path: AccessPath },
+    /// Map-binding key in a deferred for-expression
+    /// (`for (k, _) in iterable`). Substituted with the actual key when
+    /// the iterable is later resolved.
+    ForKey,
+    /// Indexed-binding index in a deferred for-expression
+    /// (`for (i, _) in iterable`). Substituted with the actual index.
+    ForIndex,
+    /// Loop-variable value in a deferred for-expression
+    /// (`for v in iterable`). Substituted with the actual element.
+    ForValue,
 }
 
 /// A part of a string interpolation expression
@@ -529,6 +555,9 @@ impl Value {
             }
             Value::Secret(inner) => inner.visit_refs(f),
             Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
+            Value::Unknown(_) => {
+                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            }
         }
     }
 }
@@ -639,6 +668,14 @@ impl Value {
             }
             Value::Secret(inner) => {
                 inner.hash_into(hasher);
+            }
+            // Stage 2 must replace this with deterministic hashing before
+            // any producer ships — `merge_lists_hashed` calls
+            // `canonical_hash` → `hash_into`, so a `Value::Unknown` inside
+            // a list element would panic before the planned plan/apply
+            // boundary checks land in stage 4 (RFC #2371).
+            Value::Unknown(_) => {
+                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
             }
         }
     }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1633,6 +1633,9 @@ impl Value {
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),
+            Value::Unknown(_) => {
+                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            }
         }
     }
 }

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -233,6 +233,9 @@ pub fn infer_type_from_value(
             schemas,
         ),
         Value::FunctionCall { name, .. } => infer_function_call(name),
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -5,8 +5,27 @@ use std::collections::HashMap;
 use argon2::Argon2;
 use indexmap::IndexMap;
 
-use crate::resource::{InterpolationPart, Value};
+use crate::resource::{InterpolationPart, UnknownReason, Value};
 use crate::utils::{convert_enum_value, is_dsl_enum_format};
+
+/// Render an `UnknownReason` to its plan-display string. See RFC #2371.
+///
+/// `pub(crate)` for stage 1: only same-crate callers (stage 2 will route
+/// `format_value_with_key` through here). Promote to `pub` in stage 3
+/// when the carina-cli display layer migrates. `#[allow(dead_code)]` is
+/// the explicit acknowledgement that no caller exists *yet* — stage 2
+/// removes the attribute when `format_value_with_key` calls in.
+#[allow(dead_code)]
+pub(crate) fn render_unknown(reason: &UnknownReason) -> String {
+    match reason {
+        UnknownReason::UpstreamRef { path } => {
+            format!("(known after upstream apply: {})", path.to_dot_string())
+        }
+        UnknownReason::ForKey => "(known after upstream apply: key)".to_string(),
+        UnknownReason::ForIndex => "(known after upstream apply: index)".to_string(),
+        UnknownReason::ForValue => "(known after upstream apply)".to_string(),
+    }
+}
 
 /// Secret value prefix used in state serialization.
 pub const SECRET_PREFIX: &str = "_secret:argon2:";
@@ -141,6 +160,9 @@ pub fn value_to_json_with_context(
                 "{SECRET_PREFIX}{hash_hex}",
             )))
         }
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 
@@ -240,6 +262,9 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
     }
 }
 
@@ -353,6 +378,13 @@ pub fn redact_secrets_in_value(value: &Value) -> Value {
             Value::Map(redacted)
         }
         Value::List(items) => Value::List(items.iter().map(redact_secrets_in_value).collect()),
+        // RFC #2371: `Value::Unknown` is plan-display only and must
+        // never reach a serialized output (state file, plan file). The
+        // `other` arm below would silently pass it through; reject
+        // explicitly so a stage-2/3 producer bug surfaces here.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         other => other.clone(),
     }
 }
@@ -499,6 +531,75 @@ pub fn map_similarity(a: &Value, b: &Value) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn render_unknown_upstream_ref() {
+        use crate::resource::AccessPath;
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
+        let r = UnknownReason::UpstreamRef { path };
+        assert_eq!(
+            render_unknown(&r),
+            "(known after upstream apply: network.vpc.vpc_id)"
+        );
+    }
+
+    #[test]
+    fn render_unknown_upstream_ref_with_subscript() {
+        use crate::resource::{AccessPath, Subscript};
+        let path = AccessPath::with_fields_and_subscripts(
+            "network",
+            "accounts",
+            Vec::new(),
+            vec![Subscript::Int { index: 0 }],
+        );
+        let r = UnknownReason::UpstreamRef { path };
+        assert_eq!(
+            render_unknown(&r),
+            "(known after upstream apply: network.accounts[0])"
+        );
+    }
+
+    #[test]
+    fn render_unknown_upstream_ref_with_string_subscript() {
+        use crate::resource::{AccessPath, Subscript};
+        let path = AccessPath::with_fields_and_subscripts(
+            "vpc",
+            "tags",
+            Vec::new(),
+            vec![Subscript::Str {
+                key: "Name".to_string(),
+            }],
+        );
+        let r = UnknownReason::UpstreamRef { path };
+        assert_eq!(
+            render_unknown(&r),
+            "(known after upstream apply: vpc.tags[\"Name\"])"
+        );
+    }
+
+    #[test]
+    fn render_unknown_for_key() {
+        assert_eq!(
+            render_unknown(&UnknownReason::ForKey),
+            "(known after upstream apply: key)"
+        );
+    }
+
+    #[test]
+    fn render_unknown_for_index() {
+        assert_eq!(
+            render_unknown(&UnknownReason::ForIndex),
+            "(known after upstream apply: index)"
+        );
+    }
+
+    #[test]
+    fn render_unknown_for_value() {
+        assert_eq!(
+            render_unknown(&UnknownReason::ForValue),
+            "(known after upstream apply)"
+        );
+    }
 
     #[test]
     fn test_value_to_json_string() {

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -46,6 +46,13 @@ pub fn core_to_wit_value(v: &CoreValue) -> wit::Value {
                 .collect();
             wit::Value::MapVal(serde_json::to_string(&json_map).unwrap())
         }
+        // RFC #2371: `Value::Unknown` is plan-display only and must
+        // never cross the WASM provider boundary — the wildcard
+        // would degrade it to `"Unknown(...)"` debug-format string.
+        // Reject explicitly so a stage-2/3 producer bug surfaces here.
+        CoreValue::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         // Managed-to-managed refs (e.g. `admins.group_id`) are expected
         // here at plan time — they get resolved at apply time by the
         // executor. Data source refs should have been resolved during
@@ -95,6 +102,11 @@ fn core_value_to_json(v: &CoreValue) -> serde_json::Value {
                 .map(|(k, v)| (k.clone(), core_value_to_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
+        }
+        // RFC #2371: `Value::Unknown` must not be serialized to JSON
+        // for provider transport. See sibling arm in `core_to_wit_value`.
+        CoreValue::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
         }
         _ => serde_json::Value::String(format!("{v:?}")),
     }

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -151,6 +151,13 @@ fn value_to_json(value: &carina_core::resource::Value) -> serde_json::Value {
         Value::String(s) => serde_json::Value::String(s.clone()),
         Value::Bool(b) => serde_json::Value::Bool(*b),
         Value::Int(i) => serde_json::Value::Number((*i).into()),
+        // RFC #2371: `Value::Unknown` is plan-display only and must
+        // never reach a state file. The wildcard below would silently
+        // map it to `null`; reject explicitly so a stage-2/3 producer
+        // bug surfaces here instead of silently corrupting the lock.
+        Value::Unknown(_) => {
+            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        }
         _ => serde_json::Value::Null,
     }
 }


### PR DESCRIPTION
Closes #2373

## Summary

Stage 1 of [RFC #2371](https://github.com/carina-rs/carina/blob/main/docs/specs/2026-05-04-unknown-value-unification-design.md). Behavior-neutral type-system scaffold:

- Adds `Value::Unknown(UnknownReason)` variant in `carina-core::resource::Value`.
- Adds `UnknownReason` enum: `UpstreamRef { path: AccessPath }`, `ForKey`, `ForIndex`, `ForValue`.
- Adds `pub(crate) fn render_unknown(&UnknownReason) -> String` in `carina-core::value`.
- Adds explicit `Value::Unknown(_) => unimplemented!(...)` arms at every `match value` site (16 total).
- No producer creates the variant yet — stage 2 migrates the upstream-attribute marker (#2367); stage 3 migrates the for-expression placeholder family.

## Two intentional deviations from the RFC

The RFC's design is the source of truth, with two refinements that emerged during review:

1. **`UnknownReason::UpstreamRef { path: AccessPath }`** instead of `{ binding: String, attribute_path: String }`. `AccessPath` already structures binding + attribute + field path + subscripts; reusing it preserves subscript shape (`network.accounts[0]`, `vpc.tags["Name"]`) for free, and stage 2's `stamp_unresolved_upstream` can pass its existing `AccessPath` directly without re-stringification.
2. **`unimplemented!()` instead of `unreachable!()`** in the new arms. The RFC proposed `unreachable!()` but `Value::Unknown` is constructible from any module — the type system does not actually prevent reaching these arms. `unimplemented!` is more accurate ("TODO, stage 2/3 fills this in"). Stage 4 will promote them to `Err(...)` at serialization boundaries, which is the real plan/apply/state/provider boundary enforcement.

## Defensive coverage beyond `unreachable!` arms

The RFC's "every match site" language was implemented as a strict policy: explicit arms at compiler-flagged exhaustive matches (11) **plus** wildcard fallthroughs that would otherwise silently coerce `Value::Unknown` to serialized output (5). The wildcards predate this PR; tightening them now keeps the RFC's "Unknown never reaches state files / providers / apply" constraints enforceable from stage 2 onwards rather than waiting until stage 4.

The 5 defensive arms:

- `carina-state/src/backend_lock.rs::value_to_json` — backend lock file
- `carina-cli/src/commands/shared/state_writeback.rs::dsl_value_to_json` — state writeback
- `carina-plugin-host/src/wasm_convert.rs` (×2) — WASM provider boundary
- `carina-core/src/value.rs::redact_secrets_in_value` — plan-file redaction

Plus three more in `carina-core/src/parser/{ast,functions}.rs` and `carina-core/src/resolver.rs` for consistency with the same policy across the codebase.

## Stage 2 trip-wires noted (will be filed as the stage 2 issue body)

Surfaced during 5-round review, deferred to stage 2:

- `Value::Unknown == Value::Unknown` returns `true` via derived `PartialEq` (because `AccessPath` derives `PartialEq`). This could suppress real diffs in the differ once stage 2 starts producing the variant. Hand-roll `PartialEq` returning `false` for any `Unknown` pair, or `debug_assert!` it out before any `==` comparison.
- `hash_into` (`carina-core/src/resource/mod.rs:680`) panics for `Value::Unknown` — `merge_lists_hashed` would trip this before stage 4's boundary checks land. Stage 2 must replace with a deterministic hash (or reject `Unknown` at the call site) before any producer ships.

## Test plan

- [x] `cargo nextest run --workspace` (2604 tests pass, +6 new `render_unknown` tests)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` invariants
- [x] No existing snapshots changed (behavior-neutral)
- [x] 4 collection walk arms covered (List, Map, Interpolation/key/value substitution, recursive Secret)

## What's next

After this merges:

- Stage 2 issue (mechanism #3 migration: replace `\0upstream_unresolved:` sentinel with `Value::Unknown(UpstreamRef)`)
- Stage 3 issue (mechanism #2 migration: replace `DEFERRED_UPSTREAM_*_PLACEHOLDER` with `Value::Unknown(For*)`)
- Stage 4 issue (promote `unimplemented!()` to `Err(...)` at serialization boundaries; subsumes #2369)
