### PR TITLE
wasm-boundary: strip-and-restore Value::ResourceRef before core_to_wit_value (#2387)

### DIFF
--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -21,7 +21,7 @@ use carina_core::provider::{
     ProviderRouter,
 };
 use carina_core::resolver::{resolve_refs_for_plan, resolve_refs_with_state_and_remote};
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value, contains_resource_ref};
 use carina_core::schema::{SchemaRegistry, resolve_block_names};
 use carina_core::utils;
 use carina_core::validation;
@@ -421,12 +421,16 @@ impl<'a> PlanPreprocessor<'a> {
         current_states: &mut HashMap<ResourceId, State>,
         provider_configs: &[ProviderConfig],
     ) {
-        // RFC #2371 stage 2: strip `Value::Unknown`-bearing attributes
-        // before handing resources to the WASM provider boundary, then
-        // restore them after. The WASM boundary panics on `Value::Unknown`
-        // by design (RFC constraint c) — this strip-and-restore is the
-        // stage 2 obligation that keeps the constraint inviolate.
-        let stripped = strip_unknown_attributes(resources);
+        // RFC #2371 stage 2 + #2387: strip every attribute the WASM
+        // provider boundary refuses to serialize — `Value::Unknown`
+        // (#2378) and `Value::ResourceRef` plus the wrappers that hide
+        // a ref (`Interpolation` / `FunctionCall` / `Secret`-of-ref,
+        // #2387) — before `normalize_desired` runs, then restore them
+        // at their original index. After this pass, `core_to_wit_value`
+        // is type-system-enforced to never see either kind.
+        let stripped = strip_attributes_matching(resources, &|v| {
+            value_contains_unknown(v) || contains_resource_ref(v)
+        });
         // Hard assert (not debug_assert): RFC #2371 constraint b says
         // state files never carry `Value::Unknown`, and the
         // strip-and-restore design depends on it. A release-mode
@@ -447,7 +451,7 @@ impl<'a> PlanPreprocessor<'a> {
         }
         resolve_enum_aliases_with_ctx(self.ctx, resources);
         resolve_enum_aliases_in_states(self.ctx, current_states);
-        restore_unknown_attributes(resources, stripped);
+        restore_stripped_attributes(resources, stripped);
     }
 }
 
@@ -459,13 +463,25 @@ struct StrippedAttribute {
     value: carina_core::resource::Value,
 }
 
-/// Remove every attribute whose value is (or recursively contains)
-/// `Value::Unknown` from each resource's attribute map. Returns a
-/// per-resource record of what was removed, keyed by `ResourceId`, so
-/// `restore_unknown_attributes` can put them back at their original
-/// `IndexMap` position. See RFC #2371 stage 2 / #2377.
-fn strip_unknown_attributes(
+/// Remove every attribute whose value matches `predicate` from each
+/// resource's attribute map. Returns a per-resource record of what was
+/// removed, keyed by `ResourceId`, so [`restore_stripped_attributes`]
+/// can put them back at their original `IndexMap` position.
+///
+/// The single caller in `PlanPreprocessor::prepare` passes a unified
+/// predicate that covers two kinds the WASM provider boundary refuses
+/// to serialize:
+///
+/// - `value_contains_unknown` — `Value::Unknown` (RFC #2371 stage 2 /
+///   #2377)
+/// - `contains_resource_ref` — `Value::ResourceRef` plus the wrappers
+///   that recursively contain one (`Interpolation` / `FunctionCall` /
+///   `Secret` / nested `List` / `Map`); without this strip the
+///   `core_to_wit_value` `_` debug-format fallback would silently
+///   stringify the ref (#2387).
+fn strip_attributes_matching(
     resources: &mut [Resource],
+    predicate: &dyn Fn(&Value) -> bool,
 ) -> HashMap<ResourceId, Vec<StrippedAttribute>> {
     let mut out: HashMap<ResourceId, Vec<StrippedAttribute>> = HashMap::new();
     for resource in resources.iter_mut() {
@@ -476,7 +492,7 @@ fn strip_unknown_attributes(
             .iter()
             .enumerate()
             .filter_map(|(i, (k, v))| {
-                if value_contains_unknown(v) {
+                if predicate(v) {
                     Some((i, k.clone()))
                 } else {
                     None
@@ -505,12 +521,12 @@ fn strip_unknown_attributes(
     out
 }
 
-/// Counterpart to `strip_unknown_attributes`. Re-inserts each stripped
-/// attribute at its original index in the resource's attribute map.
-/// Attributes appended by `normalize_desired` (e.g. provider-injected
-/// defaults) end up after the original entries, which matches behavior
-/// pre-#2377 for non-Unknown attributes.
-fn restore_unknown_attributes(
+/// Counterpart to [`strip_attributes_matching`]. Re-inserts each
+/// stripped attribute at its original index in the resource's
+/// attribute map. Attributes appended by `normalize_desired` (e.g.
+/// provider-injected defaults) end up after the original entries,
+/// which matches behavior pre-#2377 for non-stripped attributes.
+fn restore_stripped_attributes(
     resources: &mut [Resource],
     mut stripped: HashMap<ResourceId, Vec<StrippedAttribute>>,
 ) {

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -572,7 +572,7 @@ fn strip_and_restore_unknown_attributes_round_trip() {
     let mut resources = vec![r];
     let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
 
-    let stripped = super::strip_unknown_attributes(&mut resources);
+    let stripped = super::strip_attributes_matching(&mut resources, &super::value_contains_unknown);
     // After strip: vpc_id and nested_unknown removed.
     let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
     assert_eq!(
@@ -584,7 +584,7 @@ fn strip_and_restore_unknown_attributes_round_trip() {
     let entries = stripped.values().next().unwrap();
     assert_eq!(entries.len(), 2);
 
-    super::restore_unknown_attributes(&mut resources, stripped);
+    super::restore_stripped_attributes(&mut resources, stripped);
     let order_after: Vec<String> = resources[0].attributes.keys().cloned().collect();
     assert_eq!(
         order_after, order_before,
@@ -655,12 +655,12 @@ fn restore_unknown_attributes_after_normalize_injection() {
         .insert("c".into(), Value::String("c-val".into()));
     let mut resources = vec![r];
 
-    let stripped = super::strip_unknown_attributes(&mut resources);
+    let stripped = super::strip_attributes_matching(&mut resources, &super::value_contains_unknown);
     // After strip: ["a", "c"]. Simulate normalize injecting "z".
     resources[0]
         .attributes
         .insert("z".into(), Value::String("z-val".into()));
-    super::restore_unknown_attributes(&mut resources, stripped);
+    super::restore_stripped_attributes(&mut resources, stripped);
 
     let order: Vec<String> = resources[0].attributes.keys().cloned().collect();
     assert_eq!(
@@ -696,7 +696,7 @@ fn strip_and_restore_for_expression_unknowns_round_trip() {
     let mut resources = vec![r];
     let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
 
-    let stripped = super::strip_unknown_attributes(&mut resources);
+    let stripped = super::strip_attributes_matching(&mut resources, &super::value_contains_unknown);
     let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
     assert_eq!(
         after_strip,
@@ -705,7 +705,7 @@ fn strip_and_restore_for_expression_unknowns_round_trip() {
     );
     assert_eq!(stripped.values().next().unwrap().len(), 3);
 
-    super::restore_unknown_attributes(&mut resources, stripped);
+    super::restore_stripped_attributes(&mut resources, stripped);
     let order_after: Vec<String> = resources[0].attributes.keys().cloned().collect();
     assert_eq!(
         order_after, order_before,
@@ -736,4 +736,124 @@ fn value_contains_unknown_covers_for_variants() {
     assert!(super::value_contains_unknown(&Value::List(vec![
         Value::Unknown(UnknownReason::ForValue),
     ])));
+}
+
+// ----- #2387: strip-and-restore round trip for ResourceRef -----
+
+#[test]
+fn strip_and_restore_resource_ref_round_trip() {
+    // The strip-and-restore pass must remove any attribute that
+    // recursively contains a `Value::ResourceRef` so the WASM
+    // boundary's `core_to_wit_value` never sees one (#2387). This
+    // mirrors the stage-2 `Value::Unknown` round-trip test for the
+    // ResourceRef predicate.
+    use carina_core::resource::{AccessPath, InterpolationPart, Value, contains_resource_ref};
+    use indexmap::IndexMap;
+
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
+    let path = AccessPath::with_fields("admins", "group_id", vec![]);
+    r.attributes
+        .insert("name".into(), Value::String("static".into()));
+    r.attributes
+        .insert("group_id".into(), Value::ResourceRef { path: path.clone() });
+    let mut nested_map: IndexMap<String, Value> = IndexMap::new();
+    nested_map.insert("ref".into(), Value::ResourceRef { path: path.clone() });
+    r.attributes.insert("policy".into(), Value::Map(nested_map));
+    r.attributes.insert(
+        "label".into(),
+        Value::Interpolation(vec![
+            InterpolationPart::Literal("prefix-".into()),
+            InterpolationPart::Expr(Value::ResourceRef { path: path.clone() }),
+        ]),
+    );
+    r.attributes.insert(
+        "joined".into(),
+        Value::FunctionCall {
+            name: "join".into(),
+            args: vec![
+                Value::String(",".into()),
+                Value::ResourceRef { path: path.clone() },
+            ],
+        },
+    );
+    r.attributes.insert(
+        "secret_ref".into(),
+        Value::Secret(Box::new(Value::ResourceRef { path: path.clone() })),
+    );
+    let mut resources = vec![r];
+    let order_before: Vec<String> = resources[0].attributes.keys().cloned().collect();
+
+    let stripped = super::strip_attributes_matching(&mut resources, &contains_resource_ref);
+    let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        after_strip,
+        vec!["name".to_string()],
+        "every attribute that recursively contains a ResourceRef must be stripped"
+    );
+    let entries = stripped.values().next().expect("one resource stripped");
+    assert_eq!(entries.len(), 5);
+
+    super::restore_stripped_attributes(&mut resources, stripped);
+    let order_after: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(
+        order_after, order_before,
+        "ResourceRef-bearing attributes must be restored at their original indices"
+    );
+    // Spot-check that the restored values are still typed (not coerced
+    // to a debug-format String — the failure mode #2387 prevents).
+    assert!(matches!(
+        resources[0].get_attr("group_id"),
+        Some(Value::ResourceRef { .. })
+    ));
+    assert!(matches!(
+        resources[0].get_attr("label"),
+        Some(Value::Interpolation(_))
+    ));
+    assert!(matches!(
+        resources[0].get_attr("joined"),
+        Some(Value::FunctionCall { .. })
+    ));
+    assert!(matches!(
+        resources[0].get_attr("secret_ref"),
+        Some(Value::Secret(_))
+    ));
+}
+
+#[test]
+fn strip_unified_predicate_covers_unknown_and_ref() {
+    // The `prepare` pass uses the unified predicate
+    // `value_contains_unknown(v) || contains_resource_ref(v)`. Verify
+    // it strips both kinds in a single pass, in original order.
+    use carina_core::resource::{AccessPath, UnknownReason, Value, contains_resource_ref};
+
+    let mut r = carina_core::resource::Resource::new("test.t", "n");
+    let path = AccessPath::with_fields("admins", "group_id", vec![]);
+    r.attributes
+        .insert("name".into(), Value::String("static".into()));
+    r.attributes.insert(
+        "vpc_id".into(),
+        Value::Unknown(UnknownReason::UpstreamRef {
+            path: AccessPath::with_fields("network", "vpc", vec!["vpc_id".into()]),
+        }),
+    );
+    r.attributes
+        .insert("group_id".into(), Value::ResourceRef { path: path.clone() });
+    let mut resources = vec![r];
+
+    let stripped = super::strip_attributes_matching(&mut resources, &|v| {
+        super::value_contains_unknown(v) || contains_resource_ref(v)
+    });
+    let after_strip: Vec<String> = resources[0].attributes.keys().cloned().collect();
+    assert_eq!(after_strip, vec!["name".to_string()]);
+    assert_eq!(stripped.values().next().unwrap().len(), 2);
+
+    super::restore_stripped_attributes(&mut resources, stripped);
+    assert!(matches!(
+        resources[0].get_attr("vpc_id"),
+        Some(Value::Unknown(_))
+    ));
+    assert!(matches!(
+        resources[0].get_attr("group_id"),
+        Some(Value::ResourceRef { .. })
+    ));
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -23,19 +23,21 @@ use crate::wasm_bindings::carina::provider::types as wit;
 /// List and Map values are serialized to JSON strings because WIT does
 /// not support recursive types.
 ///
-/// Returns `Err(SerializationError)` for `Value::Unknown` —
-/// `PlanPreprocessor::strip_unknown_attributes` must remove it before
-/// reaching this boundary.
+/// Returns `Err(SerializationError)` for `Value::Unknown`,
+/// `Value::ResourceRef`, `Value::Interpolation`, and
+/// `Value::FunctionCall`. The plan-time pipeline strips every attribute
+/// that recursively contains one of these via
+/// `PlanPreprocessor::prepare`'s strip-and-restore pass, so reaching
+/// any of these arms is a producer-side bug — the diagnostic identifies
+/// which variant leaked. See RFC #2371 stage 2 (#2378) for `Unknown`
+/// and #2387 for `ResourceRef` / `Interpolation` / `FunctionCall`.
 ///
-/// `ResourceRef`, `Interpolation`, `FunctionCall`, and `Secret` variants
-/// fall back to `format!("{v:?}")`. The fallback is *intentional* for
-/// managed-to-managed refs (e.g. `admins.group_id`) — those genuinely
-/// arrive unresolved at plan time and get resolved by the executor at
-/// apply time. Data source refs are resolved during refresh phase 2
-/// (#1683). The asymmetry with `Value::Unknown` (which is stripped
-/// before this point) is tracked by #2387 — extending the strip-and-
-/// restore pass to `ResourceRef` will let this fallback become an
-/// `UnresolvedResourceRef` Err too.
+/// `Value::Secret` still falls back to debug format here because the
+/// WASM provider needs to receive the *value* (so a creator like
+/// `aws.iam.User` can pass a generated password to the cloud API). The
+/// strip pass takes secrets-of-refs out of this path; a plain
+/// `Secret(String)` reaches the boundary intentionally. Tightening the
+/// secret path is out of scope for #2387.
 pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError> {
     match v {
         CoreValue::String(s) => Ok(wit::Value::StrVal(s.clone())),
@@ -62,11 +64,20 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
             reason: reason.clone(),
             context: SerializationContext::WasmBoundary,
         }),
-        // Managed-to-managed refs (e.g. `admins.group_id`) are expected
-        // here at plan time — they get resolved at apply time by the
-        // executor. Data source refs should have been resolved during
-        // refresh phase 2 (#1683).
-        _ => Ok(wit::Value::StrVal(format!("{v:?}"))),
+        CoreValue::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
+            path: path.to_dot_string(),
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
+            name: name.clone(),
+            context: SerializationContext::WasmBoundary,
+        }),
+        // `Value::Secret(inner)` is expected at the WASM boundary for
+        // plain secret values — see the function doc for scope.
+        CoreValue::Secret(_) => Ok(wit::Value::StrVal(format!("{v:?}"))),
     }
 }
 
@@ -95,10 +106,9 @@ pub fn wit_to_core_value(v: &wit::Value) -> CoreValue {
 
 /// Helper: convert a core Value to a serde_json::Value for JSON
 /// encoding inside the WIT-string fallback for List/Map. Returns
-/// `Err` for `Value::Unknown`; falls back to `format!("{v:?}")` for
-/// `ResourceRef`/`Interpolation`/`FunctionCall`/`Secret` for the same
-/// reason as `core_to_wit_value` — see that function's doc and #2387
-/// for the planned tightening.
+/// `Err` for the same set of variants as `core_to_wit_value` — see
+/// that function's doc for the rationale and the strip-and-restore
+/// pass that keeps these arms unreachable in legitimate flows.
 fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationError> {
     match v {
         CoreValue::String(s) => Ok(serde_json::Value::String(s.clone())),
@@ -122,7 +132,18 @@ fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationE
             reason: reason.clone(),
             context: SerializationContext::WasmBoundary,
         }),
-        _ => Ok(serde_json::Value::String(format!("{v:?}"))),
+        CoreValue::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
+            path: path.to_dot_string(),
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::FunctionCall { name, .. } => Err(SerializationError::UnresolvedFunctionCall {
+            name: name.clone(),
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::Secret(_) => Ok(serde_json::Value::String(format!("{v:?}"))),
     }
 }
 
@@ -579,19 +600,81 @@ mod tests {
         assert_eq!(core, back);
     }
 
-    /// Unresolved `ResourceRef` falls back to debug format (#1687).
-    /// Managed-to-managed refs reach `core_to_wit_value` at plan time
-    /// via `normalize_desired` — they get resolved later by the executor.
+    /// #2387: `Value::ResourceRef` reaching `core_to_wit_value` is a
+    /// stage-2 invariant violation now — the strip-and-restore pass in
+    /// `PlanPreprocessor::prepare` removes any attribute that
+    /// recursively contains a `ResourceRef` before this boundary. The
+    /// converter returns `Err(UnresolvedResourceRef)` so a regression
+    /// surfaces as a typed error at the call site instead of a
+    /// debug-format string silently flowing into the provider.
     #[test]
-    fn core_to_wit_value_resource_ref_produces_debug_string() {
+    fn resource_ref_returns_err_in_core_to_wit_value() {
         use carina_core::resource::AccessPath;
-        let v = CoreValue::ResourceRef {
-            path: AccessPath::new("sso", "identity_store_id"),
+        let path = AccessPath::new("sso", "identity_store_id");
+        let v = CoreValue::ResourceRef { path: path.clone() };
+        let err = core_to_wit_value(&v).unwrap_err();
+        match err {
+            SerializationError::UnresolvedResourceRef {
+                path: p,
+                context: SerializationContext::WasmBoundary,
+            } => assert_eq!(p, path.to_dot_string()),
+            other => panic!("expected UnresolvedResourceRef/WasmBoundary, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interpolation_returns_err_in_core_to_wit_value() {
+        use carina_core::resource::{AccessPath, InterpolationPart};
+        let v = CoreValue::Interpolation(vec![
+            InterpolationPart::Literal("prefix-".into()),
+            InterpolationPart::Expr(CoreValue::ResourceRef {
+                path: AccessPath::new("vpc", "id"),
+            }),
+        ]);
+        let err = core_to_wit_value(&v).unwrap_err();
+        assert!(matches!(
+            err,
+            SerializationError::UnresolvedInterpolation {
+                context: SerializationContext::WasmBoundary,
+            }
+        ));
+    }
+
+    #[test]
+    fn function_call_returns_err_in_core_to_wit_value() {
+        use carina_core::resource::AccessPath;
+        let v = CoreValue::FunctionCall {
+            name: "join".into(),
+            args: vec![
+                CoreValue::String("-".into()),
+                CoreValue::ResourceRef {
+                    path: AccessPath::new("vpc", "id"),
+                },
+            ],
         };
-        let wit::Value::StrVal(s) = core_to_wit_value(&v).unwrap() else {
-            panic!("expected StrVal");
-        };
-        assert!(s.contains("ResourceRef"), "expected debug format, got: {s}");
+        let err = core_to_wit_value(&v).unwrap_err();
+        match err {
+            SerializationError::UnresolvedFunctionCall {
+                name,
+                context: SerializationContext::WasmBoundary,
+            } => assert_eq!(name, "join"),
+            other => panic!("expected UnresolvedFunctionCall/WasmBoundary, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resource_ref_returns_err_in_core_value_to_json() {
+        use carina_core::resource::AccessPath;
+        let path = AccessPath::new("sso", "identity_store_id");
+        let v = CoreValue::ResourceRef { path: path.clone() };
+        let err = core_value_to_json(&v).unwrap_err();
+        assert!(matches!(
+            err,
+            SerializationError::UnresolvedResourceRef {
+                context: SerializationContext::WasmBoundary,
+                ..
+            }
+        ));
     }
 
     // -- ResourceId roundtrip --

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -24,9 +24,7 @@ use carina_core::provider::{
     BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
     SavedAttrs,
 };
-use carina_core::resource::{
-    LifecycleConfig, Resource, ResourceId, State, Value, contains_resource_ref,
-};
+use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema};
 use carina_core::value::SerializationError;
 
@@ -43,13 +41,17 @@ fn early_provider_err<T: 'static>(e: SerializationError) -> BoxFuture<'static, P
     Box::pin(async move { Err(ProviderError::new(msg)) })
 }
 
-/// Unwrap a `core_to_wit_*` result that **must** succeed by invariant
-/// (state/saved attrs are post-apply concrete values; normalize_desired
-/// runs after `PlanPreprocessor::strip_unknown_attributes`). Embeds the
-/// failing `SerializationError` in the panic message so a stripping-pass
-/// regression surfaces with the actual `UnknownReason` + context.
-fn expect_no_unknown<T>(r: Result<T, SerializationError>, what: &'static str) -> T {
-    r.unwrap_or_else(|e| panic!("{what} must not see Value::Unknown ({e})"))
+/// Unwrap a `core_to_wit_*` result that **must** succeed by invariant.
+/// `core_to_wit_*` rejects every `Value` variant the WASM provider
+/// boundary cannot serialize — `Unknown`, `ResourceRef`,
+/// `Interpolation`, and `FunctionCall`. State and saved attrs are
+/// post-apply concrete values, and `normalize_desired` runs after
+/// `PlanPreprocessor::prepare`'s strip-and-restore pass, so reaching
+/// any of these arms is a producer-side bug. Embeds the failing
+/// `SerializationError` in the panic message so the regression
+/// surfaces with the actual variant + context.
+fn expect_unresolvable_absent<T>(r: Result<T, SerializationError>, what: &'static str) -> T {
+    r.unwrap_or_else(|e| panic!("{what} must not see an unserializable Value ({e})"))
 }
 
 // -- HTTP allow-list hooks --
@@ -1512,7 +1514,7 @@ unsafe impl Sync for WasmProviderNormalizer {}
 
 impl ProviderNormalizer for WasmProviderNormalizer {
     fn normalize_desired(&self, resources: &mut [Resource]) {
-        let wit_resources: Vec<_> = expect_no_unknown(
+        let wit_resources: Vec<_> = expect_unresolvable_absent(
             resources
                 .iter()
                 .map(wasm_convert::core_to_wit_resource)
@@ -1533,19 +1535,16 @@ impl ProviderNormalizer for WasmProviderNormalizer {
 
         match result {
             Ok(result) => {
+                // `PlanPreprocessor::prepare` strips every attribute that
+                // recursively contains `Value::ResourceRef` (alongside
+                // `Value::Unknown`) before this normalizer runs and
+                // restores them afterwards (#2387), so we can blindly
+                // accept everything the WASM normalizer returns — the
+                // pre-#2387 `contains_resource_ref` overwrite-skip
+                // workaround is no longer reachable.
                 for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
                     let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
                     for (key, value) in resolved {
-                        // Skip attributes whose original value contains a ResourceRef.
-                        // The WIT roundtrip converts ResourceRef to a debug string
-                        // (e.g., "ResourceRef { path: ... }") because the WIT Value type
-                        // has no ResourceRef variant. Overwriting would destroy the ref
-                        // and prevent resolution at apply time.
-                        if let Some(original) = core_res.attributes.get(&key)
-                            && contains_resource_ref(original)
-                        {
-                            continue;
-                        }
                         core_res.attributes.insert(key, value);
                     }
                 }
@@ -1558,8 +1557,10 @@ impl ProviderNormalizer for WasmProviderNormalizer {
         let wit_states: Vec<(String, _)> = current_states
             .iter()
             .map(|(id, state)| {
-                let wit =
-                    expect_no_unknown(wasm_convert::core_to_wit_state(state), "normalize_state");
+                let wit = expect_unresolvable_absent(
+                    wasm_convert::core_to_wit_state(state),
+                    "normalize_state",
+                );
                 (id.to_string(), wit)
             })
             .collect();
@@ -1597,7 +1598,7 @@ impl ProviderNormalizer for WasmProviderNormalizer {
         let wit_states: Vec<(String, _)> = current_states
             .iter()
             .map(|(id, state)| {
-                let wit = expect_no_unknown(
+                let wit = expect_unresolvable_absent(
                     wasm_convert::core_to_wit_state(state),
                     "hydrate_read_state (current_states)",
                 );
@@ -1608,7 +1609,7 @@ impl ProviderNormalizer for WasmProviderNormalizer {
         let wit_saved: Vec<(String, Vec<(String, _)>)> = saved_attrs
             .iter()
             .map(|(id, attrs)| {
-                let wit = expect_no_unknown(
+                let wit = expect_unresolvable_absent(
                     wasm_convert::core_to_wit_value_map(attrs),
                     "hydrate_read_state (saved_attrs)",
                 );


### PR DESCRIPTION
## Summary

- Extends RFC #2371 stage 2 strip-and-restore from `Value::Unknown` to also cover `Value::ResourceRef` and the wrappers that recursively hide one (`Interpolation`, `FunctionCall`, `Secret`-of-ref).
- After this pass, `core_to_wit_value` / `core_value_to_json` return `Err(SerializationError::Unresolved{ResourceRef,Interpolation,FunctionCall})` for these variants instead of falling through to `format!("{v:?}")`. The pre-#2387 `contains_resource_ref` overwrite-skip workaround in `WasmProviderNormalizer::normalize_desired` is no longer reachable and is removed.
- `Value::Secret(inner)` keeps its debug-format fallback at the WASM boundary; tightening the secret path is a separate concern out of scope for this PR.

## Design notes

- The single strip pass in `PlanPreprocessor::prepare` now uses a unified predicate `value_contains_unknown(v) || contains_resource_ref(v)`. The internal helper is renamed `strip_attributes_matching` (predicate-driven) with a sibling `restore_stripped_attributes`.
- `expect_no_unknown` is renamed `expect_unresolvable_absent` since it now also panics on a leaked `ResourceRef` / `Interpolation` / `FunctionCall` reaching state / saved-attrs serialization.
- `contains_resource_ref` (already in `carina-core::resource`) is reused — its recursion already covers every wrapper (List / Map / Interpolation / FunctionCall / Secret) and degrades to `false` on `Value::Unknown`, which is exactly the predicate semantics we need.

## Test plan

- [x] `cargo nextest run --workspace` (2644 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] Round-trip unit tests for the `ResourceRef` strip-and-restore added to `carina-cli/src/wiring/tests.rs` (mirrors the stage-2 `Value::Unknown` round-trip)
- [x] Typed-Err pin tests added to `carina-plugin-host/src/wasm_convert.rs` for `ResourceRef`, `Interpolation`, `FunctionCall`
- [x] Real-infra smoke test against `~/tmp/carina-upstream-state/web` (UpstreamRef -> `Value::Unknown` path)
- [x] Real-infra smoke test against a synthesized managed-to-managed ref fixture (SecurityGroup + VpcEndpoint with `security_group_ids = [primary.group_id]`) — plan succeeds, ref displays as `[primary.group_id]` correctly

Closes #2387

🤖 Generated with [Claude Code](https://claude.com/claude-code)