### PR TITLE
display: pretty-print MapExpanded entries with nested complex values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,8 @@ plan-fixtures:
 	@echo "=== policy_pretty ==="
 	@$(MAKE) plan-policy-pretty
 	@echo "---"
+	@$(MAKE) plan-policy-pretty-nested
+	@echo "---"
 	@$(MAKE) plan-pretty-long-string-list
 	@echo "---"
 	@$(MAKE) plan-pretty-short-string-list
@@ -154,6 +156,8 @@ plan-exports-multifile:
 	$(PLAN_FIXTURE) exports_multifile
 plan-policy-pretty:
 	$(PLAN_FIXTURE) policy_pretty
+plan-policy-pretty-nested:
+	$(PLAN_FIXTURE) policy_pretty_nested
 plan-pretty-long-string-list:
 	$(PLAN_FIXTURE) pretty_long_string_list
 plan-pretty-short-string-list:
@@ -167,7 +171,7 @@ plan-provider-prefix:
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
-        plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
+        plan-policy-pretty-nested plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1055,10 +1055,16 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
         }
         DetailRow::MapExpanded { key, entries } => {
             writeln!(out, "{}{}:", attr_prefix, key).unwrap();
+            let entry_indent_cols = attr_prefix.chars().count() + 2;
             for entry in entries {
+                let layout = carina_core::value::PrettyLayout {
+                    parent_indent_cols: entry_indent_cols,
+                    key: &entry.key,
+                };
+                let pretty = carina_core::value::format_value_pretty(&entry.value, layout);
                 let cv = match effect {
-                    Effect::Delete { .. } => entry.value.red().strikethrough().to_string(),
-                    _ => colored_value(&entry.value, false),
+                    Effect::Delete { .. } => pretty.red().strikethrough().to_string(),
+                    _ => colored_value(&pretty, false),
                 };
                 if let Some(ann) = &entry.annotation {
                     writeln!(

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -77,6 +77,21 @@ fn snapshot_policy_pretty() {
 }
 
 #[test]
+fn snapshot_policy_pretty_nested() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("policy_pretty_nested");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_pretty_long_string_list() {
     let (plan, schemas, _moved) = build_plan_from_fixture("pretty_long_string_list");
     let output = strip_ansi(&format_plan(

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
@@ -1,0 +1,26 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.ec2.Vpc 
+      cidr_block: "10.0.0.0/16"
+      config:
+        statement: 
+          - action: [
+              "iam:CreateRole",
+              "iam:DeleteRole",
+              "iam:GetRole",
+              "iam:UpdateRole",
+            ]
+            effect: "Allow"
+            resource: "arn:aws:iam::*:role/carina-*-deploy"
+            sid: "ManageDeployRoles"
+          - action: "iam:GetOpenIDConnectProvider"
+            effect: "Allow"
+            resource: "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com"
+            sid: "ReadOIDCProvider"
+        version: "2012-10-17"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/policy_pretty_nested/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/policy_pretty_nested/main.crn
@@ -1,0 +1,33 @@
+# Policy document wrapped in a Map attribute. Verifies that nested
+# list-of-maps and long string-lists inside a top-level Map break onto
+# multiple indented lines instead of dumping inline (issue #2409).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+  config = {
+    version = '2012-10-17'
+    statement = [
+      {
+        sid    = 'ManageDeployRoles'
+        effect = 'Allow'
+        action = [
+          'iam:CreateRole',
+          'iam:DeleteRole',
+          'iam:GetRole',
+          'iam:UpdateRole',
+        ]
+        resource = 'arn:aws:iam::*:role/carina-*-deploy'
+      },
+      {
+        sid      = 'ReadOIDCProvider'
+        effect   = 'Allow'
+        action   = 'iam:GetOpenIDConnectProvider'
+        resource = 'arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com'
+      },
+    ]
+  }
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -114,11 +114,18 @@ pub enum DetailRow {
     },
 }
 
-/// A single entry in an expanded map (e.g., tags with default_tags annotation)
+/// A single entry in an expanded map (e.g., tags with default_tags annotation).
+///
+/// `value` is kept as a raw `Value` so renderers can apply
+/// `format_value_pretty` with the actual indent column. Pre-stringifying
+/// at build time would force nested complex values (list-of-maps,
+/// long string lists) onto a single line because a `String` carries no
+/// indentation context. Renderers should pass the column at which the
+/// entry's `key` is rendered as `PrettyLayout::parent_indent_cols`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MapExpandedEntry {
     pub key: String,
-    pub value: String,
+    pub value: Value,
     /// Optional annotation (e.g., "# default_tags") shown after the value
     pub annotation: Option<String>,
 }
@@ -348,7 +355,7 @@ fn build_expanded_map_row(key: &str, map: &IndexMap<String, Value>) -> DetailRow
         .into_iter()
         .map(|k| MapExpandedEntry {
             key: k.clone(),
-            value: format_value_with_key(&map[k], Some(k)),
+            value: map[k].clone(),
             annotation: None,
         })
         .collect();
@@ -376,7 +383,7 @@ fn build_expanded_tags_row(
             };
             MapExpandedEntry {
                 key: key.clone(),
-                value: format_value_with_key(value, Some(key)),
+                value: value.clone(),
                 annotation,
             }
         })
@@ -1064,13 +1071,64 @@ mod tests {
                 assert_eq!(key, "tags");
                 assert_eq!(entries.len(), 2);
                 assert_eq!(entries[0].key, "Environment");
-                assert_eq!(entries[0].value, "\"prod\"");
+                assert_eq!(entries[0].value, Value::String("prod".to_string()));
                 assert!(entries[0].annotation.is_none());
                 assert_eq!(entries[1].key, "Name");
-                assert_eq!(entries[1].value, "\"test\"");
+                assert_eq!(entries[1].value, Value::String("test".to_string()));
                 assert!(entries[1].annotation.is_none());
             }
             other => panic!("expected MapExpanded, got {:?}", other),
+        }
+    }
+
+    /// Regression: a Map attribute whose entry value is itself a list-of-maps
+    /// must carry the raw `Value` so the renderer can pretty-print it. If
+    /// the build phase pre-stringifies entry values, the inline form
+    /// `[{...}, {...}]` is locked in and the renderer cannot expand it
+    /// onto multiple lines (issue #2409).
+    #[test]
+    fn test_create_map_expanded_carries_raw_value_for_nested_list_of_maps() {
+        let mut statement1 = IndexMap::new();
+        statement1.insert("sid".to_string(), Value::String("AllowRead".to_string()));
+        statement1.insert("effect".to_string(), Value::String("Allow".to_string()));
+        let mut statement2 = IndexMap::new();
+        statement2.insert("sid".to_string(), Value::String("DenyWrite".to_string()));
+        statement2.insert("effect".to_string(), Value::String("Deny".to_string()));
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::String("2012-10-17".to_string()),
+        );
+        policy.insert(
+            "statement".to_string(),
+            Value::List(vec![Value::Map(statement1), Value::Map(statement2.clone())]),
+        );
+        let resource = Resource::new("iam.RolePolicy", "test")
+            .with_attribute("policy_document", Value::Map(policy));
+        let effect = Effect::Create(resource);
+        let rows = build_detail_rows(&effect, None, DetailLevel::Explicit, None);
+        let entries = rows
+            .iter()
+            .find_map(|r| match r {
+                DetailRow::MapExpanded { key, entries } if key == "policy_document" => {
+                    Some(entries)
+                }
+                _ => None,
+            })
+            .expect("expected MapExpanded row for policy_document");
+        let stmt_entry = entries
+            .iter()
+            .find(|e| e.key == "statement")
+            .expect("expected `statement` entry");
+        match &stmt_entry.value {
+            Value::List(items) => {
+                assert_eq!(items.len(), 2, "list-of-maps preserved as raw Value");
+                assert!(
+                    matches!(items[0], Value::Map(_)),
+                    "inner element kept as Value::Map, not stringified"
+                );
+            }
+            other => panic!("expected Value::List, got {:?}", other),
         }
     }
 
@@ -1100,7 +1158,7 @@ mod tests {
                 assert_eq!(key, "tags");
                 assert_eq!(entries.len(), 1);
                 assert_eq!(entries[0].key, "Name");
-                assert_eq!(entries[0].value, "\"test\"");
+                assert_eq!(entries[0].value, Value::String("test".to_string()));
             }
             other => panic!("expected MapExpanded, got {:?}", other),
         }

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -127,8 +127,13 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
             }
             lines.push(header_line);
             for entry in entries {
+                let layout = carina_core::value::PrettyLayout {
+                    parent_indent_cols: 4,
+                    key: &entry.key,
+                };
+                let pretty = carina_core::value::format_value_pretty(&entry.value, layout);
                 let mut spans = vec![Span::raw(format!("    {}: ", entry.key))];
-                spans.extend(value_spans(&entry.value, false));
+                spans.extend(value_spans(&pretty, false));
                 if let Some(ann) = &entry.annotation {
                     spans.push(Span::styled(
                         format!("  {}", ann),


### PR DESCRIPTION
## Summary

Fixes Problem 1 of #2409: when a `Value::Map` resource attribute holds nested complex values (a list-of-maps, or a long string list), `carina plan` rendered the inner contents on a single unreadable line. The fix moves pretty-printing of `DetailRow::MapExpanded` entries from build time to render time, so `format_value_pretty` gets the actual indent column and can break nested values vertically.

Before:

```
+ awscc.ec2.Vpc
    config:
      statement: [{action: ["iam:CreateRole", ...], effect: "Allow", ...}, {action: ..., ...}]
```

After (new `policy_pretty_nested` snapshot):

```
+ awscc.ec2.Vpc
    cidr_block: "10.0.0.0/16"
    config:
      statement:
        - action: [
            "iam:CreateRole",
            "iam:DeleteRole",
            "iam:GetRole",
            "iam:UpdateRole",
          ]
          effect: "Allow"
          resource: "arn:aws:iam::*:role/carina-*-deploy"
          sid: "ManageDeployRoles"
        - action: "iam:GetOpenIDConnectProvider"
          effect: "Allow"
          resource: "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com"
          sid: "ReadOIDCProvider"
      version: "2012-10-17"
```

## Root cause

`MapExpandedEntry::value` was pre-stringified `String`, built via `format_value_with_key` which collapses any nested structure to its inline form. A pre-formatted string carries no indent context, so renderers could not break it back onto multiple lines.

## Fix

- `carina-core/src/detail_rows.rs`: change `MapExpandedEntry::value` from `String` to raw `Value`. Builders (`build_expanded_map_row`, `build_expanded_tags_row`) now store `map[k].clone()`.
- `carina-cli/src/display/mod.rs`: in the `MapExpanded` arm, call `format_value_pretty(&entry.value, PrettyLayout { parent_indent_cols: attr_prefix.chars().count() + 2, key })`. This mirrors the existing `PrettyAttribute` arm.
- `carina-tui/src/ui/detail.rs`: same shape with `parent_indent_cols: 4` matching the `"    "` entry prefix.

## Tests

- New `policy_pretty_nested` plan-display fixture and snapshot test (`Map` containing a 4-item string list and a 2-element list-of-maps).
- New unit test `test_create_map_expanded_carries_raw_value_for_nested_list_of_maps` asserting the raw `Value::List(Value::Map(...))` survives `build_detail_rows`.
- Updated two existing `MapExpanded` unit tests to compare against `Value` instead of `String`.
- All 2846 workspace tests pass; doctests pass; clippy clean; `scripts/check-*.sh` all pass.

## Scope

- Problem 2 of the original #2409 (module-membership signal in plan addresses) was split out to #2516.
- Two pre-existing rendering bugs surfaced during review and are tracked separately:
  - #2521 — multi-line ANSI red+strikethrough on `Effect::Delete` only styles the first line.
  - #2523 — TUI `Line` from `PrettyAttribute` / `MapExpanded` contains embedded `\n` that ratatui won't render as a row break.

Both pre-existed in the `PrettyAttribute` shape (introduced in #2414); this PR extends the same shape to `MapExpanded`. Per the project's "1 PR = 1 topic" rule, fixes belong in their own PRs.

## Test plan

- [x] `cargo nextest run --workspace` (2846 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-docs-use-new-spellings.sh`
- [x] `scripts/check-example-warnings.sh`
- [x] `scripts/check-no-direct-resources-access.sh`
- [x] `scripts/check-plan-fixtures.sh` (new fixture has Makefile target)
- [x] `scripts/check-provider-boundaries.sh`

Closes #2409
