### PR TITLE
lsp: surface in-scope bindings inside ${...} interpolations

### DIFF
--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -359,6 +359,13 @@ impl LanguageServer for Backend {
                         // requiring a manual Ctrl-Space. Harmless outside import paths:
                         // other contexts return nothing for a bare `/`.
                         "/".to_string(),
+                        // `{` opens an interpolation expression (`${`) inside a
+                        // double-quoted string. Without it the editor never asks the
+                        // server for completion at the empty interpolation position,
+                        // so in-scope binding names (`orgs`, `bucket`, …) wouldn't
+                        // surface until the user typed an identifier char or hit
+                        // Ctrl-Space manually.
+                        "{".to_string(),
                     ]),
                     ..Default::default()
                 }),

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -104,6 +104,13 @@ impl CompletionProvider {
                 .upstream_state_dot_completions(&binding, &partial, &source, position, base_path);
         }
 
+        // Without this branch the surrounding string-literal context
+        // suppresses completion entirely — the value-position path
+        // declines once `after_eq` starts with a double quote.
+        if let Some(partial) = detect_interpolation_bare_partial(&text, position) {
+            return self.in_scope_binding_completions(&text, position, &partial, base_path);
+        }
+
         let context = self.get_completion_context(&text, position);
 
         match context {
@@ -153,7 +160,7 @@ impl CompletionProvider {
                 self.upstream_state_source_completions(&partial_path, position, base_path)
             }
             CompletionContext::ForIterable { partial } => {
-                self.for_iterable_completions(&text, position, &partial, base_path)
+                self.in_scope_binding_completions(&text, position, &partial, base_path)
             }
             CompletionContext::None => vec![],
         }
@@ -967,6 +974,63 @@ struct UpstreamDepth2Match {
     source: String,
 }
 
+/// Returns `None` past a dot inside the interpolation (the
+/// depth-1/depth-2 dot detectors cover those), when no unescaped `${`
+/// opens to the left, or when the cursor isn't inside a double-quoted
+/// string on this line. Single-quoted strings are literal-only.
+fn detect_interpolation_bare_partial(text: &str, position: Position) -> Option<String> {
+    let line_idx = position.line as usize;
+    let current_line = text.lines().nth(line_idx)?;
+    // Cheap bail for the 99% common case: no `$` on this line, no
+    // interpolation possible. Avoids the prefix allocation below.
+    if !current_line.as_bytes().contains(&b'$') {
+        return None;
+    }
+
+    let col = position.character as usize;
+    let prefix: String = current_line.chars().take(col).collect();
+
+    let mut tail_start = prefix.len();
+    for (idx, ch) in prefix.char_indices().rev() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            tail_start = idx;
+        } else {
+            break;
+        }
+    }
+    let partial = &prefix[tail_start..];
+    let before_partial = &prefix[..tail_start];
+
+    let before_brace = before_partial.strip_suffix('{')?.strip_suffix('$')?;
+    if before_brace.ends_with('\\') {
+        return None;
+    }
+
+    if !is_inside_double_quoted_string(before_brace) {
+        return None;
+    }
+
+    Some(partial.to_string())
+}
+
+/// Returns true when an unmatched (odd-count) double quote opens a
+/// string literal somewhere in `prefix`. Backslash-escaped quotes
+/// (`\"`) don't open or close the literal and are skipped.
+fn is_inside_double_quoted_string(prefix: &str) -> bool {
+    let mut open = false;
+    let mut chars = prefix.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            chars.next();
+            continue;
+        }
+        if c == '"' {
+            open = !open;
+        }
+    }
+    open
+}
+
 /// Walk back from the end of `prefix` collecting the trailing run of
 /// `<id>(.<id>)*<.partial>` (where `partial` may be empty after a
 /// trailing `.`). Returns exactly `n` segments — earliest first — or
@@ -1152,8 +1216,87 @@ fn parse_source_partial_from(s: &str) -> Option<String> {
 #[cfg(test)]
 mod helper_tests {
     use super::{
-        extract_source_partial_anywhere, extract_upstream_source_partial, is_let_use_line,
+        detect_interpolation_bare_partial, extract_source_partial_anywhere,
+        extract_upstream_source_partial, is_inside_double_quoted_string, is_let_use_line,
     };
+    use tower_lsp::lsp_types::Position;
+
+    fn pos_at_end(text: &str) -> Position {
+        let last = text.lines().last().unwrap_or("");
+        Position {
+            line: text.lines().count().saturating_sub(1) as u32,
+            character: last.chars().count() as u32,
+        }
+    }
+
+    #[test]
+    fn double_quote_parity_inside_outside() {
+        assert!(!is_inside_double_quoted_string(""));
+        assert!(is_inside_double_quoted_string("foo = \""));
+        assert!(!is_inside_double_quoted_string("foo = \"bar\""));
+        // Escaped quote is a literal — neither opens nor closes.
+        assert!(is_inside_double_quoted_string("foo = \"a\\\""));
+    }
+
+    #[test]
+    fn interpolation_bare_partial_after_open_brace() {
+        let text = "policy = \"arn:${";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)).as_deref(),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn interpolation_bare_partial_with_typed_chars() {
+        let text = "policy = \"arn:${o";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)).as_deref(),
+            Some("o")
+        );
+    }
+
+    #[test]
+    fn interpolation_bare_partial_rejected_after_dot() {
+        // After a dot, depth-1/depth-2 detectors take over — the bare
+        // detector must decline.
+        let text = "policy = \"arn:${orgs.";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)),
+            None
+        );
+    }
+
+    #[test]
+    fn interpolation_bare_partial_rejected_outside_string() {
+        // `${` outside a double-quoted string isn't an interpolation.
+        let text = "policy = ${";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)),
+            None
+        );
+    }
+
+    #[test]
+    fn interpolation_bare_partial_rejected_in_single_quoted_string() {
+        // Single-quoted strings are literal-only — `${` is not an
+        // interpolation there.
+        let text = "policy = '${";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)),
+            None
+        );
+    }
+
+    #[test]
+    fn interpolation_bare_partial_rejected_when_dollar_is_escaped() {
+        // `\${` is a literal `${`, not an interpolation opener.
+        let text = "policy = \"arn:\\${";
+        assert_eq!(
+            detect_interpolation_bare_partial(text, pos_at_end(text)),
+            None
+        );
+    }
 
     #[test]
     fn single_quote_unclosed_returns_partial() {

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3234,3 +3234,104 @@ fn unannotated_upstream_export_with_function_call_rhs_is_not_offered() {
         labels
     );
 }
+
+// =====================================================================
+// String-interpolation completion: `${...}` inside double-quoted strings
+// should behave like a bare expression position — surface in-scope
+// `let` bindings, then chain into upstream-state member access. (#2472)
+// =====================================================================
+
+/// Set up a directory with a sibling `backend.crn` declaring a
+/// `let orgs = upstream_state` binding plus a `main.crn` whose contents
+/// are supplied by the test. The upstream `organizations/` exports a
+/// `map(String)` keyed `accounts` so the dot-into-export path can be
+/// exercised too.
+fn set_up_interpolation_project(downstream_main: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    std::fs::write(base.join("main.crn"), downstream_main).unwrap();
+    (tmp, base)
+}
+
+#[test]
+fn interpolation_completion_empty_offers_in_scope_binding() {
+    // `"...${<cursor>"` — bare `${` with nothing typed yet should still
+    // surface `orgs` (the cross-file `let` binding from backend.crn).
+    let provider = test_provider();
+    let main = "aws.s3.BucketPolicy {\n  policy = \"arn:aws:iam::${\"\n}\n";
+    let (_tmp, base) = set_up_interpolation_project(main);
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    // Cursor right after `${` on line 1.
+    let position = Position {
+        line: 1,
+        character: "  policy = \"arn:aws:iam::${".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"orgs"),
+        "expected `orgs` in completions inside `${{`, got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn interpolation_completion_partial_offers_matching_binding() {
+    // `"...${o<cursor>"` — should still surface `orgs` (the editor
+    // filters by partial; we just need the candidate present).
+    let provider = test_provider();
+    let main = "aws.s3.BucketPolicy {\n  policy = \"arn:aws:iam::${o\"\n}\n";
+    let (_tmp, base) = set_up_interpolation_project(main);
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "  policy = \"arn:aws:iam::${o".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"orgs"),
+        "expected `orgs` in completions for `${{o`, got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn interpolation_completion_dot_after_binding_offers_exports() {
+    // `"...${orgs.<cursor>"` — dot after the upstream_state binding
+    // should surface its exports (`accounts`).
+    let provider = test_provider();
+    let main = "aws.s3.BucketPolicy {\n  policy = \"arn:aws:iam::${orgs.\"\n}\n";
+    let (_tmp, base) = set_up_interpolation_project(main);
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "  policy = \"arn:aws:iam::${orgs.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"accounts"),
+        "expected `accounts` from upstream exports inside `${{orgs.`, got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3335,3 +3335,50 @@ fn interpolation_completion_dot_after_binding_offers_exports() {
         labels
     );
 }
+
+#[test]
+fn interpolation_completion_works_inside_deeply_nested_struct() {
+    // Mirrors the real `infra/aws/management/carina-state/main.crn` shape:
+    // `${o<cursor>` deep inside `aws.s3.BucketPolicy { policy = { statement { principal = { aws = "...${o" } } } }`.
+    // The intermediate nested blocks must not suppress completion.
+    let provider = test_provider();
+    let main = "\
+aws.s3.BucketPolicy {
+  bucket = bucket.bucket_name
+  policy = {
+    version = '2012-10-17'
+    statement {
+      sid    = 'AllowRegistryDevUpstreamRead'
+      effect = 'Allow'
+      principal = {
+        aws = \"arn:aws:iam::${o\"
+      }
+      action   = 's3:GetObject'
+    }
+  }
+}
+";
+    let (_tmp, base) = set_up_interpolation_project(main);
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    // Line index 8 (0-based) is `        aws = "arn:aws:iam::${o"`.
+    let (line_idx, line) = main_src
+        .lines()
+        .enumerate()
+        .find(|(_, l)| l.contains("${o\""))
+        .expect("could not locate `${o\"` in fixture");
+    // Cursor at the `o`, just after `${`.
+    let cursor_col = line.find("${o").expect("contains `${o`") + "${o".chars().count();
+    let position = Position {
+        line: line_idx as u32,
+        character: cursor_col as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"orgs"),
+        "expected `orgs` inside deeply-nested `${{o`, got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -595,15 +595,18 @@ impl CompletionProvider {
         ]
     }
 
-    /// Completions for `for <pat> in <HERE>` — every binding that
-    /// `check_deferred_for_iterables` treats as in-scope: `let`,
+    /// Surface every binding that `check_deferred_for_iterables` treats
+    /// as in-scope at a bare-identifier expression position: `let`,
     /// `upstream_state`, module calls, imports, and argument parameters.
+    /// Used by the `for ... in <HERE>` iterable detector and by the
+    /// `"${<HERE>"` interpolation detector — both want the same
+    /// candidates.
     ///
-    /// Bindings commonly live in sibling `.crn` files (a typical pattern
-    /// is `let orgs = upstream_state { ... }` in `backend.crn` iterated
-    /// from `main.crn`), so we read every `.crn` in `base_path`, not just
-    /// the current buffer.
-    pub(super) fn for_iterable_completions(
+    /// Bindings commonly live in sibling `.crn` files (e.g.
+    /// `let orgs = upstream_state { ... }` in `backend.crn` referenced
+    /// from `main.crn`), so we read every `.crn` in `base_path`, not
+    /// just the current buffer.
+    pub(super) fn in_scope_binding_completions(
         &self,
         text: &str,
         position: Position,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -44,7 +44,12 @@
     "configurationDefaults": {
       "[carina]": {
         "editor.formatOnSave": true,
-        "editor.wordBasedSuggestions": "off"
+        "editor.wordBasedSuggestions": "off",
+        "editor.quickSuggestions": {
+          "other": "on",
+          "comments": "off",
+          "strings": "on"
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary

Closes #2472.

Inside double-quoted string interpolations, LSP completion now offers in-scope `let` bindings (and `arguments` parameters) when the cursor sits at a bare-identifier expression position. Specifically:

- `"...${<cursor>"` → in-scope bindings appear (e.g. `orgs`)
- `"...${o<cursor>"` → matching bindings appear filtered by partial
- `"...${orgs.<cursor>"` → continues to chain through the existing depth-1/depth-2 dot detectors and surfaces upstream-state exports

Previously the value-position path suppressed completion the moment `after_eq` started with `"`, so the bare-identifier gap inside `${...}` produced zero candidates.

## Implementation

- New `detect_interpolation_bare_partial` short-circuits on lines that don't contain `$`, then validates an unescaped `${` opener inside an unmatched double-quoted region.
- The for-iterable completion handler is renamed to `in_scope_binding_completions` and reused by the new branch — both contexts want the same candidates.
- The new detector runs **after** the upstream-state dot detectors, so dotted shapes like `${orgs.acc` keep working without change (the existing depth-1 walker already strips `${` as non-identifier when scanning back from the trailing dot).
- Single-quoted strings (no interpolation in this DSL) and `\${` escapes are correctly rejected.

## Test plan

- [x] Multi-file fixture (`backend.crn` declaring `let orgs = upstream_state {...}`, `main.crn` referencing it inside `${...}`, sibling `organizations/exports.crn`) covers all three sub-cases — per CLAUDE.md "Directory-scoped, never single-file".
- [x] Six helper unit tests for `detect_interpolation_bare_partial` and `is_inside_double_quoted_string` (empty, partial, post-dot reject, outside-string reject, single-quote reject, escaped-dollar reject; double-quote parity).
- [x] `cargo nextest run -p carina-lsp` — 424 passed.
- [x] `cargo test --workspace --doc` — passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five gates green.

## Out of scope

- Syntax highlighting for `${...}` spans was split out to #2473 to keep this PR scoped to completion only.
- Comment-inside-string detection (e.g. `# "${...}"` in a Carina line comment) is a pre-existing blind spot shared by the depth-1 and depth-2 detectors; not addressed here.