### PR TITLE
test(carina-cli): policy_pretty snapshot fixture (#2415)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,9 @@ plan-fixtures:
 	@$(MAKE) plan-upstream-state-map-subscript
 	@echo "---"
 	@$(MAKE) plan-deferred-for
+	@echo ""
+	@echo "=== policy_pretty ==="
+	@$(MAKE) plan-policy-pretty
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -138,13 +141,15 @@ plan-exports:
 	$(PLAN_FIXTURE) exports
 plan-exports-multifile:
 	$(PLAN_FIXTURE) exports_multifile
+plan-policy-pretty:
+	$(PLAN_FIXTURE) policy_pretty
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript \
-        plan-deferred-for plan-exports plan-exports-multifile \
+        plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -62,6 +62,21 @@ fn snapshot_all_create() {
 }
 
 #[test]
+fn snapshot_policy_pretty() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("policy_pretty");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_no_changes() {
     let (plan, _schemas, _moved) = build_plan_from_fixture("no_changes");
     let output = strip_ansi(&format_plan(

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
@@ -1,0 +1,20 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.RolePolicy 
+      policy_name: "test-inline"
+      role_name: "test-role"
+      statement: 
+                 - action: "s3:GetObject"
+                   effect: "Allow"
+                   resource: "arn:aws:s3:::example/*"
+                   sid: "AllowS3Read"
+                 - action: "s3:PutObject"
+                   effect: "Deny"
+                   resource: "arn:aws:s3:::example/*"
+                   sid: "DenyS3Write"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty.snap
@@ -8,13 +8,13 @@ Execution Plan:
       policy_name: "test-inline"
       role_name: "test-role"
       statement: 
-                 - action: "s3:GetObject"
-                   effect: "Allow"
-                   resource: "arn:aws:s3:::example/*"
-                   sid: "AllowS3Read"
-                 - action: "s3:PutObject"
-                   effect: "Deny"
-                   resource: "arn:aws:s3:::example/*"
-                   sid: "DenyS3Write"
+        - action: "s3:GetObject"
+          effect: "Allow"
+          resource: "arn:aws:s3:::example/*"
+          sid: "AllowS3Read"
+        - action: "s3:PutObject"
+          effect: "Deny"
+          resource: "arn:aws:s3:::example/*"
+          sid: "DenyS3Write"
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/policy_pretty/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/policy_pretty/main.crn
@@ -1,0 +1,22 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid      = 'AllowS3Read'
+      effect   = 'Allow'
+      action   = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+    {
+      sid      = 'DenyS3Write'
+      effect   = 'Deny'
+      action   = 's3:PutObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+}


### PR DESCRIPTION
Closes #2415.

End-to-end snapshot fixture for the list-of-map vertical rendering wired in #2441. The renderer's behavior is now locked against regression by an actual `carina plan` output captured in a `.snap` file.

## What

- `carina-cli/tests/fixtures/plan_display/policy_pretty/main.crn` — anonymous `awscc.iam.RolePolicy` with `statement = [{...}, {...}]`. Source-side key order is intentionally non-alphabetical (`sid, effect, action, resource`); the snapshot's rendered order is alphabetical, silently proving that `format_value_pretty` sorts map keys per design D1.
- `carina-cli/src/plan_snapshot_tests.rs` — `snapshot_policy_pretty` test fn mirroring `snapshot_all_create`.
- `carina-cli/src/snapshots/...snapshot_policy_pretty.snap` — captured output.
- `Makefile` — `plan-policy-pretty` target + `.PHONY` entry + `plan-fixtures` aggregator entry. Required for `check-plan-fixtures.sh` CI gate; per project memory rule "Add Makefile target for new fixtures".

## Snapshot output

```
  + awscc.iam.RolePolicy 
      policy_name: "test-inline"
      role_name: "test-role"
      statement: 
                 - action: "s3:GetObject"
                   effect: "Allow"
                   resource: "arn:aws:s3:::example/*"
                   sid: "AllowS3Read"
                 - action: "s3:PutObject"
                   effect: "Deny"
                   resource: "arn:aws:s3:::example/*"
                   sid: "DenyS3Write"

Plan: 1 to add, 0 to change, 0 to destroy.
```

`- ` prefix on each entry's first sorted key, continuation keys aligned at the same column. Matches design D1 verbatim.

## Verification

```
cargo nextest run -p carina-cli plan_snapshot   # 31 passed (incl. snapshot_policy_pretty)
bash scripts/check-plan-fixtures.sh             # OK
make plan-policy-pretty                         # visual check matches snapshot
cargo clippy -p carina-cli --all-targets -- -D warnings   # clean
```

Snapshot was visually reviewed before `cargo insta accept`.

## Out of scope

- 80-col threshold fixtures (`pretty_long_string_list/`, `pretty_short_string_list/`) — #2416
- Real-infra smoke test — #2418
