### PR TITLE
LSP: resolve module-call completion across sibling .crn files

### DIFF
--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1764,3 +1764,138 @@ fn use_source_path_completion_works_multiline_with_trailing_brace() {
         labels
     );
 }
+
+/// Build the multi-file fixture used by the #2446 sibling-use
+/// completion tests. Layout:
+///
+///   <tmp>/modules/github-oidc/main.crn   — `arguments { <args> }`
+///   <tmp>/consumer/imports.crn           — `let github = use { source = '../modules/github-oidc' }`
+///   <tmp>/consumer/main.crn              — `<main_text>`
+///
+/// Returns `(tempdir, consumer_dir_path)`.
+fn sibling_use_module_fixture(
+    args_block: &str,
+    main_text: &str,
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    let module_dir = base.join("modules").join("github-oidc");
+    std::fs::create_dir_all(&module_dir).unwrap();
+    std::fs::write(
+        module_dir.join("main.crn"),
+        format!("arguments {{\n{args_block}\n}}\n"),
+    )
+    .unwrap();
+    let consumer = base.join("consumer");
+    std::fs::create_dir(&consumer).unwrap();
+    std::fs::write(
+        consumer.join("imports.crn"),
+        "let github = use {\n  source = '../modules/github-oidc'\n}\n",
+    )
+    .unwrap();
+    std::fs::write(consumer.join("main.crn"), main_text).unwrap();
+    (tmp, consumer)
+}
+
+/// Issue #2446: when `let X = use { source = '...' }` lives in a sibling
+/// `.crn` file, completion inside `X { ... }` in `main.crn` must offer
+/// the module's `arguments {}` parameters. Same class as PR #2120 / PR
+/// #2118: per-file blind spot in an LSP feature that should be
+/// directory-scoped.
+#[test]
+fn module_parameter_completion_with_sibling_use_decl() {
+    let main_text = "github {\n  \n}\n";
+    let (_tmp, consumer) =
+        sibling_use_module_fixture("  github_repo: String\n  role_name  : String", main_text);
+
+    let provider = test_provider();
+    let doc = create_document(main_text);
+    // Cursor on the empty body line at column 2.
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 1,
+            character: 2,
+        },
+        Some(consumer.as_path()),
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"github_repo"),
+        "expected `github_repo` parameter completion when `let X = use {{...}}` lives in a sibling `.crn`, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"role_name"),
+        "expected `role_name` parameter completion, got: {labels:?}"
+    );
+}
+
+/// Discard binding (`let _ = use {...}`) must not surface a `_ { ... }`
+/// snippet completion. Pre-existing guard at `top_level.rs` skips
+/// `binding == "_"`; this test pins that guard against regression now
+/// that the snippet loop walks merged-directory text (#2446).
+#[test]
+fn top_level_module_call_completion_skips_discard_binding() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    let module_dir = base.join("modules").join("noop");
+    std::fs::create_dir_all(&module_dir).unwrap();
+    std::fs::write(module_dir.join("main.crn"), "arguments {\n  x: String\n}\n").unwrap();
+    let consumer = base.join("consumer");
+    std::fs::create_dir(&consumer).unwrap();
+    std::fs::write(
+        consumer.join("imports.crn"),
+        "let _ = use {\n  source = '../modules/noop'\n}\n",
+    )
+    .unwrap();
+    let main_text = "";
+    std::fs::write(consumer.join("main.crn"), main_text).unwrap();
+
+    let provider = test_provider();
+    let doc = create_document(main_text);
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 0,
+            character: 0,
+        },
+        Some(consumer.as_path()),
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"_"),
+        "discard binding `_` must not surface a module-call completion, got: {labels:?}"
+    );
+}
+
+/// Issue #2446 (top-level form): the `module call` snippet completion
+/// must also surface bindings whose `let X = use {...}` lives in a
+/// sibling `.crn`. Without this, typing at the top of `main.crn` does
+/// not offer the `X { ... }` scaffold.
+#[test]
+fn top_level_module_call_completion_with_sibling_use_decl() {
+    // Empty buffer (top-level position). The user is about to type a
+    // module-call binding name; completion must include `github` from
+    // the sibling `imports.crn`.
+    let main_text = "";
+    let (_tmp, consumer) = sibling_use_module_fixture("  github_repo: String", main_text);
+
+    let provider = test_provider();
+    let doc = create_document(main_text);
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 0,
+            character: 0,
+        },
+        Some(consumer.as_path()),
+    );
+
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"github"),
+        "expected `github` module-call completion from sibling `let X = use {{...}}`, got: {labels:?}"
+    );
+}

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -184,22 +184,31 @@ impl CompletionProvider {
         ];
 
         // Generate module binding completions from `use` statements
-        // e.g., "let github = use { source = '...' }" → suggest "github" with call scaffold
-        for line in lines.iter() {
-            if let Some((binding, after_eq)) = crate::let_parse::parse_let_header(line)
-                && binding != "_"
-                && (after_eq.starts_with("use ") || after_eq.starts_with("use{"))
-            {
-                let snippet = self.build_module_call_snippet(binding, after_eq, base_path);
-                completions.push(CompletionItem {
-                    label: binding.to_string(),
-                    kind: Some(CompletionItemKind::MODULE),
-                    insert_text: Some(snippet),
-                    insert_text_format: Some(InsertTextFormat::SNIPPET),
-                    detail: Some("Module call".to_string()),
-                    ..Default::default()
-                });
+        // e.g., "let github = use { source = '...' }" → suggest "github" with call scaffold.
+        // Resolve `DslSource` once so the directory's sibling `.crn`
+        // files are read a single time per completion request — both the
+        // let-binding scan here and any `find_module_import_path`
+        // fallback inside `build_module_call_snippet` share the same
+        // merged text (#2446).
+        let mut storage = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut storage);
+        let merged = src.merged_text();
+        for (binding, after_eq) in Self::extract_let_bindings(src) {
+            if binding == "_" {
+                continue;
             }
+            if !(after_eq.starts_with("use ") || after_eq.starts_with("use{")) {
+                continue;
+            }
+            let snippet = self.build_module_call_snippet(&binding, &after_eq, merged, base_path);
+            completions.push(CompletionItem {
+                label: binding.clone(),
+                kind: Some(CompletionItemKind::MODULE),
+                insert_text: Some(snippet),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                detail: Some("Module call".to_string()),
+                ..Default::default()
+            });
         }
 
         // Generate resource type completions from schemas
@@ -334,8 +343,9 @@ impl CompletionProvider {
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
 
-        // Find the import statement for this module
-        let import_path = self.find_module_import_path(module_name, text);
+        // Find the import statement for this module — across the buffer
+        // and every sibling `.crn` in the same directory (#2446).
+        let import_path = self.find_module_import_path(module_name, text, base_path);
 
         if let Some(import_path) = import_path
             && let Some(base) = base_path
@@ -404,27 +414,51 @@ impl CompletionProvider {
     /// The real `carina-rs/infra` tree always writes the multi-line form, so
     /// scanning line-by-line and only looking at the `let` line itself misses
     /// the `source` value entirely. We instead locate the `let <name> = use {`
-    /// header and then slurp the buffer up to the matching `}` to find
+    /// header and then slurp the source text up to the matching `}` to find
     /// `source = '...'` anywhere inside.
-    pub(super) fn find_module_import_path(&self, module_name: &str, text: &str) -> Option<String> {
-        find_let_use_source(module_name, text)
+    ///
+    /// Tries the buffer first; on miss, falls back to a directory-merged
+    /// scan so a `let X = use {...}` declared in a sibling `.crn`
+    /// (e.g. `imports.crn`) is found from a consumer in `main.crn` (#2446).
+    pub(super) fn find_module_import_path(
+        &self,
+        module_name: &str,
+        text: &str,
+        base_path: Option<&Path>,
+    ) -> Option<String> {
+        // Fast path: when the `let X = use {...}` lives in the open
+        // buffer itself, skip the disk walk over sibling `.crn` files.
+        // Only the cross-file case (#2446) needs the merged scan.
+        if let Some(path) = find_let_use_source(module_name, text) {
+            return Some(path);
+        }
+        let mut storage = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut storage);
+        find_let_use_source(module_name, src.merged_text())
     }
 
     /// Build a snippet for a module call with argument placeholders.
     ///
     /// If the module can be loaded, generates a snippet with all arguments
     /// as tab stops. Falls back to a simple `name { ${1} }` if loading fails.
+    ///
+    /// `merged` is the buffer + sibling `.crn` text already resolved
+    /// once by the caller (`DslSource::resolve_directory`); reusing it
+    /// here avoids a second disk read per `let X = use {...}` binding
+    /// in the snippet loop.
     fn build_module_call_snippet(
         &self,
         binding: &str,
         after_eq: &str,
+        merged: &str,
         base_path: Option<&Path>,
     ) -> String {
-        // Extract source path from "use { source = 'path' }" or with double quotes.
-        // Only the single-line shape is resolvable here — when the `use` body
-        // spans newlines, `after_eq` is just the line tail and we fall back
-        // to the no-source scaffold below.
-        let import_path = extract_use_source_path(after_eq);
+        // Try the same-line shape first (`use { source = '...' }` on the
+        // `let` line). Falls back to scanning the merged text so the
+        // multi-line shape and the sibling-`.crn` shape (#2446) also
+        // resolve.
+        let import_path =
+            extract_use_source_path(after_eq).or_else(|| find_let_use_source(binding, merged));
 
         if let Some(path) = import_path.as_deref()
             && let Some(base) = base_path


### PR DESCRIPTION
## Summary

- Make LSP module-call completion (both forms — parameter completion inside `X { ... }` and the top-level `X { ... }` snippet) work when `let X = use { source = '...' }` lives in a sibling `.crn` file.
- Resolve the directory exactly once per top-level completion request: snippet loop and inner `build_module_call_snippet` share the same merged text.
- Buffer-first short-circuit in `find_module_import_path` — same-buffer case stays I/O-free.

## Why

`module_parameter_completions` and the snippet loop both scanned only the open buffer for `let X = use {...}`. CLAUDE.md "Directory-scoped, never single-file": same shape as PR #2120 / #2118.

## Approach

- Thread the existing `DslSource::resolve_directory` helper through `find_module_import_path` and the snippet loop.
- Snippet loop now uses the existing `extract_let_bindings` helper (buffer-first dedup) over the merged text — drops the local `HashSet` and `parse_let_header` walk.
- `build_module_call_snippet` takes the already-merged `&str` instead of re-resolving — eliminates the N+1 disk-read pattern.
- `find_module_import_path` tries the buffer first via `find_let_use_source(name, text)` and only falls back to the merged scan on miss.

## Test plan

3 multi-file tempdir tests via shared `sibling_use_module_fixture`:

- [x] `module_parameter_completion_with_sibling_use_decl` — parameter completion inside `X { ... }` returns the module's `arguments` when the `let` lives in `imports.crn`.
- [x] `top_level_module_call_completion_with_sibling_use_decl` — top-level position offers `X { ... }` snippet for the sibling-defined binding.
- [x] `top_level_module_call_completion_skips_discard_binding` — `let _ = use {...}` does NOT surface a `_` snippet (regression guard for the existing skip).

All 401 carina-lsp tests pass; clippy clean; doctests pass; 5 check scripts pass.

Real-infra smoke against `carina-rs/infra/aws/management/github-oidc/` skipped: that directory currently keeps `let github = use {...}` and `github { ... }` in the same file, so it doesn't trigger the bug. The multi-file tempdir fixtures faithfully simulate the directory shape from CLAUDE.md "Directory-scoped, never single-file" rule. Same situation as #2443.

Closes #2446
