### PR TITLE
core/differ: document Union[String, list(String)] canonical-form invariant (#2512)

### DIFF
--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -23,6 +23,27 @@ use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_jso
 ///
 /// When `secret_ctx` is provided, it is used for context-specific salt when
 /// comparing `Value::Secret` against state hash strings.
+///
+/// # Invariant: `Union[String, list(String)]` is canonicalized upstream
+///
+/// For attributes typed as `Union[String, list(String)]` (the IAM-style
+/// `string_or_list_of_strings` shape — see #2481), **both** `a` and
+/// `b` reach this function as the canonical `Value::StringList` form,
+/// never as a mix of `Value::String` and `Value::List([String])`. The
+/// canonicalization happens upstream in
+/// `value::canonicalize_resources_with_schemas` (#2511) for the
+/// desired side and `value::canonicalize_states_with_schemas` (#2513)
+/// for the actual side, both run before the differ.
+///
+/// **Do not add a special-case equality here that treats `"x"` and
+/// `["x"]` as equal for this Union type.** Doing so would mask the
+/// canonicalization invariant: if a non-canonical value reaches the
+/// differ, that is an upstream bug and should fail the comparison so
+/// the diff surfaces it. Special-case equality at the comparator
+/// hides the divergence and leaves state files recording the
+/// non-canonical shape, so plan diffs would keep firing on the next
+/// run — exactly the phantom-diff regression that #2481 set out to
+/// eliminate.
 pub(super) fn type_aware_equal(
     a: &Value,
     b: &Value,

--- a/carina-core/src/differ/comparison_tests.rs
+++ b/carina-core/src/differ/comparison_tests.rs
@@ -850,3 +850,74 @@ fn secret_in_map_with_refresh_no_false_diff() {
         changed,
     );
 }
+
+// ---- Union[String, list(String)] canonical-form invariant (#2481, #2512) ----
+
+/// Helper: build the `Union[String, list(String)]` shape used by
+/// IAM-style `string_or_list_of_strings` schema fields.
+fn string_or_list_of_strings_type() -> AttributeType {
+    AttributeType::Union(vec![
+        AttributeType::String,
+        AttributeType::list(AttributeType::String),
+    ])
+}
+
+#[test]
+fn union_string_or_list_canonical_string_list_equal_to_self() {
+    // Two `Value::StringList` values with identical contents must be
+    // equal under the differ for the `Union[String, list(String)]`
+    // type. Sanity check that the canonical form is comparable at all.
+    let union = string_or_list_of_strings_type();
+    let a = Value::StringList(vec!["repo:foo:*".to_string()]);
+    let b = Value::StringList(vec!["repo:foo:*".to_string()]);
+    assert!(type_aware_equal(&a, &b, Some(&union), None));
+}
+
+#[test]
+fn union_string_or_list_canonical_string_list_diff_on_different_content() {
+    let union = string_or_list_of_strings_type();
+    let a = Value::StringList(vec!["repo:foo:*".to_string()]);
+    let b = Value::StringList(vec!["repo:bar:*".to_string()]);
+    assert!(!type_aware_equal(&a, &b, Some(&union), None));
+}
+
+#[test]
+fn union_string_or_list_non_canonical_mixed_shapes_fail_to_equal() {
+    // Invariant guard (#2512): a non-canonical pair must NOT be
+    // treated as equal by the differ. If the canonicalization upstream
+    // (#2511 / #2513) ever regresses, this test catches the resulting
+    // phantom diff at its source instead of letting the comparator
+    // paper over it. Adding a special-case equality here would defeat
+    // the type-level canonicalization design.
+    let union = string_or_list_of_strings_type();
+    let scalar = Value::String("repo:foo:*".to_string());
+    let canonical = Value::StringList(vec!["repo:foo:*".to_string()]);
+    assert!(!type_aware_equal(&scalar, &canonical, Some(&union), None));
+
+    let legacy_list = Value::List(vec![Value::String("repo:foo:*".to_string())]);
+    assert!(!type_aware_equal(
+        &legacy_list,
+        &canonical,
+        Some(&union),
+        None
+    ));
+}
+
+#[test]
+fn union_string_or_list_through_custom_wrapper() {
+    // `Custom` wrappers around the union must remain transparent —
+    // the comparator delegates `Custom { base, .. }` to its `base`.
+    let inner = string_or_list_of_strings_type();
+    let custom = AttributeType::Custom {
+        semantic_name: Some("PolicyConditionValue".to_string()),
+        base: Box::new(inner),
+        pattern: None,
+        length: None,
+        validate: std::sync::Arc::new(|_| Ok(())),
+        namespace: None,
+        to_dsl: None,
+    };
+    let a = Value::StringList(vec!["x".to_string()]);
+    let b = Value::StringList(vec!["x".to_string()]);
+    assert!(type_aware_equal(&a, &b, Some(&custom), None));
+}


### PR DESCRIPTION
## Summary

Sub-issue 3 of #2481. Documents the type-level canonicalization invariant in the differ and adds regression-guard tests, instead of teaching `comparison.rs` a special-case equality between `Value::String` and `Value::List([String])` for `Union[String, list(String)]`.

By the time a comparison reaches `type_aware_equal`, both sides have already been canonicalized to `Value::StringList` upstream:
- desired side: `canonicalize_resources_with_schemas` (#2511)
- actual side: `canonicalize_states_with_schemas` (#2513)

A special-case equality at the comparator would mask a regression in the upstream canonicalization passes and re-introduce the phantom-diff bug that #2481 set out to eliminate.

## Changes

- **Doc comment on `type_aware_equal`** in `carina-core/src/differ/comparison.rs`: an "Invariant" section spells out that both arguments arrive in canonical form for this Union type, and that special-case equality must not be added here.
- **4 new tests** in `carina-core/src/differ/comparison_tests.rs`:
  - `union_string_or_list_canonical_string_list_equal_to_self` — sanity check that the canonical form is comparable
  - `union_string_or_list_canonical_string_list_diff_on_different_content` — diff on different content
  - `union_string_or_list_non_canonical_mixed_shapes_fail_to_equal` — **regression guard**: scalar vs StringList and `List([String])` vs StringList must NOT be equal under this Union type
  - `union_string_or_list_through_custom_wrapper` — `Custom` wrapper transparency

## Test plan

- [x] `cargo nextest run --workspace` (2887 tests passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] CI green

Closes #2512. Refs #2481.
