### PR TITLE
core/lsp/cli: catch up display + validation for Value::StringList (#2514)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -74,6 +74,10 @@ fn format_deferred_value(value: &Value) -> String {
             let formatted: Vec<String> = items.iter().map(format_deferred_value).collect();
             format!("[{}]", formatted.join(", "))
         }
+        Value::StringList(items) => {
+            let formatted: Vec<String> = items.iter().map(|s| format!("'{}'", s)).collect();
+            format!("[{}]", formatted.join(", "))
+        }
         Value::Map(map) => {
             let formatted: Vec<String> = map
                 .iter()
@@ -95,6 +99,10 @@ fn format_export_value(value: &Value) -> String {
         Value::ResourceRef { path } => path.to_dot_string().to_string(),
         Value::List(items) => {
             let formatted: Vec<String> = items.iter().map(format_export_value).collect();
+            format!("[{}]", formatted.join(", "))
+        }
+        Value::StringList(items) => {
+            let formatted: Vec<String> = items.iter().map(|s| format!("'{}'", s)).collect();
             format!("[{}]", formatted.join(", "))
         }
         Value::Map(map) => {

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -835,6 +835,22 @@ impl AttributeType {
         let AttributeType::List { inner, .. } = self else {
             unreachable!("validate_list called on non-List");
         };
+        // `Value::StringList` is the canonicalized form for fields
+        // typed as `Union[String, list(String)]` (see #2510). When
+        // validated against a `list(String)` member of that Union, it
+        // is structurally equivalent to a `Value::List` of strings —
+        // accept it the same way.
+        if let Value::StringList(items) = value {
+            for (i, s) in items.iter().enumerate() {
+                inner.validate(&Value::String(s.clone())).map_err(|e| {
+                    TypeError::ListItemError {
+                        index: i,
+                        inner: Box::new(e),
+                    }
+                })?;
+            }
+            return Ok(());
+        }
         let Value::List(items) = value else {
             return Err(TypeError::TypeMismatch {
                 expected: self.type_name(),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -2423,4 +2423,35 @@ mod tests {
             state.attributes.get("subject"),
         );
     }
+
+    // ---- LSP / display catch-up tests (#2481, #2514) ----
+
+    #[test]
+    fn validate_list_accepts_string_list() {
+        // The schema's `validate_list` must accept `Value::StringList`
+        // as the structural equivalent of `Value::List([String, ...])`,
+        // so a Union[String, list(String)] member's `list(String)`
+        // branch validates the canonical form cleanly.
+        use crate::schema::AttributeType;
+        let list_of_string = AttributeType::list(AttributeType::String);
+        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        assert!(list_of_string.validate(&v).is_ok());
+    }
+
+    #[test]
+    fn validate_union_accepts_canonical_string_list() {
+        let union = string_or_list_of_strings();
+        let v = Value::StringList(vec!["x".to_string()]);
+        assert!(union.validate(&v).is_ok());
+    }
+
+    #[test]
+    fn format_value_string_list_renders_brackets() {
+        // `format_value` must render `Value::StringList` with bracket
+        // syntax — not a `_` wildcard fallback that would print debug
+        // garbage in plan output.
+        let v = Value::StringList(vec!["a".to_string(), "b".to_string()]);
+        let formatted = format_value(&v);
+        assert_eq!(formatted, "[\"a\", \"b\"]");
+    }
 }

--- a/carina-lsp/src/hover.rs
+++ b/carina-lsp/src/hover.rs
@@ -54,7 +54,7 @@ fn format_value_for_hover(value: &Value) -> String {
         Value::Int(n) => n.to_string(),
         Value::Float(f) => f.to_string(),
         Value::Bool(b) => b.to_string(),
-        Value::List(_) => "[...]".to_string(),
+        Value::List(_) | Value::StringList(_) => "[...]".to_string(),
         Value::Map(_) => "{...}".to_string(),
         _ => format!("{:?}", value),
     }


### PR DESCRIPTION
## Summary

Sub-issue 6 of #2481. The exhaustive-match arms added in #2510 cover the compile-error sites, but several display / validation paths used `_ => ...` wildcards that silently routed `Value::StringList` through a debug-format or "(known after apply)" fallback. Also, schema `validate_list` rejected `Value::StringList` even when the inner type was `String`, so `validate_union` against `Union[String, list(String)]` failed for the canonical form.

## Changes

- **`carina-cli/src/display/mod.rs`**: `format_deferred_value` and `format_export_value` now render `Value::StringList` with bracket syntax matching `Value::List([String, ...])`.
- **`carina-lsp/src/hover.rs`**: `format_value_for_hover` returns `[...]` for `Value::StringList` (same as `List`) instead of falling through to debug print.
- **`carina-core/src/schema/mod.rs::validate_list`**: accept `Value::StringList` as the structural equivalent of a `Value::List([String, ...])` of strings. This makes `Union[String, list(String)]` validation succeed for the canonical form (the differ never sees the value as a Union mismatch).
- **3 new unit tests**: `validate_list_accepts_string_list`, `validate_union_accepts_canonical_string_list`, `format_value_string_list_renders_brackets`.

## Test plan

- [x] `cargo nextest run --workspace` (2877 tests passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] CI green

Closes #2514. Refs #2481.
