### PR TITLE
config_loader: sort find_crn_files_in_dir output and accept &Path

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
@@ -459,7 +459,7 @@ pub async fn detect_drift(
 }
 
 pub async fn run_apply(
-    path: &PathBuf,
+    path: &Path,
     auto_approve: bool,
     lock: bool,
     reconfigure: bool,
@@ -574,7 +574,7 @@ pub async fn run_apply(
                         .ok_or("Backend does not specify a provider name")?;
 
                     // Append resource definition to backend file
-                    let target_file = backend_file.clone().unwrap_or_else(|| path.clone());
+                    let target_file = backend_file.clone().unwrap_or_else(|| path.to_path_buf());
 
                     let resource_code = backend
                         .resource_definition(&bucket_name)

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
@@ -40,7 +40,7 @@ use crate::wiring::{
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_destroy(
-    path: &PathBuf,
+    path: &Path,
     auto_approve: bool,
     lock: bool,
     refresh: bool,

--- a/carina-cli/src/commands/export.rs
+++ b/carina-cli/src/commands/export.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::Path;
 
 use colored::Colorize;
 
@@ -21,7 +21,7 @@ pub enum OutputFormat {
 
 /// Run the `carina export` command.
 pub async fn run_export(
-    path: &PathBuf,
+    path: &Path,
     name: Option<String>,
     format: OutputFormat,
     provider_context: &ProviderContext,

--- a/carina-cli/src/commands/fmt.rs
+++ b/carina-cli/src/commands/fmt.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use colored::Colorize;
 use similar::{ChangeTag, TextDiff};
@@ -11,12 +11,7 @@ use carina_core::schema::collect_all_block_names;
 use crate::error::AppError;
 use crate::wiring::WiringContext;
 
-pub fn run_fmt(
-    path: &PathBuf,
-    check: bool,
-    show_diff: bool,
-    recursive: bool,
-) -> Result<(), AppError> {
+pub fn run_fmt(path: &Path, check: bool, show_diff: bool, recursive: bool) -> Result<(), AppError> {
     let config = FormatConfig::default();
 
     // Load schemas to get block_name mappings for list-to-block conversion

--- a/carina-cli/src/commands/lint.rs
+++ b/carina-cli/src/commands/lint.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 
@@ -25,7 +25,7 @@ struct LintWarning {
     message: String,
 }
 
-pub fn run_lint(path: &PathBuf, provider_context: &ProviderContext) -> Result<(), AppError> {
+pub fn run_lint(path: &Path, provider_context: &ProviderContext) -> Result<(), AppError> {
     let mut parsed = load_configuration_with_config(
         path,
         provider_context,

--- a/carina-cli/src/commands/module.rs
+++ b/carina-cli/src/commands/module.rs
@@ -37,7 +37,7 @@ pub fn run_module_command(
 
 fn run_module_list(path: &Path, provider_context: &ProviderContext) -> Result<(), AppError> {
     let config = config_loader::load_configuration_with_config(
-        &path.to_path_buf(),
+        path,
         provider_context,
         &carina_core::schema::SchemaRegistry::new(),
     )?;

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -148,8 +148,8 @@ fn format_plan_save_error(e: &carina_core::value::SerializationError, flag: &str
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_plan(
-    path: &PathBuf,
-    out: Option<&PathBuf>,
+    path: &Path,
+    out: Option<&Path>,
     detail: DetailLevel,
     tui: bool,
     refresh: bool,
@@ -679,7 +679,7 @@ async fn build_upstream_backend(
     policy: UpstreamMissingStatePolicy,
 ) -> Result<Box<dyn StateBackend>, AppError> {
     let loaded = load_configuration_with_config(
-        &source_abs.to_path_buf(),
+        source_abs,
         provider_context,
         &carina_core::schema::SchemaRegistry::new(),
     )

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap_complete::engine::{ArgValueCompleter, CompletionCandidate};
 use colored::Colorize;
@@ -204,7 +204,7 @@ pub async fn run_state_command(
 /// Run force-unlock command
 pub async fn run_force_unlock(
     lock_id: &str,
-    path: &PathBuf,
+    path: &Path,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let parsed = load_configuration_with_config(
@@ -240,7 +240,7 @@ pub async fn run_force_unlock(
 
 /// Load the state file from the backend (or local file), without acquiring a lock.
 async fn load_state_file(
-    path: &PathBuf,
+    path: &Path,
     provider_context: &ProviderContext,
 ) -> Result<StateFile, AppError> {
     let loaded = load_configuration_with_config(
@@ -284,10 +284,7 @@ fn format_state_list(state: &StateFile) -> Vec<String> {
 }
 
 /// Run state list command
-async fn run_state_list(
-    path: &PathBuf,
-    provider_context: &ProviderContext,
-) -> Result<(), AppError> {
+async fn run_state_list(path: &Path, provider_context: &ProviderContext) -> Result<(), AppError> {
     let state = load_state_file(path, provider_context).await?;
 
     if state.resources.is_empty() {
@@ -344,7 +341,7 @@ fn format_state_lookup(
 /// Run state lookup command
 async fn run_state_lookup(
     query: &str,
-    path: &PathBuf,
+    path: &Path,
     json_output: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
@@ -410,7 +407,7 @@ fn format_state_show(state: &StateFile) -> String {
 
 /// Run state show command
 async fn run_state_show(
-    path: &PathBuf,
+    path: &Path,
     tui: bool,
     json: bool,
     provider_context: &ProviderContext,
@@ -457,7 +454,7 @@ fn format_raw_value(value: &serde_json::Value) -> String {
 async fn run_state_bucket_delete(
     bucket_name: &str,
     force: bool,
-    path: &PathBuf,
+    path: &Path,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
     let parsed = load_configuration_with_config(
@@ -573,7 +570,7 @@ async fn run_state_bucket_delete(
 
 /// Run state refresh command
 pub async fn run_state_refresh(
-    path: &PathBuf,
+    path: &Path,
     lock: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {
@@ -925,7 +922,7 @@ fn diff_display_update_resource(
 /// 5. Prompts to delete the local file (unless `--auto-approve`)
 /// 6. Updates `carina-backend.lock` with the new remote config
 async fn run_state_migrate(
-    path: &PathBuf,
+    path: &Path,
     auto_approve: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {

--- a/carina-cli/src/commands/validate.rs
+++ b/carina-cli/src/commands/validate.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 use serde::Serialize;
@@ -49,7 +49,7 @@ struct ValidateWarning {
 ///
 /// Not used outside test code.
 pub fn validate_with_factories(
-    path: &PathBuf,
+    path: &Path,
     factories: Vec<Box<dyn carina_core::provider::ProviderFactory>>,
 ) -> Vec<String> {
     let provider_context = ProviderContext::default();
@@ -106,7 +106,7 @@ fn format_inference_errors(
 }
 
 pub fn run_validate(
-    path: &PathBuf,
+    path: &Path,
     json: bool,
     provider_context: &ProviderContext,
 ) -> Result<(), AppError> {

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -319,7 +319,7 @@ async fn main() {
     {
         match run_plan(
             &path,
-            out.as_ref(),
+            out.as_deref(),
             detail,
             tui,
             refresh,

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -44,7 +44,7 @@ pub struct LoadedConfig {
 }
 
 /// Load configuration from a directory containing .crn files
-pub fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
+pub fn load_configuration(path: &Path) -> Result<LoadedConfig, String> {
     load_configuration_with_config(path, &ProviderContext::default(), &SchemaRegistry::new())
 }
 
@@ -52,7 +52,7 @@ pub fn load_configuration(path: &PathBuf) -> Result<LoadedConfig, String> {
 ///
 /// File paths are rejected — pass a directory instead.
 pub fn load_configuration_with_config(
-    path: &PathBuf,
+    path: &Path,
     config: &ProviderContext,
     schemas: &SchemaRegistry,
 ) -> Result<LoadedConfig, String> {
@@ -226,8 +226,7 @@ pub fn parse_directory_with_overrides(
     config: &ProviderContext,
     overrides: &HashMap<String, String>,
 ) -> Result<ParsedFile, String> {
-    let dir_buf = dir.to_path_buf();
-    let files = find_crn_files_in_dir(&dir_buf)?;
+    let files = find_crn_files_in_dir(dir)?;
     let mut paths: Vec<(std::path::PathBuf, String)> = files
         .into_iter()
         .filter_map(|p| {
@@ -239,7 +238,7 @@ pub fn parse_directory_with_overrides(
     // buffer the user hasn't saved). Keep the list de-duplicated by name.
     for name in overrides.keys() {
         if !paths.iter().any(|(_, n)| n == name) {
-            paths.push((dir_buf.join(name), name.clone()));
+            paths.push((dir.join(name), name.clone()));
         }
     }
     if paths.is_empty() {
@@ -324,13 +323,13 @@ pub fn get_base_dir(path: &Path) -> &Path {
 }
 
 /// Find all .crn files recursively in a directory, skipping hidden dirs, target, and node_modules
-pub fn find_crn_files_recursive(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
+pub fn find_crn_files_recursive(dir: &Path) -> Result<Vec<PathBuf>, String> {
     let mut files = Vec::new();
     collect_crn_files_recursive(dir, &mut files)?;
     Ok(files)
 }
 
-fn collect_crn_files_recursive(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Result<(), String> {
+fn collect_crn_files_recursive(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
     let entries = fs::read_dir(dir)
         .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
 
@@ -352,8 +351,14 @@ fn collect_crn_files_recursive(dir: &PathBuf, files: &mut Vec<PathBuf>) -> Resul
     Ok(())
 }
 
-/// Find .crn files in a single directory (non-recursive)
-pub fn find_crn_files_in_dir(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
+/// Find .crn files in a single directory (non-recursive).
+///
+/// The returned paths are sorted by `PathBuf` ordering, which for a
+/// single-directory listing degenerates to filename order. Callers that
+/// walk siblings independently (rather than going through
+/// `parse_directory`'s merge path) get deterministic order across
+/// filesystems (#2449).
+pub fn find_crn_files_in_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
     let entries = fs::read_dir(dir)
         .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
 
@@ -365,6 +370,7 @@ pub fn find_crn_files_in_dir(dir: &PathBuf) -> Result<Vec<PathBuf>, String> {
             files.push(path);
         }
     }
+    files.sort();
     Ok(files)
 }
 
@@ -403,13 +409,41 @@ mod tests {
         fs::write(dir.join("a.crn"), "").unwrap();
         fs::write(dir.join("b.crn"), "").unwrap();
 
-        let mut result = find_crn_files_in_dir(&dir).unwrap();
-        result.sort();
+        let result = find_crn_files_in_dir(&dir).unwrap();
         assert_eq!(result.len(), 2);
         assert!(result[0].ends_with("a.crn"));
         assert!(result[1].ends_with("b.crn"));
         cleanup(&dir);
     }
+
+    #[test]
+    fn find_crn_files_in_dir_returns_paths_sorted_by_name() {
+        // #2449: callers that walk siblings independently (rather than
+        // through `parse_directory`'s merge path) used to inherit the
+        // filesystem-dependent order. Pin lexicographic order so first-
+        // match-wins lookups are deterministic across ext4 / APFS / tmpfs.
+        // Insert the files in reverse name order to defeat the common
+        // "creation order == listing order" fallback on tmpfs.
+        let dir = create_temp_dir("in_dir_sorted");
+        for name in ["z.crn", "m.crn", "a.crn", "providers.crn", "main.crn"] {
+            fs::write(dir.join(name), "").unwrap();
+        }
+        let result = find_crn_files_in_dir(&dir).unwrap();
+        let names: Vec<String> = result
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["a.crn", "m.crn", "main.crn", "providers.crn", "z.crn"]
+        );
+        cleanup(&dir);
+    }
+
+    // #2465: pin the signature as `&Path`-accepting at compile time, so a
+    // future revert to `&PathBuf` fails to build instead of silently
+    // re-introducing the `.to_path_buf()` ceremony at every LSP callsite.
+    const _: fn(&Path) -> Result<Vec<PathBuf>, String> = find_crn_files_in_dir;
 
     #[test]
     fn find_crn_files_in_dir_ignores_non_crn_files() {

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -430,8 +430,7 @@ impl DiagnosticEngine {
         base_path: &std::path::Path,
     ) -> HashSet<String> {
         let mut out: HashSet<String> = HashSet::new();
-        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(&base_path.to_path_buf())
-        else {
+        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(base_path) else {
             return out;
         };
         for file in files {
@@ -1586,8 +1585,7 @@ impl DiagnosticEngine {
         if let Some(parsed) = doc.parsed() {
             out.extend(parsed.user_functions.keys().cloned());
         }
-        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(&base_path.to_path_buf())
-        else {
+        let Ok(files) = carina_core::config_loader::find_crn_files_in_dir(base_path) else {
             return out;
         };
         for file in files {

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -26,13 +26,7 @@ fn find_use_import_path(
     {
         return Some(import.path.clone());
     }
-    let mut files =
-        carina_core::config_loader::find_crn_files_in_dir(&base_path.to_path_buf()).ok()?;
-    // `find_crn_files_in_dir` does not sort; rely on a deterministic
-    // walk so the result is stable when two siblings happen to
-    // declare the same alias (rare, but the user shouldn't see
-    // different hovers across filesystems).
-    files.sort();
+    let files = carina_core::config_loader::find_crn_files_in_dir(base_path).ok()?;
     let ctx = doc.provider_context();
     for file in files {
         let file_name = file.file_name().and_then(|n| n.to_str());


### PR DESCRIPTION
## Summary

Closes #2449.
Closes #2465.

Two related changes to the `config_loader` directory-listing API:

- **#2449**: `find_crn_files_in_dir` now sorts its output by `PathBuf` ordering. Callers that walked siblings independently (rather than going through `parse_directory`'s merge path) were inheriting filesystem-dependent order — first-match-wins lookups produced different results across ext4 / APFS / tmpfs.
- **#2465**: signature changes from `&PathBuf` to `&Path` so LSP callsites stop allocating a `PathBuf` per call just to satisfy the parameter type.

## Why one PR

The two changes touch the same function and the determinism guarantee removes a workaround that the signature change would otherwise leave behind: `carina-lsp/src/hover.rs` was sorting the result on the caller side because the callee did not. Bundling the two means the hover-side `files.sort()` workaround disappears in the same diff that introduces the contract.

## Why the cascade into CLI / module commands

`load_configuration_with_config` and its wrapper `load_configuration` both took `&PathBuf` previously. Inside their bodies the only `&PathBuf`-specific usage was the call to `find_crn_files_in_dir(path)` — once `find_crn_files_in_dir` accepts `&Path`, clippy's `ptr_arg` lint stops being suppressed and starts flagging the wrapper signatures. The lint then chains through every `pub fn run_*` in `carina-cli/src/commands/` that calls `load_configuration_with_config`, since each of them also sees its `path: &PathBuf` argument flagged once the call inside no longer pins the `PathBuf` shape.

All of these signature loosenings are mechanically forced by the topic ("`config_loader` `.crn`-listing API takes `&Path`"). Loosening a parameter from `&PathBuf` to `&Path` is strictly an API expansion: every existing caller still type-checks via `Deref<Target = Path>`. The only callsite-side adjustments needed were:

- `apply/mod.rs:577`: `path.clone()` (which on `&Path` returns `&Path`) → `path.to_path_buf()` (returns `PathBuf`, matching the surrounding `Option<PathBuf>`).
- `main.rs:322`: `out.as_ref()` (`Option<&PathBuf>`) → `out.as_deref()` (`Option<&Path>`).
- `module.rs:40`, `plan.rs:682`: dropped redundant `&path.to_path_buf()` shims now that the callee accepts `&Path` directly.

`find_crn_files_recursive` and its private helper `collect_crn_files_recursive` were also loosened to `&Path` for consistency with the sibling `find_crn_files_in_dir` and because `fmt`'s caller chain wires them together.

## Hidden bug fixed as a side effect

`parse_directory_with_overrides` merges per-file `ParsedFile` content via `extend` calls on `HashMap`s (providers, resources, variables, uses, …) and a `backend = Some(...)` assignment. Last-wins on key collision means precedence depended on the previous filesystem-dependent listing order. Sorting in `find_crn_files_in_dir` makes that precedence deterministic across platforms — strictly an improvement over the pre-fix behavior.

## Test plan

- `find_crn_files_in_dir_returns_paths_sorted_by_name` (new): inserts `["z.crn", "m.crn", "a.crn", "providers.crn", "main.crn"]` into a temp dir in reverse name order (to defeat the "creation order = listing order" fallback on tmpfs) and asserts the result is `["a.crn", "m.crn", "main.crn", "providers.crn", "z.crn"]`.
- `find_crn_files_in_dir_with_crn_files` (modified): dropped the caller-side `result.sort()`, since the contract now guarantees sorted output. Asserts the same ordering as before, but now without the workaround.
- `const _: fn(&Path) -> Result<Vec<PathBuf>, String> = find_crn_files_in_dir;` (new compile-time assertion): pins the `&Path`-accepting signature so a future revert to `&PathBuf` fails the build instead of silently re-introducing the `.to_path_buf()` ceremony at every callsite.

Verify checklist:

- [x] `cargo nextest run --workspace` (2843 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
