### PR TITLE
core: canonicalize state-side Union[String, list(String)] (#2513)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -948,6 +948,8 @@ async fn run_apply_locked(
     // Type-level canonicalization for `Union[String, list(String)]`
     // fields (IAM-style `string_or_list_of_strings`). See #2481, #2511.
     carina_core::value::canonicalize_resources_with_schemas(&mut resources_for_plan, ctx.schemas());
+    // Same for actual-state side (#2481, #2513).
+    carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());
 
     // Run the normalization pipeline (same as plan path in wiring.rs).
     let preprocessor = crate::wiring::PlanPreprocessor::new(&provider, ctx);

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -131,8 +131,9 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         .expect("Failed to resolve refs with state");
 
     // Type-level canonicalization for `Union[String, list(String)]`
-    // fields. See #2481, #2511.
+    // fields. See #2481, #2511, #2513.
     carina_core::value::canonicalize_resources_with_schemas(&mut resources, wiring.schemas());
+    carina_core::value::canonicalize_states_with_schemas(&mut current_states, wiring.schemas());
 
     normalize_desired_with_ctx(&wiring, &mut resources);
     normalize_state_with_ctx(&wiring, &mut current_states);

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1315,6 +1315,12 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     // canonical `Value::StringList` form before differ / display see
     // them. See #2481, #2511.
     carina_core::value::canonicalize_resources_with_schemas(&mut resources, ctx.schemas());
+    // Same canonicalization for the actual-side state values (#2481, #2513).
+    // Existing state files written before this change come back from
+    // serde with the legacy `String` / `List` shape; converging both
+    // sides on `StringList` lets the differ produce no diff against a
+    // canonical desired side.
+    carina_core::value::canonicalize_states_with_schemas(&mut current_states, ctx.schemas());
 
     // Run the normalization pipeline: normalize_desired → normalize_state →
     // merge_default_tags → resolve_enum_aliases (order matters).

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -957,6 +957,46 @@ pub fn canonicalize_resources_with_schemas(
     }
 }
 
+/// Walk every entry in a `current_states` map and canonicalize attribute
+/// values whose declared schema type is `Union[String, list(String)]`
+/// into `Value::StringList`.
+///
+/// State files written before #2510 / #2511 (or by an apply path that
+/// somehow produced the legacy shape) come back through serde as the
+/// natural `Value::String` / `Value::List` form. Run this immediately
+/// after `current_states` is built — typically right after
+/// `StateFile::build_state_for_resource` populates the map — so the
+/// differ never sees a non-canonical state value compared against a
+/// canonical desired value. See #2481, #2513.
+pub fn canonicalize_states_with_schemas(
+    states: &mut std::collections::HashMap<crate::resource::ResourceId, crate::resource::State>,
+    registry: &crate::schema::SchemaRegistry,
+) {
+    for state in states.values_mut() {
+        let kind = if state.id.resource_type.is_empty() {
+            None
+        } else {
+            registry.get(
+                &state.id.provider,
+                &state.id.resource_type,
+                crate::schema::SchemaKind::Managed,
+            )
+        };
+        let Some(schema) = kind else {
+            continue;
+        };
+        let mut new_attrs = std::collections::HashMap::with_capacity(state.attributes.len());
+        for (key, value) in std::mem::take(&mut state.attributes) {
+            let canon = match schema.attributes.get(&key) {
+                Some(attr_schema) => canonicalize_with_type(value, &attr_schema.attr_type),
+                None => value,
+            };
+            new_attrs.insert(key, canon);
+        }
+        state.attributes = new_attrs;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2289,5 +2329,98 @@ mod tests {
         canonicalize_resources_with_schemas(&mut a, &registry);
         canonicalize_resources_with_schemas(&mut b, &registry);
         assert_eq!(a[0].attributes, b[0].attributes);
+    }
+
+    // ---- canonicalize_states_with_schemas tests (#2481, #2513) ----
+
+    fn make_state(attrs: Vec<(&str, Value)>) -> crate::resource::State {
+        use crate::resource::{ResourceId, ResourceName, State};
+        use std::collections::{BTreeSet, HashMap};
+        let mut attributes = HashMap::new();
+        for (k, v) in attrs {
+            attributes.insert(k.to_string(), v);
+        }
+        State {
+            id: ResourceId {
+                provider: "aws".to_string(),
+                resource_type: "iam.policy".to_string(),
+                name: ResourceName::Bound("p1".to_string()),
+            },
+            identifier: Some("arn:aws:iam::123:policy/p1".to_string()),
+            attributes,
+            exists: true,
+            dependency_bindings: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn canonicalize_states_with_schemas_scalar_to_string_list() {
+        let registry = build_test_registry();
+        let mut states = std::collections::HashMap::new();
+        let s = make_state(vec![("subject", Value::String("repo:foo:*".to_string()))]);
+        states.insert(s.id.clone(), s);
+        canonicalize_states_with_schemas(&mut states, &registry);
+        let state = states.values().next().unwrap();
+        assert_eq!(
+            state.attributes.get("subject"),
+            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+        );
+    }
+
+    #[test]
+    fn canonicalize_states_with_schemas_legacy_list_to_string_list() {
+        let registry = build_test_registry();
+        let mut states = std::collections::HashMap::new();
+        let s = make_state(vec![(
+            "subject",
+            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+        )]);
+        states.insert(s.id.clone(), s);
+        canonicalize_states_with_schemas(&mut states, &registry);
+        let state = states.values().next().unwrap();
+        assert_eq!(
+            state.attributes.get("subject"),
+            Some(&Value::StringList(vec!["repo:foo:*".to_string()]))
+        );
+    }
+
+    #[test]
+    fn canonicalize_states_with_schemas_skips_unknown_resource() {
+        let registry = crate::schema::SchemaRegistry::new();
+        let mut states = std::collections::HashMap::new();
+        let s = make_state(vec![("subject", Value::String("x".to_string()))]);
+        states.insert(s.id.clone(), s);
+        canonicalize_states_with_schemas(&mut states, &registry);
+        let state = states.values().next().unwrap();
+        assert_eq!(
+            state.attributes.get("subject"),
+            Some(&Value::String("x".to_string()))
+        );
+    }
+
+    #[test]
+    fn canonicalize_states_diff_empty_after_both_sides_canonical() {
+        // The acceptance criterion from #2513: a desired side written
+        // as `["x"]` and a state side stored as `"x"` collapse to the
+        // same `Value::StringList(vec!["x"])` after both pass through
+        // canonicalization.
+        let registry = build_test_registry();
+
+        let mut resources = vec![make_resource(vec![(
+            "subject",
+            Value::List(vec![Value::String("repo:foo:*".to_string())]),
+        )])];
+        canonicalize_resources_with_schemas(&mut resources, &registry);
+
+        let mut states = std::collections::HashMap::new();
+        let s = make_state(vec![("subject", Value::String("repo:foo:*".to_string()))]);
+        states.insert(s.id.clone(), s);
+        canonicalize_states_with_schemas(&mut states, &registry);
+
+        let state = states.values().next().unwrap();
+        assert_eq!(
+            resources[0].attributes.get("subject"),
+            state.attributes.get("subject"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Sub-issue 4 of #2481. The desired side canonicalizes after #2511, but the actual-state side still came through serde as `Value::String` / `Value::List` for fields typed as `Union[String, list(String)]`. The differ saw scalar-state vs list-desired and produced a phantom diff. This converges both sides on `Value::StringList`.

## Changes

- **New public `carina_core::value::canonicalize_states_with_schemas`** — walks the `current_states: HashMap<ResourceId, State>` map, looks up each attribute's declared `attr_type` from the registry, and applies `canonicalize_with_type`. Mirrors the desired-side helper from #2511 but for the `State` shape.
- **Called from the same three CLI sites** as `canonicalize_resources_with_schemas`:
  - `wiring::create_plan_from_parsed_with_upstream`
  - `apply::execute_apply`
  - `fixture_plan`
- Both passes run back-to-back immediately before the differ, so any state file (legacy or new) converges to the canonical form.
- **4 new unit tests** in `value::tests::canonicalize_states_*` covering scalar / legacy-list inputs, schema absence, and the acceptance criterion that desired and state values collapse to byte-equal canonical forms.

## Test plan

- [x] `cargo nextest run --workspace` (2872 tests passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] CI green

Closes #2513. Refs #2481.
