### PR TITLE
inference: resolve module-call attribute exports via virtual bindings

### DIFF
--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -677,30 +677,7 @@ fn check_resource_ref_at_position(
     });
 }
 
-/// Narrow `start` through a chain of `field_path` segments and
-/// trailing `subscripts`. Returns `None` when a step doesn't fit the
-/// container kind; those mismatches are already reported by the
-/// dedicated shape checkers and a duplicate here would be noise.
-///
-/// The field-path leg delegates to `walk_type_expr_path` to keep the
-/// dot-form descent rules (map-key + struct-field) in one place.
-fn narrow_type_expr(
-    start: &TypeExpr,
-    field_path: &[String],
-    subscripts: &[crate::resource::Subscript],
-) -> Option<TypeExpr> {
-    let after_fields = walk_type_expr_path(start, field_path).ok()?;
-    let mut current = after_fields.clone();
-    use crate::resource::Subscript;
-    for sub in subscripts {
-        current = match (current, sub) {
-            (TypeExpr::List(inner), Subscript::Int { .. }) => *inner,
-            (TypeExpr::Map(inner), Subscript::Str { .. }) => *inner,
-            _ => return None,
-        };
-    }
-    Some(current)
-}
+use crate::validation::{narrow_type_expr, walk_type_expr_path};
 
 /// A `for` expression iterates an `upstream_state` field whose declared
 /// export type doesn't match the binding pattern's expected shape:
@@ -1037,40 +1014,6 @@ fn visit_attribute_access(
             });
         }
     });
-}
-
-/// Walk `field_path` against `start`. Return `Ok(tail_type)` on a
-/// clean walk and `Err((mismatched_type, bad_segment))` for the first
-/// segment that can't be resolved. Lists, maps, and scalars never host
-/// `.field` access — the parent type they reach is the right anchor
-/// for the diagnostic builder's "use iteration / subscript / nothing"
-/// suggestion.
-///
-/// Walks by reference so deep struct paths don't pay an O(depth) clone
-/// chain — the caller clones once at the return site if it needs an
-/// owned copy.
-fn walk_type_expr_path<'a, 'b>(
-    start: &'a TypeExpr,
-    field_path: &'b [String],
-) -> Result<&'a TypeExpr, (&'a TypeExpr, &'b str)> {
-    let mut current = start;
-    for segment in field_path {
-        match current {
-            TypeExpr::Struct { fields } => match fields.iter().find(|(name, _)| name == segment) {
-                Some((_, ty)) => {
-                    current = ty;
-                }
-                None => return Err((current, segment.as_str())),
-            },
-            // Dot form on a map is map-key access (`accounts.k → T`),
-            // symmetric with the subscript form `accounts['k']`. #2447.
-            TypeExpr::Map(inner) => {
-                current = inner.as_ref();
-            }
-            _ => return Err((current, segment.as_str())),
-        }
-    }
-    Ok(current)
 }
 
 /// A `[index]` subscript reads an `upstream_state` export at a depth

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -95,6 +95,12 @@ impl std::fmt::Display for InferenceError {
 /// which the inferer doesn't recursively resolve here). Distinguishing the
 /// two lets the inferer turn a true typo (`mian.vpc_id`) into a hard error
 /// while still passing through `upstream_state`-derived references.
+///
+/// `Virtual` carries the attribute map of a module-call's
+/// `ResourceKind::Virtual` resource so an `exports` reference of the form
+/// `<module_call>.<attr>` can transitively infer through the bound
+/// expression on the module's `attributes { ... }` block, instead of
+/// failing with `unknown binding` (#2493).
 #[derive(Debug, Clone)]
 pub enum InferenceBinding {
     Resource {
@@ -102,6 +108,17 @@ pub enum InferenceBinding {
         resource_type: String,
     },
     UpstreamState,
+    Virtual {
+        attributes: indexmap::IndexMap<String, Value>,
+    },
+    /// Module-call binding registered before module expansion.
+    /// Inference treats it like `UpstreamState` (known-but-non-
+    /// inferable) so a downstream `${<call>.<attr>}` doesn't fire a
+    /// false `unknown binding` at load time. Post-expansion the
+    /// matching `Virtual` resource lands in `parsed.resources` and
+    /// `bindings_from_parts` overwrites this entry with a `Virtual`
+    /// that can actually project to a `TypeExpr`. #2493.
+    ModuleCall,
 }
 
 pub type InferenceBindings = HashMap<String, InferenceBinding>;
@@ -110,7 +127,23 @@ pub type InferenceBindings = HashMap<String, InferenceBinding>;
 /// over [`bindings_from_parts`] for the common case of having a parsed
 /// file in hand.
 pub fn bindings_from_parsed(parsed: &crate::parser::ParsedFile) -> InferenceBindings {
-    bindings_from_parts(&parsed.resources, &parsed.upstream_states)
+    let mut out = bindings_from_parts(&parsed.resources, &parsed.upstream_states);
+    // Pre-expansion (load_configuration), `parsed.resources` does not
+    // yet hold the `Virtual` resources that `expand_module_call`
+    // synthesises for each module-call binding. Register the binding
+    // names here as `ModuleCall` so a downstream
+    // `${<call>.<attr>}` reference is treated as known-but-non-
+    // inferable (mirroring `upstream_state`) instead of falsely
+    // flagged as `unknown binding`. Post-expansion the `Virtual` arm
+    // takes over and resolves the type properly. #2493.
+    for call in &parsed.module_calls {
+        if let Some(name) = &call.binding_name
+            && !out.contains_key(name)
+        {
+            out.insert(name.clone(), InferenceBinding::ModuleCall);
+        }
+    }
+    out
 }
 
 /// Build an [`InferenceBindings`] map from already-extracted resource
@@ -142,15 +175,26 @@ pub fn bindings_from_parts(
         out.insert(us.binding.clone(), InferenceBinding::UpstreamState);
     }
     for resource in resources {
-        if let Some(name) = &resource.binding {
-            out.insert(
-                name.clone(),
-                InferenceBinding::Resource {
-                    provider: resource.id.provider.clone(),
-                    resource_type: resource.id.resource_type.clone(),
-                },
-            );
-        }
+        let Some(name) = &resource.binding else {
+            continue;
+        };
+        // `Virtual` resources synthesised by module-call expansion
+        // (`expand_module_call`) carry no provider identity — their
+        // attributes are projections from the module's
+        // `attributes { ... }` block. Tag them so `infer_resource_ref`
+        // recurses into the bound expression instead of trying a schema
+        // lookup that would always fail. #2493.
+        let entry = if resource.is_virtual() {
+            InferenceBinding::Virtual {
+                attributes: resource.attributes.clone(),
+            }
+        } else {
+            InferenceBinding::Resource {
+                provider: resource.id.provider.clone(),
+                resource_type: resource.id.resource_type.clone(),
+            }
+        };
+        out.insert(name.clone(), entry);
     }
     out
 }
@@ -293,9 +337,29 @@ fn infer_resource_ref(
             provider,
             resource_type,
         }) => (provider.as_str(), resource_type.as_str()),
-        Some(InferenceBinding::UpstreamState) => {
+        Some(InferenceBinding::UpstreamState) | Some(InferenceBinding::ModuleCall) => {
             return Err(InferenceError::NonInferableBinding {
                 binding: binding.to_string(),
+            });
+        }
+        Some(InferenceBinding::Virtual { attributes }) => {
+            // The module-call's virtual resource holds the module's
+            // `attributes { ... }` projections directly. Recurse on the
+            // bound expression so the type flows transitively through
+            // the inner resource's schema. #2493.
+            let inner =
+                attributes
+                    .get(attribute)
+                    .ok_or_else(|| InferenceError::UnknownAttribute {
+                        binding: binding.to_string(),
+                        attribute: attribute.to_string(),
+                    })?;
+            let inner_type = infer_type_from_value(inner, bindings, schemas)?;
+            return super::narrow_type_expr(&inner_type, field_path, subscripts).ok_or_else(|| {
+                InferenceError::UnknownAttribute {
+                    binding: binding.to_string(),
+                    attribute: attribute.to_string(),
+                }
             });
         }
         None => {
@@ -526,7 +590,7 @@ pub fn infer_export_params(
     Vec<crate::parser::InferredExportParam>,
     Vec<(String, InferenceError)>,
 ) {
-    let bindings = bindings_from_parts(&parsed.resources, &parsed.upstream_states);
+    let bindings = bindings_from_parsed(parsed);
     let mut errors = Vec::new();
     let inferred_exports: Vec<crate::parser::InferredExportParam> = parsed
         .export_params
@@ -1140,6 +1204,109 @@ mod tests {
             inferred.export_params[0].type_expr,
             TypeExpr::Simple("vpc_id".to_string())
         );
+    }
+
+    #[test]
+    fn apply_inference_resolves_module_call_attribute_via_virtual_binding() {
+        // #2493: an `exports` value referencing `<module_call>.<attr>`
+        // (e.g. `role_arn = github_actions_carina.role_arn` where
+        // `let github_actions_carina = github_module {...}`) must
+        // resolve to the same `TypeExpr` as if the user had annotated
+        // the export explicitly. The module's `attributes { role_arn =
+        // role.arn }` block lets the type be inferred transitively
+        // through the module-call's virtual resource (post-expansion)
+        // and the inner role's schema attribute.
+        //
+        // Pre-#2493 the inference walked `parsed.resources` only, missed
+        // the `Virtual` binding (which post-expansion exposes the
+        // module's attribute set), and surfaced a misleading
+        // "unknown binding" diagnostic.
+        use crate::resource::ResourceKind;
+        let mut parsed = crate::parser::ParsedFile::default();
+        // Concrete role resource with prefixed binding (post-expansion shape).
+        let role = crate::resource::Resource::with_provider(
+            "awscc",
+            "ec2.Vpc",
+            "github_actions_carina.role",
+        )
+        .with_binding("github_actions_carina.role");
+        parsed.resources.push(role); // allow: direct — fixture test inspection
+        // Virtual resource that exposes the module's attributes.
+        // `vpc_id` here stands in for the module-exposed attribute that
+        // points at the inner role's schema attribute.
+        let mut virt = crate::resource::Resource::new("_virtual", "github_actions_carina");
+        virt.binding = Some("github_actions_carina".to_string());
+        virt.kind = ResourceKind::Virtual {
+            module_name: "github_module".to_string(),
+            instance: "github_actions_carina".to_string(),
+        };
+        virt.attributes.insert(
+            "role_id".to_string(),
+            Value::resource_ref(
+                "github_actions_carina.role".to_string(),
+                "vpc_id".to_string(),
+                vec![],
+            ),
+        );
+        parsed.resources.push(virt); // allow: direct — fixture test inspection
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "role_id".to_string(),
+            type_expr: None,
+            value: Some(Value::resource_ref(
+                "github_actions_carina".to_string(),
+                "role_id".to_string(),
+                vec![],
+            )),
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &schemas_with_vpc());
+        assert!(
+            errors.is_empty(),
+            "module-call attribute export must infer cleanly, got: {errs:?}",
+            errs = errors
+        );
+        assert_eq!(inferred.export_params.len(), 1);
+        assert_eq!(
+            inferred.export_params[0].type_expr,
+            TypeExpr::Simple("vpc_id".to_string()),
+            "expected the inner attribute's type to flow through the virtual binding"
+        );
+    }
+
+    #[test]
+    fn apply_inference_treats_pre_expansion_module_call_binding_as_non_inferable() {
+        // #2493 load-time path: at `load_configuration` the parser has
+        // produced `parsed.module_calls` but module expansion hasn't
+        // run yet, so the virtual resource isn't in `parsed.resources`
+        // and the bindings map can't see the module-call's projection.
+        // The inferer must treat the binding as known-but-non-inferable
+        // (mirroring `upstream_state`) so the export gets `Unknown`
+        // without a noisy `unknown binding` error. Post-expansion the
+        // CLI re-runs inference and the type is filled in via the
+        // `Virtual` arm exercised by the sibling test above.
+        let mut parsed = crate::parser::ParsedFile::default();
+        parsed.module_calls.push(crate::parser::ModuleCall {
+            module_name: "github_module".to_string(),
+            binding_name: Some("github_actions_carina".to_string()),
+            arguments: std::collections::HashMap::new(),
+        });
+        parsed.export_params.push(crate::parser::ParsedExportParam {
+            name: "role_arn".to_string(),
+            type_expr: None,
+            value: Some(Value::resource_ref(
+                "github_actions_carina".to_string(),
+                "role_arn".to_string(),
+                vec![],
+            )),
+        });
+
+        let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
+        assert!(
+            errors.is_empty(),
+            "module-call binding without a virtual resource yet must not error, got: {:?}",
+            errors
+        );
+        assert_eq!(inferred.export_params[0].type_expr, TypeExpr::Unknown);
     }
 
     #[test]

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -895,6 +895,64 @@ fn validate_struct_fields(
     None
 }
 
+/// Walk `field_path` against `start`. Return `Ok(tail_type)` on a
+/// clean walk and `Err((mismatched_type, bad_segment))` for the first
+/// segment that can't be resolved. Lists, maps, and scalars never host
+/// `.field` access — the parent type they reach is the right anchor
+/// for the diagnostic builder's "use iteration / subscript / nothing"
+/// suggestion.
+///
+/// Walks by reference so deep struct paths don't pay an O(depth) clone
+/// chain — the caller clones once at the return site if it needs an
+/// owned copy.
+///
+/// `Map` segments unwrap to the value type so dot-form key access
+/// (`accounts.k → T`) is symmetric with the subscript form
+/// (`accounts['k']`). #2447.
+pub(crate) fn walk_type_expr_path<'a, 'b>(
+    start: &'a TypeExpr,
+    field_path: &'b [String],
+) -> Result<&'a TypeExpr, (&'a TypeExpr, &'b str)> {
+    let mut current = start;
+    for segment in field_path {
+        match current {
+            TypeExpr::Struct { fields } => match fields.iter().find(|(name, _)| name == segment) {
+                Some((_, ty)) => current = ty,
+                None => return Err((current, segment.as_str())),
+            },
+            TypeExpr::Map(inner) => current = inner.as_ref(),
+            _ => return Err((current, segment.as_str())),
+        }
+    }
+    Ok(current)
+}
+
+/// Narrow `start` through a chain of `field_path` segments and trailing
+/// `subscripts`. Returns `None` when a step doesn't fit the container
+/// kind; those mismatches are reported by the dedicated shape checkers
+/// and a duplicate here would be noise.
+///
+/// The field-path leg delegates to [`walk_type_expr_path`] to keep the
+/// dot-form descent rules in one place. Used by both upstream-export
+/// type-checking and module-call attribute-export inference.
+pub(crate) fn narrow_type_expr(
+    start: &TypeExpr,
+    field_path: &[String],
+    subscripts: &[crate::resource::Subscript],
+) -> Option<TypeExpr> {
+    let after_fields = walk_type_expr_path(start, field_path).ok()?;
+    let mut current = after_fields.clone();
+    use crate::resource::Subscript;
+    for sub in subscripts {
+        current = match (current, sub) {
+            (TypeExpr::List(inner), Subscript::Int { .. }) => *inner,
+            (TypeExpr::Map(inner), Subscript::Str { .. }) => *inner,
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
 pub mod inference;
 
 #[cfg(test)]

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1289,10 +1289,17 @@ impl DiagnosticEngine {
     ///
     /// `all_resources` provides cross-file resources for schema-level ref type
     /// checking. If None, falls back to the current file's resources.
+    ///
+    /// `merged` is the directory-merged parse used to feed inference so
+    /// module-call / `upstream_state` bindings declared in sibling
+    /// `.crn` files are visible — without it the export inference would
+    /// raise spurious `unknown binding` for an `exports.crn` that
+    /// references a `let` bound elsewhere in the directory (#2493).
     pub(super) fn check_exports_blocks(
         &self,
         doc: &Document,
         parsed: &ParsedFile,
+        merged: Option<&ParsedFile>,
         all_resources: Option<&[Resource]>,
         sibling_bindings: &HashMap<String, String>,
     ) -> Vec<Diagnostic> {
@@ -1331,15 +1338,22 @@ impl DiagnosticEngine {
         }
 
         // Schema-level ref type checking for ResourceRef values in exports.
-        // `infer_export_params` borrows `parsed` (avoiding the per-keystroke
+        // `infer_export_params` borrows the parse (avoiding the per-keystroke
         // deep clone the full `apply_inference` would force) so the LSP
         // can derive the post-inference shape without rebuilding the
-        // whole `InferredFile`.
+        // whole `InferredFile`. Use the merged parse when available so
+        // sibling-file `let` bindings (module calls, upstream_states)
+        // are visible to inference (#2493).
         let resources = all_resources.unwrap_or(&parsed.resources);
+        let inference_input = merged.unwrap_or(parsed);
         let (inferred_export_params, inference_errors) =
-            carina_core::validation::inference::infer_export_params(parsed, &self.schemas);
+            carina_core::validation::inference::infer_export_params(inference_input, &self.schemas);
         // Surface inference failures as "type annotation required"
-        // diagnostics, anchored at the export name.
+        // diagnostics, anchored at the export name. Errors for
+        // exports declared in sibling `.crn` files (visible only via
+        // `merged`) won't anchor in this buffer and are skipped here —
+        // the buffer that owns the export will surface them on its
+        // own pass.
         for (name, err) in &inference_errors {
             if let Some((line, col)) = self.find_exports_param_position(doc, name) {
                 diagnostics.push(carina_diagnostic(

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -752,7 +752,13 @@ impl DiagnosticEngine {
                 .as_ref()
                 .map(exports_sibling_bindings_from)
                 .unwrap_or_default();
-            diagnostics.extend(self.check_exports_blocks(doc, parsed, None, &sibling_bindings));
+            diagnostics.extend(self.check_exports_blocks(
+                doc,
+                parsed,
+                merged.as_ref(),
+                None,
+                &sibling_bindings,
+            ));
 
             // Unused `let` detection. When a merged parse is available,
             // run the core check against it (so references from sibling

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -2157,6 +2157,58 @@ fn exports_subscripted_cross_file_ref_does_not_false_flag() {
 }
 
 #[test]
+fn exports_referencing_module_call_attribute_does_not_require_annotation() {
+    // #2493: an `exports` value of the form `<module_call>.<attr>` (e.g.
+    // `role_arn = github_actions_carina.role_arn` where
+    // `let github_actions_carina = github { ... }` invokes a module)
+    // must not surface a `type annotation required: unknown binding`
+    // warning. The LSP doesn't run module expansion, so the inferer
+    // sees the binding as `ModuleCall` (known-but-non-inferable, like
+    // upstream_state) and the export gets `TypeExpr::Unknown` without
+    // a hard error.
+    let engine = DiagnosticEngine::new(
+        Arc::new(SchemaRegistry::new()),
+        vec!["awscc".to_string()],
+        Arc::new(vec![]),
+    );
+    let tmp = tempfile::tempdir().unwrap();
+    let module_dir = tmp.path().join("github_module");
+    std::fs::create_dir_all(&module_dir).unwrap();
+    std::fs::write(
+        module_dir.join("main.crn"),
+        "arguments {\n  name: String\n}\nattributes {\n  role_arn: String = name\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(
+        base.join("main.crn"),
+        "let github = use { source = '../github_module' }\nlet github_actions_carina = github { name = 'demo' }\n",
+    )
+    .unwrap();
+    let exports = "exports {\n  role_arn = github_actions_carina.role_arn\n}\n";
+    std::fs::write(base.join("exports.crn"), exports).unwrap();
+
+    let diagnostics = analyze_with_buffer(&engine, &base, "exports.crn", exports);
+    let annotation_warning = diagnostics
+        .iter()
+        .find(|d| d.message.contains("type annotation required"));
+    assert!(
+        annotation_warning.is_none(),
+        "module-call attribute export must not raise `type annotation required`. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let undefined = diagnostics
+        .iter()
+        .find(|d| d.message.contains("Undefined") || d.message.contains("unknown binding"));
+    assert!(
+        undefined.is_none(),
+        "module-call binding must not be flagged as unknown. Got: {:?}",
+        diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn no_undefined_resource_for_sibling_binding_in_exports() {
     let engine = DiagnosticEngine::new(
         Arc::new(SchemaRegistry::new()),


### PR DESCRIPTION
## Summary

Closes #2493 (and the duplicate #2488). `carina validate` raised a misleading

```
Error: export 'role_arn': type annotation required: unknown binding `github_actions_carina`
```

whenever an `exports.crn` re-exported a module-call binding's attribute (e.g. `role_arn = github_actions_carina.role_arn` where `let github_actions_carina = github_module {...}`). The binding is known elsewhere — the same value resolves cleanly at plan time and via the writeback path fixed by PR #2491 — so the inference layer's "unknown binding" was a false negative. The type was statically inferable through the module's `attributes { role_arn = role.arn }` projection.

## Fix

Extend `InferenceBinding` with two new variants and route module-call references through them.

- `Virtual { attributes }` is registered for `ResourceKind::Virtual` resources synthesised by module-call expansion. `infer_resource_ref` looks up the requested attribute in the virtual's attribute map and recurses on the bound expression, so the type flows transitively to the inner concrete resource's schema attribute (e.g. `IamRoleArn`).
- `ModuleCall` is registered pre-expansion (when `parsed.module_calls` has the binding name but no virtual resource exists yet). The `infer_resource_ref` arm returns `NonInferableBinding` (mirroring `upstream_state`), suppressing the false `unknown binding` at `load_configuration` time. Post-expansion, `Virtual` overwrites this placeholder.

`bindings_from_parsed` is the entry point that registers the `ModuleCall` placeholders alongside resource and upstream-state bindings.

### LSP parity

The LSP doesn't run module expansion, so it needs the directory-merged `ParsedFile` threaded into `check_exports_blocks` for sibling-file `let` bindings to be visible to inference. The pre-fix LSP code passed only the current buffer's parse, missing module-call declarations in `main.crn` from an `exports.crn` analysis pass.

### Reuse

Lifted `narrow_type_expr` and `walk_type_expr_path` from `upstream_exports.rs` into `validation/mod.rs` as `pub(crate)` shared helpers (introduced by #2475). Both the `Virtual` arm and the upstream-export type-checker now use the single source of truth for `TypeExpr` descent through `field_path` / `subscripts`.

## Test plan

3 tests:
- `apply_inference_resolves_module_call_attribute_via_virtual_binding` — pins the post-expansion `Virtual` arm in `carina-core/src/validation/inference.rs`.
- `apply_inference_treats_pre_expansion_module_call_binding_as_non_inferable` — pins the pre-expansion `ModuleCall` arm (load-time path).
- `exports_referencing_module_call_attribute_does_not_require_annotation` — LSP test that reproduces the issue body's exact scenario via a multi-file fixture (`main.crn` with the module call + `exports.crn` with the re-export); asserts no `type annotation required` warning.

- [x] `cargo nextest run --workspace` — 2811 PASS
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 4 pass
- [x] Real-infra: `carina validate aws/management/github-oidc/` on `carina-rs/infra` (the issue's literal reproduction) succeeds with `✓ 3 resources validated successfully` after the fix; pre-fix it errored on the same `exports.crn` line.

## Out of scope (follow-ups filed)

- #2497 — defensive recursion cap in the `Virtual` arm so a future module-of-module cycle can't loop without bound. Not currently reachable (the parser / module expander rejects cycles), but worth pinning.

## Design rationale (Phase 1)

Two routes were on the table for this issue: (A) treat module-call bindings as `NonInferableBinding` (validation passes silently, type stays `Unknown`), or (B) actually infer the type through the module's `attributes { ... }` block. A discards the type information the module already declared and forces consumers to repeat annotations; B preserves it and matches Carina's "Type safety over runtime checks" stance. This PR implements B for the CLI-validate path (post-expansion) and uses A as a graceful fallback for the LSP load-time path. A future PR can complete the LSP side once we decide whether per-keystroke module loading is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
