### PR TITLE
upstream_state map field access: narrow type-check, lower dot-form to ResourceRef

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,8 @@ plan-fixtures:
 	@echo "---"
 	@$(MAKE) plan-upstream-state-map-subscript
 	@echo "---"
+	@$(MAKE) plan-upstream-state-map-dot-notation
+	@echo "---"
 	@$(MAKE) plan-deferred-for
 	@echo ""
 	@echo "=== policy_pretty ==="
@@ -142,6 +144,8 @@ plan-upstream-state-empty-exports:
 	$(PLAN_FIXTURE) upstream_state_empty_exports
 plan-upstream-state-map-subscript:
 	$(PLAN_FIXTURE) upstream_state_map_subscript
+plan-upstream-state-map-dot-notation:
+	$(PLAN_FIXTURE) upstream_state_map_dot_notation
 plan-deferred-for:
 	$(PLAN_FIXTURE) deferred_for
 plan-exports:
@@ -161,7 +165,7 @@ plan-provider-prefix:
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
-        plan-upstream-state-map-subscript \
+        plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
         plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -690,6 +690,53 @@ fn plan_snapshot_upstream_state_map_subscript() {
     insta::assert_snapshot!(stripped);
 }
 
+/// Issue #2447: companion to the subscript fixture, but for the
+/// dot-notation form `${X.field.key}` / bare `X.field.key`. Pre-fix the
+/// dot form passed validate but rendered the literal substring
+/// `orgs.accounts.registry_dev` into the output (the parser fell back
+/// to `Value::String` because the head wasn't a known binding in the
+/// current file). Symmetric with the #2435 subscript fix; both forms
+/// must now resolve to the upstream's concrete map value.
+#[test]
+fn plan_snapshot_upstream_state_map_dot_notation() {
+    let (plan, schemas, moved_origins) = build_plan_from_fixture("upstream_state_map_dot_notation");
+    let output = format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &moved_origins,
+        &[],
+        &[],
+    );
+    let stripped = strip_ansi(&output);
+    // Both dot-notation forms — bare attribute value and inside `${...}`
+    // interpolation — must end up substituted with the actual account ids.
+    assert!(
+        stripped.contains("222222222222"),
+        "expected dev account id substituted, got:\n{stripped}"
+    );
+    assert!(
+        stripped.contains("111111111111"),
+        "expected prod account id substituted, got:\n{stripped}"
+    );
+    assert!(
+        stripped.contains("shared-222222222222-bucket"),
+        "expected `${{orgs.accounts.registry_dev}}` interpolation substituted, got:\n{stripped}"
+    );
+    // Pin that the bare-attribute form does not regress to the literal
+    // `orgs.accounts.registry_dev` substring (the original #2447 bug).
+    assert!(
+        stripped.contains("DevAccount: \"222222222222\""),
+        "expected bare `orgs.accounts.registry_dev` attribute substituted, got:\n{stripped}"
+    );
+    assert!(
+        !stripped.contains("orgs.accounts.registry_dev"),
+        "literal `orgs.accounts.registry_dev` substring leaked into output:\n{stripped}"
+    );
+    insta::assert_snapshot!(stripped);
+}
+
 #[test]
 fn plan_snapshot_exports() {
     use crate::commands::plan::ExportChange;

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_dot_notation.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__plan_snapshot_upstream_state_map_dot_notation.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: stripped
+---
+Execution Plan:
+
+  + awscc.s3.Bucket 
+      bucket_name: "shared-222222222222-bucket"
+      tags:
+        DevAccount: "222222222222"
+        ProdAccount: "111111111111"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/main.crn
@@ -1,0 +1,21 @@
+# Test upstream_state map dot-notation across sibling .crn files (#2447).
+#
+# Symmetric with `upstream_state_map_subscript`: `let X = upstream_state {...}`
+# lives in `state.crn`; the consuming `${X.field.key}` lives in this
+# `main.crn`. The fix in #2447 makes the dot-notation form lower to a
+# `Value::ResourceRef` so the resolver substitutes the upstream's
+# concrete map value instead of leaving the literal `orgs.accounts.k`
+# substring in the rendered plan.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.Bucket {
+  bucket_name = "shared-${orgs.accounts.registry_dev}-bucket"
+
+  tags = {
+    DevAccount  = orgs.accounts.registry_dev
+    ProdAccount = orgs.accounts.registry_prod
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/orgs/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/orgs/carina.state.json
@@ -1,0 +1,13 @@
+{
+  "version": 5,
+  "serial": 1,
+  "lineage": "remote-orgs-lineage",
+  "carina_version": "0.1.0",
+  "resources": [],
+  "exports": {
+    "accounts": {
+      "registry_prod": "111111111111",
+      "registry_dev": "222222222222"
+    }
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/orgs/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/orgs/main.crn
@@ -1,0 +1,8 @@
+backend local { path = "carina.state.json" }
+
+exports {
+  accounts: map(String) = {
+    registry_prod = "111111111111"
+    registry_dev  = "222222222222"
+  }
+}

--- a/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/state.crn
+++ b/carina-cli/tests/fixtures/plan_display/upstream_state_map_dot_notation/state.crn
@@ -1,0 +1,3 @@
+let orgs = upstream_state {
+  source = "./orgs"
+}

--- a/carina-cli/tests/plan_fixture_example.rs
+++ b/carina-cli/tests/plan_fixture_example.rs
@@ -71,3 +71,9 @@ fn plan_fixture_upstream_state_map_subscript() {
     let output = run_plan_fixture(&["upstream_state_map_subscript"]);
     assert_success(&output, "upstream_state_map_subscript");
 }
+
+#[test]
+fn plan_fixture_upstream_state_map_dot_notation() {
+    let output = run_plan_fixture(&["upstream_state_map_dot_notation"]);
+    assert_success(&output, "upstream_state_map_dot_notation");
+}

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -97,6 +97,14 @@ fn parse_namespaced_id_value(
         });
     }
 
+    // Dotted IDs that aren't an enum shorthand are binding refs; the
+    // head may live in a sibling `.crn`, so emit a structured
+    // `ResourceRef` and let `check_identifier_scope` flag genuine typos
+    // post-merge. Symmetric with the subscript fallback above. #2447.
+    if crate::utils::NamespacedId::parse(full_str).is_none() {
+        return Ok(as_resource_ref(Vec::new()));
+    }
+
     Ok(EvalValue::from_value(Value::String(full_str.to_string())))
 }
 

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -338,9 +338,16 @@ fn parse_and_resolve_resource_reference() {
 }
 
 #[test]
-fn parse_undefined_two_part_identifier_becomes_string() {
-    // When a 2-part identifier references an unknown binding,
-    // it becomes a String (e.g., "nonexistent.name") for later schema validation
+fn parse_undefined_two_part_identifier_becomes_resource_ref() {
+    // A 2-part dotted identifier whose head is not a known binding in
+    // this file lowers to `Value::ResourceRef`, not a literal string.
+    // Two reasons:
+    //   - the head may legitimately live in a sibling `.crn` (the
+    //     directory-scoped, multi-file shape), and
+    //   - the post-merge `check_identifier_scope` walk produces a
+    //     proper "Undefined identifier" diagnostic with did-you-mean
+    //     suggestions when the binding really is undeclared.
+    // Issues #2435 (subscript form) and #2447 (dot-notation form).
     let input = r#"
         let policy = aws.s3_bucket_policy {
             name = "my-policy"
@@ -348,13 +355,30 @@ fn parse_undefined_two_part_identifier_becomes_string() {
         }
     "#;
 
-    // Parsing succeeds - unknown identifiers become String
     let result = parse_and_resolve(input);
     assert!(result.is_ok());
     let parsed = result.unwrap();
-    assert_eq!(
-        parsed.resources[0].get_attr("bucket"),
-        Some(&Value::String("nonexistent.name".to_string()))
+    match parsed.resources[0].get_attr("bucket") {
+        Some(Value::ResourceRef { path }) => {
+            assert_eq!(path.binding(), "nonexistent");
+            assert_eq!(path.attribute(), "name");
+            assert!(path.field_path().is_empty());
+            assert!(path.subscripts().is_empty());
+        }
+        other => panic!("expected ResourceRef, got {other:?}"),
+    }
+
+    // Pin that the post-merge scope walk surfaces a clear undefined
+    // diagnostic for the lowered ref — without this, the silent
+    // ResourceRef shape would land in the resolver as an unresolvable
+    // dangling reference instead of the user-friendly error the
+    // previous "literal string" fallback produced indirectly.
+    let scope_errors = crate::parser::check_identifier_scope(&parsed);
+    assert!(
+        scope_errors
+            .iter()
+            .any(|e| e.to_string().contains("nonexistent")),
+        "expected check_identifier_scope to flag `nonexistent`, got: {scope_errors:?}"
     );
 }
 
@@ -7888,6 +7912,122 @@ fn parse_subscript_on_upstream_state_inside_string_interpolation_sibling_file() 
                             key: "registry_dev".to_string()
                         }]
                     );
+                    found_ref = true;
+                }
+            }
+            assert!(
+                found_ref,
+                "expected a ResourceRef expression part in the interpolation, got {parts:?}"
+            );
+        }
+        other => panic!("expected Value::Interpolation, got {other:?}"),
+    }
+}
+
+// ================================================================
+// #2447: dot-notation upstream_state field access across sibling files
+//
+// Symmetric with the #2435 subscript fixes above: `${orgs.accounts.k}` must
+// also lower to `Value::ResourceRef` when the `let orgs = upstream_state{...}`
+// declaration lives in a sibling .crn. Without this, the dotted form falls
+// through to a `Value::String("orgs.accounts.k")` literal and the literal
+// flows through the resolver into the rendered plan.
+// ================================================================
+
+#[test]
+fn parse_dot_notation_on_upstream_state_in_sibling_file() {
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("state.crn"),
+        r#"
+            let orgs = upstream_state { source = "../organizations" }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+                region = "ap-northeast-1"
+            }
+
+            test.r.res {
+                name = "x"
+                account_id = orgs.accounts.registry_dev
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("cross-file upstream dot-notation must parse");
+    let res = parsed
+        .resources
+        .iter()
+        .find(|r| r.attributes.contains_key("account_id"))
+        .expect("resource present");
+    let v = res.attributes.get("account_id").unwrap();
+    match v {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "orgs");
+            assert_eq!(path.attribute(), "accounts");
+            assert_eq!(path.field_path(), ["registry_dev".to_string()]);
+            assert!(path.subscripts().is_empty());
+        }
+        other => panic!("expected ResourceRef with field_path, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_dot_notation_on_upstream_state_inside_string_interpolation_sibling_file() {
+    // `"prefix${orgs.accounts.registry_dev}suffix"` must lower the field
+    // access into a `Value::ResourceRef` so the resolver can substitute
+    // the actual map value at plan time. Without this fix the embedded
+    // ${...} renders the literal substring `orgs.accounts.registry_dev`
+    // into the output.
+    use crate::config_loader::parse_directory;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("state.crn"),
+        r#"
+            let orgs = upstream_state { source = "../organizations" }
+        "#,
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("main.crn"),
+        r#"
+            provider test {
+                source = "x/y"
+                version = "0.1"
+                region = "ap-northeast-1"
+            }
+
+            test.r.res {
+                name = "x"
+                arn = "arn:aws:iam::${orgs.accounts.registry_dev}:root"
+            }
+        "#,
+    )
+    .unwrap();
+    let parsed = parse_directory(tmp.path(), &ProviderContext::default())
+        .expect("cross-file upstream dot-notation inside ${...} must parse");
+    let res = parsed
+        .resources
+        .iter()
+        .find(|r| r.attributes.contains_key("arn"))
+        .expect("resource present");
+    let v = res.attributes.get("arn").unwrap();
+    match v {
+        Value::Interpolation(parts) => {
+            let mut found_ref = false;
+            for p in parts {
+                if let InterpolationPart::Expr(Value::ResourceRef { path }) = p {
+                    assert_eq!(path.binding(), "orgs");
+                    assert_eq!(path.attribute(), "accounts");
+                    assert_eq!(path.field_path(), ["registry_dev".to_string()]);
                     found_ref = true;
                 }
             }

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -173,35 +173,30 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                 // Resolve the initial attribute value
                 let mut resolved = resolve_ref_value(attr_value, bindings)?;
 
-                // Traverse chained field path through nested maps
+                // For upstream bindings the loaded `Value::Map` is
+                // concrete, so a missing field/key is a user typo and
+                // gets a "key not found" error. For local bindings the
+                // value may simply not be known yet (referenced
+                // resource not created) and we keep the ref unchanged.
+                let is_upstream = matches!(
+                    bindings.source(binding_name),
+                    Some(crate::binding_index::BindingValueSource::Upstream)
+                );
                 for field in field_path {
                     match resolved {
-                        Value::Map(ref map) => {
-                            if let Some(nested) = map.get(field) {
+                        Value::Map(ref map) => match map.get(field) {
+                            Some(nested) => {
                                 resolved = resolve_ref_value(nested, bindings)?;
-                            } else {
-                                // Field not found in nested map, keep original ref
-                                return Ok(value.clone());
                             }
-                        }
-                        _ => {
-                            // Cannot traverse non-map value, keep original ref
-                            return Ok(value.clone());
-                        }
+                            None if is_upstream => {
+                                return Err(missing_map_key_error(path, map));
+                            }
+                            None => return Ok(value.clone()),
+                        },
+                        _ => return Ok(value.clone()),
                     }
                 }
 
-                // Descend into the resolved value by each post-field
-                // subscript (`orgs.accounts[0]`, `orgs.matrix[0][1]`).
-                // The validate-time shape check
-                // (`check_upstream_state_subscript_shapes`) already
-                // rejects kind mismatches against typed exports, so by
-                // the time we get here the subscripts should fit the
-                // shape — but the resolver still has to handle the
-                // happy path and bail out cleanly when an out-of-range
-                // index or missing key is encountered (e.g. resources
-                // produced by `for` whose count differs from the
-                // upstream's declared length).
                 use crate::resource::Subscript;
                 for sub in path.subscripts() {
                     match (resolved, sub) {
@@ -218,27 +213,10 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
                             Some(nested) => {
                                 resolved = resolve_ref_value(nested, bindings)?;
                             }
-                            None => {
-                                // When the map is concrete (the upstream's
-                                // value was loaded) and the requested key
-                                // is not in its keyset, the user typo'd
-                                // the key. Surface a clear error listing
-                                // the known keys instead of silently
-                                // degrading to "(known after upstream
-                                // apply: …)". Issue #2435.
-                                let known_list = if map.is_empty() {
-                                    "<no keys>".to_string()
-                                } else {
-                                    map.keys()
-                                        .map(|k| format!("{k:?}"))
-                                        .collect::<Vec<_>>()
-                                        .join(", ")
-                                };
-                                return Err(format!(
-                                    "{}: key not found; available keys: {}",
-                                    path, known_list
-                                ));
+                            None if is_upstream => {
+                                return Err(missing_map_key_error(path, &map));
                             }
+                            None => return Ok(value.clone()),
                         },
                         _ => return Ok(value.clone()),
                     }
@@ -327,6 +305,24 @@ pub fn resolve_ref_value(value: &Value, bindings: &ResolvedBindings) -> Result<V
         Value::Unknown(_) => Ok(value.clone()),
         _ => Ok(value.clone()),
     }
+}
+
+/// Format the "key not found; available keys: ..." error for a missing
+/// map entry. Shared by the `field_path` (dot-notation, #2447) and
+/// `subscripts` (#2435) walks so the message format cannot drift.
+fn missing_map_key_error(
+    path: &crate::resource::AccessPath,
+    map: &indexmap::IndexMap<String, Value>,
+) -> String {
+    let known_list = if map.is_empty() {
+        "<no keys>".to_string()
+    } else {
+        map.keys()
+            .map(|k| format!("{k:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!("{path}: key not found; available keys: {known_list}")
 }
 
 #[cfg(test)]

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -534,17 +534,98 @@ fn check_ref_against_type(
             // declared type — nothing to type-check against.
             return;
         };
-        if crate::validation::is_type_expr_compatible_with_schema(export_type, expected) {
+
+        // Narrow the export type through the access path's `field_path`
+        // and `subscripts`. `${orgs.accounts['k']}` over an export of
+        // `map(AwsAccountId)` resolves to `AwsAccountId`, not the whole
+        // map; the position-compatibility check must use the narrowed
+        // type so a bucket-policy interpolation isn't false-flagged
+        // against the outer `Struct(IamPolicyDocument)` (#2447).
+        let Some(narrowed) = narrow_type_expr(export_type, path.field_path(), path.subscripts())
+        else {
+            // Kind mismatch (subscripting an Int, dotting into a
+            // String, etc.) is the dedicated shape checkers' job —
+            // `check_upstream_state_attribute_access_shapes` for the
+            // field_path leg, `check_upstream_state_subscript_shapes`
+            // for the subscript leg. Skip here so we don't
+            // double-report.
+            return;
+        };
+
+        // Once narrowing through `field_path`/`subscripts` has reduced
+        // the export to a scalar leaf, we can't usefully compare it to
+        // the *outer* attribute type from here: the ref may sit deep
+        // inside a string interpolation, a struct field, or a list
+        // element, and only a positional walker can pick out the right
+        // inner expected type. Accepting the scalar matches reality
+        // (a resolved scalar can occupy nearly any leaf position) and
+        // stops the top-level check from false-flagging the
+        // bucket-policy shape from #2447.
+        //
+        // Only applies when the path actually narrowed: a top-level
+        // ref with neither `field_path` nor `subscripts` still gets the
+        // direct compare against the outer attribute type, preserving
+        // the existing kind-mismatch diagnostics
+        // (`type_check_flags_string_consumer_with_int_export` etc.).
+        let narrowed_below_root = !path.field_path().is_empty() || !path.subscripts().is_empty();
+        if narrowed_below_root && is_scalar_type_expr(&narrowed) {
+            return;
+        }
+
+        if crate::validation::is_type_expr_compatible_with_schema(&narrowed, expected) {
             return;
         }
         errors.push(UpstreamTypeError {
             location: location.to_string(),
             binding: binding.to_string(),
             field: field.to_string(),
-            export_type: export_type.clone(),
+            export_type: narrowed,
             expected_type: expected.clone(),
         });
     });
+}
+
+/// Narrow `start` through a chain of `field_path` segments and
+/// trailing `subscripts`. Returns `None` when a step doesn't fit the
+/// container kind; those mismatches are already reported by the
+/// dedicated shape checkers and a duplicate here would be noise.
+///
+/// The field-path leg delegates to `walk_type_expr_path` to keep the
+/// dot-form descent rules (map-key + struct-field) in one place.
+fn narrow_type_expr(
+    start: &TypeExpr,
+    field_path: &[String],
+    subscripts: &[crate::resource::Subscript],
+) -> Option<TypeExpr> {
+    let after_fields = walk_type_expr_path(start, field_path).ok()?;
+    let mut current = after_fields.clone();
+    use crate::resource::Subscript;
+    for sub in subscripts {
+        current = match (current, sub) {
+            (TypeExpr::List(inner), Subscript::Int { .. }) => *inner,
+            (TypeExpr::Map(inner), Subscript::Str { .. }) => *inner,
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
+/// True when `t` is a non-container leaf — a scalar value that can
+/// reasonably sit anywhere a string-shaped attribute position accepts.
+/// Used by `check_ref_against_type` to short-circuit the (necessarily
+/// outer-type-only) compatibility check once narrowing has bottomed out
+/// on a scalar; a positional walker would be the right tool to recover
+/// the precision lost here. See #2475 for the follow-up.
+fn is_scalar_type_expr(t: &TypeExpr) -> bool {
+    matches!(
+        t,
+        TypeExpr::String
+            | TypeExpr::Bool
+            | TypeExpr::Int
+            | TypeExpr::Float
+            | TypeExpr::Simple(_)
+            | TypeExpr::SchemaType { .. }
+    )
 }
 
 /// A `for` expression iterates an `upstream_state` field whose declared
@@ -907,6 +988,11 @@ fn walk_type_expr_path<'a, 'b>(
                 }
                 None => return Err((current, segment.as_str())),
             },
+            // Dot form on a map is map-key access (`accounts.k → T`),
+            // symmetric with the subscript form `accounts['k']`. #2447.
+            TypeExpr::Map(inner) => {
+                current = inner.as_ref();
+            }
             _ => return Err((current, segment.as_str())),
         }
     }
@@ -1760,6 +1846,154 @@ mod tests {
     }
 
     // ================================================================
+    // #2447: subscript narrows the export type before the top-level
+    // type-compatibility check
+    // ================================================================
+
+    #[test]
+    fn type_check_map_subscript_narrows_to_value_type() {
+        // `orgs.accounts['k']` against export `map(AwsAccountId)` narrows to
+        // the value type before being compared to the receiver. Without the
+        // narrowing the comparison fires `map(AwsAccountId)` against the
+        // receiver and (when the receiver is anything but a compatible map)
+        // false-flags the position. Issue #2447.
+        use crate::schema::{AttributeType, noop_validator};
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts['k']
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "accounts",
+                TypeExpr::Map(Box::new(TypeExpr::Simple("aws_account_id".to_string()))),
+            )],
+        )]);
+        // Receiver is `String`. Without narrowing, `map(AwsAccountId)`
+        // compares against `String` and fails. With narrowing,
+        // `AwsAccountId` (Custom over String) is accepted.
+        let aws_account_id = AttributeType::Custom {
+            semantic_name: Some("AwsAccountId".to_string()),
+            base: Box::new(AttributeType::String),
+            pattern: None,
+            length: None,
+            validate: noop_validator(),
+            namespace: None,
+            to_dsl: None,
+        };
+        let schemas = schema_with_attr("name", aws_account_id);
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
+        assert!(
+            errs.is_empty(),
+            "subscript narrows map(T) to T before compare, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn type_check_subscript_inside_struct_position_does_not_false_flag() {
+        // The bucket-policy repro from #2447: a deeply-nested ref inside a
+        // struct attribute (`policy: Struct(IamPolicyDocument)`) where
+        // narrowing through a subscript produces a scalar that *could*
+        // legitimately occupy a leaf string position inside the struct.
+        // The top-level check must not reject the narrowed scalar against
+        // the outer struct type — positional walking is the precise tool
+        // for that, and the existing top-level check is too coarse.
+        use crate::schema::{AttributeType, StructField};
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    policy = {
+                        statement = "arn:aws:iam::${orgs.accounts['registry_dev']}:root"
+                    }
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[(
+                "accounts",
+                TypeExpr::Map(Box::new(TypeExpr::Simple("aws_account_id".to_string()))),
+            )],
+        )]);
+        let policy_struct = AttributeType::Struct {
+            name: "IamPolicyDocument".to_string(),
+            fields: vec![StructField::new("statement", AttributeType::String).required()],
+        };
+        let schemas = schema_with_attr("policy", policy_struct);
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
+        assert!(
+            errs.is_empty(),
+            "subscript-narrowed scalar must not be rejected against outer \
+             struct attr, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn type_check_dot_form_chains_through_map_into_struct_field() {
+        // `orgs.accounts.k.account_id` where `accounts: map(struct{
+        // account_id: aws_account_id })`. The dot walk descends
+        // map(T).k → T (struct), then struct.account_id → aws_account_id.
+        // Both legs of `walk_type_expr_path` exercised by one path.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.accounts.alpha.account_id
+                }
+            "#,
+            "test",
+        );
+        let account_struct = TypeExpr::Struct {
+            fields: vec![(
+                "account_id".to_string(),
+                TypeExpr::Simple("aws_account_id".to_string()),
+            )],
+        };
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("accounts", TypeExpr::Map(Box::new(account_struct)))],
+        )]);
+        let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
+        assert!(
+            errs.is_empty(),
+            "dot-walk through map into struct field must resolve to leaf type, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn type_check_list_subscript_narrows_to_element_type() {
+        // Same shape as the map case for `list(T)[idx]`: subscript narrows
+        // to T before the top-level check.
+        let parsed = parse_project_with_provider(
+            r#"
+                let orgs = upstream_state { source = "../organizations" }
+                test.r.res {
+                    name = orgs.regions[0]
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "orgs",
+            &[("regions", TypeExpr::List(Box::new(TypeExpr::String)))],
+        )]);
+        let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
+        assert!(
+            errs.is_empty(),
+            "list subscript narrows list(T) to T before compare, got: {errs:?}"
+        );
+    }
+
+    // ================================================================
     // #1894: for-iterable shape compatibility
     // (`check_upstream_state_for_iterable_shapes`)
     // ================================================================
@@ -2285,15 +2519,12 @@ mod tests {
     }
 
     #[test]
-    fn attribute_access_against_map_export_flags_mismatch() {
-        // `orgs.accounts.alpha` against `accounts: map(_)` — same class
-        // of error. The carina parser does not currently accept
-        // subscript-after-field-access (see `parser/expressions/primary.rs`
-        // — `index access after field access is not supported`), so
-        // `accounts["alpha"]` and `accounts.alpha` are *both* errors
-        // today, just at different layers (parser vs. this check).
-        // Bare `.alpha` parses as struct-field access, which is what
-        // this check rejects against a map export.
+    fn attribute_access_against_map_export_resolves_as_key_access() {
+        // `orgs.accounts.alpha` against `accounts: map(_)` is valid
+        // map-key access, equivalent to `orgs.accounts['alpha']`. The
+        // shape walk descends `map(T).k → T` for the dot form, the
+        // same way it does for the subscript form. Issue #2447 — both
+        // notations must resolve a single map entry.
         let parsed = parse_project_with_provider(
             r#"
                 let orgs = upstream_state { source = "../organizations" }
@@ -2311,13 +2542,10 @@ mod tests {
             )],
         )]);
         let errs = check_upstream_state_attribute_access_shapes(&parsed, &exports);
-        assert_eq!(
-            errs.len(),
-            1,
-            "field access on map must fail, got: {errs:?}"
+        assert!(
+            errs.is_empty(),
+            "dot-notation against map must be accepted as key access, got: {errs:?}"
         );
-        let msg = errs[0].diagnostic_message();
-        assert!(msg.contains("map"), "message must mention map shape: {msg}");
     }
 
     #[test]

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1068,22 +1068,53 @@ impl DiagnosticEngine {
         ))
     }
 
-    /// Validate an attributes value against its declared type.
-    ///
-    /// Skips ResourceRef values (type is resolved at runtime), then delegates all
-    /// validation to `carina_core::validation::validate_type_expr_value`.
+    /// Validate an attributes value against its declared type, with
+    /// cross-file ref awareness so a `ResourceRef` whose head lives in
+    /// a sibling `.crn` is resolved against the schema instead of being
+    /// silently skipped.
     fn validate_attributes_type(
         &self,
         type_expr: &TypeExpr,
         value: &Value,
         sibling_bindings: &HashMap<String, String>,
     ) -> Option<String> {
-        // ResourceRef is always allowed (type is resolved at runtime)
-        if matches!(value, Value::ResourceRef { .. }) {
+        self.validate_type_with_ref_awareness(type_expr, value, sibling_bindings)
+    }
+
+    /// Look up `binding.attr` against `sibling_bindings` + the schema
+    /// registry, then compare the resolved schema type against
+    /// `type_expr`. Returns the formatted diagnostic on mismatch, or
+    /// `None` if the binding/attr cannot be resolved (deferred to the CLI).
+    fn check_cross_file_ref_type(
+        &self,
+        type_expr: &TypeExpr,
+        binding: &str,
+        attr: &str,
+        sibling_bindings: &HashMap<String, String>,
+    ) -> Option<String> {
+        let resource_type = sibling_bindings.get(binding)?;
+        let (provider, rt) = resource_type
+            .split_once('.')
+            .unwrap_or(("", resource_type.as_str()));
+        let schema = self
+            .schemas
+            .get(provider, rt, carina_core::schema::SchemaKind::Managed)
+            .or_else(|| {
+                self.schemas
+                    .get(provider, rt, carina_core::schema::SchemaKind::DataSource)
+            })?;
+        let attr_schema = schema.attributes.get(attr)?;
+        let ref_type = &attr_schema.attr_type;
+        if carina_core::validation::is_type_expr_compatible_with_schema(type_expr, ref_type) {
             return None;
         }
-
-        self.validate_type_with_ref_awareness(type_expr, value, sibling_bindings)
+        Some(format!(
+            "type mismatch: expected {}, got {} (from {}.{})",
+            type_expr,
+            ref_type.type_name(),
+            binding,
+            attr
+        ))
     }
 
     /// Type-check a value against a TypeExpr, resolving cross-file references
@@ -1095,48 +1126,34 @@ impl DiagnosticEngine {
         sibling_bindings: &HashMap<String, String>,
     ) -> Option<String> {
         match (type_expr, value) {
-            // Cross-file ref: look up schema type via sibling bindings
+            // Cross-file ref: look up schema type via sibling bindings.
+            // Two shapes reach this arm. The string form covers values
+            // not produced by the .crn parser — synthetic test inputs
+            // and any caller that hands us a raw `"binding.attr"` —
+            // since the parser itself now lowers dotted IDs to
+            // `Value::ResourceRef` (#2447). The ResourceRef arm below
+            // is the parser-produced path; both must agree.
             (_, Value::String(s)) if is_dot_notation_ref(s) => {
                 let parts: Vec<&str> = s.split('.').collect();
-                let binding = parts[0];
-                let attr = parts[1];
-
-                // Look up resource type from sibling bindings
-                if let Some(resource_type) = sibling_bindings.get(binding) {
-                    // Look up attribute schema type
-                    let (provider, rt) = resource_type
-                        .split_once('.')
-                        .unwrap_or(("", resource_type.as_str()));
-                    if let Some(schema) = self
-                        .schemas
-                        .get(provider, rt, carina_core::schema::SchemaKind::Managed)
-                        .or_else(|| {
-                            self.schemas.get(
-                                provider,
-                                rt,
-                                carina_core::schema::SchemaKind::DataSource,
-                            )
-                        })
-                        && let Some(attr_schema) = schema.attributes.get(attr)
-                    {
-                        let ref_type = &attr_schema.attr_type;
-                        if !carina_core::validation::is_type_expr_compatible_with_schema(
-                            type_expr, ref_type,
-                        ) {
-                            return Some(format!(
-                                "type mismatch: expected {}, got {} (from {}.{})",
-                                type_expr,
-                                ref_type.type_name(),
-                                binding,
-                                attr
-                            ));
-                        }
-                        return None;
-                    }
-                }
-                // Can't resolve: skip (will be validated by CLI)
-                None
+                self.check_cross_file_ref_type(type_expr, parts[0], parts[1], sibling_bindings)
             }
+            // Bare `binding.attribute` ref: check the head's schema type.
+            // Refs with subscripts or a field_path narrow inside the
+            // head's type and would need a positional walker to compare
+            // against the receiver precisely (#2475); skip the
+            // comparison rather than false-flag against the head's
+            // outer type.
+            (_, Value::ResourceRef { path })
+                if path.field_path().is_empty() && path.subscripts().is_empty() =>
+            {
+                self.check_cross_file_ref_type(
+                    type_expr,
+                    path.binding(),
+                    path.attribute(),
+                    sibling_bindings,
+                )
+            }
+            (_, Value::ResourceRef { .. }) => None,
             // List: recurse into elements
             (TypeExpr::List(inner), Value::List(items)) => {
                 for (i, item) in items.iter().enumerate() {
@@ -1175,8 +1192,6 @@ impl DiagnosticEngine {
                 }
                 None
             }
-            // ResourceRef: skip (resolved at runtime)
-            (_, Value::ResourceRef { .. }) => None,
             // Everything else: normal validation
             _ => carina_core::validation::validate_type_expr_value(
                 type_expr,

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2110,6 +2110,53 @@ fn exports_map_type_warning_for_cross_file_ref() {
 }
 
 #[test]
+fn exports_subscripted_cross_file_ref_does_not_false_flag() {
+    // Counterpart to the bare-attribute test above: when an exports
+    // value is a `ResourceRef` with a `field_path` or `subscripts`
+    // (e.g. `accounts['k']` against a sibling-file binding), the LSP
+    // must not compare the receiver type against the head's full
+    // attribute type — the subscript narrows the position and a
+    // positional walker (#2475) is the precise tool. Today the LSP
+    // skips the comparison rather than false-flag, matching the
+    // behaviour of the core `check_ref_against_type` after #2447.
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let schema = ResourceSchema::new("organizations.account").attribute(AttributeSchema::new(
+        "accounts",
+        AttributeType::map(AttributeType::String),
+    ));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let engine = custom_engine(schemas);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let orgs = awscc.organizations.account { name = 'orgs' }\n",
+    )
+    .unwrap();
+    // Receiver expects String. Pre-#2447 (or with naive ResourceRef
+    // handling), the LSP would compare `map(String)` vs `String` and
+    // emit a spurious mismatch; with subscript-awareness it must stay
+    // silent.
+    let exports = "exports {\n  dev: String = orgs.accounts['registry_dev']\n}\n";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
+
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
+
+    let type_warning = diagnostics
+        .iter()
+        .find(|d| d.message.contains("type mismatch") || d.message.contains("expected"));
+    assert!(
+        type_warning.is_none(),
+        "Subscripted ref must not be compared against head's outer type. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn no_undefined_resource_for_sibling_binding_in_exports() {
     let engine = DiagnosticEngine::new(
         Arc::new(SchemaRegistry::new()),


### PR DESCRIPTION
## Summary

Closes #2447. Symmetric with #2435 / PR #2440 (subscript form), so both `${orgs.accounts['k']}` and `${orgs.accounts.k}` reach the resolver as `Value::ResourceRef` and substitute the upstream's concrete map value at plan time.

Two bugs from the issue:

**Subscript form** — `${orgs.accounts['registry_dev']}` passed the parser but `check_upstream_state_field_types` compared the whole `map(AwsAccountId)` export against the *outer* attribute schema (`Struct(IamPolicyDocument)` for the bucket-policy shape), false-flagging the position. Fix: a new `narrow_type_expr` walks `field_path` (delegating to the existing `walk_type_expr_path`) and `subscripts` through the export type before the compatibility check; once narrowing bottoms out on a scalar leaf the comparison is skipped (a positional walker would be the precise tool — filed #2475 as a follow-up).

**Dot-notation form** — `${orgs.accounts.registry_dev}` parsed but the parser fell through to a literal `Value::String("orgs.accounts.registry_dev")` because the head wasn't a known binding *in the current file*. Fix: when the dotted ID isn't a DSL enum shorthand (`NamespacedId::parse(s).is_none()`), `parse_namespaced_id_value` emits a structured `ResourceRef` instead — symmetric with the #2440 subscript fallback. The post-merge `check_identifier_scope` walk handles genuine typos.

## Sweeps

- `walk_type_expr_path` accepts `TypeExpr::Map(_)` for dot-form key access (`accounts.k → T`).
- Resolver gates the "key not found" error on `BindingValueSource::Upstream` for both the dot and subscript walks; local bindings keep the ref unchanged when a field is missing (value may not be known yet). Shared `missing_map_key_error` helper prevents the message from drifting.
- LSP `validate_type_with_ref_awareness` handles the new `Value::ResourceRef` shape via `check_cross_file_ref_type` (extracted from the legacy `Value::String("a.b")` arm), but skips refs with `field_path`/`subscripts` to match what the core checker now does.

## Test plan

- [x] `cargo nextest run --workspace` — 2759/2759 PASS (8 new tests across carina-core, carina-lsp, carina-cli)
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 4 pass
- [x] `cargo build --release` — no release-only issues
- [x] Real-infra smoke: ran the built binary against the issue's exact reproduction (`carina-rs/infra` branch `management-state-bucket-policy-cross-account`, `aws/management/carina-state/`):
  ```
  $ carina validate aws/management/carina-state/
  Validating...
  ✓ 2 resources validated successfully.
    • awscc.s3.Bucket.bucket
    • aws.s3.BucketPolicy.aws_s3_bucket_policy_a3057f3d
  ```
  (Pre-fix: errored on `upstream_state `orgs.accounts` is declared as `map(AwsAccountId)` but this position expects `Struct(IamPolicyDocument)``.)
- [x] Plan-display fixture + snapshot pin both forms (`upstream_state_map_subscript` already present, new `upstream_state_map_dot_notation` mirrors it). Snapshot asserts the bare-attribute form is substituted to the concrete value (`DevAccount: "222222222222"`) and that the literal `orgs.accounts.registry_dev` substring does not leak into the rendered plan.

## Behaviour change worth noting

Previously, `orgs.accounts.alpha` against `accounts: map(_)` raised `field access on map ...; iterate the map with for k, v in orgs.accounts to access entries`. With this PR the dot form is accepted as map-key access (equivalent to `orgs.accounts['alpha']`), matching the subscript symmetry asserted by #2435. The renamed test `attribute_access_against_map_export_resolves_as_key_access` pins the new behaviour.

## Follow-up

#2475 — replace the `is_scalar_type_expr` short-circuit with a positional walker that descends `Value::Map`/`Value::List`/`Value::Interpolation` alongside the receiver `AttributeType`, so a narrowed `String` against an expected `Int` receiver is no longer silently accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
