### PR TITLE
formatter: accept 'let X = module_call { ... }' as let-binding RHS

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -195,8 +195,14 @@ fn_local_let = { kw_let ~ trivia+ ~ identifier ~ trivia* ~ equals ~ trivia* ~ ex
 // Variable/resource definition: let name = value
 // discard_pattern allows `let _ = expr` to suppress unused binding warnings
 discard_pattern = @{ "_" }
+// `module_call` is admitted explicitly as a let-binding RHS (issue #2504)
+// for the same reason `use_expr` is — it is not a regular expression in
+// `primary` (see comment on `primary`), but it is a valid RHS surface.
+// `module_call` must be tried before `expression` so the more specific
+// `name { ... }` shape commits before `expression` reaches `variable_ref`
+// and leaves `{ ... }` unconsumed.
 let_binding = {
-    kw_let ~ trivia+ ~ (discard_pattern | identifier) ~ trivia* ~ equals ~ trivia* ~ (use_expr | expression)
+    kw_let ~ trivia+ ~ (discard_pattern | identifier) ~ trivia* ~ equals ~ trivia* ~ (use_expr | module_call | expression)
 }
 
 // Block content: local let bindings, attributes, trivia, nested blocks, or nested elements
@@ -255,6 +261,15 @@ upstream_state_expr = {
 // Primary value
 // `use_expr` is intentionally NOT here — mirrors carina.pest. It is only
 // valid as the RHS of a let binding (see `let_binding`). Issue #2233.
+//
+// `module_call` is also intentionally NOT here. The formatter's
+// `module_call` body accepts `block_content*` (which includes
+// `nested_block`), making it greedy enough to swallow `if cond { x }`
+// or `for x in xs { y { z = 1 } }` whenever the iterable/condition
+// expression hits primary. Restricting module-call to its specific
+// surface — top-level `statement`, `for_body_content`,
+// `if_body_content`, and the let-binding RHS — keeps the grammar
+// unambiguous.
 primary = {
     read_resource_expr
   | upstream_state_expr

--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -411,6 +411,46 @@ mod tests {
         assert!(result.contains("let bucket = aws.s3.Bucket {"));
     }
 
+    // Regression: `if cond { ... }` must keep the condition `cond` on
+    // the same line as `if`, even when a module-call-shaped node sits in
+    // an expression position. An earlier draft of the #2504 fix added
+    // `module_call` to `primary`, which made `cond { body }` parse as a
+    // module call inside the if condition — mangling the formatted
+    // output. The shipped fix scopes module-call to the let-binding RHS.
+    #[test]
+    fn issue_2504_if_cond_with_block_body_unaffected() {
+        let input =
+            "let g = if cond {\n  github { repo = 'a' }\n} else {\n  github { repo = 'b' }\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert!(
+            result.contains("if cond {"),
+            "if condition must stay on the `if` line. Got:\n{}",
+            result
+        );
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
+    }
+
+    #[test]
+    fn issue_2504_let_binding_with_module_call_rhs_renders_inline() {
+        // `let X = module_call { ... }` must format with the module name
+        // on the same line as the `=`, not on its own indented line.
+        let input =
+            "let github = use {\n  source = './m'\n}\n\nlet g = github {\n  repo = 'r'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+
+        assert!(
+            result.contains("let g = github {"),
+            "Module-call RHS should render inline with `let X = name {{`. Got:\n{}",
+            result
+        );
+        // Idempotence
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
+    }
+
     #[test]
     fn test_needs_format() {
         let config = FormatConfig::default();

--- a/carina-core/src/formatter/parser.rs
+++ b/carina-core/src/formatter/parser.rs
@@ -302,4 +302,26 @@ mod tests {
             result.unwrap_err()
         );
     }
+
+    #[test]
+    fn issue_2504_let_binding_with_module_call_rhs() {
+        // `let X = module_call { ... }` is accepted by the main parser
+        // but rejected by the formatter parser. See carina-rs/carina#2504.
+        let input = r#"let github = use {
+  source = '../../../modules/github-oidc'
+}
+
+let github_actions_carina = github {
+  github_repo         = 'carina-rs/infra'
+  role_name           = 'github-actions-carina'
+  managed_policy_arns = ['arn:aws:iam::aws:policy/AdministratorAccess']
+}
+"#;
+        let result = parse(input);
+        assert!(
+            result.is_ok(),
+            "let binding with module call RHS should parse, got: {}",
+            result.unwrap_err()
+        );
+    }
 }

--- a/carina-core/src/formatter/rules/module.rs
+++ b/carina-core/src/formatter/rules/module.rs
@@ -11,7 +11,15 @@ impl Formatter {
 
     pub(in crate::formatter) fn format_module_call(&mut self, node: &CstNode) {
         self.write_indent();
+        self.format_module_call_inline(node);
+        self.write_newline();
+    }
 
+    /// Emit `name { ... }` without the surrounding indent / trailing newline.
+    /// Used when a module call appears as an expression (e.g. the RHS of
+    /// `let X = module_call { ... }`), where the caller has already
+    /// positioned the cursor and is responsible for line breaks.
+    pub(in crate::formatter) fn format_module_call_inline(&mut self, node: &CstNode) {
         // Find and write module name
         for child in &node.children {
             if let CstChild::Token(token) = child
@@ -22,16 +30,7 @@ impl Formatter {
             }
         }
 
-        self.write(" {");
-        self.write_newline();
-        self.current_indent += 1;
-
-        self.format_block_attributes(node);
-
-        self.current_indent -= 1;
-        self.write_indent();
-        self.write("}");
-        self.write_newline();
+        self.format_block_body_tail(node);
     }
 
     /// Format a state block (import, removed, moved)

--- a/carina-core/src/formatter/rules/resource.rs
+++ b/carina-core/src/formatter/rules/resource.rs
@@ -1,7 +1,7 @@
 //! Formatter methods for resources, `let` bindings, and state-mutation
 //! blocks (`import`, `removed`, `moved`).
 
-use super::super::cst::{CstChild, CstNode};
+use super::super::cst::{CstChild, CstNode, NodeKind};
 use super::super::format::Formatter;
 
 impl Formatter {
@@ -100,7 +100,14 @@ impl Formatter {
                 }
                 CstChild::Node(n) => {
                     if found_equals {
-                        self.format_node(n);
+                        // ModuleCall as let-binding RHS: emit inline so we
+                        // get `let X = name { ... }` instead of an indented
+                        // module_call statement on the next line.
+                        if n.kind == NodeKind::ModuleCall {
+                            self.format_module_call_inline(n);
+                        } else {
+                            self.format_node(n);
+                        }
                     }
                 }
                 CstChild::Trivia(_) => {}

--- a/carina-core/tests/fixtures/fmt_smoke/github-oidc/main.crn
+++ b/carina-core/tests/fixtures/fmt_smoke/github-oidc/main.crn
@@ -1,0 +1,14 @@
+# GitHub Actions OIDC for management account
+#
+# Allows GitHub Actions in carina-rs/infra to assume a role
+# with AdministratorAccess for plan/apply.
+
+let github = use {
+  source = '../../../modules/github-oidc'
+}
+
+let github_actions_carina = github {
+  github_repo         = 'carina-rs/infra'
+  role_name           = 'github-actions-carina'
+  managed_policy_arns = ['arn:aws:iam::aws:policy/AdministratorAccess']
+}

--- a/carina-core/tests/fmt_infra_smoke.rs
+++ b/carina-core/tests/fmt_infra_smoke.rs
@@ -79,3 +79,43 @@ fn fmt_idempotent_on_identity_center_fixture() {
         }
     }
 }
+
+// `github-oidc/` mirrors `carina-rs/infra/aws/management/github-oidc/` from
+// issue #2504: `let X = module_call { ... }` is accepted by validate/plan
+// but rejected by the formatter parser, so any infra layout that names a
+// module instantiation (to expose its outputs via `exports.crn`) blocks
+// CI fmt enforcement.
+#[test]
+fn fmt_accepts_github_oidc_fixture() {
+    let dir = fixture_dir("github-oidc");
+    let result = format_all_crn_files(&dir);
+    assert!(
+        result.is_ok(),
+        "`carina fmt` must parse every .crn file in {}. Failures:\n{}",
+        dir.display(),
+        result.unwrap_err()
+    );
+}
+
+#[test]
+fn fmt_idempotent_on_github_oidc_fixture() {
+    let dir = fixture_dir("github-oidc");
+    let config = FormatConfig::default();
+    let entries = fs::read_dir(&dir).expect("read_dir");
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "crn") {
+            let source = fs::read_to_string(&path).expect("read file");
+            let first = format(&source, &config)
+                .unwrap_or_else(|e| panic!("{}: format failed: {}", path.display(), e));
+            let second = format(&first, &config)
+                .unwrap_or_else(|e| panic!("{}: second format failed: {}", path.display(), e));
+            assert_eq!(
+                first,
+                second,
+                "format must be idempotent on {}",
+                path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- The formatter parser rejected `let X = module_call { ... }` (named module instantiation), even though `carina validate` and `carina plan` accept it. CI `carina fmt --check` enforcement was blocked because of this gap.
- Admit `module_call` as a let-binding RHS alternative in `carina_fmt.pest` (the same surface as `use_expr`), instead of putting it in `primary` — putting it in `primary` regresses `if cond { body }` parsing because `cond { body }` is then greedy-matched as a module call.
- Split `format_module_call` into a statement wrapper and an inline helper. The let-binding formatter calls the inline helper so `let X = name { ... }` renders on one line rather than as an indented module-call statement.

## Test plan

- [x] `carina-core/src/formatter/parser.rs::issue_2504_let_binding_with_module_call_rhs` — pest parse-only regression on the full repro from the issue
- [x] `carina-core/src/formatter/format.rs::issue_2504_let_binding_with_module_call_rhs_renders_inline` — format output + idempotence on a synthetic snippet
- [x] `carina-core/src/formatter/format.rs::issue_2504_if_cond_with_block_body_unaffected` — regression guard so the fix doesn't break `if cond { body }` (5-round review caught this in an earlier draft)
- [x] `carina-core/tests/fmt_infra_smoke.rs::fmt_accepts_github_oidc_fixture` / `fmt_idempotent_on_github_oidc_fixture` — directory fixture mirroring `carina-rs/infra/aws/management/github-oidc/`
- [x] `cargo nextest run --workspace` (2831 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --release -p carina-core`
- [x] `scripts/check-provider-boundaries.sh`, `scripts/check-no-direct-resources-access.sh`, `scripts/check-plan-fixtures.sh`, `scripts/validate-crn-files.sh`, `scripts/check-example-warnings.sh`
- [x] Real-infra smoke: `carina fmt --check carina-rs/infra/aws/management/github-oidc/` succeeds

Closes #2504
