### PR TITLE
core: carry export Value through UpstreamExports

### DIFF
--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -22,13 +22,27 @@ use crate::parser::{ProviderContext, ResourceContext, TypeExpr, UpstreamState};
 use crate::resource::{Subscript, Value};
 use crate::schema::{AttributeType, SchemaRegistry, suggest_similar_name};
 
+/// One export's declared type and literal value, as carried through
+/// [`UpstreamExports`]. `type_expr` is `None` when the upstream's
+/// `exports` block omits the annotation and inference can't recover
+/// it. `value` is currently always `Some` (the parser requires
+/// `name = expr`) but is kept `Option` for forward compatibility with
+/// future grammar widenings.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpstreamExportEntry {
+    pub type_expr: Option<TypeExpr>,
+    pub value: Option<Value>,
+}
+
+/// Exports for a single `upstream_state` binding: export name → entry.
+pub type UpstreamExportEntries = HashMap<String, UpstreamExportEntry>;
+
 /// Exports declared by each `upstream_state` binding: binding name →
-/// (export name → declared type, or `None` if the export has no annotation).
-///
-/// Phase 1 (#1990) only needed the key set; Phase 2 (#1992) adds the type
-/// side so downstream consumers whose expected type is known can be checked
-/// for shape compatibility.
-pub type UpstreamExports = HashMap<String, HashMap<String, Option<TypeExpr>>>;
+/// per-export entry map. Carrying the literal `Value` alongside the
+/// `TypeExpr` lets downstream consumers (LSP map-literal-key
+/// completion, future doc tools) read the body without re-parsing
+/// the upstream directory.
+pub type UpstreamExports = HashMap<String, UpstreamExportEntries>;
 
 /// A diagnostic about a `binding.field` reference whose downstream usage
 /// doesn't fit the upstream's exports.
@@ -197,7 +211,7 @@ pub fn resolve_upstream_exports_with_schemas(
                 // are silently dropped here: the upstream's own
                 // validate run reports them, and re-emitting from this
                 // resolver would double-report.
-                let keys: HashMap<String, Option<TypeExpr>> = match schemas {
+                let entries: UpstreamExportEntries = match schemas {
                     Some(s) => {
                         let (inferred, _errors) =
                             crate::validation::inference::apply_inference(parsed, s);
@@ -207,7 +221,15 @@ pub fn resolve_upstream_exports_with_schemas(
                             // Preserve the legacy "no static type"
                             // surface for sentinels — Unknown carries
                             // nothing worth forwarding to the consumer.
-                            .map(|e| (e.name, e.type_expr.into_known()))
+                            .map(|e| {
+                                (
+                                    e.name,
+                                    UpstreamExportEntry {
+                                        type_expr: e.type_expr.into_known(),
+                                        value: e.value,
+                                    },
+                                )
+                            })
                             .collect()
                     }
                     // `schemas` is None (legacy entry point) — forward
@@ -217,10 +239,18 @@ pub fn resolve_upstream_exports_with_schemas(
                     None => parsed
                         .export_params
                         .into_iter()
-                        .map(|e| (e.name, e.type_expr))
+                        .map(|e| {
+                            (
+                                e.name,
+                                UpstreamExportEntry {
+                                    type_expr: e.type_expr,
+                                    value: e.value,
+                                },
+                            )
+                        })
                         .collect(),
                 };
-                out.insert(us.binding.clone(), keys);
+                out.insert(us.binding.clone(), entries);
             }
             Err(reason) => {
                 errors.push(UpstreamResolveError {
@@ -644,7 +674,11 @@ fn check_resource_ref_at_position(
     let Some(keys) = exports.get(binding) else {
         return;
     };
-    let Some(Some(export_type)) = keys.get(field) else {
+    let Some(UpstreamExportEntry {
+        type_expr: Some(export_type),
+        ..
+    }) = keys.get(field)
+    else {
         return;
     };
     let Some(narrowed) = narrow_type_expr(export_type, path.field_path(), path.subscripts()) else {
@@ -804,7 +838,11 @@ pub fn check_upstream_state_for_iterable_shapes<E>(
         let Some(fields) = exports.get(deferred.iterable_binding.as_str()) else {
             continue;
         };
-        let Some(Some(export_type)) = fields.get(&deferred.iterable_attr) else {
+        let Some(UpstreamExportEntry {
+            type_expr: Some(export_type),
+            ..
+        }) = fields.get(&deferred.iterable_attr)
+        else {
             continue;
         };
         let binding_kind = ForIterableBindingKind::from_for_binding(&deferred.binding);
@@ -1000,7 +1038,11 @@ fn visit_attribute_access(
         let Some(fields) = exports.get(binding) else {
             return;
         };
-        let Some(Some(export_type)) = fields.get(attribute) else {
+        let Some(UpstreamExportEntry {
+            type_expr: Some(export_type),
+            ..
+        }) = fields.get(attribute)
+        else {
             return;
         };
         if let Err((mismatched_at, bad_segment)) = walk_type_expr_path(export_type, field_path) {
@@ -1153,7 +1195,11 @@ fn visit_subscript_access(
         let Some(fields) = exports.get(binding) else {
             return;
         };
-        let Some(Some(export_type)) = fields.get(attribute) else {
+        let Some(UpstreamExportEntry {
+            type_expr: Some(export_type),
+            ..
+        }) = fields.get(attribute)
+        else {
             return;
         };
         // If the field path itself doesn't resolve, the
@@ -1224,7 +1270,17 @@ mod tests {
             .map(|(binding, keys)| {
                 (
                     binding.to_string(),
-                    keys.iter().map(|s| (s.to_string(), None)).collect(),
+                    keys.iter()
+                        .map(|s| {
+                            (
+                                s.to_string(),
+                                UpstreamExportEntry {
+                                    type_expr: None,
+                                    value: None,
+                                },
+                            )
+                        })
+                        .collect(),
                 )
             })
             .collect()
@@ -1393,11 +1449,58 @@ mod tests {
             resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
         assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
         let keys = got.get("orgs").expect("resolved");
-        let accounts_ty = keys.get("accounts").expect("accounts export").as_ref();
-        let ty = accounts_ty.expect("type annotation present");
+        let entry = keys.get("accounts").expect("accounts export");
+        let ty = entry.type_expr.as_ref().expect("type annotation present");
         assert!(
             matches!(ty, TypeExpr::Struct { fields } if fields.len() == 2),
             "expected struct with 2 fields, got {ty:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_carries_map_literal_value_alongside_type() {
+        // #2492: each resolved export entry must carry both its declared
+        // `TypeExpr` and the literal `Value` from the upstream's
+        // `exports { }` block. Without the value, downstream consumers
+        // (LSP map-literal-key completion, future doc-extracting tools)
+        // have to re-parse the upstream directory a second time per call.
+        use crate::resource::Value;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let upstream_dir = tmp.path().join("organizations");
+        fs::create_dir(&upstream_dir).unwrap();
+        write_crn(
+            &upstream_dir,
+            "exports.crn",
+            r#"exports {
+                accounts: map(String) = {
+                    registry_prod = "111111111111"
+                    registry_dev  = "222222222222"
+                }
+            }"#,
+        );
+        let base = tmp.path().join("downstream");
+        fs::create_dir(&base).unwrap();
+
+        let (got, errs) =
+            resolve_upstream_exports(&base, &[upstream("orgs", "../organizations")], &ctx());
+        assert!(errs.is_empty(), "unexpected resolve errors: {errs:?}");
+        let entries = got.get("orgs").expect("resolved");
+        let entry = entries.get("accounts").expect("accounts export");
+        assert!(
+            entry.type_expr.is_some(),
+            "type annotation must still be present"
+        );
+        let value = entry.value.as_ref().expect("export value must be carried");
+        let Value::Map(entries) = value else {
+            panic!("expected Value::Map for map literal export, got {value:?}");
+        };
+        let mut keys: Vec<&String> = entries.keys().collect();
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["registry_dev", "registry_prod"],
+            "map literal keys must be reachable from UpstreamExports without re-parsing"
         );
     }
 
@@ -1651,7 +1754,15 @@ mod tests {
                     binding.to_string(),
                     fields
                         .iter()
-                        .map(|(name, ty)| (name.to_string(), Some(ty.clone())))
+                        .map(|(name, ty)| {
+                            (
+                                name.to_string(),
+                                UpstreamExportEntry {
+                                    type_expr: Some(ty.clone()),
+                                    value: None,
+                                },
+                            )
+                        })
                         .collect(),
                 )
             })
@@ -1740,7 +1851,13 @@ mod tests {
         );
         let mut exports: UpstreamExports = HashMap::new();
         let mut fields = HashMap::new();
-        fields.insert("count".to_string(), None);
+        fields.insert(
+            "count".to_string(),
+            UpstreamExportEntry {
+                type_expr: None,
+                value: None,
+            },
+        );
         exports.insert("orgs".to_string(), fields);
         let schemas = schema_with_attr("name", crate::schema::AttributeType::String);
         let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
@@ -2374,7 +2491,13 @@ mod tests {
         );
         let mut exports = UpstreamExports::new();
         let mut fields = HashMap::new();
-        fields.insert("accounts".to_string(), None);
+        fields.insert(
+            "accounts".to_string(),
+            UpstreamExportEntry {
+                type_expr: None,
+                value: None,
+            },
+        );
         exports.insert("orgs".to_string(), fields);
         let errs = check_upstream_state_for_iterable_shapes(&parsed, &exports);
         assert!(errs.is_empty(), "no annotation → silent, got: {errs:?}");
@@ -2799,7 +2922,13 @@ mod tests {
         );
         let mut exports = UpstreamExports::new();
         let mut fields = HashMap::new();
-        fields.insert("account".to_string(), None);
+        fields.insert(
+            "account".to_string(),
+            UpstreamExportEntry {
+                type_expr: None,
+                value: None,
+            },
+        );
         exports.insert("orgs".to_string(), fields);
         let errs = check_upstream_state_attribute_access_shapes(&parsed, &exports);
         assert!(errs.is_empty(), "no annotation → silent, got: {errs:?}");
@@ -3239,7 +3368,13 @@ mod tests {
         );
         let mut exports = UpstreamExports::new();
         let mut fields = HashMap::new();
-        fields.insert("accounts".to_string(), None);
+        fields.insert(
+            "accounts".to_string(),
+            UpstreamExportEntry {
+                type_expr: None,
+                value: None,
+            },
+        );
         exports.insert("orgs".to_string(), fields);
         let errs = check_upstream_state_subscript_shapes(&parsed, &exports);
         assert!(errs.is_empty(), "no annotation → silent, got: {errs:?}");
@@ -3476,7 +3611,7 @@ mod tests {
         let region_type = exports
             .get("ups")
             .and_then(|m| m.get("region"))
-            .and_then(|t| t.as_ref())
+            .and_then(|e| e.type_expr.as_ref())
             .expect("region should be inferred");
         assert_eq!(region_type, &TypeExpr::String);
     }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -135,7 +135,7 @@ impl CompletionProvider {
         let upstream_sources = super::collect_upstream_state_bindings(src);
         let mut exports_cache: std::collections::HashMap<
             String,
-            std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+            carina_core::upstream_exports::UpstreamExportEntries,
         > = std::collections::HashMap::new();
 
         // Type-based reference completions: walk every binding in scope and
@@ -213,8 +213,8 @@ impl CompletionProvider {
                     &self.schemas,
                     &mut exports_cache,
                 );
-                for (export_name, export_type) in exports {
-                    let Some(export_type) = export_type else {
+                for (export_name, entry) in exports {
+                    let Some(export_type) = &entry.type_expr else {
                         continue;
                     };
                     if !carina_core::validation::is_type_expr_compatible_with_schema(
@@ -697,10 +697,10 @@ impl CompletionProvider {
         // phrasing (still useful; tells the user which binding it came from).
         let mut items: Vec<CompletionItem> = keys
             .iter()
-            .map(|(key, type_expr)| CompletionItem {
+            .map(|(key, entry)| CompletionItem {
                 label: key.clone(),
                 kind: Some(CompletionItemKind::FIELD),
-                detail: Some(match type_expr {
+                detail: Some(match &entry.type_expr {
                     Some(t) => format!("export from upstream_state `{}`: {}", binding, t),
                     None => format!("export from upstream_state `{}`", binding),
                 }),
@@ -738,7 +738,10 @@ impl CompletionProvider {
         else {
             return Vec::new();
         };
-        let Some(Some(type_expr)) = keys.get(key) else {
+        let Some(entry) = keys.get(key) else {
+            return Vec::new();
+        };
+        let Some(type_expr) = &entry.type_expr else {
             // Untyped or unknown key: we have no fields to descend into.
             return Vec::new();
         };
@@ -770,20 +773,24 @@ impl CompletionProvider {
                 items
             }
             carina_core::parser::TypeExpr::Map(value_type) => {
-                // Mine the upstream's literal map for its statically-
-                // declared keys. Empty map → empty completion set.
-                // Failure to re-parse the upstream falls back silently
-                // so a transient mid-edit state in the upstream
-                // doesn't take cross-file completion offline. See
-                // #2490.
-                let Some(keys_in_literal) =
-                    resolve_upstream_map_literal_keys(source, key, base_path)
-                else {
+                // Read the upstream's literal map keys from the value
+                // already carried alongside the TypeExpr. Empty map →
+                // empty completion set. A non-Map value (annotation-only
+                // `accounts: map(String)` with no body, or a transient
+                // mid-edit upstream where the body hasn't parsed yet)
+                // also yields no candidates — silently, so cross-file
+                // completion stays online while the user types (#2490).
+                let Some(carina_core::resource::Value::Map(entries)) = &entry.value else {
                     return Vec::new();
                 };
                 let value_type = value_type.to_string();
-                let mut items: Vec<CompletionItem> = keys_in_literal
-                    .into_iter()
+                let mut items: Vec<CompletionItem> = entries
+                    .keys()
+                    // Filter to identifier-shaped keys only. Map literals
+                    // accept string keys in the grammar (`"prod-1" = ...`),
+                    // but `<binding>.<key>` dot access on the consumer
+                    // side only works for identifier keys.
+                    .filter(|k| carina_core::utils::is_identifier_safe(k))
                     .map(|name| CompletionItem {
                         label: name.clone(),
                         // VARIABLE rather than FIELD — these are runtime
@@ -792,7 +799,7 @@ impl CompletionProvider {
                         detail: Some(format!("{}: {}", name, value_type)),
                         text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
                             range,
-                            new_text: name,
+                            new_text: name.clone(),
                         })),
                         ..Default::default()
                     })
@@ -1293,52 +1300,14 @@ impl CompletionProvider {
     }
 }
 
-/// Re-parse the upstream directory and return the literal keys of the
-/// map-typed export named `key`. Used by depth-2 completion to surface
-/// the statically-declared keys of `upstream.<map_export>.<HERE>` —
-/// only the map case calls this, since struct fields come from the
-/// `TypeExpr` and list/scalar exports have no named keys at all.
-///
-/// Returns `None` when `base_path` is missing, the upstream directory
-/// can't be parsed, the named export has no literal value or isn't a
-/// `Value::Map`, or the binding isn't found. The completion handler
-/// treats that the same as "no candidates" — an upstream mid-edit
-/// shouldn't take downstream completion offline. See #2490.
-fn resolve_upstream_map_literal_keys(
-    source: &str,
-    key: &str,
-    base_path: Option<&Path>,
-) -> Option<Vec<String>> {
-    let base = base_path?;
-    let source_abs = base.join(source);
-    if !source_abs.is_dir() {
-        return None;
-    }
-    let parsed =
-        carina_core::config_loader::parse_directory(&source_abs, &Default::default()).ok()?;
-    let export = parsed.export_params.into_iter().find(|e| e.name == key)?;
-    let value = export.value?;
-    let carina_core::resource::Value::Map(entries) = value else {
-        return None;
-    };
-    // Filter to identifier-shaped keys only. Map literals accept string
-    // keys in the grammar (`"prod-1" = ...`), but `<binding>.<key>` dot
-    // access on the consumer side only works for identifier keys —
-    // surfacing a `prod-1` candidate would insert into a position where
-    // it can't be referenced.
-    Some(
-        entries
-            .into_keys()
-            .filter(|k| carina_core::utils::is_identifier_safe(k))
-            .collect(),
-    )
-}
-
-/// Resolve the export name → `TypeExpr` map for an `upstream_state`
+/// Resolve the export name → entry map for an `upstream_state`
 /// binding. Returns `None` when `base_path` is missing or the upstream
 /// directory has no export entry for `binding`. Both depth-1 and
-/// depth-2 dot completion build on this — they only differ in how
-/// they consume the resulting map.
+/// depth-2 dot completion build on this — they only differ in how they
+/// consume the resulting map. Map-literal-key completion (depth-2 over
+/// a `: map(T) = { ... }` export) reads the keys directly from the
+/// entry's `Value`, so there is no second `parse_directory` round-trip
+/// per keystroke.
 ///
 /// Use [`resolve_upstream_exports_cached`] instead when calling from
 /// `value_completions_for_attr`, which has multiple consumers and pays
@@ -1348,7 +1317,7 @@ fn resolve_upstream_export_keys(
     source: &str,
     base_path: Option<&Path>,
     schemas: &carina_core::schema::SchemaRegistry,
-) -> Option<std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>> {
+) -> Option<carina_core::upstream_exports::UpstreamExportEntries> {
     let base = base_path?;
     let upstream = carina_core::parser::UpstreamState {
         binding: binding.to_string(),
@@ -1384,9 +1353,9 @@ fn resolve_upstream_exports_cached<'a>(
     schemas: &carina_core::schema::SchemaRegistry,
     cache: &'a mut std::collections::HashMap<
         String,
-        std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+        carina_core::upstream_exports::UpstreamExportEntries,
     >,
-) -> &'a std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>> {
+) -> &'a carina_core::upstream_exports::UpstreamExportEntries {
     cache.entry(binding.to_string()).or_insert_with(|| {
         resolve_upstream_export_keys(binding, source, base_path, schemas).unwrap_or_default()
     })
@@ -1413,7 +1382,7 @@ fn infer_for_binding_type(
     schemas: &carina_core::schema::SchemaRegistry,
     exports_cache: &mut std::collections::HashMap<
         String,
-        std::collections::HashMap<String, Option<carina_core::parser::TypeExpr>>,
+        carina_core::upstream_exports::UpstreamExportEntries,
     >,
 ) -> Option<carina_core::parser::TypeExpr> {
     use super::top_level::ForBindingSlot;
@@ -1430,16 +1399,18 @@ fn infer_for_binding_type(
                 binding: iterable.binding.clone(),
                 source: std::path::PathBuf::from(source),
             };
-            let (resolved, _errors) =
+            let (mut resolved, _errors) =
                 carina_core::upstream_exports::resolve_upstream_exports_with_schemas(
                     base,
                     &[upstream],
                     &Default::default(),
                     Some(schemas),
                 );
-            resolved.get(&iterable.binding).cloned().unwrap_or_default()
+            // Move the entry out of `resolved` rather than cloning so we
+            // don't pay a deep `Value` clone on the per-keystroke path.
+            resolved.remove(&iterable.binding).unwrap_or_default()
         });
-    let export_type = exports.get(&iterable.export)?.as_ref()?;
+    let export_type = exports.get(&iterable.export)?.type_expr.as_ref()?;
 
     match (export_type, binding.slot) {
         (TypeExpr::List(inner), ForBindingSlot::Value | ForBindingSlot::PairValue) => {


### PR DESCRIPTION
## Summary

- `UpstreamExports` carried only an `Option<TypeExpr>` per export, so the LSP's depth-2 map-literal-key completion (#2490) had to call `parse_directory` a second time to read the literal keys — once per keystroke. For upstreams with large `Value` graphs that re-parse dominates the completion path.
- Widen the inner-map payload to a named `UpstreamExportEntry { type_expr, value }` struct populated alongside the existing `TypeExpr` extraction in the resolver's inference loop. Expose `UpstreamExportEntries = HashMap<String, UpstreamExportEntry>` publicly so the LSP names the same shape carina-core does instead of redefining it.
- LSP `value_completions_for_attr` now reads `entry.value` from the cached resolver result; `resolve_upstream_map_literal_keys` (the duplicate `parse_directory` path) is removed. The four `check_upstream_state_*` fns in `carina-core` switch from `Some(Some(t))` tuple destructure to `UpstreamExportEntry { type_expr: Some(t), .. }` field access.

Closes #2492

## Test plan

- [x] `cargo nextest run --workspace` — 2843 passed (1 new test: `resolve_carries_map_literal_value_alongside_type`; existing 9 depth-2 LSP completion tests still pass)
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass
- [x] `bash scripts/check-*.sh` — all 5 pass