### PR TITLE
parser/lsp: accept empty ${} mid-edit; surface as LSP warning

### DIFF
--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -205,6 +205,7 @@ fn deterministic_value_string(value: &Value) -> String {
                 UnknownReason::ForKey => "Unknown(ForKey)".to_string(),
                 UnknownReason::ForIndex => "Unknown(ForIndex)".to_string(),
                 UnknownReason::ForValue => "Unknown(ForValue)".to_string(),
+                UnknownReason::EmptyInterpolation => "Unknown(EmptyInterpolation)".to_string(),
             }
         }
     }

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -291,7 +291,16 @@ number = @{ "-"? ~ ASCII_DIGIT+ }
 string = ${ single_quoted_string | double_quoted_string }
 double_quoted_string = ${ "\"" ~ string_part* ~ "\"" }
 string_part = ${ interpolation | string_literal }
-interpolation = ${ "${" ~ expression ~ "}" }
+// `expression` is optional so a mid-edit empty `${}` doesn't abort
+// the AST. `inline_ws*` (space/tab only) lets `${ }` parse too —
+// `WHITESPACE` is auto-disabled inside compound-atomic (`${ ... }`)
+// rules, so without an explicit allowance the inner whitespace is
+// rejected. Newlines are deliberately excluded so the parser stays
+// in sync with the single-line LSP `check_empty_interpolations`
+// scanner — no silent gap where `${\n}` parses but no diagnostic
+// fires. See #2480.
+interpolation = ${ "${" ~ inline_ws* ~ expression? ~ inline_ws* ~ "}" }
+inline_ws = _{ " " | "\t" }
 string_literal = @{ string_char+ }
 string_char = {
     !("\"" | "\\" | "${") ~ ANY

--- a/carina-core/src/parser/expressions/string_literal.rs
+++ b/carina-core/src/parser/expressions/string_literal.rs
@@ -4,7 +4,7 @@
 //! (interpolated) string forms, plus the related unescape routines.
 
 use crate::parser::{ParseContext, ParseError, Rule, first_inner, parse_expression};
-use crate::resource::{InterpolationPart, Value};
+use crate::resource::{InterpolationPart, UnknownReason, Value};
 
 pub(crate) fn parse_string_literal(
     pair: pest::iterators::Pair<Rule>,
@@ -65,9 +65,15 @@ pub(crate) fn parse_string_value(
                 }
                 Rule::interpolation => {
                     has_interpolation = true;
-                    let expr_pair =
-                        first_inner(inner, "interpolation expression", "interpolation")?;
-                    let value = parse_expression(expr_pair, ctx)?;
+                    // Grammar makes the inner expression optional so
+                    // mid-edit `${}` doesn't poison the AST. An empty
+                    // interpolation lands as `Value::Unknown(EmptyInterpolation)`
+                    // — the LSP surfaces it as a diagnostic; downstream
+                    // resolvers carry it as an unresolved value. See #2480.
+                    let value = match inner.into_inner().next() {
+                        Some(expr_pair) => parse_expression(expr_pair, ctx)?,
+                        None => Value::Unknown(UnknownReason::EmptyInterpolation),
+                    };
                     parts.push(InterpolationPart::Expr(value));
                 }
                 _ => {}

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2684,6 +2684,104 @@ fn parse_string_escaped_interpolation() {
 }
 
 #[test]
+fn parse_empty_interpolation_accepted_as_unknown() {
+    // `${}` mid-edit must NOT abort parsing — instead it is stamped as
+    // `Value::Unknown(EmptyInterpolation)` so other diagnostics in the
+    // file (sibling let bindings, type mismatches, etc.) keep running.
+    // See #2480 — pre-fix, this input rejected the entire AST with
+    // `expected primary` and made every let binding appear undefined.
+    let input = r#"
+        let bucket = aws.s3.Bucket {
+            name = "arn:${}:root"
+        }
+    "#;
+
+    let result =
+        parse(input, &ProviderContext::default()).expect("empty `${}` must parse, not abort");
+    let bucket = &result.resources[0];
+    let attr = bucket.get_attr("name").expect("name attr");
+    let parts = match attr {
+        Value::Interpolation(parts) => parts,
+        other => panic!("expected Value::Interpolation, got {:?}", other),
+    };
+    let has_empty = parts.iter().any(|p| {
+        matches!(
+            p,
+            crate::resource::InterpolationPart::Expr(Value::Unknown(
+                crate::resource::UnknownReason::EmptyInterpolation
+            ))
+        )
+    });
+    assert!(
+        has_empty,
+        "expected an InterpolationPart::Expr(Value::Unknown(EmptyInterpolation)) in the parsed parts; got {:?}",
+        parts
+    );
+}
+
+#[test]
+fn parse_whitespace_only_interpolation_accepted_as_unknown() {
+    // `${ }` (only whitespace inside) must also be accepted, not just
+    // the zero-char `${}` shape. The grammar's `inline_ws*` covers
+    // space and tab; both stamp the same `EmptyInterpolation` marker.
+    let input = "
+        let bucket = aws.s3.Bucket {
+            name = \"arn:${ \t  \t}:root\"
+        }
+    ";
+
+    let result = parse(input, &ProviderContext::default())
+        .expect("`${  }` (whitespace-only) must parse, not abort");
+    let bucket = &result.resources[0];
+    let attr = bucket.get_attr("name").expect("name attr");
+    let parts = match attr {
+        Value::Interpolation(parts) => parts,
+        other => panic!("expected Value::Interpolation, got {:?}", other),
+    };
+    let has_empty = parts.iter().any(|p| {
+        matches!(
+            p,
+            crate::resource::InterpolationPart::Expr(Value::Unknown(
+                crate::resource::UnknownReason::EmptyInterpolation
+            ))
+        )
+    });
+    assert!(
+        has_empty,
+        "whitespace-only `${{}}` must stamp EmptyInterpolation; got {:?}",
+        parts
+    );
+}
+
+#[test]
+fn parse_empty_interpolation_does_not_break_sibling_bindings() {
+    // The whole file's other let bindings stay accessible — concretely,
+    // a binding declared after the empty `${}` line still appears in
+    // the resulting resource set. Pre-fix the parse error short-
+    // circuited everything past the offending line.
+    let input = r#"
+        let bucket = aws.s3.Bucket {
+            name = "arn:${}:root"
+        }
+        let vpc = aws.ec2.Vpc {
+            cidr_block = "10.0.0.0/16"
+        }
+    "#;
+
+    let result = parse(input, &ProviderContext::default()).expect("must parse");
+    let resource_names: Vec<&str> = result
+        .resources
+        .iter()
+        .map(|r| r.binding.as_deref().unwrap_or(""))
+        .collect();
+    assert!(
+        resource_names.contains(&"bucket") && resource_names.contains(&"vpc"),
+        "both let-bound resources must survive an empty `${{}}`; got: {:?}",
+        resource_names
+    );
+}
+
+#[test]
 fn parse_string_interpolation_with_bool() {
     let input = r#"
         let vpc = aws.ec2.Vpc {

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -375,6 +375,11 @@ pub enum UnknownReason {
     /// Loop-variable value in a deferred for-expression
     /// (`for v in iterable`). Substituted with the actual element.
     ForValue,
+    /// Mid-edit empty `${}` interpolation. Carries no payload — the
+    /// presence of the marker is enough for the LSP to surface a
+    /// diagnostic at the `${}` span and for downstream resolvers to
+    /// stay tolerant. See #2480.
+    EmptyInterpolation,
 }
 
 /// A part of a string interpolation expression
@@ -730,9 +735,13 @@ impl Value {
                     // the `ResourceRef` arm above) — no per-call String
                     // allocation.
                     UnknownReason::UpstreamRef { path } => path.hash(hasher),
-                    // `For{Key,Index,Value}` carry no payload; the
-                    // discriminant alone already distinguishes them.
-                    UnknownReason::ForKey | UnknownReason::ForIndex | UnknownReason::ForValue => {}
+                    // `For{Key,Index,Value}` and `EmptyInterpolation`
+                    // carry no payload; the discriminant alone already
+                    // distinguishes them.
+                    UnknownReason::ForKey
+                    | UnknownReason::ForIndex
+                    | UnknownReason::ForValue
+                    | UnknownReason::EmptyInterpolation => {}
                 }
             }
         }

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -109,6 +109,7 @@ impl std::fmt::Display for UnknownReason {
             UnknownReason::ForKey => write!(f, "deferred for-binding key"),
             UnknownReason::ForIndex => write!(f, "deferred for-binding index"),
             UnknownReason::ForValue => write!(f, "deferred for-binding value"),
+            UnknownReason::EmptyInterpolation => write!(f, "empty interpolation"),
         }
     }
 }
@@ -122,6 +123,7 @@ pub fn render_unknown(reason: &UnknownReason) -> String {
         UnknownReason::ForKey => "(known after upstream apply: key)".to_string(),
         UnknownReason::ForIndex => "(known after upstream apply: index)".to_string(),
         UnknownReason::ForValue => "(known after upstream apply)".to_string(),
+        UnknownReason::EmptyInterpolation => "(empty interpolation)".to_string(),
     }
 }
 

--- a/carina-core/tests/pest_grammar_parity.rs
+++ b/carina-core/tests/pest_grammar_parity.rs
@@ -39,6 +39,10 @@ const ALLOWED_MISSING: &[&str] = &[
     // productions instead of the implicit `WHITESPACE` / `COMMENT` hooks.
     "WHITESPACE",
     "COMMENT",
+    // Silent helper used only inside `interpolation` to admit empty
+    // `${ }` mid-edit. The formatter has its own whitespace handling
+    // and doesn't need a counterpart. See #2480.
+    "inline_ws",
     // Lexer-level string/comment helpers. The formatter consumes these
     // inline via its own string/comment productions.
     "string_char",

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1789,4 +1789,103 @@ impl DiagnosticEngine {
         }
         None
     }
+
+    /// Walk the buffer line-by-line and emit a `WARNING` diagnostic for every
+    /// empty `${}` interpolation inside a double-quoted string. The parser
+    /// accepts the empty form (so the rest of the AST stays intact and other
+    /// diagnostics keep running), but a buffer that ships with literal `${}`
+    /// will produce a meaningless value at apply time — so the user wants a
+    /// hint that the placeholder is unfilled. See #2480.
+    ///
+    /// Text scan rather than AST walk: the parser stamps the empty case as
+    /// `Value::Unknown(UnknownReason::EmptyInterpolation)` but discards the
+    /// source span, so the diagnostic range has to come from a source-level
+    /// pass anyway.
+    pub(super) fn check_empty_interpolations(&self, doc: &Document) -> Vec<Diagnostic> {
+        let text = doc.text();
+        let mut out = Vec::new();
+        for (line_idx, line) in text.lines().enumerate() {
+            // 99% of lines have no `$` — bail before allocating chars.
+            if !line.as_bytes().contains(&b'$') {
+                continue;
+            }
+            let chars: Vec<char> = line.chars().collect();
+            let mut i = 0;
+            let mut in_double_quoted = false;
+            while i < chars.len() {
+                let c = chars[i];
+                if !in_double_quoted {
+                    if c == '"' {
+                        in_double_quoted = true;
+                    } else if c == '\'' {
+                        // Skip past the single-quoted string entirely so a
+                        // `${}` inside it (which is a literal in this DSL)
+                        // doesn't trigger the diagnostic.
+                        i += 1;
+                        while i < chars.len() && chars[i] != '\'' {
+                            i += 1;
+                        }
+                    }
+                    i += 1;
+                    continue;
+                }
+
+                if c == '\\' {
+                    i += 2;
+                    continue;
+                }
+                if c == '"' {
+                    in_double_quoted = false;
+                    i += 1;
+                    continue;
+                }
+                if c == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+                    let start = i;
+                    // Brace-balance the interpolation body so `${ {}.a }`
+                    // closes at the matching `}`, not the first one.
+                    let mut depth = 1usize;
+                    let mut j = i + 2;
+                    let mut only_whitespace = true;
+                    while j < chars.len() && depth > 0 {
+                        match chars[j] {
+                            '\\' if j + 1 < chars.len() => {
+                                only_whitespace = false;
+                                j += 2;
+                                continue;
+                            }
+                            '{' => {
+                                depth += 1;
+                                only_whitespace = false;
+                            }
+                            '}' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    j += 1;
+                                    break;
+                                }
+                                only_whitespace = false;
+                            }
+                            ch if !ch.is_whitespace() => only_whitespace = false,
+                            _ => {}
+                        }
+                        j += 1;
+                    }
+                    if depth == 0 && only_whitespace {
+                        out.push(carina_diagnostic(
+                            line_idx as u32,
+                            start as u32,
+                            j as u32,
+                            DiagnosticSeverity::WARNING,
+                            "empty interpolation `${}` — fill in the expression or remove it"
+                                .to_string(),
+                        ));
+                    }
+                    i = j;
+                    continue;
+                }
+                i += 1;
+            }
+        }
+        out
+    }
 }

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -126,6 +126,12 @@ impl DiagnosticEngine {
             diagnostics.push(parse_error_to_diagnostic(error));
         }
 
+        // Empty `${}` interpolation hint. Runs even when other parses
+        // succeeded — and especially before the buffer-only checks
+        // below — so users get an actionable warning right at the
+        // placeholder rather than only learning at apply time.
+        diagnostics.extend(self.check_empty_interpolations(doc));
+
         // Build the directory-scoped merged parse once up-front — it is
         // the authoritative source of truth for every check that needs
         // cross-file context: undefined-identifier (#2132), upstream-

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3492,3 +3492,136 @@ fn check_attributes_blocks_still_warns_when_truly_undefined() {
         diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// =====================================================================
+// Empty `${}` interpolation: parser must accept it, LSP surfaces a
+// per-location diagnostic, sibling `let` bindings stay visible (#2480).
+// =====================================================================
+
+#[test]
+fn empty_interpolation_emits_diagnostic_at_span() {
+    let engine = test_engine();
+    let buffer = "let bucket = aws.s3.Bucket {\n    name = \"arn:${}:root\"\n}\n";
+    let doc = create_document(buffer);
+    let diagnostics = engine.analyze(&doc, None);
+
+    let empty = diagnostics
+        .iter()
+        .find(|d| d.message.to_lowercase().contains("empty interpolation"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected an EmptyInterpolation diagnostic; got: {:?}",
+                diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+            )
+        });
+
+    // The `${}` span sits inside `name = "arn:${}:root"` on line 1.
+    // The diagnostic must point at that interpolation, not the whole
+    // string and not the resource block.
+    assert_eq!(
+        empty.range.start.line, 1,
+        "expected line 1, got: {:?}",
+        empty
+    );
+    let line1 = buffer.lines().nth(1).unwrap();
+    let dollar_col = line1.find("${").unwrap() as u32;
+    let close_col = (line1.find("${}").unwrap() + "${}".len()) as u32;
+    assert_eq!(
+        empty.range.start.character, dollar_col,
+        "diagnostic start should be at `${{`; got: {:?}",
+        empty.range
+    );
+    assert_eq!(
+        empty.range.end.character, close_col,
+        "diagnostic end should be just after `}}`; got: {:?}",
+        empty.range
+    );
+}
+
+#[test]
+fn empty_interpolation_does_not_cascade_undefined_for_sibling_bindings() {
+    // Cross-file repro from #2480: an empty `${}` in main.crn must not
+    // cause sibling-declared `bucket` (in backend.crn) to be flagged
+    // as undefined.
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let bucket = aws.s3.Bucket {\n    name = 'state-bucket'\n}\n",
+    )
+    .unwrap();
+    let main = "aws.s3.BucketPolicy {\n    bucket = bucket.bucket_name\n    policy = \"arn:${}:root\"\n}\n";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+
+    let engine = test_engine();
+    let doc = create_document(main);
+    let diagnostics = engine.analyze_with_filename(&doc, Some("main.crn"), Some(&base));
+
+    let bucket_undefined = diagnostics
+        .iter()
+        .any(|d| d.message.contains("Undefined") && d.message.contains("bucket"));
+    assert!(
+        !bucket_undefined,
+        "sibling `let bucket = ...` must stay visible despite empty `${{}}`; got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_interpolation_does_not_misfire_on_nested_object_literal() {
+    // `${ {a = 1}.a }` is a non-empty expression that *contains* `{}`
+    // within. The brace-balanced scanner must stop at the matching `}`,
+    // not the first one, so this must NOT produce an EmptyInterpolation
+    // diagnostic.
+    let engine = test_engine();
+    let buffer = "let x = aws.s3.Bucket {\n    name = \"prefix-${ {a = 1}.a }\"\n}\n";
+    let doc = create_document(buffer);
+    let diagnostics = engine.analyze(&doc, None);
+
+    let empty = diagnostics
+        .iter()
+        .find(|d| d.message.to_lowercase().contains("empty interpolation"));
+    assert!(
+        empty.is_none(),
+        "nested object literal inside `${{}}` is not empty; got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_interpolation_does_not_misfire_on_escape_inside_braces() {
+    // `${\\}` contains an escaped backslash inside the braces. The body
+    // is non-whitespace (a `\\` pair), so the scanner must NOT flag it
+    // as empty.
+    let engine = test_engine();
+    let buffer = "let x = aws.s3.Bucket {\n    name = \"prefix-${\\\\}\"\n}\n";
+    let doc = create_document(buffer);
+    let diagnostics = engine.analyze(&doc, None);
+
+    let empty = diagnostics
+        .iter()
+        .find(|d| d.message.to_lowercase().contains("empty interpolation"));
+    assert!(
+        empty.is_none(),
+        "escape pair inside `${{}}` is not empty; got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_interpolation_diagnostic_is_warning_not_error() {
+    let engine = test_engine();
+    let buffer = "let x = aws.s3.Bucket {\n    name = \"prefix-${}\"\n}\n";
+    let doc = create_document(buffer);
+    let diagnostics = engine.analyze(&doc, None);
+
+    let empty = diagnostics
+        .iter()
+        .find(|d| d.message.to_lowercase().contains("empty interpolation"))
+        .expect("expected an EmptyInterpolation diagnostic");
+    assert_eq!(
+        empty.severity,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::WARNING),
+        "empty interpolation is a mid-edit hint, not a hard error"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #2480.

Pre-fix, an empty `${}` in any double-quoted string aborted the entire file's AST with `expected primary` at the `}`. The diagnostics pass had no parsed file to consult, so it treated **every** sibling `let` binding as undefined — a single mid-edit placeholder cascaded "Undefined resource" warnings across the whole buffer.

This PR is parser-level recovery (Option 1C from the issue discussion):

- The grammar accepts empty `${}` and `${ }` (single-line whitespace only — newline excluded so the parser stays in sync with the LSP single-line scanner).
- The empty case stamps `Value::Unknown(UnknownReason::EmptyInterpolation)` into the AST, reusing the existing `Unknown` machinery so the resolver, plan display, identifier round-trip, and serialization paths each gain one match arm and nothing more.
- The LSP emits a `WARNING` diagnostic at the exact `${}` span via a new `check_empty_interpolations` text scan (text-scan rather than AST walk because the AST doesn't carry source spans on `Unknown` variants).

## Out of scope

The CLI half — making `carina validate` / `plan` / `apply` reject `EmptyInterpolation` explicitly so it can't reach a provider with literal `${}` text — is tracked separately as **#2487**.

## Test plan

8 new tests:

- [x] `parse_empty_interpolation_accepted_as_unknown` — zero-char `${}` parses, stamps `EmptyInterpolation`.
- [x] `parse_whitespace_only_interpolation_accepted_as_unknown` — `${ \t  \t}` (mixed inline whitespace) parses too.
- [x] `parse_empty_interpolation_does_not_break_sibling_bindings` — both `let` bindings survive a buffer with `${}`.
- [x] `empty_interpolation_emits_diagnostic_at_span` — diagnostic range covers the `${}` exactly (line + col).
- [x] `empty_interpolation_does_not_cascade_undefined_for_sibling_bindings` — multi-file fixture (`backend.crn` + `main.crn`); cross-file `let` stays visible.
- [x] `empty_interpolation_diagnostic_is_warning_not_error` — severity is WARNING.
- [x] `empty_interpolation_does_not_misfire_on_nested_object_literal` — `${ {a = 1}.a }` is non-empty (brace-balanced).
- [x] `empty_interpolation_does_not_misfire_on_escape_inside_braces` — `${\\}` (escape pair body) is non-empty.

Verify cycle:

- [x] `cargo nextest run --workspace` — 2789 passed.
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five gates green.
- [x] `pest_grammar_parity::every_main_rule_has_a_formatter_counterpart` — `inline_ws` added to `ALLOWED_MISSING` (silent helper for `${}` recovery, the formatter has its own whitespace handling).

## Notes

- 5-round self-review identified the parser/LSP newline mismatch (round 2) and the parity-test gap (final verify); both resolved before opening the PR.
- Other partial-syntax shapes (`${orgs.}` trailing dot, unmatched braces) are not addressed here — they'd need separate parser-recovery work and are out of scope.
