### PR TITLE
Resolve sibling-defined user-fn calls at directory parse time

### DIFF
--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -5,7 +5,6 @@
 use super::ast::{FnParam, TypeExpr, UserFunction, UserFunctionBody};
 use super::context::{ParseContext, next_pair};
 use super::error::{ParseError, ParseWarning};
-use super::static_eval::is_static_value;
 use super::types::parse_type_expr;
 use super::util::{pascal_to_snake, value_type_name};
 use super::{ProviderContext, Rule, parse_expression};
@@ -551,22 +550,20 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                         ),
                     }),
                 Err(_builtin_err) => {
-                    // Try user-defined function
+                    // Try user-defined function declared in *this* file.
                     if let Some(user_fn) = ctx.user_functions.get(name) {
                         evaluate_user_function(user_fn, &evaluated_args, ctx)
                     } else {
-                        // Keep as FunctionCall (may contain unresolved refs)
-                        if evaluated_args.iter().all(is_static_value) {
-                            Err(ParseError::InvalidExpression {
-                                line: 0,
-                                message: format!("Unknown function: {name}"),
-                            })
-                        } else {
-                            Ok(Value::FunctionCall {
-                                name: name.clone(),
-                                args: evaluated_args,
-                            })
-                        }
+                        // Defer the call — the user-fn may live in a
+                        // sibling `.crn` and only become visible after
+                        // `merge_parsed_file` (#2444). Truly-undefined
+                        // names are caught at the post-merge resolver
+                        // pass (`resolve_value_with_config`), which has
+                        // the full directory's `user_functions`.
+                        Ok(Value::FunctionCall {
+                            name: name.clone(),
+                            args: evaluated_args,
+                        })
                     }
                 }
             }

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -126,6 +126,12 @@ pub fn resolve_resource_refs(parsed: &mut ParsedFile) -> Result<(), ParseError> 
 }
 
 /// Resolve resource references with the given parser configuration.
+///
+/// `parsed.user_functions` is consulted when resolving `Value::FunctionCall`
+/// values — a name that isn't a builtin but is a user-defined function in
+/// the merged directory parse triggers user-fn evaluation here, even when
+/// the per-file parse couldn't evaluate it because the `fn` declaration
+/// lived in a sibling `.crn` (#2444).
 pub fn resolve_resource_refs_with_config(
     parsed: &mut ParsedFile,
     config: &ProviderContext,
@@ -170,17 +176,44 @@ pub fn resolve_resource_refs_with_config(
         binding_map.entry(us.binding.clone()).or_default();
     }
 
+    // Build a `ParseContext` once, populated with the merged
+    // directory's user functions so a `Value::FunctionCall` whose name
+    // is a sibling-defined user-fn (visible only in the merged parse —
+    // #2444) is evaluated here rather than rejected as "Unknown
+    // built-in function". The HashMap is small (typically a handful of
+    // user-defined functions). Restructuring the surrounding
+    // `&mut parsed` borrow to avoid the clone is hairy on the error
+    // path (would need to restore on every `?` exit), so we accept a
+    // single map clone per call.
+    let mut fn_ctx = super::ParseContext::new(config);
+    fn_ctx.user_functions = parsed.user_functions.clone();
+
     // Resolve references in each resource. Keep `IndexMap` to preserve
     // the user's source order through resolution (#2222).
     for resource in &mut parsed.resources {
         let mut resolved_attrs: IndexMap<String, Value> = IndexMap::new();
 
         for (key, expr) in &resource.attributes {
-            let resolved = resolve_value_with_config(expr, &binding_map, config)?;
+            let resolved = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
             resolved_attrs.insert(key.clone(), resolved);
         }
 
         resource.attributes = resolved_attrs;
+    }
+
+    // Resolve top-level `let v = ...` bindings that contain
+    // `Value::FunctionCall` placeholders deferred by the per-file
+    // parse — typically `fn X(...)` lives in a sibling `.crn` (#2444).
+    // The variant below only mutates `FunctionCall` arms, leaving
+    // other shapes (`Value::String("${vpc}")` placeholder,
+    // `Value::ResourceRef`, etc.) untouched so earlier passes
+    // (`upstream_exports`, `BindingNameSet`) keep seeing the raw
+    // unresolved forms they expect.
+    let var_keys: Vec<String> = parsed.variables.keys().cloned().collect();
+    for key in var_keys {
+        let expr = parsed.variables[&key].clone();
+        let resolved = resolve_function_calls_only(&expr, &binding_map, &fn_ctx)?;
+        parsed.variables[&key] = resolved;
     }
 
     // Resolve cross-file forward references in export_params.
@@ -318,14 +351,14 @@ fn accumulate_deferred_iterable_errors(
 fn resolve_value_with_config(
     value: &Value,
     binding_map: &HashMap<String, HashMap<String, Value>>,
-    config: &ProviderContext,
+    fn_ctx: &super::ParseContext<'_>,
 ) -> Result<Value, ParseError> {
     match value {
         Value::ResourceRef { path } => match binding_map.get(path.binding()) {
             Some(attributes) => match attributes.get(path.attribute()) {
                 Some(attr_value) => {
                     // Recursively resolve in case the attribute itself is a reference
-                    resolve_value_with_config(attr_value, binding_map, config)
+                    resolve_value_with_config(attr_value, binding_map, fn_ctx)
                 }
                 None => {
                     // Attribute not found, keep as reference (might be resolved at runtime)
@@ -346,7 +379,7 @@ fn resolve_value_with_config(
         Value::List(items) => {
             let resolved: Result<Vec<Value>, ParseError> = items
                 .iter()
-                .map(|item| resolve_value_with_config(item, binding_map, config))
+                .map(|item| resolve_value_with_config(item, binding_map, fn_ctx))
                 .collect();
             Ok(Value::List(resolved?))
         }
@@ -355,7 +388,7 @@ fn resolve_value_with_config(
             for (k, v) in map {
                 resolved.insert(
                     k.clone(),
-                    resolve_value_with_config(v, binding_map, config)?,
+                    resolve_value_with_config(v, binding_map, fn_ctx)?,
                 );
             }
             Ok(Value::Map(resolved))
@@ -366,7 +399,7 @@ fn resolve_value_with_config(
                 .iter()
                 .map(|p| match p {
                     InterpolationPart::Expr(v) => Ok(InterpolationPart::Expr(
-                        resolve_value_with_config(v, binding_map, config)?,
+                        resolve_value_with_config(v, binding_map, fn_ctx)?,
                     )),
                     other => Ok(other.clone()),
                 })
@@ -376,7 +409,7 @@ fn resolve_value_with_config(
         Value::FunctionCall { name, args } => {
             let resolved_args: Result<Vec<Value>, ParseError> = args
                 .iter()
-                .map(|a| resolve_value_with_config(a, binding_map, config))
+                .map(|a| resolve_value_with_config(a, binding_map, fn_ctx))
                 .collect();
             let resolved_args = resolved_args?;
 
@@ -387,7 +420,7 @@ fn resolve_value_with_config(
                 .cloned()
                 .map(EvalValue::from_value)
                 .collect();
-            match crate::builtins::evaluate_builtin_with_config(name, &eval_args, config) {
+            match crate::builtins::evaluate_builtin_with_config(name, &eval_args, fn_ctx.config) {
                 Ok(result) => result
                     .into_value()
                     .map_err(|leak| ParseError::InvalidExpression {
@@ -399,6 +432,19 @@ fn resolve_value_with_config(
                         ),
                     }),
                 Err(e) => {
+                    // Builtin lookup failed. The name may be a user-fn
+                    // that became visible only after directory merge
+                    // (#2444): evaluate against the merged `fn_ctx`
+                    // built once at the top of the resolver pass.
+                    // Truly-undefined names with all-static args still
+                    // error.
+                    if let Some(user_fn) = fn_ctx.user_functions.get(name) {
+                        return super::functions::evaluate_user_function(
+                            user_fn,
+                            &resolved_args,
+                            fn_ctx,
+                        );
+                    }
                     if all_args_resolved {
                         // All args are resolved but builtin failed — propagate the error
                         Err(ParseError::InvalidExpression {
@@ -414,6 +460,54 @@ fn resolve_value_with_config(
                     }
                 }
             }
+        }
+        _ => Ok(value.clone()),
+    }
+}
+
+/// Walk a value tree and finalize any `Value::FunctionCall` placeholder
+/// that the per-file parse deferred (typically because the user-fn
+/// lives in a sibling `.crn` — #2444). Recurses through `List` / `Map`
+/// / `Interpolation` containers so deferred calls inside them surface
+/// too. Non-FunctionCall arms (`String`, `ResourceRef`,
+/// `Interpolation` literals, etc.) pass through unchanged so earlier
+/// passes that read raw forms keep working.
+fn resolve_function_calls_only(
+    value: &Value,
+    binding_map: &HashMap<String, HashMap<String, Value>>,
+    fn_ctx: &super::ParseContext<'_>,
+) -> Result<Value, ParseError> {
+    use crate::resource::InterpolationPart;
+    match value {
+        Value::FunctionCall { .. } => resolve_value_with_config(value, binding_map, fn_ctx),
+        Value::List(items) => {
+            let resolved: Result<Vec<Value>, ParseError> = items
+                .iter()
+                .map(|v| resolve_function_calls_only(v, binding_map, fn_ctx))
+                .collect();
+            Ok(Value::List(resolved?))
+        }
+        Value::Map(map) => {
+            let mut resolved: IndexMap<String, Value> = IndexMap::new();
+            for (k, v) in map {
+                resolved.insert(
+                    k.clone(),
+                    resolve_function_calls_only(v, binding_map, fn_ctx)?,
+                );
+            }
+            Ok(Value::Map(resolved))
+        }
+        Value::Interpolation(parts) => {
+            let resolved: Result<Vec<InterpolationPart>, ParseError> = parts
+                .iter()
+                .map(|p| match p {
+                    InterpolationPart::Expr(v) => Ok(InterpolationPart::Expr(
+                        resolve_function_calls_only(v, binding_map, fn_ctx)?,
+                    )),
+                    other => Ok(other.clone()),
+                })
+                .collect();
+            Ok(Value::Interpolation(resolved?).canonicalize())
         }
         _ => Ok(value.clone()),
     }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -7899,3 +7899,237 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
         other => panic!("expected Value::Interpolation, got {other:?}"),
     }
 }
+
+// ================================================================
+// #2444: eager user-fn eval errors on sibling-file fn with static args
+// ================================================================
+
+/// Build the multi-file fixture used by the #2444 sibling-fn tests.
+/// Layout: `helpers.crn` defines `fn timestamp() { "2026-05-05" }`;
+/// `main.crn` carries a `provider test` block plus a resource whose
+/// `created_at` attribute is the `call_text` argument.
+fn sibling_user_fn_fixture(call_text: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("helpers.crn"),
+        r#"
+            fn timestamp() {
+                "2026-05-05"
+            }
+        "#,
+    )
+    .unwrap();
+    let main = format!(
+        r#"
+            provider test {{
+                source = "x/y"
+                version = "0.1"
+                region = "ap-northeast-1"
+            }}
+
+            test.r.res {{
+                name = "x"
+                created_at = {call_text}
+            }}
+        "#
+    );
+    std::fs::write(tmp.path().join("main.crn"), main).unwrap();
+    tmp
+}
+
+#[test]
+fn parse_directory_resolves_sibling_user_fn_with_static_args() {
+    use crate::config_loader::parse_directory;
+    let tmp = sibling_user_fn_fixture("timestamp()");
+
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("sibling-file user-fn with static args must parse");
+    let res = parsed
+        .resources
+        .iter()
+        .find(|r| r.attributes.contains_key("created_at"))
+        .expect("resource present");
+    let v = res.attributes.get("created_at").unwrap();
+    match v {
+        Value::String(s) if s == "2026-05-05" => {}
+        Value::FunctionCall { name, .. } if name == "timestamp" => {}
+        other => panic!(
+            "expected timestamp() to resolve to a String or be kept as FunctionCall, got {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn parse_directory_truly_undefined_fn_with_static_args_still_errors() {
+    use crate::config_loader::parse_directory;
+    let tmp = sibling_user_fn_fixture("no_such_fn()");
+
+    let result = parse_directory(tmp.path(), &ProviderContext::default());
+    assert!(
+        result.is_err(),
+        "directory parse must error when calling a fn that exists nowhere in the directory"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("no_such_fn"),
+        "error should name the unknown function `no_such_fn`, got: {err}"
+    );
+}
+
+/// Issue #2444's exact reproduction: top-level `let v = X()` where
+/// `fn X(...)` lives in a sibling.
+#[test]
+fn parse_directory_resolves_sibling_user_fn_in_top_level_let() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("helpers.crn"),
+        r#"
+            fn timestamp() {
+                "2026-05-05"
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            let v = timestamp()
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("top-level `let` calling a sibling user-fn must parse");
+    let v = parsed
+        .variables
+        .get("v")
+        .expect("variable `v` should be present");
+    assert!(
+        matches!(v, Value::String(s) if s == "2026-05-05"),
+        "expected `v` to resolve to the user-fn body, got: {v:?}"
+    );
+}
+
+#[test]
+fn parse_directory_truly_undefined_fn_in_top_level_let_still_errors() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("helpers.crn"),
+        r#"
+            fn timestamp() {
+                "2026-05-05"
+            }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            let v = no_such_fn()
+        "#,
+    )
+    .unwrap();
+    let result = parse_directory(tmp.path(), &ProviderContext::default());
+    assert!(
+        result.is_err(),
+        "top-level `let v = no_such_fn()` must error when no `fn no_such_fn` exists in the directory"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("no_such_fn"),
+        "error should name the unknown function `no_such_fn`, got: {err}"
+    );
+}
+
+/// Container shapes (List/Map/Interpolation) at the top-level `let`
+/// position must also resolve sibling user-fn placeholders. Round 3
+/// found the narrowed walk skipped containers entirely — adding
+/// `resolve_function_calls_only` recurses through them.
+#[test]
+fn parse_directory_resolves_sibling_user_fn_in_let_list() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("helpers.crn"), "fn ts() { \"2026\" }\n").unwrap();
+    std::fs::write(tmp.path().join("main.crn"), "let xs = [ts(), \"static\"]\n").unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("List containing sibling user-fn must parse");
+    let v = parsed.variables.get("xs").expect("xs present");
+    match v {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2);
+            assert!(
+                matches!(&items[0], Value::String(s) if s == "2026"),
+                "first item should resolve to user-fn body, got: {:?}",
+                items[0]
+            );
+        }
+        other => panic!("expected Value::List, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_directory_resolves_sibling_user_fn_in_let_map() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("helpers.crn"), "fn ts() { \"2026\" }\n").unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        "let m = { created_at = ts() }\n",
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("Map containing sibling user-fn must parse");
+    let v = parsed.variables.get("m").expect("m present");
+    match v {
+        Value::Map(map) => {
+            let entry = map.get("created_at").expect("created_at key");
+            assert!(
+                matches!(entry, Value::String(s) if s == "2026"),
+                "map value should resolve to user-fn body, got: {entry:?}"
+            );
+        }
+        other => panic!("expected Value::Map, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_directory_resolves_sibling_user_fn_in_let_interpolation() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("helpers.crn"), "fn ts() { \"2026\" }\n").unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        "let s = \"prefix-${ts()}-suffix\"\n",
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("Interpolation containing sibling user-fn must parse");
+    let v = parsed.variables.get("s").expect("s present");
+    assert!(
+        matches!(v, Value::String(s) if s == "prefix-2026-suffix"),
+        "interpolation should canonicalize to the joined string, got: {v:?}"
+    );
+}
+
+#[test]
+fn parse_directory_truly_undefined_fn_in_let_list_still_errors() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("helpers.crn"), "fn ts() { \"2026\" }\n").unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        "let xs = [no_such_fn(), \"static\"]\n",
+    )
+    .unwrap();
+    let result = parse_directory(tmp.path(), &ProviderContext::default());
+    assert!(
+        result.is_err(),
+        "List containing a truly-undefined fn must error"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("no_such_fn"),
+        "error should name the unknown fn, got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- Defer rather than reject when `fn X(...) {...}` and a static-args call to `X()` live in different `.crn` files in the same directory.
- The post-merge resolver evaluates the deferred `Value::FunctionCall` against the merged `parsed.user_functions`, so the call resolves cleanly even though the per-file parse couldn't see the sibling-defined function.
- Truly-undefined names with all-static args still produce a hard error.

## Why

The per-file `try_evaluate_fn_value` and the resolver's `resolve_value_with_config` both took the strict static-args error path on a name that wasn't a builtin and wasn't in the *current* file's `user_functions`. CLAUDE.md "Directory-scoped, never single-file": same shape as #2435 / PR #2120 / PR #2118.

This was the prerequisite for #2442 (LSP `check_unknown_functions`): the LSP's directory-merged parse could not even reach `parsed.user_functions` because this resolver bug killed the merge with `Err("Unknown built-in function: X")`. With this PR, the merge succeeds and #2442 becomes implementable.

## Approach

1. `parser/functions.rs` — `try_evaluate_fn_value` defers `Value::FunctionCall` instead of erroring on unknown name in the static-args case.
2. `parser/resolve.rs::resolve_resource_refs_with_config` — builds a hoisted `ParseContext` populated with the merged `parsed.user_functions`. Threads it through `resolve_value_with_config(&fn_ctx)`. When builtin lookup fails AND the name is in `fn_ctx.user_functions`, calls `evaluate_user_function`.
3. `parser/resolve.rs` — new walk over `parsed.variables` via a dedicated `resolve_function_calls_only` helper that recurses through `List`/`Map`/`Interpolation` containers but **only** mutates `FunctionCall` arms. Other shapes (`Value::String("${vpc}")` placeholder, `Value::ResourceRef`, etc.) pass through unchanged so earlier passes (`upstream_exports`, `BindingNameSet`) keep reading the raw forms they expect.

## Test plan

8 multi-file directory fixtures via `parse_directory` covering each shape:

- [x] resource attribute (`x.y.z { ... = ts() }`) — happy + truly-undefined
- [x] top-level `let v = ts()` — happy + truly-undefined (the issue's exact reproduction)
- [x] `let xs = [ts(), ...]` — happy + truly-undefined safety net for nested calls
- [x] `let m = { k = ts() }` — happy
- [x] `let s = "${ts()}"` — happy

Workspace nextest 2731/2731 PASS; doctests pass; clippy `-D warnings` clean; 5 check scripts pass.

Real-infra smoke against `carina-rs/infra/` skipped: that directory currently has no user-defined `fn` declarations, so the bug is latent there. The multi-file tempdir fixtures faithfully simulate the directory shape from CLAUDE.md "Directory-scoped, never single-file" rule. Same situation as #2443 / #2446.

## Follow-up (filed separately)

- #2460 — Resolver does not walk `module_calls[*].arguments` / `attribute_params[*].value` / `export_params[*].value` for sibling-fn `Value::FunctionCall` placeholders. Same bug class but in adjacent positions; kept out of this PR's scope to honour 1 PR = 1 topic.

Closes #2444
