### PR TITLE
state(s3): seed state-bucket identifier so apply does not recreate it

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -607,6 +607,7 @@ pub async fn run_apply(
                         &bucket_name,
                         backend_provider_name,
                     )
+                    .with_identifier(&bucket_name)
                     .with_attribute("bucket".to_string(), serde_json::json!(bucket_name))
                     .with_protected(true);
 

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -11,9 +11,15 @@ use carina_core::utils::convert_region_value;
 
 use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, StateFile};
+use crate::state::{self, ResourceState, StateFile};
 
 const REGION_UNRESOLVED_MESSAGE: &str = "S3 backend has no region: set `region` in the backend block, or configure AWS_REGION / a profile region";
+
+/// Provider name reported for the storage resource (the state bucket).
+const BACKEND_PROVIDER_NAME: &str = "aws";
+
+/// Resource type used to surface the state bucket in carina state.
+const BACKEND_RESOURCE_TYPE: &str = "s3.Bucket";
 
 /// S3-based state backend
 pub struct S3Backend {
@@ -341,18 +347,27 @@ impl StateBackend for S3Backend {
     }
 
     async fn init(&self) -> BackendResult<()> {
-        // Check if bucket exists
+        // Track whether we just created the bucket: if so, the bucket is
+        // unambiguously owned by carina and must be seeded into state. Without
+        // the seed, plan diffs an empty state against a desired aws.s3.Bucket
+        // and the next apply re-issues CreateBucket — failing with
+        // BucketAlreadyOwnedByYou (#2533).
+        let mut bucket_was_just_created = false;
         if !self.bucket_exists().await? {
             if self.auto_create {
                 self.create_bucket().await?;
+                bucket_was_just_created = true;
             } else {
                 return Err(BackendError::BucketNotFound(self.bucket.clone()));
             }
         }
 
-        // Initialize empty state if none exists
         if self.read_state().await?.is_none() {
-            let state = StateFile::new();
+            let state = if bucket_was_just_created {
+                state_bucket_seed(&self.bucket)
+            } else {
+                StateFile::new()
+            };
             self.write_state(&state).await?;
         }
 
@@ -375,11 +390,11 @@ impl StateBackend for S3Backend {
     }
 
     fn provider_name(&self) -> Option<&str> {
-        Some("aws")
+        Some(BACKEND_PROVIDER_NAME)
     }
 
     fn resource_type(&self) -> Option<&str> {
-        Some("s3.Bucket")
+        Some(BACKEND_RESOURCE_TYPE)
     }
 
     fn resource_definition(&self, name: &str) -> Option<String> {
@@ -423,6 +438,24 @@ impl StateBackend for S3Backend {
 
         Ok(())
     }
+}
+
+/// Build the initial `StateFile` for a freshly-created state bucket,
+/// recording the bucket itself as a protected `aws.s3.Bucket` resource.
+/// Without this seed, plan would diff an empty state against the
+/// auto-injected desired bucket and apply would re-issue `CreateBucket`.
+///
+/// `identifier` must be set — `StateFile::build_state_for_resource` treats
+/// a `None` identifier as "resource does not exist", which would defeat
+/// the seed and reproduce the original bug.
+fn state_bucket_seed(bucket_name: &str) -> StateFile {
+    let bucket = ResourceState::new(BACKEND_RESOURCE_TYPE, bucket_name, BACKEND_PROVIDER_NAME)
+        .with_identifier(bucket_name)
+        .with_attribute("bucket", serde_json::json!(bucket_name))
+        .with_protected(true);
+    let mut state = StateFile::new();
+    state.upsert_resource(bucket);
+    state
 }
 
 /// Render the auto-generated `aws.s3.Bucket` block that `carina apply`
@@ -586,6 +619,37 @@ mod tests {
         assert!(
             !definition.contains("versioning_status"),
             "auto-definition must not reference the removed versioning_status attribute, got: {definition}"
+        );
+    }
+
+    #[test]
+    fn test_state_bucket_seed_records_bucket_as_protected_resource() {
+        // After `carina init` auto-creates the bucket, plan must already see
+        // it in state — otherwise apply re-issues CreateBucket and hits
+        // BucketAlreadyOwnedByYou.
+        let seed = state_bucket_seed("my-state-bucket");
+        assert_eq!(
+            seed.resources.len(),
+            1,
+            "seed should contain exactly one resource"
+        );
+        let bucket = &seed.resources[0];
+        assert_eq!(bucket.resource_type, "s3.Bucket");
+        assert_eq!(bucket.name, "my-state-bucket");
+        assert_eq!(bucket.provider, "aws");
+        assert!(bucket.protected, "state bucket must be protected");
+        assert_eq!(
+            bucket.attributes.get("bucket"),
+            Some(&serde_json::json!("my-state-bucket")),
+            "seed must carry the bucket attribute"
+        );
+        // identifier is load-bearing: build_state_for_resource treats
+        // identifier=None as "resource does not exist", which would defeat
+        // the seed and reproduce #2533.
+        assert_eq!(
+            bucket.identifier.as_deref(),
+            Some("my-state-bucket"),
+            "seed must populate identifier so the differ recognises the bucket as existing"
         );
     }
 


### PR DESCRIPTION
## Summary

- The auto-bootstrap path constructed the protected state-bucket `ResourceState` without an `identifier`. `StateFile::build_state_for_resource` treats `identifier=None` as "resource does not exist", so the differ emitted `Create` for the bucket the backend had just made — and the next `carina apply` failed with `BucketAlreadyOwnedByYou`.
- Fix the seed at both production sites:
  - `S3Backend::init` now seeds the freshly-created bucket via a new `state_bucket_seed` helper (only when this process actually created the bucket; pre-existing buckets are left for explicit import).
  - The apply bootstrap path's parallel seed gains the same `.with_identifier(&bucket_name)`.
- Extracts `BACKEND_PROVIDER_NAME` / `BACKEND_RESOURCE_TYPE` constants to dedupe the `"aws"` / `"s3.Bucket"` literals shared by the trait impl and the seed helper.
- Adds a regression test asserting the seed shape including the `identifier`, so the same blind spot cannot recur silently.
- Cross-crate dedup of the two seed call sites is tracked in #2538.

Closes #2533

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (468 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` and `bash scripts/validate-crn-files.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
