### PR TITLE
Resolve upstream_state map subscript across sibling files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ plan-fixtures:
 	@echo "---"
 	@$(MAKE) plan-upstream-state-empty-exports
 	@echo "---"
+	@$(MAKE) plan-upstream-state-map-subscript
+	@echo "---"
 	@$(MAKE) plan-deferred-for
 
 plan-upstream-state:
@@ -128,6 +130,8 @@ plan-upstream-state-unresolved:
 	$(PLAN_FIXTURE) upstream_state_unresolved
 plan-upstream-state-empty-exports:
 	$(PLAN_FIXTURE) upstream_state_empty_exports
+plan-upstream-state-map-subscript:
+	$(PLAN_FIXTURE) upstream_state_map_subscript
 plan-deferred-for:
 	$(PLAN_FIXTURE) deferred_for
 plan-exports:
@@ -139,6 +143,7 @@ plan-exports-multifile:
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
+        plan-upstream-state-map-subscript \
         plan-deferred-for plan-exports plan-exports-multifile \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -579,6 +579,49 @@ fn plan_snapshot_upstream_state_empty_exports() {
     insta::assert_snapshot!(stripped);
 }
 
+/// Issue #2435: `let X = upstream_state {...}` lives in `state.crn`,
+/// the consuming `${X.field['key']}` and bare `X.field['key']` live in
+/// `main.crn`. The plan must resolve both forms to the concrete value
+/// from the upstream's exports map.
+#[test]
+fn plan_snapshot_upstream_state_map_subscript() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("upstream_state_map_subscript");
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+    );
+    let stripped = strip_ansi(&output);
+    // Both subscript forms — bare attribute value and inside `${...}`
+    // interpolation — must end up substituted with the actual account ids.
+    assert!(
+        stripped.contains("222222222222"),
+        "expected dev account id substituted, got:\n{stripped}"
+    );
+    assert!(
+        stripped.contains("111111111111"),
+        "expected prod account id substituted, got:\n{stripped}"
+    );
+    assert!(
+        stripped.contains("shared-222222222222-bucket"),
+        "expected `${{orgs.accounts['registry_dev']}}` interpolation substituted, got:\n{stripped}"
+    );
+    // Pin the bare-attribute form distinctly from the interpolation
+    // form: a regression that re-rendered the bare-attribute case as
+    // the literal `orgs.accounts['registry_dev']` (the original #2435
+    // bug) would still satisfy the broad "contains the id" checks
+    // above because the interpolation case would still substitute.
+    assert!(
+        stripped.contains("DevAccount: \"222222222222\""),
+        "expected bare `orgs.accounts['registry_dev']` attribute substituted, got:\n{stripped}"
+    );
+    insta::assert_snapshot!(stripped);
+}
+
 #[test]
 fn plan_snapshot_exports() {
     use crate::commands::plan::ExportChange;

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_subscript.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_subscript.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: stripped
+---
+Execution Plan:
+
+  + awscc.s3.Bucket 
+      bucket_name: "shared-222222222222-bucket"
+      tags:
+        DevAccount: "222222222222"
+        ProdAccount: "111111111111"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/main.crn
@@ -1,0 +1,18 @@
+# Test upstream_state map subscript across sibling .crn files (#2435).
+#
+# `let X = upstream_state {...}` lives in `state.crn`; the consuming
+# `${X.field['key']}` lives in this `main.crn`. The fix in #2435 makes
+# this directory shape parse and resolve.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.Bucket {
+  bucket_name = "shared-${orgs.accounts['registry_dev']}-bucket"
+
+  tags = {
+    DevAccount  = orgs.accounts['registry_dev']
+    ProdAccount = orgs.accounts['registry_prod']
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/orgs/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/orgs/carina.state.json
@@ -1,0 +1,13 @@
+{
+  "version": 5,
+  "serial": 1,
+  "lineage": "remote-orgs-lineage",
+  "carina_version": "0.1.0",
+  "resources": [],
+  "exports": {
+    "accounts": {
+      "registry_prod": "111111111111",
+      "registry_dev": "222222222222"
+    }
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/orgs/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/orgs/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+exports {
+  accounts: map(String) = {
+    registry_prod = "111111111111"
+    registry_dev  = "222222222222"
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/state.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_subscript/state.crn
@@ -1,0 +1,3 @@
+let orgs = upstream_state {
+  source = "./orgs"
+}

--- a/carina-cli/tests/plan_fixture_example.rs
+++ b/carina-cli/tests/plan_fixture_example.rs
@@ -65,3 +65,9 @@ fn plan_fixture_upstream_state() {
     let output = run_plan_fixture(&["upstream_state"]);
     assert_success(&output, "upstream_state");
 }
+
+#[test]
+fn plan_fixture_upstream_state_map_subscript() {
+    let output = run_plan_fixture(&["upstream_state_map_subscript"]);
+    assert_success(&output, "upstream_state_map_subscript");
+}

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -59,26 +59,29 @@ fn parse_namespaced_id_value(
         full_str
     );
 
-    if ctx.is_resource_binding(parts[0]) {
-        let attribute = parts[1].to_string();
-        let field_path = parts[2..].iter().map(|s| s.to_string()).collect();
+    let as_resource_ref = |subscripts: Vec<Subscript>| {
         let path = AccessPath::with_fields_and_subscripts(
             parts[0].to_string(),
-            attribute,
-            field_path,
+            parts[1].to_string(),
+            parts[2..].iter().map(|s| s.to_string()).collect(),
             subscripts,
         );
-        return Ok(EvalValue::from_value(Value::ResourceRef { path }));
+        EvalValue::from_value(Value::ResourceRef { path })
+    };
+
+    if ctx.is_resource_binding(parts[0]) {
+        return Ok(as_resource_ref(subscripts));
     }
 
+    // Subscripts (`a.b['k']`, `a.b[0]`) unambiguously mean binding
+    // access — no enum shorthand uses `[...]`. So when the head is not
+    // yet known as a resource binding in this file, emit a structured
+    // `ResourceRef` anyway and let cross-file resolution / scope checks
+    // either confirm the binding (e.g. an `upstream_state` declared in
+    // a sibling `.crn`) or surface an undefined-identifier diagnostic
+    // post-merge. Issue #2435.
     if !subscripts.is_empty() {
-        return Err(ParseError::InvalidExpression {
-            line: 0,
-            message: format!(
-                "cannot subscript `{}` — it is not a known resource binding",
-                full_str
-            ),
-        });
+        return Ok(as_resource_ref(subscripts));
     }
 
     if parts.len() == 2

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -332,11 +332,16 @@ fn resolve_value_with_config(
                     Ok(value.clone())
                 }
             },
-            None => Err(ParseError::UndefinedVariable(format!(
-                "{}.{}",
-                path.binding(),
-                path.attribute()
-            ))),
+            // Binding not found in *this* file's binding_map. The same
+            // resolver runs both per-file (config_loader.rs L93) and on
+            // the merged `ParsedFile` (L178); a per-file miss may be a
+            // legitimate cross-file ref (`upstream_state` declared in a
+            // sibling `.crn`, resource binding from another file).
+            // Keep the ref as-is and let the post-merge
+            // `check_identifier_scope` walk surface any genuine
+            // undefined identifiers — that walk has full directory
+            // context plus did-you-mean suggestions.
+            None => Ok(value.clone()),
         },
         Value::List(items) => {
             let resolved: Result<Vec<Value>, ParseError> = items

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -7769,3 +7769,133 @@ fn inferred_file_holds_inferred_export_param() {
     };
     assert_eq!(f.export_params[0].type_expr, TypeExpr::String);
 }
+
+// ================================================================
+// #2435: upstream_state map subscript across sibling files
+//
+// In the real reproduction the `let X = upstream_state {...}` lives in
+// one .crn file and the consuming `${X.field['key']}` lives in a sibling
+// .crn — typical multi-file directory shape (CLAUDE.md "Directory-scoped,
+// never single-file"). The single-file path was already covered by
+// #2318's tests; the cross-file path was rejected at parse time with
+// "cannot subscript ... not a known resource binding" because the
+// per-file ParseContext did not yet know about the upstream binding.
+// ================================================================
+
+#[test]
+fn parse_subscript_on_upstream_state_in_sibling_file() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("state.crn"),
+        r#"
+            let orgs = upstream_state { source = "../organizations" }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+                region = "ap-northeast-1"
+            }
+
+            test.r.res {
+                name = "x"
+                account_id = orgs.accounts["registry_dev"]
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("cross-file upstream subscript must parse");
+    let res = parsed
+        .resources
+        .iter()
+        .find(|r| r.attributes.contains_key("account_id"))
+        .expect("resource present");
+    let v = res.attributes.get("account_id").unwrap();
+    match v {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert!(path.field_path().is_empty());
+            assert_eq!(
+                path.subscripts(),
+                [crate::resource::Subscript::Str {
+                    key: "registry_dev".to_string()
+                }]
+            );
+        }
+        other => panic!("expected ResourceRef with map subscript, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() {
+    // `"prefix${orgs.accounts['registry_dev']}suffix"` inside an
+    // interpolation must lower the same as the bare attribute case.
+    // Issue #2435 try-2 (subscript) needs to work both as a direct
+    // attribute value and embedded in `${...}` so policy-document
+    // strings like `"arn:aws:iam::${orgs.accounts['x']}:root"` resolve.
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("state.crn"),
+        r#"
+            let orgs = upstream_state { source = "../organizations" }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+                region = "ap-northeast-1"
+            }
+
+            test.r.res {
+                name = "x"
+                arn = "arn:aws:iam::${orgs.accounts['registry_dev']}:root"
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("cross-file upstream subscript inside ${...} must parse");
+    let res = parsed
+        .resources
+        .iter()
+        .find(|r| r.attributes.contains_key("arn"))
+        .expect("resource present");
+    let v = res.attributes.get("arn").unwrap();
+    match v {
+        Value::Interpolation(parts) => {
+            // The middle Expr part should be the upstream ResourceRef
+            // with a string subscript.
+            let mut found_ref = false;
+            for p in parts {
+                if let InterpolationPart::Expr(Value::ResourceRef { path }) = p {
+                    assert_eq!(path.binding(), "orgs");
+                    assert_eq!(path.attribute(), "accounts");
+                    assert_eq!(
+                        path.subscripts(),
+                        [crate::resource::Subscript::Str {
+                            key: "registry_dev".to_string()
+                        }]
+                    );
+                    found_ref = true;
+                }
+            }
+            assert!(
+                found_ref,
+                "expected a ResourceRef expression part in the interpolation, got {parts:?}"
+            );
+        }
+        other => panic!("expected Value::Interpolation, got {other:?}"),
+    }
+}

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -218,7 +218,27 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                             Some(nested) => {
                                 resolved = resolve_ref_value(nested, bindings)?;
                             }
-                            None => return Ok(value.clone()),
+                            None => {
+                                // When the map is concrete (the upstream's
+                                // value was loaded) and the requested key
+                                // is not in its keyset, the user typo'd
+                                // the key. Surface a clear error listing
+                                // the known keys instead of silently
+                                // degrading to "(known after upstream
+                                // apply: …)". Issue #2435.
+                                let known_list = if map.is_empty() {
+                                    "<no keys>".to_string()
+                                } else {
+                                    map.keys()
+                                        .map(|k| format!("{k:?}"))
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                };
+                                return Err(format!(
+                                    "{}: key not found; available keys: {}",
+                                    path, known_list
+                                ));
+                            }
                         },
                         _ => return Ok(value.clone()),
                     }
@@ -806,6 +826,268 @@ mod tests {
         assert_eq!(
             resources[0].get_attr("vpc_id"),
             Some(&Value::String("vpc-123".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_map_subscript_substitutes_value() {
+        // Issue #2435: `${orgs.accounts['registry_dev']}` against an
+        // upstream that exports `accounts: map(AwsAccountId)` must
+        // resolve to the concrete account id, not the literal substring
+        // or an unresolved ref.
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "principal_arn",
+                // orgs.accounts["registry_dev"]
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "accounts",
+                        Vec::new(),
+                        vec![crate::resource::Subscript::Str {
+                            key: "registry_dev".to_string(),
+                        }],
+                    ),
+                },
+            )],
+        )];
+
+        let mut accounts_map: IndexMap<String, Value> = IndexMap::new();
+        accounts_map.insert(
+            "registry_prod".to_string(),
+            Value::String("111111111111".to_string()),
+        );
+        accounts_map.insert(
+            "registry_dev".to_string(),
+            Value::String("222222222222".to_string()),
+        );
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts_map));
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            .unwrap();
+
+        assert_eq!(
+            resources[0].get_attr("principal_arn"),
+            Some(&Value::String("222222222222".to_string())),
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_map_subscript_missing_key_errors() {
+        // Issue #2435 acceptance: when the upstream map IS loaded
+        // (concrete `Value::Map`) but the requested string key is not
+        // among its entries, the resolver must surface a clear error
+        // naming the binding, attribute, and key — otherwise a typo
+        // silently degrades to "(known after upstream apply: …)".
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "principal_arn",
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "accounts",
+                        Vec::new(),
+                        vec![crate::resource::Subscript::Str {
+                            key: "registry_qa".to_string(),
+                        }],
+                    ),
+                },
+            )],
+        )];
+
+        let mut accounts_map: IndexMap<String, Value> = IndexMap::new();
+        accounts_map.insert(
+            "registry_prod".to_string(),
+            Value::String("111111111111".to_string()),
+        );
+        accounts_map.insert(
+            "registry_dev".to_string(),
+            Value::String("222222222222".to_string()),
+        );
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("accounts".to_string(), Value::Map(accounts_map));
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        let err =
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+                .expect_err("missing key in concrete upstream map must error");
+        assert!(
+            err.contains("orgs.accounts") && err.contains("registry_qa"),
+            "error must name the upstream path and the missing key, got: {err}"
+        );
+        // Should also list available keys so the user can fix the typo.
+        assert!(
+            err.contains("registry_prod") && err.contains("registry_dev"),
+            "error should list known keys, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_map_subscript_empty_map_errors() {
+        // Empty `Value::Map` exists but has no keys — the error must
+        // still fire and the available-keys list must say so explicitly
+        // ("<no keys>") rather than render an empty string.
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("accounts".to_string(), Value::Map(IndexMap::new()));
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "principal_arn",
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "accounts",
+                        Vec::new(),
+                        vec![crate::resource::Subscript::Str {
+                            key: "registry_dev".to_string(),
+                        }],
+                    ),
+                },
+            )],
+        )];
+        let err =
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+                .expect_err("empty map subscript must error");
+        assert!(
+            err.contains("<no keys>"),
+            "empty-map error must say '<no keys>', got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_map_subscript_unloaded_keeps_ref() {
+        // The new missing-key error must NOT fire when the upstream
+        // binding itself isn't loaded yet (e.g. plan-time before the
+        // upstream apply has run). The resolver should keep the ref so
+        // `resolve_refs_for_plan` can stamp it as
+        // `Unknown(UpstreamRef)`. Guards against a future refactor that
+        // hoists the subscript walk above the binding-presence check.
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "principal_arn",
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "accounts",
+                        Vec::new(),
+                        vec![crate::resource::Subscript::Str {
+                            key: "anything".to_string(),
+                        }],
+                    ),
+                },
+            )],
+        )];
+
+        let remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            .expect("unloaded upstream subscript must not error");
+        assert!(
+            matches!(
+                resources[0].get_attr("principal_arn"),
+                Some(Value::ResourceRef { .. })
+            ),
+            "ref must stay as ResourceRef when upstream is not loaded"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_chained_subscripts() {
+        // `orgs.regions['us'][0]` against a `map(list(String))` should
+        // walk the map, then index into the list, returning the leaf.
+        let inner_list = Value::List(vec![
+            Value::String("aza".to_string()),
+            Value::String("azb".to_string()),
+        ]);
+        let mut regions_map: IndexMap<String, Value> = IndexMap::new();
+        regions_map.insert("us".to_string(), inner_list);
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("regions".to_string(), Value::Map(regions_map));
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "az",
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "regions",
+                        Vec::new(),
+                        vec![
+                            crate::resource::Subscript::Str {
+                                key: "us".to_string(),
+                            },
+                            crate::resource::Subscript::Int { index: 0 },
+                        ],
+                    ),
+                },
+            )],
+        )];
+        resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+            .unwrap();
+        assert_eq!(
+            resources[0].get_attr("az"),
+            Some(&Value::String("aza".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_upstream_state_chained_subscript_missing_key_errors() {
+        // `orgs.regions['eu'][0]` where map has only 'us' — the missing
+        // string key surfaces the same key-not-found error as the
+        // single-subscript case.
+        let mut regions_map: IndexMap<String, Value> = IndexMap::new();
+        regions_map.insert(
+            "us".to_string(),
+            Value::List(vec![Value::String("aza".to_string())]),
+        );
+        let mut orgs_attrs = HashMap::new();
+        orgs_attrs.insert("regions".to_string(), Value::Map(regions_map));
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("orgs".to_string(), orgs_attrs);
+
+        let mut resources = vec![make_resource(
+            "policy",
+            None,
+            vec![(
+                "az",
+                Value::ResourceRef {
+                    path: crate::resource::AccessPath::with_fields_and_subscripts(
+                        "orgs",
+                        "regions",
+                        Vec::new(),
+                        vec![
+                            crate::resource::Subscript::Str {
+                                key: "eu".to_string(),
+                            },
+                            crate::resource::Subscript::Int { index: 0 },
+                        ],
+                    ),
+                },
+            )],
+        )];
+        let err =
+            resolve_refs_with_state_and_remote(&mut resources, &HashMap::new(), &remote_bindings)
+                .expect_err("chained subscript with missing key must error");
+        assert!(
+            err.contains("eu") && err.contains("us"),
+            "error must mention the missing key and known keys, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Make `${orgs.accounts['key']}` and bare `orgs.accounts['key']` resolve to the upstream's exported map value, even when `let orgs = upstream_state {...}` lives in a sibling `.crn` file.
- Surface a clear "key not found; available keys: ..." error when the upstream value is loaded but the string subscript misses (no more silent "(known after upstream apply: ...)" for typos).
- Lock the behavior with directory-fixture parser tests, resolver unit tests covering the happy path, missing-key, empty-map, unloaded-keep-ref, and chained-subscript variants, plus a plan-display fixture + insta snapshot.

## Why

The parser rejected `subscripted_id` whose head was not yet known as a resource binding *in the current file*, even though `let X = upstream_state {...}` may legitimately live in `state.crn` while `${X.field['k']}` lives in `main.crn` — the standard "Directory-scoped, never single-file" shape. Subscripts unambiguously mean binding access (no enum shorthand uses `[...]`), so the parser now emits `Value::ResourceRef` regardless of binding-knowledge in the current file; cross-file resolution and the post-merge `check_identifier_scope` walk handle the rest.

The per-file `resolve_value_with_config` also stops erroring on unknown bindings — `check_identifier_scope` runs after merge with full directory context and gives better did-you-mean diagnostics.

## Design choice

Issue listed two options (dot-notation vs subscript). Chose **subscript** for long-term type safety:

- 1:1 syntax-to-semantics correspondence (subscript = map lookup, dot = field access; never ambiguous).
- Reuses existing `subscripted_id` grammar and `AccessPath::subscripts`.
- Arbitrary string keys (including ones with `.` or hyphens) work.
- Chains naturally for nested types (`a.b['k1']['k2']`).

Discussion in carina-rs/carina#2435.

## Test plan

- [x] `cargo nextest run --workspace` — 2681/2681 PASS (6 new tests)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 pass (including `check-plan-fixtures.sh` which verifies the new fixture has a Makefile target)
- [x] Real-binary smoke test: `cargo run --bin carina -- validate <multi-file-dir>` no longer errors with `Undefined variable: orgs.accounts`
- [x] Plan-display snapshot pins both the bare-attribute form (`tags.DevAccount: "222222222222"`) and the interpolation form (`bucket_name: "shared-222222222222-bucket"`) substituted to concrete values

## Related class of bugs (directory-scoped audit)

Triaging this PR surfaced the same class of "per-file blind spot" bug in 5 other locations across the codebase. Each is filed separately to keep this PR's scope tight (1 PR = 1 topic). Filed during the audit pass:

- #2439 — `Value::Secret(Map(...))` subscript silently keeps unresolved ref (resolver gap, surfaced more by this PR).
- #2442 — LSP `check_unknown_functions` flags sibling-file `fn` declarations as Unknown.
- #2443 — LSP `module_call_hover` returns None when `let X = use {...}` lives in a sibling `.crn`.
- #2444 — Parser eager user-fn eval errors on sibling-file `fn` with static-only args.
- #2445 — LSP `check_attributes_blocks` raises false "Undefined resource" for sibling-file bindings.
- #2446 — LSP `find_let_use_source` scans only current buffer; sibling-file `use {}` breaks module-call completion.

CLAUDE.md "Directory-scoped, never single-file" applies to all of them; same shape as PR #2120 (#2043) and PR #2118 (#2117) precedents.

Closes #2435
