### PR TITLE
display: drop redundant provider.type prefix from moved-from label

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -468,7 +468,7 @@ impl<'a> TreeRenderContext<'a> {
                 let moved_note = self
                     .moved_origins
                     .get(id)
-                    .map(|from| format!(" (moved from: {}.{})", from.display_type(), from.name));
+                    .map(|from| format!(" (moved from: {})", from.name_str()));
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(to, id.name_str(), parent_binding);
                     writeln!(
@@ -507,7 +507,7 @@ impl<'a> TreeRenderContext<'a> {
                 let moved_note = self
                     .moved_origins
                     .get(id)
-                    .map(|from| format!(" (moved from: {}.{})", from.display_type(), from.name));
+                    .map(|from| format!(" (moved from: {})", from.name_str()));
                 if self.detail == DetailLevel::None {
                     let name_part = format_compact_name(to, id.name_str(), parent_binding);
                     writeln!(
@@ -620,7 +620,7 @@ impl<'a> TreeRenderContext<'a> {
                     colored_symbol,
                     to.display_type().cyan().bold(),
                     to.name_str().yellow().bold(),
-                    format!("(moved from: {})", from).dimmed()
+                    format!("(moved from: {})", from.name_str()).dimmed()
                 )
                 .unwrap();
             }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -446,6 +446,29 @@ fn snapshot_moved_pure() {
     insta::assert_snapshot!(output);
 }
 
+/// Compact (`DetailLevel::None`) rendering of a moved Update effect.
+///
+/// Locks in the `(moved from: <name>)` annotation form on the
+/// compact path of `display::TreeRenderer::render_node` (#2470). The
+/// detailed branch is already covered by `snapshot_moved_with_changes`;
+/// this fixture-reusing test guards the compact branch separately so a
+/// regression to the redundant `<provider>.<type>.<name>` form would
+/// surface here instead of going unnoticed.
+#[test]
+fn snapshot_moved_with_changes_compact() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("moved_with_changes");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::None,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
 /// Collect unused `let` bindings across every fixture subdirectory of
 /// `fixtures_root`. A fixture is any immediate subdirectory containing at
 /// least one `.crn` file (the file need not be named `main.crn` — sibling

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_prev_keys.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.Vpc new_vpc (moved from: awscc.ec2.Vpc.old_vpc)
+  ~ awscc.ec2.Vpc new_vpc (moved from: old_vpc)
       tags: [{key: "Name", value: "old"}] → (removed)
       # (1 unchanged attribute hidden)
         │

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_pure.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_pure.snap
@@ -4,6 +4,6 @@ expression: output
 ---
 Execution Plan:
 
-  -> awscc.ec2.Vpc new_vpc (moved from: awscc.ec2.Vpc.old_vpc)
+  -> awscc.ec2.Vpc new_vpc (moved from: old_vpc)
 
 Plan: 0 to add, 0 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  ~ awscc.ec2.Vpc new_vpc (moved from: awscc.ec2.Vpc.old_vpc)
+  ~ awscc.ec2.Vpc new_vpc (moved from: old_vpc)
       tags: (none) → {Name: "updated"}
       # (1 unchanged attribute hidden)
         │

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes_compact.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes_compact.snap
@@ -1,0 +1,10 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.ec2.Vpc new_vpc (moved from: old_vpc)
+        └─ + awscc.ec2.Subnet (cidr_block: 10.0.1.0/24)
+
+Plan: 1 to add, 1 to change, 0 to destroy, 1 to move.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_state_blocks.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_state_blocks.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 Execution Plan:
 
-  -> awscc.ec2.SecurityGroup renamed-sg (moved from: awscc.ec2.SecurityGroup.old-sg)
+  -> awscc.ec2.SecurityGroup renamed-sg (moved from: old-sg)
   x awscc.ec2.Subnet legacy-subnet (remove from state)
   <- awscc.ec2.Vpc imported-vpc (import: vpc-0abc123def456)
       id: vpc-0abc123def456


### PR DESCRIPTION
## Summary

- Drop redundant `{provider}.{type}.` prefix from `(moved from: ...)` annotations in `carina plan` output (closes #2470).
- The full type is already shown on the destination side of the same line, so the prefix was pure noise — keep just the source name.
- All three render paths in `carina-cli/src/display/mod.rs` updated (Update / Replace / pure Move) to use `from.name_str()` consistently.
- Updates 4 existing plan snapshots mechanically (prefix-only drop) and adds `snapshot_moved_with_changes_compact` to lock in the `DetailLevel::None` (compact) branch separately, since the prior moved snapshots only exercised `DetailLevel::Full`.

## Why this is safe

After #2469, anonymous identifier names already self-encode the provider (`awscc_sso_assignment_92ee7bf1` vs legacy `sso_assignment_92ee7bf1`). The name alone identifies the source.

The DSL grammar permits cross-type `moved` blocks (e.g. `awscc.ec2.Vpc → awscc.ec2.VpcV2`); for such moves the from-type information is no longer surfaced in the annotation. This is an accepted trade-off — cross-type moves are a niche case and the common case (same-type renames) was the source of redundancy this issue called out.

## Out of scope

- `format_effect` single-line label (`display/mod.rs:1435`) is intentionally untouched — it has no surrounding type context, so the full `Move <from> -> <to>` form is still right there.
- `carina-tui` `effect_label` strings are internal test selectors, not user-visible, so they remain unchanged.

## Test plan

- [x] `cargo nextest run -p carina-cli` (355 tests, all pass; 1 new compact-moved snapshot test included)
- [x] `cargo clippy -p carina-cli --all-targets -- -D warnings` clean
- [x] `bash scripts/check-*.sh` all pass
- [x] Snapshot diffs reviewed: each affected `.snap` differs only in the dropped prefix
- [x] Render `infra/aws/management/identity-center` plan mentally — produces `(moved from: sso_assignment_92ee7bf1)`, matching the expected form in the issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)
