### PR TITLE
carina-state: hoist state-bucket seed into StateFile/ResourceState

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -18,7 +18,7 @@ use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
-use carina_state::{LockInfo, ResourceState, StateBackend, StateFile, resolve_backend};
+use carina_state::{LockInfo, StateBackend, StateFile, resolve_backend};
 
 use carina_core::parser::ProviderContext;
 
@@ -598,22 +598,14 @@ pub async fn run_apply(
                         target_file.display()
                     );
 
-                    // Create a protected ResourceState for the auto-created bucket
                     let backend_resource_type = backend
                         .resource_type()
                         .ok_or("Backend does not specify a resource type")?;
-                    let bucket_state = ResourceState::new(
+                    let initial_state = StateFile::with_managed_state_bucket(
+                        backend_provider_name,
                         backend_resource_type,
                         &bucket_name,
-                        backend_provider_name,
-                    )
-                    .with_identifier(&bucket_name)
-                    .with_attribute("bucket".to_string(), serde_json::json!(bucket_name))
-                    .with_protected(true);
-
-                    // Initialize state with the protected bucket
-                    let mut initial_state = StateFile::new();
-                    initial_state.upsert_resource(bucket_state);
+                    );
                     backend
                         .write_state(&initial_state)
                         .await

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -11,7 +11,7 @@ use carina_core::utils::convert_region_value;
 
 use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
-use crate::state::{self, ResourceState, StateFile};
+use crate::state::{self, StateFile};
 
 const REGION_UNRESOLVED_MESSAGE: &str = "S3 backend has no region: set `region` in the backend block, or configure AWS_REGION / a profile region";
 
@@ -364,7 +364,11 @@ impl StateBackend for S3Backend {
 
         if self.read_state().await?.is_none() {
             let state = if bucket_was_just_created {
-                state_bucket_seed(&self.bucket)
+                StateFile::with_managed_state_bucket(
+                    BACKEND_PROVIDER_NAME,
+                    BACKEND_RESOURCE_TYPE,
+                    &self.bucket,
+                )
             } else {
                 StateFile::new()
             };
@@ -438,24 +442,6 @@ impl StateBackend for S3Backend {
 
         Ok(())
     }
-}
-
-/// Build the initial `StateFile` for a freshly-created state bucket,
-/// recording the bucket itself as a protected `aws.s3.Bucket` resource.
-/// Without this seed, plan would diff an empty state against the
-/// auto-injected desired bucket and apply would re-issue `CreateBucket`.
-///
-/// `identifier` must be set — `StateFile::build_state_for_resource` treats
-/// a `None` identifier as "resource does not exist", which would defeat
-/// the seed and reproduce the original bug.
-fn state_bucket_seed(bucket_name: &str) -> StateFile {
-    let bucket = ResourceState::new(BACKEND_RESOURCE_TYPE, bucket_name, BACKEND_PROVIDER_NAME)
-        .with_identifier(bucket_name)
-        .with_attribute("bucket", serde_json::json!(bucket_name))
-        .with_protected(true);
-    let mut state = StateFile::new();
-    state.upsert_resource(bucket);
-    state
 }
 
 /// Render the auto-generated `aws.s3.Bucket` block that `carina apply`
@@ -619,37 +605,6 @@ mod tests {
         assert!(
             !definition.contains("versioning_status"),
             "auto-definition must not reference the removed versioning_status attribute, got: {definition}"
-        );
-    }
-
-    #[test]
-    fn test_state_bucket_seed_records_bucket_as_protected_resource() {
-        // After `carina init` auto-creates the bucket, plan must already see
-        // it in state — otherwise apply re-issues CreateBucket and hits
-        // BucketAlreadyOwnedByYou.
-        let seed = state_bucket_seed("my-state-bucket");
-        assert_eq!(
-            seed.resources.len(),
-            1,
-            "seed should contain exactly one resource"
-        );
-        let bucket = &seed.resources[0];
-        assert_eq!(bucket.resource_type, "s3.Bucket");
-        assert_eq!(bucket.name, "my-state-bucket");
-        assert_eq!(bucket.provider, "aws");
-        assert!(bucket.protected, "state bucket must be protected");
-        assert_eq!(
-            bucket.attributes.get("bucket"),
-            Some(&serde_json::json!("my-state-bucket")),
-            "seed must carry the bucket attribute"
-        );
-        // identifier is load-bearing: build_state_for_resource treats
-        // identifier=None as "resource does not exist", which would defeat
-        // the seed and reproduce #2533.
-        assert_eq!(
-            bucket.identifier.as_deref(),
-            Some("my-state-bucket"),
-            "seed must populate identifier so the differ recognises the bucket as existing"
         );
     }
 

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -49,6 +49,41 @@ impl StateFile {
         }
     }
 
+    /// Create a fresh state file pre-seeded with a backend-owned state
+    /// bucket recorded as a protected, managed resource. This is the seed
+    /// the state backend writes after auto-creating its own storage —
+    /// see [`ResourceState::managed_state_bucket`] for the shape.
+    ///
+    /// Single-resource by design: today only the S3 backend bootstraps a
+    /// single storage resource. A backend that needs to seed multiple
+    /// resources (e.g. a DynamoDB lock table alongside an S3 bucket)
+    /// will need a different API.
+    ///
+    /// ```
+    /// use carina_state::StateFile;
+    ///
+    /// let state = StateFile::with_managed_state_bucket(
+    ///     "aws",
+    ///     "s3.Bucket",
+    ///     "my-state-bucket",
+    /// );
+    /// assert_eq!(state.resources.len(), 1);
+    /// assert_eq!(state.resources[0].name, "my-state-bucket");
+    /// ```
+    pub fn with_managed_state_bucket(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        bucket_name: impl Into<String>,
+    ) -> Self {
+        let mut state = Self::new();
+        state.upsert_resource(ResourceState::managed_state_bucket(
+            provider,
+            resource_type,
+            bucket_name,
+        ));
+        state
+    }
+
     /// Create a new state file with a specific lineage (for initialization)
     pub fn with_lineage(lineage: String) -> Self {
         Self {
@@ -487,6 +522,26 @@ impl ResourceState {
     pub fn with_protected(mut self, protected: bool) -> Self {
         self.protected = protected;
         self
+    }
+
+    /// Build the seed `ResourceState` for a backend-owned state bucket.
+    ///
+    /// This is the canonical shape the state backend records when it
+    /// auto-creates its own storage (e.g. the S3 state bucket): protected,
+    /// with `identifier` populated so the differ recognises the resource as
+    /// existing — without `identifier`, `StateFile::build_state_for_resource`
+    /// returns "not found" and the next apply re-issues `CreateBucket`,
+    /// reproducing #2533 (`BucketAlreadyOwnedByYou`).
+    pub fn managed_state_bucket(
+        provider: impl Into<String>,
+        resource_type: impl Into<String>,
+        bucket_name: impl Into<String>,
+    ) -> Self {
+        let bucket_name = bucket_name.into();
+        Self::new(resource_type, &bucket_name, provider)
+            .with_identifier(&bucket_name)
+            .with_attribute("bucket", serde_json::json!(bucket_name))
+            .with_protected(true)
     }
 
     /// Merge write-only attribute values from the desired resource into this state.

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -66,6 +66,33 @@ fn test_resource_state_protected() {
 }
 
 #[test]
+fn test_resource_state_managed_state_bucket_shape() {
+    // The seed produced for backend-owned state buckets must carry
+    // identifier, the bucket attribute, and the protected flag.
+    // Missing identifier reproduces #2533 (BucketAlreadyOwnedByYou).
+    let resource = ResourceState::managed_state_bucket("aws", "s3.Bucket", "my-state-bucket");
+    assert_eq!(resource.provider, "aws");
+    assert_eq!(resource.resource_type, "s3.Bucket");
+    assert_eq!(resource.name, "my-state-bucket");
+    assert_eq!(resource.identifier.as_deref(), Some("my-state-bucket"));
+    assert!(resource.protected);
+    assert_eq!(
+        resource.attributes.get("bucket"),
+        Some(&serde_json::json!("my-state-bucket"))
+    );
+}
+
+#[test]
+fn test_state_file_with_managed_state_bucket_contains_one_resource() {
+    let state = StateFile::with_managed_state_bucket("aws", "s3.Bucket", "my-state-bucket");
+    assert_eq!(state.resources.len(), 1);
+    let bucket = &state.resources[0];
+    assert_eq!(bucket.name, "my-state-bucket");
+    assert_eq!(bucket.identifier.as_deref(), Some("my-state-bucket"));
+    assert!(bucket.protected);
+}
+
+#[test]
 fn test_state_file_serialization() {
     let mut state = StateFile::new();
     let resource = ResourceState::new("s3.Bucket", "my-bucket", "aws")


### PR DESCRIPTION
## Summary

- #2533 left two near-identical state-bucket seed constructions: a private `state_bucket_seed` in `carina-state/src/backends/s3.rs` and an inline build in `carina-cli/src/commands/apply/mod.rs::run_apply` bootstrap. Promote the pattern to public API on `carina-state` and route both call sites through a single canonical seed.
- New: `ResourceState::managed_state_bucket(provider, resource_type, bucket_name)` (primitive) builds the protected resource with `identifier` populated; docstring captures the load-bearing-identifier invariant from #2533.
- New: `StateFile::with_managed_state_bucket(...)` (thin wrapper) returns a fresh pre-seeded `StateFile`. Doctest covers canonical usage; an explicit "single-resource by design" note documents the scope for future multi-resource backends.
- `S3Backend::init` and the apply bootstrap path now both call the `StateFile` wrapper. Private helper, its inline test, and the no-longer-needed `ResourceState` imports at the call sites are removed. Two unit tests in `carina-state/src/state/tests.rs` pin the contract (provider, type, name, identifier, protected, attribute shape).

Closes #2538

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (469 tests pass)
- [x] `cargo test --workspace --doc` (new doctest on `with_managed_state_bucket`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` and `bash scripts/validate-crn-files.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
