### PR TITLE
fix(carina-core): route Value::List through PrettyAttribute (#2459)

### DIFF
--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -292,7 +292,12 @@ fn build_create_rows(
             rows.push(build_expanded_tags_row(map, &default_tag_keys));
             continue;
         }
-        if is_list_of_maps(value) {
+        // `Value::List` (any element type) goes through PrettyAttribute so
+        // `format_value_pretty` can apply its 80-col threshold and YAML-style
+        // vertical layout. `Value::Map` keeps the existing MapExpanded path
+        // because that variant carries per-entry annotation slots that
+        // PrettyAttribute does not represent (used by tags/default_tags).
+        if let Value::List(_) = value {
             rows.push(DetailRow::PrettyAttribute {
                 key: key.to_string(),
                 value: value.clone(),
@@ -1201,6 +1206,54 @@ mod tests {
                 DetailRow::Attribute { key, .. } if key == "role_name"
             )),
             "scalar attribute should still emit DetailRow::Attribute, got: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn create_row_list_of_strings_emits_pretty_attribute() {
+        // list-of-string must route through PrettyAttribute so
+        // format_value_pretty's 80-col threshold can apply.
+        let resource = Resource::new("iam.Role", "test").with_attribute(
+            "managed_policy_arns",
+            Value::List(vec![
+                Value::String("arn:aws:iam::aws:policy/Policy1".to_string()),
+                Value::String("arn:aws:iam::aws:policy/Policy2".to_string()),
+            ]),
+        );
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+
+        let pretty = rows.iter().find_map(|row| match row {
+            DetailRow::PrettyAttribute { key, value } if key == "managed_policy_arns" => {
+                Some(value)
+            }
+            _ => None,
+        });
+        assert!(
+            pretty.is_some(),
+            "expected PrettyAttribute row for list-of-string attribute, got: {rows:?}"
+        );
+        assert!(
+            matches!(pretty.unwrap(), Value::List(_)),
+            "PrettyAttribute should carry the raw Value::List"
+        );
+    }
+
+    #[test]
+    fn create_row_empty_list_emits_pretty_attribute() {
+        // Pins down `tags = []` behavior — a regression that re-introduces
+        // an `!items.is_empty()` guard would silently bypass the routing
+        // for empty lists, breaking the formatting-path uniformity.
+        let resource =
+            Resource::new("iam.Role", "test").with_attribute("tags", Value::List(vec![]));
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+        assert!(
+            rows.iter().any(|row| matches!(
+                row,
+                DetailRow::PrettyAttribute { key, .. } if key == "tags"
+            )),
+            "empty list should also emit PrettyAttribute, got: {rows:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

`build_create_rows` のディスパッチが `is_list_of_maps(value)` で list-of-map のみを `DetailRow::PrettyAttribute` に流していた。list-of-string などの list-of-scalar は `DetailRow::Attribute` に落ちて `format_value_with_key` で事前文字列化され、`format_value_pretty` の 80 桁しきい値ロジックを完全にバイパスしていた。結果、長い list-of-string (例: `managed_policy_arns`) が長さに関わらずインライン表示されていた。

条件を `if let Value::List(_) = value` に置き換えて、すべての `Value::List` を `PrettyAttribute` 経由にする。`Value::Map` は `tags + default_tags` の per-entry 注釈スロットを持つ `MapExpanded` 経由のまま (`PrettyAttribute` は注釈を表現できない)。

## Test plan

- [x] `cargo nextest run -p carina-core` — 1628 passed
- [x] `cargo nextest run -p carina-cli plan_snapshot` — 31/31 passed (既存 fixture でしきい値を超える list-of-string がないため churn なし)
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings` — clean
- [x] 新規ユニットテスト 2 本: `create_row_list_of_strings_emits_pretty_attribute`, `create_row_empty_list_emits_pretty_attribute`

Closes #2459. Refs #2416 (この PR がマージされたら unblock される), #2409.
