### PR TITLE
test(carina-cli): pretty list-of-string snapshot fixtures (#2416)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ plan-fixtures:
 	@echo ""
 	@echo "=== policy_pretty ==="
 	@$(MAKE) plan-policy-pretty
+	@echo "---"
+	@$(MAKE) plan-pretty-long-string-list
+	@echo "---"
+	@$(MAKE) plan-pretty-short-string-list
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -143,6 +147,10 @@ plan-exports-multifile:
 	$(PLAN_FIXTURE) exports_multifile
 plan-policy-pretty:
 	$(PLAN_FIXTURE) policy_pretty
+plan-pretty-long-string-list:
+	$(PLAN_FIXTURE) pretty_long_string_list
+plan-pretty-short-string-list:
+	$(PLAN_FIXTURE) pretty_short_string_list
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
@@ -150,6 +158,7 @@ plan-policy-pretty:
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
+        plan-pretty-long-string-list plan-pretty-short-string-list \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -77,6 +77,36 @@ fn snapshot_policy_pretty() {
 }
 
 #[test]
+fn snapshot_pretty_long_string_list() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("pretty_long_string_list");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_pretty_short_string_list() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("pretty_short_string_list");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_no_changes() {
     let (plan, _schemas, _moved) = build_plan_from_fixture("no_changes");
     let output = strip_ansi(&format_plan(

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_long_string_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_long_string_list.snap
@@ -1,0 +1,15 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.Role 
+      managed_policy_arns: [
+        "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+        "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess",
+        "arn:aws:iam::aws:policy/IAMReadOnlyAccess",
+      ]
+      role_name: "test-role"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_short_string_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_pretty_short_string_list.snap
@@ -1,0 +1,11 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.Role 
+      role_name: "short-list-test"
+      short_tags: ["a", "b", "c"]
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/pretty_long_string_list/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/pretty_long_string_list/main.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.Role {
+  role_name = 'test-role'
+  managed_policy_arns = [
+    'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess',
+    'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess',
+    'arn:aws:iam::aws:policy/IAMReadOnlyAccess',
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/pretty_short_string_list/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/pretty_short_string_list/main.crn
@@ -1,0 +1,8 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.Role {
+  role_name = 'short-list-test'
+  short_tags = ['a', 'b', 'c']
+}


### PR DESCRIPTION
## Summary

`#2459` (PrettyAttribute routing) と `#2463` (colored_value multi-line preservation) のマージで unblock。list-of-string の 80 桁しきい値挙動を pin する 2 つの snapshot fixture を追加。

- **`pretty_long_string_list/`**: `managed_policy_arns` に長い ARN 3 本 (~147 cols inline / 27 cols indent)。snapshot は D2 vertical 形 (`[\n  "x",\n  "y",\n  "z",\n]`) を pin。
- **`pretty_short_string_list/`**: `short_tags = ['a', 'b', 'c']` (~15 cols inline / 18 cols indent)。snapshot は inline 形 (`["a", "b", "c"]`) を pin — しきい値ロジックが「常に展開」に flip した場合の regression guard。

両 fixture とも threshold の両側に余裕がある (long: 174 vs 80 cap、short: 33 vs 80 cap) ので fragile ではない。

## Test plan

- [x] `cargo nextest run -p carina-cli` — 353/353 passed (元 351 + 新 2)
- [x] `cargo nextest run -p carina-cli snapshot_pretty_long_string_list` — pass
- [x] `cargo nextest run -p carina-cli snapshot_pretty_short_string_list` — pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` × 5 — all OK (`check-plan-fixtures.sh` を含む)
- [x] `make plan-pretty-long-string-list` — D2 vertical 確認
- [x] `make plan-pretty-short-string-list` — inline 確認

## Notes

`scripts/check-plan-fixtures.sh` 通過のため Makefile に 3 ターゲット追加 (個別 2 つ + `plan-fixtures` 統合ターゲットへの組み込み + `.PHONY`)。

Closes #2416. Refs #2409, #2459, #2463.
