### PR TITLE
docs: design + plan for anonymous resource provider prefix (#2419)

### DIFF
--- a/docs/specs/2026-05-05-anonymous-resource-provider-prefix-design.md
+++ b/docs/specs/2026-05-05-anonymous-resource-provider-prefix-design.md
@@ -1,0 +1,120 @@
+# Anonymous resource name: provider prefix — design
+
+Issue: [#2419](https://github.com/carina-rs/carina/issues/2419) (provider prefix portion).
+
+## Goal
+
+Make anonymous resource names in `carina plan` output (and state files) include the provider identifier as a prefix, so that operators can tell at a glance which provider produced each anonymous resource.
+
+Today:
+
+```
++ awscc.iam.RolePolicy iam_role_policy_b94fde85
+```
+
+After this change:
+
+```
++ awscc.iam.RolePolicy awscc_iam_role_policy_b94fde85
+```
+
+The `awscc` provider prefix is added in front of the snake_case resource type and the SimHash digest. This is the smaller of two changes contemplated by Issue #2419; the second change (verifying / fixing module-instance prefixing) is tracked separately.
+
+## Chosen approach
+
+Modify the single name-assembly site in `carina-core/src/identifier/mod.rs` (currently around line 467–473):
+
+```rust
+// Before:
+let identifier = format!("{}_{}", type_snake, hash_str);
+
+// After:
+let provider_snake = pascal_to_snake_components(&resource.id.provider);
+let identifier = format!("{}_{}_{}", provider_snake, type_snake, hash_str);
+```
+
+`pascal_to_snake_components` here is a no-op for already-snake provider names (`awscc`, `aws`, `my_alias`); it exists only to keep the call site uniform with the existing `type_snake` step.
+
+A second site requires a small change so the rename of state entries stays consistent:
+
+- The module expander (`module_resolver/expander.rs:155`) prefixes `instance_prefix.<inner_name>`. Since `<inner_name>` is the assembled identifier returned by `compute_anonymous_identifiers`, the new provider prefix flows through automatically. A module-internal anonymous resource named `iam_role_policy_b94fde85` becomes `bootstrap.awscc_iam_role_policy_b94fde85` after expansion.
+- `reconcile_anonymous_identifiers` (`identifier/mod.rs:570-592`) — the SimHash-distance match path that today copies the *old state's name* back into the new resource's id (line 587-591) — is updated to **keep the freshly-computed new-format identifier** instead of overwriting it with the legacy state name. The state file is then re-keyed to the new identifier (the existing rename detection / state-rewrite plumbing handles this). Resource identity (which physical resource it represents) is preserved via the SimHash distance check; only the display name is normalized to the new format. This avoids the destroy+recreate that would happen if we let the old name stand and treated it as a non-match.
+
+### Why this shape
+
+- **Single mutation site.** The whole behavior change lives in one `format!`. Easy to review, easy to revert.
+- **No reconciliation special-case.** The hash is independent of the surrounding name, so backward-compat shims would have to be string-pattern matching (`"^<type_snake>_<hex>$"`). That couples future changes to a regex and adds a permanent compatibility branch. Per project policy ("No backward compatibility — and don't mention it"), we don't add it.
+- **Provider prefix is taken from `Resource.id.provider`, not from a config-name resolution step.** The DSL identifier the user typed (`awscc.iam.RolePolicy`) already populates `Resource.id.provider = "awscc"`. Using the config-name (e.g. an alias) would require touching wiring code and isn't aligned with what users see.
+
+## Key design decisions
+
+### D1. Apply only to anonymous resources
+
+Named bindings (`let bootstrap = github { ... }`) keep their user-supplied name verbatim. Provider prefix appears only when `compute_anonymous_identifiers` assembles an identifier — i.e. the `Resource.id.name` was `Pending` at compute time.
+
+### D2. Prefix derives from `Resource.id.provider` directly
+
+No alias resolution, no config lookup. Whatever the parser stored as the provider segment of the resource type (`awscc.iam.RolePolicy` → `awscc`) becomes the prefix.
+
+For provider names that contain dots (none today, but the type system allows it), apply the same `pascal_to_snake` + dot-split logic the type segment already uses, joined by `_`. For the current provider universe (`aws`, `awscc`, `mock`, plus user aliases), this is a no-op.
+
+### D3. Reconciliation normalizes old state names to the new format
+
+`reconcile_anonymous_identifiers` is changed at one point: when the SimHash-distance match succeeds against a state entry, the resource's `id.name` is **kept as the freshly-computed new-format identifier** (`awscc_iam_role_policy_<hash>`) instead of being overwritten with the state's legacy name (`iam_role_policy_<hash>`). The state file's rename plumbing then carries the entry forward under the new key.
+
+This is not a backward-compatibility shim — there is no branch on "is this old format?" The behavior change is uniform: SimHash-distance matches always yield the new-format identifier. Old-format state entries naturally become orphaned strings under the new key, no special parsing required.
+
+Why not the strict alternative (let the SimHash distance match fail and treat old-format entries as non-existent):
+
+- That destroys and recreates every existing anonymous resource on the next `apply` — a real, user-visible side-effect on infra that has nothing to do with the operator's actual intent (which was just renaming a display label).
+- "No backward compatibility" applies to *code* (don't keep old read paths alive); it doesn't justify destroying production resources to avoid a 3-line normalization.
+
+A note in the PR body and CHANGELOG documents the user-visible effect: state files written by older Carina versions will be silently re-keyed on the next plan/apply cycle.
+
+### D4. Snapshot churn is expected
+
+Every `carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_*.snap` that contains an anonymous resource will need its expected name updated. `cargo insta review` walks them. Per memory rule "Review snapshots before accepting", each pending snapshot is inspected, not blanket-accepted.
+
+## File structure / architecture
+
+| File | Change |
+| ---- | ------ |
+| `carina-core/src/identifier/mod.rs` | Update the name format string at the assembly site (`format!("{}_{}_{}", ...)`). Add unit tests covering the prefix presence, snake-case conversion, and zero-collision guarantee for same-type-different-provider resources. |
+| `carina-cli/tests/fixtures/plan_display/provider_prefix/main.crn` | New fixture: a single anonymous resource whose plan output proves the prefix appears. |
+| `carina-cli/src/plan_snapshot_tests.rs` | Add `snapshot_provider_prefix` test function. |
+| `carina-cli/src/snapshots/*.snap` | Updated snapshots for every existing fixture that produces anonymous resources. |
+| `Makefile` | Add `plan-provider-prefix` target and include in `plan-fixtures` aggregator. |
+
+## Edge cases and constraints
+
+### Anonymous resources with no provider
+
+If `Resource.id.provider` is empty (which `compute_anonymous_identifiers` already early-returns for at line 392–394), no identifier is computed, so no prefix question arises. Existing behavior preserved.
+
+### Module-internal anonymous resources
+
+Order: module expand → anonymous-identifier compute. Module expand prefixes `<binding>.<inner_name>`; at that point `<inner_name>` is `Pending`. After compute, `<inner_name>` becomes `awscc_iam_role_policy_<hash>`, so the final name is `bootstrap.awscc_iam_role_policy_<hash>`. No additional code changes; the prefix flows through automatically.
+
+### Provider name with non-ASCII / dotted chars
+
+Current provider names are `[a-z][a-z0-9_]*`. The DSL grammar (`carina.pest`) doesn't allow dots in provider declarations. If a future provider name contains uppercase letters, apply the same `pascal_to_snake` step used for the type segment. No special handling for non-ASCII because the parser rejects it.
+
+### State file reconciliation
+
+After this change, an `apply` against an existing state file with old-format names goes through the SimHash-distance match path: each old anonymous entry matches its desired counterpart on identity-attribute SimHash distance, and the entry is re-keyed under the new-format name. No destroy+create churn. The user sees a regular plan / apply with no anonymous-resource diffs — only the state file's keys are silently normalized.
+
+If the SimHash distance has *also* exceeded the threshold (i.e. the resource itself was independently edited beyond the rename detector's reach), the resource appears as a Create + an orphan Delete, which is the same behavior the system has today for any out-of-band rename.
+
+### TUI plan view
+
+TUI uses the same `Resource.id.name` via `format_effect_tree`. Display will pick up the new prefix automatically. No code change needed.
+
+## Risks
+
+- **Snapshot churn is large.** Hard to spot a regression among many cosmetic name changes. Mitigation: implement the change in 2 commits — (1) the format change with `cargo insta review` performed once, locking in the new baseline; (2) the new dedicated `provider_prefix` fixture and any subsequent feature work. Reviewers diff each `.snap` only against the `_<type>_<hash>` → `_<provider>_<type>_<hash>` substitution pattern.
+- **A user with hand-crafted state files breaks.** Acceptable per project policy. Mention in PR body.
+- **Module-prefix issue may not actually be present** (Issue B). After this lands, re-run the original Issue #2409 reproduction. If `bootstrap.awscc_iam_role_policy_<hash>` is what we see, Issue B may turn out to be a false alarm and can be closed without code change. If we still see prefix-less output, Issue B has a real bug to chase.
+
+## Acceptance
+
+The Issue #2409 reproduction's plan output shows `awscc_iam_role_policy_<hash>` (or `bootstrap.awscc_iam_role_policy_<hash>` for module-internal resources) instead of `iam_role_policy_<hash>`. The provider segment is visible at a glance.

--- a/docs/specs/2026-05-05-anonymous-resource-provider-prefix-plan.md
+++ b/docs/specs/2026-05-05-anonymous-resource-provider-prefix-plan.md
@@ -1,0 +1,519 @@
+# Anonymous resource provider prefix — implementation plan
+
+<!-- derived-from #2026-05-05-anonymous-resource-provider-prefix-design -->
+
+Issue: [#2419](https://github.com/carina-rs/carina/issues/2419) (provider prefix portion).
+Design: [`2026-05-05-anonymous-resource-provider-prefix-design.md`](./2026-05-05-anonymous-resource-provider-prefix-design.md).
+
+## Architecture summary
+
+Two-layer change:
+
+1. **`carina-core/src/identifier/mod.rs`** — change the assembled identifier format from `{type_snake}_{hash}` to `{provider_snake}_{type_snake}_{hash}` at the single name-assembly site (around line 474). Provider segment derives from `Resource.id.provider` via the same `pascal_to_snake` helper used for the type segment.
+
+2. **State reconciliation** — when `reconcile_anonymous_identifiers` finds a SimHash-distance match against an old-format state entry (`iam_role_policy_<hash>`), keep the freshly-computed new-format identifier (`awscc_iam_role_policy_<hash>`) and **emit a rename pair** so the wiring layer can re-key the state entry. Mirrors the existing `apply_anonymous_to_named_renames` plumbing.
+
+Snapshot churn is expected — every plan-display fixture that contains an anonymous resource gets its `.snap` updated. A new dedicated fixture `provider_prefix/` makes the prefix presence intent explicit.
+
+## File map
+
+| File | Type | Purpose |
+| ---- | ---- | ------- |
+| `carina-core/src/identifier/mod.rs` | modify | Update name format. Update `reconcile_anonymous_identifiers` to return rename pairs. Add unit tests. |
+| `carina-cli/src/wiring/mod.rs` | modify | Apply the new rename pairs to `current_states` / `prev_desired_keys` / `saved_attrs`, mirroring `apply_anonymous_to_named_renames`. |
+| `carina-cli/tests/fixtures/plan_display/provider_prefix/main.crn` | create | Fixture: a single anonymous resource. Snapshot proves the new prefix appears. |
+| `carina-cli/src/plan_snapshot_tests.rs` | modify | Add `snapshot_provider_prefix` test function. |
+| `carina-cli/src/snapshots/*.snap` | modify (auto, via `cargo insta review`) | Updated names for every fixture that produces anonymous resources. |
+| `Makefile` | modify | Add `plan-provider-prefix` target; include in `plan-fixtures` aggregator. |
+
+## Task list
+
+**PR-merge boundary note**: Tasks 1–5 must land as a single PR (or as a series of fast-merging PRs). Splitting Task 1 from Task 2 leaves the workspace red on identifier-format assertion failures, and splitting Task 3 from Task 4 leaves the reconciliation rename plumbing partial. The Issue list below uses task labels for tracking, but the implementing PRs should bundle these tightly-coupled tasks together.
+
+### Task 1: Add `provider_snake` to identifier assembly
+
+**Goal**: Change the format string in `compute_anonymous_identifiers` so identifiers gain a provider prefix. This is the smallest correct change — no reconciliation tweaks yet, so existing state-comparison tests will fail in a controlled way that Task 2 fixes.
+
+**Files**: `carina-core/src/identifier/mod.rs`
+
+**Test** (add to existing tests module in `identifier/mod.rs`):
+
+```rust
+#[test]
+fn anonymous_identifier_includes_provider_prefix() {
+    use crate::resource::{Resource, ResourceId, ResourceName};
+    use crate::schema::SchemaRegistry;
+
+    let mut r = Resource::new("iam.RolePolicy", "");
+    r.id = ResourceId {
+        provider: "awscc".to_string(),
+        resource_type: "iam.RolePolicy".to_string(),
+        name: ResourceName::Pending,
+    };
+    r.attributes.insert(
+        "policy_name".to_string(),
+        crate::value::Value::String("foo".to_string()),
+    );
+
+    let mut resources = vec![r];
+    let registry = SchemaRegistry::new();
+    compute_anonymous_identifiers(&mut resources, &[], &registry, &|_| vec![]).unwrap();
+
+    let name = resources[0].id.name_str();
+    assert!(
+        name.starts_with("awscc_"),
+        "identifier should begin with the provider prefix, got: {name}"
+    );
+    assert!(
+        name.contains("iam_role_policy_"),
+        "identifier should still contain the snake-case type, got: {name}"
+    );
+}
+
+#[test]
+fn anonymous_identifier_provider_prefix_for_aws_provider() {
+    use crate::resource::{Resource, ResourceId, ResourceName};
+    use crate::schema::SchemaRegistry;
+
+    let mut r = Resource::new("s3.Bucket", "");
+    r.id = ResourceId {
+        provider: "aws".to_string(),
+        resource_type: "s3.Bucket".to_string(),
+        name: ResourceName::Pending,
+    };
+
+    let mut resources = vec![r];
+    let registry = SchemaRegistry::new();
+    compute_anonymous_identifiers(&mut resources, &[], &registry, &|_| vec![]).unwrap();
+    assert!(resources[0].id.name_str().starts_with("aws_s3_bucket_"));
+}
+```
+
+**Implementation**: At `identifier/mod.rs:467-474`:
+
+```rust
+let provider_snake = resource
+    .id
+    .provider
+    .split('.')
+    .map(crate::parser::pascal_to_snake)
+    .collect::<Vec<_>>()
+    .join("_");
+let type_snake = resource
+    .id
+    .resource_type
+    .split('.')
+    .map(crate::parser::pascal_to_snake)
+    .collect::<Vec<_>>()
+    .join("_");
+let identifier = format!("{}_{}_{}", provider_snake, type_snake, hash_str);
+```
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-core anonymous_identifier_includes_provider_prefix
+cargo nextest run -p carina-core anonymous_identifier_provider_prefix_for_aws_provider
+```
+
+Both new tests pass. Existing `compute_anonymous_identifiers` tests (`carina-core/src/identifier/mod.rs` and `carina-cli/src/tests.rs`) will start failing with name-mismatch errors — Task 2 / Task 3 update them to the new format.
+
+---
+
+### Task 2: Update existing identifier-format tests to the new format
+
+**Goal**: Refresh every existing test that asserts an anonymous identifier matches a specific string. These tests are correct in intent (verify identifier shape) but their expected values are now stale.
+
+**Files**:
+- `carina-core/src/identifier/mod.rs` (test module)
+- `carina-cli/src/tests.rs`
+
+**Test**: No new tests — only updates to existing assertions. Run the full test scope to see which assertions fail:
+
+```bash
+cargo nextest run -p carina-core 2>&1 | grep -A2 "FAILED" | head -50
+cargo nextest run -p carina-cli 2>&1 | grep -A2 "FAILED" | head -50
+```
+
+For each failing test, update the expected name from `<type>_<hash>` to `<provider>_<type>_<hash>`. The hash digest itself does NOT change (SimHash is over identity attributes, not over the assembled name).
+
+**Implementation**: Mechanical string substitution per test. Examples:
+
+- `"ec2_vpc_a3f2b1c8"` → `"awscc_ec2_vpc_a3f2b1c8"`
+- `"s3_bucket_cafef00d"` → `"aws_s3_bucket_cafef00d"`
+
+The `carina-cli/src/tests.rs:591-947` block has many `compute_anonymous_identifiers` invocations — methodically update each assertion.
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-core
+cargo nextest run -p carina-cli identifier
+cargo nextest run -p carina-cli compute_anonymous
+```
+
+All pass.
+
+---
+
+### Task 3: Update `reconcile_anonymous_identifiers` SimHash-match path to keep the new identifier and emit a rename pair
+
+**Goal**: When the SimHash-distance match path (`identifier/mod.rs:570-592`) finds an old-format state entry as the closest match, keep the freshly-computed new-format identifier in `resource.id.name` (instead of overwriting with the state's old name) and return a rename pair so the wiring layer can re-key state file entries.
+
+**Files**: `carina-core/src/identifier/mod.rs`
+
+**Test**:
+
+```rust
+#[test]
+fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
+    use crate::resource::{Resource, ResourceId, ResourceName};
+    use crate::schema::SchemaRegistry;
+
+    // Build a resource that has been freshly assigned the new-format name.
+    let mut r = Resource::new("iam.RolePolicy", "awscc_iam_role_policy_b94fde85");
+    r.id = ResourceId::with_provider("awscc", "iam.RolePolicy", "awscc_iam_role_policy_b94fde85");
+
+    // Build a state entry under the old-format name with a SimHash within reconciliation distance.
+    // For this test, hash equality (distance 0) is sufficient.
+    let state_info = AnonymousIdStateInfo {
+        name: "iam_role_policy_b94fde85".to_string(),
+        create_only_values: BTreeMap::new(),
+    };
+
+    let mut resources = vec![r];
+    let registry = SchemaRegistry::new();
+    let renames = reconcile_anonymous_identifiers(
+        &mut resources,
+        &registry,
+        &|_, _| vec![state_info.clone()],
+        &[],
+        &|_| vec![],
+    );
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        "awscc_iam_role_policy_b94fde85",
+        "resource id should retain the new-format identifier",
+    );
+    assert_eq!(
+        renames,
+        vec![("iam_role_policy_b94fde85".to_string(), "awscc_iam_role_policy_b94fde85".to_string())],
+        "should emit a rename pair from the old state name to the new identifier",
+    );
+}
+```
+
+**Implementation**: Two changes to `reconcile_anonymous_identifiers`:
+
+1. Change the function signature to return `Vec<(String, String)>` (old_name, new_name pairs).
+2. Replace lines 586-592 (the SimHash-match write-back) with rename emission:
+
+```rust
+if let Some((state_name, _)) = best_match {
+    // The state entry uses an older identifier format. Keep our
+    // freshly-computed new-format name on the resource (already
+    // stored in resource.id) and record the rename so wiring can
+    // re-key the state entry.
+    renames.push((state_name.to_string(), resource.id.name_str().to_string()));
+}
+continue;
+```
+
+(The function should accumulate `renames: Vec<(String, String)>` from the start of the resource loop.)
+
+3. Audit existing callers of `reconcile_anonymous_identifiers` for the new return value. Most callers ignore the return; only `wiring/mod.rs` consumes it (Task 4).
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-core reconcile_simhash_match_keeps_new_format
+cargo nextest run -p carina-core reconcile
+```
+
+Both pass. Existing reconciliation tests may fail if they assumed name overwrite — update them to check for rename emission instead.
+
+---
+
+### Task 4: Apply the rename pairs in the wiring layer
+
+**Goal**: Take the `Vec<(old_name, new_name)>` from Task 3 and re-key state entries (`current_states`, `prev_desired_keys`, `saved_attrs`) so the differ sees the resource under its new identifier.
+
+**Files**: `carina-cli/src/wiring/mod.rs`
+
+**Test** (in `wiring` test module):
+
+```rust
+#[test]
+fn apply_provider_prefix_renames_re_keys_current_states() {
+    use carina_core::resource::{ResourceId, State};
+    use std::collections::HashMap;
+
+    let old_id = ResourceId::with_provider(
+        "awscc",
+        "iam.RolePolicy",
+        "iam_role_policy_b94fde85",
+    );
+    let new_id = ResourceId::with_provider(
+        "awscc",
+        "iam.RolePolicy",
+        "awscc_iam_role_policy_b94fde85",
+    );
+
+    let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+    current_states.insert(
+        old_id.clone(),
+        State {
+            id: old_id.clone(),
+            identifier: Some("real-aws-id".to_string()),
+            attributes: HashMap::new(),
+            exists: true,
+            dependency_bindings: Default::default(),
+        },
+    );
+    let mut prev_desired_keys: HashMap<ResourceId, Vec<String>> = HashMap::new();
+    let mut saved_attrs: HashMap<ResourceId, HashMap<String, carina_core::value::Value>> = HashMap::new();
+
+    let renames = vec![(
+        "iam_role_policy_b94fde85".to_string(),
+        "awscc_iam_role_policy_b94fde85".to_string(),
+    )];
+
+    apply_provider_prefix_renames(
+        &renames,
+        &mut current_states,
+        &mut prev_desired_keys,
+        &mut saved_attrs,
+    );
+
+    assert!(current_states.contains_key(&new_id), "state should be re-keyed under new identifier");
+    assert!(!current_states.contains_key(&old_id), "state should no longer be under old identifier");
+}
+```
+
+**Implementation**: Add to `carina-cli/src/wiring/mod.rs`:
+
+```rust
+/// Re-key state entries when `reconcile_anonymous_identifiers` produced rename
+/// pairs (anonymous → anonymous due to identifier-format upgrade).
+///
+/// For each `(old_name, new_name)` pair, scan each map for a `ResourceId`
+/// whose `.name` segment equals `old_name`. Remove that entry, and reinsert
+/// it under a `ResourceId` whose `.name` is `new_name` (preserving provider
+/// and resource_type).
+pub fn apply_provider_prefix_renames(
+    renames: &[(String, String)],
+    current_states: &mut HashMap<ResourceId, State>,
+    prev_desired_keys: &mut HashMap<ResourceId, Vec<String>>,
+    saved_attrs: &mut HashMap<ResourceId, HashMap<String, Value>>,
+) {
+    for (old_name, new_name) in renames {
+        rekey_map(current_states, old_name, new_name, |state, new_id| {
+            State { id: new_id, ..state }
+        });
+        rekey_map(prev_desired_keys, old_name, new_name, |v, _| v);
+        rekey_map(saved_attrs, old_name, new_name, |v, _| v);
+    }
+}
+
+fn rekey_map<V, F>(
+    map: &mut HashMap<ResourceId, V>,
+    old_name: &str,
+    new_name: &str,
+    transform: F,
+)
+where
+    F: Fn(V, ResourceId) -> V,
+{
+    let old_keys: Vec<ResourceId> = map
+        .keys()
+        .filter(|k| k.name_str() == old_name)
+        .cloned()
+        .collect();
+    for old_key in old_keys {
+        if let Some(value) = map.remove(&old_key) {
+            let new_key = ResourceId::with_provider(
+                &old_key.provider,
+                &old_key.resource_type,
+                new_name,
+            );
+            let transformed = transform(value, new_key.clone());
+            map.insert(new_key, transformed);
+        }
+    }
+}
+```
+
+Then update the wiring call site in `carina-cli/src/commands/mod.rs:335` so it captures the rename pairs returned by Task 3's modified `reconcile_anonymous_identifiers_with_ctx` and invokes `apply_provider_prefix_renames` immediately afterward, threading `current_states`, `prev_desired_keys`, and `saved_attrs` through. Note: `compute_anonymous_identifiers_with_ctx` (line 383 of `wiring/mod.rs`) is the wrapper that calls `reconcile_anonymous_identifiers`; its return type also expands to include renames. Locate the corresponding call sites in `carina-cli/src/commands/plan.rs` and `apply.rs` and apply the same pattern.
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-cli provider_prefix_rename
+cargo nextest run -p carina-cli wiring
+```
+
+Pass. Then run the full carina-cli suite to confirm no regression in unrelated reconciliation tests:
+
+```bash
+cargo nextest run -p carina-cli
+```
+
+---
+
+### Task 5: Update existing plan-display snapshots to the new format
+
+**Goal**: Every existing snapshot file that contains an anonymous identifier needs its expected name updated. This is mechanical: `cargo insta review` walks each diff and accepts only correct ones.
+
+**Files**: `carina-cli/src/snapshots/*.snap` (multiple)
+
+**Test**: Snapshot tests themselves. Run:
+
+```bash
+cargo nextest run -p carina-cli plan_snapshot
+```
+
+Expect failures. For each failing snapshot:
+
+1. `cargo insta review` opens an interactive review.
+2. For each pending snapshot, verify the only change is the addition of `<provider>_` in front of every anonymous resource name. **Reject** any snapshot where other content has changed (would indicate a regression beyond name format).
+3. Accept the snapshot.
+
+Per memory rule "Review snapshots before accepting": **do not** `cargo insta accept` blindly. Each snapshot's diff must be inspected.
+
+**Implementation**: No code change — snapshot acceptance only.
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-cli plan_snapshot
+```
+
+All snapshots pass without pending changes.
+
+---
+
+### Task 6: Add `provider_prefix/` fixture and snapshot test
+
+**Goal**: A dedicated fixture whose snapshot makes the new-prefix intent explicit. Future regressions in identifier format are caught by name on this snapshot, not buried in shared fixtures.
+
+**Files**:
+- `carina-cli/tests/fixtures/plan_display/provider_prefix/main.crn` (create)
+- `carina-cli/src/plan_snapshot_tests.rs` (modify)
+
+**Test** (add to `plan_snapshot_tests.rs`):
+
+```rust
+#[test]
+fn snapshot_provider_prefix() {
+    let fp = build_plan_from_fixture_name("provider_prefix");
+    let plan = fp.plan;
+    let registry = fp.schemas;
+    let mut output = String::new();
+    let _ = format_plan(
+        &plan,
+        DetailLevel::Default,
+        Some(&registry),
+        None,
+        &mut output,
+    );
+    insta::assert_snapshot!(strip_ansi(&output));
+}
+```
+
+**Implementation** (`provider_prefix/main.crn`):
+
+```
+# Single anonymous resource — Create plan should display
+# `awscc_<type>_<hash>` form to confirm provider prefix is applied.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  policy_document = {
+    version   = '2012-10-17'
+    statement = []
+  }
+}
+```
+
+**Verification**:
+
+```bash
+cargo nextest run -p carina-cli snapshot_provider_prefix
+cargo insta review
+# Expected: header line shows
+#   + awscc.iam.RolePolicy awscc_iam_role_policy_<8hex>
+```
+
+Per memory rule "Review snapshots before accepting": confirm the visible identifier on the header line begins with `awscc_iam_role_policy_` before accepting.
+
+---
+
+### Task 7: Makefile target
+
+**Goal**: Add `plan-provider-prefix` target and register in `plan-fixtures`.
+
+**Files**: `Makefile`
+
+**Implementation**:
+
+```make
+plan-provider-prefix:
+	$(PLAN_FIXTURE) provider_prefix
+```
+
+Add to `plan-fixtures`:
+
+```make
+	@echo "=== provider_prefix ==="
+	@$(MAKE) plan-provider-prefix
+	@echo ""
+```
+
+Add `plan-provider-prefix` to the `.PHONY` list.
+
+**Verification**:
+
+```bash
+make plan-provider-prefix
+make plan-fixtures
+```
+
+Both run; the target's output shows `+ awscc.iam.RolePolicy awscc_iam_role_policy_<hash>`.
+
+---
+
+### Task 8: Final verify sweep
+
+**Goal**: Workspace-level health after the change.
+
+```bash
+cargo nextest run --workspace        # carina-core touched → workspace-wide
+cargo test --workspace --doc
+cargo clippy --workspace --all-targets -- -D warnings
+ls scripts/check-*.sh | xargs -n1 bash
+```
+
+All green. No `dead_code` warnings, no clippy warnings. Per memory rule "Local cargo green ≠ CI green", run the repo's check scripts too.
+
+---
+
+## Out of scope (deferred follow-up)
+
+- **Module-instance prefix verification** (Issue #2419's second part). Once provider prefix lands, re-run the original Issue #2409 reproduction. If the output shows `bootstrap.awscc_iam_role_policy_<hash>`, the module-prefix concern was already handled by `expander.rs:155` and the follow-up issue can be closed without code change. If not, a real bug exists and a separate PR investigates.
+- TUI changes (TUI consumes the same `Resource.id.name` and picks up the new prefix automatically).
+- State-file format upgrades beyond name re-keying.
+
+## Risks tracked
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Snapshot churn obscures unrelated regressions | Task 5's review step is mechanical-but-careful — every `.snap` diff is verified to be ONLY the prefix addition, not other content. |
+| Reconciliation rename loses state for resources whose SimHash drifted independently | Existing behavior: those resources already manifest as Create + orphan Delete today. Task 3's change does not regress this. |
+| `Resource.id.provider` is unexpectedly empty | Existing early-return at `identifier/mod.rs:392-394` skips the resource entirely, so no empty-prefix identifier is ever produced. |
+| Provider name with dots or PascalCase | `pascal_to_snake` handles them. Only ASCII alphanumeric + `_` provider names are valid in the DSL grammar today. |


### PR DESCRIPTION
Design document and implementation plan for the **provider prefix** portion of Issue #2419 — making anonymous resource identifiers self-describe their provider so plan output and state files distinguish `aws.iam.RolePolicy` from `awscc.iam.RolePolicy` at a glance.

This is a brainstorming-phase Draft PR carrying only design + plan
artifacts. Implementation tasks are split into separate Issues
(`task-1/8` … `task-8/8`):

- #2426 task-1/8: change identifier format to `{provider}_{type}_{hash}`
- #2427 task-2/8: update existing identifier-format assertions to new format
- #2428 task-3/8: `reconcile_anonymous_identifiers` normalizes legacy state names
- #2429 task-4/8: apply rename pairs to wiring state maps
- #2430 task-5/8: update existing plan-display snapshots
- #2431 task-6/8: dedicated `provider_prefix/` snapshot fixture
- #2432 task-7/8: Makefile target
- #2433 task-8/8: real-infra smoke test + workspace verify sweep

**Bundling note**: Tasks 1–5 (#2426–#2430) must land in a single PR since splitting them leaves the workspace red on identifier-format assertions. Tasks 6–7 can be a follow-up PR; Task 8 is a verification gate, not a code change.

The module-instance prefix question (Issue #2419's second concern) is
deferred. Task 8 above answers it via direct observation of the post-merge plan output: if `bootstrap.awscc_iam_role_policy_<hash>` displays correctly, the concern is resolved without further code; if not, a new bug Issue is filed.

## Scope

- **In scope:** anonymous resource name format change, from
  `<type_snake>_<hash>` to `<provider_snake>_<type_snake>_<hash>`.
  Reconciliation re-keys old-format state entries to the new format
  (no destroy+recreate).
- **Out of scope:** module-instance prefix verification (deferred to Task 8 observation).

## Key design decisions

- Single mutation site at `carina-core/src/identifier/mod.rs:474`
  (the `format!` call). Provider segment derives from
  `Resource.id.provider` via the existing `pascal_to_snake` helper.
- Reconciliation normalizes legacy state names: when SimHash distance
  matches an old-format state entry, keep the new-format identifier and
  emit a rename pair so wiring re-keys the state. Avoids the
  destroy+recreate that would otherwise happen — "no backward
  compatibility" applies to code, not to user data.
- Snapshot churn is expected. Every `.snap` containing an anonymous
  identifier is reviewed individually with `cargo insta review` to
  confirm the only change is the prefix.

## Documents

- [Design](docs/specs/2026-05-05-anonymous-resource-provider-prefix-design.md)
- [Implementation Plan](docs/specs/2026-05-05-anonymous-resource-provider-prefix-plan.md)

Refs #2419
