### PR TITLE
value: migrate upstream-attribute marker to Value::Unknown(UpstreamRef) (#2371 stage 2)

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -326,13 +326,10 @@ pub async fn run_plan(
         .collect();
 
     if json {
-        // Refuse to serialize a plan whose attributes contain stamped
-        // unresolved-upstream markers. The marker is plan-display only;
-        // letting it leak into JSON or `--out plan.json` would either
-        // confuse JSON consumers (NUL-prefixed sentinel) or — worse —
-        // round-trip through `apply --plan plan.json` and reach the
-        // provider as a literal string. Force the user to apply the
-        // upstreams first. See #2366.
+        // RFC #2371: `Value::Unknown` cannot be serialized (stage-2
+        // serialization-boundary panics + `#[serde(skip)]` on the
+        // variant). Detect it here so the user sees an actionable
+        // error instead of a panic backtrace.
         check_no_unresolved_upstream_in_plan(&ctx.plan)?;
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx);
         let json_str = serde_json::to_string_pretty(&plan_file)
@@ -366,9 +363,7 @@ pub async fn run_plan(
 
     // Save plan to file if --out was specified
     if let Some(out_path) = out {
-        // See `check_no_unresolved_upstream_in_plan` and the matching
-        // gate above the `--json` branch for why an unresolved-upstream
-        // marker must not be persisted (#2366).
+        // See the `--json` branch above for why this gate exists.
         check_no_unresolved_upstream_in_plan(&ctx.plan)?;
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx);
         let json_out = serde_json::to_string_pretty(&plan_file)
@@ -553,17 +548,17 @@ pub fn compute_export_diffs(
     changes
 }
 
-/// Refuse to persist a plan whose attributes carry the unresolved-
-/// upstream marker stamped by `resolve_refs_for_plan`. The marker is
-/// plan-display only; serializing it would either confuse JSON consumers
-/// (NUL-prefixed sentinel) or, via `apply --plan plan.json`, hand the
-/// literal sentinel to a provider as if it were a real attribute value.
-/// See #2366.
+/// Refuse to persist a plan whose attributes carry `Value::Unknown`
+/// (RFC #2371 stage 2). The serialization paths panic on Unknown by
+/// design (`#[serde(skip)]` + explicit `unimplemented!()` arms in
+/// `value_to_json` / `dsl_value_to_json` / `core_to_wit_value`); this
+/// check exists so the user sees an actionable "apply upstreams first"
+/// message instead of a panic backtrace from `--out` or `--json`.
 fn check_no_unresolved_upstream_in_plan(plan: &carina_core::plan::Plan) -> Result<(), AppError> {
     let mut offending: Vec<String> = plan
         .effects()
         .iter()
-        .filter_map(unresolved_marker_in_effect)
+        .filter_map(unresolved_upstream_ref_in_effect)
         .collect();
     if offending.is_empty() {
         return Ok(());
@@ -578,7 +573,7 @@ fn check_no_unresolved_upstream_in_plan(plan: &carina_core::plan::Plan) -> Resul
     )))
 }
 
-fn unresolved_marker_in_effect(effect: &Effect) -> Option<String> {
+fn unresolved_upstream_ref_in_effect(effect: &Effect) -> Option<String> {
     let mut resources: Vec<&Resource> = Vec::new();
     match effect {
         Effect::Read { resource } | Effect::Create(resource) => resources.push(resource),
@@ -589,11 +584,6 @@ fn unresolved_marker_in_effect(effect: &Effect) -> Option<String> {
             ..
         } => {
             resources.push(to);
-            // `cascading_updates[*].to` carries the dependent resource's
-            // full attribute map verbatim. A cascade-triggered dependent
-            // that itself references an unapplied upstream would
-            // otherwise round-trip the marker through the persisted
-            // plan (#2366 round-5 finding).
             for cu in cascading_updates {
                 resources.push(&cu.to);
             }
@@ -605,25 +595,27 @@ fn unresolved_marker_in_effect(effect: &Effect) -> Option<String> {
     }
     for resource in resources {
         for value in resource.attributes.values() {
-            if let Some(reference) = first_unresolved_marker(value) {
-                return Some(reference.to_string());
+            if let Some(reference) = first_unresolved_upstream_ref(value) {
+                return Some(reference);
             }
         }
     }
     None
 }
 
-fn first_unresolved_marker(value: &Value) -> Option<&str> {
+fn first_unresolved_upstream_ref(value: &Value) -> Option<String> {
+    use carina_core::resource::{InterpolationPart, UnknownReason};
     match value {
-        Value::String(s) => carina_core::parser::decode_unresolved_upstream_marker(s),
-        Value::List(items) => items.iter().find_map(first_unresolved_marker),
-        Value::Map(map) => map.values().find_map(first_unresolved_marker),
+        Value::Unknown(UnknownReason::UpstreamRef { path }) => Some(path.to_dot_string()),
+        Value::Unknown(_) => Some("for-expression placeholder".to_string()),
+        Value::List(items) => items.iter().find_map(first_unresolved_upstream_ref),
+        Value::Map(map) => map.values().find_map(first_unresolved_upstream_ref),
         Value::Interpolation(parts) => parts.iter().find_map(|p| match p {
-            carina_core::resource::InterpolationPart::Expr(v) => first_unresolved_marker(v),
+            InterpolationPart::Expr(v) => first_unresolved_upstream_ref(v),
             _ => None,
         }),
-        Value::FunctionCall { args, .. } => args.iter().find_map(first_unresolved_marker),
-        Value::Secret(inner) => first_unresolved_marker(inner),
+        Value::FunctionCall { args, .. } => args.iter().find_map(first_unresolved_upstream_ref),
+        Value::Secret(inner) => first_unresolved_upstream_ref(inner),
         _ => None,
     }
 }
@@ -1051,99 +1043,6 @@ exports { region: String = "ap-northeast-1" }"#,
 }
 
 #[cfg(test)]
-mod unresolved_marker_persistence_tests {
-    use super::*;
-    use carina_core::effect::Effect;
-    use carina_core::parser::encode_unresolved_upstream_marker;
-    use carina_core::plan::Plan;
-    use carina_core::resource::Resource;
-
-    fn make_plan_with(attrs: Vec<(&str, Value)>) -> Plan {
-        let mut r = Resource::new("test.resource", "name");
-        for (k, v) in attrs {
-            r.attributes.insert(k.to_string(), v);
-        }
-        let mut plan = Plan::new();
-        plan.add(Effect::Create(r));
-        plan
-    }
-
-    #[test]
-    fn check_no_unresolved_upstream_in_plan_passes_when_clean() {
-        let plan = make_plan_with(vec![("vpc_id", Value::String("vpc-123".to_string()))]);
-        assert!(check_no_unresolved_upstream_in_plan(&plan).is_ok());
-    }
-
-    #[test]
-    fn check_no_unresolved_upstream_in_plan_errors_on_top_level_marker() {
-        let plan = make_plan_with(vec![(
-            "vpc_id",
-            Value::String(encode_unresolved_upstream_marker("network.vpc.vpc_id")),
-        )]);
-        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("network.vpc.vpc_id"), "got: {}", msg);
-        assert!(msg.contains("upstream"), "got: {}", msg);
-    }
-
-    #[test]
-    fn check_no_unresolved_upstream_in_plan_recurses_into_lists_and_maps() {
-        let inner = Value::String(encode_unresolved_upstream_marker("network.public_sg"));
-        let plan = make_plan_with(vec![(
-            "security_group_ids",
-            Value::List(vec![Value::String("sg-1".to_string()), inner]),
-        )]);
-        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
-        assert!(
-            err.to_string().contains("network.public_sg"),
-            "got: {}",
-            err
-        );
-    }
-
-    /// `Effect::Replace::cascading_updates[*].to` carries the dependent
-    /// resource's full attribute map. A cascade dependent that references
-    /// an unapplied upstream must also block plan persistence (#2366).
-    #[test]
-    fn check_no_unresolved_upstream_in_plan_scans_replace_cascading_updates() {
-        use carina_core::effect::CascadingUpdate;
-        use carina_core::resource::{LifecycleConfig, State};
-
-        let mut top = Resource::new("test.resource", "primary");
-        top.attributes
-            .insert("name".to_string(), Value::String("clean".to_string()));
-        let top_id = top.id.clone();
-
-        let mut dep = Resource::new("test.resource", "dependent");
-        dep.attributes.insert(
-            "vpc_id".to_string(),
-            Value::String(encode_unresolved_upstream_marker("network.vpc_id")),
-        );
-        let dep_id = dep.id.clone();
-        let cascade = CascadingUpdate {
-            id: dep_id.clone(),
-            from: Box::new(State::not_found(dep_id)),
-            to: dep,
-        };
-
-        let mut plan = Plan::new();
-        plan.add(Effect::Replace {
-            id: top_id.clone(),
-            from: Box::new(State::not_found(top_id)),
-            to: top,
-            lifecycle: LifecycleConfig::default(),
-            changed_create_only: Vec::new(),
-            cascading_updates: vec![cascade],
-            temporary_name: None,
-            cascade_ref_hints: Vec::new(),
-        });
-
-        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
-        assert!(err.to_string().contains("network.vpc_id"), "got: {}", err);
-    }
-}
-
-#[cfg(test)]
 mod export_diff_tests {
     use super::*;
     use carina_core::parser::{InferredExportParam, TypeExpr};
@@ -1208,5 +1107,132 @@ mod export_diff_tests {
         assert_eq!(changes[0].name(), "added");
         assert_eq!(changes[1].name(), "modified");
         assert_eq!(changes[2].name(), "removed");
+    }
+}
+
+#[cfg(test)]
+mod check_no_unresolved_upstream_in_plan_tests {
+    use super::*;
+    use carina_core::effect::{CascadingUpdate, Effect};
+    use carina_core::plan::Plan;
+    use carina_core::resource::{
+        AccessPath, LifecycleConfig, Resource, ResourceId, State, UnknownReason, Value,
+    };
+
+    fn unknown_value() -> Value {
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+        Value::Unknown(UnknownReason::UpstreamRef { path })
+    }
+
+    fn make_plan_with(attrs: Vec<(&str, Value)>) -> Plan {
+        let mut r = Resource::new("test.resource", "name");
+        for (k, v) in attrs {
+            r.attributes.insert(k.to_string(), v);
+        }
+        let mut plan = Plan::new();
+        plan.add(Effect::Create(r));
+        plan
+    }
+
+    #[test]
+    fn passes_when_clean() {
+        let plan = make_plan_with(vec![("vpc_id", Value::String("vpc-123".into()))]);
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_ok());
+    }
+
+    #[test]
+    fn errors_on_top_level_unknown() {
+        let plan = make_plan_with(vec![("vpc_id", unknown_value())]);
+        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("network.vpc.vpc_id"), "got: {}", msg);
+        assert!(msg.contains("upstream"), "got: {}", msg);
+    }
+
+    #[test]
+    fn errors_on_unknown_inside_list_or_map() {
+        let plan = make_plan_with(vec![(
+            "tags",
+            Value::List(vec![Value::String("a".into()), unknown_value()]),
+        )]);
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_err());
+
+        let mut m: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+        m.insert("Name".into(), unknown_value());
+        let plan = make_plan_with(vec![("tags", Value::Map(m))]);
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_err());
+    }
+
+    /// Cascade dependents of a Replace also carry attribute maps that
+    /// must be checked — a dependent referencing an unapplied upstream
+    /// must block plan persistence.
+    #[test]
+    fn errors_on_unknown_in_cascading_update() {
+        let mut top = Resource::new("test.resource", "primary");
+        top.attributes
+            .insert("name".into(), Value::String("clean".into()));
+        let top_id = top.id.clone();
+
+        let mut dep = Resource::new("test.resource", "dependent");
+        dep.attributes.insert("vpc_id".into(), unknown_value());
+        let dep_id = dep.id.clone();
+
+        let mut plan = Plan::new();
+        plan.add(Effect::Replace {
+            id: top_id.clone(),
+            from: Box::new(State::not_found(top_id)),
+            to: top,
+            lifecycle: LifecycleConfig::default(),
+            changed_create_only: Vec::new(),
+            cascading_updates: vec![CascadingUpdate {
+                id: dep_id.clone(),
+                from: Box::new(State::not_found(dep_id)),
+                to: dep,
+            }],
+            temporary_name: None,
+            cascade_ref_hints: Vec::new(),
+        });
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_err());
+    }
+
+    /// Delete / Import / Remove / Move effects do not carry attribute
+    /// maps that need checking; they must be skipped silently.
+    #[test]
+    fn delete_import_remove_move_effects_are_skipped() {
+        let id = ResourceId::new("test", "name");
+        let mut plan = Plan::new();
+        plan.add(Effect::Delete {
+            id: id.clone(),
+            identifier: "x".into(),
+            lifecycle: LifecycleConfig::default(),
+            binding: None,
+            dependencies: std::collections::HashSet::new(),
+        });
+        plan.add(Effect::Import {
+            id: id.clone(),
+            identifier: "x".into(),
+        });
+        plan.add(Effect::Remove { id: id.clone() });
+        plan.add(Effect::Move {
+            from: id.clone(),
+            to: id,
+        });
+        assert!(check_no_unresolved_upstream_in_plan(&plan).is_ok());
+    }
+
+    /// Multiple effects with the same Unknown ref dedup in the message.
+    #[test]
+    fn dedup_same_reference_across_effects() {
+        let mut plan = Plan::new();
+        for n in ["a", "b"] {
+            let mut r = Resource::new("test.resource", n);
+            r.attributes.insert("vpc_id".into(), unknown_value());
+            plan.add(Effect::Create(r));
+        }
+        let err = check_no_unresolved_upstream_in_plan(&plan).unwrap_err();
+        let msg = err.to_string();
+        // The reference should appear only once in the comma-separated list.
+        let count = msg.matches("network.vpc.vpc_id").count();
+        assert_eq!(count, 1, "ref must dedup, got: {}", msg);
     }
 }

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -134,7 +134,9 @@ pub(crate) fn dsl_value_to_json(value: &carina_core::resource::Value) -> Option<
         // drop it (`-> None`), losing the plan/apply boundary contract;
         // reject explicitly so a stage-2/3 producer bug surfaces here.
         Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
         _ => None, // ResourceRef, Null, etc. — skip
     }
@@ -285,5 +287,23 @@ pub(crate) fn build_orphan_resource(sf: &carina_state::StateFile, id: &ResourceI
         dependency_bindings: rs.dependency_bindings.clone(),
         module_source: None,
         quoted_string_attrs: std::collections::HashSet::new(),
+    }
+}
+
+#[cfg(test)]
+mod stage2_unknown_panic_tests {
+    use super::*;
+    use carina_core::resource::{AccessPath, UnknownReason, Value};
+
+    /// RFC #2371 contract pin: `dsl_value_to_json` panics on
+    /// `Value::Unknown`. State files must never carry the variant
+    /// (constraint b); a future change that swaps for a silent
+    /// fallback would re-introduce the v1 corruption bug.
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_dsl_value_to_json() {
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+        let v = Value::Unknown(UnknownReason::UpstreamRef { path });
+        let _ = dsl_value_to_json(&v);
     }
 }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -421,6 +421,21 @@ impl<'a> PlanPreprocessor<'a> {
         current_states: &mut HashMap<ResourceId, State>,
         provider_configs: &[ProviderConfig],
     ) {
+        // RFC #2371 stage 2: strip `Value::Unknown`-bearing attributes
+        // before handing resources to the WASM provider boundary, then
+        // restore them after. The WASM boundary panics on `Value::Unknown`
+        // by design (RFC constraint c) — this strip-and-restore is the
+        // stage 2 obligation that keeps the constraint inviolate.
+        let stripped = strip_unknown_attributes(resources);
+        // Hard assert (not debug_assert): RFC #2371 constraint b says
+        // state files never carry `Value::Unknown`, and the
+        // strip-and-restore design depends on it. A release-mode
+        // violation would degrade silently into a WASM-boundary panic
+        // far from the source — fail fast here instead.
+        assert!(
+            !current_states_contain_unknown(current_states),
+            "Value::Unknown found in current_states — RFC #2371 constraint b violated"
+        );
         self.normalizer.normalize_desired(resources);
         self.normalizer.normalize_state(current_states);
         let schemas = self.ctx.schemas();
@@ -432,7 +447,105 @@ impl<'a> PlanPreprocessor<'a> {
         }
         resolve_enum_aliases_with_ctx(self.ctx, resources);
         resolve_enum_aliases_in_states(self.ctx, current_states);
+        restore_unknown_attributes(resources, stripped);
     }
+}
+
+/// One stripped attribute, retained so it can be re-inserted at its
+/// original position after `normalize_desired` returns.
+struct StrippedAttribute {
+    insert_index: usize,
+    key: String,
+    value: carina_core::resource::Value,
+}
+
+/// Remove every attribute whose value is (or recursively contains)
+/// `Value::Unknown` from each resource's attribute map. Returns a
+/// per-resource record of what was removed, keyed by `ResourceId`, so
+/// `restore_unknown_attributes` can put them back at their original
+/// `IndexMap` position. See RFC #2371 stage 2 / #2377.
+fn strip_unknown_attributes(
+    resources: &mut [Resource],
+) -> HashMap<ResourceId, Vec<StrippedAttribute>> {
+    let mut out: HashMap<ResourceId, Vec<StrippedAttribute>> = HashMap::new();
+    for resource in resources.iter_mut() {
+        let mut stripped: Vec<StrippedAttribute> = Vec::new();
+        // Collect keys to remove first so we don't mutate while iterating.
+        let to_remove: Vec<(usize, String)> = resource
+            .attributes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, (k, v))| {
+                if value_contains_unknown(v) {
+                    Some((i, k.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        // Process highest-index-first so each `shift_remove` doesn't
+        // shift the indices of later removals.
+        for (i, key) in to_remove.into_iter().rev() {
+            if let Some(value) = resource.attributes.shift_remove(&key) {
+                stripped.push(StrippedAttribute {
+                    insert_index: i,
+                    key,
+                    value,
+                });
+            }
+        }
+        if !stripped.is_empty() {
+            // Restoration order: lowest insert_index first, so each
+            // `shift_insert` lands the entry at its pre-strip position
+            // without disturbing entries with smaller indices.
+            stripped.sort_by_key(|s| s.insert_index);
+            out.insert(resource.id.clone(), stripped);
+        }
+    }
+    out
+}
+
+/// Counterpart to `strip_unknown_attributes`. Re-inserts each stripped
+/// attribute at its original index in the resource's attribute map.
+/// Attributes appended by `normalize_desired` (e.g. provider-injected
+/// defaults) end up after the original entries, which matches behavior
+/// pre-#2377 for non-Unknown attributes.
+fn restore_unknown_attributes(
+    resources: &mut [Resource],
+    mut stripped: HashMap<ResourceId, Vec<StrippedAttribute>>,
+) {
+    for resource in resources.iter_mut() {
+        if let Some(entries) = stripped.remove(&resource.id) {
+            for entry in entries {
+                let target = entry.insert_index.min(resource.attributes.len());
+                resource
+                    .attributes
+                    .shift_insert(target, entry.key, entry.value);
+            }
+        }
+    }
+}
+
+fn value_contains_unknown(value: &carina_core::resource::Value) -> bool {
+    use carina_core::resource::{InterpolationPart, Value};
+    match value {
+        Value::Unknown(_) => true,
+        Value::List(items) => items.iter().any(value_contains_unknown),
+        Value::Map(map) => map.values().any(value_contains_unknown),
+        Value::Interpolation(parts) => parts.iter().any(|p| match p {
+            InterpolationPart::Expr(v) => value_contains_unknown(v),
+            _ => false,
+        }),
+        Value::FunctionCall { args, .. } => args.iter().any(value_contains_unknown),
+        Value::Secret(inner) => value_contains_unknown(inner),
+        _ => false,
+    }
+}
+
+fn current_states_contain_unknown(states: &HashMap<ResourceId, State>) -> bool {
+    states
+        .values()
+        .any(|state| state.attributes.values().any(value_contains_unknown))
 }
 
 /// Run provider-specific normalization on desired resources.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -546,3 +546,131 @@ fn module_and_provider_wrappers_return_vec_app_error() {
         "module_attribute_param_types: got {errors:?}",
     );
 }
+
+// ----- RFC #2371 stage 2 (#2377): strip-and-restore round trip -----
+
+#[test]
+fn strip_and_restore_unknown_attributes_round_trip() {
+    use carina_core::resource::{AccessPath, UnknownReason, Value};
+    use indexmap::IndexMap;
+
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    r.attributes
+        .insert("group_description".into(), Value::String("web".into()));
+    r.attributes.insert(
+        "vpc_id".into(),
+        Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() }),
+    );
+    let mut tags: IndexMap<String, Value> = IndexMap::new();
+    tags.insert("Name".into(), Value::String("web-sg".into()));
+    r.attributes.insert("tags".into(), Value::Map(tags));
+    r.attributes.insert(
+        "nested_unknown".into(),
+        Value::List(vec![Value::Unknown(UnknownReason::UpstreamRef { path })]),
+    );
+    let mut resources = vec![r];
+    let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
+
+    let stripped = super::strip_unknown_attributes(&mut resources);
+    // After strip: vpc_id and nested_unknown removed.
+    let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        after_strip,
+        vec!["group_description".to_string(), "tags".to_string()]
+    );
+    // Stripped record contains both attributes.
+    assert_eq!(stripped.len(), 1);
+    let entries = stripped.values().next().unwrap();
+    assert_eq!(entries.len(), 2);
+
+    super::restore_unknown_attributes(&mut resources, stripped);
+    let order_after: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        order_after, order_before,
+        "restore must put attributes back at their original index"
+    );
+    // The restored Unknown values are still typed (not coerced to string).
+    assert!(matches!(
+        resources[0].get_attr("vpc_id"),
+        Some(Value::Unknown(_))
+    ));
+    match resources[0].get_attr("nested_unknown") {
+        Some(Value::List(items)) => {
+            assert!(matches!(items[0], Value::Unknown(_)));
+        }
+        other => panic!(
+            "nested_unknown should still be Value::List, got {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn value_contains_unknown_recurses() {
+    use carina_core::resource::{AccessPath, InterpolationPart, UnknownReason, Value};
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    let unknown = || Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+
+    assert!(super::value_contains_unknown(&unknown()));
+    assert!(super::value_contains_unknown(&Value::List(vec![unknown()])));
+    assert!(super::value_contains_unknown(&Value::Map({
+        let mut m = indexmap::IndexMap::new();
+        m.insert("k".into(), unknown());
+        m
+    })));
+    assert!(super::value_contains_unknown(&Value::Interpolation(vec![
+        InterpolationPart::Expr(unknown()),
+    ])));
+    assert!(super::value_contains_unknown(&Value::FunctionCall {
+        name: "f".into(),
+        args: vec![unknown()],
+    }));
+    assert!(super::value_contains_unknown(&Value::Secret(Box::new(
+        unknown()
+    ))));
+
+    assert!(!super::value_contains_unknown(&Value::String("x".into())));
+    assert!(!super::value_contains_unknown(&Value::Int(1)));
+}
+
+#[test]
+fn restore_unknown_attributes_after_normalize_injection() {
+    // When `normalize_desired` injects new attributes between strip and
+    // restore, the originally-stripped Unknown attributes still land at
+    // their original `insert_index`; injected attributes end up
+    // trailing them. Verifies that `min(len)` clamping doesn't reorder
+    // the originals when the post-normalize map has different length.
+    use carina_core::resource::{AccessPath, UnknownReason, Value};
+
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    r.attributes
+        .insert("a".into(), Value::String("a-val".into()));
+    r.attributes.insert(
+        "b".into(),
+        Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() }),
+    );
+    r.attributes
+        .insert("c".into(), Value::String("c-val".into()));
+    let mut resources = vec![r];
+
+    let stripped = super::strip_unknown_attributes(&mut resources);
+    // After strip: ["a", "c"]. Simulate normalize injecting "z".
+    resources[0]
+        .attributes
+        .insert("z".into(), Value::String("z-val".into()));
+    super::restore_unknown_attributes(&mut resources, stripped);
+
+    let order: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        order,
+        vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "z".to_string()
+        ],
+        "originals must keep their indices; injected attrs trail them"
+    );
+}

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -422,9 +422,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
         Value::Secret(_) => "Secret",
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        Value::Unknown(_) => "Unknown",
     }
 }
 

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -196,8 +196,16 @@ fn deterministic_value_string(value: &Value) -> String {
         Value::Secret(inner) => {
             format!("Secret({})", deterministic_value_string(inner))
         }
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+        Value::Unknown(reason) => {
+            use crate::resource::UnknownReason;
+            match reason {
+                UnknownReason::UpstreamRef { path } => {
+                    format!("Unknown(UpstreamRef({}))", path.to_dot_string())
+                }
+                UnknownReason::ForKey => "Unknown(ForKey)".to_string(),
+                UnknownReason::ForIndex => "Unknown(ForIndex)".to_string(),
+                UnknownReason::ForValue => "Unknown(ForValue)".to_string(),
+            }
         }
     }
 }

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -175,9 +175,7 @@ fn format_value(value: &Value) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        Value::Unknown(reason) => crate::value::render_unknown(reason),
     }
 }
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -13,55 +13,6 @@ use std::collections::{HashMap, HashSet};
 
 /// Placeholder text for values that depend on an upstream apply.
 pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
-/// Internal marker stamped onto an `upstream_state` reference that survived
-/// resolution (state file missing, or export value absent). Plan display
-/// detects this prefix and renders the value as
-/// `(known after upstream apply: <ref>)`. The leading NUL byte keeps the
-/// marker disjoint from any user-authored string and from
-/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` / `DEFERRED_UPSTREAM_INDEX_PLACEHOLDER`,
-/// which share the human-readable `(known after upstream apply: ...)`
-/// shape. Use [`encode_unresolved_upstream_marker`] /
-/// [`decode_unresolved_upstream_marker`] instead of inlining the prefix.
-/// See issue #2366.
-pub(crate) const UPSTREAM_UNRESOLVED_MARKER_PREFIX: &str = "\0upstream_unresolved:";
-
-/// Encode `<ref>` (e.g. `network.vpc.vpc_id`) into the marker string
-/// stamped into a `Value::String` by `resolver::resolve_refs_for_plan`.
-pub fn encode_unresolved_upstream_marker(reference: &str) -> String {
-    format!("{}{}", UPSTREAM_UNRESOLVED_MARKER_PREFIX, reference)
-}
-
-/// If `s` carries the unresolved-upstream marker, return the original
-/// `<ref>` payload; otherwise `None`. Used by plan display to detect
-/// stamped values without inlining the prefix.
-pub fn decode_unresolved_upstream_marker(s: &str) -> Option<&str> {
-    s.strip_prefix(UPSTREAM_UNRESOLVED_MARKER_PREFIX)
-}
-
-#[cfg(test)]
-mod marker_tests {
-    use super::*;
-
-    #[test]
-    fn encode_decode_roundtrip() {
-        let encoded = encode_unresolved_upstream_marker("network.vpc.vpc_id");
-        assert_eq!(
-            decode_unresolved_upstream_marker(&encoded),
-            Some("network.vpc.vpc_id")
-        );
-    }
-
-    #[test]
-    fn decode_returns_none_for_user_strings() {
-        assert_eq!(decode_unresolved_upstream_marker(""), None);
-        assert_eq!(decode_unresolved_upstream_marker("vpc-abc123"), None);
-        assert_eq!(
-            decode_unresolved_upstream_marker("(known after upstream apply: key)"),
-            None,
-            "must not collide with DEFERRED_UPSTREAM_KEY_PLACEHOLDER"
-        );
-    }
-}
 /// Placeholder reserved for map-binding key variables. Distinct from the
 /// value-var placeholder so expansion can substitute each correctly.
 pub(crate) const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
@@ -813,11 +764,11 @@ pub(super) fn substitute_placeholder(
         }
         // Stage 3 (RFC #2371) replaces this whole function with an
         // enum-match on `Value::Unknown(UnknownReason::{ForKey, ForIndex,
-        // ForValue})` instead of the string sentinel above. Until then,
-        // no producer creates `Value::Unknown`, so this arm is dead.
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        // ForValue})` instead of the string sentinel above. In stage 2,
+        // an Unknown that flows through here is `UpstreamRef` (stamped
+        // by `stamp_unresolved_upstream`); it is not a for-binding
+        // placeholder and must not be substituted.
+        Value::Unknown(_) => {}
         _ => {}
     }
 }

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -469,12 +469,8 @@ fn substitute_fn_params(value: &Value, substitutions: &HashMap<String, Value>) -
                 .collect(),
         ),
         Value::Secret(inner) => Value::Secret(Box::new(substitute_fn_params(inner, substitutions))),
-        // RFC #2371: `Value::Unknown` is plan-display only and has no
-        // producer in stage 1. The wildcard below would silently
-        // pass it through; reject explicitly.
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        // `Value::Unknown` is not a function-param placeholder. Pass through.
+        Value::Unknown(_) => value.clone(),
         other => other.clone(),
     }
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -22,7 +22,6 @@ pub use ast::{
     InferredFile, ModuleCall, ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock,
     ResourceContext, ResourceTypePath, StateBlock, TypeExpr, UpstreamState, UseStatement,
     UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
-    decode_unresolved_upstream_marker, encode_unresolved_upstream_marker,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub use entry::{parse, parse_and_resolve};

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -16,11 +16,8 @@ pub(crate) fn is_static_value(value: &Value) -> bool {
         Value::List(items) => items.iter().all(is_static_value),
         Value::Map(map) => map.values().all(is_static_value),
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
-        Value::ResourceRef { .. } | Value::Interpolation(_) => false,
+        Value::ResourceRef { .. } | Value::Interpolation(_) | Value::Unknown(_) => false,
         Value::Secret(inner) => is_static_value(inner),
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
     }
 }
 

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -59,9 +59,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Interpolation(_) => "string",
         Value::FunctionCall { .. } => "function call",
         Value::Secret(_) => "secret",
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        Value::Unknown(_) => "unknown",
     }
 }
 

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -45,10 +45,10 @@ pub fn resolve_refs_with_state_and_remote(
 /// its export is absent. Behaves like
 /// [`resolve_refs_with_state_and_remote`], but any surviving
 /// `Value::ResourceRef` whose root binding is named in `remote_bindings`
-/// is replaced with a marker `Value::String` (built via
-/// `crate::parser::encode_unresolved_upstream_marker`) so plan display
-/// can render it as `(known after upstream apply: <ref>)` instead of the
-/// raw dot-form. `apply` continues to call the strict variant. See #2366.
+/// is replaced with `Value::Unknown(UnknownReason::UpstreamRef { path })`
+/// so plan display can render it as `(known after upstream apply: <ref>)`
+/// instead of the raw dot-form. `apply` continues to call the strict
+/// variant. See #2366 / RFC #2371.
 pub fn resolve_refs_for_plan(
     resources: &mut [Resource],
     current_states: &HashMap<ResourceId, State>,
@@ -112,10 +112,8 @@ fn stamp_unresolved_upstream(
     upstream_binding_names: &std::collections::HashSet<&str>,
 ) -> Value {
     match value {
-        Value::ResourceRef { ref path } if upstream_binding_names.contains(path.binding()) => {
-            Value::String(crate::parser::encode_unresolved_upstream_marker(
-                &path.to_dot_string(),
-            ))
+        Value::ResourceRef { path } if upstream_binding_names.contains(path.binding()) => {
+            Value::Unknown(crate::resource::UnknownReason::UpstreamRef { path })
         }
         Value::List(items) => Value::List(
             items
@@ -152,13 +150,9 @@ fn stamp_unresolved_upstream(
             *inner,
             upstream_binding_names,
         ))),
-        // Stage 2 (RFC #2371) replaces this whole function — the
-        // current `Value::String("\0upstream_unresolved:...")` output
-        // becomes `Value::Unknown(UnknownReason::UpstreamRef { ... })`.
-        // Until then no producer creates `Value::Unknown`.
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        // An already-stamped `Value::Unknown` (from an earlier pass)
+        // is passed through unchanged — it cannot be resolved further.
+        other @ Value::Unknown(_) => other,
         other => other,
     }
 }
@@ -308,11 +302,9 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
             let resolved_inner = resolve_ref_value(inner, bindings)?;
             Ok(Value::Secret(Box::new(resolved_inner)))
         }
-        // RFC #2371: stage 1 has no producer; stage 2 will route the
-        // `Value::Unknown` cases through this resolver explicitly.
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        // `Value::Unknown` is the result of stamping a previously-
+        // unresolved upstream ref; it cannot be resolved further.
+        Value::Unknown(_) => Ok(value.clone()),
         _ => Ok(value.clone()),
     }
 }
@@ -848,11 +840,11 @@ mod tests {
     }
 
     /// `resolve_refs_for_plan` stamps any surviving `ResourceRef` whose
-    /// root binding is in `remote_bindings.keys()` with the unresolved-
-    /// upstream marker. Plan display detects the marker via
-    /// `parser::decode_unresolved_upstream_marker`.
+    /// root binding is in `remote_bindings.keys()` as
+    /// `Value::Unknown(UnknownReason::UpstreamRef { path })`.
     #[test]
     fn test_resolve_refs_for_plan_stamps_top_level_unresolved_upstream() {
+        use crate::resource::UnknownReason;
         let mut resources = vec![make_resource(
             "web-sg",
             None,
@@ -871,12 +863,10 @@ mod tests {
         resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
 
         match resources[0].get_attr("vpc_id") {
-            Some(Value::String(s)) => {
-                let payload = crate::parser::decode_unresolved_upstream_marker(s)
-                    .expect("expected marker prefix");
-                assert_eq!(payload, "network.vpc.vpc_id");
+            Some(Value::Unknown(UnknownReason::UpstreamRef { path })) => {
+                assert_eq!(path.to_dot_string(), "network.vpc.vpc_id");
             }
-            other => panic!("expected marker String, got {:?}", other),
+            other => panic!("expected Value::Unknown(UpstreamRef), got {:?}", other),
         }
     }
 
@@ -960,15 +950,12 @@ mod tests {
             Some(Value::List(items)) => {
                 assert_eq!(items.len(), 2);
                 for (idx, item) in items.iter().enumerate() {
-                    match item {
-                        Value::String(s) => assert!(
-                            crate::parser::decode_unresolved_upstream_marker(s).is_some(),
-                            "list[{}] should be marker String, got {:?}",
-                            idx,
-                            s
-                        ),
-                        other => panic!("list[{}] should be marker String, got {:?}", idx, other),
-                    }
+                    assert!(
+                        matches!(item, Value::Unknown(_)),
+                        "list[{}] should be Value::Unknown, got {:?}",
+                        idx,
+                        item
+                    );
                 }
             }
             other => panic!("expected List, got {:?}", other),
@@ -1028,12 +1015,8 @@ mod tests {
 
         match resources[0].get_attr("tags") {
             Some(Value::Map(m)) => match m.get("VpcId") {
-                Some(Value::String(s)) => assert!(
-                    crate::parser::decode_unresolved_upstream_marker(s).is_some(),
-                    "expected marker prefix, got {:?}",
-                    s
-                ),
-                other => panic!("nested entry should be marker String, got {:?}", other),
+                Some(Value::Unknown(_)) => {}
+                other => panic!("nested entry should be Value::Unknown, got {:?}", other),
             },
             other => panic!("expected Map, got {:?}", other),
         }

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -307,7 +307,7 @@ impl std::fmt::Display for AccessPath {
 }
 
 /// Attribute value of a resource
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Value {
     String(String),
     Int(i64),
@@ -340,6 +340,17 @@ pub enum Value {
     Secret(Box<Value>),
     /// A value not known at plan time. Plan-display only — must never
     /// reach `apply`, state files, or provider plugins. See RFC #2371.
+    ///
+    /// `#[serde(skip)]` blocks both serialization (returns `Err`) and
+    /// deserialization (the variant is unreachable from any JSON input).
+    /// This is the type-system enforcement of RFC constraints b and c:
+    /// even a hand-edited state/plan file cannot resurrect a
+    /// `Value::Unknown` and route it past the explicit `unimplemented!()`
+    /// guards in `value_to_json` / `dsl_value_to_json` /
+    /// `core_to_wit_value`. Stage 4 may further tighten by replacing
+    /// the panics with `Result::Err`, but the deserialization seal
+    /// already covers the round-trip attack surface today.
+    #[serde(skip)]
     Unknown(UnknownReason),
 }
 
@@ -373,6 +384,36 @@ pub enum InterpolationPart {
     Literal(String),
     /// An expression to be evaluated and converted to string
     Expr(Value),
+}
+
+/// `PartialEq` for `Value` is hand-rolled (not derived) to enforce one
+/// invariant the differ depends on: **`Value::Unknown` is never equal
+/// to anything**, including another `Value::Unknown` with the same
+/// reason. An unresolved value is, by definition, unknown — two
+/// independently-unresolved attributes are not the "same value", so a
+/// derived `PartialEq` would silently suppress real diffs in
+/// `merge_lists_hashed` and `semantically_equal`. See RFC #2371.
+impl PartialEq for Value {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            // Constraint: Unknown is never equal to anything.
+            (Value::Unknown(_), _) | (_, Value::Unknown(_)) => false,
+            (Value::String(a), Value::String(b)) => a == b,
+            (Value::Int(a), Value::Int(b)) => a == b,
+            (Value::Float(a), Value::Float(b)) => a == b,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            (Value::List(a), Value::List(b)) => a == b,
+            (Value::Map(a), Value::Map(b)) => a == b,
+            (Value::ResourceRef { path: a }, Value::ResourceRef { path: b }) => a == b,
+            (Value::Interpolation(a), Value::Interpolation(b)) => a == b,
+            (
+                Value::FunctionCall { name: an, args: aa },
+                Value::FunctionCall { name: bn, args: ba },
+            ) => an == bn && aa == ba,
+            (Value::Secret(a), Value::Secret(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 
 /// Body of `Value::canonicalize_in_place` for the `Interpolation` arm:
@@ -555,9 +596,12 @@ impl Value {
             }
             Value::Secret(inner) => inner.visit_refs(f),
             Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
-            Value::Unknown(_) => {
-                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-            }
+            // `Value::Unknown` is what a previously-unresolved
+            // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.
+            // It carries an `AccessPath` for display, but it is no longer
+            // a live reference to walk — dependency analysis happens
+            // upstream of the stamping pass.
+            Value::Unknown(_) => {}
         }
     }
 }
@@ -669,13 +713,27 @@ impl Value {
             Value::Secret(inner) => {
                 inner.hash_into(hasher);
             }
-            // Stage 2 must replace this with deterministic hashing before
-            // any producer ships — `merge_lists_hashed` calls
-            // `canonical_hash` → `hash_into`, so a `Value::Unknown` inside
-            // a list element would panic before the planned plan/apply
-            // boundary checks land in stage 4 (RFC #2371).
-            Value::Unknown(_) => {
-                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            Value::Unknown(reason) => {
+                // `Value::Unknown` reaches `merge_lists_hashed` → this
+                // function whenever a list element is unresolved. Hash
+                // deterministically: the outer `discriminant(self)`
+                // already separates `Unknown` from concrete variants;
+                // here we add the reason discriminant + payload so two
+                // structurally-identical `Unknown`s produce the same
+                // hash. Note: `PartialEq for Value` still returns
+                // `false` between any two `Unknown`s (RFC #2371) — the
+                // `a == b ⇒ hash(a) == hash(b)` precondition only
+                // matters between concrete values.
+                std::mem::discriminant(reason).hash(hasher);
+                match reason {
+                    // Reuse `AccessPath`'s native `Hash` impl (matches
+                    // the `ResourceRef` arm above) — no per-call String
+                    // allocation.
+                    UnknownReason::UpstreamRef { path } => path.hash(hasher),
+                    // `For{Key,Index,Value}` carry no payload; the
+                    // discriminant alone already distinguishes them.
+                    UnknownReason::ForKey | UnknownReason::ForIndex | UnknownReason::ForValue => {}
+                }
             }
         }
     }

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -1012,3 +1012,109 @@ fn canonicalize_is_idempotent() {
         assert_eq!(once, twice, "canonicalize must be idempotent for {:?}", v);
     }
 }
+
+// ----- RFC #2371 stage 2 (#2377): Value::Unknown semantics -----
+
+#[test]
+fn unknown_never_equals_unknown() {
+    // Two Value::Unknown must compare unequal even when their reasons
+    // are identical — an unknown value is, by definition, not equal to
+    // anything (including itself). Without this, the differ would
+    // suppress real diffs between two attributes that both happen to
+    // be "unresolved upstream" of the same binding.
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    let a = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+    let b = Value::Unknown(UnknownReason::UpstreamRef { path });
+    assert_ne!(a, b, "two `Value::Unknown`s must never compare equal");
+}
+
+#[test]
+fn unknown_never_equals_concrete() {
+    let a = Value::Unknown(UnknownReason::ForKey);
+    let b = Value::String("anything".into());
+    assert_ne!(a, b);
+    assert_ne!(b, a);
+}
+
+#[test]
+fn unknown_for_variants_never_equal() {
+    assert_ne!(
+        Value::Unknown(UnknownReason::ForKey),
+        Value::Unknown(UnknownReason::ForKey)
+    );
+    assert_ne!(
+        Value::Unknown(UnknownReason::ForIndex),
+        Value::Unknown(UnknownReason::ForValue)
+    );
+}
+
+#[test]
+fn unknown_hash_is_deterministic_per_path() {
+    use std::hash::Hasher;
+    fn hash_of(v: &Value) -> u64 {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        v.hash_into(&mut h);
+        h.finish()
+    }
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    let a = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+    let b = Value::Unknown(UnknownReason::UpstreamRef { path });
+    assert_eq!(
+        hash_of(&a),
+        hash_of(&b),
+        "same UpstreamRef path must hash to the same value"
+    );
+}
+
+#[test]
+fn unknown_hash_differs_per_path() {
+    use std::hash::Hasher;
+    fn hash_of(v: &Value) -> u64 {
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        v.hash_into(&mut h);
+        h.finish()
+    }
+    let p1 = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    let p2 = AccessPath::with_fields("network", "vpc", vec!["cidr_block".into()]);
+    let a = Value::Unknown(UnknownReason::UpstreamRef { path: p1 });
+    let b = Value::Unknown(UnknownReason::UpstreamRef { path: p2 });
+    assert_ne!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn unknown_hash_does_not_panic_for_for_variants() {
+    use std::hash::Hasher;
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    Value::Unknown(UnknownReason::ForKey).hash_into(&mut h);
+    Value::Unknown(UnknownReason::ForIndex).hash_into(&mut h);
+    Value::Unknown(UnknownReason::ForValue).hash_into(&mut h);
+    let _ = h.finish();
+}
+
+#[test]
+fn unknown_cannot_round_trip_through_serde_json() {
+    // RFC #2371 constraint c: `Value::Unknown` must never reach state
+    // files / plan files / providers. The variant has `#[serde(skip)]`
+    // so attempting to serialize it returns Err — even a hand-edited
+    // JSON cannot resurrect the variant via deserialization.
+    let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+    let v = Value::Unknown(UnknownReason::UpstreamRef { path });
+
+    // Serialization must fail.
+    let r = serde_json::to_string(&v);
+    assert!(
+        r.is_err(),
+        "serializing Value::Unknown must error, got Ok({:?})",
+        r
+    );
+
+    // Deserialization of `{"Unknown": {...}}` must fail (the variant is
+    // effectively absent from the externally-tagged enum).
+    let payload = r#"{"Unknown":{"UpstreamRef":{"path":{"binding":"x","attribute":"y","field_path":[],"subscripts":[]}}}}"#;
+    let r: Result<Value, _> = serde_json::from_str(payload);
+    assert!(
+        r.is_err(),
+        "deserializing Value::Unknown must error, got Ok({:?})",
+        r
+    );
+}

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1633,9 +1633,7 @@ impl Value {
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),
-            Value::Unknown(_) => {
-                unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-            }
+            Value::Unknown(_) => "Unknown".to_string(),
         }
     }
 }

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -233,9 +233,9 @@ pub fn infer_type_from_value(
             schemas,
         ),
         Value::FunctionCall { name, .. } => infer_function_call(name),
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        Value::Unknown(_) => Err(InferenceError::UnknownType {
+            reason: "value not yet known at plan time (unresolved upstream)".to_string(),
+        }),
     }
 }
 

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -10,12 +10,9 @@ use crate::utils::{convert_enum_value, is_dsl_enum_format};
 
 /// Render an `UnknownReason` to its plan-display string. See RFC #2371.
 ///
-/// `pub(crate)` for stage 1: only same-crate callers (stage 2 will route
-/// `format_value_with_key` through here). Promote to `pub` in stage 3
-/// when the carina-cli display layer migrates. `#[allow(dead_code)]` is
-/// the explicit acknowledgement that no caller exists *yet* — stage 2
-/// removes the attribute when `format_value_with_key` calls in.
-#[allow(dead_code)]
+/// `pub(crate)` because stage 2 only needs same-crate callers
+/// (`format_value_with_key`). Stage 3 promotes to `pub` when carina-cli's
+/// display layer migrates.
 pub(crate) fn render_unknown(reason: &UnknownReason) -> String {
     match reason {
         UnknownReason::UpstreamRef { path } => {
@@ -161,7 +158,9 @@ pub fn value_to_json_with_context(
             )))
         }
         Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
     }
 }
@@ -210,12 +209,6 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             if s.starts_with(SECRET_PREFIX) {
                 return "(secret)".to_string();
             }
-            // Unresolved upstream_state references stamped by
-            // `resolve_refs_for_plan` — render unquoted as
-            // `(known after upstream apply: <ref>)`.
-            if let Some(rest) = crate::parser::decode_unresolved_upstream_marker(s) {
-                return format!("(known after upstream apply: {})", rest);
-            }
             // DSL enum format (namespaced identifiers) - resolve to provider value
             if is_dsl_enum_format(s) {
                 let resolved = convert_enum_value(s);
@@ -262,9 +255,7 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
             format!("{}({})", name, arg_strs.join(", "))
         }
         Value::Secret(_) => "(secret)".to_string(),
-        Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
-        }
+        Value::Unknown(reason) => render_unknown(reason),
     }
 }
 
@@ -383,7 +374,9 @@ pub fn redact_secrets_in_value(value: &Value) -> Value {
         // `other` arm below would silently pass it through; reject
         // explicitly so a stage-2/3 producer bug surfaces here.
         Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
         other => other.clone(),
     }
@@ -837,19 +830,37 @@ mod tests {
         assert_eq!(format_value(&v), "vpc.id");
     }
 
-    /// `Value::String` carrying the upstream-unresolved marker prefix
-    /// renders unquoted as `(known after upstream apply: <ref>)`. The
-    /// marker is stamped by `resolve_refs_for_plan` and detected here by
-    /// `format_value_with_key` (#2366).
+    /// `Value::Unknown(UpstreamRef)` renders unquoted as
+    /// `(known after upstream apply: <ref>)` via `format_value_with_key`.
+    /// Stage 2 of RFC #2371 — the variant replaced the NUL-prefixed
+    /// `Value::String` sentinel from #2367.
     #[test]
-    fn test_format_value_unresolved_upstream_marker() {
-        let v = Value::String(crate::parser::encode_unresolved_upstream_marker(
-            "network.vpc.vpc_id",
-        ));
+    fn test_format_value_unresolved_upstream() {
+        use crate::resource::{AccessPath, UnknownReason};
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
+        let v = Value::Unknown(UnknownReason::UpstreamRef { path });
         assert_eq!(
             format_value(&v),
             "(known after upstream apply: network.vpc.vpc_id)"
         );
+    }
+
+    /// RFC #2371 contract pin: serialization boundaries panic on
+    /// `Value::Unknown`. A future change that swaps the arm for a
+    /// silent fallback would re-introduce the v1 corruption bug;
+    /// these `#[should_panic]` tests pin the contract.
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_value_to_json() {
+        let v = Value::Unknown(UnknownReason::ForKey);
+        let _ = value_to_json(&v);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_redact_secrets_in_value() {
+        let v = Value::Unknown(UnknownReason::ForKey);
+        let _ = redact_secrets_in_value(&v);
     }
 
     #[test]

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -51,7 +51,9 @@ pub fn core_to_wit_value(v: &CoreValue) -> wit::Value {
         // would degrade it to `"Unknown(...)"` debug-format string.
         // Reject explicitly so a stage-2/3 producer bug surfaces here.
         CoreValue::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
         // Managed-to-managed refs (e.g. `admins.group_id`) are expected
         // here at plan time — they get resolved at apply time by the
@@ -106,7 +108,9 @@ fn core_value_to_json(v: &CoreValue) -> serde_json::Value {
         // RFC #2371: `Value::Unknown` must not be serialized to JSON
         // for provider transport. See sibling arm in `core_to_wit_value`.
         CoreValue::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
         _ => serde_json::Value::String(format!("{v:?}")),
     }
@@ -422,6 +426,31 @@ fn proto_struct_field_to_core(f: &proto::StructField) -> CoreStructField {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// RFC #2371 contract pin: `Value::Unknown` reaching either WASM-
+    /// boundary converter is a stage-2 invariant violation
+    /// (`PlanPreprocessor::strip_unknown_attributes` must remove it
+    /// first). A future change that swaps these `unimplemented!()` arms
+    /// for a `format!("{v:?}")` fallback would silently re-introduce
+    /// the v1 corruption bug (#2375); these `#[should_panic]` tests
+    /// pin the contract.
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_core_to_wit_value() {
+        use carina_core::resource::{AccessPath, UnknownReason};
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
+        let v = CoreValue::Unknown(UnknownReason::UpstreamRef { path });
+        let _ = core_to_wit_value(&v);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_core_value_to_json() {
+        use carina_core::resource::{AccessPath, UnknownReason};
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".to_string()]);
+        let v = CoreValue::Unknown(UnknownReason::UpstreamRef { path });
+        let _ = core_value_to_json(&v);
+    }
 
     // -- Value roundtrips --
 

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -156,7 +156,9 @@ fn value_to_json(value: &carina_core::resource::Value) -> serde_json::Value {
         // map it to `null`; reject explicitly so a stage-2/3 producer
         // bug surfaces here instead of silently corrupting the lock.
         Value::Unknown(_) => {
-            unimplemented!("Value::Unknown handling lands in RFC #2371 stage 2/3")
+            unimplemented!(
+                "Value::Unknown reached a stage-4 serialization boundary; the producer should have stripped or resolved it (RFC #2371)"
+            )
         }
         _ => serde_json::Value::Null,
     }
@@ -276,5 +278,18 @@ mod tests {
         assert!(diff.contains("backend type"));
         assert!(diff.contains("local"));
         assert!(diff.contains("s3"));
+    }
+
+    /// RFC #2371 contract pin: `value_to_json` panics on
+    /// `Value::Unknown`. Backend lock files must never carry the
+    /// variant (constraint b); a future change that swaps for a silent
+    /// fallback would re-introduce v1-style corruption.
+    #[test]
+    #[should_panic(expected = "Value::Unknown")]
+    fn unknown_panics_in_value_to_json() {
+        use carina_core::resource::{AccessPath, UnknownReason, Value};
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+        let v = Value::Unknown(UnknownReason::UpstreamRef { path });
+        let _ = value_to_json(&v);
     }
 }


### PR DESCRIPTION
Closes #2377

## Summary

Stage 2 of [RFC #2371](https://github.com/carina-rs/carina/blob/main/docs/specs/2026-05-04-unknown-value-unification-design.md). Migrates the upstream-attribute marker from `Value::String("\0upstream_unresolved:...")` (sentinel from #2367) to the typed `Value::Unknown(UnknownReason::UpstreamRef { path: AccessPath })` introduced in stage 1 (#2374).

The first attempt at this stage (#2375) was abandoned because the WASM provider boundary corrupted `Value::Unknown` into a debug-format string. PR #2376 updated the RFC to pair the producer migration with a `PlanPreprocessor` strip-and-restore. This implements that.

## Changes

### Producer / consumer migration

- `resolver::stamp_unresolved_upstream` produces `Value::Unknown(UpstreamRef { path })` instead of the NUL-prefixed sentinel.
- `value::format_value_with_key` routes through `render_unknown` (display string unchanged: `(known after upstream apply: <ref>)`).
- Removed: `UPSTREAM_UNRESOLVED_MARKER_PREFIX`, `encode_/decode_unresolved_upstream_marker`, the `marker_tests` mod, and the parser re-exports of those.

### WASM boundary handling

`PlanPreprocessor::prepare` now strips every `Value::Unknown`-bearing attribute before calling `normalize_desired`, then restores them at their original `IndexMap` index after. The provider only sees concrete attributes; the type-level guarantee is the `Value::Unknown(_) => unimplemented!(...)` arm in `core_to_wit_value`.

### Type-system seal against round-trip attacks

- `Value::Unknown` carries `#[serde(skip)]`. Both `serde_json::to_string(&value)` and `from_str` of `{"Unknown":...}` error cleanly. Combined with the `unimplemented!()` arms at every concrete serialization boundary (`value_to_json`, `dsl_value_to_json`, `core_to_wit_value`, `redact_secrets_in_value`, `backend_lock::value_to_json`), the variant cannot reach state files / plan files / providers — even by hand-edited JSON.

### Trip-wires from PR #2374 — addressed

- **`PartialEq` landmine**: `Value::PartialEq` is hand-rolled returning `false` for any `(Unknown, _)` pair, so two identically-stamped Unknowns never compare equal in the differ.
- **`hash_into` panic**: implemented via reason discriminant + `AccessPath::hash` (no allocation).

### Persistence guard for `--out` / `--json` (scope addition vs issue body)

The issue body listed `check_no_unresolved_upstream_in_plan` for removal, but real-infra smoke testing showed the `unimplemented!()`-only path produces a panic backtrace instead of an actionable error. The guard is restored — it walks effects and returns `AppError::Config` with the specific upstream binding name so the user sees:

```
Error: Cannot save plan: it depends on upstream values that are not yet
applied (network.vpc_id). Apply the upstream module(s) first, then re-run
`carina plan --out` (or `--json`).
```

instead of a panic. The boundary `unimplemented!()` arms remain as defense in depth.

## Test plan

- [x] `cargo nextest run --workspace` (2620 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` invariants pass
- [x] Existing `plan_snapshot_upstream_state*` snapshots **unchanged** (display string identical to v1)
- [x] `grep -rn 'UPSTREAM_UNRESOLVED|encode_unresolved_upstream_marker|decode_unresolved_upstream_marker'` returns empty
- [x] **Real-infra smoke test** against `~/tmp/carina-upstream-state/web` passes:
  - State missing → `vpc_id: (known after upstream apply: network.vpc_id)` rendered cleanly, exit 0
  - State present + empty exports → same rendering, exit 0
  - `plan --out plan.json` → clean error message ("apply upstream module first")

New tests:

- `Value::Unknown` PartialEq, Hash, serde-skip round-trip rejection
- `strip_unknown_attributes` / `restore_unknown_attributes` round trip + interleaving with normalize-injected attrs
- `check_no_unresolved_upstream_in_plan` against bare / nested / cascading-update / Effect-skipped / dedup cases
- `should_panic` tests pinning every serialization-boundary `unimplemented!()` arm so a future change to a silent fallback fails the build

## What's next

Stage 3 (mechanism #2 migration: for-expression `DEFERRED_UPSTREAM_*_PLACEHOLDER` → `Value::Unknown(For*)`) and stage 4 (promote `unimplemented!()` to `Err(...)` at serialization boundaries) remain.
