### PR TITLE
fix: surface provider init errors as user-facing errors instead of panicking

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -539,7 +539,7 @@ pub async fn run_apply(
                     .find(|p| p.name == backend_provider_name)
                     .map(|p| p.attributes.clone())
                     .unwrap_or_default();
-                let bucket_provider = factory.create_provider(&provider_config_attrs).await;
+                let bucket_provider = factory.create_provider(&provider_config_attrs).await?;
 
                 match bucket_provider.create(bucket_resource).await {
                     Ok(_) => {
@@ -742,7 +742,7 @@ async fn run_apply_locked(
     apply_name_overrides(&mut parsed.resources, &state_file);
 
     // Select appropriate Provider based on configuration
-    let provider = get_provider_with_ctx(ctx, parsed, base_dir).await;
+    let provider = get_provider_with_ctx(ctx, parsed, base_dir).await?;
 
     // Upstream state bindings are loaded up front so refs that target
     // `upstream_state` blocks can be resolved during refresh (#1683).
@@ -1293,7 +1293,7 @@ async fn run_apply_from_plan_locked(
         .collect();
 
     // Create provider early for drift detection
-    let provider = create_providers_from_configs(&plan_file.provider_configs, base_dir).await;
+    let provider = create_providers_from_configs(&plan_file.provider_configs, base_dir).await?;
 
     // Drift detection: re-read actual infrastructure state and compare against planned states
     println!("{}", "Checking for infrastructure drift...".cyan());

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -174,7 +174,7 @@ async fn run_destroy_locked(
     }
 
     // Select appropriate Provider based on configuration
-    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await;
+    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await?;
 
     // Build current states -- either from provider (refresh=true) or from state file
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -541,7 +541,7 @@ async fn run_state_bucket_delete(
         .find(|p| p.name == backend_provider_name)
         .map(|p| p.attributes.clone())
         .unwrap_or_default();
-    let bucket_provider = factory.create_provider(&provider_config_attrs).await;
+    let bucket_provider = factory.create_provider(&provider_config_attrs).await?;
 
     // First, try to empty the bucket (delete all objects and versions)
     println!();
@@ -665,7 +665,7 @@ pub(crate) async fn run_state_refresh_locked(
     let sorted_resources = sort_resources_by_dependencies(&parsed.resources)?;
 
     // Select provider
-    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await;
+    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await?;
 
     println!();
     println!("{}", "Refreshing state...".cyan().bold());

--- a/carina-cli/src/error.rs
+++ b/carina-cli/src/error.rs
@@ -3,6 +3,117 @@
 use carina_core::provider::ProviderError;
 use carina_state::BackendError;
 
+/// Render a provider initialization error as user-facing text.
+///
+/// Detects the carina-provider-aws / carina-provider-awscc account
+/// guard message shape ("AWS account ID ... is not in ...
+/// allowed_account_ids ..." or "... in ... forbidden_account_ids ...")
+/// and reformats it as a structured block. Any other provider error
+/// flows through unchanged so the caller can still print it as
+/// `Error: {msg}` (#2407).
+///
+/// Returns `None` when the message does not match the account-guard
+/// shape; the caller should fall back to the generic display.
+pub fn format_account_guard_error(msg: &str, provider_name: Option<&str>) -> Option<String> {
+    // Both providers wrap the eventual error string; the carina-provider-awscc
+    // path tags it with "Provider initialization failed:" before the
+    // shared "AWS account ID ..." sentence. Strip that prefix if present
+    // so the structured renderer doesn't have to special-case it.
+    let stripped = msg
+        .strip_prefix("Provider initialization failed: ")
+        .unwrap_or(msg)
+        .trim();
+
+    let allowed = parse_account_guard_clause(stripped, "allowed_account_ids");
+    let forbidden = parse_account_guard_clause(stripped, "forbidden_account_ids");
+    let parsed = allowed.or(forbidden)?;
+
+    let provider = provider_name.unwrap_or("aws");
+    let kind_label = match parsed.kind {
+        AccountGuardKind::Allowed => "allowed_account_ids",
+        AccountGuardKind::Forbidden => "forbidden_account_ids",
+    };
+    let expected_summary = match parsed.kind {
+        AccountGuardKind::Allowed => format!("{} ({})", parsed.list_summary, kind_label),
+        AccountGuardKind::Forbidden => format!("not {} ({})", parsed.list_summary, kind_label),
+    };
+
+    let mut out = String::from("AWS account mismatch\n");
+    out.push_str(&format!("  Provider:    {}\n", provider));
+    out.push_str(&format!("  Expected:    {}\n", expected_summary));
+    out.push_str(&format!("  Actual:      {}\n", parsed.actual));
+    out.push_str(
+        "  Action:      Refusing to operate. Check AWS_PROFILE / aws-vault / SSO session.",
+    );
+    Some(out)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AccountGuardKind {
+    Allowed,
+    Forbidden,
+}
+
+#[derive(Debug)]
+struct AccountGuardClause {
+    kind: AccountGuardKind,
+    actual: String,
+    /// Comma-separated rendering of the configured list, with surrounding
+    /// brackets and quotes stripped — e.g. `151116838382`.
+    list_summary: String,
+}
+
+/// Look for `AWS account ID '<id>' is (not) in (the provider's)?
+/// <kind> [...]` or the plain-quote variant produced by
+/// carina-provider-aws ("AWS account ID 019115212452 ..."). Returns
+/// the parsed pieces if `kind` matches.
+fn parse_account_guard_clause(msg: &str, kind: &str) -> Option<AccountGuardClause> {
+    if !msg.contains(kind) {
+        return None;
+    }
+    let after_id = msg.strip_prefix("AWS account ID ")?;
+    // Account ID may be quoted (awscc shape) or unquoted (aws shape).
+    let (account, rest) = if let Some(quoted) = after_id.strip_prefix('\'') {
+        let end = quoted.find('\'')?;
+        (&quoted[..end], &quoted[end + 1..])
+    } else {
+        let end = after_id.find(' ')?;
+        (&after_id[..end], &after_id[end..])
+    };
+    let rest = rest.trim_start();
+
+    let guard_kind = if rest.starts_with("is not in") {
+        AccountGuardKind::Allowed
+    } else if rest.starts_with("is in") || rest.starts_with("is listed in") {
+        AccountGuardKind::Forbidden
+    } else {
+        return None;
+    };
+
+    // Match the kind we were asked to detect.
+    match (guard_kind, kind) {
+        (AccountGuardKind::Allowed, "allowed_account_ids") => {}
+        (AccountGuardKind::Forbidden, "forbidden_account_ids") => {}
+        _ => return None,
+    }
+
+    // Extract `["..."]` style list. Both providers debug-format a Vec<String>.
+    let bracket_start = rest.find('[')?;
+    let bracket_end = rest[bracket_start..].find(']')?;
+    let inner = &rest[bracket_start + 1..bracket_start + bracket_end];
+    let summary = inner
+        .split(',')
+        .map(|s| s.trim().trim_matches('"').to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Some(AccountGuardClause {
+        kind: guard_kind,
+        actual: account.to_string(),
+        list_summary: summary,
+    })
+}
+
 /// Typed error enum for carina-cli operations
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
@@ -118,5 +229,104 @@ mod tests {
     fn implements_std_error() {
         let app_err = AppError::Validation("test".to_string());
         let _: &dyn std::error::Error = &app_err;
+    }
+
+    // -- account-guard formatter tests (#2407) --
+
+    /// The exact message shape produced by carina-provider-awscc's
+    /// `account_guard.rs::validate_account_against_lists` once it has
+    /// been wrapped by `CarinaProvider::initialize` with the
+    /// "Provider initialization failed: " prefix.
+    const AWSCC_ALLOWED_MISMATCH: &str = "Provider initialization failed: AWS account ID '019115212452' is not in the \
+         provider's allowed_account_ids [\"151116838382\"]. Refusing to operate \
+         against this account. Check the AWS credentials in your environment.";
+
+    /// The shape produced by carina-provider-aws's
+    /// `account_guard.rs::check_account_id` (no prefix, unquoted ID).
+    const AWS_ALLOWED_MISMATCH: &str = "AWS account ID 019115212452 is not in allowed_account_ids [\"151116838382\"]; \
+         refusing to operate against this account";
+
+    #[test]
+    fn account_guard_formatter_recognizes_awscc_allowed_mismatch() {
+        let out = format_account_guard_error(AWSCC_ALLOWED_MISMATCH, Some("aws"))
+            .expect("awscc allowed mismatch should match");
+        assert!(
+            out.contains("AWS account mismatch"),
+            "header missing: {out}"
+        );
+        assert!(out.contains("Provider:    aws"), "provider missing: {out}");
+        assert!(
+            out.contains("Expected:    151116838382 (allowed_account_ids)"),
+            "expected line missing: {out}"
+        );
+        assert!(
+            out.contains("Actual:      019115212452"),
+            "actual line missing: {out}"
+        );
+        assert!(out.contains("Action:"), "action line missing: {out}");
+        // Must NOT leak hosting-mechanism details.
+        assert!(!out.contains("WASM"), "must not leak WASM detail: {out}");
+        assert!(!out.contains("panicked"), "must not surface panic: {out}");
+        assert!(
+            !out.contains("RUST_BACKTRACE"),
+            "must not surface backtrace hint: {out}"
+        );
+    }
+
+    #[test]
+    fn account_guard_formatter_recognizes_aws_allowed_mismatch() {
+        let out = format_account_guard_error(AWS_ALLOWED_MISMATCH, Some("aws"))
+            .expect("aws allowed mismatch should match");
+        assert!(
+            out.contains("Expected:    151116838382 (allowed_account_ids)"),
+            "expected line missing: {out}"
+        );
+        assert!(
+            out.contains("Actual:      019115212452"),
+            "actual line missing: {out}"
+        );
+    }
+
+    #[test]
+    fn account_guard_formatter_recognizes_forbidden_mismatch() {
+        let msg = "Provider initialization failed: AWS account ID '019115212452' is listed \
+                   in the provider's forbidden_account_ids [\"019115212452\"]. \
+                   Refusing to operate against this account. \
+                   Check the AWS credentials in your environment.";
+        let out = format_account_guard_error(msg, Some("awscc"))
+            .expect("forbidden mismatch should match");
+        assert!(
+            out.contains("Provider:    awscc"),
+            "provider missing: {out}"
+        );
+        assert!(out.contains("forbidden_account_ids"), "kind missing: {out}");
+    }
+
+    #[test]
+    fn account_guard_formatter_returns_none_for_unrelated_error() {
+        // Generic provider init failure (e.g. invalid region, missing
+        // creds chain) MUST NOT be coerced into the structured shape —
+        // callers fall back to the generic `Error: {msg}` rendering.
+        let msg = "Provider initialization failed: failed to load AWS credentials \
+                   from the environment";
+        assert!(format_account_guard_error(msg, Some("aws")).is_none());
+    }
+
+    #[test]
+    fn account_guard_formatter_returns_none_for_validation_error() {
+        let msg = "invalid region 'foo-bar-1'";
+        assert!(format_account_guard_error(msg, None).is_none());
+    }
+
+    #[test]
+    fn account_guard_formatter_handles_multi_id_list() {
+        let msg = "AWS account ID '019115212452' is not in the provider's \
+                   allowed_account_ids [\"111111111111\", \"222222222222\"]. \
+                   Refusing to operate against this account.";
+        let out = format_account_guard_error(msg, Some("aws")).expect("multi-id list should match");
+        assert!(
+            out.contains("Expected:    111111111111, 222222222222 (allowed_account_ids)"),
+            "expected list missing: {out}"
+        );
     }
 }

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -335,8 +335,7 @@ async fn main() {
                 }
             }
             Err(e) => {
-                eprint!("{}", format_error_lines(&e.to_string()));
-                std::process::exit(1);
+                handle_app_error(e);
             }
         }
         return;
@@ -452,17 +451,51 @@ async fn main() {
     };
 
     if let Err(e) = result {
-        match e {
-            error::AppError::Interrupted => {
-                // Exit code 130 = 128 + 2 (SIGINT), the Unix convention
-                std::process::exit(130);
-            }
-            _ => {
-                eprint!("{}", format_error_lines(&e.to_string()));
-                std::process::exit(1);
+        handle_app_error(e);
+    }
+}
+
+/// Outcome of rendering an `AppError`: the text to write to stderr
+/// and the exit code to terminate with.
+struct AppErrorRendering {
+    stderr: String,
+    exit_code: i32,
+}
+
+/// Pure rendering of `AppError`. Split out from `handle_app_error` so
+/// the formatting can be tested without invoking `process::exit`.
+fn render_app_error(e: &error::AppError) -> AppErrorRendering {
+    match e {
+        error::AppError::Interrupted => AppErrorRendering {
+            stderr: String::new(),
+            // Exit code 130 = 128 + 2 (SIGINT), the Unix convention
+            exit_code: 130,
+        },
+        error::AppError::Provider(pe) => {
+            let body = error::format_account_guard_error(&pe.message, pe.provider_name.as_deref())
+                .unwrap_or_else(|| e.to_string());
+            AppErrorRendering {
+                stderr: format_error_lines(&body),
+                exit_code: 1,
             }
         }
+        _ => AppErrorRendering {
+            stderr: format_error_lines(&e.to_string()),
+            exit_code: 1,
+        },
     }
+}
+
+/// Render a top-level `AppError` and exit. Provider init failures get
+/// the structured account-guard rendering when the message shape
+/// matches; everything else falls through to the generic `Error: ...`
+/// formatter (#2407).
+fn handle_app_error(e: error::AppError) -> ! {
+    let rendering = render_app_error(&e);
+    if !rendering.stderr.is_empty() {
+        eprint!("{}", rendering.stderr);
+    }
+    std::process::exit(rendering.exit_code);
 }
 
 fn format_error_lines(msg: &str) -> String {
@@ -491,5 +524,122 @@ mod error_format_tests {
         colored::control::set_override(false);
         let result = format_error_lines("first error\nsecond error");
         assert_eq!(result, "Error: first error\nError: second error\n");
+    }
+
+    // -- #2407 acceptance: AppError -> stderr rendering --
+
+    #[test]
+    fn provider_account_guard_renders_structured_block() {
+        colored::control::set_override(false);
+        let pe = carina_core::provider::ProviderError::new(
+            "Provider initialization failed: AWS account ID '019115212452' \
+             is not in the provider's allowed_account_ids [\"151116838382\"]. \
+             Refusing to operate against this account. \
+             Check the AWS credentials in your environment.",
+        );
+        let app_err: error::AppError = pe.into();
+        let r = render_app_error(&app_err);
+        assert_eq!(r.exit_code, 1);
+        assert!(
+            r.stderr.contains("AWS account mismatch"),
+            "header missing: {}",
+            r.stderr
+        );
+        assert!(
+            r.stderr
+                .contains("Expected:    151116838382 (allowed_account_ids)"),
+            "expected line missing: {}",
+            r.stderr
+        );
+        assert!(
+            r.stderr.contains("Actual:      019115212452"),
+            "actual line missing: {}",
+            r.stderr
+        );
+        // Acceptance criteria from #2407.
+        assert!(
+            !r.stderr.contains("panicked"),
+            "must not surface panic framing: {}",
+            r.stderr
+        );
+        assert!(
+            !r.stderr.contains("RUST_BACKTRACE"),
+            "must not surface backtrace hint: {}",
+            r.stderr
+        );
+        assert!(
+            !r.stderr.contains("WASM provider instance"),
+            "must not leak WASM hosting detail: {}",
+            r.stderr
+        );
+        assert!(
+            !r.stderr.contains("wasm_factory.rs"),
+            "must not surface source-file path: {}",
+            r.stderr
+        );
+    }
+
+    #[test]
+    fn provider_non_account_guard_falls_back_to_plain_error() {
+        // Generic provider init failures (invalid region, missing
+        // credentials chain, etc.) must still be surfaced — just not
+        // through the structured account-guard renderer.
+        colored::control::set_override(false);
+        let pe = carina_core::provider::ProviderError::new(
+            "Provider initialization failed: failed to load AWS credentials \
+             from the environment",
+        );
+        let app_err: error::AppError = pe.into();
+        let r = render_app_error(&app_err);
+        assert_eq!(r.exit_code, 1);
+        assert!(
+            r.stderr.starts_with("Error: "),
+            "missing Error: prefix, got: {}",
+            r.stderr
+        );
+        assert!(
+            r.stderr.contains("failed to load AWS credentials"),
+            "inner message missing: {}",
+            r.stderr
+        );
+        // Must NOT have promoted itself to the structured shape.
+        assert!(
+            !r.stderr.contains("AWS account mismatch"),
+            "non-account-guard must not be coerced into structured shape: {}",
+            r.stderr
+        );
+        // Acceptance: still no panic / backtrace / WASM leak.
+        assert!(!r.stderr.contains("panicked"));
+        assert!(!r.stderr.contains("RUST_BACKTRACE"));
+        assert!(!r.stderr.contains("WASM provider instance"));
+    }
+
+    #[test]
+    fn provider_account_guard_uses_attached_provider_name() {
+        // When the wiring layer has attached a provider name via
+        // ProviderError::for_provider, the structured renderer uses
+        // it instead of the "aws" default. Catches awscc-vs-aws
+        // mislabeling.
+        colored::control::set_override(false);
+        let pe = carina_core::provider::ProviderError::new(
+            "Provider initialization failed: AWS account ID '019115212452' \
+             is not in the provider's allowed_account_ids [\"151116838382\"]. \
+             Refusing to operate against this account.",
+        )
+        .for_provider("awscc");
+        let app_err: error::AppError = pe.into();
+        let r = render_app_error(&app_err);
+        assert!(
+            r.stderr.contains("Provider:    awscc"),
+            "provider label not picked up from ProviderError: {}",
+            r.stderr
+        );
+    }
+
+    #[test]
+    fn interrupted_error_renders_quietly_with_sigint_exit_code() {
+        let r = render_app_error(&error::AppError::Interrupted);
+        assert_eq!(r.exit_code, 130);
+        assert!(r.stderr.is_empty(), "interrupted stderr: {}", r.stderr);
     }
 }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -768,13 +768,13 @@ pub async fn get_provider_with_ctx<E>(
     ctx: &WiringContext,
     parsed: &carina_core::parser::File<E>,
     base_dir: &Path,
-) -> ProviderRouter {
+) -> Result<ProviderRouter, AppError> {
     let mut router = ProviderRouter::new();
 
     for provider_config in &parsed.providers {
         // If the provider has a source, load it as a WASM plugin
         if let Some(ref source) = provider_config.source {
-            try_add_source_provider(&mut router, source, provider_config, base_dir).await;
+            try_add_source_provider(&mut router, source, provider_config, base_dir).await?;
             continue;
         }
 
@@ -785,7 +785,10 @@ pub async fn get_provider_with_ctx<E>(
                 "{}",
                 format!("Using {} (region: {})", factory.display_name(), region).cyan()
             );
-            let provider = factory.create_provider(&provider_config.attributes).await;
+            let provider = factory
+                .create_provider(&provider_config.attributes)
+                .await
+                .map_err(|e| e.for_provider(provider_config.name.clone()))?;
             router.add_provider(provider_config.name.clone(), provider);
             router.add_normalizer(factory.create_normalizer(&provider_config.attributes).await);
         } else if !provider_config.name.is_empty() {
@@ -807,7 +810,7 @@ pub async fn get_provider_with_ctx<E>(
         router.add_provider(String::new(), Box::new(MockProvider::new()));
     }
 
-    router
+    Ok(router)
 }
 
 async fn try_add_source_provider(
@@ -815,7 +818,7 @@ async fn try_add_source_provider(
     source: &str,
     config: &ProviderConfig,
     base_dir: &Path,
-) {
+) -> Result<(), AppError> {
     match load_source_provider(source, config, base_dir).await {
         Ok((factory, provider, name)) => {
             let region = factory.extract_region(&config.attributes);
@@ -825,56 +828,84 @@ async fn try_add_source_provider(
             );
             router.add_provider(name, provider);
             router.add_normalizer(factory.create_normalizer(&config.attributes).await);
+            Ok(())
         }
-        Err(e) => {
+        Err(LoadSourceError::Provider(e)) => {
+            // Provider init failure (e.g. allowed_account_ids mismatch).
+            // Propagate verbatim so the CLI boundary can render it
+            // structurally without leaking implementation-detail
+            // wrappers like "Failed to load provider '...': ...".
+            // Attach provider name so the renderer can label the
+            // structured block with the right provider.
+            Err(AppError::Provider(e.for_provider(config.name.clone())))
+        }
+        Err(LoadSourceError::Other(msg)) => {
             eprintln!(
                 "{}",
-                format!("Failed to load provider '{}': {}", config.name, e).red()
+                format!("Failed to load provider '{}': {}", config.name, msg).red()
             );
+            Ok(())
         }
     }
+}
+
+/// Failure mode for `load_source_provider`. Distinguishing between a
+/// provider init rejection and other plumbing failures lets the caller
+/// surface the former as a structured error without the
+/// "Failed to load provider '...': ..." wrapper that obscures the
+/// real message (#2407).
+enum LoadSourceError {
+    /// The provider's `init` step rejected the configuration (e.g.,
+    /// `allowed_account_ids` mismatch). Message is user-facing.
+    Provider(ProviderError),
+    /// Plumbing failure: binary not found, unsupported source scheme,
+    /// invalid config, etc. Logged and skipped.
+    Other(String),
 }
 
 async fn load_source_provider(
     source: &str,
     config: &ProviderConfig,
     base_dir: &Path,
-) -> Result<(Box<dyn ProviderFactory>, Box<dyn Provider>, String), String> {
+) -> Result<(Box<dyn ProviderFactory>, Box<dyn Provider>, String), LoadSourceError> {
     let binary_path = if source.starts_with("file://") || source.starts_with("github.com/") {
         carina_provider_resolver::find_installed_provider(base_dir, config)
-            .map_err(|e| format!("Provider '{}' {}", config.name, e))?
+            .map_err(|e| LoadSourceError::Other(format!("Provider '{}' {}", config.name, e)))?
     } else {
-        return Err(format!(
+        return Err(LoadSourceError::Other(format!(
             "Unsupported source format: {source}. Use file:// for local binaries or github.com/owner/repo for remote."
-        ));
+        )));
     };
 
     if !carina_provider_resolver::is_wasm_provider(&binary_path) {
-        return Err(format!(
+        return Err(LoadSourceError::Other(format!(
             "Provider '{}': native binaries are no longer supported. Use a .wasm component instead.",
             config.name
-        ));
+        )));
     }
 
     let factory: Box<dyn ProviderFactory> = Box::new(
         carina_plugin_host::WasmProviderFactory::new(binary_path.clone())
             .await
-            .map_err(|e| format!("Failed to load WASM provider: {e}"))?,
+            .map_err(|e| LoadSourceError::Other(format!("Failed to load WASM provider: {e}")))?,
     );
     let name = factory.name().to_string();
 
     factory
         .validate_config(&config.attributes)
-        .map_err(|e| format!("Config validation failed: {e}"))?;
+        .map_err(|e| LoadSourceError::Other(format!("Config validation failed: {e}")))?;
 
-    let provider = factory.create_provider(&config.attributes).await;
+    let provider = factory
+        .create_provider(&config.attributes)
+        .await
+        .map_err(LoadSourceError::Provider)?;
     Ok((factory, provider, name))
 }
 
 pub async fn create_providers_from_configs(
     configs: &[ProviderConfig],
     base_dir: &Path,
-) -> ProviderRouter {
+) -> Result<ProviderRouter, AppError> {
     let (factories, _) = build_factories_from_providers(configs, base_dir);
     let ctx = WiringContext::new(factories);
     let mut router = ProviderRouter::new();
@@ -882,7 +913,7 @@ pub async fn create_providers_from_configs(
     for config in configs {
         // If the provider has a source, load it as a WASM plugin
         if let Some(ref source) = config.source {
-            try_add_source_provider(&mut router, source, config, base_dir).await;
+            try_add_source_provider(&mut router, source, config, base_dir).await?;
             continue;
         }
 
@@ -892,7 +923,10 @@ pub async fn create_providers_from_configs(
                 "{}",
                 format!("Using {} (region: {})", factory.display_name(), region).cyan()
             );
-            let provider = factory.create_provider(&config.attributes).await;
+            let provider = factory
+                .create_provider(&config.attributes)
+                .await
+                .map_err(|e| e.for_provider(config.name.clone()))?;
             router.add_provider(config.name.clone(), provider);
             router.add_normalizer(factory.create_normalizer(&config.attributes).await);
         }
@@ -903,7 +937,7 @@ pub async fn create_providers_from_configs(
         router.add_provider(String::new(), Box::new(MockProvider::new()));
     }
 
-    router
+    Ok(router)
 }
 
 /// Create a plan from parsed configuration (without upstream state bindings).
@@ -934,7 +968,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         sort_resources_by_dependencies(&parsed.resources).map_err(AppError::Validation)?;
 
     // Select appropriate Provider based on configuration
-    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await;
+    let provider = get_provider_with_ctx(&ctx, parsed, base_dir).await?;
 
     let mut current_states: HashMap<ResourceId, State> = HashMap::new();
 

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -183,8 +183,8 @@ impl ProviderFactory for TestProviderFactory {
     fn create_provider(
         &self,
         _attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn Provider>> {
-        Box::pin(async { Box::new(NoopProvider) as Box<dyn Provider> })
+    ) -> BoxFuture<'_, carina_core::provider::ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
     }
 
     fn create_normalizer(
@@ -818,8 +818,8 @@ impl ProviderFactory for WasmStyleProviderFactory {
     fn create_provider(
         &self,
         _attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn Provider>> {
-        Box::pin(async { Box::new(NoopProvider) as Box<dyn Provider> })
+    ) -> BoxFuture<'_, carina_core::provider::ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
     }
     fn create_normalizer(
         &self,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1288,14 +1288,7 @@ impl Provider for RecordingMockProvider {
         _id: &ResourceId,
         _identifier: Option<&str>,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async {
-            Err(ProviderError {
-                message: "not implemented".to_string(),
-                resource_id: None,
-                cause: None,
-                is_timeout: false,
-            })
-        })
+        Box::pin(async { Err(ProviderError::new("not implemented")) })
     }
 
     fn read_data_source(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
@@ -1317,14 +1310,7 @@ impl Provider for RecordingMockProvider {
         _from: &State,
         _to: &Resource,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async {
-            Err(ProviderError {
-                message: "not implemented".to_string(),
-                resource_id: None,
-                cause: None,
-                is_timeout: false,
-            })
-        })
+        Box::pin(async { Err(ProviderError::new("not implemented")) })
     }
 
     fn delete(
@@ -1333,14 +1319,7 @@ impl Provider for RecordingMockProvider {
         _identifier: &str,
         _lifecycle: &LifecycleConfig,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        Box::pin(async {
-            Err(ProviderError {
-                message: "not implemented".to_string(),
-                resource_id: None,
-                cause: None,
-                is_timeout: false,
-            })
-        })
+        Box::pin(async { Err(ProviderError::new("not implemented")) })
     }
 }
 

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -16,9 +16,15 @@ use crate::schema::SchemaRegistry;
 #[derive(Debug)]
 pub struct ProviderError {
     pub message: String,
-    pub resource_id: Option<ResourceId>,
+    pub resource_id: Option<Box<ResourceId>>,
     pub cause: Option<Box<dyn std::error::Error + Send + Sync>>,
     pub is_timeout: bool,
+    /// Optional provider name (e.g. `"aws"`, `"awscc"`) attached when
+    /// the error is raised at provider boundary points where the name
+    /// is known but no specific resource is in scope (e.g. provider
+    /// init / `create_provider`). Display ignores this field; CLI
+    /// renderers can read it to label structured output.
+    pub provider_name: Option<String>,
 }
 
 impl std::fmt::Display for ProviderError {
@@ -50,11 +56,12 @@ impl ProviderError {
             resource_id: None,
             cause: None,
             is_timeout: false,
+            provider_name: None,
         }
     }
 
     pub fn for_resource(mut self, id: ResourceId) -> Self {
-        self.resource_id = Some(id);
+        self.resource_id = Some(Box::new(id));
         self
     }
 
@@ -65,6 +72,15 @@ impl ProviderError {
 
     pub fn timeout(mut self) -> Self {
         self.is_timeout = true;
+        self
+    }
+
+    /// Attach a provider name (e.g. `"aws"`, `"awscc"`) for boundary
+    /// errors that don't carry a specific resource id (e.g.
+    /// `create_provider` / provider init failures). Used by the CLI
+    /// renderer to label structured account-guard output.
+    pub fn for_provider(mut self, provider_name: impl Into<String>) -> Self {
+        self.provider_name = Some(provider_name.into());
         self
     }
 }
@@ -434,10 +450,15 @@ pub trait ProviderFactory: Send + Sync {
     fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String;
 
     /// Create a provider instance from configuration attributes.
+    ///
+    /// Returns `Err(ProviderError)` when the provider rejects the
+    /// supplied configuration (e.g., an `allowed_account_ids` mismatch
+    /// detected during `init`). Callers MUST surface the inner message
+    /// verbatim — it is the user-facing error text.
     fn create_provider(
         &self,
         attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn Provider>>;
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>>;
 
     /// Create a normalizer instance from configuration attributes.
     ///
@@ -993,6 +1014,77 @@ mod tests {
                 .unwrap_err()
                 .message
                 .contains("Unknown provider: nonexistent")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_factory_create_provider_propagates_error() {
+        // Issue #2407: providers can fail to initialize on user input
+        // (e.g. allowed_account_ids mismatch). The trait method must
+        // return ProviderResult so the host can surface the error
+        // verbatim instead of panicking with .expect(...).
+        use crate::schema::ResourceSchema;
+
+        struct FailingFactory;
+
+        impl ProviderFactory for FailingFactory {
+            fn name(&self) -> &str {
+                "failing"
+            }
+            fn display_name(&self) -> &str {
+                "Failing provider"
+            }
+            fn provider_config_attribute_types(
+                &self,
+            ) -> HashMap<String, crate::schema::AttributeType> {
+                HashMap::new()
+            }
+            fn validate_config(&self, _attrs: &IndexMap<String, Value>) -> Result<(), String> {
+                Ok(())
+            }
+            fn extract_region(&self, _attrs: &IndexMap<String, Value>) -> String {
+                "us-east-1".to_string()
+            }
+            fn create_provider(
+                &self,
+                _attrs: &IndexMap<String, Value>,
+            ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+                Box::pin(async {
+                    Err(ProviderError::new(
+                        "AWS account ID '019115212452' is not in the provider's \
+                         allowed_account_ids [\"151116838382\"]. Refusing to operate \
+                         against this account. Check the AWS credentials in your environment.",
+                    ))
+                })
+            }
+            fn schemas(&self) -> Vec<ResourceSchema> {
+                Vec::new()
+            }
+        }
+
+        let factory = FailingFactory;
+        let result = factory.create_provider(&IndexMap::new()).await;
+        let err = match result {
+            Ok(_) => panic!("create_provider must surface the init error"),
+            Err(e) => e,
+        };
+        // Inner message must be preserved verbatim; no implementation-detail wrapper.
+        let msg = err.message;
+        assert!(
+            msg.contains("019115212452"),
+            "actual account missing: {msg}"
+        );
+        assert!(
+            msg.contains("allowed_account_ids"),
+            "kind label missing: {msg}"
+        );
+        assert!(
+            !msg.contains("WASM provider instance"),
+            "must not leak WASM hosting detail: {msg}"
+        );
+        assert!(
+            !msg.contains("panicked"),
+            "must not surface panic framing: {msg}"
         );
     }
 

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -287,10 +287,15 @@ pub fn json_to_provider_error(json: &str) -> carina_core::provider::ProviderErro
         carina_core::provider::ProviderError {
             message: proto_err.message,
             resource_id: proto_err.resource_id.map(|pid| {
-                CoreResourceId::with_provider(&pid.provider, &pid.resource_type, &pid.name)
+                Box::new(CoreResourceId::with_provider(
+                    &pid.provider,
+                    &pid.resource_type,
+                    &pid.name,
+                ))
             }),
             cause: None,
             is_timeout: proto_err.is_timeout,
+            provider_name: None,
         }
     } else {
         carina_core::provider::ProviderError {
@@ -298,6 +303,7 @@ pub fn json_to_provider_error(json: &str) -> carina_core::provider::ProviderErro
             resource_id: None,
             cause: None,
             is_timeout: false,
+            provider_name: None,
         }
     }
 }

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -1265,17 +1265,22 @@ impl ProviderFactory for WasmProviderFactory {
     fn create_provider(
         &self,
         attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn Provider>> {
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
         let attrs = attributes.clone();
         Box::pin(async move {
+            // Surface the inner error string verbatim — it carries the
+            // user-actionable message (e.g. allowed_account_ids
+            // mismatch) produced by the provider's init step. Adding a
+            // wrapper prefix here would leak the WASM hosting detail
+            // into the user-facing error (see #2407).
             let instance = self
                 .get_or_create_shared_instance(&attrs)
                 .await
-                .expect("Failed to create WASM provider instance");
-            Box::new(WasmProvider {
+                .map_err(ProviderError::new)?;
+            Ok(Box::new(WasmProvider {
                 instance,
                 name: self.name.clone(),
-            }) as Box<dyn Provider>
+            }) as Box<dyn Provider>)
         })
     }
 

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -66,7 +66,10 @@ async fn test_wasm_mock_provider_factory() {
 async fn test_wasm_mock_provider_create_and_read() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let provider = factory.create_provider(&indexmap::IndexMap::new()).await;
+    let provider = factory
+        .create_provider(&indexmap::IndexMap::new())
+        .await
+        .expect("provider should init");
 
     assert_eq!(provider.name(), "mock");
 
@@ -123,7 +126,10 @@ async fn test_wasm_mock_provider_create_and_read() {
 async fn test_wasm_mock_provider_update_and_delete() {
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let provider = factory.create_provider(&indexmap::IndexMap::new()).await;
+    let provider = factory
+        .create_provider(&indexmap::IndexMap::new())
+        .await
+        .expect("provider should init");
 
     let id = ResourceId::with_provider("mock", "test.resource", "updatable");
 
@@ -226,7 +232,10 @@ async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     // that flag shows up, the WASM bridge forwarded the call correctly.
     let path = skip_if_no_wasm!();
     let (factory, _cache) = load_factory(&path).await;
-    let provider = factory.create_provider(&indexmap::IndexMap::new()).await;
+    let provider = factory
+        .create_provider(&indexmap::IndexMap::new())
+        .await
+        .expect("provider should init");
 
     let mut resource = Resource::with_provider("mock", "test.data_source", "example");
     resource.attributes = indexmap::IndexMap::from([

--- a/carina-plugin-host/tests/wasm_precompile_test.rs
+++ b/carina-plugin-host/tests/wasm_precompile_test.rs
@@ -146,7 +146,10 @@ async fn test_precompiled_factory_creates_provider() {
         .expect("from_precompiled should succeed");
 
     // Verify the factory can actually create a working provider
-    let provider = factory.create_provider(&indexmap::IndexMap::new()).await;
+    let provider = factory
+        .create_provider(&indexmap::IndexMap::new())
+        .await
+        .expect("provider should init");
     assert_eq!(provider.name(), "mock");
 }
 


### PR DESCRIPTION
## Summary

- Trait `ProviderFactory::create_provider` now returns `ProviderResult<Box<dyn Provider>>` so user-input rejections from a provider's init step (e.g. `allowed_account_ids` mismatch) propagate as a structured error instead of `.expect(...)`-ing through `carina-plugin-host/src/wasm_factory.rs`.
- Adds a structured CLI renderer for the carina-provider-aws / carina-provider-awscc account-guard message shapes; non-account-guard provider init errors still surface as plain `Error: {msg}` with exit code 1.
- Adds `ProviderError::for_provider` so provider-boundary errors that have no specific resource id can carry the provider name; the wiring layer attaches it before propagation.

## Acceptance (from #2407)

- Triggering an `allowed_account_ids` mismatch produces a non-panic error message and exit code 1.
- The output does not mention `panicked at`, file:line of carina-plugin-host, `WASM provider instance`, or `RUST_BACKTRACE`.
- The same path works for any other provider init error (invalid region, missing credentials chain, etc.) — covered by `provider_non_account_guard_falls_back_to_plain_error`.

Example output for an `allowed_account_ids` mismatch:

```
Error: AWS account mismatch
Error:   Provider:    aws
Error:   Expected:    151116838382 (allowed_account_ids)
Error:   Actual:      019115212452
Error:   Action:      Refusing to operate. Check AWS_PROFILE / aws-vault / SSO session.
```

## Test plan

- [x] `cargo nextest run --workspace` (2667 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` + `bash scripts/validate-crn-files.sh`
- [x] New tests cover the trait change, the structured account-guard renderer (awscc-prefixed shape, aws-unprefixed shape, forbidden variant, multi-id list, fall-through case), and the top-level CLI rendering (no `panicked` / `RUST_BACKTRACE` / `WASM provider instance` / source-file path leaks).

Closes #2407

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>