### PR TITLE
Surface VS Code extension dependency failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,3 +173,18 @@ install-lsp:
 	@echo "Installed $(INSTALL_DIR)/carina-lsp"
 
 .PHONY: install install-cli install-lsp
+
+# ---------------------------------------------------------------------------
+# VS Code extension packaging
+# ---------------------------------------------------------------------------
+#
+# `make vscode-package` builds a `.vsix` for the VS Code extension. Install
+# the result with: `code --install-extension editors/vscode/carina-X.Y.Z.vsix`.
+# Do NOT install by copying the source directory into ~/.vscode/extensions/ —
+# that path skips `npm install` and produces the silent activation failure
+# described in #2420.
+
+vscode-package:
+	cd editors/vscode && npm run package
+
+.PHONY: vscode-package

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,107 @@
+# Carina VS Code Extension
+
+Language support for the Carina DSL (`.crn` files): syntax highlighting,
+completions, and live diagnostics. The completion and diagnostic features
+are powered by the `carina-lsp` language server, which the extension
+launches as a child process.
+
+## Installation
+
+The extension is **not** published to the marketplace. Install from source.
+
+### 1. Build and install the LSP binary
+
+The extension launches `carina-lsp` from `PATH` by default. Install it
+with the repo's standard target:
+
+```bash
+make install-lsp
+```
+
+This places `carina-lsp` in `$HOME/.cargo/bin` (or wherever
+`INSTALL_DIR` points). Verify it is on `PATH`:
+
+```bash
+which carina-lsp
+```
+
+If it is not, add `$HOME/.cargo/bin` to `PATH`, or set
+`carina.server.path` in VS Code settings to an absolute path.
+
+### 2. Build the `.vsix`
+
+From the repo root:
+
+```bash
+make vscode-package
+```
+
+This runs `npm install`, compiles the TypeScript, and produces
+`editors/vscode/carina-<version>.vsix`.
+
+### 3. Install the `.vsix` into VS Code
+
+```bash
+code --install-extension editors/vscode/carina-0.1.0.vsix
+```
+
+Then **reload the VS Code window** (Command Palette →
+`Developer: Reload Window`). Open any `.crn` file and confirm the status
+bar shows "Carina" and that completions appear on Ctrl+Space.
+
+> [!IMPORTANT]
+> Do **not** install by copying `editors/vscode/` directly into
+> `~/.vscode/extensions/`. That path skips `npm install`, so
+> `node_modules/vscode-languageclient/` is missing at activation time
+> and the language client silently fails to start (#2420). Always go
+> through `code --install-extension <path-to-vsix>`.
+
+## Troubleshooting
+
+If completions or diagnostics never appear in `.crn` files:
+
+1. **Open the language server output channel.** In VS Code:
+   `View → Output`, then pick **Carina Language Server** from the
+   dropdown. Errors from `carina-lsp` and the language client appear
+   here.
+2. **Look for an error popup at activation.** The extension performs a
+   startup self-check (`tryStartLanguageClient` in
+   `src/extension.ts`); if loading `vscode-languageclient` fails or the
+   language client constructor throws, an error message is shown
+   directly with reinstall instructions. If you missed it, reload the
+   window to trigger activation again.
+3. **Confirm `carina-lsp` is on `PATH`.** Run `which carina-lsp` in a
+   terminal. If it is missing, run `make install-lsp` from the repo
+   root. If it lives somewhere unusual, set `carina.server.path` in VS
+   Code settings.
+4. **Confirm the file is tagged as `carina`.** Run
+   `Developer: Inspect Editor Tokens and Scopes` from the Command
+   Palette inside a `.crn` file. The language ID at the top should be
+   `carina`. If it is not, the LSP will not engage.
+5. **Reinstall from a fresh `.vsix`.** When in doubt:
+   ```bash
+   code --uninstall-extension mizzy.carina
+   make vscode-package
+   code --install-extension editors/vscode/carina-0.1.0.vsix
+   ```
+   then reload the window.
+
+## Development
+
+```bash
+cd editors/vscode
+npm install
+npm run watch     # incremental compile on save
+```
+
+In VS Code, press F5 in this directory to launch an Extension
+Development Host with the in-tree extension loaded; this picks up
+changes without producing a `.vsix`.
+
+## Future work
+
+#2421 will bundle the runtime dependency (`vscode-languageclient`) into
+`out/extension.js` with esbuild, eliminating the missing-`node_modules/`
+failure mode entirely. Once that lands, the startup self-check in
+`tryStartLanguageClient` becomes defense in depth — it should never
+trigger on a properly-built `.vsix`.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -50,7 +50,8 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "package": "npm install && npm run compile && npx --yes @vscode/vsce package"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,17 +1,50 @@
-import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
-import {
-  LanguageClient,
+import { workspace, window, ExtensionContext } from 'vscode';
+import type {
+  LanguageClient as LanguageClientType,
   LanguageClientOptions,
   ServerOptions,
 } from 'vscode-languageclient/node';
 
-let client: LanguageClient;
+let client: LanguageClientType | undefined;
 
-export function activate(context: ExtensionContext) {
-  // Get the server path from settings, or use 'carina-lsp' from PATH
-  const config = workspace.getConfiguration('carina');
-  const serverPath = config.get<string>('server.path') || 'carina-lsp';
+/**
+ * Attempt to load `vscode-languageclient/node` and start the LSP client.
+ *
+ * VS Code does NOT automatically surface exceptions thrown from `activate`
+ * to the user — the activation just silently fails. So when the runtime
+ * dependency is missing (e.g. the extension was installed by copying the
+ * source directory into `~/.vscode/extensions/` without running
+ * `npm install`), users see the language registration succeed but get
+ * zero completions and zero diagnostics, with no visible error.
+ *
+ * This helper isolates the dependency load so failures can be surfaced
+ * via `showError` and logged. Returns the started client on success, or
+ * `undefined` if the dependency is missing or the client failed to start.
+ *
+ * Factored out (and parameterised over `requireFn` and `showError`) so
+ * the failure path can be exercised without a real VS Code host.
+ */
+export function tryStartLanguageClient(
+  serverPath: string,
+  showError: (msg: string) => void,
+  requireFn: (id: string) => unknown = require,
+): LanguageClientType | undefined {
+  let mod: typeof import('vscode-languageclient/node');
+  try {
+    mod = requireFn('vscode-languageclient/node') as typeof import('vscode-languageclient/node');
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const msg =
+      'Carina extension dependencies are missing (failed to load ' +
+      "'vscode-languageclient'). Reinstall via: " +
+      'code --install-extension <path/to/carina-X.Y.Z.vsix>. ' +
+      "If you don't have a .vsix, build one with: " +
+      'cd editors/vscode && npm install && npx vsce package. ' +
+      `Underlying error: ${detail}`;
+    console.error('[carina] ' + msg);
+    showError(msg);
+    return undefined;
+  }
 
   const serverOptions: ServerOptions = {
     run: { command: serverPath },
@@ -25,14 +58,34 @@ export function activate(context: ExtensionContext) {
     },
   };
 
-  client = new LanguageClient(
-    'carina',
-    'Carina Language Server',
-    serverOptions,
-    clientOptions
-  );
+  try {
+    const started = new mod.LanguageClient(
+      'carina',
+      'Carina Language Server',
+      serverOptions,
+      clientOptions,
+    );
+    started.start();
+    return started;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    const msg =
+      'Carina language client failed to start: ' +
+      detail +
+      ". Check the 'Carina Language Server' output channel and verify " +
+      `that '${serverPath}' is on PATH (or set 'carina.server.path').`;
+    console.error('[carina] ' + msg);
+    showError(msg);
+    return undefined;
+  }
+}
 
-  client.start();
+export function activate(_context: ExtensionContext): void {
+  const config = workspace.getConfiguration('carina');
+  const serverPath = config.get<string>('server.path') || 'carina-lsp';
+  client = tryStartLanguageClient(serverPath, (msg) => {
+    void window.showErrorMessage(msg);
+  });
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
## Summary

Fixes the silent activation failure surfaced by #2420: when the Carina VS Code extension is installed without its `node_modules/` directory (e.g. by copying the source into `~/.vscode/extensions/`), VS Code shows "Carina" in the status bar but completions and diagnostics never appear, with no visible error.

The root cause: the compiled `extension.js` had a top-level `require('vscode-languageclient/node')` that threw at activation. VS Code does NOT auto-surface exceptions thrown from `activate`, so the failure was invisible.

This PR makes that failure mode loud and recoverable. #2421 will eliminate it entirely by bundling the runtime dependency with esbuild — at which point the self-check here becomes defense in depth.

## Changes

- `editors/vscode/src/extension.ts`: convert the static `import { LanguageClient ... }` to `import type` + a runtime `require` inside `tryStartLanguageClient`. When the require throws (or the language client constructor throws), the helper calls `vscode.window.showErrorMessage` with reinstall instructions and `console.error`s to the output channel.
- The bring-up is factored into `tryStartLanguageClient(serverPath, showError, requireFn)` so the failure path can be exercised by passing a deliberately-broken `requireFn` from a node REPL, without a real VS Code host.
- `editors/vscode/README.md` (new): canonical install flow plus a troubleshooting section.
- `Makefile` + `editors/vscode/package.json`: `make vscode-package` / `npm run package` produce the `.vsix` via one canonical command.

## Test plan

- [x] `npm run compile` — TypeScript compiles cleanly.
- [x] `npx @vscode/vsce package` — produces a `.vsix` containing `out/extension.js` and `node_modules/vscode-languageclient/`.
- [x] Compiled JS no longer has a top-level `require('vscode-languageclient/node')`; the only top-level require is `vscode` itself.
- [x] Failure-path smoke test: load the compiled extension in node with a stub `vscode` module and a broken `requireFn`; confirms `showErrorMessage` is called with the reinstall guidance and the function returns `undefined`.
- [x] `cargo check --workspace` clean (no Rust files touched, sanity only).
- [x] `bash scripts/check-*.sh` all pass.

## Out of scope

- Bundling the runtime deps into a single `extension.js` — that is the goal of #2421. This PR is the minimal change to make the failure mode visible.

Closes #2420
Refs #2421