### PR TITLE
cli: reject empty ${} interpolation in validate/plan/apply

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -26,7 +26,7 @@ use crate::error::AppError;
 use crate::wiring::{
     WiringContext, build_factories_from_providers, compute_anonymous_identifiers_with_ctx,
     resolve_names_with_ctx, validate_attribute_param_ref_types_with_ctx,
-    validate_module_attribute_param_types, validate_module_calls,
+    validate_module_attribute_param_types, validate_module_calls, validate_no_empty_interpolations,
     validate_provider_region_with_ctx, validate_resource_ref_types_with_ctx,
     validate_resources_with_ctx,
 };
@@ -290,6 +290,12 @@ pub fn validate_and_resolve_errors_with_factories(
     }
 
     if !skip_resource_validation {
+        // Mid-edit `${}` is parser-accepted (#2480) so the AST stays
+        // intact for LSP diagnostics, but it must not reach a provider —
+        // surface it as a hard error before the schema-level checks
+        // below try to type-check around the marker. See #2487.
+        errors.extend(validate_no_empty_interpolations(parsed));
+
         errors.extend(validate_resources_with_ctx(&ctx, parsed, &enriched_context));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -222,6 +222,74 @@ pub fn validate_attribute_param_ref_types_with_ctx(
     ))
 }
 
+/// Reject any resolved value that still carries
+/// `Value::Unknown(UnknownReason::EmptyInterpolation)`. The parser
+/// accepts mid-edit `${}` to keep the AST intact (#2480) and the LSP
+/// surfaces it as a per-location warning, but `carina validate` /
+/// `plan` / `apply` must refuse to proceed — letting the marker flow
+/// to a provider would render the literal text `${}` (or worse, an
+/// empty substitution) into a real API call. See #2487.
+pub fn validate_no_empty_interpolations<E>(parsed: &carina_core::parser::File<E>) -> Vec<AppError>
+where
+    E: carina_core::parser::ExportParamLike,
+{
+    let mut errors = Vec::new();
+    for resource in &parsed.resources {
+        for (attr_name, value) in &resource.attributes {
+            if value_contains_empty_interpolation(value) {
+                errors.push(AppError::Validation(format!(
+                    "{}: attribute `{}`: empty interpolation `${{}}` — fill in the expression or remove it",
+                    resource.id, attr_name
+                )));
+            }
+        }
+    }
+    for export in &parsed.export_params {
+        if let Some(value) = export.value()
+            && value_contains_empty_interpolation(value)
+        {
+            errors.push(AppError::Validation(format!(
+                "exports `{}`: empty interpolation `${{}}` — fill in the expression or remove it",
+                export.name()
+            )));
+        }
+    }
+    for param in &parsed.attribute_params {
+        if let Some(value) = &param.value
+            && value_contains_empty_interpolation(value)
+        {
+            errors.push(AppError::Validation(format!(
+                "attributes `{}` default: empty interpolation `${{}}` — fill in the expression or remove it",
+                param.name
+            )));
+        }
+    }
+    errors
+}
+
+/// Recursively walk a `Value` tree looking for any
+/// `Value::Unknown(UnknownReason::EmptyInterpolation)`. Returns `true`
+/// when one is found at any depth — inside lists, maps, secrets,
+/// function-call arguments, or as the `Expr` segment of an
+/// `Interpolation`. Mirrors the variant coverage of the sibling
+/// `value_contains_unknown` to keep them in lockstep when new `Value`
+/// variants land.
+fn value_contains_empty_interpolation(value: &Value) -> bool {
+    use carina_core::resource::{InterpolationPart, UnknownReason};
+    match value {
+        Value::Unknown(UnknownReason::EmptyInterpolation) => true,
+        Value::Interpolation(parts) => parts.iter().any(|p| match p {
+            InterpolationPart::Expr(v) => value_contains_empty_interpolation(v),
+            InterpolationPart::Literal(_) => false,
+        }),
+        Value::List(items) => items.iter().any(value_contains_empty_interpolation),
+        Value::Map(entries) => entries.values().any(value_contains_empty_interpolation),
+        Value::Secret(inner) => value_contains_empty_interpolation(inner),
+        Value::FunctionCall { args, .. } => args.iter().any(value_contains_empty_interpolation),
+        _ => false,
+    }
+}
+
 /// Resolve block name aliases and attribute prefixes in one step.
 pub fn resolve_names_with_ctx(ctx: &WiringContext, resources: &mut [Resource]) -> Vec<AppError> {
     let mut errors = lift_validation_result(resolve_block_names(resources, ctx.schemas()));

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -857,3 +857,215 @@ fn strip_unified_predicate_covers_unknown_and_ref() {
         Some(Value::ResourceRef { .. })
     ));
 }
+
+// =====================================================================
+// Empty `${}` interpolation rejection (#2487)
+//
+// The parser accepts `${}` mid-edit (#2480) and the LSP surfaces it as
+// a per-location warning. CLI validate / plan / apply must reject it
+// explicitly so a buffer with literal `${}` can't reach a provider and
+// surface only at the AWS edge.
+// =====================================================================
+
+fn parsed_with_attr(attr_name: &str, attr_value: Value) -> ParsedFile {
+    let mut r = Resource::new("foo.bar", "x");
+    r.attributes.insert(attr_name.to_string(), attr_value);
+    ParsedFile {
+        resources: vec![r],
+        ..ParsedFile::default()
+    }
+}
+
+#[test]
+fn validate_rejects_top_level_empty_interpolation() {
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let value = Value::Interpolation(vec![
+        InterpolationPart::Literal("arn:aws:iam::".to_string()),
+        InterpolationPart::Expr(Value::Unknown(UnknownReason::EmptyInterpolation)),
+        InterpolationPart::Literal(":root".to_string()),
+    ]);
+    let parsed = parsed_with_attr("aws", value);
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(errors.len(), 1, "expected one error, got: {:?}", errors);
+    let msg = match &errors[0] {
+        AppError::Validation(s) => s,
+        other => panic!("expected AppError::Validation, got {:?}", other),
+    };
+    assert!(
+        msg.contains("empty interpolation"),
+        "message must mention 'empty interpolation'; got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("foo.bar.x"),
+        "message must include the resource id (provider.type.name); got: {}",
+        msg
+    );
+    assert!(
+        msg.contains("aws"),
+        "message must name the offending attribute; got: {}",
+        msg
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_inside_secret() {
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let inner = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+        UnknownReason::EmptyInterpolation,
+    ))]);
+    let parsed = parsed_with_attr("password", Value::Secret(Box::new(inner)));
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "empty `${{}}` wrapped in `secret(...)` must error; got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_inside_function_call() {
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+        UnknownReason::EmptyInterpolation,
+    ))]);
+    let fn_call = Value::FunctionCall {
+        name: "join".to_string(),
+        args: vec![Value::String("-".to_string()), bad],
+    };
+    let parsed = parsed_with_attr("name", fn_call);
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "empty `${{}}` inside a function-call arg must error; got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_nested_in_map() {
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+    use indexmap::IndexMap;
+
+    let inner = Value::Interpolation(vec![
+        InterpolationPart::Literal("prefix-".to_string()),
+        InterpolationPart::Expr(Value::Unknown(UnknownReason::EmptyInterpolation)),
+    ]);
+    let mut map = IndexMap::new();
+    map.insert("key".to_string(), inner);
+    let parsed = parsed_with_attr("tags", Value::Map(map));
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "nested-in-map empty `${{}}` must error; got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_nested_in_list() {
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let inner = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+        UnknownReason::EmptyInterpolation,
+    ))]);
+    let parsed = parsed_with_attr("items", Value::List(vec![inner]));
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "nested-in-list empty `${{}}` must error; got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_in_export_value() {
+    use carina_core::parser::ParsedExportParam;
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+        UnknownReason::EmptyInterpolation,
+    ))]);
+    let parsed = ParsedFile {
+        export_params: vec![ParsedExportParam {
+            name: "url".to_string(),
+            type_expr: None,
+            value: Some(bad),
+        }],
+        ..ParsedFile::default()
+    };
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "empty `${{}}` in `exports {{ ... }}` value must error; got: {:?}",
+        errors
+    );
+    let msg = match &errors[0] {
+        AppError::Validation(s) => s,
+        _ => panic!("not a Validation error"),
+    };
+    assert!(
+        msg.contains("exports") && msg.contains("url"),
+        "message must name the offending export; got: {}",
+        msg
+    );
+}
+
+#[test]
+fn validate_rejects_empty_interpolation_in_attribute_param_default() {
+    use carina_core::parser::AttributeParameter;
+    use carina_core::resource::{InterpolationPart, UnknownReason, Value};
+
+    let bad = Value::Interpolation(vec![InterpolationPart::Expr(Value::Unknown(
+        UnknownReason::EmptyInterpolation,
+    ))]);
+    let parsed = ParsedFile {
+        attribute_params: vec![AttributeParameter {
+            name: "region".to_string(),
+            type_expr: None,
+            value: Some(bad),
+        }],
+        ..ParsedFile::default()
+    };
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert_eq!(
+        errors.len(),
+        1,
+        "empty `${{}}` in `attributes {{ ... }}` default must error; got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_passes_when_no_empty_interpolation() {
+    use carina_core::resource::{InterpolationPart, Value};
+
+    // Non-empty interpolation: must not error.
+    let value = Value::Interpolation(vec![
+        InterpolationPart::Literal("prefix-".to_string()),
+        InterpolationPart::Expr(Value::String("real-value".to_string())),
+    ]);
+    let parsed = parsed_with_attr("aws", value);
+
+    let errors = validate_no_empty_interpolations(&parsed);
+    assert!(
+        errors.is_empty(),
+        "non-empty interpolation must pass; got: {:?}",
+        errors
+    );
+}


### PR DESCRIPTION
## Summary

Closes #2487.

Pre-fix, an empty `${}` parsed (per #2480) and stamped as `Value::Unknown(UnknownReason::EmptyInterpolation)` flowed through schema validation untouched — `validate_resources` silently skips all `Value::Unknown(_)` variants. Plan and apply then handed the marker to a provider, which rendered the literal text `${}` (or worse, an empty substitution) into a real API call, and the failure surfaced only at the AWS edge.

This PR is the CLI half of the empty-interpolation story (the LSP half — accepting `${}` in the parser and emitting a per-location warning — landed in #2480 / PR #2489).

## Implementation

- **New `validate_no_empty_interpolations`** walks every resolved `Value` in `parsed.resources` attributes, `parsed.export_params` values, and `parsed.attribute_params` defaults.
- **Recursive walker `value_contains_empty_interpolation`** follows `List` / `Map` / `Interpolation::Expr` / `Secret` / `FunctionCall::args`. Variant coverage is in lockstep with the sibling `value_contains_unknown` so future `Value` variants get audited at the same time.
- **Wired into the validate suite** in `commands/mod.rs` ahead of `validate_resources_with_ctx`, so the marker can't reach a provider and schema-level errors don't mask the real cause.
- **`carina destroy` and `carina state ...` paths intentionally bypass** via `skip_resource_validation: true` — they don't issue provider calls with desired-state values, and bypassing lets users recover from partially-broken configs.

## Test plan

8 new tests in `carina-cli/src/wiring/tests.rs`:

- [x] `validate_rejects_top_level_empty_interpolation`
- [x] `validate_rejects_empty_interpolation_nested_in_map`
- [x] `validate_rejects_empty_interpolation_nested_in_list`
- [x] `validate_rejects_empty_interpolation_inside_secret`
- [x] `validate_rejects_empty_interpolation_inside_function_call`
- [x] `validate_rejects_empty_interpolation_in_export_value`
- [x] `validate_rejects_empty_interpolation_in_attribute_param_default`
- [x] `validate_passes_when_no_empty_interpolation`

Verify:

- [x] `cargo nextest run --workspace` — 2808 tests passed.
- [x] `cargo test --workspace --doc` — pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-*.sh` — all five gates green.

## Design notes

- **Span-aware errors deferred.** The error message names the resource id, export name, or attribute name, but does not include file path or source span. `AppError::Validation(String)` has no span field and every sibling validator has the same structural limitation. Adding spans is a workspace-wide error-shape refactor outside this PR's scope.
- **`validate_no_empty_interpolations` does not take `WiringContext`.** The sibling validators use a `_with_ctx` suffix, but the new function performs a pure AST walk with no schema lookup — adding the suffix would be misleading.

## Out of scope (already filed)

- **#2492**: widen `UpstreamExports` to carry the export's `Value` (LSP performance improvement).
- File/span info in `AppError` — workspace-wide concern, would touch every existing validator. No issue filed yet.
