### PR TITLE
Detect module call inside let-binding for completion

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -291,6 +291,24 @@ impl CompletionProvider {
                     module_name = Some(name.to_string());
                     resource_type.clear();
                 }
+            } else if brace_depth == 0
+                && trimmed.ends_with('{')
+                && let Some(name) = extract_let_module_call_name(trimmed)
+            {
+                // Named-binding module call: `let <binding> = <module-name> {`.
+                // The RHS is a bare identifier (not `use`, `upstream_state`, or
+                // a resource path), so this is a call into an imported module.
+                // Without this branch the line falls through both
+                // `extract_resource_type` (no schema match) and the anonymous
+                // module-call branch above (which excludes `let `), leaving
+                // `module_name` unset and the cursor classified as
+                // `InsideResourceBlock { resource_type: "" }` — which surfaces
+                // no candidates and lets VS Code fall back to word-based
+                // suggestions. See #2423.
+                module_name = Some(name);
+                resource_type.clear();
+                current_binding =
+                    crate::let_parse::parse_let_header(trimmed).map(|(n, _)| n.to_string());
             }
 
             // At brace_depth >= 1, detect nested block in two forms:
@@ -805,6 +823,42 @@ fn is_let_upstream_state_line(trimmed: &str) -> bool {
     // longer identifier like `upstream_states`.
     let next = rest.trim_start();
     next.starts_with('{') || next.is_empty()
+}
+
+/// If `trimmed` is a `let <binding> = <module-name> {` header (named-binding
+/// module call), return `<module-name>`. Otherwise return `None`.
+///
+/// Distinguished from the other `let` shapes:
+///   - `let x = use { ... }`         → handled by `is_let_use_line`
+///   - `let x = upstream_state { ... }` → handled by `is_let_upstream_state_line`
+///   - `let x = aws.ec2.Vpc { ... }` → handled by `extract_resource_type`
+///
+/// The RHS must be a bare ASCII identifier followed by `{` (with optional
+/// whitespace). Anything else — provider-prefixed paths, `read`, dotted
+/// expressions, function calls — is rejected so callers can rely on this
+/// only matching the module-call shape.
+fn extract_let_module_call_name(trimmed: &str) -> Option<String> {
+    let (_, rhs) = crate::let_parse::parse_let_header(trimmed)?;
+    let rhs = rhs.trim_end_matches('{').trim_end();
+    if rhs.is_empty() {
+        return None;
+    }
+    if !rhs.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+    // Reject reserved RHS keywords that have their own shapes.
+    if rhs == "use" || rhs == "upstream_state" || rhs == "read" {
+        return None;
+    }
+    // First char must be an identifier-start (not a digit).
+    if !rhs
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+    {
+        return None;
+    }
+    Some(rhs.to_string())
 }
 
 fn is_let_use_line(trimmed: &str) -> bool {

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -252,6 +252,90 @@ let bootstrap = github {
 }
 
 #[test]
+fn module_parameter_completion_for_multiline_use_block() {
+    // Regression test for the second bug uncovered by #2423: the real
+    // `carina-rs/infra` tree writes `let <name> = use { ... }` across
+    // multiple lines, with the `source = '...'` on its own line:
+    //
+    //   let github = use {
+    //     source = '../../../modules/github-oidc'
+    //   }
+    //
+    // `find_module_import_path` previously scanned line-by-line and only
+    // recognized the single-line form, so it returned `None` here and the
+    // user saw zero completions. The fix must scan across the body of the
+    // `use` block. This fixture mirrors the production module's
+    // `arguments { ... }` shape, including default values and dotted/list
+    // types.
+    use std::fs;
+    use tempfile::tempdir;
+
+    let provider = test_provider();
+
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let base_path = temp_dir.path();
+
+    let module_dir = base_path.join("modules").join("github-oidc");
+    fs::create_dir_all(&module_dir).expect("Failed to create module dir");
+
+    // Match the real-infra module shape (multi-arg, default value, list type).
+    let module_main = r#"arguments {
+  github_repo        : String
+  role_name          : String
+  managed_policy_arns: list(IamPolicyArn) = []
+  subject_patterns   : list(String)       = ["repo:${github_repo}:*"]
+}
+"#;
+    fs::write(module_dir.join("main.crn"), module_main).expect("Failed to write module main.crn");
+
+    // Main file uses the multi-line `use { ... }` form, exactly as the
+    // real infra writes it.
+    let main_content = r#"let github = use {
+  source = './modules/github-oidc'
+}
+
+let bootstrap = github {
+  gi
+}
+"#;
+    let doc = create_document(main_content);
+
+    // Cursor at end of `  gi` on line 5 (0-indexed).
+    let position = Position {
+        line: 5,
+        character: 4,
+    };
+
+    let completions = provider.complete(&doc, position, Some(base_path));
+
+    assert!(
+        !completions.is_empty(),
+        "Should have module parameter completions for multi-line `use {{ ... }}` block; \
+         got empty (the real-infra reproduction of #2423). \
+         Hint: `find_module_import_path` is line-by-line and won't find `source` on its own line."
+    );
+
+    let github_repo = completions.iter().find(|c| c.label == "github_repo");
+    assert!(
+        github_repo.is_some(),
+        "Should have github_repo parameter completion. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+
+    let role_name = completions.iter().find(|c| c.label == "role_name");
+    assert!(
+        role_name.is_some(),
+        "Should have role_name parameter completion"
+    );
+
+    let subject_patterns = completions.iter().find(|c| c.label == "subject_patterns");
+    assert!(
+        subject_patterns.is_some(),
+        "Should have subject_patterns parameter completion (default value with list type)"
+    );
+}
+
+#[test]
 #[ignore = "requires provider schemas"]
 fn instance_tenancy_completion_for_aws_vpc() {
     let provider = test_provider();

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -184,6 +184,74 @@ web_tier {
 }
 
 #[test]
+fn module_parameter_completion_for_let_binding_module_call() {
+    // Regression test for #2423: inside `let <name> = <module> { <CURSOR> }`,
+    // completion must surface the module's parameters (from `exports.crn` /
+    // `arguments { ... }`). Previously the context walker excluded *all*
+    // lines starting with `let `, so the named-binding form of a module
+    // call was misclassified and the LSP returned an empty array. VS Code
+    // then fell back to word-based suggestions.
+    use std::fs;
+    use tempfile::tempdir;
+
+    let provider = test_provider();
+
+    // Multi-file directory fixture per CLAUDE.md "Directory-scoped, never
+    // single-file" rule. Module lives in a sibling directory.
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let base_path = temp_dir.path();
+
+    let module_dir = base_path.join("modules").join("github-oidc");
+    fs::create_dir_all(&module_dir).expect("Failed to create module dir");
+
+    let module_arguments = r#"
+arguments {
+role_name: String
+policy_name: String
+repository: String
+}
+"#;
+    fs::write(module_dir.join("exports.crn"), module_arguments)
+        .expect("Failed to write module exports");
+
+    // Main file uses the let-binding form: `let bootstrap = github { ... }`.
+    let main_content = r#"let github = use { source = "./modules/github-oidc" }
+
+let bootstrap = github {
+  gi
+}
+"#;
+    let doc = create_document(main_content);
+
+    // Cursor at end of `  gi` on line 3.
+    let position = Position {
+        line: 3,
+        character: 4,
+    };
+
+    let completions = provider.complete(&doc, position, Some(base_path));
+
+    assert!(
+        !completions.is_empty(),
+        "Should have module parameter completions for `let X = module {{ ... }}` form, \
+         got empty (regression of #2423)"
+    );
+
+    let role_name = completions.iter().find(|c| c.label == "role_name");
+    assert!(
+        role_name.is_some(),
+        "Should have role_name parameter completion. Got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+
+    let policy_name = completions.iter().find(|c| c.label == "policy_name");
+    assert!(
+        policy_name.is_some(),
+        "Should have policy_name parameter completion"
+    );
+}
+
+#[test]
 #[ignore = "requires provider schemas"]
 fn instance_tenancy_completion_for_aws_vpc() {
     let provider = test_provider();

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -390,17 +390,24 @@ impl CompletionProvider {
         }
     }
 
-    /// Find the module `source` path for a given module binding from `let name = use { source = '...' }`.
+    /// Find the module `source` path for a given module binding from
+    /// `let <name> = use { source = '...' }`.
+    ///
+    /// Recognizes both the single-line shape and the multi-line shape:
+    ///
+    /// ```text
+    /// let github = use {
+    ///   source = '../../../modules/github-oidc'
+    /// }
+    /// ```
+    ///
+    /// The real `carina-rs/infra` tree always writes the multi-line form, so
+    /// scanning line-by-line and only looking at the `let` line itself misses
+    /// the `source` value entirely. We instead locate the `let <name> = use {`
+    /// header and then slurp the buffer up to the matching `}` to find
+    /// `source = '...'` anywhere inside.
     pub(super) fn find_module_import_path(&self, module_name: &str, text: &str) -> Option<String> {
-        for line in text.lines() {
-            if let Some((alias, after_eq)) = crate::let_parse::parse_let_header(line)
-                && alias == module_name
-                && let Some(path) = extract_use_source_path(after_eq)
-            {
-                return Some(path);
-            }
-        }
-        None
+        find_let_use_source(module_name, text)
     }
 
     /// Build a snippet for a module call with argument placeholders.
@@ -414,6 +421,9 @@ impl CompletionProvider {
         base_path: Option<&Path>,
     ) -> String {
         // Extract source path from "use { source = 'path' }" or with double quotes.
+        // Only the single-line shape is resolvable here — when the `use` body
+        // spans newlines, `after_eq` is just the line tail and we fall back
+        // to the no-source scaffold below.
         let import_path = extract_use_source_path(after_eq);
 
         if let Some(path) = import_path.as_deref()
@@ -441,18 +451,84 @@ impl CompletionProvider {
     }
 }
 
-/// Extract the `source` path from a `let` RHS of the shape `use { source = 'path' }`
-/// (or with double quotes). Returns `None` if `after_eq` doesn't look like a `use` block
-/// or if the `source` value can't be parsed.
-pub(super) fn extract_use_source_path(after_eq: &str) -> Option<String> {
-    let trimmed = after_eq.trim_start();
-    let rest = trimmed
-        .strip_prefix("use ")
-        .or_else(|| trimmed.strip_prefix("use{"))
-        .map(|s| s.trim_start_matches('{').trim_start())?;
+/// Find the `source` path for `let <module_name> = use { ... source = '...' ... }`
+/// anywhere in `text`, including the multi-line form where the body of the `use`
+/// block spans several lines.
+///
+/// The scan looks for a `let <module_name> = use {` opening, then walks forward
+/// tracking brace depth until the matching closing `}`. Inside that range the
+/// first `source = '<path>'` (or with double quotes) wins. Returns `None` if
+/// the binding isn't found, isn't a `use { ... }`, or has no parseable `source`.
+fn find_let_use_source(module_name: &str, text: &str) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let Some((alias, after_eq)) = crate::let_parse::parse_let_header(line) else {
+            continue;
+        };
+        if alias != module_name {
+            continue;
+        }
+        let trimmed = after_eq.trim_start();
+        // Recognize both `use {` and `use{` openings.
+        let body_head = match trimmed
+            .strip_prefix("use ")
+            .or_else(|| trimmed.strip_prefix("use{"))
+        {
+            Some(rest) => rest.trim_start_matches('{'),
+            None => continue,
+        };
 
-    let idx = rest.find("source")?;
-    let after = rest[idx + "source".len()..].trim_start();
+        // Single-line shape: try the existing fast path first.
+        if let Some(path) = extract_source_in_block(body_head) {
+            return Some(path);
+        }
+
+        // Multi-line shape: slurp body lines until braces balance, then scan.
+        // The opening `{` was consumed when we stripped `use {`, so brace_depth
+        // starts at 1.
+        let mut body = String::from(body_head);
+        let mut brace_depth: i32 = 1 + count_braces(body_head);
+        if brace_depth <= 0 {
+            // Already balanced on the same line but no `source` found above;
+            // give up — this is a `use { ... }` without a source.
+            return None;
+        }
+        for next_line in lines.iter().skip(i + 1) {
+            body.push('\n');
+            body.push_str(next_line);
+            brace_depth += count_braces(next_line);
+            if brace_depth <= 0 {
+                break;
+            }
+        }
+        return extract_source_in_block(&body);
+    }
+    None
+}
+
+/// Net brace delta of `s`: number of `{` minus number of `}`. Used to balance
+/// the body of a `use { ... }` block when the shape spans multiple lines.
+/// String literals are not specially handled — `use` block bodies in practice
+/// are key-value pairs whose values are quoted paths, not free-form text with
+/// embedded braces, so a naive count is sufficient.
+fn count_braces(s: &str) -> i32 {
+    let mut depth: i32 = 0;
+    for b in s.bytes() {
+        match b {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            _ => {}
+        }
+    }
+    depth
+}
+
+/// Locate `source = '<path>'` (or with double quotes) anywhere in `block_body`,
+/// where `block_body` is the text inside a `use { ... }` block (possibly across
+/// newlines). Returns the unquoted path on the first match.
+fn extract_source_in_block(block_body: &str) -> Option<String> {
+    let idx = block_body.find("source")?;
+    let after = block_body[idx + "source".len()..].trim_start();
     let after = after.strip_prefix('=')?.trim_start();
     let quote = after.chars().next()?;
     if quote != '\'' && quote != '"' {
@@ -461,6 +537,23 @@ pub(super) fn extract_use_source_path(after_eq: &str) -> Option<String> {
     let body = &after[1..];
     let end = body.find(quote)?;
     Some(body[..end].to_string())
+}
+
+/// Extract the `source` path from a `let` RHS of the shape `use { source = 'path' }`
+/// (or with double quotes). Returns `None` if `after_eq` doesn't look like a `use` block
+/// or if the `source` value can't be parsed.
+///
+/// This is the single-line fast path used by snippet generation, where we only
+/// have the line tail after `=`. For the multi-line shape used by the real
+/// infra, callers must use `find_let_use_source` instead, which reaches across
+/// newlines to find `source` on its own line.
+pub(super) fn extract_use_source_path(after_eq: &str) -> Option<String> {
+    let trimmed = after_eq.trim_start();
+    let rest = trimmed
+        .strip_prefix("use ")
+        .or_else(|| trimmed.strip_prefix("use{"))
+        .map(|s| s.trim_start_matches('{').trim_start())?;
+    extract_source_in_block(rest)
 }
 
 /// Build a navigation-anchor `CompletionItem` for `./` or `../`.


### PR DESCRIPTION
## Summary

This PR fixes two bugs that combine to produce the empty-completion symptom in #2423. Either alone leaves the user with VS Code's word-fallback suggestions; both have to land for the real `carina-rs/infra` tree to surface `arguments` candidates.

**Bug 1 — context misclassification (commit 1):** The completion context walker excluded every line starting with `let ` from the anonymous-module-call branch, so the named form `let bootstrap = github { <CURSOR> }` was routed away from the `InsideModuleCall` arm and produced zero candidates. Adds an `extract_let_module_call_name` detection branch that recognizes `let <binding> = <module-name> {` (RHS is a bare identifier, not `use` / `upstream_state` / `read` / a provider-prefixed resource path) and routes the cursor into the existing `InsideModuleCall { module_name }` arm.

**Bug 2 — multi-line `use { ... }` source not resolved (commit 2):** With bug 1 fixed, the cursor reaches `module_parameter_completions`, but `find_module_import_path` was line-by-line and only recognized the single-line `let github = use { source = '...' }` shape. The real infra writes the body across newlines:

```
let github = use {
  source = '../../../modules/github-oidc'
}
```

So `find_module_import_path` returned `None`, no module was loaded, and the candidate list was still empty. Now scans the body of the matched `let X = use { ... }` with brace tracking and locates `source` anywhere inside it. Both shapes still work; the existing single-line test continues to pass.

Each commit ships its own multi-file `tempdir()` regression test per the project's "directory-scoped, never single-file" rule. The bug-2 fixture mirrors the production `infra/.worktrees/issue-24-registry-dev-bootstrap/modules/github-oidc/main.crn` shape (multi-arg `arguments` block including default values and list types).

Closes #2423

## Test plan

- [x] `cargo nextest run -p carina-lsp` (388 passed, 0 failed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five clean)
- [x] Existing anonymous-form module-call test (`module_parameter_completion_with_directory_module`) still passes
- [x] Bug-1 regression test (`module_parameter_completion_for_let_binding_module_call`) passes
- [x] Bug-2 regression test (`module_parameter_completion_for_multiline_use_block`) — fails before the second commit, passes after
- [x] Manual VS Code verification against `carina-rs/infra` with the rebuilt `~/.cargo/bin/carina-lsp`