### PR TITLE
LSP: keep sibling bindings visible when directory parse fails

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -410,6 +410,51 @@ impl DiagnosticEngine {
         .ok()
     }
 
+    /// Collect every binding name declared anywhere in `base_path` by
+    /// parsing each sibling `.crn` independently. Used as a fallback
+    /// when the full directory parse fails (`parse_merged_with_buffer`
+    /// returns `None`). A per-file failure is non-fatal — that file's
+    /// declarations are skipped. The current document's text replaces
+    /// its on-disk copy so unsaved edits are honored.
+    ///
+    /// Mirrors the merge-success path's
+    /// `BindingNameSet::from_parsed`, so the same eight binding kinds
+    /// (resources, module-calls, upstream-states, arguments, uses,
+    /// user-functions, structural, variables) stay covered when the
+    /// merge fails. Without this, an unrelated parse error in one
+    /// sibling redlines every cross-file binding as Unknown (#2445).
+    pub(super) fn collect_sibling_binding_names(
+        &self,
+        buffer_text: &str,
+        current_file_name: Option<&str>,
+        base_path: &std::path::Path,
+    ) -> HashSet<String> {
+        let mut out: HashSet<String> = HashSet::new();
+        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(&base_path.to_path_buf())
+        else {
+            return out;
+        };
+        for file in files {
+            let file_name = file.file_name().and_then(|n| n.to_str());
+            let content = match (file_name, current_file_name) {
+                (Some(name), Some(current)) if name == current => buffer_text.to_string(),
+                _ => match std::fs::read_to_string(&file) {
+                    Ok(text) => text,
+                    Err(_) => continue,
+                },
+            };
+            let Ok(parsed) = carina_core::parser::parse(&content, &self.provider_context) else {
+                continue;
+            };
+            out.extend(
+                carina_core::binding_index::BindingNameSet::from_parsed(&parsed)
+                    .iter_names()
+                    .map(String::from),
+            );
+        }
+        out
+    }
+
     /// Reject references like `orgs.account` whose field isn't declared by
     /// the upstream's `exports { }` block.
     ///

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -142,19 +142,29 @@ impl DiagnosticEngine {
         }
 
         // `known_bindings` for the text-scan undefined-reference check.
-        // When no merged parse is available (no base_path, or directory
-        // parse fails) the fallback is the current buffer's `let` headers
-        // only — cross-file bindings become undetectable and we'd rather
-        // miss typos than manufacture false positives against
-        // `upstream_state` / `import` bindings the old text scan used to
-        // mishandle (#2131 / #2132).
+        // When the merged parse succeeds, `BindingNameSet::from_parsed`
+        // yields every binding declared anywhere in the directory. When
+        // it fails (`merged = None` because a parse error somewhere in
+        // the directory blocked the merge), fall back to a per-file
+        // resilient walk: parse each sibling `.crn` independently,
+        // swallow per-file errors, run `BindingNameSet::from_parsed` on
+        // each successful parse. Without this, sibling-defined
+        // bindings (including `arguments`, `import`, `fn`, ...) redline
+        // as Unknown the moment any sibling fails to parse (#2445).
+        // When no `base_path` is available at all, the buffer-only scan
+        // remains the last resort.
         let declared_providers = self.extract_declared_provider_names(&text);
-        let known_bindings: HashSet<String> = match merged.as_ref() {
-            Some(merged) => carina_core::binding_index::BindingNameSet::from_parsed(merged)
+        let known_bindings: HashSet<String> = match (merged.as_ref(), base_path) {
+            (Some(merged), _) => carina_core::binding_index::BindingNameSet::from_parsed(merged)
                 .iter_names()
                 .map(String::from)
                 .collect(),
-            None => self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text)),
+            (None, Some(base)) => {
+                self.collect_sibling_binding_names(&text, current_file_name, base)
+            }
+            (None, None) => {
+                self.extract_resource_bindings(crate::completion::DslSource::BufferOnly(&text))
+            }
         };
         diagnostics.extend(self.check_undefined_references(
             &text,

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3258,3 +3258,190 @@ fn check_unknown_functions_still_warns_when_truly_undefined() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+/// Build the multi-file fixture used by the #2445 sibling-binding tests.
+/// Layout:
+///   `<tmp>/network.crn`  — `let bar = awscc.ec2.Vpc { ... }`
+///   `<tmp>/providers.crn` — fake `provider awscc { ... }`
+///   `<tmp>/main.crn`     — `<main_text>`
+///
+/// Returns `(tempdir, base_path)`.
+fn sibling_resource_binding_fixture(main_text: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("network.crn"),
+        "let bar = awscc.ec2.Vpc {\n    cidr_block = \"10.0.0.0/16\"\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base.join("providers.crn"),
+        "provider awscc {\n  source = 'x/y'\n  version = '0.1'\n  region = 'ap-northeast-1'\n}\n",
+    )
+    .unwrap();
+    std::fs::write(base.join("main.crn"), main_text).unwrap();
+    (tmp, base)
+}
+
+/// Issue #2445: when `let bar = X { ... }` lives in a sibling `.crn`
+/// (e.g. `network.crn`) and `attributes { foo = bar.cidr_block }` lives
+/// in `main.crn`, the LSP must NOT emit `Undefined resource 'bar'` —
+/// even when the directory-merged parse fails for unrelated reasons.
+///
+/// In the happy path (merged parse succeeds), the existing
+/// `BindingNameSet::from_parsed(merged)` already covers sibling
+/// bindings. The bug surfaces when `merged = None`: the buffer-only
+/// `extract_resource_bindings` fallback misses sibling-defined `bar`
+/// and the text-scan `check_undefined_references` redlines it as
+/// Unknown.
+///
+/// CLAUDE.md "Directory-scoped, never single-file": same shape as
+/// #2435 / #2442 / #2443 / #2446.
+#[test]
+fn check_attributes_blocks_skips_sibling_resource_binding() {
+    let main_text = "attributes {\n    foo = bar.cidr_block\n}\n";
+    let (_tmp, base) = sibling_resource_binding_fixture(main_text);
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let undefined_resource = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("'bar'"));
+    assert!(
+        undefined_resource.is_none(),
+        "sibling-defined `let bar = ...` must not produce 'Undefined resource' diagnostic. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// The actual user-visible bug from #2445: when the directory parse
+/// fails for an unrelated reason (broken sibling), `merged = None`
+/// and the buffer-only fallback for `known_bindings` misses sibling-
+/// defined `bar`, redlining it as Unknown. Per-file resilient walk
+/// must keep sibling let-bindings visible.
+#[test]
+fn check_attributes_blocks_skips_sibling_resource_binding_even_when_merge_fails() {
+    let main_text = "attributes {\n    foo = bar.cidr_block\n}\n";
+    let (_tmp, base) = sibling_resource_binding_fixture(main_text);
+    // Deliberately broken sibling — half-typed `provider` block. This
+    // makes `parse_directory_with_overrides` return Err, so `merged`
+    // is None and the LSP must fall back to a per-file walk over
+    // siblings to keep `bar` visible.
+    std::fs::write(base.join("broken.crn"), "provider gcp { region = ").unwrap();
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let undefined_resource = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("'bar'"));
+    assert!(
+        undefined_resource.is_none(),
+        "sibling-defined `bar` must not redline as Unknown when an *unrelated* sibling fails to parse. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Coverage parity: when the merge fails, the fallback path must
+/// recognize non-`let`-shaped sibling bindings — `arguments`,
+/// `fn`, `import`, etc. — same as the merge-success
+/// `BindingNameSet::from_parsed` set. A regression that narrowed the
+/// fallback to `let X = ...` headers would phantom-redline arguments
+/// referenced from a sibling. Pins the round-2 coverage-parity gap.
+#[test]
+fn check_attributes_blocks_skips_sibling_argument_even_when_merge_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    // `vpc_id` is declared via an `arguments` block in a sibling — no
+    // `let` header. Only the per-file parse + `BindingNameSet`
+    // recognizes it as a binding.
+    std::fs::write(
+        base.join("inputs.crn"),
+        "arguments {\n    vpc_id: String\n}\n",
+    )
+    .unwrap();
+    // Force the directory parse to fail so the LSP must hit the
+    // (None, Some(base)) fallback arm.
+    std::fs::write(base.join("broken.crn"), "provider gcp { region = ").unwrap();
+    let main_text = "attributes {\n    foo = vpc_id\n}\n";
+    std::fs::write(base.join("main.crn"), main_text).unwrap();
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let phantom_arg = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("vpc_id"));
+    assert!(
+        phantom_arg.is_none(),
+        "sibling-defined `arguments {{ vpc_id }}` must not redline as Unknown when an unrelated sibling fails to parse. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Companion to the merge-fails case: even on the directory-aware
+/// fallback path, a *truly* unknown identifier must still produce the
+/// diagnostic. Pins the regression class where a future refactor
+/// returning an empty `known_bindings` set on the `(None, Some)` arm
+/// would silently let typos through.
+#[test]
+fn check_attributes_blocks_warns_when_truly_undefined_even_when_merge_fails() {
+    let main_text = "attributes {\n    foo = bar.cidr_block\n    bad = nope.cidr_block\n}\n";
+    let (_tmp, base) = sibling_resource_binding_fixture(main_text);
+    std::fs::write(base.join("broken.crn"), "provider gcp { region = ").unwrap();
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let phantom_bar = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("'bar'"));
+    assert!(
+        phantom_bar.is_none(),
+        "sibling-defined `bar` must not redline. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let undefined_nope = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("nope"));
+    assert!(
+        undefined_nope.is_some(),
+        "truly undefined `nope` must still produce 'Undefined resource' even on the merge-fails fallback. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+/// Companion: a *truly* unknown binding name in `attributes` must
+/// still produce the diagnostic.
+#[test]
+fn check_attributes_blocks_still_warns_when_truly_undefined() {
+    // `bar` is sibling-defined; `nope` is not declared anywhere.
+    let main_text = "attributes {\n    bad = nope.cidr_block\n}\n";
+    let (_tmp, base) = sibling_resource_binding_fixture(main_text);
+
+    let engine = test_engine();
+    let doc = create_document(main_text);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let undefined_resource = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("nope"));
+    assert!(
+        undefined_resource.is_some(),
+        "genuinely undefined `nope.*` must still produce 'Undefined resource'. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let phantom_bar = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined resource") && d.message.contains("'bar'"));
+    assert!(
+        phantom_bar.is_none(),
+        "sibling-defined `bar` must NOT be reported even when another binding is truly unknown. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

- Stop redlining sibling-defined `let` / `arguments` / `import` / `fn` bindings as `Undefined resource` whenever the directory parse fails for an unrelated reason (any other sibling has a parse error).
- The merge-success path was already correct via `BindingNameSet::from_parsed(merged)`. The bug was the **fallback** path: a buffer-only text scan that missed every sibling-defined binding the moment any sibling failed to parse.

## Why

The diff in the issue body cited `check_attributes_blocks` but the actual emitter is `check_undefined_references` (the text-scan path). Both feed off the same `known_bindings` set built in `mod.rs::analyze_with_filename`. CLAUDE.md "Directory-scoped, never single-file": same shape as #2435 / #2442 / #2443 / #2446 / #2462 / #2466.

## Approach

`mod.rs::analyze_with_filename` builds `known_bindings` via a 3-arm match on `(merged, base_path)`:

1. `(Some(merged), _)` → `BindingNameSet::from_parsed(merged)` — the canonical 8-kind name set (resources, module-calls, upstream-states, arguments, uses, user-functions, structural, variables).
2. `(None, Some(base))` → new `collect_sibling_binding_names` helper. **Per-file resilient walk**: parses each sibling `.crn` independently, swallows per-file errors via `continue`, runs `BindingNameSet::from_parsed` on each, unions the results. The current document's text replaces its on-disk copy so unsaved edits are honored.
3. `(None, None)` → buffer-only scan (single-file last resort).

The fallback's per-file walk preserves the same coverage as the success path — it does NOT narrow to `let` headers.

## Test plan

5 multi-file tempdir fixtures (`sibling_resource_binding_fixture` shared helper):

- [x] `check_attributes_blocks_skips_sibling_resource_binding` — happy path; merged succeeds.
- [x] `check_attributes_blocks_still_warns_when_truly_undefined` — typo'd identifier on the merge-success path still warns; sibling `bar` does not phantom.
- [x] `check_attributes_blocks_skips_sibling_resource_binding_even_when_merge_fails` — broken `provider gcp { region = ` sibling kills the merge; sibling `let bar = ...` still recognized (the actual #2445 bug).
- [x] `check_attributes_blocks_skips_sibling_argument_even_when_merge_fails` — non-`let` shape (`arguments { vpc_id }`) recognized on the merge-fails fallback. Pins coverage parity with the success path.
- [x] `check_attributes_blocks_warns_when_truly_undefined_even_when_merge_fails` — typo on the merge-fails fallback still warns (regression guard for an empty-set fallback bug).

All 413 carina-lsp tests pass; clippy clean; doctests pass; 5 check scripts pass.

Real-infra smoke against `carina-rs/infra/` skipped: that directory does not currently use the cross-file `attributes { x = bar.field }` shape, so the bug is latent there. The multi-file tempdir fixtures faithfully simulate the directory shape from CLAUDE.md "Directory-scoped, never single-file" rule. Same situation as #2443 / #2446 / #2462 / #2466.

Closes #2445
