### PR TITLE
module-resolver: resolve cross-argument refs in default values (#2393)

### DIFF
--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -51,7 +51,17 @@ impl ModuleResolver<'_> {
             }
         }
 
-        // Build argument value map
+        // Build argument value map.
+        //
+        // Defaults may interpolate other arguments (#2393), e.g.
+        // `subject_patterns: list(String) = ["repo:${github_repo}:*"]`.
+        // The parser registers each argument as a placeholder ResourceRef
+        // binding while parsing the block, so the default lands here as a
+        // tree containing `Value::ResourceRef { binding: "<other_arg>" }`
+        // nodes. Resolve those against arguments processed so far, in
+        // declaration order, before storing — that way every downstream
+        // consumer (type check, validate, require, attribute substitution)
+        // sees a fully-resolved value.
         let mut argument_values: HashMap<String, Value> = HashMap::new();
         for arg in &module.arguments {
             let value = call
@@ -60,7 +70,13 @@ impl ModuleResolver<'_> {
                 .cloned()
                 .or_else(|| arg.default.clone())
                 .unwrap();
-            argument_values.insert(arg.name.clone(), value);
+            let mut resolved = substitute_arguments(&value, &argument_values);
+            // Substitution may turn an `Interpolation` whose parts now hold
+            // only literal scalars into a flat `String`; canonicalize so
+            // downstream consumers (type check, validate, plan rendering)
+            // see the collapsed form rather than a single-Expr Interpolation.
+            resolved.canonicalize_in_place();
+            argument_values.insert(arg.name.clone(), resolved);
         }
 
         // Type-check argument values against declared types

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -2314,6 +2314,347 @@ fn test_load_module_directory_merges_sibling_files_with_main() {
     let _ = fs::remove_dir_all(&tmp_dir);
 }
 
+/// Helper for #2393 regression tests: write a module body and a calling
+/// root body to a tempdir, parse and resolve, return the parsed root with
+/// modules expanded. Mirrors the directory-scoped fixture shape required by
+/// CLAUDE.md so single-file thinking can't sneak back in.
+fn resolve_default_arg_fixture(module_body: &str, root_body: &str) -> ParsedFile {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let module_dir = tmp.path().join("modules/m");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(module_dir.join("main.crn"), module_body).unwrap();
+
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(root_dir.join("main.crn"), root_body).unwrap();
+
+    let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+    resolve_modules(&mut parsed, &root_dir).expect("resolve_modules should succeed");
+    parsed
+}
+
+fn role_attr<'a>(parsed: &'a ParsedFile, attr: &str) -> &'a Value {
+    parsed
+        .resources
+        .iter()
+        .find(|r| r.id.resource_type == "iam.Role")
+        .expect("Role resource should exist")
+        .get_attr(attr)
+        .unwrap_or_else(|| panic!("Role.{attr} should exist"))
+}
+
+// Regression for #2393. A module argument default that interpolates another
+// argument (`["repo:${github_repo}:*"]`) must resolve `${github_repo}` against
+// the caller-provided value, not leave it as the literal binding name.
+#[test]
+fn test_argument_default_interpolates_other_arguments() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  github_repo     : String
+  subject_patterns: list(String) = ["repo:${github_repo}:*"]
+}
+
+let role = awscc.iam.Role {
+  role_name = 'r'
+  assume_role_policy_document = {
+    patterns = subject_patterns
+  }
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {
+  github_repo = 'carina-rs/infra'
+}
+"#,
+    );
+
+    let policy = role_attr(&parsed, "assume_role_policy_document");
+    let Value::Map(policy_map) = policy else {
+        panic!("assume_role_policy_document should be a Map, got {policy:?}");
+    };
+    let patterns = policy_map.get("patterns").expect("patterns should exist");
+    let Value::List(items) = patterns else {
+        panic!("patterns should be a List, got {patterns:?}");
+    };
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0],
+        Value::String("repo:carina-rs/infra:*".to_string()),
+        "default's ${{github_repo}} interpolation must resolve against the caller's value"
+    );
+}
+
+// #2393 — block-form default with `${other_arg}` interpolation must also
+// resolve, not just the simple `name: T = expr` form.
+#[test]
+fn test_argument_default_block_form_interpolates_other_arguments() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  github_repo: String
+  subject_pattern: String {
+    description = "subject pattern"
+    default     = "repo:${github_repo}:*"
+  }
+}
+
+let role = awscc.iam.Role {
+  role_name                   = subject_pattern
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {
+  github_repo = 'carina-rs/infra'
+}
+"#,
+    );
+
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("repo:carina-rs/infra:*".to_string()),
+        "block-form default's `${{github_repo}}` must resolve against the caller's value"
+    );
+}
+
+// #2393 — bare-identifier default (`b: String = a`, no `${}` wrapping) is a
+// `Value::ResourceRef { binding: "a" }` after parse and must resolve to the
+// caller-supplied value of `a`.
+#[test]
+fn test_argument_default_bare_identifier_resolves() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  primary  : String
+  secondary: String = primary
+}
+
+let role = awscc.iam.Role {
+  role_name                   = secondary
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {
+  primary = 'p'
+}
+"#,
+    );
+
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("p".to_string()),
+        "bare-identifier default `secondary = primary` must resolve to caller's `primary`"
+    );
+}
+
+// #2393 — transitive default chain `a → b → c`. Each default is resolved
+// against arguments already in scope, so by the time `c = "${b}!"` is
+// resolved, `b` has been canonicalized to a flat string `"X-X"`. Pinning
+// this is important because removing the `canonicalize_in_place` call in
+// the expander would produce a nested `Interpolation` in `c` that no
+// downstream consumer flattens.
+#[test]
+fn test_argument_default_transitive_chain_resolves() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  a: String = 'X'
+  b: String = "${a}-${a}"
+  c: String = "${b}!"
+}
+
+let role = awscc.iam.Role {
+  role_name                   = c
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {}
+"#,
+    );
+
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("X-X!".to_string()),
+        "transitive default chain `a → b → c` must collapse to a flat string"
+    );
+}
+
+// #2393 — interpolation nested inside a Map value within a list default
+// must be resolved by `substitute_arguments`'s recursion through
+// List/Map/Interpolation arms.
+#[test]
+fn test_argument_default_nested_collection_interpolates() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  region : String
+  tags   : map(String) = {
+    managed_by = 'carina'
+    region     = "${region}-tag"
+  }
+}
+
+let role = awscc.iam.Role {
+  role_name                   = 'r'
+  assume_role_policy_document = {
+    tags = tags
+  }
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {
+  region = 'ap-northeast-1'
+}
+"#,
+    );
+
+    let policy = role_attr(&parsed, "assume_role_policy_document");
+    let Value::Map(policy_map) = policy else {
+        panic!("policy should be Map, got {policy:?}");
+    };
+    let tags = policy_map.get("tags").expect("tags should exist");
+    let Value::Map(tag_map) = tags else {
+        panic!("tags should be Map, got {tags:?}");
+    };
+    assert_eq!(
+        tag_map.get("region"),
+        Some(&Value::String("ap-northeast-1-tag".to_string())),
+        "interpolation inside a nested map default must resolve recursively"
+    );
+}
+
+// #2393 — module with arguments but no defaults at all must work; the new
+// substitute+canonicalize pass is a no-op on caller-supplied scalars.
+#[test]
+fn test_argument_no_defaults_caller_scalars_pass_through() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  x: String
+  y: Int
+}
+
+let role = awscc.iam.Role {
+  role_name                   = x
+  assume_role_policy_document = {
+    y_value = y
+  }
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {
+  x = 'hello'
+  y = 42
+}
+"#,
+    );
+
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("hello".to_string()),
+    );
+    let policy = role_attr(&parsed, "assume_role_policy_document");
+    let Value::Map(policy_map) = policy else {
+        panic!("policy should be Map, got {policy:?}");
+    };
+    assert_eq!(policy_map.get("y_value"), Some(&Value::Int(42)));
+}
+
+// #2393 — argument defaults are resolved in declaration order; a default
+// that refers to a later-declared argument has no in-scope binding when its
+// expression is parsed and degrades to the literal identifier name. This
+// test pins the current behavior so any future change (e.g. moving to a
+// two-pass resolution that allows forward refs) is explicit.
+#[test]
+fn test_argument_default_forward_ref_degrades_to_literal() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  prefix: String = later
+  later : String = 'L'
+}
+
+let role = awscc.iam.Role {
+  role_name                   = prefix
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {}
+"#,
+    );
+
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("later".to_string()),
+        "forward-ref default falls back to the literal identifier name; \
+         resolution is order-sensitive (see #2393)"
+    );
+}
+
+// #2393 — caller-supplied ResourceRefs (cross-module data flow) must NOT be
+// substituted by the new default-resolution pass: their binding names are
+// not argument names, so they should pass through untouched until the outer
+// resolver rewrites them.
+#[test]
+fn test_argument_caller_resource_ref_passes_through() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  source_arn: String
+}
+
+let role = awscc.iam.Role {
+  role_name                   = source_arn
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let upstream = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+let m = use { source = '../modules/m' }
+
+m {
+  source_arn = upstream.arn
+}
+"#,
+    );
+
+    // Find the module's expanded `role` (the upstream Vpc has type Vpc, not Role).
+    let role_name = role_attr(&parsed, "role_name");
+    match role_name {
+        Value::ResourceRef { path } => {
+            assert_eq!(
+                path.binding(),
+                "upstream",
+                "caller's `upstream.arn` must remain a ResourceRef with binding=upstream"
+            );
+            assert_eq!(path.attribute(), "arn");
+        }
+        other => panic!("role_name should be a ResourceRef, got {other:?}"),
+    }
+}
+
 #[test]
 fn test_load_module_directory_merge_order_is_deterministic() {
     // Merged vectors must be ordered by file path so that downstream

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -12,17 +12,19 @@ use crate::parser::expressions::string_literal::parse_string_value;
 use crate::parser::expressions::validate_expr::parse_validate_expr;
 use crate::parser::parse_expression;
 use crate::parser::types::parse_type_expr;
-use crate::resource::{LifecycleConfig, Value};
+use crate::resource::{LifecycleConfig, Resource, Value};
 use indexmap::IndexMap;
 
-/// Parse arguments block
+/// Parse arguments block. See `register_argument_binding` for the
+/// incremental scoping discipline that lets a later argument's default
+/// expression reference earlier arguments (#2393).
 pub(in crate::parser) fn parse_arguments_block(
     pair: pest::iterators::Pair<Rule>,
     config: &ProviderContext,
+    ctx: &mut ParseContext,
     warnings: &mut Vec<ParseWarning>,
 ) -> Result<Vec<ArgumentParameter>, ParseError> {
     let mut arguments = Vec::new();
-    let ctx = ParseContext::new(config);
 
     for param in pair.into_inner() {
         if param.as_rule() == Rule::arguments_param {
@@ -36,13 +38,12 @@ pub(in crate::parser) fn parse_arguments_block(
                 warnings,
             )?;
 
-            // Check if the next element is a block form or simple default
+            let mut description = None;
+            let mut default = None;
+            let mut validations = Vec::new();
+
             if let Some(next) = param_inner.next() {
                 if next.as_rule() == Rule::arguments_param_block {
-                    // Block form: parse description, default, validate blocks from attrs
-                    let mut description = None;
-                    let mut default = None;
-                    let mut validations = Vec::new();
                     for attr in next.into_inner() {
                         if attr.as_rule() == Rule::arguments_param_attr {
                             let inner_attr =
@@ -51,7 +52,7 @@ pub(in crate::parser) fn parse_arguments_block(
                                 Rule::arg_description_attr => {
                                     let string_pair =
                                         first_inner(inner_attr, "string", "arg_description_attr")?;
-                                    let value = parse_string_value(string_pair, &ctx)?;
+                                    let value = parse_string_value(string_pair, ctx)?;
                                     if let Value::String(s) = value {
                                         description = Some(s);
                                     }
@@ -59,7 +60,7 @@ pub(in crate::parser) fn parse_arguments_block(
                                 Rule::arg_default_attr => {
                                     let expr_pair =
                                         first_inner(inner_attr, "expression", "arg_default_attr")?;
-                                    default = Some(parse_expression(expr_pair, &ctx)?);
+                                    default = Some(parse_expression(expr_pair, ctx)?);
                                 }
                                 Rule::arg_validation_block => {
                                     let mut rule = None;
@@ -88,7 +89,7 @@ pub(in crate::parser) fn parse_arguments_block(
                                                         "validation_error_message_attr",
                                                     )?;
                                                     let value =
-                                                        parse_string_value(string_pair, &ctx)?;
+                                                        parse_string_value(string_pair, ctx)?;
                                                     if let Value::String(s) = value {
                                                         error_msg = Some(s);
                                                     }
@@ -108,38 +109,36 @@ pub(in crate::parser) fn parse_arguments_block(
                             }
                         }
                     }
-                    arguments.push(ArgumentParameter {
-                        name,
-                        type_expr,
-                        default,
-                        description,
-                        validations,
-                    });
                 } else {
-                    // Simple form: the next element is the default expression
-                    let default = Some(parse_expression(next, &ctx)?);
-                    arguments.push(ArgumentParameter {
-                        name,
-                        type_expr,
-                        default,
-                        description: None,
-                        validations: Vec::new(),
-                    });
+                    // Simple form: the next element is the default expression itself.
+                    default = Some(parse_expression(next, ctx)?);
                 }
-            } else {
-                // No default, no block
-                arguments.push(ArgumentParameter {
-                    name,
-                    type_expr,
-                    default: None,
-                    description: None,
-                    validations: Vec::new(),
-                });
             }
+
+            register_argument_binding(ctx, &name);
+            arguments.push(ArgumentParameter {
+                name,
+                type_expr,
+                default,
+                description,
+                validations,
+            });
         }
     }
 
     Ok(arguments)
+}
+
+/// Register an argument name as a lexical binding so subsequent expressions
+/// (later argument defaults, resource bodies, etc.) resolve it as a
+/// `ResourceRef` placeholder rather than a literal string. Without this
+/// incremental registration, `${other_arg}` inside a default would have no
+/// in-scope binding and degrade to the literal string `"other_arg"` (#2393).
+fn register_argument_binding(ctx: &mut ParseContext, name: &str) {
+    let placeholder_ref = Value::resource_ref(name.to_string(), String::new(), vec![]);
+    ctx.set_variable(name.to_string(), placeholder_ref);
+    let placeholder = Resource::new("_argument", name);
+    ctx.set_resource_binding(name.to_string(), placeholder);
 }
 
 /// Parse attributes block

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -69,22 +69,22 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                 providers.push(provider);
                             }
                             Rule::arguments_block => {
-                                let parsed_arguments =
-                                    parse_arguments_block(stmt, config, &mut ctx.warnings)?;
-                                for arg in &parsed_arguments {
-                                    // Register argument names as lexical bindings so that
-                                    // `vpc.vpc_id` resolves as ResourceRef and `cidr_block`
-                                    // resolves as a variable reference during parsing.
-                                    // No `arguments.` prefix needed.
-                                    let placeholder_ref = Value::resource_ref(
-                                        arg.name.clone(),
-                                        String::new(),
-                                        vec![],
+                                // `parse_arguments_block` registers each argument as a
+                                // lexical binding inside `ctx` as it is parsed, so a
+                                // later argument's default expression can reference
+                                // earlier arguments (#2393).
+                                let parsed_arguments = {
+                                    let warnings = std::mem::take(&mut ctx.warnings);
+                                    let mut warnings = warnings;
+                                    let result = parse_arguments_block(
+                                        stmt,
+                                        config,
+                                        &mut ctx,
+                                        &mut warnings,
                                     );
-                                    ctx.set_variable(arg.name.clone(), placeholder_ref);
-                                    let placeholder = Resource::new("_argument", &arg.name);
-                                    ctx.set_resource_binding(arg.name.clone(), placeholder);
-                                }
+                                    ctx.warnings = warnings;
+                                    result?
+                                };
                                 arguments.extend(parsed_arguments);
                             }
                             Rule::attributes_block => {


### PR DESCRIPTION
Closes #2393.

## Summary

Module argument default values that interpolate another argument
(`subject_patterns: list(String) = ["repo:${github_repo}:*"]`) now
correctly resolve `${github_repo}` against the caller-supplied value
instead of leaving the literal identifier name in the rendered output.

## Why it broke

Two bugs in series:

1. **Parser**: `parse_arguments_block` registered argument names as
   in-scope bindings only *after* parsing the whole block, so an
   identifier inside an earlier argument's default expression had no
   binding to resolve against and silently degraded to
   `Value::String("github_repo")`.
2. **Expander**: defaults were inserted into `argument_values` raw, so
   any surviving `Value::ResourceRef { binding: <other_arg> }` flowed
   unresolved through type-check, validate, require, and attribute
   substitution.

## Fix

- `parser/blocks/attributes.rs` — `parse_arguments_block` now takes
  `&mut ParseContext` and registers each argument incrementally via a
  new `register_argument_binding` helper. A later argument's default
  expression can then reference earlier arguments via `${...}`
  interpolation or as a bare identifier.
- `parser/entry.rs` — drop the post-block registration loop (now
  handled inside `parse_arguments_block`).
- `module_resolver/expander.rs` — when building `argument_values`, run
  each value through `substitute_arguments` against arguments resolved
  so far, then `canonicalize_in_place`, before storing. Every
  downstream consumer (type check, validate, require, attribute
  substitution) sees a fully-resolved value.

Resolution is declaration-order; forward references degrade to literal
identifier strings (pinned by a regression test).

## Test plan

- [x] 8 new directory-fixture (`tempdir`) regression tests in
      `carina-core/src/module_resolver/tests.rs` covering: simple-form
      `${other}` interpolation (the original issue), block-form
      interpolation, bare-identifier default, transitive 3-arg chain
      (`a → b → c`), nested-collection default (`${a}` inside a map
      value), no-defaults caller scalar pass-through, forward-ref
      degradation, caller-supplied ResourceRef pass-through.
- [x] `cargo nextest run --workspace` (2656 tests) passes.
- [x] `cargo test --workspace --doc` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] All 5 `scripts/check-*.sh` CI gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
