### PR TITLE
core: add Value::StringList canonical form + canonicalize_with_type

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -167,6 +167,12 @@ pub(crate) fn dsl_value_to_json(
                 .collect::<Result<_, _>>()?;
             Ok(Some(serde_json::Value::Array(json_items)))
         }
+        Value::StringList(items) => Ok(Some(serde_json::Value::Array(
+            items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+        ))),
         Value::Map(map) => {
             let json_map: serde_json::Map<String, serde_json::Value> = map
                 .iter()

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -417,6 +417,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Float(_) => "Float",
         Value::Bool(_) => "Bool",
         Value::List(_) => "List",
+        Value::StringList(_) => "StringList",
         Value::Map(_) => "Map",
         Value::ResourceRef { .. } => "ResourceRef",
         Value::Interpolation(_) => "Interpolation",

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -164,6 +164,10 @@ fn deterministic_value_string(value: &Value) -> String {
             let parts: Vec<String> = items.iter().map(deterministic_value_string).collect();
             format!("List([{}])", parts.join(", "))
         }
+        Value::StringList(items) => {
+            let parts: Vec<String> = items.iter().map(|s| format!("{:?}", s)).collect();
+            format!("StringList([{}])", parts.join(", "))
+        }
         Value::Map(map) => {
             let mut entries: Vec<(&String, &Value)> = map.iter().collect();
             entries.sort_by_key(|(k, _)| *k);

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -145,6 +145,16 @@ fn format_value(value: &Value) -> String {
                 format!("[{} items]", items.len())
             }
         }
+        Value::StringList(items) => {
+            if items.is_empty() {
+                "[]".to_string()
+            } else if items.len() <= 3 {
+                let strs: Vec<_> = items.iter().map(|s| format!("\"{}\"", s)).collect();
+                format!("[{}]", strs.join(", "))
+            } else {
+                format!("[{} items]", items.len())
+            }
+        }
         Value::Map(map) => {
             if map.is_empty() {
                 "{}".to_string()

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -12,7 +12,11 @@ use crate::resource::Value;
 /// Check whether a Value is fully static (no runtime dependencies).
 pub(crate) fn is_static_value(value: &Value) -> bool {
     match value {
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => true,
+        Value::String(_)
+        | Value::Int(_)
+        | Value::Float(_)
+        | Value::Bool(_)
+        | Value::StringList(_) => true,
         Value::List(items) => items.iter().all(is_static_value),
         Value::Map(map) => map.values().all(is_static_value),
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -54,6 +54,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::Float(_) => "float",
         Value::Bool(_) => "bool",
         Value::List(_) => "list",
+        Value::StringList(_) => "list",
         Value::Map(_) => "map",
         Value::ResourceRef { .. } => "resource reference",
         Value::Interpolation(_) => "string",

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -314,6 +314,20 @@ pub enum Value {
     Float(f64),
     Bool(bool),
     List(Vec<Value>),
+    /// Canonical form for fields whose schema type is
+    /// `Union(vec![String, list(String)])` — the IAM-style
+    /// `string_or_list_of_strings` shape. AWS normalizes single-element
+    /// list condition values back to scalars, so a desired `["x"]` and
+    /// the actual `"x"` would otherwise diff forever. Carrying the
+    /// canonical shape in the type system makes the divergence
+    /// impossible at the differ boundary. See #2481, #2510.
+    ///
+    /// Producers must always go through
+    /// [`crate::value::canonicalize_with_type`] — never construct
+    /// `StringList` directly from user input or wire data without the
+    /// type, because the canonicalization decision depends on the
+    /// declared `AttributeType`.
+    StringList(Vec<String>),
     Map(IndexMap<String, Value>),
     /// Reference to another resource's attribute via an access path.
     ///
@@ -408,6 +422,7 @@ impl PartialEq for Value {
             (Value::Float(a), Value::Float(b)) => a == b,
             (Value::Bool(a), Value::Bool(b)) => a == b,
             (Value::List(a), Value::List(b)) => a == b,
+            (Value::StringList(a), Value::StringList(b)) => a == b,
             (Value::Map(a), Value::Map(b)) => a == b,
             (Value::ResourceRef { path: a }, Value::ResourceRef { path: b }) => a == b,
             (Value::Interpolation(a), Value::Interpolation(b)) => a == b,
@@ -600,7 +615,11 @@ impl Value {
                 }
             }
             Value::Secret(inner) => inner.visit_refs(f),
-            Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) => {}
+            Value::String(_)
+            | Value::Int(_)
+            | Value::Float(_)
+            | Value::Bool(_)
+            | Value::StringList(_) => {}
             // `Value::Unknown` is what a previously-unresolved
             // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.
             // It carries an `AccessPath` for display, but it is no longer
@@ -677,6 +696,21 @@ impl Value {
                 let mut sum_hash: u64 = 0;
                 for item in items {
                     sum_hash = sum_hash.wrapping_add(item.canonical_hash());
+                }
+                sum_hash.hash(hasher);
+            }
+            Value::StringList(items) => {
+                // Hash with the same order-independent shape as
+                // `Value::List` so that a `List([String("x")])` and a
+                // `StringList(vec!["x"])` cannot collide on hash equality
+                // (the outer discriminant separates them) but each
+                // individually preserves the merge-list invariant.
+                items.len().hash(hasher);
+                let mut sum_hash: u64 = 0;
+                for s in items {
+                    let mut h = std::collections::hash_map::DefaultHasher::new();
+                    s.hash(&mut h);
+                    sum_hash = sum_hash.wrapping_add(h.finish());
                 }
                 sum_hash.hash(hasher);
             }

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1634,6 +1634,7 @@ impl Value {
             Value::Float(_) => "Float".to_string(),
             Value::Bool(_) => "Bool".to_string(),
             Value::List(_) => "List".to_string(),
+            Value::StringList(_) => "StringList".to_string(),
             Value::Map(_) => "Map".to_string(),
             Value::ResourceRef { path } => {
                 format!("ResourceRef({})", path.to_dot_string())

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -652,8 +652,12 @@ fn walk_value_against_type(
                 walk_value_against_type(arg, expected, exports, location, errors);
             }
         }
-        Value::String(_) | Value::Int(_) | Value::Float(_) | Value::Bool(_) | Value::Unknown(_) => {
-        }
+        Value::String(_)
+        | Value::Int(_)
+        | Value::Float(_)
+        | Value::Bool(_)
+        | Value::StringList(_)
+        | Value::Unknown(_) => {}
     }
 }
 

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -267,6 +267,7 @@ pub fn infer_type_from_value(
         Value::Interpolation(_) => Ok(TypeExpr::String),
         Value::Secret(_) => Ok(TypeExpr::String),
         Value::List(items) => infer_collection(items, bindings, schemas, TypeExpr::List),
+        Value::StringList(_) => Ok(TypeExpr::List(Box::new(TypeExpr::String))),
         Value::Map(entries) => infer_collection(entries.values(), bindings, schemas, TypeExpr::Map),
         Value::ResourceRef { path } => infer_resource_ref(
             path.binding(),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use thiserror::Error;
 
 use crate::resource::{InterpolationPart, UnknownReason, Value};
+use crate::schema::AttributeType;
 use crate::utils::{convert_enum_value, is_dsl_enum_format};
 
 /// Where in the pipeline a `Value` is being serialized. Used so the
@@ -226,6 +227,12 @@ pub fn value_to_json_with_context(
                 .collect();
             Ok(serde_json::Value::Array(arr?))
         }
+        Value::StringList(items) => Ok(serde_json::Value::Array(
+            items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+        )),
         Value::Map(map) => {
             let obj: Result<serde_json::Map<_, _>, _> = map
                 .iter()
@@ -326,6 +333,10 @@ pub fn format_value_with_key(value: &Value, _key: Option<&str>) -> String {
         Value::Bool(b) => b.to_string(),
         Value::List(items) => {
             let strs: Vec<_> = items.iter().map(format_value).collect();
+            format!("[{}]", strs.join(", "))
+        }
+        Value::StringList(items) => {
+            let strs: Vec<_> = items.iter().map(|s| format!("\"{}\"", s)).collect();
             format!("[{}]", strs.join(", "))
         }
         Value::Map(map) => {
@@ -792,6 +803,128 @@ pub fn map_similarity(a: &Value, b: &Value) -> usize {
             })
             .count(),
         _ => 0,
+    }
+}
+
+/// Returns true when `attr_type` is exactly the IAM-style
+/// `string_or_list_of_strings` shape — `Union(vec![String, list(String)])`
+/// in either order — peeling through `Custom` wrappers.
+fn is_string_or_list_of_strings(attr_type: &AttributeType) -> bool {
+    let unwrapped = peel_custom(attr_type);
+    let AttributeType::Union(members) = unwrapped else {
+        return false;
+    };
+    if members.len() != 2 {
+        return false;
+    }
+    let mut has_string = false;
+    let mut has_list_of_string = false;
+    for m in members {
+        match peel_custom(m) {
+            AttributeType::String => has_string = true,
+            AttributeType::List { inner, .. }
+                if matches!(peel_custom(inner.as_ref()), AttributeType::String) =>
+            {
+                has_list_of_string = true;
+            }
+            _ => return false,
+        }
+    }
+    has_string && has_list_of_string
+}
+
+fn peel_custom(t: &AttributeType) -> &AttributeType {
+    let mut cur = t;
+    while let AttributeType::Custom { base, .. } = cur {
+        cur = base.as_ref();
+    }
+    cur
+}
+
+/// Convert `value` to the canonical `Value::StringList` form when
+/// `attr_type` is the `string_or_list_of_strings` shape, recursing into
+/// containers (List, Map, Struct) so nested fields are also
+/// canonicalized.
+///
+/// Conversion rules for `string_or_list_of_strings`:
+/// - `Value::String(s)` → `Value::StringList(vec![s])`
+/// - `Value::List([Value::String(_), ...])` (every element a String) →
+///   `Value::StringList(vec![..])`
+/// - `Value::StringList(_)` is returned unchanged
+/// - any other shape (e.g. a list with non-string elements, a Map, a
+///   ResourceRef, an unresolved Interpolation/FunctionCall) is returned
+///   unchanged. Such shapes either fail validation downstream (wrong
+///   type for the schema) or carry an unresolved expression that must
+///   be canonicalized after resolution by a later pass.
+///
+/// For non-`string_or_list_of_strings` types, the function still
+/// recurses into containers so that struct/list/map fields whose
+/// declared type *is* the union are canonicalized in place. Returns
+/// `value` unchanged when no nested canonicalization applies.
+///
+/// See #2481, #2510.
+pub fn canonicalize_with_type(value: Value, attr_type: &AttributeType) -> Value {
+    let unwrapped = peel_custom(attr_type);
+    if is_string_or_list_of_strings(unwrapped) {
+        return canonicalize_to_string_list(value);
+    }
+    match (value, unwrapped) {
+        (Value::List(items), AttributeType::List { inner, .. }) => {
+            let canonicalized = items
+                .into_iter()
+                .map(|v| canonicalize_with_type(v, inner.as_ref()))
+                .collect();
+            Value::List(canonicalized)
+        }
+        (Value::Map(map), AttributeType::Map { value: vt, .. }) => {
+            let canonicalized = map
+                .into_iter()
+                .map(|(k, v)| (k, canonicalize_with_type(v, vt.as_ref())))
+                .collect();
+            Value::Map(canonicalized)
+        }
+        (Value::Map(map), AttributeType::Struct { fields, .. }) => {
+            let canonicalized = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let field_type = fields
+                        .iter()
+                        .find(|f| f.name == k || f.provider_name.as_deref() == Some(k.as_str()))
+                        .map(|f| &f.field_type);
+                    let canon = match field_type {
+                        Some(ft) => canonicalize_with_type(v, ft),
+                        None => v,
+                    };
+                    (k, canon)
+                })
+                .collect();
+            Value::Map(canonicalized)
+        }
+        (Value::Secret(inner), _) => {
+            Value::Secret(Box::new(canonicalize_with_type(*inner, attr_type)))
+        }
+        (v, _) => v,
+    }
+}
+
+/// Body of [`canonicalize_with_type`] for the
+/// `string_or_list_of_strings` case.
+fn canonicalize_to_string_list(value: Value) -> Value {
+    match value {
+        Value::StringList(items) => Value::StringList(items),
+        Value::String(s) => Value::StringList(vec![s]),
+        Value::List(items) => {
+            let mut strings = Vec::with_capacity(items.len());
+            for item in &items {
+                match item {
+                    Value::String(s) => strings.push(s.clone()),
+                    _ => return Value::List(items),
+                }
+            }
+            Value::StringList(strings)
+        }
+        Value::Secret(inner) => Value::Secret(Box::new(canonicalize_to_string_list(*inner))),
+        other => other,
     }
 }
 
@@ -1812,5 +1945,207 @@ mod tests {
                 "scalar fallthrough drift for variant: {v:?}"
             );
         }
+    }
+
+    // ---- canonicalize_with_type tests (#2481, #2510) ----
+
+    fn string_or_list_of_strings() -> AttributeType {
+        AttributeType::Union(vec![
+            AttributeType::String,
+            AttributeType::list(AttributeType::String),
+        ])
+    }
+
+    #[test]
+    fn canonicalize_scalar_to_string_list() {
+        let t = string_or_list_of_strings();
+        let v = Value::String("repo:foo:*".to_string());
+        let canon = canonicalize_with_type(v, &t);
+        assert_eq!(canon, Value::StringList(vec!["repo:foo:*".to_string()]));
+    }
+
+    #[test]
+    fn canonicalize_single_element_list_to_string_list() {
+        let t = string_or_list_of_strings();
+        let v = Value::List(vec![Value::String("repo:foo:*".to_string())]);
+        let canon = canonicalize_with_type(v, &t);
+        assert_eq!(canon, Value::StringList(vec!["repo:foo:*".to_string()]));
+    }
+
+    #[test]
+    fn canonicalize_multi_element_list_to_string_list() {
+        let t = string_or_list_of_strings();
+        let v = Value::List(vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+            Value::String("c".to_string()),
+        ]);
+        let canon = canonicalize_with_type(v, &t);
+        assert_eq!(
+            canon,
+            Value::StringList(vec!["a".to_string(), "b".to_string(), "c".to_string()])
+        );
+    }
+
+    #[test]
+    fn canonicalize_idempotent_on_string_list() {
+        let t = string_or_list_of_strings();
+        let v = Value::StringList(vec!["a".to_string()]);
+        let canon = canonicalize_with_type(v.clone(), &t);
+        assert_eq!(canon, v);
+    }
+
+    #[test]
+    fn canonicalize_passes_through_non_applicable_type() {
+        let v = Value::String("foo".to_string());
+        let canon = canonicalize_with_type(v.clone(), &AttributeType::String);
+        assert_eq!(canon, v);
+    }
+
+    #[test]
+    fn canonicalize_passes_through_non_string_list() {
+        let t = string_or_list_of_strings();
+        // List with non-String elements stays as List — not the canonical
+        // form. Schema validation will flag it elsewhere.
+        let v = Value::List(vec![Value::Int(1)]);
+        let canon = canonicalize_with_type(v.clone(), &t);
+        assert_eq!(canon, v);
+    }
+
+    #[test]
+    fn canonicalize_recurses_into_struct_fields() {
+        let t = AttributeType::Struct {
+            name: "Statement".to_string(),
+            fields: vec![crate::schema::StructField::new(
+                "action",
+                string_or_list_of_strings(),
+            )],
+        };
+        let mut map = IndexMap::new();
+        map.insert(
+            "action".to_string(),
+            Value::String("s3:GetObject".to_string()),
+        );
+        let v = Value::Map(map);
+        let canon = canonicalize_with_type(v, &t);
+        match canon {
+            Value::Map(m) => {
+                assert_eq!(
+                    m.get("action"),
+                    Some(&Value::StringList(vec!["s3:GetObject".to_string()]))
+                );
+            }
+            _ => panic!("expected Map"),
+        }
+    }
+
+    #[test]
+    fn canonicalize_recurses_into_struct_via_provider_name() {
+        let t = AttributeType::Struct {
+            name: "Statement".to_string(),
+            fields: vec![
+                crate::schema::StructField::new("action", string_or_list_of_strings())
+                    .with_provider_name("Action"),
+            ],
+        };
+        let mut map = IndexMap::new();
+        map.insert(
+            "Action".to_string(),
+            Value::String("s3:GetObject".to_string()),
+        );
+        let v = Value::Map(map);
+        let canon = canonicalize_with_type(v, &t);
+        match canon {
+            Value::Map(m) => {
+                assert_eq!(
+                    m.get("Action"),
+                    Some(&Value::StringList(vec!["s3:GetObject".to_string()]))
+                );
+            }
+            _ => panic!("expected Map"),
+        }
+    }
+
+    #[test]
+    fn canonicalize_recurses_into_map_value_type() {
+        let t = AttributeType::Map {
+            key: Box::new(AttributeType::String),
+            value: Box::new(string_or_list_of_strings()),
+        };
+        let mut map = IndexMap::new();
+        map.insert(
+            "token.actions.githubusercontent.com:sub".to_string(),
+            Value::String("repo:foo:*".to_string()),
+        );
+        let v = Value::Map(map);
+        let canon = canonicalize_with_type(v, &t);
+        match canon {
+            Value::Map(m) => {
+                assert_eq!(
+                    m.get("token.actions.githubusercontent.com:sub"),
+                    Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+                );
+            }
+            _ => panic!("expected Map"),
+        }
+    }
+
+    #[test]
+    fn canonicalize_through_custom_wrapper() {
+        // Custom wrappers must be transparent for type matching.
+        let t = AttributeType::Custom {
+            semantic_name: Some("PolicyConditionValue".to_string()),
+            base: Box::new(string_or_list_of_strings()),
+            pattern: None,
+            length: None,
+            validate: std::sync::Arc::new(|_| Ok(())),
+            namespace: None,
+            to_dsl: None,
+        };
+        let v = Value::String("x".to_string());
+        let canon = canonicalize_with_type(v, &t);
+        assert_eq!(canon, Value::StringList(vec!["x".to_string()]));
+    }
+
+    #[test]
+    fn canonicalize_secret_recurses_inner() {
+        let t = string_or_list_of_strings();
+        let v = Value::Secret(Box::new(Value::String("s".to_string())));
+        let canon = canonicalize_with_type(v, &t);
+        match canon {
+            Value::Secret(inner) => {
+                assert_eq!(*inner, Value::StringList(vec!["s".to_string()]));
+            }
+            _ => panic!("expected Secret"),
+        }
+    }
+
+    #[test]
+    fn canonicalize_value_to_json_string_list_serializes_as_array() {
+        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let json = value_to_json(&v).expect("StringList serializes cleanly");
+        assert_eq!(
+            json,
+            serde_json::Value::Array(vec![
+                serde_json::Value::String("a".to_string()),
+                serde_json::Value::String("b".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn canonicalize_format_value_string_list() {
+        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(format_value(&v), "[\"a\", \"b\"]");
+    }
+
+    #[test]
+    fn canonicalize_partial_eq_distinguishes_list_and_string_list() {
+        // `Value::List([String("x")])` and `Value::StringList(vec!["x"])`
+        // are *not* equal under PartialEq — the type system carries the
+        // canonical-form invariant. Producers must canonicalize first.
+        let a = Value::List(vec![Value::String("x".to_string())]);
+        let b = Value::StringList(vec!["x".to_string()]);
+        assert_ne!(a, b);
     }
 }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -52,6 +52,19 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
                 .expect("serde_json::Value -> String is infallible");
             Ok(wit::Value::ListVal(json_str))
         }
+        CoreValue::StringList(items) => {
+            // Cross the WASM boundary as a plain JSON array of strings —
+            // the provider sees the same shape as `Value::List([String])`,
+            // matching AWS's wire-format expectation for the
+            // `string_or_list_of_strings` IAM shape.
+            let json_arr: Vec<serde_json::Value> = items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect();
+            let json_str = serde_json::to_string(&json_arr)
+                .expect("serde_json::Value -> String is infallible");
+            Ok(wit::Value::ListVal(json_str))
+        }
         CoreValue::Map(map) => {
             let json_map: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .iter()
@@ -137,6 +150,12 @@ fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationE
             let arr: Result<Vec<_>, _> = items.iter().map(core_value_to_json).collect();
             Ok(serde_json::Value::Array(arr?))
         }
+        CoreValue::StringList(items) => Ok(serde_json::Value::Array(
+            items
+                .iter()
+                .map(|s| serde_json::Value::String(s.clone()))
+                .collect(),
+        )),
         CoreValue::Map(map) => {
             let obj: Result<serde_json::Map<String, serde_json::Value>, _> = map
                 .iter()


### PR DESCRIPTION
## Summary

Foundation for the type-level canonicalization of `Union[String, list(String)]` (the IAM-style `string_or_list_of_strings` shape). This is sub-issue 1 of the #2481 split — it adds the data-model primitive but does not wire it into parser, differ, state, provider, or LSP yet (those land in #2511, #2512, #2513, carina-rs/carina-provider-awscc#180, #2514).

## Changes

- **`Value::StringList(Vec<String>)`** — new enum variant. Carries the canonical shape for the union type so the differ cannot see scalar-vs-list mismatches at the typed boundary. `PartialEq` and `hash_into` distinguish it from `Value::List([String])` so the invariant survives equality and hashing.
- **`carina_core::value::canonicalize_with_type(value, attr_type)`** — walks a `Value` tree using the schema as a guide. When the declared type unwraps (through `Custom` wrappers) to `Union(vec![String, list(String)])`, it folds `Value::String(s)` → `Value::StringList(vec![s])` and `Value::List([String, ...])` → `Value::StringList(...)`. Otherwise recurses into `List` / `Map` / `Struct` / `Secret` containers so nested fields with the union type are canonicalized in place.
- **Exhaustive `StringList` arms** added at every non-wildcard match site across the workspace (12 sites: 8 in carina-core, 2 in carina-plugin-host, 1 in carina-cli, 1 in resource/mod.rs `hash_into`). Each arm preserves the existing shape behavior — JSON serializes as an array of strings, display renders as `[..]`, type name is `"StringList"` / `"list"`. The variant is dormant: no code constructs it yet, so behavior is unchanged.
- **14 new unit tests** in `carina-core/src/value.rs::tests::canonicalize_*` covering: scalar / single-element list / multi-element list / idempotent / non-applicable type / non-string list (passes through) / `Struct` field canonical name / `Struct` field via `provider_name` alias / `Map` value type / `Custom` wrapper transparency / `Secret` recursion / serde shape / display shape / `PartialEq` distinguishes `List([String])` from `StringList`.

## Test plan

- [x] `cargo nextest run --workspace` (2858 tests passed)
- [x] `cargo test --workspace --doc` (doctests passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `bash scripts/check-*.sh` (all repo invariants pass)
- [ ] CI green

## Why type-level

Differ-level equality (`"x" == ["x"]` for this type) hides the divergence in the comparator and leaves state files recording the non-canonical shape, so plan diffs keep firing. Type-level canonicalization converges every consumer (differ, plan display, state writeback, provider boundary) on one representation. See #2481 comments for the design discussion.

Closes #2510. Refs #2481.
