### PR TITLE
value: migrate for-expression placeholders to Value::Unknown(For*) (#2371 stage 3)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -11,7 +11,6 @@ use carina_core::diff_helpers::compute_map_diff;
 #[cfg(test)]
 use carina_core::effect::CascadingUpdate;
 use carina_core::effect::Effect;
-use carina_core::parser::DEFERRED_UPSTREAM_PLACEHOLDER;
 use carina_core::plan::Plan;
 #[cfg(test)]
 use carina_core::plan_tree::shorten_attr_name;
@@ -51,11 +50,19 @@ fn format_compact_name(
 }
 
 /// Format a value in a deferred for-expression template.
-/// Placeholder strings are shown dimmed; resolved values are shown normally.
+/// Placeholder values (`Value::Unknown`) are shown dimmed; resolved
+/// values are shown normally.
 fn format_deferred_value(value: &Value) -> String {
+    /// Catch-all placeholder text for value variants whose contents
+    /// cannot be sensibly inlined into a deferred-for template
+    /// (e.g. `Interpolation`, `FunctionCall`, `Secret`). The wording
+    /// matches `render_unknown(ForValue)` so display stays uniform
+    /// across the deferred and resolved-Unknown paths.
+    const DEFERRED_FALLBACK: &str = "(known after upstream apply)";
+
     match value {
-        Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
-            format!("{}", s.dimmed())
+        Value::Unknown(reason) => {
+            format!("{}", carina_core::value::render_unknown(reason).dimmed())
         }
         Value::String(s) => format!("'{}'", s),
         Value::Int(i) => i.to_string(),
@@ -73,7 +80,7 @@ fn format_deferred_value(value: &Value) -> String {
                 .collect();
             format!("{{{}}}", formatted.join(", "))
         }
-        _ => format!("{}", DEFERRED_UPSTREAM_PLACEHOLDER.dimmed()),
+        _ => format!("{}", DEFERRED_FALLBACK.dimmed()),
     }
 }
 

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -674,3 +674,66 @@ fn restore_unknown_attributes_after_normalize_injection() {
         "originals must keep their indices; injected attrs trail them"
     );
 }
+
+#[test]
+fn strip_and_restore_for_expression_unknowns_round_trip() {
+    // The strip-and-restore helpers must cover every `UnknownReason`
+    // variant — the WASM provider boundary must never see a
+    // `Value::Unknown` of any reason.
+    use carina_core::resource::{UnknownReason, Value};
+
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
+    r.attributes
+        .insert("name".into(), Value::String("static".into()));
+    r.attributes
+        .insert("target_id".into(), Value::Unknown(UnknownReason::ForValue));
+    r.attributes.insert(
+        "items".into(),
+        Value::List(vec![Value::Unknown(UnknownReason::ForKey)]),
+    );
+    r.attributes
+        .insert("index".into(), Value::Unknown(UnknownReason::ForIndex));
+    let mut resources = vec![r];
+    let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
+
+    let stripped = super::strip_unknown_attributes(&mut resources);
+    let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        after_strip,
+        vec!["name".to_string()],
+        "all three for-expression Unknown attributes must be stripped"
+    );
+    assert_eq!(stripped.values().next().unwrap().len(), 3);
+
+    super::restore_unknown_attributes(&mut resources, stripped);
+    let order_after: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        order_after, order_before,
+        "for-expression Unknowns must be restored at their original indices"
+    );
+    assert!(matches!(
+        resources[0].get_attr("target_id"),
+        Some(Value::Unknown(UnknownReason::ForValue))
+    ));
+    assert!(matches!(
+        resources[0].get_attr("index"),
+        Some(Value::Unknown(UnknownReason::ForIndex))
+    ));
+}
+
+#[test]
+fn value_contains_unknown_covers_for_variants() {
+    use carina_core::resource::{UnknownReason, Value};
+    assert!(super::value_contains_unknown(&Value::Unknown(
+        UnknownReason::ForValue
+    )));
+    assert!(super::value_contains_unknown(&Value::Unknown(
+        UnknownReason::ForKey
+    )));
+    assert!(super::value_contains_unknown(&Value::Unknown(
+        UnknownReason::ForIndex
+    )));
+    assert!(super::value_contains_unknown(&Value::List(vec![
+        Value::Unknown(UnknownReason::ForValue),
+    ])));
+}

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -43,8 +43,8 @@ pub(super) fn check_type_match(
     config: &ProviderContext,
 ) -> TypeCheckResult {
     match type_expr {
-        // FunctionCall results are not known statically; defer validation
-        _ if matches!(value, Value::FunctionCall { .. }) => TypeCheckResult::Ok,
+        // Deferred-resolution values: type unknown at parse time.
+        _ if matches!(value, Value::FunctionCall { .. } | Value::Unknown(_)) => TypeCheckResult::Ok,
         TypeExpr::String => {
             if matches!(
                 value,

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -6,20 +6,10 @@ use super::error::ParseWarning;
 use super::expressions::for_expr::ForBinding;
 use super::expressions::validate_expr::CompareOp;
 use super::util::snake_to_pascal;
-use crate::resource::{Resource, ResourceId, Value};
+use crate::resource::{Resource, ResourceId, UnknownReason, Value};
 use crate::version_constraint::VersionConstraint;
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
-
-/// Placeholder text for values that depend on an upstream apply.
-pub const DEFERRED_UPSTREAM_PLACEHOLDER: &str = "(known after upstream apply)";
-/// Placeholder reserved for map-binding key variables. Distinct from the
-/// value-var placeholder so expansion can substitute each correctly.
-pub(crate) const DEFERRED_UPSTREAM_KEY_PLACEHOLDER: &str = "(known after upstream apply: key)";
-/// Placeholder reserved for indexed-binding index variables — distinct from
-/// key and value placeholders so `for (i, x) in list` expansion can
-/// substitute `i` with the integer index.
-pub(crate) const DEFERRED_UPSTREAM_INDEX_PLACEHOLDER: &str = "(known after upstream apply: index)";
 
 /// A for-expression whose iterable is unresolved (e.g., upstream_state not yet available).
 /// Captures the structural shape of the loop body so the plan can show what
@@ -710,13 +700,16 @@ fn substitute_attrs(
 
 /// Substitute deferred-for-expression placeholders in a Value tree.
 ///
-/// Replaces `DEFERRED_UPSTREAM_PLACEHOLDER` with `value`. If `index` is
-/// supplied (indexed-binding expansion), replaces
-/// `DEFERRED_UPSTREAM_INDEX_PLACEHOLDER` with the integer index. If `key`
-/// is supplied (map-binding expansion), replaces
-/// `DEFERRED_UPSTREAM_KEY_PLACEHOLDER` with the key string. Recurses into
-/// all compound Value variants so placeholders nested inside
+/// Replaces `Value::Unknown(UnknownReason::ForValue)` with `value`. If
+/// `index` is supplied (indexed-binding expansion), replaces
+/// `Value::Unknown(UnknownReason::ForIndex)` with the integer index. If
+/// `key` is supplied (map-binding expansion), replaces
+/// `Value::Unknown(UnknownReason::ForKey)` with the key string. Recurses
+/// into all compound Value variants so placeholders nested inside
 /// interpolations / function calls / secrets are reached.
+///
+/// `UnknownReason::UpstreamRef` is the upstream-attribute marker, not a
+/// for-binding placeholder, so it is preserved unchanged.
 pub(super) fn substitute_placeholder(
     v: &mut Value,
     index: Option<i64>,
@@ -724,19 +717,22 @@ pub(super) fn substitute_placeholder(
     value: &Value,
 ) {
     match v {
-        Value::String(s) if s == DEFERRED_UPSTREAM_PLACEHOLDER => {
+        Value::Unknown(UnknownReason::ForValue) => {
             *v = value.clone();
         }
-        Value::String(s) if s == DEFERRED_UPSTREAM_KEY_PLACEHOLDER => {
+        Value::Unknown(UnknownReason::ForKey) => {
             if let Some(k) = key {
                 *v = Value::String(k.to_string());
             }
         }
-        Value::String(s) if s == DEFERRED_UPSTREAM_INDEX_PLACEHOLDER => {
+        Value::Unknown(UnknownReason::ForIndex) => {
             if let Some(i) = index {
                 *v = Value::Int(i);
             }
         }
+        // Explicit arm (not wildcard) so a new `UnknownReason` variant
+        // forces a compile-error decision here.
+        Value::Unknown(UnknownReason::UpstreamRef { .. }) => {}
         Value::List(items) => {
             for item in items.iter_mut() {
                 substitute_placeholder(item, index, key, value);
@@ -762,13 +758,97 @@ pub(super) fn substitute_placeholder(
         Value::Secret(inner) => {
             substitute_placeholder(inner, index, key, value);
         }
-        // Stage 3 (RFC #2371) replaces this whole function with an
-        // enum-match on `Value::Unknown(UnknownReason::{ForKey, ForIndex,
-        // ForValue})` instead of the string sentinel above. In stage 2,
-        // an Unknown that flows through here is `UpstreamRef` (stamped
-        // by `stamp_unresolved_upstream`); it is not a for-binding
-        // placeholder and must not be substituted.
-        Value::Unknown(_) => {}
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod substitute_placeholder_tests {
+    use super::*;
+    use crate::resource::{AccessPath, InterpolationPart, UnknownReason, Value};
+
+    #[test]
+    fn replaces_for_value_with_bound_value() {
+        let mut v = Value::Unknown(UnknownReason::ForValue);
+        substitute_placeholder(&mut v, None, None, &Value::String("acct-1".into()));
+        assert_eq!(v, Value::String("acct-1".into()));
+    }
+
+    #[test]
+    fn replaces_for_key_with_key_string() {
+        let mut v = Value::Unknown(UnknownReason::ForKey);
+        substitute_placeholder(&mut v, None, Some("east"), &Value::String("ignored".into()));
+        assert_eq!(v, Value::String("east".into()));
+    }
+
+    #[test]
+    fn replaces_for_index_with_integer_index() {
+        let mut v = Value::Unknown(UnknownReason::ForIndex);
+        substitute_placeholder(&mut v, Some(7), None, &Value::String("ignored".into()));
+        assert_eq!(v, Value::Int(7));
+    }
+
+    #[test]
+    fn leaves_upstream_ref_unchanged() {
+        let path = AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]);
+        let mut v = Value::Unknown(UnknownReason::UpstreamRef { path: path.clone() });
+        substitute_placeholder(
+            &mut v,
+            Some(0),
+            Some("k"),
+            &Value::String("anything".into()),
+        );
+        // `Value::Unknown` never compares equal (see `impl PartialEq for Value`),
+        // so destructure to verify the path survives.
+        match v {
+            Value::Unknown(UnknownReason::UpstreamRef { path: p }) => assert_eq!(p, path),
+            other => panic!("UpstreamRef must pass through unchanged, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn recurses_into_compound_values() {
+        let mut v = Value::List(vec![
+            Value::Unknown(UnknownReason::ForValue),
+            Value::Map({
+                let mut m = indexmap::IndexMap::new();
+                m.insert("k".into(), Value::Unknown(UnknownReason::ForValue));
+                m
+            }),
+            Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+                UnknownReason::ForValue,
+            ))]),
+        ]);
+        substitute_placeholder(&mut v, None, None, &Value::String("X".into()));
+        match &v {
+            Value::List(items) => {
+                assert_eq!(items[0], Value::String("X".into()));
+                match &items[1] {
+                    Value::Map(m) => {
+                        assert_eq!(m["k"], Value::String("X".into()));
+                    }
+                    other => panic!("expected Map, got {:?}", other),
+                }
+                match &items[2] {
+                    Value::Interpolation(parts) => match &parts[0] {
+                        InterpolationPart::Expr(inner) => {
+                            assert_eq!(*inner, Value::String("X".into()));
+                        }
+                        _ => panic!("expected Expr part"),
+                    },
+                    other => panic!("expected Interpolation, got {:?}", other),
+                }
+            }
+            other => panic!("expected List, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn legacy_string_sentinel_is_no_longer_recognised() {
+        // Only `Value::Unknown(For*)` is substituted. A bare string that
+        // happens to match the historical sentinel must be left alone.
+        let mut v = Value::String("(known after upstream apply)".into());
+        substitute_placeholder(&mut v, None, None, &Value::String("X".into()));
+        assert_eq!(v, Value::String("(known after upstream apply)".into()));
     }
 }

--- a/carina-core/src/parser/expressions/for_expr.rs
+++ b/carina-core/src/parser/expressions/for_expr.rs
@@ -9,12 +9,11 @@
 
 use crate::parser::expressions::primary::parse_primary_eval;
 use crate::parser::{
-    DEFERRED_UPSTREAM_INDEX_PLACEHOLDER, DEFERRED_UPSTREAM_KEY_PLACEHOLDER,
-    DEFERRED_UPSTREAM_PLACEHOLDER, DeferredForExpression, ModuleCall, ParseContext, ParseError,
-    ParseWarning, Rule, evaluate_static_value, first_inner, next_pair, parse_expression,
-    parse_module_call, parse_read_resource_expr, parse_resource_expr,
+    DeferredForExpression, ModuleCall, ParseContext, ParseError, ParseWarning, Rule,
+    evaluate_static_value, first_inner, next_pair, parse_expression, parse_module_call,
+    parse_read_resource_expr, parse_resource_expr,
 };
-use crate::resource::{Resource, Value};
+use crate::resource::{Resource, UnknownReason, Value};
 
 /// Binding pattern for a for expression
 #[derive(Debug, Clone, PartialEq)]
@@ -236,7 +235,7 @@ pub(crate) fn parse_for_expr(
             // Try to parse the body once with placeholder values for the loop
             // variable(s) to extract the resource type and attribute template.
             let mut template_ctx = ctx.clone();
-            let placeholder = || Value::String(DEFERRED_UPSTREAM_PLACEHOLDER.to_string());
+            let placeholder = || Value::Unknown(UnknownReason::ForValue);
             let bind = |c: &mut ParseContext, name: &str, v: Value| {
                 if name != "_" {
                     c.set_variable(name.to_string(), v);
@@ -250,16 +249,12 @@ pub(crate) fn parse_for_expr(
                     bind(
                         &mut template_ctx,
                         idx,
-                        Value::String(DEFERRED_UPSTREAM_INDEX_PLACEHOLDER.to_string()),
+                        Value::Unknown(UnknownReason::ForIndex),
                     );
                     bind(&mut template_ctx, val, placeholder());
                 }
                 ForBinding::Map(k, v) => {
-                    bind(
-                        &mut template_ctx,
-                        k,
-                        Value::String(DEFERRED_UPSTREAM_KEY_PLACEHOLDER.to_string()),
-                    );
+                    bind(&mut template_ctx, k, Value::Unknown(UnknownReason::ForKey));
                     bind(&mut template_ctx, v, placeholder());
                 }
             }
@@ -314,7 +309,7 @@ pub(crate) fn parse_for_expr(
                     ForBinding::Map(k, v) => format!("for {}, {} in {}", k, v, s),
                 };
                 let mut template_ctx = ctx.clone();
-                let placeholder = || Value::String(DEFERRED_UPSTREAM_PLACEHOLDER.to_string());
+                let placeholder = || Value::Unknown(UnknownReason::ForValue);
                 let bind = |c: &mut ParseContext, name: &str, v: Value| {
                     if name != "_" {
                         c.set_variable(name.to_string(), v);
@@ -328,16 +323,12 @@ pub(crate) fn parse_for_expr(
                         bind(
                             &mut template_ctx,
                             idx,
-                            Value::String(DEFERRED_UPSTREAM_INDEX_PLACEHOLDER.to_string()),
+                            Value::Unknown(UnknownReason::ForIndex),
                         );
                         bind(&mut template_ctx, val, placeholder());
                     }
                     ForBinding::Map(k, v) => {
-                        bind(
-                            &mut template_ctx,
-                            k,
-                            Value::String(DEFERRED_UPSTREAM_KEY_PLACEHOLDER.to_string()),
-                        );
+                        bind(&mut template_ctx, k, Value::Unknown(UnknownReason::ForKey));
                         bind(&mut template_ctx, v, placeholder());
                     }
                 }

--- a/carina-core/src/parser/expressions/string_literal.rs
+++ b/carina-core/src/parser/expressions/string_literal.rs
@@ -78,10 +78,11 @@ pub(crate) fn parse_string_value(
     if has_interpolation {
         // Deliberately do *not* call `Value::canonicalize` here. The
         // deferred-for placeholder substitution in
-        // `parser/ast.rs::substitute_placeholder` matches whole
-        // `Value::String` placeholders, so we must keep `Expr` parts
-        // intact through parse → for-expansion. Canonicalization runs
-        // later, after resolution (see #2227).
+        // `parser/ast.rs::substitute_placeholder` walks the `Expr`
+        // parts to replace `Value::Unknown(For*)` placeholders with the
+        // resolved iterable element, so the parts must stay intact
+        // through parse → for-expansion. Canonicalization runs later,
+        // after resolution (see #2227).
         Ok(Value::Interpolation(parts))
     } else {
         // No interpolation — collapse to a plain String

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -228,6 +228,7 @@ pub fn validate_custom_type(
         (_, Value::ResourceRef { .. }) => Ok(()), // will be resolved later
         (_, Value::FunctionCall { .. }) => Ok(()), // will be resolved later
         (_, Value::Interpolation(_)) => Ok(()),   // will be resolved later
+        (_, Value::Unknown(_)) => Ok(()),         // resolved at upstream apply
         (name, Value::String(s)) => {
             // Check custom validators from config (schema-extracted)
             if let Some(validator) = config.validators.get(name) {
@@ -256,6 +257,12 @@ fn check_fn_arg_type(
     value: &Value,
     ctx: &ParseContext,
 ) -> Result<(), ParseError> {
+    // `Value::Unknown` resolves at upstream apply; the concrete type
+    // is unknowable at parse time. Skip the type check — same convention
+    // the schema validator follows.
+    if matches!(value, Value::Unknown(_)) {
+        return Ok(());
+    }
     let type_matches = match type_expr {
         TypeExpr::String => matches!(
             value,
@@ -343,6 +350,11 @@ fn check_fn_return_type(
     value: &Value,
     config: &ProviderContext,
 ) -> Result<(), ParseError> {
+    // Same skip as `check_fn_arg_type`: a `Value::Unknown` propagated
+    // through a typed user fn carries no concrete type at parse time.
+    if matches!(value, Value::Unknown(_)) {
+        return Ok(());
+    }
     let type_matches = match type_expr {
         TypeExpr::String => matches!(
             value,

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -17,11 +17,11 @@ mod types;
 mod util;
 
 pub use ast::{
-    ArgumentParameter, AttributeParameter, BackendConfig, DEFERRED_UPSTREAM_PLACEHOLDER,
-    DeferredForExpression, ExportParamLike, ExportParameter, File, FnParam, InferredExportParam,
-    InferredFile, ModuleCall, ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock,
-    ResourceContext, ResourceTypePath, StateBlock, TypeExpr, UpstreamState, UseStatement,
-    UserFunction, UserFunctionBody, ValidateExpr, ValidationBlock,
+    ArgumentParameter, AttributeParameter, BackendConfig, DeferredForExpression, ExportParamLike,
+    ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
+    ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceTypePath,
+    StateBlock, TypeExpr, UpstreamState, UseStatement, UserFunction, UserFunctionBody,
+    ValidateExpr, ValidationBlock,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub use entry::{parse, parse_and_resolve};
@@ -36,7 +36,6 @@ pub use resolve::{
 pub(crate) use util::{eval_type_name, value_type_name};
 pub use util::{pascal_to_snake, snake_to_pascal};
 
-pub(crate) use ast::{DEFERRED_UPSTREAM_INDEX_PLACEHOLDER, DEFERRED_UPSTREAM_KEY_PLACEHOLDER};
 pub(crate) use blocks::module_call::parse_module_call;
 pub(crate) use blocks::resource::{
     parse_block_contents, parse_read_resource_expr, parse_resource_expr,

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -5102,6 +5102,66 @@ fn user_fn_typed_param_bool_mismatch() {
 }
 
 #[test]
+fn typed_user_fn_accepts_value_unknown_in_deferred_for_body() {
+    // RFC #2371 stage 3: a deferred for-expression binds the loop var
+    // to `Value::Unknown(ForValue)` during template parsing. If a typed
+    // user function is invoked with that placeholder, `check_fn_arg_type`
+    // must skip the type check (the concrete type resolves at upstream
+    // apply). Without the skip, parsing fails with `expects type 'String'`.
+    let input = r#"
+        fn label(s: String) {
+            s
+        }
+
+        let net = upstream_state {
+            source = "../net"
+        }
+
+        for x in net.names {
+            aws.s3_bucket {
+                name = label(x)
+            }
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default());
+    assert!(
+        result.is_ok(),
+        "deferred-for body must accept typed user fn called with Unknown loop var, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn typed_return_user_fn_accepts_value_unknown_in_deferred_for_body() {
+    // Same skip rule must apply to return-type checking. The user fn
+    // here has both a typed param and a typed return; both must let
+    // `Value::Unknown` pass through.
+    let input = r#"
+        fn label(s: String): String {
+            s
+        }
+
+        let net = upstream_state {
+            source = "../net"
+        }
+
+        for x in net.names {
+            aws.s3_bucket {
+                name = label(x)
+            }
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default());
+    assert!(
+        result.is_ok(),
+        "typed-return user fn must accept Unknown propagation, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
 fn user_fn_param_type_stored_in_parsed_file() {
     let input = r#"
         fn greet(name: String, count: Int) {
@@ -6751,10 +6811,33 @@ fn expand_deferred_for_substitutes_placeholder_inside_interpolation() {
         "interpolation should contain substituted account id, got: {}",
         rendered
     );
+    // After expansion no `Value::Unknown(ForValue)` placeholder must
+    // remain in the resource tree — every for-binding occurrence is
+    // replaced by the resolved iterable element. RFC #2371 stage 3.
+    fn contains_for_unknown(v: &Value) -> bool {
+        use crate::resource::{InterpolationPart, UnknownReason};
+        match v {
+            Value::Unknown(UnknownReason::ForValue)
+            | Value::Unknown(UnknownReason::ForKey)
+            | Value::Unknown(UnknownReason::ForIndex) => true,
+            Value::List(items) => items.iter().any(contains_for_unknown),
+            Value::Map(m) => m.values().any(contains_for_unknown),
+            Value::Interpolation(parts) => parts.iter().any(|p| match p {
+                InterpolationPart::Expr(inner) => contains_for_unknown(inner),
+                InterpolationPart::Literal(_) => false,
+            }),
+            Value::FunctionCall { args, .. } => args.iter().any(contains_for_unknown),
+            Value::Secret(inner) => contains_for_unknown(inner),
+            _ => false,
+        }
+    }
+    let leaked = parsed.resources[0]
+        .attributes
+        .values()
+        .any(contains_for_unknown);
     assert!(
-        !rendered.contains(DEFERRED_UPSTREAM_PLACEHOLDER),
-        "placeholder must not leak into rendered label, got: {}",
-        rendered
+        !leaked,
+        "for-binding Value::Unknown placeholder must not leak into expanded resource"
     );
 }
 

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -87,14 +87,16 @@ fn walk_custom_lookup(
     lookup: CustomTypeLookup<'_>,
     errors: &mut Vec<TypeError>,
 ) {
-    // Values that resolve at runtime are skipped — the same convention
-    // the schema-attached `validate` closure follows.
+    // Skip deferred-resolution values — same convention as
+    // `AttributeType::validate`, plus `ResourceRef` / `Interpolation`
+    // which only resolve to a concrete string at apply time.
     if matches!(
         value,
         Value::FunctionCall { .. }
             | Value::Secret(_)
             | Value::ResourceRef { .. }
             | Value::Interpolation(_)
+            | Value::Unknown(_)
     ) {
         return;
     }
@@ -487,8 +489,12 @@ impl AttributeType {
     /// value (or one of the variant-specific dynamic shapes like
     /// `ResourceRef`/`Interpolation` that the helpers handle individually).
     pub fn validate(&self, value: &Value) -> Result<(), TypeError> {
-        // FunctionCall and Secret values are resolved at runtime, skip validation
-        if matches!(value, Value::FunctionCall { .. } | Value::Secret(_)) {
+        // Deferred-resolution values carry no concrete type at plan
+        // time — skip them.
+        if matches!(
+            value,
+            Value::FunctionCall { .. } | Value::Secret(_) | Value::Unknown(_)
+        ) {
             return Ok(());
         }
 
@@ -528,9 +534,11 @@ impl AttributeType {
     }
 
     fn collect_into(&self, path: &FieldPath, value: &Value, out: &mut Vec<(FieldPath, TypeError)>) {
-        // FunctionCall and Secret resolve at runtime — same skip rule
-        // as `validate`.
-        if matches!(value, Value::FunctionCall { .. } | Value::Secret(_)) {
+        // Same skip rule as `validate` — deferred-resolution values.
+        if matches!(
+            value,
+            Value::FunctionCall { .. } | Value::Secret(_) | Value::Unknown(_)
+        ) {
             return;
         }
 

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -3301,3 +3301,64 @@ fn schema_registry_has_managed_only_does_not_imply_data_source() {
     assert!(registry.has_managed("aws", "s3.Bucket"));
     assert!(!registry.has_data_source("aws", "s3.Bucket"));
 }
+
+#[test]
+fn validate_skips_value_unknown_for_primitive_types() {
+    // `Value::Unknown` carries no concrete type at plan time, so it
+    // takes the same skip path as `FunctionCall` and `Secret`. Without
+    // this, a `for x in upstream.list { ... attr = x ... }` body fails
+    // parse-time validation with `expected <type>, got unknown`.
+    use crate::resource::{AccessPath, UnknownReason};
+    let unknown = Value::Unknown(UnknownReason::ForValue);
+    assert!(AttributeType::String.validate(&unknown).is_ok());
+    assert!(AttributeType::Int.validate(&unknown).is_ok());
+    assert!(AttributeType::Bool.validate(&unknown).is_ok());
+
+    let upstream = Value::Unknown(UnknownReason::UpstreamRef {
+        path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
+    });
+    assert!(AttributeType::String.validate(&upstream).is_ok());
+    assert!(AttributeType::Int.validate(&upstream).is_ok());
+}
+
+#[test]
+fn walk_custom_lookup_skips_value_unknown() {
+    // Custom-typed attributes (e.g. AWS resource-id types like `vpc_id`)
+    // run through `walk_custom_lookup` instead of `validate`. Skip
+    // `Value::Unknown` here too, otherwise a custom-typed attribute
+    // bound from a for-expression element fails plan with
+    // `expected vpc_id, got unknown`.
+    use crate::resource::UnknownReason;
+
+    let always_fail = validator(|_v: &Value| {
+        Err(TypeError::ValidationFailed {
+            message: "validator must not run for Value::Unknown".to_string(),
+        })
+    });
+    let custom_type = AttributeType::Custom {
+        base: Box::new(AttributeType::String),
+        validate: always_fail,
+        semantic_name: Some("vpc_id".to_string()),
+        namespace: None,
+        pattern: None,
+        length: None,
+        to_dsl: None,
+    };
+
+    let mut errors = Vec::new();
+    walk_custom_lookup(
+        &custom_type,
+        &Value::Unknown(UnknownReason::ForValue),
+        "vpc_id",
+        &|_, _| {
+            Err(TypeError::ValidationFailed {
+                message: "should never be called".to_string(),
+            })
+        },
+        &mut errors,
+    );
+    assert!(
+        errors.is_empty(),
+        "Value::Unknown must not invoke the custom validator, got: {errors:?}"
+    );
+}

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -795,6 +795,12 @@ pub fn validate_type_expr_value(
     value: &Value,
     config: &ProviderContext,
 ) -> Option<String> {
+    // `Value::Unknown` resolves at upstream apply — the concrete type
+    // is unknowable here. Same skip rule the schema validator and
+    // `check_fn_arg_type` follow.
+    if matches!(value, Value::Unknown(_)) {
+        return None;
+    }
     match (type_expr, value) {
         (TypeExpr::Simple(name), _) => validate_custom_type(name, value, config).err(),
         (TypeExpr::List(inner), Value::List(items)) => {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2149,3 +2149,31 @@ fn read_against_managed_only_type_is_rejected() {
         "expected fix hint, got: {err}"
     );
 }
+
+#[test]
+fn validate_type_expr_value_skips_value_unknown() {
+    // RFC #2371 stage 3: a `Value::Unknown` reaching this validator
+    // (e.g. from a deferred-for body where a typed module-call argument
+    // is bound to the loop var) must short-circuit rather than emit
+    // `expected <type>, got unknown`.
+    use crate::resource::{UnknownReason, Value};
+    use crate::validation::TypeExpr;
+
+    let unknown = Value::Unknown(UnknownReason::ForValue);
+    let cfg = ProviderContext::default();
+
+    assert!(super::validate_type_expr_value(&TypeExpr::String, &unknown, &cfg).is_none());
+    assert!(super::validate_type_expr_value(&TypeExpr::Int, &unknown, &cfg).is_none());
+    assert!(super::validate_type_expr_value(&TypeExpr::Bool, &unknown, &cfg).is_none());
+
+    let struct_ty = TypeExpr::Struct {
+        fields: vec![("name".to_string(), TypeExpr::String)],
+    };
+    assert!(super::validate_type_expr_value(&struct_ty, &unknown, &cfg).is_none());
+
+    let upstream = Value::Unknown(UnknownReason::UpstreamRef {
+        path: crate::resource::AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
+    });
+    assert!(super::validate_type_expr_value(&TypeExpr::String, &upstream, &cfg).is_none());
+    assert!(super::validate_type_expr_value(&struct_ty, &upstream, &cfg).is_none());
+}

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -8,12 +8,8 @@ use indexmap::IndexMap;
 use crate::resource::{InterpolationPart, UnknownReason, Value};
 use crate::utils::{convert_enum_value, is_dsl_enum_format};
 
-/// Render an `UnknownReason` to its plan-display string. See RFC #2371.
-///
-/// `pub(crate)` because stage 2 only needs same-crate callers
-/// (`format_value_with_key`). Stage 3 promotes to `pub` when carina-cli's
-/// display layer migrates.
-pub(crate) fn render_unknown(reason: &UnknownReason) -> String {
+/// Render an `UnknownReason` to its plan-display string.
+pub fn render_unknown(reason: &UnknownReason) -> String {
     match reason {
         UnknownReason::UpstreamRef { path } => {
             format!("(known after upstream apply: {})", path.to_dot_string())

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -485,22 +485,28 @@ impl DiagnosticEngine {
                                     },
                                     value,
                                 ) => {
-                                    let name = semantic_name.as_deref().unwrap_or("");
-                                    // Handle bare/shorthand enum identifiers by expanding to full namespace format.
-                                    // These are String values like "dedicated" or "InstanceTenancy.dedicated".
-                                    let resolved_value = carina_core::utils::expand_enum_shorthand(
-                                        value,
-                                        name,
-                                        namespace.as_deref(),
-                                    );
+                                    // `Value::Unknown` resolves at upstream apply — skip,
+                                    // matching the CLI's `walk_custom_lookup` behavior.
+                                    if matches!(value, carina_core::resource::Value::Unknown(_)) {
+                                        None
+                                    } else {
+                                        let name = semantic_name.as_deref().unwrap_or("");
+                                        // Handle bare/shorthand enum identifiers by expanding to full namespace format.
+                                        // These are String values like "dedicated" or "InstanceTenancy.dedicated".
+                                        let resolved_value =
+                                            carina_core::utils::expand_enum_shorthand(
+                                                value,
+                                                name,
+                                                namespace.as_deref(),
+                                            );
 
-                                    // Run the schema-attached validator first; for WASM-plugin
-                                    // types it is a noop, so fall back to the provider-context
-                                    // lookup which reaches the factory's `validate_custom_type`.
-                                    let lookup = carina_core::parser::provider_context_lookup(
-                                        &self.provider_context,
-                                    );
-                                    validate(&resolved_value)
+                                        // Run the schema-attached validator first; for WASM-plugin
+                                        // types it is a noop, so fall back to the provider-context
+                                        // lookup which reaches the factory's `validate_custom_type`.
+                                        let lookup = carina_core::parser::provider_context_lookup(
+                                            &self.provider_context,
+                                        );
+                                        validate(&resolved_value)
                                         .err()
                                         .or_else(|| {
                                             (!name.is_empty())
@@ -530,6 +536,7 @@ impl DiagnosticEngine {
                                             inner_msg
                                         }
                                     })
+                                    }
                                 }
                                 // String type - check for bare resource binding
                                 (carina_core::schema::AttributeType::String, Value::String(s)) => {


### PR DESCRIPTION
## Summary

- Replaces three string sentinels (`DEFERRED_UPSTREAM_PLACEHOLDER` and the `KEY`/`INDEX` siblings) with typed `Value::Unknown(UnknownReason::ForValue/ForKey/ForIndex)` for-expression placeholders. Stage 3 of RFC #2371.
- Adds `Value::Unknown` skip arms at 9 schema/validation sites (parse-time, LSP, module-call typecheck) so for-bodies that reference custom-typed attributes parse cleanly. Surfaced by real-infra smoke testing — all-green workspace tests did not catch it.
- `format_deferred_value` is **kept** rather than deleted; #2370 (display convergence) is **not** auto-closed by this PR.

Closes #2379

## What changed

### Producer / consumer

- `carina-core/src/parser/expressions/for_expr.rs` stamps `Value::Unknown(For*)` instead of `Value::String(DEFERRED_UPSTREAM_*)` during deferred for-template parsing.
- `carina-core/src/parser/ast.rs::substitute_placeholder` now matches the typed enum. The `Value::Unknown(UnknownReason::UpstreamRef { .. })` arm is **explicit (not wildcard)** so a future `UnknownReason` variant addition forces a compile-error decision here.

### Schema / validation skip arms

`Value::Unknown` carries no concrete type at plan time, so 9 sites that previously rejected non-matching variants now skip:

- `carina-core/src/schema/mod.rs::AttributeType::validate`
- `carina-core/src/schema/mod.rs::AttributeType::collect_into`
- `carina-core/src/schema/mod.rs::walk_custom_lookup`
- `carina-core/src/parser/functions.rs::validate_custom_type`
- `carina-core/src/parser/functions.rs::check_fn_arg_type`
- `carina-core/src/parser/functions.rs::check_fn_return_type`
- `carina-core/src/module_resolver/typecheck.rs::check_type_match`
- `carina-core/src/validation/mod.rs::validate_type_expr_value`
- `carina-lsp/src/diagnostics/mod.rs` — Custom-arm

Without these, real-infra plans fail with `expected vpc_id, got unknown` when a for-body assigns a custom-typed attribute (`vpc_id = vpc_id`, etc.) where the loop var resolves at upstream apply.

### Display

- `format_value_with_key`'s existing `Value::Unknown(reason) => render_unknown(reason)` arm covers the new typed placeholders without further change.
- `format_deferred_value` (carina-cli) is kept. Its resolved-string rendering uses single-quote style (`'arn:...'`) which diverges from `format_value_with_key`'s double-quote style (`"arn:..."`); collapsing them is independent of the data-model migration and is left for a separate PR. Only the inner sentinel-match is rewritten to `Value::Unknown(reason) => render_unknown(reason).dimmed()`.
- `render_unknown` is promoted from `pub(crate)` to `pub` so the carina-cli display layer can reuse it.

### Cleanup

`DEFERRED_UPSTREAM_PLACEHOLDER`, `DEFERRED_UPSTREAM_KEY_PLACEHOLDER`, `DEFERRED_UPSTREAM_INDEX_PLACEHOLDER` constants and their re-exports in `carina-core/src/parser/mod.rs` are removed.

### WASM boundary

The stage-2 strip-and-restore helpers (`PlanPreprocessor::prepare`) handle For variants automatically because `value_contains_unknown` matches `Value::Unknown(_)`. A new round-trip test pins this.

## Out of scope

- Promoting any `unimplemented!()` to `Err(...)` — that's stage 4.
- `format_deferred_value` deletion / display-style convergence — #2370 stays open.
- Provider crate edits, DSL surface changes.

## Test plan

- [x] `cargo nextest run --workspace` — 2633 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All `scripts/check-*.sh` — pass
- [x] Existing snapshots (`snapshot_deferred_for`, `plan_snapshot_upstream_state_*`) — **unchanged**
- [x] `grep -rn 'DEFERRED_UPSTREAM_' carina-core carina-cli` — empty
- [x] Real-infra smoke test — `for vpc_id in network.vpc_ids { aws.ec2.SecurityGroup { vpc_id = vpc_id ... } }` against `~/tmp/carina-upstream-state/iam-roles` renders `vpc_id: (known after upstream apply)` cleanly with no debug-format string leaking from the WASM provider boundary.

## New tests

- `substitute_placeholder` 5 unit tests — For 3 variants substituted; `UpstreamRef` left untouched; concrete scalars unchanged; recursion into compound values.
- `strip_and_restore_for_expression_unknowns_round_trip` (`carina-cli/src/wiring/tests.rs`) — confirms the WASM-boundary strip-and-restore covers For variants.
- `value_contains_unknown_covers_for_variants`.
- `validate_skips_value_unknown_for_primitive_types`, `walk_custom_lookup_skips_value_unknown` (`carina-core/src/schema/tests.rs`).
- `validate_type_expr_value_skips_value_unknown` (`carina-core/src/validation/tests.rs`).
- `typed_user_fn_accepts_value_unknown_in_deferred_for_body`, `typed_return_user_fn_accepts_value_unknown_in_deferred_for_body` — pin the parse-time regression where typed user fn calls inside a for-body would reject the loop var as `expects type 'String', got unknown`.
- `expand_deferred_for_substitutes_placeholder_inside_interpolation` strengthened from a string-substring check to a recursive `Value::Unknown(For*)` leak detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)