### PR TITLE
LSP: stop redlining sibling-defined user functions

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1453,20 +1453,79 @@ impl DiagnosticEngine {
     }
 
     /// Check for unknown built-in function calls in parsed resource attributes.
+    ///
+    /// User-defined functions declared in any sibling `.crn` are excluded
+    /// from the unknown-function diagnostic — without this, `fn X(...)` in
+    /// `helpers.crn` is flagged as Unknown when called from `main.crn`
+    /// (#2442).
+    ///
+    /// The "known user-fns" set is built defensively:
+    ///   * `merged.user_functions` when the directory-merged parse
+    ///     succeeded (the cheap, common case); else
+    ///   * a per-file walk of `base_path`'s `.crn` siblings via
+    ///     `collect_sibling_user_fn_names`. Without this fallback any
+    ///     unrelated parse-blocking error elsewhere in the directory
+    ///     would redline every correctly-defined sibling `fn` as
+    ///     Unknown. Else
+    ///   * the buffer's own `parsed.user_functions` (single-file path,
+    ///     no `base_path`).
     pub(super) fn check_unknown_functions(
         &self,
         doc: &Document,
         parsed: &ParsedFile,
+        merged: Option<&ParsedFile>,
+        base_path: Option<&std::path::Path>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
+        // Build a flat name set — the diagnostic only checks
+        // `contains(name)`, never inspects the function body. Avoiding
+        // `UserFunction` clones keeps the slow path cheap.
+        let user_fns: HashSet<String> = match (merged, base_path) {
+            (Some(m), _) => m.user_functions.keys().cloned().collect(),
+            (None, Some(base)) => self.collect_sibling_user_fn_names(doc, base),
+            (None, None) => parsed.user_functions.keys().cloned().collect(),
+        };
 
         for (_ctx, resource) in parsed.iter_all_resources() {
             for value in resource.attributes.values() {
-                self.collect_unknown_function_diagnostics(doc, value, &mut diagnostics);
+                self.collect_unknown_function_diagnostics(doc, value, &user_fns, &mut diagnostics);
             }
         }
 
         diagnostics
+    }
+
+    /// Walk every `.crn` file in `base_path` independently and collect
+    /// their user-function names. Used as a fallback when the full
+    /// directory parse failed (`parse_directory_with_overrides` returns
+    /// `Err` if any sibling has a parse error or the resolver bails).
+    /// A per-file failure is non-fatal — we just skip that file. The
+    /// open buffer's own user-fn names are taken from `doc` so unsaved
+    /// edits are honored.
+    fn collect_sibling_user_fn_names(
+        &self,
+        doc: &Document,
+        base_path: &std::path::Path,
+    ) -> HashSet<String> {
+        let mut out: HashSet<String> = HashSet::new();
+        // Buffer-defined fns first (unsaved edits beat on-disk).
+        if let Some(parsed) = doc.parsed() {
+            out.extend(parsed.user_functions.keys().cloned());
+        }
+        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(&base_path.to_path_buf())
+        else {
+            return out;
+        };
+        for file in files {
+            let Ok(content) = std::fs::read_to_string(&file) else {
+                continue;
+            };
+            let Ok(parsed) = carina_core::parser::parse(&content, &self.provider_context) else {
+                continue;
+            };
+            out.extend(parsed.user_functions.into_keys());
+        }
+        out
     }
 
     /// Recursively walk a Value tree to find FunctionCall nodes with unknown names.
@@ -1474,11 +1533,13 @@ impl DiagnosticEngine {
         &self,
         doc: &Document,
         value: &Value,
+        user_fns: &HashSet<String>,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         match value {
             Value::FunctionCall { name, args } => {
                 if !builtins::is_known_builtin(name)
+                    && !user_fns.contains(name)
                     && let Some((line, col)) = self.find_function_call_position(doc, name)
                 {
                     diagnostics.push(carina_diagnostic(
@@ -1491,23 +1552,23 @@ impl DiagnosticEngine {
                 }
                 // Also check nested function calls in arguments
                 for arg in args {
-                    self.collect_unknown_function_diagnostics(doc, arg, diagnostics);
+                    self.collect_unknown_function_diagnostics(doc, arg, user_fns, diagnostics);
                 }
             }
             Value::List(items) => {
                 for item in items {
-                    self.collect_unknown_function_diagnostics(doc, item, diagnostics);
+                    self.collect_unknown_function_diagnostics(doc, item, user_fns, diagnostics);
                 }
             }
             Value::Map(map) => {
                 for v in map.values() {
-                    self.collect_unknown_function_diagnostics(doc, v, diagnostics);
+                    self.collect_unknown_function_diagnostics(doc, v, user_fns, diagnostics);
                 }
             }
             Value::Interpolation(parts) => {
                 for part in parts {
                     if let carina_core::resource::InterpolationPart::Expr(expr) = part {
-                        self.collect_unknown_function_diagnostics(doc, expr, diagnostics);
+                        self.collect_unknown_function_diagnostics(doc, expr, user_fns, diagnostics);
                     }
                 }
             }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -708,8 +708,20 @@ impl DiagnosticEngine {
                 }
             }
 
-            // Check for unknown built-in function calls
-            diagnostics.extend(self.check_unknown_functions(doc, parsed));
+            // Check for unknown built-in function calls. Pass the merged
+            // parse so user-defined `fn X(...)` declared in a sibling
+            // `.crn` is not flagged as unknown (#2442). `base_path` is
+            // threaded so the check can fall back to a per-file walk
+            // when the directory parse failed (e.g. an unrelated error
+            // elsewhere in the directory) — without that fallback,
+            // every sibling-defined fn would redline as Unknown the
+            // moment any sibling fails to parse.
+            diagnostics.extend(self.check_unknown_functions(
+                doc,
+                parsed,
+                merged.as_ref(),
+                base_path,
+            ));
 
             // Check attributes blocks
             diagnostics.extend(self.check_attributes_blocks(doc, parsed));

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3175,3 +3175,86 @@ fn exports_type_check_resolves_resource_binding_from_sibling_file() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+/// Build the multi-file fixture used by the #2442 sibling-fn tests.
+/// Layout:
+///   `<tmp>/helpers.crn`   — `fn double(x: Int) { x }`
+///   `<tmp>/providers.crn` — fake `provider test { ... }`
+///   `<tmp>/main.crn`      — `<main_text>`
+///
+/// Returns `(tempdir, base_path)`.
+fn sibling_user_fn_fixture(main_text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(base.join("helpers.crn"), "fn double(x: Int) {\n    x\n}\n").unwrap();
+    std::fs::write(
+        base.join("providers.crn"),
+        "provider test {\n  source = 'x/y'\n  version = '0.1'\n  region = 'ap-northeast-1'\n}\n",
+    )
+    .unwrap();
+    std::fs::write(base.join("main.crn"), main_text).unwrap();
+    (tmp, base)
+}
+
+/// Issue #2442: when `fn X(...) { ... }` lives in a sibling `.crn`
+/// (e.g. `helpers.crn`) and a consumer in `main.crn` calls `X(...)`,
+/// `check_unknown_functions` must NOT emit `Unknown function 'X'`.
+/// The check previously consulted only `builtins::is_known_builtin`;
+/// the fix threads the merged-directory `user_functions` through.
+/// CLAUDE.md "Directory-scoped, never single-file": same shape as
+/// #2435 / PR #2120 / PR #2118.
+#[test]
+fn check_unknown_functions_skips_sibling_user_fn() {
+    let main_text = "test.r.res {\n    name = \"x\"\n    val = double(2)\n}\n";
+    let (_tmp, base) = sibling_user_fn_fixture(main_text);
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let unknown_fn = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown function 'double'"));
+    assert!(
+        unknown_fn.is_none(),
+        "sibling-file `fn double(...)` must not produce 'Unknown function' diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Companion: a *truly* unknown function name in the consumer must
+/// still produce the diagnostic. Wrap inside another (deferred) call
+/// so the per-file parser keeps the FunctionCall placeholder rather
+/// than rejecting it outright at parse time.
+///
+/// Also pins the round-2 regression class: even when the directory
+/// parse fails (because of the truly-undefined call), sibling-defined
+/// `fn double(...)` must NOT be redlined. Without the per-file
+/// fallback walk, the `merged = None` path would fall back to the
+/// buffer's empty `parsed.user_functions` and report `double` too.
+#[test]
+fn check_unknown_functions_still_warns_when_truly_undefined() {
+    let main_text = "test.r.res {\n    name = \"x\"\n    val = triple(double(2))\n}\n";
+    let (_tmp, base) = sibling_user_fn_fixture(main_text);
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let unknown_fn = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown function 'triple'"));
+    assert!(
+        unknown_fn.is_some(),
+        "genuinely undefined `triple(...)` must still produce 'Unknown function'. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let phantom_double = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Unknown function 'double'"));
+    assert!(
+        phantom_double.is_none(),
+        "sibling-defined `fn double(...)` must NOT be reported even when the directory parse fails. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Stop redlining `Unknown function 'X'` when `fn X(...)` lives in a sibling `.crn` and the consumer in `main.crn` calls `X(...)`.
- Resilient to per-file parse errors: even when the directory parse fails (e.g. an unrelated typo elsewhere in the directory), correctly-defined sibling fns are NOT phantom-redlined — the diagnostic walks each sibling `.crn` independently for fn names.
- Honors unsaved buffer edits: the open buffer's own `fn` declarations beat the on-disk copy when collecting names.

## Why

`check_unknown_functions` walked `Value::FunctionCall` and emitted "Unknown function 'X'" whenever the name wasn't a builtin — never consulting the merged directory's `user_functions`. CLAUDE.md "Directory-scoped, never single-file": same shape as #2435 / PR #2120 / PR #2118.

This was blocked on #2444 — without that resolver fix, the directory-merged parse couldn't even reach `parsed.user_functions` (the resolver killed the merge on sibling `fn` calls). With #2444 merged, the LSP fix is now small.

## Approach

`check_unknown_functions(doc, parsed, merged, base_path)` builds a `HashSet<String>` of known user-fn names with three-level fallback:

1. `merged: Some(...)` → `merged.user_functions` (cheap, common case).
2. `merged: None + base_path: Some(...)` → per-file resilient walk via new `collect_sibling_user_fn_names`. Critical for the in-progress-edit case: any unrelated parse error in the directory blocks merge, but the user's sibling-defined fns must NOT all redline as a result.
3. Both `None` → buffer's own `parsed.user_functions` (single-file path).

The diagnostic only checks `contains(name)`, so the name set is `HashSet<String>` rather than `HashMap<String, UserFunction>` — no `UserFunction` clones.

## Test plan

2 multi-file tempdir tests via shared `sibling_user_fn_fixture`:

- [x] `check_unknown_functions_skips_sibling_user_fn` — sibling-defined `fn double(...)` called from main.crn, no `Unknown function 'double'` diagnostic.
- [x] `check_unknown_functions_still_warns_when_truly_undefined` — `triple(double(2))` where `triple` is genuinely undefined. Asserts BOTH that `Unknown function 'triple'` fires AND that `Unknown function 'double'` does NOT (regression guard for the round-2 phantom-redline class).

All 409 carina-lsp tests pass; clippy clean; doctests pass; 5 check scripts pass.

Real-infra smoke against `carina-rs/infra/` skipped: that directory has no `fn` declarations, so the bug is latent there. The multi-file tempdir fixtures faithfully simulate the directory shape from CLAUDE.md "Directory-scoped, never single-file" rule. Same situation as #2443 / #2446 / #2462.

## Follow-up (filed separately)

- #2465 — `find_crn_files_in_dir` takes `&PathBuf`; should take `&Path`. Cleanup; this PR keeps the `&base_path.to_path_buf()` shim.

Closes #2442
