### PR TITLE
core: canonicalize Union[String, list(String)] after ref resolution (#2511)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -904,8 +904,12 @@ async fn run_apply_locked(
 
     // Phase 2: resolve data source inputs against the consolidated state
     // and refresh them via `read_data_source` (#1683, #1685).
-    let resolved_data_sources =
-        resolve_data_source_refs_for_refresh(&sorted_resources, &current_states, &remote_bindings)?;
+    let resolved_data_sources = resolve_data_source_refs_for_refresh(
+        &sorted_resources,
+        &current_states,
+        &remote_bindings,
+        ctx.schemas(),
+    )?;
     let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
         stream::iter(resolved_data_sources.iter())
             .map(|resource| {
@@ -940,6 +944,10 @@ async fn run_apply_locked(
     // Resolve references and enum identifiers, then create initial plan for display
     let mut resources_for_plan = sorted_resources.clone();
     resolve_refs_with_state_and_remote(&mut resources_for_plan, &current_states, &remote_bindings)?;
+
+    // Type-level canonicalization for `Union[String, list(String)]`
+    // fields (IAM-style `string_or_list_of_strings`). See #2481, #2511.
+    carina_core::value::canonicalize_resources_with_schemas(&mut resources_for_plan, ctx.schemas());
 
     // Run the normalization pipeline (same as plan path in wiring.rs).
     let preprocessor = crate::wiring::PlanPreprocessor::new(&provider, ctx);

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -130,6 +130,10 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
     resolve_refs_for_plan(&mut resources, &current_states, &remote_bindings)
         .expect("Failed to resolve refs with state");
 
+    // Type-level canonicalization for `Union[String, list(String)]`
+    // fields. See #2481, #2511.
+    carina_core::value::canonicalize_resources_with_schemas(&mut resources, wiring.schemas());
+
     normalize_desired_with_ctx(&wiring, &mut resources);
     normalize_state_with_ctx(&wiring, &mut current_states);
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1223,6 +1223,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
             &sorted_resources,
             &current_states,
             remote_bindings,
+            ctx.schemas(),
         )?;
         let phase2_results: Vec<Result<(ResourceId, State), AppError>> =
             stream::iter(resolved_data_sources.iter())
@@ -1307,6 +1308,13 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     // unresolved upstream references.
     let mut resources = sorted_resources.clone();
     resolve_refs_for_plan(&mut resources, &current_states, remote_bindings)?;
+
+    // Type-level canonicalization for `Union[String, list(String)]`
+    // fields (IAM-style `string_or_list_of_strings`). Done after refs
+    // resolve so concrete `String` / `List` shapes can be folded to the
+    // canonical `Value::StringList` form before differ / display see
+    // them. See #2481, #2511.
+    carina_core::value::canonicalize_resources_with_schemas(&mut resources, ctx.schemas());
 
     // Run the normalization pipeline: normalize_desired → normalize_state →
     // merge_default_tags → resolve_enum_aliases (order matters).
@@ -1652,10 +1660,12 @@ pub(crate) fn resolve_data_source_refs_for_refresh(
     sorted_resources: &[Resource],
     current_states: &HashMap<ResourceId, State>,
     remote_bindings: &HashMap<String, HashMap<String, Value>>,
+    schemas: &carina_core::schema::SchemaRegistry,
 ) -> Result<Vec<Resource>, AppError> {
     let mut resolved = sorted_resources.to_vec();
     resolve_refs_with_state_and_remote(&mut resolved, current_states, remote_bindings)
         .map_err(AppError::Validation)?;
+    carina_core::value::canonicalize_resources_with_schemas(&mut resolved, schemas);
     Ok(resolved
         .into_iter()
         .filter(|r| !r.is_virtual() && r.is_data_source())

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -458,9 +458,14 @@ fn resolve_data_source_refs_replaces_resource_ref_with_concrete_value() {
     );
     current_states.insert(sso.id.clone(), sso_state);
 
-    let resolved =
-        resolve_data_source_refs_for_refresh(&[sso, mizzy], &current_states, &HashMap::new())
-            .expect("resolution should succeed");
+    let empty_registry = carina_core::schema::SchemaRegistry::new();
+    let resolved = resolve_data_source_refs_for_refresh(
+        &[sso, mizzy],
+        &current_states,
+        &HashMap::new(),
+        &empty_registry,
+    )
+    .expect("resolution should succeed");
 
     assert_eq!(resolved.len(), 1, "only the data source should be returned");
     let resolved_mizzy = &resolved[0];

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -928,6 +928,35 @@ fn canonicalize_to_string_list(value: Value) -> Value {
     }
 }
 
+/// Walk every resource's attributes, canonicalizing values whose
+/// declared schema type is `Union[String, list(String)]` into
+/// `Value::StringList`. Resources whose schema is not in the registry
+/// (provider not loaded, unknown resource type) are skipped — schema
+/// validation surfaces the mismatch elsewhere.
+///
+/// Call this once after `resolver::resolve_refs_*` and before the
+/// differ runs, so every `Resource` flowing into the plan / state /
+/// provider boundary carries the canonical shape. See #2481, #2511.
+pub fn canonicalize_resources_with_schemas(
+    resources: &mut [crate::resource::Resource],
+    registry: &crate::schema::SchemaRegistry,
+) {
+    for resource in resources.iter_mut() {
+        let Some(schema) = registry.get_for(resource) else {
+            continue;
+        };
+        let mut new_attrs: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+        for (key, value) in std::mem::take(&mut resource.attributes) {
+            let canon = match schema.attributes.get(&key) {
+                Some(attr_schema) => canonicalize_with_type(value, &attr_schema.attr_type),
+                None => value,
+            };
+            new_attrs.insert(key, canon);
+        }
+        resource.attributes = new_attrs;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2147,5 +2176,118 @@ mod tests {
         let a = Value::List(vec![Value::String("x".to_string())]);
         let b = Value::StringList(vec!["x".to_string()]);
         assert_ne!(a, b);
+    }
+
+    // ---- canonicalize_resources_with_schemas tests (#2481, #2511) ----
+
+    fn build_test_registry() -> crate::schema::SchemaRegistry {
+        use crate::schema::{AttributeSchema, ResourceSchema, SchemaRegistry};
+        let mut reg = SchemaRegistry::new();
+        let schema = ResourceSchema::new("iam.policy")
+            .attribute(AttributeSchema::new("subject", string_or_list_of_strings()));
+        reg.insert("aws", schema);
+        reg
+    }
+
+    fn make_resource(attrs: Vec<(&str, Value)>) -> crate::resource::Resource {
+        use crate::resource::{Resource, ResourceId, ResourceKind, ResourceName};
+        use std::collections::{BTreeSet, HashMap, HashSet};
+        let mut attributes = IndexMap::new();
+        for (k, v) in attrs {
+            attributes.insert(k.to_string(), v);
+        }
+        Resource {
+            id: ResourceId {
+                provider: "aws".to_string(),
+                resource_type: "iam.policy".to_string(),
+                name: ResourceName::Bound("p1".to_string()),
+            },
+            attributes,
+            kind: ResourceKind::Managed,
+            lifecycle: Default::default(),
+            prefixes: HashMap::new(),
+            binding: Some("p1".to_string()),
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_scalar_to_string_list() {
+        let registry = build_test_registry();
+        let mut resources = vec![make_resource(vec![(
+            "subject",
+            Value::String("repo:foo:*".to_string()),
+        )])];
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+        assert_eq!(
+            resources[0].attributes.get("subject"),
+            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+        );
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_single_list_to_string_list() {
+        let registry = build_test_registry();
+        let mut resources = vec![make_resource(vec![(
+            "subject",
+            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+        )])];
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+        assert_eq!(
+            resources[0].attributes.get("subject"),
+            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+        );
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_skips_unknown_resource() {
+        // No schema registered for the resource type — pass through.
+        let registry = crate::schema::SchemaRegistry::new();
+        let mut resources = vec![make_resource(vec![(
+            "subject",
+            Value::String("x".to_string()),
+        )])];
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+        assert_eq!(
+            resources[0].attributes.get("subject"),
+            Some(&Value::String("x".to_string()))
+        );
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_passes_through_unrelated_attr() {
+        // Schema has only `subject`, but the resource has an extra
+        // unknown attribute — leave it alone.
+        let registry = build_test_registry();
+        let mut resources = vec![make_resource(vec![
+            ("subject", Value::String("x".to_string())),
+            ("name", Value::String("p1".to_string())),
+        ])];
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+        assert_eq!(
+            resources[0].attributes.get("name"),
+            Some(&Value::String("p1".to_string()))
+        );
+    }
+
+    #[test]
+    fn canonicalize_resources_with_schemas_scalar_and_list_yield_same_value() {
+        // The acceptance criterion from #2511: scalar literal and
+        // single-element list literal produce byte-equal canonical
+        // values once canonicalization runs.
+        let registry = build_test_registry();
+        let mut a = vec![make_resource(vec![(
+            "subject",
+            Value::String("repo:foo:*".to_string()),
+        )])];
+        let mut b = vec![make_resource(vec![(
+            "subject",
+            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+        )])];
+        canonicalize_resources_with_schemas(&mut a, &registry);
+        canonicalize_resources_with_schemas(&mut b, &registry);
+        assert_eq!(a[0].attributes, b[0].attributes);
     }
 }


### PR DESCRIPTION
## Summary

Sub-issue 2 of #2481. Wires `canonicalize_with_type` (the foundation added in #2510) into the plan / apply pipeline so every resource attribute typed as `Union[String, list(String)]` (the IAM-style `string_or_list_of_strings` shape) is folded to the canonical `Value::StringList` form before the differ, plan display, state writeback, or provider boundary sees it.

## Changes

- **New public `carina_core::value::canonicalize_resources_with_schemas`** — walks resources, looks up each top-level attribute's `attr_type` via `SchemaRegistry::get_for`, and applies `canonicalize_with_type`. Unknown resources (provider not loaded) are skipped; schema validation surfaces those elsewhere.
- **Called from three CLI sites**, immediately after `resolve_refs_*`:
  - `wiring::create_plan_from_parsed_with_upstream` (plan path)
  - `apply::execute_apply` (apply path)
  - `fixture_plan` (test fixture loader)
- `resolve_data_source_refs_for_refresh` gains a `&SchemaRegistry` parameter so data-source refresh canonicalizes too.
- **5 new unit tests** in `value::tests::canonicalize_resources_with_schemas_*` covering scalar/list inputs, schema absence, unrelated attributes, and the acceptance criterion that scalar-vs-single-list literals yield byte-equal canonical resources.

## Test plan

- [x] `cargo nextest run --workspace` (2866 tests passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] CI green

Closes #2511. Refs #2481.
