### PR TITLE
core/cli/tui: blank line between list-of-maps and next sibling (#2555)

### DIFF
--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1064,7 +1064,17 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
         DetailRow::MapExpanded { key, entries } => {
             writeln!(out, "{}{}:", attr_prefix, key).unwrap();
             let entry_indent_cols = attr_prefix.chars().count() + 2;
+            let mut prev_needs_separator = false;
             for entry in entries {
+                // Inject a blank line after a multi-element list-of-maps
+                // before the next sibling key so the list boundary stays
+                // visible — the `*` marker disambiguates element starts
+                // but not element ends (#2555). The blank only fires
+                // when a sibling actually follows.
+                if prev_needs_separator {
+                    writeln!(out).unwrap();
+                }
+                prev_needs_separator = carina_core::value::needs_trailing_separator(&entry.value);
                 let layout = carina_core::value::PrettyLayout {
                     parent_indent_cols: entry_indent_cols,
                     key: &entry.key,

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_policy_pretty_nested.snap
@@ -22,6 +22,7 @@ Execution Plan:
             effect: "Allow"
             resource: "arn:aws:iam::*:oidc-provider/token.actions.githubusercontent.com"
             sid: "ReadOIDCProvider"
+
         version: "2012-10-17"
 
 Plan: 1 to add, 0 to change, 0 to destroy.

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -884,11 +884,15 @@ pub(crate) fn inline_width(value: &Value, budget: usize) -> Option<usize> {
 /// Render a list-of-maps vertically. The first key of each element is
 /// prefixed with a `* ` marker at `entry_indent_cols`; remaining keys
 /// align under it at `entry_indent_cols + 2`. Consecutive elements are
-/// also separated by a blank line. The marker uses `*` rather than the
+/// separated by a blank line. The marker uses `*` rather than the
 /// YAML-style `-` because `-` collides with the destroy action marker
-/// at the resource-row level (#2545 dropped the marker; #2552 brings
-/// it back as `*` to restore the per-element visual anchor without
-/// recreating the collision).
+/// at the resource-row level (#2545 dropped the marker; #2552 brought
+/// it back as `*`). Callers that iterate sibling keys (`format_map_vertical`
+/// here, `DetailRow::MapExpanded` in `carina-cli/src/display/mod.rs` and
+/// `carina-tui/src/ui/detail.rs`) consult `needs_trailing_separator` to
+/// insert a blank line before any sibling key that follows a multi-element
+/// list-of-maps so the boundary stays visible (#2555); this function only
+/// handles the inter-element separators inside the list itself.
 fn format_list_of_maps_vertical(items: &[Value], entry_indent_cols: usize) -> String {
     let entry_indent = " ".repeat(entry_indent_cols);
     let continuation_indent = " ".repeat(entry_indent_cols + 2);
@@ -946,18 +950,28 @@ fn format_list_of_scalars_vertical(items: &[Value], item_indent_cols: usize) -> 
 }
 
 /// Render a map vertically. Each key is at `key_indent_cols` and its value
-/// recurses with that key as the new parent key.
+/// recurses with that key as the new parent key. A blank line is injected
+/// before any key that follows a multi-element list-of-maps so the list
+/// boundary stays visible — the `*` per-element marker disambiguates
+/// element starts but not element *ends* (#2555). The blank is only
+/// inserted when a sibling actually follows, avoiding orphan whitespace
+/// at the end of a block.
 fn format_map_vertical(map: &IndexMap<String, Value>, key_indent_cols: usize) -> String {
     let mut keys: Vec<_> = map.keys().collect();
     keys.sort();
     let key_indent = " ".repeat(key_indent_cols);
     let mut out = String::new();
+    let mut prev_needs_separator = false;
     for k in keys {
         let child_layout = PrettyLayout {
             parent_indent_cols: key_indent_cols,
             key: k,
         };
         let val_str = format_value_pretty(&map[k], child_layout);
+        if prev_needs_separator {
+            out.push('\n');
+        }
+        prev_needs_separator = needs_trailing_separator(&map[k]);
         out.push('\n');
         out.push_str(&key_indent);
         out.push_str(k);
@@ -974,6 +988,17 @@ pub fn is_list_of_maps(value: &Value) -> bool {
     } else {
         false
     }
+}
+
+/// Whether `value` renders to a vertical block whose final line sits at
+/// the element's key column, leaving a sibling key visually attached
+/// to the last element. A blank line should follow such a value before
+/// the next sibling key. Currently only multi-element list-of-maps
+/// matches — a lone element is visually no more ambiguous than a
+/// regular map under the parent key, and skipping the blank for it
+/// avoids noise around common single-statement policies. (#2555)
+pub fn needs_trailing_separator(value: &Value) -> bool {
+    is_list_of_maps(value) && matches!(value, Value::List(items) if items.len() >= 2)
 }
 
 /// Count the number of shared key-value pairs between two map Values.
@@ -2028,9 +2053,11 @@ mod tests {
         };
         let v = Value::List(vec![make("A"), make("B"), make("C")]);
         let out = format_value_pretty(&v, layout(4, "items"));
-        // Exactly N-1 = 2 blank-line separators between three elements,
-        // and no trailing blank that would double-up with the resource
-        // block separator when the list-of-maps is the last attribute.
+        // Exactly N-1 = 2 blank-line separators between three elements.
+        // The trailing blank before the next sibling key (#2555) is
+        // emitted by the parent (`format_map_vertical` /
+        // `display::MapExpanded`), not by this function — so the bare
+        // output contains no trailing whitespace.
         let blank_separators = out.matches("\n\n").count();
         assert_eq!(
             blank_separators, 2,
@@ -2039,6 +2066,61 @@ mod tests {
         assert!(
             !out.ends_with("\n\n"),
             "trailing whitespace must not double the resource block separator: {out:?}"
+        );
+    }
+
+    /// Inside a vertical Map, a multi-element list-of-maps key followed
+    /// by a sibling key gets a blank-line separator so the boundary
+    /// stays visible — the `*` marker disambiguates element starts but
+    /// not element *ends*. The element values are deliberately long to
+    /// force the outer Map to expand vertically rather than render
+    /// inline. (#2555)
+    #[test]
+    fn format_value_pretty_map_with_list_of_maps_then_sibling_separates() {
+        let long = "x".repeat(40);
+        let mut s1 = IndexMap::new();
+        s1.insert("sid_a".to_string(), Value::String(long.clone()));
+        let mut s2 = IndexMap::new();
+        s2.insert("sid_b".to_string(), Value::String(long.clone()));
+        let mut outer = IndexMap::new();
+        outer.insert(
+            "statement".to_string(),
+            Value::List(vec![Value::Map(s1), Value::Map(s2)]),
+        );
+        outer.insert("version".to_string(), Value::String("2012".to_string()));
+        let v = Value::Map(outer);
+        let out = format_value_pretty(&v, layout(2, "config"));
+        // The blank-line MUST sit between the last element's last key
+        // and the sibling `version:` key. Use unique key names so the
+        // assertion can't be satisfied by the inter-element blank
+        // between two `sid:`s.
+        assert!(
+            out.contains(&format!("sid_b: \"{long}\"\n\n")),
+            "blank line must follow last list-of-maps element before sibling: {out:?}"
+        );
+    }
+
+    /// A multi-element list-of-maps that is the LAST key of its parent
+    /// must NOT receive a trailing blank, otherwise the resource-block
+    /// separator above it doubles into two blank lines. (#2555)
+    #[test]
+    fn format_value_pretty_map_with_trailing_list_of_maps_no_orphan_blank() {
+        let long = "x".repeat(40);
+        let mut s1 = IndexMap::new();
+        s1.insert("sid".to_string(), Value::String(long.clone()));
+        let mut s2 = IndexMap::new();
+        s2.insert("sid".to_string(), Value::String(long.clone()));
+        let mut outer = IndexMap::new();
+        outer.insert("version".to_string(), Value::String("2012".to_string()));
+        outer.insert(
+            "statement".to_string(),
+            Value::List(vec![Value::Map(s1), Value::Map(s2)]),
+        );
+        let v = Value::Map(outer);
+        let out = format_value_pretty(&v, layout(2, "config"));
+        assert!(
+            !out.ends_with("\n\n"),
+            "trailing list-of-maps must not leave an orphan blank: {out:?}"
         );
     }
 

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -126,7 +126,17 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
                 header_line = header_line.style(Style::default().bg(Color::DarkGray));
             }
             lines.push(header_line);
+            let mut prev_needs_separator = false;
             for entry in entries {
+                // Inject a blank line after a multi-element list-of-maps
+                // before the next sibling key so the list boundary stays
+                // visible — the `*` marker disambiguates element starts
+                // but not element ends (#2555). Mirrors the same logic
+                // in `carina-cli/src/display/mod.rs::MapExpanded`.
+                if prev_needs_separator {
+                    lines.push(Line::from(""));
+                }
+                prev_needs_separator = carina_core::value::needs_trailing_separator(&entry.value);
                 let layout = carina_core::value::PrettyLayout {
                     parent_indent_cols: 4,
                     key: &entry.key,
@@ -348,5 +358,100 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::detail_rows::MapExpandedEntry;
+    use carina_core::resource::Value;
+    use indexmap::IndexMap;
+
+    /// A multi-element list-of-maps entry inside a `MapExpanded` row
+    /// must be followed by a blank `Line` before the next sibling
+    /// entry, mirroring the CLI behavior added in #2555. A `*` marker
+    /// alone is not enough to delimit the *end* of the list.
+    #[test]
+    fn map_expanded_inserts_blank_after_multi_element_list_of_maps() {
+        let stmt = |sid: &str| {
+            let mut m = IndexMap::new();
+            m.insert("sid".to_string(), Value::String(sid.to_string()));
+            Value::Map(m)
+        };
+        let row = DetailRow::MapExpanded {
+            key: "policy_document".to_string(),
+            entries: vec![
+                MapExpandedEntry {
+                    key: "statement".to_string(),
+                    value: Value::List(vec![stmt("A"), stmt("B")]),
+                    annotation: None,
+                },
+                MapExpandedEntry {
+                    key: "version".to_string(),
+                    value: Value::String("2012-10-17".to_string()),
+                    annotation: None,
+                },
+            ],
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        render_detail_row_to_lines(&mut lines, &row, false);
+
+        let version_idx = lines
+            .iter()
+            .position(|l| line_text(l).contains("version:"))
+            .expect("version line must be rendered");
+        assert!(
+            version_idx >= 1,
+            "version must not be the first rendered line"
+        );
+        assert!(
+            line_text(&lines[version_idx - 1]).trim().is_empty(),
+            "expected blank line immediately before version: lines={lines:?}",
+        );
+    }
+
+    /// A multi-element list-of-maps that is the LAST entry in a
+    /// `MapExpanded` row must NOT receive a trailing blank line —
+    /// avoids orphan whitespace before the resource-block separator.
+    #[test]
+    fn map_expanded_no_orphan_blank_after_trailing_list_of_maps() {
+        let stmt = |sid: &str| {
+            let mut m = IndexMap::new();
+            m.insert("sid".to_string(), Value::String(sid.to_string()));
+            Value::Map(m)
+        };
+        let row = DetailRow::MapExpanded {
+            key: "policy_document".to_string(),
+            entries: vec![
+                MapExpandedEntry {
+                    key: "version".to_string(),
+                    value: Value::String("2012-10-17".to_string()),
+                    annotation: None,
+                },
+                MapExpandedEntry {
+                    key: "statement".to_string(),
+                    value: Value::List(vec![stmt("A"), stmt("B")]),
+                    annotation: None,
+                },
+            ],
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        render_detail_row_to_lines(&mut lines, &row, false);
+
+        let last = lines.last().expect("at least one line");
+        assert!(
+            !line_text(last).trim().is_empty(),
+            "trailing list-of-maps must not leave an orphan blank line: lines={lines:?}",
+        );
+    }
+
+    fn line_text(line: &Line) -> String {
+        line.spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>()
     }
 }


### PR DESCRIPTION
Closes #2555.

## Summary

After #2552 added `*` per-element markers to list-of-maps, the marker disambiguates the *start* of each element but not the *end*. When a Map field renders a list-of-maps and is followed by another sibling field at the same Map level (the canonical IAM `policy_document.statement` then `version` shape), the next field reads as a continuation of the last list element.

This PR re-introduces `pub fn carina_core::value::needs_trailing_separator` and has the three sibling-iterating renderers insert a blank line before the next sibling whenever the previous value matches.

## Sample (from updated `policy_pretty_nested.snap`)

Before:
```
        statement: 
          * action: ["sts:AssumeRoleWithWebIdentity"]
            ...
            sid: "ReadOIDCProvider"
        version: "2012-10-17"     ← reads as a continuation
```

After:
```
        statement: 
          * action: ["sts:AssumeRoleWithWebIdentity"]
            ...
            sid: "ReadOIDCProvider"

        version: "2012-10-17"     ← clearly a sibling
```

## Notable details

- **Three caller sites** are kept in sync via the shared predicate: `format_map_vertical` (carina-core, for nested Maps), `display::MapExpanded` (carina-cli, for top-level Map attributes), and `MapExpanded` in `ui/detail.rs` (carina-tui). Keeping the predicate next to `is_list_of_maps` in `value.rs` prevents the three sites from drifting.
- **Gated on "sibling actually follows"** — the blank only fires when the previous value needs separation AND a next entry exists. Avoids an orphan trailing blank when a list-of-maps is the last attribute of a block (which would otherwise double-up with the resource-block separator).
- **Single-element lists not separated** — a lone element is no more ambiguous than a regular map under the parent key; emitting a blank for every list-of-maps would noisify the common single-statement-policy case.
- **Diff/Update path scoped out** — `MapDiff` and `ListOfMapsDiff` use a different IR and renderer; tracked separately as #2556.

## Test plan

- [x] 2 unit tests in `carina-core/src/value.rs` (`Map + list-of-maps then sibling`, `trailing list-of-maps no orphan blank`).
- [x] 2 unit tests in `carina-tui/src/ui/detail.rs::tests` directly assert the `Line` structure (no dependency on TUI's `value_spans` newline-flattening behavior).
- [x] 1 plan snapshot (`policy_pretty_nested.snap`) re-accepted after manual diff review.
- [x] `cargo nextest run --workspace` — 2922 passed.
- [x] `cargo test --workspace --doc`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `bash scripts/check-*.sh`.
- [x] `target/debug/carina validate` against `infra/.../registry/dev/bootstrap` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)