### PR TITLE
state(s3): seed bucket with resolved resource name to prevent recreate loop

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -12,7 +12,6 @@ use carina_core::deps::sort_resources_by_dependencies;
 use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::executor::{ExecutionInput, ExecutionResult};
-use carina_core::module_resolver;
 use carina_core::plan::Plan;
 use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
@@ -45,7 +44,7 @@ use crate::wiring::{
     WiringContext, build_factories_from_providers, create_providers_from_configs,
     get_provider_with_ctx, read_data_source_with_retry, read_with_retry,
     reconcile_anonymous_identifiers_with_ctx, reconcile_prefixed_names,
-    resolve_data_source_refs_for_refresh, resolve_names_with_ctx,
+    resolve_data_source_refs_for_refresh,
 };
 
 /// Re-export ExecutionResult as the public API for apply results.
@@ -598,12 +597,46 @@ pub async fn run_apply(
                         target_file.display()
                     );
 
+                    // Re-parse and re-resolve the updated configuration so the
+                    // bucket resource is fully addressed (in particular: its
+                    // anonymous identifier is computed) before we seed state.
+                    // Without this, the seed can't use the resolved name and
+                    // the differ produces phantom Create + Delete entries on
+                    // the next plan (#2533). `skip_resource_validation = true`
+                    // reuses the heavier preflight pipeline only for its
+                    // resolve+anon-id steps; the schema validation already
+                    // ran on the pre-injection configuration.
+                    parsed = load_configuration_with_config(
+                        path,
+                        provider_context,
+                        &carina_core::schema::SchemaRegistry::new(),
+                    )?
+                    .parsed;
+                    validate_and_resolve_with_config(&mut parsed, base_dir, true)?;
+
                     let backend_resource_type = backend
                         .resource_type()
                         .ok_or("Backend does not specify a resource type")?;
+                    let bucket_resource_name = parsed
+                        .find_resource_by_attr(backend_resource_type, "bucket", &bucket_name)
+                        .map(|r| r.id.name_str().to_string())
+                        .ok_or_else(|| {
+                            format!(
+                                "Auto-injected state bucket resource '{}' not found after re-parse",
+                                bucket_name
+                            )
+                        })?;
+                    if bucket_resource_name.is_empty() {
+                        return Err(AppError::Config(format!(
+                            "Auto-injected state bucket resource '{}' has no resolved name; \
+                             anonymous identifier computation may have silently skipped it",
+                            bucket_name
+                        )));
+                    }
                     let initial_state = StateFile::with_managed_state_bucket(
                         backend_provider_name,
                         backend_resource_type,
+                        bucket_resource_name,
                         &bucket_name,
                     );
                     backend
@@ -614,25 +647,6 @@ pub async fn run_apply(
                         "  {} Registered state bucket as protected resource",
                         "✓".green()
                     );
-
-                    // Re-parse the updated configuration to include the new resource
-                    parsed = load_configuration_with_config(
-                        path,
-                        provider_context,
-                        &carina_core::schema::SchemaRegistry::new(),
-                    )?
-                    .parsed;
-                    if let Err(e) = module_resolver::resolve_modules_with_config(
-                        &mut parsed,
-                        get_base_dir(path),
-                        provider_context,
-                    ) {
-                        return Err(AppError::Config(format!("Module resolution error: {}", e)));
-                    }
-                    let name_errors = resolve_names_with_ctx(&ctx, &mut parsed.resources);
-                    if !name_errors.is_empty() {
-                        return Err(super::collapse_errors(name_errors));
-                    }
                 } else {
                     return Err(AppError::Config(format!(
                         "Backend bucket '{}' not found and auto_create is disabled",

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -347,32 +347,21 @@ impl StateBackend for S3Backend {
     }
 
     async fn init(&self) -> BackendResult<()> {
-        // Track whether we just created the bucket: if so, the bucket is
-        // unambiguously owned by carina and must be seeded into state. Without
-        // the seed, plan diffs an empty state against a desired aws.s3.Bucket
-        // and the next apply re-issues CreateBucket — failing with
-        // BucketAlreadyOwnedByYou (#2533).
-        let mut bucket_was_just_created = false;
+        // Seeding the state bucket as a managed resource needs the resolved
+        // anonymous identifier of the desired aws.s3.Bucket block in the
+        // user's .crn — not reachable from this layer. The carina-cli apply
+        // bootstrap path owns that responsibility (it parses the .crn,
+        // resolves the identifier, then writes the seeded StateFile).
         if !self.bucket_exists().await? {
             if self.auto_create {
                 self.create_bucket().await?;
-                bucket_was_just_created = true;
             } else {
                 return Err(BackendError::BucketNotFound(self.bucket.clone()));
             }
         }
 
         if self.read_state().await?.is_none() {
-            let state = if bucket_was_just_created {
-                StateFile::with_managed_state_bucket(
-                    BACKEND_PROVIDER_NAME,
-                    BACKEND_RESOURCE_TYPE,
-                    &self.bucket,
-                )
-            } else {
-                StateFile::new()
-            };
-            self.write_state(&state).await?;
+            self.write_state(&StateFile::new()).await?;
         }
 
         Ok(())

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -54,6 +54,11 @@ impl StateFile {
     /// the state backend writes after auto-creating its own storage —
     /// see [`ResourceState::managed_state_bucket`] for the shape.
     ///
+    /// `resource_name` must equal the desired resource's resolved name
+    /// (e.g. `aws_s3_bucket_<hash>` for the auto-injected anonymous block);
+    /// `bucket_name` is the AWS bucket identifier the provider acts on.
+    /// Conflating the two reproduces #2533.
+    ///
     /// Single-resource by design: today only the S3 backend bootstraps a
     /// single storage resource. A backend that needs to seed multiple
     /// resources (e.g. a DynamoDB lock table alongside an S3 bucket)
@@ -65,20 +70,23 @@ impl StateFile {
     /// let state = StateFile::with_managed_state_bucket(
     ///     "aws",
     ///     "s3.Bucket",
+    ///     "aws_s3_bucket_a3f2b1c8",
     ///     "my-state-bucket",
     /// );
     /// assert_eq!(state.resources.len(), 1);
-    /// assert_eq!(state.resources[0].name, "my-state-bucket");
+    /// assert_eq!(state.resources[0].name, "aws_s3_bucket_a3f2b1c8");
     /// ```
     pub fn with_managed_state_bucket(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
+        resource_name: impl Into<String>,
         bucket_name: impl Into<String>,
     ) -> Self {
         let mut state = Self::new();
         state.upsert_resource(ResourceState::managed_state_bucket(
             provider,
             resource_type,
+            resource_name,
             bucket_name,
         ));
         state
@@ -532,13 +540,21 @@ impl ResourceState {
     /// existing — without `identifier`, `StateFile::build_state_for_resource`
     /// returns "not found" and the next apply re-issues `CreateBucket`,
     /// reproducing #2533 (`BucketAlreadyOwnedByYou`).
+    ///
+    /// `resource_name` is the state-side resource name and must equal the
+    /// resolved name of the desired resource (anonymous resources get a
+    /// hash-derived id like `aws_s3_bucket_<hash>`); `bucket_name` is the
+    /// AWS bucket name used as the provider identifier and as the value
+    /// of the `bucket` attribute. Mixing the two breaks the differ — see
+    /// #2533 for the failure mode.
     pub fn managed_state_bucket(
         provider: impl Into<String>,
         resource_type: impl Into<String>,
+        resource_name: impl Into<String>,
         bucket_name: impl Into<String>,
     ) -> Self {
         let bucket_name = bucket_name.into();
-        Self::new(resource_type, &bucket_name, provider)
+        Self::new(resource_type, resource_name, provider)
             .with_identifier(&bucket_name)
             .with_attribute("bucket", serde_json::json!(bucket_name))
             .with_protected(true)

--- a/carina-state/src/state/tests.rs
+++ b/carina-state/src/state/tests.rs
@@ -67,14 +67,28 @@ fn test_resource_state_protected() {
 
 #[test]
 fn test_resource_state_managed_state_bucket_shape() {
-    // The seed produced for backend-owned state buckets must carry
-    // identifier, the bucket attribute, and the protected flag.
-    // Missing identifier reproduces #2533 (BucketAlreadyOwnedByYou).
-    let resource = ResourceState::managed_state_bucket("aws", "s3.Bucket", "my-state-bucket");
+    // The seed must use the desired resource's resolved anonymous identifier
+    // as `name` (so the differ matches the seed against the desired resource)
+    // AND set the AWS bucket name as `identifier`. Conflating the two
+    // reproduces #2533: phantom Delete on the seed's name plus phantom
+    // Create on the desired's name.
+    let resource = ResourceState::managed_state_bucket(
+        "aws",
+        "s3.Bucket",
+        "aws_s3_bucket_a3f2b1c8",
+        "my-state-bucket",
+    );
     assert_eq!(resource.provider, "aws");
     assert_eq!(resource.resource_type, "s3.Bucket");
-    assert_eq!(resource.name, "my-state-bucket");
-    assert_eq!(resource.identifier.as_deref(), Some("my-state-bucket"));
+    assert_eq!(
+        resource.name, "aws_s3_bucket_a3f2b1c8",
+        "name must match the desired resource's anonymous identifier"
+    );
+    assert_eq!(
+        resource.identifier.as_deref(),
+        Some("my-state-bucket"),
+        "identifier must be the AWS bucket name so the provider can Read/Update it"
+    );
     assert!(resource.protected);
     assert_eq!(
         resource.attributes.get("bucket"),
@@ -84,10 +98,15 @@ fn test_resource_state_managed_state_bucket_shape() {
 
 #[test]
 fn test_state_file_with_managed_state_bucket_contains_one_resource() {
-    let state = StateFile::with_managed_state_bucket("aws", "s3.Bucket", "my-state-bucket");
+    let state = StateFile::with_managed_state_bucket(
+        "aws",
+        "s3.Bucket",
+        "aws_s3_bucket_a3f2b1c8",
+        "my-state-bucket",
+    );
     assert_eq!(state.resources.len(), 1);
     let bucket = &state.resources[0];
-    assert_eq!(bucket.name, "my-state-bucket");
+    assert_eq!(bucket.name, "aws_s3_bucket_a3f2b1c8");
     assert_eq!(bucket.identifier.as_deref(), Some("my-state-bucket"));
     assert!(bucket.protected);
 }


### PR DESCRIPTION
## Summary

The previous #2533 fix (PR #2539) only covered the missing `identifier`. The seed still set the state-side `name` to the AWS bucket name, while the desired `aws.s3.Bucket { bucket = "..." }` block (auto-injected into the user's `.crn`) is anonymous and gets a hash-derived id like `aws_s3_bucket_<hash>` after `compute_anonymous_identifiers`. The mismatch made the differ treat the seed entry as orphaned (emit `Delete`) and the desired entry as new (emit `Create`) — reproducing the original `BucketAlreadyOwnedByYou` plus a phantom `Delete` on the next apply.

Two intertwined defects, both fixed:

1. apply bootstrap re-parsed the `.crn` after auto-inject but never re-ran `compute_anonymous_identifiers_with_ctx`, leaving the bucket resource with `Pending` name (rendered as empty string in plan output: `aws.s3.Bucket. [0.5s]`). Replace the manual resolve sequence with `validate_and_resolve_with_config(&mut parsed, base_dir, true)` which runs the full resolve pipeline. `skip_resource_validation = true` keeps the heavy schema checks the original preflight already covered.

2. `ResourceState::managed_state_bucket` and `StateFile::with_managed_state_bucket` now take `resource_name` and `bucket_name` as separate parameters. `resource_name` is the state-side identifier and must equal the resolved anonymous id of the desired resource; `bucket_name` is the AWS bucket name used for `identifier` and the `bucket` attribute. Docstrings and doctest carry the invariant.

apply bootstrap looks up the resolved resource via `find_resource_by_attr(type, "bucket", &bucket_name)` after the resolve pipeline runs, then passes its `id.name_str()` into the seed. A defensive empty-name check guards against silent failure modes in the anon-id pipeline.

`S3Backend::init` no longer attempts to seed the state bucket: the seed needs anonymous-identifier resolution from carina-core, which is not reachable from `carina-state`. The cli apply bootstrap owns that responsibility now. `init` falls back to the pre-#2533 behavior of writing an empty `StateFile` when none exists.

Tests updated for the 4-arg API and assert that `name` and `identifier` are kept distinct.

Closes #2533

## Migration note

State files written by PR #2539 (with the wrong `name` field) will not migrate automatically — `bucket_exists()` skips the bootstrap branch, the differ sees the stale entry as orphan, and the `protected = true` flag blocks the `Delete` so apply errors out rather than silently destroying. Users who ran `apply` against PR #2539's seed during the few-hour window between merges need to remove the stale state entry by hand.

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (469 tests pass)
- [x] `cargo test --workspace --doc` (doctest on `with_managed_state_bucket` exercises the new shape)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`, `bash scripts/validate-crn-files.sh`
- [ ] Real-AWS smoke test from clean state (per the reopen comment's repro recipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
