### PR TITLE
state writeback: include virtual module-call bindings when resolving exports

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -283,7 +283,7 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
 
     // Resolve exports and persist to state
     if !input.export_params.is_empty() {
-        let exports = resolve_exports(input.export_params, &state)?;
+        let exports = resolve_exports(input.export_params, input.sorted_resources, &state)?;
         state.exports = exports;
     }
 
@@ -336,10 +336,11 @@ pub(crate) async fn persist_exports_only(
     backend: &dyn StateBackend,
     lock: Option<&LockInfo>,
     state_file: Option<StateFile>,
+    sorted_resources: &[Resource],
     export_params: &[carina_core::parser::InferredExportParam],
 ) -> Result<(), AppError> {
     let mut state = state_file.unwrap_or_default();
-    let exports = resolve_exports(export_params, &state)?;
+    let exports = resolve_exports(export_params, sorted_resources, &state)?;
     state.exports = exports;
     if let Some(lk) = lock {
         save_state_locked(backend, lk, &mut state).await?;
@@ -1034,7 +1035,14 @@ async fn run_apply_locked(
             )
             .cyan()
         );
-        persist_exports_only(backend, lock, state_file, &parsed.export_params).await?;
+        persist_exports_only(
+            backend,
+            lock,
+            state_file,
+            &sorted_resources,
+            &parsed.export_params,
+        )
+        .await?;
         return Ok(());
     }
 

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -473,12 +473,182 @@ fn resolve_exports_resolves_cross_file_dot_notation_strings() {
         value: Some(Value::String("registry_prod.account_id".to_string())),
     }];
 
-    let exports = resolve_exports(&export_params, &state).unwrap();
+    // Mirror production callers: the resource is in sorted_resources
+    // with a binding; provider-returned attributes flow in via
+    // `current_states` derived from `state.resources`.
+    let mut registry_prod =
+        Resource::with_provider("awscc", "organizations.account", "registry-prod");
+    registry_prod.binding = Some("registry_prod".to_string());
+    let sorted_resources = vec![registry_prod];
+
+    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
 
     assert_eq!(
         exports.get("account_id"),
         Some(&serde_json::Value::String("459524413166".to_string())),
         "resolve_exports should resolve dot-notation strings to actual values. Got: {:?}",
+        exports
+    );
+}
+
+#[test]
+fn resolve_exports_resolves_module_call_attribute_via_virtual_resource() {
+    // #2479: writeback used to build bindings from `state.resources`
+    // only. A virtual resource (synthesised by module-call expansion to
+    // expose `attributes { role_arn = role.arn }`) carries no provider
+    // identity and never lands in `state.resources`, so an export
+    // referencing `<module_call>.<attr>` failed with
+    // `unresolved reference <call>.<attr>`.
+    use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
+    use carina_core::resource::{AccessPath, ResourceKind, Value};
+    use carina_state::StateFile;
+
+    let state = {
+        let json = serde_json::json!({
+            "version": 5,
+            "serial": 1,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": [
+                {
+                    "resource_type": "iam.Role",
+                    "name": "github_actions_carina.role",
+                    "identifier": "github-actions-carina",
+                    "provider": "awscc",
+                    "binding": "github_actions_carina.role",
+                    "attributes": {
+                        "arn": "arn:aws:iam::123456789012:role/github-actions-carina"
+                    }
+                }
+            ]
+        });
+        serde_json::from_value::<StateFile>(json).unwrap()
+    };
+
+    let mut role_resource =
+        Resource::with_provider("awscc", "iam.Role", "github_actions_carina.role");
+    role_resource.binding = Some("github_actions_carina.role".to_string());
+
+    // Virtual resource as `expand_module_call` produces it: binding is
+    // the module-call alias, and each attribute is a ResourceRef into
+    // an expanded sub-resource.
+    let mut virtual_resource = Resource::new("_virtual", "github_actions_carina");
+    virtual_resource.binding = Some("github_actions_carina".to_string());
+    virtual_resource.kind = ResourceKind::Virtual {
+        module_name: "github_module".to_string(),
+        instance: "github_actions_carina".to_string(),
+    };
+    virtual_resource.attributes.insert(
+        "role_arn".to_string(),
+        Value::ResourceRef {
+            path: AccessPath::new("github_actions_carina.role", "arn"),
+        },
+    );
+    let sorted_resources = vec![role_resource, virtual_resource];
+
+    let export_params = vec![ExportParameter {
+        name: "role_arn".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::ResourceRef {
+            path: AccessPath::new("github_actions_carina", "role_arn"),
+        }),
+    }];
+
+    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
+
+    assert_eq!(
+        exports.get("role_arn"),
+        Some(&serde_json::Value::String(
+            "arn:aws:iam::123456789012:role/github-actions-carina".to_string()
+        )),
+        "module-call attribute export must resolve via virtual binding + provider state, got: {:?}",
+        exports
+    );
+}
+
+#[test]
+fn resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals() {
+    // #2479 follow-up: a module-call binding whose attribute itself
+    // points at *another* module-call binding's attribute (e.g.
+    // `${outer_module.public_role_arn}` where the outer module's
+    // `attributes { public_role_arn = inner_module.role_arn }` exposes
+    // an inner module-call binding's attribute). Two `Virtual` hops
+    // through `ResourceRef` recursion before bottoming out at the real
+    // role's `arn` from state. Pins the resolver's transitive walk so a
+    // regression that broke after a single hop would surface.
+    use carina_core::parser::{InferredExportParam as ExportParameter, TypeExpr};
+    use carina_core::resource::{AccessPath, ResourceKind, Value};
+    use carina_state::StateFile;
+
+    let state = {
+        let json = serde_json::json!({
+            "version": 5,
+            "serial": 1,
+            "lineage": "test",
+            "carina_version": "0.4.0",
+            "resources": [
+                {
+                    "resource_type": "iam.Role",
+                    "name": "outer.inner.role",
+                    "identifier": "github-actions-carina",
+                    "provider": "awscc",
+                    "binding": "outer.inner.role",
+                    "attributes": {
+                        "arn": "arn:aws:iam::123456789012:role/chained"
+                    }
+                }
+            ]
+        });
+        serde_json::from_value::<StateFile>(json).unwrap()
+    };
+
+    let mut role_resource = Resource::with_provider("awscc", "iam.Role", "outer.inner.role");
+    role_resource.binding = Some("outer.inner.role".to_string());
+
+    let mut inner_virtual = Resource::new("_virtual", "outer.inner");
+    inner_virtual.binding = Some("outer.inner".to_string());
+    inner_virtual.kind = ResourceKind::Virtual {
+        module_name: "inner_module".to_string(),
+        instance: "outer.inner".to_string(),
+    };
+    inner_virtual.attributes.insert(
+        "role_arn".to_string(),
+        Value::ResourceRef {
+            path: AccessPath::new("outer.inner.role", "arn"),
+        },
+    );
+
+    let mut outer_virtual = Resource::new("_virtual", "outer");
+    outer_virtual.binding = Some("outer".to_string());
+    outer_virtual.kind = ResourceKind::Virtual {
+        module_name: "outer_module".to_string(),
+        instance: "outer".to_string(),
+    };
+    outer_virtual.attributes.insert(
+        "public_role_arn".to_string(),
+        Value::ResourceRef {
+            path: AccessPath::new("outer.inner", "role_arn"),
+        },
+    );
+
+    let sorted_resources = vec![role_resource, inner_virtual, outer_virtual];
+
+    let export_params = vec![ExportParameter {
+        name: "role_arn".to_string(),
+        type_expr: TypeExpr::Unknown,
+        value: Some(Value::ResourceRef {
+            path: AccessPath::new("outer", "public_role_arn"),
+        }),
+    }];
+
+    let exports = resolve_exports(&export_params, &sorted_resources, &state).unwrap();
+
+    assert_eq!(
+        exports.get("role_arn"),
+        Some(&serde_json::Value::String(
+            "arn:aws:iam::123456789012:role/chained".to_string()
+        )),
+        "two-hop module-call chain must resolve through both virtuals, got: {:?}",
         exports
     );
 }

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -74,16 +74,34 @@ pub(crate) struct FinalizeApplyInput<'a> {
 }
 
 /// Resolve export expressions using bindings built from applied state.
+///
+/// `sorted_resources` carries the in-memory resource graph including any
+/// `ResourceKind::Virtual` resources synthesised by module-call expansion
+/// (`expand_module_call`). Virtual resources are not persisted to
+/// `state.resources` because they have no provider-side identity, so a
+/// writeback that consults `state.resources` alone misses module-call
+/// bindings — a downstream `exports { x = my_module_call.attr }` then
+/// fails with `unresolved reference my_module_call.attr` even though
+/// `carina plan` rendered the value cleanly. Issue #2479.
 pub(crate) fn resolve_exports(
     export_params: &[carina_core::parser::InferredExportParam],
+    sorted_resources: &[Resource],
     state: &StateFile,
 ) -> Result<HashMap<String, serde_json::Value>, carina_core::value::SerializationError> {
-    use carina_core::binding_index::{BindingValueSource, ResolvedBindings};
+    use carina_core::binding_index::ResolvedBindings;
     use carina_core::resource::Value;
 
-    let mut bindings = ResolvedBindings::default();
-    for rs in &state.resources {
-        if let Some(ref binding) = rs.binding {
+    // `from_resources_with_state` merges DSL-side attributes
+    // (`sorted_resources`, including `ResourceKind::Virtual` synthesised
+    // by module-call expansion) with provider-returned post-apply
+    // attributes (`current_states`, derived from `state.resources`).
+    // Same merge order the planner uses, so plan and writeback resolve
+    // identically.
+    let current_states = state
+        .resources
+        .iter()
+        .map(|rs| {
+            let id = ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
             let attrs: HashMap<String, Value> = rs
                 .attributes
                 .iter()
@@ -91,9 +109,17 @@ pub(crate) fn resolve_exports(
                     carina_core::value::json_to_dsl_value(v).map(|val| (k.clone(), val))
                 })
                 .collect();
-            bindings.set(binding, attrs, BindingValueSource::Local);
-        }
-    }
+            (
+                id.clone(),
+                carina_core::resource::State::existing(id, attrs),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let bindings = ResolvedBindings::from_resources_with_state(
+        sorted_resources,
+        &current_states,
+        &HashMap::new(),
+    );
 
     let mut exports = HashMap::new();
     for param in export_params {

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -766,6 +766,7 @@ pub(crate) async fn run_state_refresh_locked(
     if !parsed.export_params.is_empty() {
         state.exports = crate::commands::shared::state_writeback::resolve_exports(
             &parsed.export_params,
+            &sorted_resources,
             &state,
         )?;
     }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -2697,9 +2697,14 @@ async fn persist_exports_only_clears_state_exports_when_params_empty() {
         .exports
         .insert("old".to_string(), serde_json::json!("stale"));
 
-    let result =
-        crate::commands::apply::persist_exports_only(&backend, Some(&lock), Some(state_in), &[])
-            .await;
+    let result = crate::commands::apply::persist_exports_only(
+        &backend,
+        Some(&lock),
+        Some(state_in),
+        &[],
+        &[],
+    )
+    .await;
 
     assert!(result.is_ok(), "persist_exports_only failed: {:?}", result);
 
@@ -2733,6 +2738,7 @@ async fn persist_exports_only_writes_state_with_new_exports() {
         &backend,
         Some(&lock),
         Some(StateFile::new()),
+        &[],
         &export_params,
     )
     .await;


### PR DESCRIPTION
## Summary

Closes #2479. `carina apply` failed at the state-writeback step whenever an `exports.crn` referenced a module-call binding's attribute:

```
Error: cannot serialize at state writeback: unresolved reference github_actions_carina.role_arn
```

`carina plan` rendered the change cleanly with the resolved value, so the bug was specific to writeback.

**Root cause**: `resolve_exports` in `carina-cli/src/commands/shared/state_writeback.rs` built bindings from `state.resources` alone. Module-call expansion produces a synthetic `ResourceKind::Virtual` resource that exposes the module's `attributes { role_arn = role.arn }` block; virtual resources have no provider identity and are deliberately not persisted to state, so the writeback view missed every module-call binding name.

**Fix**: thread `sorted_resources: &[Resource]` through `resolve_exports` and use `carina_core::binding_index::ResolvedBindings::from_resources_with_state` to build bindings. This is the same primitive the planner uses (`commands/plan.rs::resolve_export_value`), so plan and writeback now resolve module-call exports identically. Provider-returned attributes flow in via `current_states` derived from `state.resources`; the helper's "DSL wins on collision, state fills gaps" merge order is preserved.

The signature change touches three production call sites (`apply/mod.rs::finalize_apply`, `apply/mod.rs::persist_exports_only`, `state.rs` refresh re-resolution) plus two pre-existing test sites updated to mirror the new contract.

## Test plan

3 tests in `carina-cli/src/commands/apply/tests.rs`:
- `resolve_exports_resolves_cross_file_dot_notation_strings` — existing; updated to pass real `sorted_resources` so it mirrors production callers.
- `resolve_exports_resolves_module_call_attribute_via_virtual_resource` — pins #2479's exact reproduction shape (binding `github_actions_carina`, attribute `role_arn`, awscc IAM role).
- `resolve_exports_resolves_chained_module_call_attribute_via_two_virtuals` — pins the resolver's transitive `ResourceRef` walk through stacked module-call virtuals.

- [x] `cargo nextest run --workspace` — 2796 / 2796 PASS
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 4 pass
- [ ] Real-infra apply on `carina-rs/infra/aws/management/github-oidc/` deferred to post-merge SSO availability; the chained-virtual unit test pins the resolver path the production failure walked.

## Out of scope

The validate / LSP side has the symmetric blind spot — `carina validate aws/management/github-oidc/` raises `export 'role_arn': type annotation required: unknown binding 'github_actions_carina'` even on this branch. Tracked separately as #2488 so this PR stays focused on the apply-time writeback bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
