### PR TITLE
feat: wire DetailRow::PrettyAttribute through detail_rows + display + tui (#2414)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -19,6 +19,7 @@ use carina_core::plan_tree::{
 };
 use carina_core::resource::{ResourceId, Value};
 use carina_core::schema::SchemaRegistry;
+use carina_core::value::format_value_pretty;
 #[cfg(test)]
 use carina_core::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
 
@@ -987,6 +988,19 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                 writeln!(out, "{}{}: {}", attr_prefix, key, cv).unwrap();
             }
         }
+        DetailRow::PrettyAttribute { key, value } => {
+            // The value starts at the column after `<attr_prefix><key>: `.
+            // attr_prefix may contain the tree glyph `│` (U+2502, 1 column
+            // wide but 3 bytes in UTF-8), so use `chars().count()` for column
+            // count, not `.len()`.
+            let indent_cols = attr_prefix.chars().count() + key.chars().count() + 2;
+            let pretty = format_value_pretty(value, indent_cols);
+            let cv = match effect {
+                Effect::Delete { .. } => pretty.red().strikethrough().to_string(),
+                _ => colored_value(&pretty, false),
+            };
+            writeln!(out, "{}{}: {}", attr_prefix, key, cv).unwrap();
+        }
         DetailRow::MapExpanded { key, entries } => {
             writeln!(out, "{}{}:", attr_prefix, key).unwrap();
             for entry in entries {
@@ -1007,19 +1021,6 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
                 } else {
                     writeln!(out, "{}  {}: {}", attr_prefix, entry.key, cv).unwrap();
                 }
-            }
-        }
-        DetailRow::ListOfMaps { key, items } => {
-            writeln!(out, "{}{}:", attr_prefix, key).unwrap();
-            for item in items {
-                writeln!(
-                    out,
-                    "{}  {} {{{}}}",
-                    attr_prefix,
-                    "+".green().bold(),
-                    item.fields
-                )
-                .unwrap();
             }
         }
         DetailRow::Changed { key, old, new } => {

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -43,11 +43,11 @@ pub enum DetailRow {
         key: String,
         entries: Vec<MapExpandedEntry>,
     },
-    /// A list-of-maps attribute (for Create effects)
-    ListOfMaps {
-        key: String,
-        items: Vec<ListOfMapsItem>,
-    },
+    /// An attribute whose value is rendered with `format_value_pretty` at
+    /// render time. Used for list-of-map attributes on Create — carries the
+    /// raw `Value` rather than a pre-stringified form so the renderer can
+    /// supply the actual indent column when calling `format_value_pretty`.
+    PrettyAttribute { key: String, value: Value },
     /// An attribute that changed (for Update effects)
     Changed {
         key: String,
@@ -112,13 +112,6 @@ pub enum DetailRow {
         count: usize,
         updates: Vec<CascadingUpdateIR>,
     },
-}
-
-/// A single item in a list-of-maps (for Create effects)
-#[derive(Debug, Clone, PartialEq)]
-pub struct ListOfMapsItem {
-    /// Pre-formatted fields string: "key1: val1, key2: val2"
-    pub fields: String,
 }
 
 /// A single entry in an expanded map (e.g., tags with default_tags annotation)
@@ -300,7 +293,10 @@ fn build_create_rows(
             continue;
         }
         if is_list_of_maps(value) {
-            rows.push(build_list_of_maps_row(key, value));
+            rows.push(DetailRow::PrettyAttribute {
+                key: key.to_string(),
+                value: value.clone(),
+            });
         } else if let Value::Map(map) = value {
             rows.push(build_expanded_map_row(key, map));
         } else {
@@ -383,40 +379,6 @@ fn build_expanded_tags_row(
     DetailRow::MapExpanded {
         key: "tags".to_string(),
         entries,
-    }
-}
-
-fn build_list_of_maps_row(key: &str, value: &Value) -> DetailRow {
-    let items = match value {
-        Value::List(items) => items,
-        _ => {
-            return DetailRow::Attribute {
-                key: key.to_string(),
-                value: format_value(value),
-                ref_binding: None,
-                annotation: None,
-            };
-        }
-    };
-
-    let mut list_items = Vec::new();
-    for item in items {
-        if let Value::Map(map) = item {
-            let mut map_keys: Vec<_> = map.keys().collect();
-            map_keys.sort();
-            let fields: Vec<String> = map_keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            list_items.push(ListOfMapsItem {
-                fields: fields.join(", "),
-            });
-        }
-    }
-
-    DetailRow::ListOfMaps {
-        key: key.to_string(),
-        items: list_items,
     }
 }
 
@@ -1201,5 +1163,44 @@ mod tests {
             &Value::String("plain".to_string()),
             "vpc"
         ));
+    }
+
+    #[test]
+    fn create_row_list_of_maps_emits_pretty_attribute() {
+        let mut entry = indexmap::IndexMap::new();
+        entry.insert("sid".to_string(), Value::String("S1".to_string()));
+        entry.insert("effect".to_string(), Value::String("Allow".to_string()));
+        let resource = Resource::new("iam.RolePolicy", "test")
+            .with_attribute("statement", Value::List(vec![Value::Map(entry)]));
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+
+        let pretty_value = rows.iter().find_map(|row| match row {
+            DetailRow::PrettyAttribute { key, value } if key == "statement" => Some(value),
+            _ => None,
+        });
+        assert!(
+            pretty_value.is_some(),
+            "expected PrettyAttribute row for statement, got: {rows:?}"
+        );
+        assert!(
+            matches!(pretty_value.unwrap(), Value::List(_)),
+            "PrettyAttribute should carry the raw Value::List"
+        );
+    }
+
+    #[test]
+    fn create_row_scalar_attribute_unchanged() {
+        let resource = Resource::new("iam.Role", "test")
+            .with_attribute("role_name", Value::String("foo".to_string()));
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+        assert!(
+            rows.iter().any(|row| matches!(
+                row,
+                DetailRow::Attribute { key, .. } if key == "role_name"
+            )),
+            "scalar attribute should still emit DetailRow::Attribute, got: {rows:?}"
+        );
     }
 }

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -4,7 +4,7 @@ use carina_core::detail_rows::DetailRow;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
-use crate::app::{App, EffectKind, FocusedPanel};
+use crate::app::{App, FocusedPanel};
 
 use super::diff::{render_list_of_maps_diff, render_map_diff_entries};
 use super::style::effect_style;
@@ -56,7 +56,7 @@ pub(super) fn draw_detail(frame: &mut Frame, app: &App, area: Rect) {
         let is_detail_focused = app.focused_panel == FocusedPanel::Detail;
         for (row_idx, row) in node.detail_rows.iter().enumerate() {
             let is_selected = is_detail_focused && row_idx == app.detail_selected;
-            render_detail_row_to_lines(&mut lines, row, node.kind, is_selected);
+            render_detail_row_to_lines(&mut lines, row, is_selected);
         }
     }
 
@@ -73,12 +73,7 @@ pub(super) fn draw_detail(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 /// Render a single `DetailRow` into TUI `Line`s.
-fn render_detail_row_to_lines(
-    lines: &mut Vec<Line>,
-    row: &DetailRow,
-    kind: EffectKind,
-    is_selected: bool,
-) {
+fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selected: bool) {
     let dim_style = Style::default().fg(Color::DarkGray);
 
     match row {
@@ -109,6 +104,20 @@ fn render_detail_row_to_lines(
             }
             lines.push(line);
         }
+        DetailRow::PrettyAttribute { key, value } => {
+            // Indent is fixed at the TUI's "  " (2 cols) prefix plus the
+            // "key: " width — the TUI doesn't have the CLI's dynamic
+            // tree-indent string, so the layout is approximated.
+            let pretty =
+                carina_core::value::format_value_pretty(value, 2 + key.chars().count() + 2);
+            let mut spans = vec![Span::raw(format!("  {}: ", key))];
+            spans.push(Span::raw(pretty));
+            let mut line = Line::from(spans);
+            if is_selected {
+                line = line.style(Style::default().bg(Color::DarkGray));
+            }
+            lines.push(line);
+        }
         DetailRow::MapExpanded { key, entries } => {
             let mut header_line = Line::from(vec![Span::raw(format!("  {}:", key))]);
             if is_selected {
@@ -126,31 +135,6 @@ fn render_detail_row_to_lines(
                 }
                 lines.push(Line::from(spans));
             }
-        }
-        DetailRow::ListOfMaps { key, items } => {
-            let value_style = if kind == EffectKind::Create {
-                Style::default().fg(Color::Green)
-            } else {
-                Style::default()
-            };
-            let mut first_line = Line::from(vec![
-                Span::raw(format!("  {}: ", key)),
-                Span::styled("[", value_style),
-            ]);
-            if is_selected {
-                first_line = first_line.style(Style::default().bg(Color::DarkGray));
-            }
-            lines.push(first_line);
-            for item in items {
-                lines.push(Line::from(vec![
-                    Span::raw("    "),
-                    Span::styled(format!("{{{}}}", item.fields), value_style),
-                ]));
-            }
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled("]", value_style),
-            ]));
         }
         DetailRow::Changed { key, old, new } => {
             let mut spans = vec![


### PR DESCRIPTION
Closes #2414.

Wires `format_value_pretty` (added in #2437) into the plan display pipeline. After this PR, list-of-map attributes on Create effects render vertically with one entry per line under a `- ` prefix, with map keys sorted alphabetically.

## What

- **`carina-core/src/detail_rows.rs`**: add `DetailRow::PrettyAttribute { key, value: Value }`. Route the `is_list_of_maps` branch in `build_create_rows` to emit it. Delete dead `build_list_of_maps_row`, `DetailRow::ListOfMaps` variant, and `ListOfMapsItem` struct (per project policy "No backward compatibility").
- **`carina-cli/src/display/mod.rs`**: render arm computes `indent_cols = attr_prefix.chars().count() + key.chars().count() + 2` and calls `format_value_pretty(value, indent_cols)`.
- **`carina-tui/src/ui/detail.rs`**: TUI render arm with fixed indent (TUI doesn't reproduce CLI's dynamic tree-indent string). Drops the now-unused `kind: EffectKind` parameter from the private renderer fn.

## Why raw `Value` in the variant?

The renderer needs the actual `attr_prefix` width — which is dynamic (whitespace + `│  ` continuation glyphs depending on tree depth and last-child position). Pre-stringifying at `build_create_rows` time would lock in an incorrect indent. Carrying the raw `Value` lets the renderer call `format_value_pretty` with the runtime width.

## Why `chars().count()` instead of `len()`?

`attr_prefix` may contain the `│` tree glyph (U+2502): 1 column wide but 3 bytes in UTF-8. `len()` would over-count and shift the pretty-print indent right. The inline comment documents this.

## Out of scope

- Snapshot fixtures (`policy_pretty/`, `pretty_long_string_list/`, `pretty_short_string_list/`) — tracked in #2415, #2416.
- Makefile targets — #2417.
- Real-infra smoke test — #2418.

End-to-end snapshot verification of the rendered output happens in #2415's snapshot fixture.

## Verification

```
cargo nextest run --workspace                         # 2693 passed
cargo test --workspace --doc                          # 0 failures
cargo clippy --workspace --all-targets -- -D warnings # clean
bash scripts/check-*.sh                               # all OK
```

## Notes

- Pre-existing `value.clone()` cost in the emit path: typical IAM policy
  list-of-map clones on the order of 50–80 `Value` nodes per resource.
  Acceptable for the interactive `plan` path; perf optimization tracked
  separately in #2434.
