### PR TITLE
fix(carina-cli): preserve multi-line vertical layout in colored_value (#2463)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -878,6 +878,15 @@ fn color_atom_dimmed(rendered: &str) -> String {
 /// - Lists (`[...]`) → each element colored individually
 /// - Maps (`{...}`) → each value colored individually
 fn colored_value(rendered: &str, ref_binding: bool) -> String {
+    // Multi-line input from `format_value_pretty`'s vertical layout
+    // (`format_list_of_scalars_vertical` / `format_map_vertical`). The inline
+    // `starts_with('[') && ends_with(']')` branch below would `split_top_level`
+    // the body and re-`join(", ")` it, collapsing the layout back to inline.
+    // Color atoms in place and preserve newlines + leading indentation +
+    // structural punctuation (`[`, `]`, `{`, `}`, `,`) verbatim instead.
+    if rendered.contains('\n') {
+        return color_lines(rendered, ref_binding);
+    }
     // List: color each element individually
     if rendered.starts_with('[') && rendered.ends_with(']') {
         let inner = &rendered[1..rendered.len() - 1];
@@ -913,6 +922,47 @@ fn colored_value(rendered: &str, ref_binding: bool) -> String {
         return format!("{{{}}}", colored_entries.join(", "));
     }
     color_atom(rendered, ref_binding)
+}
+
+/// Color a multi-line `format_value_pretty` payload while preserving its
+/// vertical layout. For each line, separate leading whitespace and a trailing
+/// `,`, then color the middle. Atoms that look like list items (`"x"`, `42`)
+/// or `key: value` map entries get atom-coloring; structural lines like `[`,
+/// `]`, `{`, `}` fall through `color_atom` unchanged.
+fn color_lines(rendered: &str, ref_binding: bool) -> String {
+    let mut out = String::with_capacity(rendered.len());
+    for (i, line) in rendered.split('\n').enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let indent_end = line
+            .find(|c: char| !c.is_whitespace())
+            .unwrap_or(line.len());
+        let (indent, body) = line.split_at(indent_end);
+        out.push_str(indent);
+        if body.is_empty() {
+            continue;
+        }
+        let (core, trailing_comma) = if let Some(stripped) = body.strip_suffix(',') {
+            (stripped, ",")
+        } else {
+            (body, "")
+        };
+        // Split `key: value` to color only the value half. Safe because keys
+        // emitted by `format_map_vertical` are bare attribute names (never
+        // quoted strings that could contain `": "`).
+        if let Some(colon_pos) = core.find(": ") {
+            let key = &core[..colon_pos];
+            let val = &core[colon_pos + 2..];
+            out.push_str(key);
+            out.push_str(": ");
+            out.push_str(&color_atom(val, ref_binding));
+        } else {
+            out.push_str(&color_atom(core, ref_binding));
+        }
+        out.push_str(trailing_comma);
+    }
+    out
 }
 
 /// Apply type-based coloring to a value, with dimmed modifier for default values.

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1321,3 +1321,58 @@ fn colored_value_empty_list() {
 fn colored_value_empty_map() {
     assert_eq!(colored_value("{}", false), "{}");
 }
+
+/// Strip ANSI SGR (color) escape sequences for assertion purposes.
+/// Matches the helper used by `plan_snapshot_tests.rs` and
+/// `module_info_snapshot_tests.rs` (both call sites use this same regex).
+fn strip_ansi(s: &str) -> String {
+    let re = regex_lite::Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    re.replace_all(s, "").to_string()
+}
+
+#[test]
+fn colored_value_preserves_vertical_list_layout() {
+    // `format_value_pretty` emits a multi-line bracketed form for lists that
+    // exceed the 80-col threshold. `colored_value` must NOT collapse the
+    // layout back to inline — it should color atoms in place and keep
+    // newlines / leading indentation intact.
+    let input = "[\n  \"a\",\n  \"b\",\n  \"c\",\n]";
+    let result = colored_value(input, false);
+    let stripped = strip_ansi(&result);
+    assert_eq!(
+        stripped, input,
+        "vertical layout (newlines, indent, trailing comma, closing bracket) must be preserved verbatim",
+    );
+    let green_a = "\"a\"".green().to_string();
+    assert!(
+        result.contains(&green_a),
+        "string atoms inside the vertical list should still be colored: {result:?}",
+    );
+}
+
+#[test]
+fn colored_value_preserves_vertical_list_closing_bracket_alone() {
+    // The closing `]` sits on its own line, indented to the parent. This is
+    // the most layout-fragile token — earlier impls collapsed it into the
+    // previous line as `,]`. Pin its standalone-line preservation explicitly.
+    let input = "[\n  \"x\",\n]";
+    let result = colored_value(input, false);
+    let stripped = strip_ansi(&result);
+    assert_eq!(stripped, input);
+    assert!(
+        stripped.ends_with("\n]"),
+        "closing bracket must remain on its own line, got: {stripped:?}",
+    );
+}
+
+#[test]
+fn colored_value_preserves_vertical_map_layout() {
+    // Same constraint for `format_map_vertical` output.
+    let input = "\n  k1: \"v1\"\n  k2: 42";
+    let result = colored_value(input, false);
+    let stripped = strip_ansi(&result);
+    assert_eq!(
+        stripped, input,
+        "vertical map layout must be preserved verbatim, got: {result:?}",
+    );
+}


### PR DESCRIPTION
## Summary

`colored_value` (`carina-cli/src/display/mod.rs`) の `[`/`]` `{`/`}` ブランチがインライン専用実装で、`split_top_level` → `.trim()` → `.join(", ")` で改行と先頭インデントを破壊して inline に潰していた。`#2459` で `Value::List` が `PrettyAttribute` 経由になったことで `format_value_pretty` の vertical 出力 (`[\n  "x",\n  "y",\n]`) がここを通るようになり、`["x",\n  "y",]` のような壊れた形でレンダリングされていた。

`if rendered.contains('\n')` の早期分岐を 1 行追加し、新規 `color_lines` ヘルパーへ委譲。`color_lines` は line ごとに leading whitespace と trailing `,` を分離し、`key: value` は value 半分のみ `color_atom` に通し、それ以外は `color_atom` 素通り (`[` `]` `{` `}` などの structural token はどの atom rule にも match せずそのまま返る)。vertical layout は SGR エスケープを除き byte-for-byte で保存される。

## Test plan

- [x] `cargo nextest run -p carina-cli` — 351/351 passed (既存 plan_snapshot 31/31 churn なし)
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` × 5 — all OK
- [x] 新規ユニットテスト 4 本:
  - `colored_value_preserves_vertical_list_layout`
  - `colored_value_preserves_vertical_list_closing_bracket_alone`
  - `colored_value_preserves_vertical_map_layout`
  - 既存 inline tests も pass (regression guard)

## Notes

シングルライン path は不変 — `contains('\n')` の memchr スキャンが 1 回入るだけで実質無コスト。

Closes #2463. Refs #2459 (the routing change that exposed this), #2416 (unblocked once this lands).
