### PR TITLE
value: cleanup follow-ups for RFC #2371 stage 4

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -130,28 +130,23 @@ pub(crate) fn dsl_value_to_json(
         Value::Int(i) => Ok(Some(serde_json::Value::Number((*i).into()))),
         Value::Float(f) => Ok(serde_json::Number::from_f64(*f).map(serde_json::Value::Number)),
         Value::List(items) => {
-            let json_items: Result<Vec<_>, _> = items
+            // `Result::transpose` flips `Result<Option<T>, E>` to
+            // `Option<Result<T, E>>`, so `filter_map` drops the
+            // `Ok(None)` skips and propagates `Err`.
+            let json_items: Vec<_> = items
                 .iter()
                 .map(dsl_value_to_json)
-                .filter_map(|r| match r {
-                    Ok(Some(v)) => Some(Ok(v)),
-                    Ok(None) => None,
-                    Err(e) => Some(Err(e)),
-                })
-                .collect();
-            Ok(Some(serde_json::Value::Array(json_items?)))
+                .filter_map(Result::transpose)
+                .collect::<Result<_, _>>()?;
+            Ok(Some(serde_json::Value::Array(json_items)))
         }
         Value::Map(map) => {
-            let json_map: Result<serde_json::Map<String, serde_json::Value>, _> = map
+            let json_map: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .map(|(k, v)| dsl_value_to_json(v).map(|jv| jv.map(|j| (k.clone(), j))))
-                .filter_map(|r| match r {
-                    Ok(Some(pair)) => Some(Ok(pair)),
-                    Ok(None) => None,
-                    Err(e) => Some(Err(e)),
-                })
-                .collect();
-            Ok(Some(serde_json::Value::Object(json_map?)))
+                .filter_map(Result::transpose)
+                .collect::<Result<_, _>>()?;
+            Ok(Some(serde_json::Value::Object(json_map)))
         }
         Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
             reason: reason.clone(),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -68,13 +68,6 @@ pub enum SerializationError {
         value: f64,
         context: SerializationContext,
     },
-    /// `serde_json` reported a serialization failure on a sub-value.
-    /// Currently only reachable when hashing a `Value::Secret`.
-    #[error("cannot serialize at {context}: {message}")]
-    SerdeJson {
-        message: String,
-        context: SerializationContext,
-    },
 }
 
 impl std::fmt::Display for UnknownReason {
@@ -232,11 +225,11 @@ pub fn value_to_json_with_context(
         }
         Value::Secret(inner) => {
             let inner_json = value_to_json_with_context(inner, context)?;
-            let json_str =
-                serde_json::to_string(&inner_json).map_err(|e| SerializationError::SerdeJson {
-                    message: format!("failed to serialize secret inner value: {e}"),
-                    context: ctx,
-                })?;
+            // `serde_json::Value -> String` only fails on a custom
+            // `Serialize` impl or invalid map keys, neither of which a
+            // freshly-built `serde_json::Value` can produce.
+            let json_str = serde_json::to_string(&inner_json)
+                .expect("serde_json::Value -> String is infallible");
             let hash_hex = argon2id_hash(json_str.as_bytes(), context);
             Ok(serde_json::Value::String(format!(
                 "{SECRET_PREFIX}{hash_hex}",
@@ -441,11 +434,8 @@ pub fn redact_secrets_in_value(value: &Value) -> Result<Value, SerializationErro
     match value {
         Value::Secret(inner) => {
             let inner_json = value_to_json(inner)?;
-            let json_str =
-                serde_json::to_string(&inner_json).map_err(|e| SerializationError::SerdeJson {
-                    message: format!("failed to serialize secret inner value: {e}"),
-                    context: SerializationContext::SecretRedaction,
-                })?;
+            let json_str = serde_json::to_string(&inner_json)
+                .expect("serde_json::Value -> String is infallible");
             let hash_hex = argon2id_hash(json_str.as_bytes(), None);
             Ok(Value::String(format!("{SECRET_PREFIX}{hash_hex}")))
         }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -43,11 +43,8 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
         CoreValue::List(items) => {
             let json_items: Result<Vec<serde_json::Value>, _> =
                 items.iter().map(core_value_to_json).collect();
-            let json_str =
-                serde_json::to_string(&json_items?).map_err(|e| SerializationError::SerdeJson {
-                    message: e.to_string(),
-                    context: SerializationContext::WasmBoundary,
-                })?;
+            let json_str = serde_json::to_string(&json_items?)
+                .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::ListVal(json_str))
         }
         CoreValue::Map(map) => {
@@ -55,11 +52,8 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
                 .iter()
                 .map(|(k, v)| core_value_to_json(v).map(|jv| (k.clone(), jv)))
                 .collect();
-            let json_str =
-                serde_json::to_string(&json_map?).map_err(|e| SerializationError::SerdeJson {
-                    message: e.to_string(),
-                    context: SerializationContext::WasmBoundary,
-                })?;
+            let json_str = serde_json::to_string(&json_map?)
+                .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::MapVal(json_str))
         }
         CoreValue::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -28,10 +28,29 @@ use carina_core::resource::{
     LifecycleConfig, Resource, ResourceId, State, Value, contains_resource_ref,
 };
 use carina_core::schema::{CompletionValue, ResourceSchema};
+use carina_core::value::SerializationError;
 
 use crate::wasm_bindings::CarinaProvider;
 use crate::wasm_bindings_http::CarinaProviderWithHttp;
 use crate::wasm_convert;
+
+/// Wrap a `SerializationError` from a sync `core_to_wit_*` call site
+/// into the matching async `BoxFuture` shape that `Provider` trait
+/// methods return. Pulls the `e.to_string()` allocation out of the
+/// async block so the future is `'static`.
+fn early_provider_err<T: 'static>(e: SerializationError) -> BoxFuture<'static, ProviderResult<T>> {
+    let msg = e.to_string();
+    Box::pin(async move { Err(ProviderError::new(msg)) })
+}
+
+/// Unwrap a `core_to_wit_*` result that **must** succeed by invariant
+/// (state/saved attrs are post-apply concrete values; normalize_desired
+/// runs after `PlanPreprocessor::strip_unknown_attributes`). Embeds the
+/// failing `SerializationError` in the panic message so a stripping-pass
+/// regression surfaces with the actual `UnknownReason` + context.
+fn expect_no_unknown<T>(r: Result<T, SerializationError>, what: &'static str) -> T {
+    r.unwrap_or_else(|e| panic!("{what} must not see Value::Unknown ({e})"))
+}
 
 // -- HTTP allow-list hooks --
 
@@ -1336,7 +1355,7 @@ impl Provider for WasmProvider {
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_resource = match wasm_convert::core_to_wit_resource(resource) {
             Ok(v) => v,
-            Err(e) => return Box::pin(async move { Err(ProviderError::new(e.to_string())) }),
+            Err(e) => return early_provider_err(e),
         };
         let id = resource.id.clone();
         Box::pin(async move {
@@ -1369,7 +1388,7 @@ impl Provider for WasmProvider {
     fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_resource = match wasm_convert::core_to_wit_resource(resource) {
             Ok(v) => v,
-            Err(e) => return Box::pin(async move { Err(ProviderError::new(e.to_string())) }),
+            Err(e) => return early_provider_err(e),
         };
         let id = resource.id.clone();
         Box::pin(async move {
@@ -1410,11 +1429,11 @@ impl Provider for WasmProvider {
         let identifier = identifier.to_string();
         let wit_from = match wasm_convert::core_to_wit_state(from) {
             Ok(v) => v,
-            Err(e) => return Box::pin(async move { Err(ProviderError::new(e.to_string())) }),
+            Err(e) => return early_provider_err(e),
         };
         let wit_to = match wasm_convert::core_to_wit_resource(to) {
             Ok(v) => v,
-            Err(e) => return Box::pin(async move { Err(ProviderError::new(e.to_string())) }),
+            Err(e) => return early_provider_err(e),
         };
         let id = id.clone();
         Box::pin(async move {
@@ -1493,14 +1512,13 @@ unsafe impl Sync for WasmProviderNormalizer {}
 
 impl ProviderNormalizer for WasmProviderNormalizer {
     fn normalize_desired(&self, resources: &mut [Resource]) {
-        // `Value::Unknown` is stripped by
-        // `PlanPreprocessor::strip_unknown_attributes` before this
-        // point; an `Err` here would mean that pass is buggy.
-        let wit_resources: Vec<_> = resources
-            .iter()
-            .map(wasm_convert::core_to_wit_resource)
-            .collect::<Result<Vec<_>, _>>()
-            .expect("strip_unknown_attributes must run before normalize_desired");
+        let wit_resources: Vec<_> = expect_no_unknown(
+            resources
+                .iter()
+                .map(wasm_convert::core_to_wit_resource)
+                .collect::<Result<Vec<_>, _>>(),
+            "normalize_desired",
+        );
 
         let result = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
@@ -1537,14 +1555,12 @@ impl ProviderNormalizer for WasmProviderNormalizer {
     }
 
     fn normalize_state(&self, current_states: &mut HashMap<ResourceId, State>) {
-        // State files only carry concrete post-apply values, never
-        // `Value::Unknown`. An `Err` here means a stage-2 bug.
         let wit_states: Vec<(String, _)> = current_states
             .iter()
             .map(|(id, state)| {
-                wasm_convert::core_to_wit_state(state)
-                    .map(|s| (id.to_string(), s))
-                    .expect("state must not carry Value::Unknown")
+                let wit =
+                    expect_no_unknown(wasm_convert::core_to_wit_state(state), "normalize_state");
+                (id.to_string(), wit)
             })
             .collect();
 
@@ -1578,22 +1594,25 @@ impl ProviderNormalizer for WasmProviderNormalizer {
         current_states: &mut HashMap<ResourceId, State>,
         saved_attrs: &SavedAttrs,
     ) {
-        // Both inputs are post-apply (concrete) values.
         let wit_states: Vec<(String, _)> = current_states
             .iter()
             .map(|(id, state)| {
-                wasm_convert::core_to_wit_state(state)
-                    .map(|s| (id.to_string(), s))
-                    .expect("state must not carry Value::Unknown")
+                let wit = expect_no_unknown(
+                    wasm_convert::core_to_wit_state(state),
+                    "hydrate_read_state (current_states)",
+                );
+                (id.to_string(), wit)
             })
             .collect();
 
         let wit_saved: Vec<(String, Vec<(String, _)>)> = saved_attrs
             .iter()
             .map(|(id, attrs)| {
-                wasm_convert::core_to_wit_value_map(attrs)
-                    .map(|v| (id.to_string(), v))
-                    .expect("saved attrs must not carry Value::Unknown")
+                let wit = expect_no_unknown(
+                    wasm_convert::core_to_wit_value_map(attrs),
+                    "hydrate_read_state (saved_attrs)",
+                );
+                (id.to_string(), wit)
             })
             .collect();
 


### PR DESCRIPTION
## Summary

Four mechanical refactors deferred from RFC #2371 stage 4 review (#2382). Internal cleanup — no user-visible behaviour change.

1. **Drop `SerializationError::SerdeJson` variant.** The `serde_json::to_string(&serde_json::Value)` calls in `value.rs` (Secret hashing) and `wasm_convert.rs` (List/Map serialization) are infallible by construction — the input is a `serde_json::Value` we just built, and its built-in `Serialize` impl cannot fail. Each call site becomes `.expect("serde_json::Value -> String is infallible")`. Variant deleted from the enum. Shrinks the public error API.

2. **Extract `early_provider_err` helper in `wasm_factory.rs`.** The four `Box::pin(async move { Err(ProviderError::new(e.to_string())) })` sites in the `Provider` trait methods (`read_data_source`, `create`, `update`'s two conversions) collapse to `early_provider_err(e)`. Pulls the `to_string()` allocation out of the async block so the future is `'static`.

3. **Extract `expect_no_unknown` helper in `wasm_factory.rs`.** The four `.expect("...")` sites in `WasmProviderNormalizer` (`normalize_desired`, `normalize_state`, `hydrate_read_state` × 2) had four different ad-hoc panic messages, none of which embedded the actual `SerializationError` content. The helper unifies the format to `"{what} must not see Value::Unknown ({e})"`, surfacing the failing `UnknownReason` + context if a strip-pass regression ever fires the panic.

4. **Apply `Result::transpose` idiom in `dsl_value_to_json`.** The List/Map arms used a verbose `filter_map(|r| match r { Ok(Some(v)) => Some(Ok(v)), Ok(None) => None, Err(e) => Some(Err(e)) })` shape. `Result::transpose` flips `Result<Option<T>, E>` to `Option<Result<T, E>>`, so `filter_map(Result::transpose)` does the same job in one line. Cuts ~14 lines.

Closes #2383

Refs: #2371 (parent RFC), #2381 / #2382 (stage 4)

## Out of scope

- Lifting `wasm_factory.rs` callers' `String` error to `SerializationError` end-to-end (separate refactor).
- Adding `AppError::Serialization(SerializationError)` variant (LSP / library consumers don't exist yet).
- Snapshot-testing `SerializationContext::Display` strings.

## Test plan

- [x] `cargo nextest run --workspace` — 2633 passed (unchanged from stage 4)
- [x] `cargo test --workspace --doc` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `bash scripts/check-*.sh` (5 scripts) all pass
- [x] All 4 acceptance grep checks return expected results:
  - `grep -rn 'SerdeJson'` → empty
  - `grep -rn 'Box::pin(async move { Err(ProviderError'` → 1 match (inside helper)
  - `grep -rn 'must not see Value::Unknown'` → 1 match (inside helper)
  - `grep -rn 'Ok(Some(v)) => Some(Ok(v))\|Ok(None) => None,'` → empty
- [x] All 6 `unknown_returns_err_*` boundary tests still pass

## Stats

- 4 files changed, +65 / -67 lines
- 5-round self-review: all clean (no fixes needed; mechanical refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
