### PR TITLE
module_resolver,identifier: keep module instance prefix on anonymous resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ plan-fixtures:
 	@echo ""
 	@echo "=== provider_prefix ==="
 	@$(MAKE) plan-provider-prefix
+	@echo ""
+	@echo "=== module_anonymous_resource ==="
+	@$(MAKE) plan-module-anonymous-resource
 
 plan-upstream-state:
 	$(PLAN_FIXTURE) upstream_state
@@ -164,6 +167,8 @@ plan-pretty-short-string-list:
 	$(PLAN_FIXTURE) pretty_short_string_list
 plan-provider-prefix:
 	$(PLAN_FIXTURE) provider_prefix
+plan-module-anonymous-resource:
+	$(PLAN_FIXTURE) module_anonymous_resource
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
@@ -172,6 +177,7 @@ plan-provider-prefix:
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
         plan-policy-pretty-nested plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
+        plan-module-anonymous-resource \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -61,6 +61,27 @@ fn snapshot_all_create() {
     insta::assert_snapshot!(output);
 }
 
+/// Locks in the no-trailing-dot regression from #2516. The hash-with-
+/// instance-prefix path is covered by the unit tests in
+/// `carina-core/src/identifier/tests.rs`; fixture mode skips the hash
+/// step (no schemas), so the rendered name is empty rather than
+/// `bootstrap.<hash>` — the value of this snapshot is asserting that
+/// the anonymous resource is *not* rendered as `bootstrap.`.
+#[test]
+fn snapshot_module_anonymous_resource() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("module_anonymous_resource");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_policy_pretty() {
     let (plan, schemas, _moved) = build_plan_from_fixture("policy_pretty");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_module_anonymous_resource.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_module_anonymous_resource.snap
@@ -1,0 +1,14 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.iam.Role bootstrap.role
+      role_name: "carina-bootstrap"
+        │
+        └─ + awscc.iam.RolePolicy 
+              policy_name: "inline"
+              role_name: "carina-bootstrap"
+
+Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/module_anonymous_resource/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/module_anonymous_resource/main.crn
@@ -1,0 +1,12 @@
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let github = use {
+  source = './oidc-module'
+}
+
+let bootstrap = github {
+  github_repo = 'carina-rs/infra'
+  role_name   = 'carina-bootstrap'
+}

--- a/carina-cli/tests/fixtures/plan_display/module_anonymous_resource/oidc-module/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/module_anonymous_resource/oidc-module/main.crn
@@ -1,0 +1,13 @@
+arguments {
+  github_repo: String
+  role_name:   String
+}
+
+let role = awscc.iam.Role {
+  role_name = role_name
+}
+
+awscc.iam.RolePolicy {
+  policy_name = 'inline'
+  role_name   = role.role_name
+}

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -486,7 +486,19 @@ pub fn compute_anonymous_identifiers(
             .map(crate::parser::pascal_to_snake)
             .collect::<Vec<_>>()
             .join("_");
-        let identifier = format!("{}_{}_{}", provider_snake, type_snake, hash_str);
+        let bare_identifier = format!("{}_{}_{}", provider_snake, type_snake, hash_str);
+        // If this anonymous resource lives inside a module instantiation,
+        // surface the owning instance in the identifier (`<instance>.<bare>`).
+        // The expander leaves anonymous resources `Pending` so this pass
+        // still sees them; without the prefix, a `Pending` module-internal
+        // resource would land at the same address as a top-level
+        // `Pending` resource with matching create-only attrs (#2516).
+        let identifier = match &resource.module_source {
+            Some(crate::resource::ModuleSource::Module { instance, .. }) => {
+                format!("{}.{}", instance, bare_identifier)
+            }
+            _ => bare_identifier,
+        };
 
         computed.push((idx, identifier));
     }

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -360,6 +360,60 @@ fn test_reconcile_anonymous_id_single_create_only_no_reconcile() {
     assert_eq!(resources[0].id.name_str(), original_id);
 }
 
+/// Anonymous resources declared inside a module instantiation must
+/// surface the owning instance in their final identifier so the plan
+/// address shows the module they belong to (#2516). Without the prefix
+/// `iam_role_policy_<hash>` is indistinguishable from a top-level
+/// anonymous resource.
+#[test]
+fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
+    use crate::resource::ModuleSource;
+
+    let schema = ResourceSchema::new("iam.RolePolicy")
+        .attribute(AttributeSchema::new("policy_name", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("awscc", schema);
+    let providers = vec![ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: vec![(
+            "region".to_string(),
+            Value::String("ap-northeast-1".to_string()),
+        )]
+        .into_iter()
+        .collect(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+    }];
+    let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
+
+    let mut r = Resource::with_provider("awscc", "iam.RolePolicy", "");
+    r.set_attr(
+        "policy_name".to_string(),
+        Value::String("inline".to_string()),
+    );
+    r.module_source = Some(ModuleSource::Module {
+        name: "github_oidc".to_string(),
+        instance: "bootstrap".to_string(),
+    });
+
+    let mut resources = vec![r];
+    compute_anonymous_identifiers(&mut resources, &providers, &schemas, &identity_fn).unwrap();
+
+    let name = resources[0].id.name_str();
+    assert!(
+        name.starts_with("bootstrap."),
+        "expected `bootstrap.<hash>` prefix, got {:?}",
+        name,
+    );
+    assert!(
+        name.contains("awscc_iam_role_policy_"),
+        "expected hash-based identifier suffix, got {:?}",
+        name,
+    );
+}
+
 #[test]
 fn test_anonymous_resource_no_create_only_properties() {
     // Resources with no create-only properties should still work as anonymous resources

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use indexmap::IndexMap;
 
 use crate::parser::ModuleCall;
-use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, Value};
+use crate::resource::{LifecycleConfig, Resource, ResourceId, ResourceKind, ResourceName, Value};
 
 use super::error::ModuleError;
 use super::resolver::ModuleResolver;
@@ -151,13 +151,19 @@ impl ModuleResolver<'_> {
         for resource in &module.resources {
             let mut new_resource = resource.clone();
 
-            // Prefix the resource name with instance path (dot-separated)
-            let new_name = format!("{}.{}", instance_prefix, new_resource.id.name_str());
-            new_resource.id = ResourceId::with_provider(
-                &new_resource.id.provider,
-                &new_resource.id.resource_type,
-                new_name.clone(),
-            );
+            // Only Bound names take the prefix here. Pending names stay
+            // Pending so `compute_anonymous_identifiers` can later attach
+            // both the hash and the instance prefix in one shot — see
+            // `identifier::compute_anonymous_identifiers` for the full
+            // story (#2516).
+            if let ResourceName::Bound(name) = &new_resource.id.name {
+                let new_name = format!("{}.{}", instance_prefix, name);
+                new_resource.id = ResourceId::with_provider(
+                    &new_resource.id.provider,
+                    &new_resource.id.resource_type,
+                    new_name,
+                );
+            }
 
             // Rewrite binding with instance path (dot-separated)
             if let Some(ref binding) = new_resource.binding {

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -106,6 +106,89 @@ fn test_substitute_arguments_nested() {
     }
 }
 
+/// Module containing one anonymous resource (`id.name` is `Pending`,
+/// no `let` binding). Used to verify that expansion preserves
+/// `Pending` rather than collapsing it to `Bound("<instance>.")` —
+/// a `Bound` value with a trailing dot would slip past
+/// `compute_anonymous_identifiers`'s `is_pending` filter and never
+/// receive its hash-derived suffix (#2516).
+fn create_test_module_with_anonymous_resource() -> ParsedFile {
+    ParsedFile {
+        providers: vec![],
+        resources: vec![Resource {
+            id: ResourceId::with_provider("awscc", "iam.RolePolicy", ""),
+            attributes: {
+                let mut attrs = IndexMap::new();
+                attrs.insert(
+                    "policy_name".to_string(),
+                    Value::String("inline".to_string()),
+                );
+                attrs
+            },
+            kind: ResourceKind::Managed,
+            lifecycle: LifecycleConfig::default(),
+            prefixes: HashMap::new(),
+            binding: None,
+            dependency_bindings: BTreeSet::new(),
+            module_source: None,
+            quoted_string_attrs: std::collections::HashSet::new(),
+        }],
+        variables: IndexMap::new(),
+        uses: vec![],
+        module_calls: vec![],
+        arguments: vec![],
+        attribute_params: vec![],
+        export_params: vec![],
+        backend: None,
+        state_blocks: vec![],
+        user_functions: HashMap::new(),
+        upstream_states: vec![],
+        requires: vec![],
+        structural_bindings: HashSet::new(),
+        warnings: vec![],
+        deferred_for_expressions: vec![],
+    }
+}
+
+#[test]
+fn test_expand_anonymous_resource_in_named_module_keeps_name_pending() {
+    use crate::resource::ResourceName;
+
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert(
+            "policy_module".to_string(),
+            create_test_module_with_anonymous_resource(),
+        );
+        r
+    };
+    let call = ModuleCall {
+        module_name: "policy_module".to_string(),
+        binding_name: Some("bootstrap".to_string()),
+        arguments: HashMap::new(),
+    };
+
+    let expanded = resolver.expand_module_call(&call, "bootstrap").unwrap();
+    assert_eq!(expanded.len(), 1);
+    let policy = &expanded[0];
+    assert!(
+        matches!(policy.id.name, ResourceName::Pending),
+        "anonymous resource inside a module instance must remain Pending after expansion \
+         (compute_anonymous_identifiers filters on Pending and would skip a Bound value); \
+         got {:?}",
+        policy.id.name,
+    );
+    assert_eq!(
+        policy.module_source,
+        Some(crate::resource::ModuleSource::Module {
+            name: "policy_module".to_string(),
+            instance: "bootstrap".to_string(),
+        }),
+        "module_source must be set so compute_anonymous_identifiers can prepend \
+         the instance prefix when the Pending name is bound"
+    );
+}
+
 #[test]
 fn test_expand_module_call() {
     let resolver = {


### PR DESCRIPTION
## Summary

Fixes #2516. Anonymous resources declared inside a named module instantiation rendered as `bootstrap.` (trailing dot) in plan output instead of `bootstrap.awscc_iam_role_policy_<hash>`. This PR makes the module-instance prefix flow through to the final identifier so the address surfaces the owning module instance, matching how `let`-bound module-internal resources already render (`bootstrap.role`).

## Root cause

Two bugs in series:

1. `module_resolver/expander.rs` built the prefixed name with `format!("{instance_prefix}.{}", name_str())` against `Pending` names. `name_str()` collapses `Pending` to `""`, so the result was `"bootstrap."`, and `ResourceName::from_string` re-classified it as `Bound("bootstrap.")` because the string was non-empty.
2. `compute_anonymous_identifiers` filters on `is_pending`, so the laundered Bound name slipped past it and never received the hash-based suffix.

End result: `bootstrap.` (or worse, an empty suffix in fixture mode) instead of `bootstrap.awscc_iam_role_policy_<hash>`.

## Fix

- `carina-core/src/module_resolver/expander.rs`: match on `ResourceName::Bound(name)` and only then build the prefixed identifier. `Pending` names stay Pending; the instance prefix is recorded in the existing typed `module_source` field for the next stage.
- `carina-core/src/identifier/mod.rs`: in `compute_anonymous_identifiers`, read `module_source` and prepend `<instance>.` to the bare hash identifier when the resource lives inside a `ModuleSource::Module { instance, .. }`. Collision detection sees the prefixed form, so anonymous resources with matching create-only attrs in different module instances stay at distinct addresses.

The fix uses the existing `ResourceName` enum and existing `module_source` typed field — no new public API, no state migration, no schema change. The `ResourceName` enum now has its first production-code `match` site, surfacing the `Pending` / `Bound` distinction at the expander call site instead of laundering through `name_str()`.

## Tests

- `test_expand_anonymous_resource_in_named_module_keeps_name_pending` in `carina-core/src/module_resolver/tests.rs` — guards the expander against the Pending → Bound laundering.
- `test_anonymous_resource_inside_module_keeps_instance_prefix` in `carina-core/src/identifier/tests.rs` — guards the prefix-on-finalize path; asserts `bootstrap.awscc_iam_role_policy_<hash>`.
- New `module_anonymous_resource` plan-display fixture + snapshot test + Makefile target — locks in the no-trailing-dot regression at the rendered-output level. Fixture mode skips schema-based hash computation, so the snapshot does not include the `<hash>` suffix; the unit tests cover that path.
- All 2877 workspace tests pass; doctests pass; clippy clean; `scripts/check-*.sh` all pass.

## Scope

- State migration is intentionally out of scope. The user instructed this change can use `moved` blocks for any per-environment migration; no inline backward-compat shims are introduced.
- Display option D (annotation/tag style) was discussed and discarded in favor of B (namespace propagation) per user choice.

## Test plan

- [x] `cargo nextest run --workspace` (2877 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-docs-use-new-spellings.sh`
- [x] `scripts/check-example-warnings.sh`
- [x] `scripts/check-no-direct-resources-access.sh`
- [x] `scripts/check-plan-fixtures.sh` (new fixture has Makefile target)
- [x] `scripts/check-provider-boundaries.sh`

Closes #2516
