### PR TITLE
fix: highlight single-quoted strings in tmLanguage grammar

### DIFF
--- a/carina-core/tests/tmlanguage_keyword_parity.rs
+++ b/carina-core/tests/tmlanguage_keyword_parity.rs
@@ -123,6 +123,41 @@ fn tmlanguage_has_pascal_case_type_pattern() {
     );
 }
 
+fn assert_grammar_has_single_quoted_string_pattern(path: &str) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let content = fs::read_to_string(manifest_dir.join(path)).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    let patterns = json
+        .pointer("/repository/strings/patterns")
+        .and_then(|v| v.as_array())
+        .unwrap_or_else(|| panic!("expected repository.strings.patterns array in {path}"));
+
+    let has_single_quoted = patterns.iter().any(|p| {
+        p.get("begin").and_then(|v| v.as_str()) == Some("'")
+            && p.get("end").and_then(|v| v.as_str()) == Some("'")
+    });
+    assert!(
+        has_single_quoted,
+        "{path} strings repository must include a single-quoted string \
+         pattern (begin: \"'\", end: \"'\"). Carina's pest grammar accepts \
+         single-quoted strings (e.g. 'arn:aws:...'); without this pattern, \
+         policy_document blocks render with no string highlighting and \
+         PascalCase tokens inside ARNs (Allow, PutObject) leak into the \
+         entity.name.type scope."
+    );
+}
+
+#[test]
+fn vscode_grammar_has_single_quoted_string_pattern() {
+    assert_grammar_has_single_quoted_string_pattern(VSCODE_GRAMMAR);
+}
+
+#[test]
+fn tmbundle_grammar_has_single_quoted_string_pattern() {
+    assert_grammar_has_single_quoted_string_pattern(TMBUNDLE_GRAMMAR);
+}
+
 #[test]
 fn vscode_and_tmbundle_grammars_are_byte_identical() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -86,6 +86,17 @@
               "match": "\\\\."
             }
           ]
+        },
+        {
+          "name": "string.quoted.single.carina",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.carina",
+              "match": "\\\\."
+            }
+          ]
         }
       ]
     },

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -86,6 +86,17 @@
               "match": "\\\\."
             }
           ]
+        },
+        {
+          "name": "string.quoted.single.carina",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.carina",
+              "match": "\\\\."
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary

- The pest grammar accepts both `'...'` and `"..."` strings, but the TextMate grammar only had a double-quoted pattern. Without a string scope on `'...'`, PascalCase tokens inside ARN values (`Allow`, `PutObject`, `GetObject`) were captured by the broad `entity.name.type` pattern, making `.crn` files with `policy_document` / `policy` blocks render with broken-looking, mostly-unscoped highlighting.
- Add `string.quoted.single.carina` (begin/end: `'`, with the same escape sub-pattern as the double-quoted variant) to both `editors/vscode/syntaxes/carina.tmLanguage.json` and the byte-identical mirror at `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json`.
- Add a regression test asserting the single-quote pattern exists in each grammar file.

The issue body's "begin/end pairs in nested blocks" hypothesis was a misdiagnosis — TextMate tokenization actually proceeds fine through deeply nested `{ }` / `[ ]` blocks; the visual breakage was the missing string scope letting PascalCase leak into type scope, not a parser bailout.

Closes #2408

## Test plan

- [x] `cargo nextest run -p carina-core --test tmlanguage_keyword_parity` — 6 passed
- [x] `cargo nextest run -p carina-core` — 1595 passed
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all green
- [x] Reproduced the bug locally with `vscode-textmate` against a fixture mirroring the issue's `policy_document`; confirmed `'arn:aws:...'` and `'Allow'` now receive `string.quoted.single.carina` instead of leaking into `entity.name.type.carina`

🤖 Generated with [Claude Code](https://claude.com/claude-code)