### PR TITLE
editors: add heredoc rule with ${...} parity to TextMate grammars

### DIFF
--- a/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
+++ b/editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json
@@ -77,6 +77,59 @@
     "strings": {
       "patterns": [
         {
+          "name": "string.unquoted.heredoc.literal.carina",
+          "comment": "Quoted heredoc form (`<<'EOT'` / `<<-'EOT'`): body is literal — `${...}` is NOT expanded by the parser, so no interpolation pattern is embedded.",
+          "begin": "<<-?'([A-Za-z_][A-Za-z0-9_]*)'",
+          "end": "^\\s*\\1\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.carina" },
+            "1": { "name": "entity.name.tag.heredoc.carina" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.carina" }
+          }
+        },
+        {
+          "name": "string.unquoted.heredoc.carina",
+          "comment": "Unquoted heredoc form (`<<EOT` / `<<-EOT`): body hosts `${...}` interpolation, mirroring the double-quoted-string treatment.",
+          "begin": "<<-?([A-Za-z_][A-Za-z0-9_]*)",
+          "end": "^\\s*\\1\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.carina" },
+            "1": { "name": "entity.name.tag.heredoc.carina" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.carina" }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.carina",
+              "match": "\\\\."
+            },
+            {
+              "name": "meta.embedded.expression.carina",
+              "begin": "\\$\\{",
+              "end": "\\}",
+              "beginCaptures": {
+                "0": { "name": "punctuation.section.embedded.begin.carina" }
+              },
+              "endCaptures": {
+                "0": { "name": "punctuation.section.embedded.end.carina" }
+              },
+              "patterns": [
+                {
+                  "name": "variable.other.carina",
+                  "match": "[A-Za-z_][A-Za-z0-9_]*"
+                },
+                {
+                  "name": "punctuation.accessor.carina",
+                  "match": "\\."
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "string.quoted.double.carina",
           "begin": "\"",
           "end": "\"",

--- a/editors/vscode/syntaxes/carina.tmLanguage.json
+++ b/editors/vscode/syntaxes/carina.tmLanguage.json
@@ -77,6 +77,59 @@
     "strings": {
       "patterns": [
         {
+          "name": "string.unquoted.heredoc.literal.carina",
+          "comment": "Quoted heredoc form (`<<'EOT'` / `<<-'EOT'`): body is literal — `${...}` is NOT expanded by the parser, so no interpolation pattern is embedded.",
+          "begin": "<<-?'([A-Za-z_][A-Za-z0-9_]*)'",
+          "end": "^\\s*\\1\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.carina" },
+            "1": { "name": "entity.name.tag.heredoc.carina" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.carina" }
+          }
+        },
+        {
+          "name": "string.unquoted.heredoc.carina",
+          "comment": "Unquoted heredoc form (`<<EOT` / `<<-EOT`): body hosts `${...}` interpolation, mirroring the double-quoted-string treatment.",
+          "begin": "<<-?([A-Za-z_][A-Za-z0-9_]*)",
+          "end": "^\\s*\\1\\s*$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.string.begin.carina" },
+            "1": { "name": "entity.name.tag.heredoc.carina" }
+          },
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.string.end.carina" }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.carina",
+              "match": "\\\\."
+            },
+            {
+              "name": "meta.embedded.expression.carina",
+              "begin": "\\$\\{",
+              "end": "\\}",
+              "beginCaptures": {
+                "0": { "name": "punctuation.section.embedded.begin.carina" }
+              },
+              "endCaptures": {
+                "0": { "name": "punctuation.section.embedded.end.carina" }
+              },
+              "patterns": [
+                {
+                  "name": "variable.other.carina",
+                  "match": "[A-Za-z_][A-Za-z0-9_]*"
+                },
+                {
+                  "name": "punctuation.accessor.carina",
+                  "match": "\\."
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "string.quoted.double.carina",
           "begin": "\"",
           "end": "\"",


### PR DESCRIPTION
## Summary

Closes #2499.

After #2482 / PR #2500 added LSP semantic-token highlighting for `${...}` inside heredoc bodies, editors using only the TextMate grammar (no `carina-lsp` running) still rendered heredoc bodies as plain text — neither the surrounding STRING coloring nor the `${...}` MACRO coloring kicked in. This PR adds the heredoc rule to both grammars so the LSP-off fallback matches the LSP path.

## Implementation

- **`string.unquoted.heredoc.literal.carina`** matches `<<'MARKER'` / `<<-'MARKER'` and treats the body as literal, mirroring the parser's no-interpolation semantics for quoted markers.
- **`string.unquoted.heredoc.carina`** matches `<<MARKER` / `<<-MARKER` and embeds the same `meta.embedded.expression.carina` rule that the double-quoted-string rule already carries (#2473 / PR #2484), so `${...}` highlights distinctly in the body.
- Both `begin` regexes capture the marker into group 1; the `end` regex back-references it as `^\s*\1\s*$` so each heredoc closes on its own marker, supporting `<<-` indented form via the leading-whitespace allowance.
- Marker scope is `entity.name.tag.heredoc.carina` — a user-chosen identifier delimiter, not a control-flow keyword.

Both grammar files are kept byte-identical per `carina-core/tests/tmlanguage_keyword_parity.rs`.

## Test plan

- [x] `cargo nextest run -p carina-core tmlanguage` — parity test passes (`tmlanguage_has_pascal_case_type_pattern`).
- [x] `bash scripts/check-*.sh` — all five gates green.
- [x] `diff editors/vscode/syntaxes/carina.tmLanguage.json editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` — empty.

## Edge cases verified during 5-round self-review

- Same-line opener (`let x = <<EOT`)
- Multiple heredocs in one document — `\1` back-reference is per-match
- `<<` inside a string literal — string-rule context blocks heredoc match
- Indented body with `<<-` — `meta.embedded.expression.carina` is indentation-agnostic
- Quoted-marker literal stays literal — `<<'EOT'\n${name}\nEOT` does not split

## Notes

- 5-round review fixed scope-name choice: `keyword.control.heredoc.marker.carina` → `entity.name.tag.heredoc.carina`. The marker is a user-chosen identifier delimiter, not a control-flow keyword; the `keyword.control` scope would mis-render the marker as a flow-control keyword in default themes.
- No Rust code changes. The LSP semantic-token path (#2482 / PR #2500) is unchanged — TextMate is the LSP-off fallback that this PR fills in.
