### PR TITLE
value: handle Value::StringList in format_value_pretty layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ plan-fixtures:
 	@echo "---"
 	@$(MAKE) plan-policy-pretty-nested
 	@echo "---"
+	@$(MAKE) plan-policy-pretty-dynamic-key-list
+	@echo "---"
 	@$(MAKE) plan-pretty-long-string-list
 	@echo "---"
 	@$(MAKE) plan-pretty-short-string-list
@@ -161,6 +163,8 @@ plan-policy-pretty:
 	$(PLAN_FIXTURE) policy_pretty
 plan-policy-pretty-nested:
 	$(PLAN_FIXTURE) policy_pretty_nested
+plan-policy-pretty-dynamic-key-list:
+	$(PLAN_FIXTURE) policy_pretty_dynamic_key_list
 plan-pretty-long-string-list:
 	$(PLAN_FIXTURE) pretty_long_string_list
 plan-pretty-short-string-list:
@@ -176,7 +180,8 @@ plan-module-anonymous-resource:
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \
         plan-upstream-state-map-subscript plan-upstream-state-map-dot-notation \
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
-        plan-policy-pretty-nested plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
+        plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
+        plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
         plan-module-anonymous-resource \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -113,6 +113,27 @@ fn snapshot_policy_pretty_nested() {
 }
 
 #[test]
+fn snapshot_policy_pretty_dynamic_key_list() {
+    // #2528 acceptance: an IAM trust-policy `condition.<op>.<context-key>:
+    // [list]` shape — a multi-element list-of-strings nested under a
+    // dynamic-key Map — must break across lines all the way down, the
+    // same way `statement[].action` does. Pre-fix the deepest list
+    // collapsed to one line because the inline-vs-vertical decision did
+    // not bubble down to nested Map values.
+    let (plan, schemas, _moved) = build_plan_from_fixture("policy_pretty_dynamic_key_list");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_pretty_long_string_list() {
     let (plan, schemas, _moved) = build_plan_from_fixture("pretty_long_string_list");
     let output = strip_ansi(&format_plan(

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_dynamic_key_list.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_dynamic_key_list.snap
@@ -1,0 +1,24 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + awscc.ec2.Vpc 
+      cidr_block: "10.0.0.0/16"
+      config:
+        statement: 
+          - action: ["sts:AssumeRoleWithWebIdentity"]
+            condition: 
+              string_equals: 
+                token.actions.githubusercontent.com:aud: ["sts.amazonaws.com"]
+              string_like: 
+                token.actions.githubusercontent.com:sub: [
+                  "repo:carina-rs/infra:ref:refs/heads/main",
+                  "repo:carina-rs/infra:pull_request",
+                ]
+            effect: "Allow"
+            sid: "AssumeRole"
+        version: "2012-10-17"
+
+Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/policy_pretty_dynamic_key_list/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/policy_pretty_dynamic_key_list/main.crn
@@ -1,0 +1,38 @@
+# IAM trust-policy `condition` shape that mirrors the real
+# `registry/dev/bootstrap` plan (#2528): a multi-element list-of-strings
+# nested under a *dynamic-key* Map (the GitHub OIDC subject context key).
+# This fixture pins the multi-line form across the full nesting depth
+# for the `Value::List` path. The `Value::StringList` path (the
+# canonicalized form `Union[String, list(String)]` collapses to in
+# #2511) is not reachable through this fixture because `awscc.ec2.Vpc`
+# has no schema attribute typed as that union; the unit tests at
+# `format_value_pretty_string_list_*` cover that path directly.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+  config = {
+    version = '2012-10-17'
+    statement = [
+      {
+        sid    = 'AssumeRole'
+        effect = 'Allow'
+        action = ['sts:AssumeRoleWithWebIdentity']
+        condition = {
+          string_equals = {
+            'token.actions.githubusercontent.com:aud' = ['sts.amazonaws.com']
+          }
+          string_like = {
+            'token.actions.githubusercontent.com:sub' = [
+              'repo:carina-rs/infra:ref:refs/heads/main',
+              'repo:carina-rs/infra:pull_request',
+            ]
+          }
+        }
+      },
+    ]
+  }
+}

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -791,8 +791,15 @@ impl<'a> PrettyLayout<'a> {
 /// - `Value::List` of scalars renders inline `[a, b, c]` if the entire line
 ///   (`<indent>key: <inline>`) fits within `PRETTY_LINE_LIMIT`; otherwise
 ///   expands to a bracketed multi-line form.
+/// - `Value::StringList` (the canonicalized `Union[String, list(String)]`
+///   form, #2511) follows the same inline-vs-vertical rule as
+///   `Value::List` of `Value::String` (#2528).
 /// - `Value::Map` renders inline if it fits, otherwise expands vertically
 ///   with each key at `parent_indent_cols + 2`.
+///
+/// When adding a new layout-bearing `Value` variant, add a new arm here
+/// — the wildcard fallthrough collapses to the inline form and skips
+/// the line-budget check, which is wrong for any container variant.
 pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
     match value {
         Value::List(items) => {
@@ -813,6 +820,27 @@ pub fn format_value_pretty(value: &Value, layout: PrettyLayout<'_>) -> String {
                 return format_value_with_key(value, None);
             }
             format_list_of_scalars_vertical(items, layout.child_indent_cols())
+        }
+        Value::StringList(items) => {
+            // #2528: `Value::StringList` is the canonicalized form the
+            // `Union[String, list(String)]` shape collapses to (#2511).
+            // It behaves like `Value::List` of `Value::String` for
+            // layout purposes — apply the same inline-vs-vertical
+            // decision so a long list under a dynamic-key Map (e.g. an
+            // IAM `condition.string_like.<context-key>: [a, b]`) breaks
+            // across lines instead of dumping inline. Lift items to
+            // `Value::String` for the vertical fallback so the per-item
+            // rendering (SECRET_PREFIX redaction, DSL-enum resolution)
+            // stays byte-identical to `format_value_with_key`'s arm.
+            if items.is_empty() {
+                return "[]".to_string();
+            }
+            let budget = PRETTY_LINE_LIMIT.saturating_sub(layout.prefix_cols());
+            if inline_width(value, budget).is_some() {
+                return format_value_with_key(value, None);
+            }
+            let lifted: Vec<Value> = items.iter().cloned().map(Value::String).collect();
+            format_list_of_scalars_vertical(&lifted, layout.child_indent_cols())
         }
         Value::Map(map) => {
             if map.is_empty() {
@@ -2086,6 +2114,119 @@ mod tests {
         assert!(
             out.contains("\"iam:Action000\","),
             "expected first action on its own line: {out}"
+        );
+    }
+
+    #[test]
+    fn format_value_pretty_string_list_under_dynamic_key_breaks_vertically() {
+        // #2528 hypothesis: when the deepest value is `Value::StringList`
+        // (the canonical form #2511 folds `Union[String, list(String)]`
+        // into) rather than `Value::List`, `format_value_pretty` treats
+        // it as a scalar fallthrough and renders inline. This pins the
+        // expected vertical break.
+        let mut string_like = IndexMap::new();
+        string_like.insert(
+            "token.actions.githubusercontent.com:sub".to_string(),
+            Value::StringList(vec![
+                "repo:carina-rs/infra:ref:refs/heads/main".to_string(),
+                "repo:carina-rs/infra:pull_request".to_string(),
+            ]),
+        );
+        let v = Value::Map(string_like);
+        // Mirror the layout under `condition.string_like:` (parent at
+        // col 12 from the MapExpanded entry indentation). Inside a Map
+        // the value text starts after `<key>: ` so the bracketed form
+        // appears as `<key>: [\n   "...",\n   "..."\n  ]` — one element
+        // per line with a trailing comma. The inline form is the
+        // single-line `<key>: ["...", "..."]` with no `\n` mid-list.
+        let out = format_value_pretty(&v, layout(12, "string_like"));
+        assert!(
+            out.contains(":sub: [\n"),
+            "expected dynamic-key StringList to start its bracketed form, got:\n{out}"
+        );
+        assert!(
+            out.contains("refs/heads/main\",\n"),
+            "expected first element on its own line with trailing comma, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_value_pretty_top_level_string_list_breaks_vertically_when_oversize() {
+        // The same fix applies when a top-level attribute value is
+        // already canonicalized to `Value::StringList`. Pre-fix the
+        // wildcard arm collapsed it to `["a", "b", ...]` even when the
+        // line exceeded `PRETTY_LINE_LIMIT`.
+        let v = Value::StringList(vec!["a".repeat(40), "b".repeat(40)]);
+        let out = format_value_pretty(&v, layout(0, "k"));
+        assert!(
+            out.starts_with("[\n"),
+            "expected oversize StringList to expand vertically, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_value_pretty_string_list_vertical_redacts_secret_prefix_strings() {
+        // Pin parity with `Value::List<Value::String>`: a string with
+        // the SECRET_PREFIX must render as `(secret)` even when reached
+        // through the StringList vertical path. Pre-fix attempt
+        // (a dedicated `format_list_of_strings_vertical` that quoted the
+        // raw &str) would have leaked the hash; the current shape lifts
+        // items to `Value::String` and reuses
+        // `format_list_of_scalars_vertical`, so the SECRET_PREFIX arm
+        // in `format_value_with_key` runs unchanged.
+        let v = Value::StringList(vec![
+            format!("{}deadbeef", SECRET_PREFIX),
+            "x".repeat(80), // force vertical
+        ]);
+        let out = format_value_pretty(&v, layout(0, "k"));
+        assert!(
+            out.contains("(secret),"),
+            "expected SECRET_PREFIX item to render as `(secret),` in the vertical form, got:\n{out}"
+        );
+        assert!(
+            !out.contains("deadbeef"),
+            "expected hash bytes to not leak into the vertical form, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_value_pretty_nested_map_with_dynamic_key_list_value_breaks_vertically() {
+        // #2528: an IAM trust-policy `condition.<operator>.<context-key>:
+        // [list]` shape — a multi-element list-of-strings nested inside
+        // a Map inside a Map inside a list-of-maps inside a Map field.
+        // After #2524 the outer list-of-maps and its `action` siblings
+        // break vertically, but the deepest list (under a dynamic Map
+        // key) used to stay on one line because the prefix-width budget
+        // check looked only at the immediate parent key, not at the
+        // *sum* of all nested key prefixes once expansion bubbles down.
+        //
+        // Pin the expected break: the multi-element list under the
+        // dynamic key must render with its bracketed multi-line form,
+        // not collapse to `key: ["a", "b"]`.
+        let mut string_like = IndexMap::new();
+        string_like.insert(
+            "token.actions.githubusercontent.com:sub".to_string(),
+            Value::List(vec![
+                Value::String("repo:carina-rs/infra:ref:refs/heads/main".to_string()),
+                Value::String("repo:carina-rs/infra:pull_request".to_string()),
+            ]),
+        );
+        let mut condition = IndexMap::new();
+        condition.insert("string_like".to_string(), Value::Map(string_like));
+        let mut entry = IndexMap::new();
+        entry.insert("sid".to_string(), Value::String("AssumeRole".to_string()));
+        entry.insert("condition".to_string(), Value::Map(condition));
+        let v = Value::List(vec![Value::Map(entry)]);
+        let out = format_value_pretty(&v, layout(4, "statement"));
+        // The dynamic-key list value must break across lines (bracketed
+        // form), not collapse to `<dynamic-key>: ["a", "b"]`.
+        assert!(
+            out.contains(":sub: ["),
+            "expected dynamic-key list to start its bracket form, got:\n{out}"
+        );
+        assert!(
+            out.contains("\"repo:carina-rs/infra:ref:refs/heads/main\","),
+            "expected first list element on its own line with trailing comma, got:\n{out}"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #2528.

`format_value_pretty` had no arm for `Value::StringList`, the canonical form `Union[String, list(String)]` collapses to since #2511. The wildcard fallthrough sent the whole value to `format_value_with_key` and skipped the line-budget check, so a long list-of-strings reached through the canonical form rendered inline even when it overflowed `PRETTY_LINE_LIMIT`. In real plan output (the IAM trust-policy `condition.string_like.<context-key>: [list]` shape from `registry/dev/bootstrap`) the deepest list under a dynamic-key Map collapsed to a single line — the exact case #2528 reported.

## Fix

Add a `Value::StringList` arm to `format_value_pretty` mirroring the `Value::List` shape:

1. Empty list → `"[]"`.
2. Otherwise, `inline_width(value, budget)` — does the inline form fit on the rest of the line?
3. If yes → `format_value_with_key(value, None)` (single-line `["a", "b"]`).
4. If no → lift items to `Value::String` and delegate to the existing `format_list_of_scalars_vertical`.

Lifting to `Value::String` (rather than writing a new `format_list_of_strings_vertical`) keeps SECRET_PREFIX redaction and DSL-enum resolution on the vertical path byte-for-byte identical to the `Value::List<Value::String>` path. A standalone helper that quoted `&str` directly would have leaked secret hashes and skipped enum resolution; the lift costs one `String` clone per item on the cold (overflow) path and zero on the success path.

## Why this drifted

`Value::StringList` was added in #2510 / #2511 with `format_value_into` updated to handle it. `format_value_pretty` was not — its `match` enumerates only the layout-bearing variants known at the time. The doc comment is now updated to call out the asymmetry: when a new layout-bearing variant lands, `format_value_pretty`'s `match` needs an arm too, because the wildcard fallthrough collapses to the inline form.

## Test plan

Unit tests in `carina-core/src/value.rs`:

- `format_value_pretty_string_list_under_dynamic_key_breaks_vertically`: pins the IAM trust-policy condition shape — a `Value::StringList` reached through a dynamic-key Map breaks across lines.
- `format_value_pretty_top_level_string_list_breaks_vertically_when_oversize`: pins the simpler top-level case.
- `format_value_pretty_string_list_vertical_redacts_secret_prefix_strings`: pins SECRET_PREFIX parity with the `Value::List<Value::String>` path — fails if a future refactor reintroduces a standalone vertical helper that bypasses `format_value_with_key`'s String arm.
- `format_value_pretty_nested_map_with_dynamic_key_list_value_breaks_vertically`: regression pin for the surrounding `Value::List` shape (the path #2524 fixed at the outer level).

Snapshot test:

- `snapshot_policy_pretty_dynamic_key_list` (new fixture `policy_pretty_dynamic_key_list/main.crn`): regression coverage for the `Value::List`-side rendering of the IAM trust-policy `condition.string_like.<context-key>` shape across the full nesting depth (`statement[].condition.<operator>.<key>: [list]`). The `Value::StringList` path is not reachable through this fixture because `awscc.ec2.Vpc` has no `Union[String, list(String)]` schema attribute; the unit tests cover that path directly.

Verify:

- [x] `cargo nextest run --workspace` (2884 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
