### PR TITLE
inference: cycle-detect Virtual binding chains via visited-set

### DIFF
--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -63,6 +63,15 @@ pub enum InferenceError {
     /// Could not look up the binding's resource schema (provider
     /// not loaded, etc.).
     SchemaUnavailable { binding: String },
+    /// Inference re-entered a `Virtual` binding it was already
+    /// resolving — a cycle in the module-call attribute graph. Today
+    /// the parser and module resolver reject module-of-module cycles,
+    /// so this is reachable only via hand-constructed bindings or a
+    /// future refactor that breaks that invariant; the variant is the
+    /// inferer's defense in depth (#2497). `cycle` records the
+    /// binding-name path in the order they were entered, so the
+    /// diagnostic can name which bindings closed the loop.
+    CyclicVirtualBinding { cycle: Vec<String> },
 }
 
 impl std::fmt::Display for InferenceError {
@@ -83,6 +92,9 @@ impl std::fmt::Display for InferenceError {
             }
             InferenceError::SchemaUnavailable { binding } => {
                 write!(f, "no schema available for binding `{}`", binding)
+            }
+            InferenceError::CyclicVirtualBinding { cycle } => {
+                write!(f, "cyclic virtual binding chain: {}", cycle.join(" -> "))
             }
         }
     }
@@ -259,6 +271,24 @@ pub fn infer_type_from_value(
     bindings: &InferenceBindings,
     schemas: &SchemaRegistry,
 ) -> Result<TypeExpr, InferenceError> {
+    let mut visiting = indexmap::IndexSet::new();
+    infer_type_from_value_with_visiting(value, bindings, schemas, &mut visiting)
+}
+
+/// Internal core of [`infer_type_from_value`] threading the
+/// currently-being-resolved `Virtual` binding chain through the
+/// recursive calls. Cycle detection lives on the `Virtual` arm of
+/// [`infer_resource_ref_with_visiting`] (#2497); every other arm just
+/// forwards the set unchanged. The set is scope-popped when each
+/// `Virtual` recursion returns, so unrelated sibling traversals (two
+/// list elements that each resolve through different `Virtual`
+/// bindings) do not see each other.
+fn infer_type_from_value_with_visiting(
+    value: &Value,
+    bindings: &InferenceBindings,
+    schemas: &SchemaRegistry,
+    visiting: &mut indexmap::IndexSet<String>,
+) -> Result<TypeExpr, InferenceError> {
     match value {
         Value::String(_) => Ok(TypeExpr::String),
         Value::Int(_) => Ok(TypeExpr::Int),
@@ -266,15 +296,18 @@ pub fn infer_type_from_value(
         Value::Bool(_) => Ok(TypeExpr::Bool),
         Value::Interpolation(_) => Ok(TypeExpr::String),
         Value::Secret(_) => Ok(TypeExpr::String),
-        Value::List(items) => infer_collection(items, bindings, schemas, TypeExpr::List),
-        Value::Map(entries) => infer_collection(entries.values(), bindings, schemas, TypeExpr::Map),
-        Value::ResourceRef { path } => infer_resource_ref(
+        Value::List(items) => infer_collection(items, bindings, schemas, visiting, TypeExpr::List),
+        Value::Map(entries) => {
+            infer_collection(entries.values(), bindings, schemas, visiting, TypeExpr::Map)
+        }
+        Value::ResourceRef { path } => infer_resource_ref_with_visiting(
             path.binding(),
             path.attribute(),
             path.field_path(),
             path.subscripts(),
             bindings,
             schemas,
+            visiting,
         ),
         Value::FunctionCall { name, .. } => infer_function_call(name),
         Value::Unknown(_) => Err(InferenceError::UnknownType {
@@ -287,6 +320,7 @@ fn infer_collection<'a, I, F>(
     items: I,
     bindings: &InferenceBindings,
     schemas: &SchemaRegistry,
+    visiting: &mut indexmap::IndexSet<String>,
     wrap: F,
 ) -> Result<TypeExpr, InferenceError>
 where
@@ -303,7 +337,7 @@ where
     // can add an explicit annotation to the export.
     let mut iter = items.into_iter();
     let first = match iter.next() {
-        Some(v) => infer_type_from_value(v, bindings, schemas)?,
+        Some(v) => infer_type_from_value_with_visiting(v, bindings, schemas, visiting)?,
         None => {
             return Err(InferenceError::UnknownType {
                 reason: "empty collection — element type cannot be inferred".to_string(),
@@ -311,7 +345,7 @@ where
         }
     };
     for next in iter {
-        let next_type = infer_type_from_value(next, bindings, schemas)?;
+        let next_type = infer_type_from_value_with_visiting(next, bindings, schemas, visiting)?;
         if next_type != first {
             return Err(InferenceError::HeterogeneousCollection {
                 reason: format!(
@@ -324,13 +358,14 @@ where
     Ok(wrap(Box::new(first)))
 }
 
-fn infer_resource_ref(
+fn infer_resource_ref_with_visiting(
     binding: &str,
     attribute: &str,
     field_path: &[String],
     subscripts: &[crate::resource::Subscript],
     bindings: &InferenceBindings,
     schemas: &SchemaRegistry,
+    visiting: &mut indexmap::IndexSet<String>,
 ) -> Result<TypeExpr, InferenceError> {
     let target = match bindings.get(binding) {
         Some(InferenceBinding::Resource {
@@ -347,6 +382,7 @@ fn infer_resource_ref(
             // `attributes { ... }` projections directly. Recurse on the
             // bound expression so the type flows transitively through
             // the inner resource's schema. #2493.
+            //
             let inner =
                 attributes
                     .get(attribute)
@@ -354,7 +390,26 @@ fn infer_resource_ref(
                         binding: binding.to_string(),
                         attribute: attribute.to_string(),
                     })?;
-            let inner_type = infer_type_from_value(inner, bindings, schemas)?;
+            // #2497: register the binding in `visiting` before the
+            // recursive descend; on a cycle (`a -> b -> a`) the second
+            // entry's `insert` returns `false` and we surface the
+            // chain as a `CyclicVirtualBinding` diagnostic instead of
+            // looping until stack exhaustion. Pop the binding back off
+            // once the recursion returns so unrelated sibling subtrees
+            // (e.g. two list elements that each resolve through
+            // different `Virtual` bindings) do not see each other.
+            // Use `shift_remove` (not `swap_remove`) so the cycle
+            // diagnostic preserves entry order if the next traversal
+            // re-enters after this pop.
+            if !visiting.insert(binding.to_string()) {
+                let mut cycle: Vec<String> = visiting.iter().cloned().collect();
+                cycle.push(binding.to_string());
+                return Err(InferenceError::CyclicVirtualBinding { cycle });
+            }
+            let inner_type_result =
+                infer_type_from_value_with_visiting(inner, bindings, schemas, visiting);
+            visiting.shift_remove(binding);
+            let inner_type = inner_type_result?;
             return super::narrow_type_expr(&inner_type, field_path, subscripts).ok_or_else(|| {
                 InferenceError::UnknownAttribute {
                     binding: binding.to_string(),
@@ -1324,5 +1379,123 @@ mod tests {
         let (inferred, errors) = apply_inference(parsed, &SchemaRegistry::new());
         assert!(errors.is_empty());
         assert_eq!(inferred.export_params[0].type_expr, TypeExpr::Unknown);
+    }
+
+    /// Convenience for the `Virtual`-binding cycle tests below.
+    fn virtual_binding(attrs: &[(&str, Value)]) -> InferenceBinding {
+        let mut map = indexmap::IndexMap::new();
+        for (k, v) in attrs {
+            map.insert((*k).to_string(), v.clone());
+        }
+        InferenceBinding::Virtual { attributes: map }
+    }
+
+    #[test]
+    fn virtual_binding_two_node_cycle_reports_cycle_path() {
+        // #2497: a synthetic 2-binding `Virtual` cycle (`a.x -> b.y ->
+        // a.x`) must be detected as a cycle and surface the chain in
+        // the diagnostic, not loop until stack exhaustion. Parser and
+        // module resolver reject module-of-module cycles in practice,
+        // so this shape is reachable today only via hand-constructed
+        // bindings (or a future refactor that breaks the no-cycle
+        // invariant); the inferer's defense in depth is what this test
+        // pins.
+        let mut bindings = InferenceBindings::new();
+        bindings.insert(
+            "a".to_string(),
+            virtual_binding(&[(
+                "x",
+                Value::resource_ref("b".to_string(), "y".to_string(), vec![]),
+            )]),
+        );
+        bindings.insert(
+            "b".to_string(),
+            virtual_binding(&[(
+                "y",
+                Value::resource_ref("a".to_string(), "x".to_string(), vec![]),
+            )]),
+        );
+
+        let entry = Value::resource_ref("a".to_string(), "x".to_string(), vec![]);
+        let r = infer_type_from_value(&entry, &bindings, &SchemaRegistry::new());
+        match r {
+            Err(InferenceError::CyclicVirtualBinding { cycle }) => {
+                assert_eq!(
+                    cycle,
+                    vec!["a".to_string(), "b".to_string(), "a".to_string()],
+                    "cycle must record entry order with the closing binding repeated"
+                );
+                assert_eq!(
+                    cycle.first(),
+                    cycle.last(),
+                    "first and last entries must match for the cycle to be visually obvious"
+                );
+            }
+            other => panic!(
+                "expected CyclicVirtualBinding error for 2-binding Virtual cycle, got: {other:?}"
+            ),
+        }
+    }
+
+    #[test]
+    fn virtual_binding_self_cycle_reports_cycle_path() {
+        // #2497 edge case: a 1-binding self-referential `Virtual`
+        // (`a.x -> a.x`) must also surface as a cycle, not loop. The
+        // visited-set must register the binding at entry, before the
+        // recursive descend.
+        let mut bindings = InferenceBindings::new();
+        bindings.insert(
+            "a".to_string(),
+            virtual_binding(&[(
+                "x",
+                Value::resource_ref("a".to_string(), "x".to_string(), vec![]),
+            )]),
+        );
+
+        let entry = Value::resource_ref("a".to_string(), "x".to_string(), vec![]);
+        let r = infer_type_from_value(&entry, &bindings, &SchemaRegistry::new());
+        match r {
+            Err(InferenceError::CyclicVirtualBinding { cycle }) => {
+                assert_eq!(
+                    cycle,
+                    vec!["a".to_string(), "a".to_string()],
+                    "self-cycle must record the binding twice (entry + closure)"
+                );
+            }
+            other => panic!("expected CyclicVirtualBinding error for self-cycle, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn virtual_binding_two_unrelated_visits_do_not_false_positive() {
+        // Defensive: visiting `a` and then (after returning) visiting
+        // `b` from a sibling collection element must NOT trip the cycle
+        // guard. Pins that the visited-set is scope-popped between
+        // sibling subtrees rather than accumulating across unrelated
+        // traversals — a naive `&mut HashSet` that only ever grows
+        // would surface a false-positive cycle here.
+        let mut bindings = InferenceBindings::new();
+        bindings.insert(
+            "a".to_string(),
+            virtual_binding(&[("x", Value::String("hi".to_string()))]),
+        );
+        bindings.insert(
+            "b".to_string(),
+            virtual_binding(&[("y", Value::String("there".to_string()))]),
+        );
+
+        // List of two refs to *different* Virtual bindings. After the
+        // first ref returns, the visited-set must no longer contain `a`
+        // when the second ref descends into `b`.
+        let entries = Value::List(vec![
+            Value::resource_ref("a".to_string(), "x".to_string(), vec![]),
+            Value::resource_ref("b".to_string(), "y".to_string(), vec![]),
+        ]);
+        let r = infer_type_from_value(&entries, &bindings, &SchemaRegistry::new());
+        assert_eq!(
+            r,
+            Ok(TypeExpr::List(Box::new(TypeExpr::String))),
+            "sibling Virtual visits must not trigger a false cycle"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #2497.

`InferenceBinding::Virtual`'s arm in `infer_resource_ref` (added by #2493) recursively calls `infer_type_from_value` on a virtual binding's bound expression. If that expression is itself a `Value::ResourceRef` to another `Virtual` binding, inference reenters `infer_resource_ref` with no visited-set or depth cap. Today the parser and module resolver reject module-of-module cycles, so the recursion always terminates at a real `Resource` binding — but the inference layer has no defense in depth, and a future change to module expansion (or a hand-constructed `ParsedFile` in a unit test) would loop until stack exhaustion.

## Fix

Thread an `IndexSet<String>` `visiting` through the recursive helpers. Cycle detection lives on the `Virtual` arm only — every other arm forwards the set unchanged. On a cycle (`a -> b -> a`) the second `insert("a")` returns `false` and we surface a new `InferenceError::CyclicVirtualBinding { cycle: Vec<String> }` diagnostic naming the binding chain. The set is scope-popped via `shift_remove` once each `Virtual` recursion returns, so unrelated sibling subtrees (e.g. two list elements that resolve through different `Virtual` bindings) do not see each other.

## Why visited-set, not depth cap

The issue floated two design options: a depth cap (e.g. 32 levels) or a visited-set. Visited-set was picked for two reasons:

1. **Diagnostic precision.** `CyclicVirtualBinding { cycle: ["a", "b", "a"] }` names the loop. A depth-cap diagnostic ("module-call recursion depth exceeded") would just say "too deep" — leaving the user to guess whether they hit a cycle or a legitimately deep nesting.
2. **No magic number.** A depth cap is a guess about future workloads. The visited-set respects the actual invariant (no cycle ⇒ finite depth) and removes a number that would otherwise be debated when a legitimately deep module graph runs into it.

The pub `infer_type_from_value` signature is unchanged: it allocates a fresh `IndexSet` and forwards to the new internal `infer_type_from_value_with_visiting` (and `infer_resource_ref_with_visiting`). All existing callers — including `infer_type_expr` and `apply_inference` — are unaffected.

The `_with_<param>` naming follows the established carina-core convention (`load_configuration_with_config`, `parse_directory_with_overrides`, `resolve_upstream_exports_with_schemas`).

## Side notes

- `shift_remove` (not `swap_remove`) so the cycle path preserves entry order if the next traversal re-enters after a pop.
- Attribute lookup hoisted *before* `visiting.insert` so a missing attribute on the `Virtual` does not register/unregister the binding.
- The 4 DFS-with-cycle-detection sites in the workspace (`deps.rs::compute_depth`, `deps.rs::topological_sort::visit`, `module_resolver/resolver.rs`, and now `inference.rs`) all inline their own cycle scaffolding. Folding them into a generic helper would touch four unrelated subsystems and is left as a follow-up.

## Test plan

- `virtual_binding_two_node_cycle_reports_cycle_path` (new): synthetic `a.x -> b.y -> a.x` cycle. Asserts `cycle == ["a", "b", "a"]` (entry order, closing binding repeated) plus `first == last`.
- `virtual_binding_self_cycle_reports_cycle_path` (new): synthetic `a.x -> a.x`. Asserts `cycle == ["a", "a"]`.
- `virtual_binding_two_unrelated_visits_do_not_false_positive` (new): list of two refs to different `Virtual` bindings. Pins that the visited-set is scope-popped between sibling subtrees, not accumulated globally — a naive monotonic `&mut HashSet` would surface a false-positive cycle here.
- `virtual_binding(attrs)` helper extracted to keep the cycle-topology readable in each test.

Verify checklist:

- [x] `cargo nextest run --workspace` (2847 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
