### PR TITLE
value: typed Err for unresolved ResourceRef/Interpolation/FunctionCall (#2385 #2386)

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -113,17 +113,18 @@ pub(crate) fn resolve_exports(
 ///
 /// Returns:
 /// - `Ok(Some(json))` for a representable concrete value
-/// - `Ok(None)` for variants that have no JSON representation in
-///   exports (`ResourceRef`, `Interpolation`, etc.) — the caller
-///   filters these out
-/// - `Err(SerializationError)` for `Value::Unknown`, so apply-time
-///   export resolution surfaces an actionable error rather than
-///   silently dropping or panicking.
+/// - `Ok(None)` for `Value::Secret` (state.exports must not embed
+///   plaintext secrets, so exports of secret-typed values are skipped)
+/// - `Err(SerializationError)` for variants that should not have
+///   reached this boundary — the resolver / canonicalize / for-expand
+///   pass should have eliminated them. Surfacing as Err names the
+///   specific resolver bug instead of silently losing the export.
 pub(crate) fn dsl_value_to_json(
     value: &carina_core::resource::Value,
 ) -> Result<Option<serde_json::Value>, carina_core::value::SerializationError> {
     use carina_core::resource::Value;
     use carina_core::value::{SerializationContext, SerializationError};
+    let ctx = SerializationContext::StateWriteback;
     match value {
         Value::String(s) => Ok(Some(serde_json::Value::String(s.clone()))),
         Value::Bool(b) => Ok(Some(serde_json::Value::Bool(*b))),
@@ -150,9 +151,20 @@ pub(crate) fn dsl_value_to_json(
         }
         Value::Unknown(reason) => Err(SerializationError::UnknownNotAllowed {
             reason: reason.clone(),
-            context: SerializationContext::StateWriteback,
+            context: ctx,
         }),
-        _ => Ok(None), // ResourceRef, Null, etc. — skip
+        Value::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
+            path: path.to_dot_string(),
+            context: ctx,
+        }),
+        Value::Interpolation(_) => {
+            Err(SerializationError::UnresolvedInterpolation { context: ctx })
+        }
+        Value::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
+            name: name.clone(),
+            context: ctx,
+        }),
+        Value::Secret(_) => Ok(None),
     }
 }
 
@@ -330,12 +342,71 @@ mod stage4_unknown_err_tests {
         }
     }
 
-    /// `Value::ResourceRef` keeps its existing `Ok(None)` skip semantic.
+    /// `Value::ResourceRef` reaching apply-time export resolution
+    /// is a resolver bug — surface as `UnresolvedResourceRef` instead
+    /// of silently dropping the export. (#2385)
     #[test]
-    fn resource_ref_returns_ok_none() {
+    fn resource_ref_returns_unresolved_err() {
         let v = Value::ResourceRef {
             path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
         };
+        let err = dsl_value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedResourceRef {
+                    path,
+                    context: SerializationContext::StateWriteback,
+                } if path == "net.vpc.vpc_id"
+            ),
+            "expected UnresolvedResourceRef/net.vpc.vpc_id/StateWriteback, got: {err:?}"
+        );
+    }
+
+    /// `Value::Interpolation` reaching apply-time is a resolver /
+    /// canonicalize bug — surface as `UnresolvedInterpolation`. (#2386)
+    #[test]
+    fn interpolation_returns_unresolved_err() {
+        use carina_core::resource::InterpolationPart;
+        let v = Value::Interpolation(vec![InterpolationPart::Literal("x".into())]);
+        let err = dsl_value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedInterpolation {
+                    context: SerializationContext::StateWriteback,
+                }
+            ),
+            "expected UnresolvedInterpolation/StateWriteback, got: {err:?}"
+        );
+    }
+
+    /// `Value::FunctionCall` reaching apply-time is a resolver bug —
+    /// surface as `UnresolvedFunctionCall`. (#2386)
+    #[test]
+    fn function_call_returns_unresolved_err() {
+        let v = Value::FunctionCall {
+            name: "join".into(),
+            args: vec![],
+        };
+        let err = dsl_value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedFunctionCall {
+                    name,
+                    context: SerializationContext::StateWriteback,
+                } if name == "join"
+            ),
+            "expected UnresolvedFunctionCall/join/StateWriteback, got: {err:?}"
+        );
+    }
+
+    /// `Value::Secret` continues to be skipped silently — exports must
+    /// not embed plaintext secrets in state.
+    #[test]
+    fn secret_returns_ok_none() {
+        let v = Value::Secret(Box::new(Value::String("password".into())));
         assert!(matches!(dsl_value_to_json(&v), Ok(None)));
     }
 }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -68,6 +68,36 @@ pub enum SerializationError {
         value: f64,
         context: SerializationContext,
     },
+    /// A `Value::ResourceRef` reached a serialization boundary that
+    /// expected a concrete value. Resolvers must substitute the
+    /// reference before this point. Reaching this arm at apply-time
+    /// state writeback or plan-file write is a resolver bug.
+    ///
+    /// `path` is stored as a pre-formatted `String` rather than the
+    /// structured `AccessPath` (cf. `UnknownReason::UpstreamRef`)
+    /// because `SerializationError` is terminating diagnostic data
+    /// consumed only via `Display`; programmatic path inspection has
+    /// no callers today. Lift to `AccessPath` if a future caller needs
+    /// it.
+    #[error("cannot serialize at {context}: unresolved reference {path}")]
+    UnresolvedResourceRef {
+        path: String,
+        context: SerializationContext,
+    },
+    /// A `Value::Interpolation` reached a serialization boundary. The
+    /// canonicalize pass should collapse interpolations to a `String`
+    /// once all parts resolve; reaching this arm means a part stayed
+    /// unresolved through apply-time export resolution.
+    #[error("cannot serialize at {context}: unresolved interpolation")]
+    UnresolvedInterpolation { context: SerializationContext },
+    /// A `Value::FunctionCall` reached a serialization boundary. The
+    /// resolver should evaluate the function (built-in or user-defined)
+    /// before this point; reaching this arm is a resolver bug.
+    #[error("cannot serialize at {context}: unresolved function call {name}(...)")]
+    UnresolvedFunctionCall {
+        name: String,
+        context: SerializationContext,
+    },
 }
 
 impl std::fmt::Display for UnknownReason {
@@ -201,28 +231,17 @@ pub fn value_to_json_with_context(
                 .collect();
             Ok(serde_json::Value::Object(obj?))
         }
-        Value::ResourceRef { path } => Ok(serde_json::Value::String(format!(
-            "${{{}}}",
-            path.to_dot_string()
-        ))),
-        Value::Interpolation(parts) => {
-            let s = parts
-                .iter()
-                .map(|p| match p {
-                    InterpolationPart::Literal(s) => s.clone(),
-                    InterpolationPart::Expr(v) => format_value(v),
-                })
-                .collect::<String>();
-            Ok(serde_json::Value::String(s))
+        Value::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
+            path: path.to_dot_string(),
+            context: ctx,
+        }),
+        Value::Interpolation(_) => {
+            Err(SerializationError::UnresolvedInterpolation { context: ctx })
         }
-        Value::FunctionCall { name, args } => {
-            let arg_strs: Vec<_> = args.iter().map(format_value).collect();
-            Ok(serde_json::Value::String(format!(
-                "{}({})",
-                name,
-                arg_strs.join(", ")
-            )))
-        }
+        Value::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
+            name: name.clone(),
+            context: ctx,
+        }),
         Value::Secret(inner) => {
             let inner_json = value_to_json_with_context(inner, context)?;
             // `serde_json::Value -> String` only fails on a custom
@@ -790,9 +809,64 @@ mod tests {
     }
 
     #[test]
-    fn test_value_to_json_resource_ref() {
+    fn test_value_to_json_resource_ref_returns_err() {
+        // RFC #2371 #2385: `Value::ResourceRef` reaching JSON
+        // serialization is a resolver bug — surface as a structured
+        // `UnresolvedResourceRef` Err instead of the legacy
+        // `"${vpc.id}"` debug-string fallback.
         let v = Value::resource_ref("vpc", "id", vec![]);
-        assert_eq!(value_to_json(&v).unwrap(), serde_json::json!("${vpc.id}"));
+        let err = value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedResourceRef {
+                    path,
+                    context: SerializationContext::ValueToJson,
+                } if path == "vpc.id"
+            ),
+            "expected UnresolvedResourceRef/vpc.id/ValueToJson, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_value_to_json_interpolation_returns_err() {
+        // RFC #2371 #2386: `Value::Interpolation` reaching JSON
+        // serialization is a canonicalize / resolver bug — surface as
+        // `UnresolvedInterpolation` instead of producing a partial
+        // string with embedded debug formatting.
+        let v = Value::Interpolation(vec![InterpolationPart::Literal("hello".into())]);
+        let err = value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedInterpolation {
+                    context: SerializationContext::ValueToJson,
+                }
+            ),
+            "expected UnresolvedInterpolation/ValueToJson, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_value_to_json_function_call_returns_err() {
+        // RFC #2371 #2386: `Value::FunctionCall` reaching JSON
+        // serialization is a resolver bug — the function should have
+        // been evaluated by this point.
+        let v = Value::FunctionCall {
+            name: "join".into(),
+            args: vec![],
+        };
+        let err = value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedFunctionCall {
+                    name,
+                    context: SerializationContext::ValueToJson,
+                } if name == "join"
+            ),
+            "expected UnresolvedFunctionCall/join/ValueToJson, got: {err:?}"
+        );
     }
 
     #[test]
@@ -1002,15 +1076,20 @@ mod tests {
     }
 
     #[test]
-    fn test_value_to_json_resource_ref_with_field_path() {
+    fn test_value_to_json_resource_ref_with_field_path_returns_err() {
         let v = Value::resource_ref(
             "web",
             "output",
             vec!["network".to_string(), "vpc_id".to_string()],
         );
-        assert_eq!(
-            value_to_json(&v).unwrap(),
-            serde_json::json!("${web.output.network.vpc_id}")
+        let err = value_to_json(&v).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                SerializationError::UnresolvedResourceRef { path, .. }
+                    if path == "web.output.network.vpc_id"
+            ),
+            "expected UnresolvedResourceRef/web.output.network.vpc_id, got: {err:?}"
         );
     }
 

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -23,17 +23,19 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// List and Map values are serialized to JSON strings because WIT does
 /// not support recursive types.
 ///
-/// Returns `Err(SerializationError)` for `Value::Unknown` (RFC #2371
-/// stage 4) — `PlanPreprocessor::strip_unknown_attributes` must remove
-/// it before reaching this boundary.
+/// Returns `Err(SerializationError)` for `Value::Unknown` —
+/// `PlanPreprocessor::strip_unknown_attributes` must remove it before
+/// reaching this boundary.
 ///
 /// `ResourceRef`, `Interpolation`, `FunctionCall`, and `Secret` variants
-/// are stringified via `format!("{v:?}")` as a fallback. Managed-to-
-/// managed refs (e.g. `admins.group_id`) are *expected* to be unresolved
-/// at plan time — they get resolved at apply time by the executor.
-/// Data source refs are resolved during refresh phase 2 (#1683); if one
-/// slips through, the provider receives a debug string that will fail
-/// at the remote API with a clear error.
+/// fall back to `format!("{v:?}")`. The fallback is *intentional* for
+/// managed-to-managed refs (e.g. `admins.group_id`) — those genuinely
+/// arrive unresolved at plan time and get resolved by the executor at
+/// apply time. Data source refs are resolved during refresh phase 2
+/// (#1683). The asymmetry with `Value::Unknown` (which is stripped
+/// before this point) is tracked by #2387 — extending the strip-and-
+/// restore pass to `ResourceRef` will let this fallback become an
+/// `UnresolvedResourceRef` Err too.
 pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError> {
     match v {
         CoreValue::String(s) => Ok(wit::Value::StrVal(s.clone())),
@@ -93,8 +95,10 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
 
 /// Helper: convert a core Value to a serde_json::Value for JSON
 /// encoding inside the WIT-string fallback for List/Map. Returns
-/// `Err` for `Value::Unknown` (RFC #2371 stage 4) — sibling contract
-/// to `core_to_wit_value`.
+/// `Err` for `Value::Unknown`; falls back to `format!("{v:?}")` for
+/// `ResourceRef`/`Interpolation`/`FunctionCall`/`Secret` for the same
+/// reason as `core_to_wit_value` — see that function's doc and #2387
+/// for the planned tightening.
 fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationError> {
     match v {
         CoreValue::String(s) => Ok(serde_json::Value::String(s.clone())),

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -1062,3 +1062,35 @@ fn check_and_migrate_canonicalizes_legacy_map_key_addresses() {
     assert!(deps.contains(&"other.a"));
     assert!(deps.contains(&"_envs['prod-east']"));
 }
+
+/// RFC #2371 #2385: state writeback rejects unresolved `Value` variants
+/// surfaced from a buggy provider that returns a `Value::ResourceRef`
+/// in `state.attributes`. Provider-returned states must be concrete; a
+/// resolver / provider bug produces a typed `UnresolvedResourceRef`
+/// error rather than a debug-formatted string in state JSON.
+#[test]
+fn from_provider_state_rejects_resource_ref_in_provider_attributes() {
+    use carina_core::resource::{AccessPath, Resource, State as ProviderState, Value};
+
+    let resource = Resource::with_provider("awscc", "s3.Bucket", "my-bucket");
+    let provider_state = ProviderState {
+        id: resource.id.clone(),
+        identifier: Some("my-bucket".to_string()),
+        attributes: [(
+            "owner".to_string(),
+            Value::ResourceRef {
+                path: AccessPath::with_fields("net", "vpc", vec!["vpc_id".into()]),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        exists: true,
+        dependency_bindings: BTreeSet::new(),
+    };
+
+    let err = ResourceState::from_provider_state(&resource, &provider_state, None).unwrap_err();
+    assert!(
+        err.contains("unresolved reference") && err.contains("net.vpc.vpc_id"),
+        "expected UnresolvedResourceRef diagnostic in error, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Extends RFC #2371 stage 4's typed-error pattern to three more `Value` variants that previously silently degraded at JSON-serialization boundaries. Closes #2385 and #2386 in one PR — both were follow-ups split out of umbrella #2369.

## What changed

### Three new `SerializationError` variants

```rust
SerializationError::UnresolvedResourceRef { path: String, context }
SerializationError::UnresolvedInterpolation { context }
SerializationError::UnresolvedFunctionCall { name: String, context }
```

Each variant surfaces a specific resolver / canonicalize bug rather than producing a debug-format string or silently dropping the export. Three separate variants (rather than one collapsed `Unresolved`) so callers can distinguish which kind of resolver bug surfaced.

### Three serialization paths Err on the new variants

| Path | Before | After |
|---|---|---|
| `value_to_json_with_context` (`carina-core/src/value.rs`) | `Ok(serde_json::Value::String(format!("${{{}}}", path)))` for `ResourceRef`, similar debug strings for `Interpolation` / `FunctionCall` | `Err(UnresolvedResourceRef { ... })` etc. |
| `dsl_value_to_json` (`carina-cli/src/commands/shared/state_writeback.rs`) | `_ => Ok(None)` silent drop covering 4 variants | Explicit 11-variant match. `Value::Secret` keeps `Ok(None)` (legitimate skip — exports must not embed plaintext secrets) |
| `ResourceState::from_provider_state` (`carina-state/src/state/mod.rs`) | propagated the legacy `Ok(<debug-string>)` into state JSON | `?`-propagates the new Err |

### Out of scope

- WASM-boundary `core_to_wit_value` `ResourceRef` debug-format fallback is **intentionally left as-is**. Managed-to-managed refs (e.g. `admins.group_id`) genuinely arrive at the WASM boundary at plan time and the executor resolves them at apply time. The doc comment now references companion issue #2387, which proposes extending RFC #2371 stage 2's `strip_unknown_attributes` pass to `ResourceRef` so this fallback can also become a typed `Err`.

### Behaviour change

Any provider returning `Value::ResourceRef` (or `Value::Interpolation` / `Value::FunctionCall`) in `state.attributes` now produces a typed error rather than a debug-string in state JSON. `carina-provider-aws` and `carina-provider-awscc` do not do this; the new regression test in `carina-state/src/state/tests.rs` pins the contract. The plan-display path (`compute_export_diffs` in `plan.rs`) tolerates the new Err the same way it tolerated the old `Ok(None)` — `.ok().flatten()` maps both to `None`, so plan display is unchanged.

## Test plan

- [x] `cargo nextest run --workspace` — 2639 passed (+7 new tests)
- [x] `cargo test --workspace --doc` — exit 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] All 5 `scripts/check-*.sh` pass
- [x] Plan-display snapshots (`plan_snapshot_*`) unchanged — display path untouched
- [x] Real-infra smoke test against `~/tmp/carina-upstream-state/web` (UpstreamRef path) and `iam-roles` (deferred-for path): no regression. Plan display unchanged; `--out` produces the existing actionable error.

## New tests

- `value.rs`: `test_value_to_json_resource_ref_returns_err`, `test_value_to_json_resource_ref_with_field_path_returns_err`, `test_value_to_json_interpolation_returns_err`, `test_value_to_json_function_call_returns_err` (4 unit tests pinning the entry-point Err shape)
- `state_writeback.rs`: `resource_ref_returns_unresolved_err`, `interpolation_returns_unresolved_err`, `function_call_returns_unresolved_err`, `secret_returns_ok_none` (4 unit tests pinning each new variant + the legitimate Secret skip)
- `state/tests.rs`: `from_provider_state_rejects_resource_ref_in_provider_attributes` (1 regression test asserting the new Err propagates through state writeback)

## RFC #2371 wrap-up

Stage 1-4 already merged. This PR + companion #2387 (open) complete the typed-error surface for **all** `Value` variants that should never reach a serialization boundary at apply / state-writeback / plan-file write. After both merge, every JSON-serialization path enumerates `Value` variants in the type system; new variants force compile errors at every consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
