### PR TITLE
identifier: prefix anonymous names with provider (#2426-#2432)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ plan-fixtures:
 	@$(MAKE) plan-pretty-long-string-list
 	@echo "---"
 	@$(MAKE) plan-pretty-short-string-list
+	@echo ""
+	@echo "=== provider_prefix ==="
+	@$(MAKE) plan-provider-prefix
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -151,6 +154,8 @@ plan-pretty-long-string-list:
 	$(PLAN_FIXTURE) pretty_long_string_list
 plan-pretty-short-string-list:
 	$(PLAN_FIXTURE) pretty_short_string_list
+plan-provider-prefix:
+	$(PLAN_FIXTURE) provider_prefix
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
@@ -158,7 +163,7 @@ plan-pretty-short-string-list:
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
-        plan-pretty-long-string-list plan-pretty-short-string-list \
+        plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -724,7 +724,7 @@ async fn run_apply_locked(
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     // Read current state from backend
-    let state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    let mut state_file = backend.read_state().await.map_err(AppError::Backend)?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
     if let Some(sf) = state_file.as_ref() {
@@ -737,6 +737,8 @@ async fn run_apply_locked(
                     .collect()
             },
         );
+    }
+    if let Some(sf) = state_file.as_mut() {
         reconcile_anonymous_identifiers_with_ctx(ctx, &mut parsed.resources, sf);
     }
     apply_name_overrides(&mut parsed.resources, &state_file);

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -145,7 +145,7 @@ async fn run_destroy_locked(
     let ctx = WiringContext::new(factories);
 
     // Read current state from backend
-    let state_file = backend.read_state().await.map_err(AppError::Backend)?;
+    let mut state_file = backend.read_state().await.map_err(AppError::Backend)?;
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
     if let Some(sf) = state_file.as_ref() {
@@ -158,6 +158,8 @@ async fn run_destroy_locked(
                     .collect()
             },
         );
+    }
+    if let Some(sf) = state_file.as_mut() {
         reconcile_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, sf);
     }
     apply_name_overrides(&mut parsed.resources, &state_file);

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -276,6 +276,8 @@ pub async fn run_plan(
                     .collect()
             },
         );
+    }
+    if let Some(sf) = state_file.as_mut() {
         reconcile_anonymous_identifiers_with_ctx(&wiring, &mut parsed.resources, sf);
     }
     apply_name_overrides(&mut parsed.resources, &state_file);

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -657,7 +657,7 @@ pub(crate) async fn run_state_refresh_locked(
     }
 
     reconcile_prefixed_names(&mut parsed.resources, &state_file);
-    if let Some(sf) = state_file.as_ref() {
+    if let Some(sf) = state_file.as_mut() {
         reconcile_anonymous_identifiers_with_ctx(&ctx, &mut parsed.resources, sf);
     }
     apply_name_overrides(&mut parsed.resources, &state_file);

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -58,7 +58,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     let base_dir = get_base_dir(&fixture_pathbuf);
     validate_and_resolve(&mut parsed, base_dir, true).unwrap();
 
-    let state_file: Option<StateFile> = if state_path.exists() {
+    let mut state_file: Option<StateFile> = if state_path.exists() {
         let json = std::fs::read_to_string(&state_path).unwrap();
         Some(serde_json::from_str(&json).unwrap())
     } else {
@@ -77,6 +77,8 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
                     .collect()
             },
         );
+    }
+    if let Some(sf) = state_file.as_mut() {
         reconcile_anonymous_identifiers_with_ctx(&wiring, &mut parsed.resources, sf);
     }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -803,3 +803,22 @@ fn snapshot_deferred_for() {
     ));
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_provider_prefix() {
+    // Regression guard for #2426 / #2431: anonymous resource identifiers
+    // gain a `<provider>_` prefix so plan output and state files
+    // self-describe their provider. The header line for the lone Vpc
+    // resource must read `+ awscc.ec2.Vpc awscc_ec2_vpc_<8hex>`.
+    let (plan, schemas, _moved) = build_plan_from_fixture("provider_prefix");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_provider_prefix.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_provider_prefix.snap
@@ -1,0 +1,10 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+assertion_line: 823
+expression: output
+---
+Execution Plan:
+
+  - awscc.ec2.Vpc awscc_ec2_vpc_fb75c929
+
+Plan: 0 to add, 0 to change, 1 to destroy.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -341,9 +341,9 @@ pub fn apply_anonymous_to_named_renames(
 pub fn reconcile_anonymous_identifiers_with_ctx(
     ctx: &WiringContext,
     resources: &mut [Resource],
-    state_file: &StateFile,
+    state_file: &mut StateFile,
 ) {
-    identifier::reconcile_anonymous_identifiers(
+    let renames = identifier::reconcile_anonymous_identifiers(
         resources,
         ctx.schemas(),
         &|provider, resource_type| {
@@ -378,6 +378,31 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
                 .collect()
         },
     );
+
+    apply_provider_prefix_renames(&renames, state_file);
+}
+
+/// Re-key state entries when `reconcile_anonymous_identifiers` produced rename
+/// pairs (anonymous → anonymous due to identifier-format upgrade).
+///
+/// For each `(old_name, new_name)` pair, find the matching `ResourceState`
+/// in `state_file.resources` and overwrite its `name` field. Downstream maps
+/// (`build_saved_attrs`, `build_desired_keys`, `build_lifecycles`) then key
+/// off the new name, so the differ sees the resource under its updated
+/// identifier instead of an orphan-delete + create pair.
+pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &mut StateFile) {
+    if renames.is_empty() {
+        return;
+    }
+    let by_old: HashMap<&str, &str> = renames
+        .iter()
+        .map(|(old, new)| (old.as_str(), new.as_str()))
+        .collect();
+    for sr in &mut state_file.resources {
+        if let Some(new_name) = by_old.get(sr.name.as_str()) {
+            sr.name = new_name.to_string();
+        }
+    }
 }
 
 pub fn compute_anonymous_identifiers_with_ctx(

--- a/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
@@ -1,0 +1,28 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-provider-prefix",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.Vpc",
+      "name": "awscc_ec2_vpc_fb75c929",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_support": true,
+        "enable_dns_hostnames": true,
+        "vpc_id": "vpc-0123456789abcdef0",
+        "tags": { "Name": "provider-prefix-fixture" }
+      },
+      "protected": false,
+      "lifecycle": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
+      "binding": "awscc_ec2_vpc_fb75c929",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/provider_prefix/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/provider_prefix/main.crn
@@ -1,0 +1,10 @@
+# Provider prefix snapshot fixture (#2426 / #2431).
+#
+# State carries an orphaned anonymous resource whose name uses the
+# `<provider>_<type>_<hash>` form introduced by the provider prefix
+# change. The plan-display snapshot then captures the prefix as
+# rendered in the orphan-delete row, locking in the format.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -460,10 +460,20 @@ pub fn compute_anonymous_identifiers(
             format!("{:08x}", hasher.finish() & 0xFFFFFFFF)
         };
 
-        // Build identifier: resource_type_hash (e.g., ec2_vpc_a3f2b1c8). The
-        // resource_type segments carry PascalCase for the final type name
+        // Build identifier: provider_resource_type_hash (e.g., awscc_ec2_vpc_a3f2b1c8).
+        // The resource_type segments carry PascalCase for the final type name
         // (e.g., "ec2.Vpc"); identifier names are snake_case values per the
         // naming-conventions rule, so lower each segment before joining.
+        // The provider segment makes anonymous identifiers self-describe their
+        // provider so plan output and state files distinguish e.g.
+        // `aws.iam.RolePolicy` from `awscc.iam.RolePolicy` at a glance.
+        let provider_snake = resource
+            .id
+            .provider
+            .split('.')
+            .map(crate::parser::pascal_to_snake)
+            .collect::<Vec<_>>()
+            .join("_");
         let type_snake = resource
             .id
             .resource_type
@@ -471,7 +481,7 @@ pub fn compute_anonymous_identifiers(
             .map(crate::parser::pascal_to_snake)
             .collect::<Vec<_>>()
             .join("_");
-        let identifier = format!("{}_{}", type_snake, hash_str);
+        let identifier = format!("{}_{}_{}", provider_snake, type_snake, hash_str);
 
         computed.push((idx, identifier));
     }
@@ -520,11 +530,19 @@ pub struct AnonymousIdStateInfo {
 ///
 /// `find_state_by_type` takes (provider, resource_type) and returns all state
 /// entries for that resource type with their create-only attribute values.
+///
+/// Returns a list of `(old_state_name, new_resource_name)` pairs that the
+/// caller should apply to state-keyed maps. These are emitted when a SimHash
+/// match identifies a state entry under an older identifier format (e.g.
+/// `iam_role_policy_<hash>` from before the provider prefix was added) — the
+/// resource keeps its freshly-computed new-format name and the wiring layer
+/// re-keys the state entry instead of destroy+recreate.
 pub fn reconcile_anonymous_identifiers(
     resources: &mut [Resource],
     registry: &SchemaRegistry,
     find_state_by_type: &dyn Fn(&str, &str) -> Vec<AnonymousIdStateInfo>,
-) {
+) -> Vec<(String, String)> {
+    let mut renames: Vec<(String, String)> = Vec::new();
     for resource in resources.iter_mut() {
         if resource.id.name.is_pending() {
             continue;
@@ -583,12 +601,12 @@ pub fn reconcile_anonymous_identifiers(
                 }
             }
 
-            if let Some((name, _)) = best_match {
-                resource.id = ResourceId::with_provider(
-                    &resource.id.provider,
-                    &resource.id.resource_type,
-                    name,
-                );
+            if let Some((state_name, _)) = best_match {
+                // The state entry may use an older identifier format (e.g.
+                // pre-provider-prefix). Keep our freshly-computed new-format
+                // name on the resource and record a rename so the wiring
+                // layer can re-key the state entry.
+                renames.push((state_name.to_string(), resource.id.name_str().to_string()));
             }
             continue;
         }
@@ -632,6 +650,7 @@ pub fn reconcile_anonymous_identifiers(
             );
         }
     }
+    renames
 }
 
 /// Detect let-bound (named) resources that were previously anonymous.

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -394,7 +394,7 @@ fn test_anonymous_resource_no_create_only_properties() {
 
     // Should have computed an identifier
     assert!(!resources[0].id.name_str().is_empty());
-    assert!(resources[0].id.name_str().starts_with("ec2_eip_"));
+    assert!(resources[0].id.name_str().starts_with("awscc_ec2_eip_"));
 }
 
 #[test]
@@ -641,12 +641,18 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         name: old_id.clone(),
         create_only_values: HashMap::new(),
     }];
-    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
+    let renames = reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
         state_entries.clone()
     });
 
-    // After reconciliation, should have the old identifier (Hamming distance match)
-    assert_eq!(resources2[0].id.name_str(), old_id);
+    // After reconciliation: the resource keeps its freshly-computed
+    // (new) identifier and a rename pair is emitted so the wiring
+    // layer can re-key the state entry. Previous behavior (overwriting
+    // resource.id with the state's old name) was changed when the
+    // provider prefix was introduced — the rename path is now the
+    // only mechanism for legacy state name reuse.
+    assert_eq!(resources2[0].id.name_str(), new_id);
+    assert_eq!(renames, vec![(old_id.clone(), new_id.clone())]);
 }
 
 #[test]
@@ -704,7 +710,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
 
     // Should have computed an identifier (not errored)
     assert!(!resources[0].id.name_str().is_empty());
-    assert!(resources[0].id.name_str().starts_with("ec2_eip_"));
+    assert!(resources[0].id.name_str().starts_with("awscc_ec2_eip_"));
 
     // Reconciliation should use Hamming distance (create-only values empty)
     let current_id = resources[0].id.name_str().to_string();
@@ -915,25 +921,37 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         },
     ];
 
-    reconcile_anonymous_identifiers(&mut resources_current, &schemas, &|_provider, _rt| {
-        state_entries.clone()
-    });
+    let current_id_before = resources_current[0].id.name_str().to_string();
+    let renames =
+        reconcile_anonymous_identifiers(&mut resources_current, &schemas, &|_provider, _rt| {
+            state_entries.clone()
+        });
 
-    // Should match orig (closer: 1 attr changed) rather than distant (2 attrs changed)
-    // Note: This depends on SimHash producing closer hashes for more similar inputs.
-    // If the Hamming distance for both is below the threshold, the closest is picked.
-    let current_hash = extract_hash_from_identifier(resources_current[0].id.name_str()).unwrap();
+    // Resource keeps its freshly-computed identifier; the rename pair (if any)
+    // points from the closest state entry to the new identifier so the wiring
+    // layer can re-key the legacy state row.
+    assert_eq!(
+        resources_current[0].id.name_str(),
+        current_id_before,
+        "Resource should retain its freshly-computed identifier",
+    );
+
+    let current_hash = extract_hash_from_identifier(&current_id_before).unwrap();
     let orig_hash = extract_hash_from_identifier(&orig_id).unwrap();
     let distant_hash = extract_hash_from_identifier(&distant_id).unwrap();
     let dist_to_orig = (current_hash ^ orig_hash).count_ones();
     let dist_to_distant = (current_hash ^ distant_hash).count_ones();
 
-    if dist_to_orig < SIMHASH_HAMMING_THRESHOLD {
-        // If orig is within threshold, it should have been picked (as closest)
-        assert_eq!(resources_current[0].id.name_str(), orig_id);
+    if dist_to_orig < SIMHASH_HAMMING_THRESHOLD && dist_to_orig <= dist_to_distant {
+        // Orig is within threshold and at least as close as distant: rename pair
+        // should reference orig as the source name.
+        assert_eq!(
+            renames,
+            vec![(orig_id.clone(), current_id_before.clone())],
+            "Closest state entry (orig) should drive the rename pair",
+        );
     }
     if dist_to_orig < dist_to_distant {
-        // Orig should be closer than distant
         assert!(
             dist_to_orig < dist_to_distant,
             "1-attr change (dist={}) should be closer than 2-attr change (dist={})",
@@ -1085,8 +1103,8 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
     compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
 
     // Both should have identifiers computed
-    assert!(resources[0].id.name_str().starts_with("ec2_vpc_"));
-    assert!(resources[1].id.name_str().starts_with("ec2_eip_"));
+    assert!(resources[0].id.name_str().starts_with("awscc_ec2_vpc_"));
+    assert!(resources[1].id.name_str().starts_with("awscc_ec2_eip_"));
 
     // VPC uses standard hash (8 hex chars), EIP uses SimHash (16 hex chars)
     let vpc_hash_part = resources[0].id.name_str().rsplit('_').next().unwrap();
@@ -1420,15 +1438,23 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         name: step1_id.clone(),
         create_only_values: HashMap::new(), // No create-only values in state either
     }];
-    reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
+    let renames = reconcile_anonymous_identifiers(&mut resources2, &schemas, &|_provider, _rt| {
         state_entries.clone()
     });
 
-    // After reconciliation, step2 should have step1's identifier (in-place update)
+    // After reconciliation, step2 keeps its freshly-computed identifier
+    // and emits a rename pair so the wiring layer re-keys the state
+    // entry from step1's name to step2's name. This produces an
+    // in-place update on the same state row instead of delete+create.
     assert_eq!(
         resources2[0].id.name_str(),
-        step1_id,
-        "Tag-only change on EIP with unset create-only props should reconcile to same identifier"
+        step2_id,
+        "Resource should retain its freshly-computed identifier"
+    );
+    assert_eq!(
+        renames,
+        vec![(step1_id.clone(), step2_id.clone())],
+        "Reconcile should emit rename pair for re-keying the state entry"
     );
 }
 
@@ -1701,7 +1727,7 @@ fn test_detect_rename_no_create_only_matches_by_simhash() {
     compute_anonymous_identifiers(&mut anon_vec, &providers, &schemas, &identity_fn).unwrap();
     let anonymous_name = anon_vec[0].id.name_str().to_string();
     assert!(
-        anonymous_name.starts_with("sso_instance_"),
+        anonymous_name.starts_with("awscc_sso_instance_"),
         "expected hash-derived name, got {anonymous_name}"
     );
 
@@ -1921,5 +1947,122 @@ fn test_detect_rename_no_create_only_skips_when_two_orphans_tie_on_distance() {
         renames.is_empty(),
         "two orphans tie on distance, should skip to avoid rebinding wrong entry: {:?}",
         renames
+    );
+}
+
+#[test]
+fn anonymous_identifier_includes_provider_prefix() {
+    let schema = ResourceSchema::new("iam.RolePolicy")
+        .attribute(AttributeSchema::new("policy_name", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+    }];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    r.set_attr("policy_name".to_string(), Value::String("foo".to_string()));
+    let mut resources = vec![r];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+
+    let name = resources[0].id.name_str();
+    assert!(
+        name.starts_with("awscc_"),
+        "identifier should begin with the provider prefix, got: {name}"
+    );
+    assert!(
+        name.contains("iam_role_policy_"),
+        "identifier should still contain the snake-case type, got: {name}"
+    );
+}
+
+#[test]
+fn anonymous_identifier_provider_prefix_for_aws_provider() {
+    let schema = ResourceSchema::new("s3.Bucket")
+        .attribute(AttributeSchema::new("bucket_name", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
+    let providers = vec![ProviderConfig {
+        name: "aws".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+    }];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    let mut r = Resource::with_provider("aws", "s3.Bucket", "");
+    r.set_attr(
+        "bucket_name".to_string(),
+        Value::String("example".to_string()),
+    );
+    let mut resources = vec![r];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    assert!(
+        resources[0].id.name_str().starts_with("aws_s3_bucket_"),
+        "identifier should begin with `aws_s3_bucket_`, got: {}",
+        resources[0].id.name_str()
+    );
+}
+
+#[test]
+fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
+    // Schema with NO create-only attrs forces the SimHash-distance branch.
+    let schema = ResourceSchema::new("iam.RolePolicy")
+        .attribute(AttributeSchema::new("policy_name", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+    }];
+    let identity_fn = |_: &str| -> Vec<String> { vec![] };
+
+    // Build a resource and let compute_anonymous_identifiers assign its
+    // freshly-computed new-format name.
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    r.set_attr(
+        "policy_name".to_string(),
+        Value::String("inline".to_string()),
+    );
+    let mut resources = vec![r];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+    let new_name = resources[0].id.name_str().to_string();
+    assert!(new_name.starts_with("awscc_iam_role_policy_"));
+
+    // Strip the provider prefix to simulate a state entry written under the
+    // older identifier format.
+    let old_name = new_name
+        .strip_prefix("awscc_")
+        .expect("new format starts with awscc_ prefix")
+        .to_string();
+    let state_entries = vec![AnonymousIdStateInfo {
+        name: old_name.clone(),
+        create_only_values: HashMap::new(),
+    }];
+
+    let renames =
+        reconcile_anonymous_identifiers(&mut resources, &schemas, &|_p, _rt| state_entries.clone());
+
+    assert_eq!(
+        resources[0].id.name_str(),
+        new_name,
+        "resource id should retain the new-format identifier",
+    );
+    assert_eq!(
+        renames,
+        vec![(old_name, new_name)],
+        "should emit a rename pair from the old state name to the new identifier",
     );
 }


### PR DESCRIPTION
## Summary

- Anonymous resource identifiers gain a `<provider>_` prefix
  (`{type}_{hash}` → `{provider}_{type}_{hash}`) so plan output
  and state files self-describe their provider.
- `reconcile_anonymous_identifiers` keeps the freshly-computed
  new-format identifier on the resource and returns rename pairs
  the wiring layer applies to `StateFile.resources` — legacy state
  rows are re-keyed instead of triggering destroy+create.
- New `provider_prefix` plan-display fixture + Makefile target +
  snapshot test lock the prefix into the rendered output.

Bundles task-1/8 through task-7/8 from the original split.

## Implementation notes

- Format change at the single assembly site
  `carina-core/src/identifier/mod.rs:474`. `Resource.id.provider`
  goes through the same `pascal_to_snake` helper as the type
  segment, so providers like `awscc` flow through unchanged and
  any future hierarchical names already snake-case correctly.
- Reconciliation's SimHash branch previously overwrote
  `resource.id.name` with the matched state entry's name. That
  branch now records `(state_name → new_name)` in a
  `Vec<(String, String)>` returned to the caller. Partial-match
  (create-only) reconciliation is unchanged because the matched
  state name and the resource's name end up in the same
  identifier-format generation post-PR.
- Wiring layer threads renames through by mutating
  `StateFile.resources[].name` directly. Downstream maps
  (`build_saved_attrs`, `build_desired_keys`, `build_lifecycles`)
  derive their keys from those names, so a single mutation
  re-keys all of them coherently. Picked this over the planned
  three-map signature because the maps don't exist yet at the
  call site.
- All four CLI command sites (plan, apply, destroy, state-refresh)
  plus the fixture loader now take `&mut StateFile` for the
  reconcile call.

## Test plan

- [x] `cargo nextest run --workspace` (2749 tests, all green)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all pass)
- [x] `make plan-provider-prefix` shows `awscc_ec2_vpc_<hash>`
- [x] New `snapshot_provider_prefix` test passes
- [ ] Real-infra smoke test deferred — provider WASM components
      fail to instantiate locally with `wasi:http/types@0.2.9`
      not found; that's an environment limitation independent of
      this change. Will re-verify post-merge if needed.

Closes #2426
Closes #2427
Closes #2428
Closes #2429
Closes #2430
Closes #2431
Closes #2432

Refs #2419 (provider-prefix portion of #2433 verify will follow as needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)