### PR TITLE
lsp: surface upstream map literal keys at depth-2 dot completion

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -2012,13 +2012,107 @@ fn upstream_state_depth2_dot_completion_text_edit_replaces_partial() {
 }
 
 #[test]
-fn upstream_state_depth2_dot_completion_skips_map_typed_export() {
-    // `accounts: map(string)` — depth-2 completion has no named keys to
-    // suggest (the map's runtime keys aren't part of the type). Falling
-    // through to no-op is the documented behavior, deferred per #2041.
+fn upstream_state_depth2_dot_completion_lists_map_literal_keys() {
+    // `accounts: map(String) = { registry_prod = ..., registry_dev = ... }` —
+    // depth-2 completion now mines the upstream's literal map for the
+    // statically-declared keys (#2490). Pre-fix this returned nothing
+    // because the map's runtime values weren't carried in the type
+    // information. Post-fix the LSP re-parses the upstream's
+    // `exports.crn` and offers each key.
     let provider = test_provider();
     let (_tmp, base) = set_up_upstream_project(
-        "exports {\n  accounts: map(String) = \"x\"\n}\n",
+        "exports {\n  accounts: map(String) = {\n    registry_prod = \"111111111111\"\n    registry_dev  = \"222222222222\"\n  }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.accounts.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.accounts.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod") && labels.contains(&"registry_dev"),
+        "expected `registry_prod` and `registry_dev` from upstream map literal; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_lists_map_literal_keys_inside_interpolation() {
+    // Same as the bare `orgs.accounts.<cursor>` case, but with the
+    // cursor inside a `${...}` interpolation. Must also surface the
+    // upstream map literal's keys. This is the original UX pain point
+    // from issue #2490 (`"arn:aws:iam::${orgs.accounts.}:root"`).
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(String) = {\n    registry_prod = \"111111111111\"\n    registry_dev  = \"222222222222\"\n  }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = \"arn:${orgs.accounts.}:root\"\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let line1 = main_src.lines().nth(1).unwrap();
+    // Cursor at the `}` (just after the trailing `.`), so the prefix
+    // ends with `${orgs.accounts.`.
+    let cursor_col = line1.find("${orgs.accounts.").unwrap() + "${orgs.accounts.".chars().count();
+    let position = Position {
+        line: 1,
+        character: cursor_col as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_prod") && labels.contains(&"registry_dev"),
+        "expected upstream map keys inside `${{...}}`; got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_filters_non_identifier_map_keys() {
+    // Map literals accept string keys (`"prod-1" = ...`) but
+    // `<binding>.<key>` dot access only resolves identifier-shaped
+    // keys. Surfacing `prod-1` would be misleading — the user accepts
+    // the candidate and the resulting expression is invalid. Filter
+    // to identifier-shaped keys only.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(String) = {\n    \"prod-1\" = \"111111111111\"\n    registry_dev = \"222222222222\"\n  }\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.accounts.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.accounts.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"registry_dev"),
+        "identifier-shaped key must be present; got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"prod-1"),
+        "non-identifier key must be filtered out (dot access can't reference it); got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_unparseable_upstream_yields_nothing() {
+    // The upstream's `exports.crn` has a syntax error — the LSP must
+    // not crash and must return an empty completion set. The silent-
+    // fallback contract is documented in `extract_map_literal_keys`.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        // Trailing `=` makes the rhs missing → parse error.
+        "exports {\n  accounts: map(String) =\n}\n",
         "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.accounts.\n",
     );
     let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
@@ -2031,7 +2125,31 @@ fn upstream_state_depth2_dot_completion_skips_map_typed_export() {
     let completions = provider.complete(&doc, position, Some(&base));
     assert!(
         completions.is_empty(),
-        "depth-2 completion on a map(_) export must yield nothing, got: {:?}",
+        "an unparseable upstream must yield no completions, not panic; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn upstream_state_depth2_dot_completion_empty_map_yields_nothing() {
+    // `accounts: map(String) = { }` — empty map literal. No keys to
+    // suggest. Must not panic, must return empty completion set.
+    let provider = test_provider();
+    let (_tmp, base) = set_up_upstream_project(
+        "exports {\n  accounts: map(String) = {}\n}\n",
+        "let orgs = upstream_state { source = '../organizations' }\nlet x = orgs.accounts.\n",
+    );
+    let main_src = std::fs::read_to_string(base.join("main.crn")).unwrap();
+    let doc = create_document(&main_src);
+    let position = Position {
+        line: 1,
+        character: "let x = orgs.accounts.".chars().count() as u32,
+    };
+
+    let completions = provider.complete(&doc, position, Some(&base));
+    assert!(
+        completions.is_empty(),
+        "depth-2 on empty map literal must yield nothing; got: {:?}",
         completions.iter().map(|c| &c.label).collect::<Vec<_>>()
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -718,12 +718,13 @@ impl CompletionProvider {
     /// Completions for `<binding>.<key>.<partial>` — depth-2 descent
     /// into an `upstream_state` export's declared `TypeExpr`.
     ///
-    /// When the export's type is `TypeExpr::Struct`, every field name
-    /// is offered with the field type rendered into `detail`. Other
-    /// type variants (`Map`, `List`, scalars, `Simple`, `Ref`,
-    /// `SchemaType`) have no named child positions at this depth and
-    /// produce an empty list. Map-key recursion via the runtime
-    /// `Value` is intentionally deferred per #2041.
+    /// `TypeExpr::Struct` offers every field name with the field type
+    /// rendered into `detail`. `TypeExpr::Map` mines the upstream's
+    /// literal map for its statically-declared keys (#2490) — only
+    /// identifier-shaped keys, since `<binding>.<key>` dot access
+    /// can't reach quoted string keys. List / scalar / `Simple` /
+    /// `Ref` / `SchemaType` have no named child positions at this
+    /// depth and produce an empty list.
     pub(super) fn upstream_state_depth2_dot_completions(
         &self,
         binding: &str,
@@ -741,13 +742,6 @@ impl CompletionProvider {
             // Untyped or unknown key: we have no fields to descend into.
             return Vec::new();
         };
-        let carina_core::parser::TypeExpr::Struct { fields } = type_expr else {
-            // Map / List / scalars: depth-2 names are runtime values, not
-            // part of the type. Suggest nothing rather than something
-            // potentially invalid (#2041).
-            return Vec::new();
-        };
-
         let partial_chars = partial.chars().count() as u32;
         let range = Range {
             start: Position {
@@ -757,21 +751,62 @@ impl CompletionProvider {
             end: position,
         };
 
-        let mut items: Vec<CompletionItem> = fields
-            .iter()
-            .map(|(name, field_type)| CompletionItem {
-                label: name.clone(),
-                kind: Some(CompletionItemKind::FIELD),
-                detail: Some(format!("{}: {}", name, field_type)),
-                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
-                    range,
-                    new_text: name.clone(),
-                })),
-                ..Default::default()
-            })
-            .collect();
-        items.sort_by(|a, b| a.label.cmp(&b.label));
-        items
+        match type_expr {
+            carina_core::parser::TypeExpr::Struct { fields } => {
+                let mut items: Vec<CompletionItem> = fields
+                    .iter()
+                    .map(|(name, field_type)| CompletionItem {
+                        label: name.clone(),
+                        kind: Some(CompletionItemKind::FIELD),
+                        detail: Some(format!("{}: {}", name, field_type)),
+                        text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                            range,
+                            new_text: name.clone(),
+                        })),
+                        ..Default::default()
+                    })
+                    .collect();
+                items.sort_by(|a, b| a.label.cmp(&b.label));
+                items
+            }
+            carina_core::parser::TypeExpr::Map(value_type) => {
+                // Mine the upstream's literal map for its statically-
+                // declared keys. Empty map → empty completion set.
+                // Failure to re-parse the upstream falls back silently
+                // so a transient mid-edit state in the upstream
+                // doesn't take cross-file completion offline. See
+                // #2490.
+                let Some(keys_in_literal) =
+                    resolve_upstream_map_literal_keys(source, key, base_path)
+                else {
+                    return Vec::new();
+                };
+                let value_type = value_type.to_string();
+                let mut items: Vec<CompletionItem> = keys_in_literal
+                    .into_iter()
+                    .map(|name| CompletionItem {
+                        label: name.clone(),
+                        // VARIABLE rather than FIELD — these are runtime
+                        // map entries, not type-declared struct fields.
+                        kind: Some(CompletionItemKind::VARIABLE),
+                        detail: Some(format!("{}: {}", name, value_type)),
+                        text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                            range,
+                            new_text: name,
+                        })),
+                        ..Default::default()
+                    })
+                    .collect();
+                items.sort_by(|a, b| a.label.cmp(&b.label));
+                items
+            }
+            _ => {
+                // List / scalars: depth-2 names are runtime values, not
+                // part of the type. Suggest nothing rather than something
+                // potentially invalid (#2041).
+                Vec::new()
+            }
+        }
     }
 
     pub(super) fn upstream_state_block_completions(&self) -> Vec<CompletionItem> {
@@ -1256,6 +1291,47 @@ impl CompletionProvider {
                 .collect(),
         }
     }
+}
+
+/// Re-parse the upstream directory and return the literal keys of the
+/// map-typed export named `key`. Used by depth-2 completion to surface
+/// the statically-declared keys of `upstream.<map_export>.<HERE>` —
+/// only the map case calls this, since struct fields come from the
+/// `TypeExpr` and list/scalar exports have no named keys at all.
+///
+/// Returns `None` when `base_path` is missing, the upstream directory
+/// can't be parsed, the named export has no literal value or isn't a
+/// `Value::Map`, or the binding isn't found. The completion handler
+/// treats that the same as "no candidates" — an upstream mid-edit
+/// shouldn't take downstream completion offline. See #2490.
+fn resolve_upstream_map_literal_keys(
+    source: &str,
+    key: &str,
+    base_path: Option<&Path>,
+) -> Option<Vec<String>> {
+    let base = base_path?;
+    let source_abs = base.join(source);
+    if !source_abs.is_dir() {
+        return None;
+    }
+    let parsed =
+        carina_core::config_loader::parse_directory(&source_abs, &Default::default()).ok()?;
+    let export = parsed.export_params.into_iter().find(|e| e.name == key)?;
+    let value = export.value?;
+    let carina_core::resource::Value::Map(entries) = value else {
+        return None;
+    };
+    // Filter to identifier-shaped keys only. Map literals accept string
+    // keys in the grammar (`"prod-1" = ...`), but `<binding>.<key>` dot
+    // access on the consumer side only works for identifier keys —
+    // surfacing a `prod-1` candidate would insert into a position where
+    // it can't be referenced.
+    Some(
+        entries
+            .into_keys()
+            .filter(|k| carina_core::utils::is_identifier_safe(k))
+            .collect(),
+    )
 }
 
 /// Resolve the export name → `TypeExpr` map for an `upstream_state`


### PR DESCRIPTION
## Summary

Closes #2490.

`${orgs.accounts.<cursor>}` (depth-2 dot completion on a `map(_)` upstream export) now offers the literal map's keys — `registry_prod`, `registry_dev`, etc. — as completion candidates. Previously the depth-2 handler returned an empty Vec for any non-`Struct` type because the keys aren't part of the static `TypeExpr`. Re-parsing the upstream lets us mine them from the literal `Value::Map`.

## Implementation

- New `resolve_upstream_map_literal_keys` re-parses the upstream directory via `carina_core::config_loader::parse_directory` and reads the export's `Value::Map`. Filters to identifier-shaped keys only — quoted string keys (`"prod-1" = ...`) parse fine but `<binding>.<key>` dot access can't reach them, so surfacing them would produce an unresolvable insert.
- The depth-2 handler grows a `TypeExpr::Map` arm that calls the helper and emits each key as a `CompletionItemKind::VARIABLE` with detail showing the value type (`registry_dev: AwsAccountId`).
- Silent fallback when the upstream is missing / unparseable / lacks the named export — a mid-edit upstream shouldn't take downstream completion offline.

## Test plan

5 new/repurposed tests in `carina-lsp/src/completion/tests/extended.rs`:

- [x] `upstream_state_depth2_dot_completion_lists_map_literal_keys` — bare `orgs.accounts.<cursor>` surfaces both keys.
- [x] `upstream_state_depth2_dot_completion_lists_map_literal_keys_inside_interpolation` — same shape inside `"...${orgs.accounts.}..."` (the original UX wording from the issue).
- [x] `upstream_state_depth2_dot_completion_filters_non_identifier_map_keys` — mixed `"prod-1"` + `registry_dev` map yields only `registry_dev`.
- [x] `upstream_state_depth2_dot_completion_unparseable_upstream_yields_nothing` — silent fallback for upstream parse error.
- [x] `upstream_state_depth2_dot_completion_empty_map_yields_nothing` — explicit empty map.

Verify cycle:

- [x] `cargo nextest run -p carina-lsp` — 446 passed.
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five gates green.

## Out of scope (filed)

- **#2492**: widen `UpstreamExports` (in `carina-core`) to carry the export's `Value` so the depth-2 path can stop calling `parse_directory` a second time per keystroke. Touches `carina-core` API and every consumer of `UpstreamExports` — left for a dedicated PR.
- Deeply nested maps (`map(map(_))`): only top-level keys are surfaced; depth-3 dot completion doesn't have a handler at all yet. Acceptable for the issue's scope.

## Notes

- 5-round self-review found and fixed: stale doc comment referencing #2041, missing identifier filter (with test), `format!("{}", x)` → `to_string()`, and a naming drift (`extract_*` → `resolve_upstream_*` for sibling consistency).
