### PR TITLE
provider: thread changed_attributes through Provider::update (#2565)

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -990,6 +990,7 @@ mod tests {
             _identifier: &str,
             _from: &State,
             _to: &Resource,
+            _changed_attributes: &[String],
         ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { unreachable!() })
         }

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -84,6 +84,7 @@ impl Provider for TestProvider {
         _identifier: &str,
         _from: &State,
         _to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         Box::pin(async { Err(ProviderError::new("unexpected update")) })
     }
@@ -1596,6 +1597,7 @@ impl Provider for RecordingProvider {
         _identifier: &str,
         _from: &State,
         to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         self.update_calls
             .lock()
@@ -1649,6 +1651,7 @@ impl Provider for RenameFailProvider {
         _identifier: &str,
         _from: &State,
         _to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         Box::pin(async { Err(ProviderError::new("rename failed: API error")) })
     }

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -227,6 +227,7 @@ impl Provider for NoopProvider {
         _identifier: &str,
         _from: &State,
         _to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -13,6 +13,41 @@ use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
 
+/// Compute the list of attribute keys that differ between `from` (current
+/// recorded state) and `to` (desired resource).
+///
+/// Used by cascading-update and rename code paths inside the executor where
+/// the planner did not pre-compute a `changed_attributes` list (because these
+/// updates are derived at apply time, not at plan time). Mirrors the differ's
+/// behaviour conservatively: any key present in only one side, or whose value
+/// differs by `PartialEq`, is reported as changed.
+///
+/// The differ's plan-time `find_changed_attributes` is more precise (it
+/// excludes provider-returned computed fields by consulting `prev_desired_keys`),
+/// but cascade/rename inputs do not carry that history; falling back to a
+/// straight key-by-key comparison is correct for the apply-time signal we
+/// actually have.
+pub(super) fn compute_changed_attributes(from: &State, to: &Resource) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let to_attrs = &to.attributes;
+    let from_attrs = &from.attributes;
+
+    for (key, to_value) in to_attrs.iter() {
+        match from_attrs.get(key) {
+            Some(from_value) if from_value == to_value => {}
+            _ => out.push(key.clone()),
+        }
+    }
+    for key in from_attrs.keys() {
+        if !to_attrs.contains_key(key) {
+            out.push(key.clone());
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// Result of executing a basic effect (Create, Update, or Delete).
 ///
 /// This is the shared result type used by `execute_basic_effect` to avoid
@@ -261,7 +296,12 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             }
         }
-        Effect::Update { id, from, to, .. } => {
+        Effect::Update {
+            id,
+            from,
+            to,
+            changed_attributes,
+        } => {
             let resolve_source = unresolved.get(id).unwrap_or(to);
             let resolved_to = match resolve_resource_with_source(to, resolve_source, bindings) {
                 Ok(r) => r,
@@ -279,7 +319,10 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             };
             let identifier = from.identifier.as_deref().unwrap_or("");
-            match provider.update(id, identifier, from, &resolved_to).await {
+            match provider
+                .update(id, identifier, from, &resolved_to, changed_attributes)
+                .await
+            {
                 Ok(state) => {
                     observer.on_event(&ExecutionEvent::EffectSucceeded {
                         effect,

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -564,12 +564,17 @@ pub(super) async fn execute_effects_phased(
                                         };
                                     let cascade_identifier =
                                         cascade.from.identifier.as_deref().unwrap_or("");
+                                    let cascade_changed = super::basic::compute_changed_attributes(
+                                        &cascade.from,
+                                        &resolved_to,
+                                    );
                                     match provider
                                         .update(
                                             &cascade.id,
                                             cascade_identifier,
                                             &cascade.from,
                                             &resolved_to,
+                                            &cascade_changed,
                                         )
                                         .await
                                     {
@@ -984,8 +989,15 @@ pub(super) async fn execute_effects_phased(
                                     temp.attribute.clone(),
                                     Value::String(temp.original_value.clone()),
                                 );
+                                let rename_changed = vec![temp.attribute.clone()];
                                 match provider
-                                    .update(&id, new_identifier, &state, &rename_to)
+                                    .update(
+                                        &id,
+                                        new_identifier,
+                                        &state,
+                                        &rename_to,
+                                        &rename_changed,
+                                    )
                                     .await
                                 {
                                     Ok(renamed_state) => {

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -112,8 +112,16 @@ pub(super) async fn execute_cbd_replace_parallel(
                     }
                 };
                 let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
+                let cascade_changed =
+                    super::basic::compute_changed_attributes(&cascade.from, &resolved_to);
                 match provider
-                    .update(&cascade.id, cascade_identifier, &cascade.from, &resolved_to)
+                    .update(
+                        &cascade.id,
+                        cascade_identifier,
+                        &cascade.from,
+                        &resolved_to,
+                        &cascade_changed,
+                    )
                     .await
                 {
                     Ok(cascade_state) => {
@@ -172,8 +180,9 @@ pub(super) async fn execute_cbd_replace_parallel(
                             temp.attribute.clone(),
                             Value::String(temp.original_value.clone()),
                         );
+                        let rename_changed = vec![temp.attribute.clone()];
                         match provider
-                            .update(ctx.id, new_identifier, &state, &rename_to)
+                            .update(ctx.id, new_identifier, &state, &rename_to, &rename_changed)
                             .await
                         {
                             Ok(renamed_state) => {

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -92,6 +92,7 @@ impl Provider for MockProvider {
         _identifier: &str,
         _from: &State,
         _to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
         self.call_log
@@ -886,6 +887,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
             _identifier: &str,
             _from: &State,
             _to: &Resource,
+            _changed_attributes: &[String],
         ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { Err(ProviderError::new("not implemented")) })
         }
@@ -1309,6 +1311,7 @@ impl Provider for RecordingMockProvider {
         _identifier: &str,
         _from: &State,
         _to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         Box::pin(async { Err(ProviderError::new("not implemented")) })
     }

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -131,15 +131,26 @@ pub trait Provider: Send + Sync {
     /// Returns State with identifier set to the AWS internal ID (e.g., vpc-xxx)
     fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>>;
 
-    /// Update a resource
+    /// Update a resource toward the desired `to` state.
     ///
-    /// The identifier is the AWS internal ID (e.g., vpc-xxx)
+    /// The identifier is the cloud-side internal ID (e.g., `vpc-xxx`).
+    ///
+    /// `changed_attributes` is the set of attribute keys the user explicitly
+    /// intends to add, replace, or remove on this update; fields not in this
+    /// list MUST be left untouched by the provider. The list is computed by
+    /// the differ from the user's current desired configuration vs. the
+    /// previously-recorded desired configuration in state, so it excludes
+    /// provider-returned computed fields and fields the user has never
+    /// specified. Providers that build partial-update payloads (e.g.
+    /// CloudControl JSON Patch) MUST gate their patch operations on this
+    /// list rather than comparing `from` and `to` directly.
     fn update(
         &self,
         id: &ResourceId,
         identifier: &str,
         from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>>;
 
     /// Delete a resource
@@ -355,9 +366,10 @@ impl Provider for ProviderRouter {
         identifier: &str,
         from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         match self.get_provider_or_error(&id.provider) {
-            Ok(provider) => provider.update(id, identifier, from, to),
+            Ok(provider) => provider.update(id, identifier, from, to, changed_attributes),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -683,8 +695,9 @@ impl Provider for Box<dyn Provider> {
         identifier: &str,
         from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        (**self).update(id, identifier, from, to)
+        (**self).update(id, identifier, from, to, changed_attributes)
     }
 
     fn delete(
@@ -739,6 +752,7 @@ mod tests {
             _identifier: &str,
             _from: &State,
             to: &Resource,
+            _changed_attributes: &[String],
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
             let attrs = to.attributes.clone();
@@ -816,6 +830,7 @@ mod tests {
             _identifier: &str,
             _from: &State,
             _to: &Resource,
+            _changed_attributes: &[String],
         ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { Err(ProviderError::new("not supported")) })
         }
@@ -988,8 +1003,84 @@ mod tests {
         let id = ResourceId::with_provider("mock", "test", "example");
         let from = State::existing(id.clone(), HashMap::new());
         let to = Resource::with_provider("mock", "test", "example");
-        let state = router.update(&id, "mock-id-123", &from, &to).await.unwrap();
+        let state = router
+            .update(&id, "mock-id-123", &from, &to, &[])
+            .await
+            .unwrap();
         assert!(state.exists);
+    }
+
+    #[tokio::test]
+    async fn provider_update_receives_changed_attributes_verbatim() {
+        // Issue #2565: the executor must pass Effect::Update.changed_attributes
+        // verbatim into Provider::update so providers can build precise
+        // partial-update payloads.
+        use std::sync::Mutex;
+
+        struct RecordingProvider {
+            received: Mutex<Vec<String>>,
+        }
+
+        impl Provider for RecordingProvider {
+            fn name(&self) -> &str {
+                "recording"
+            }
+            fn read(
+                &self,
+                id: &ResourceId,
+                _identifier: Option<&str>,
+            ) -> BoxFuture<'_, ProviderResult<State>> {
+                let id = id.clone();
+                Box::pin(async move { Ok(State::not_found(id)) })
+            }
+            fn read_data_source(
+                &self,
+                resource: &Resource,
+            ) -> BoxFuture<'_, ProviderResult<State>> {
+                self.read(&resource.id, None)
+            }
+            fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+                let id = resource.id.clone();
+                Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+            }
+            fn update(
+                &self,
+                id: &ResourceId,
+                _identifier: &str,
+                _from: &State,
+                _to: &Resource,
+                changed_attributes: &[String],
+            ) -> BoxFuture<'_, ProviderResult<State>> {
+                *self.received.lock().unwrap() = changed_attributes.to_vec();
+                let id = id.clone();
+                Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+            }
+            fn delete(
+                &self,
+                _id: &ResourceId,
+                _identifier: &str,
+                _lifecycle: &LifecycleConfig,
+            ) -> BoxFuture<'_, ProviderResult<()>> {
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        let provider = RecordingProvider {
+            received: Mutex::new(Vec::new()),
+        };
+        let id = ResourceId::with_provider("recording", "test", "x");
+        let from = State::existing(id.clone(), HashMap::new());
+        let to = Resource::with_provider("recording", "test", "x");
+        let changed = vec!["color".to_string(), "size".to_string()];
+        provider
+            .update(&id, "ident", &from, &to, &changed)
+            .await
+            .unwrap();
+        assert_eq!(*provider.received.lock().unwrap(), changed);
+
+        // Empty list also round-trips correctly (signaling "nothing changed").
+        let _ = provider.update(&id, "ident", &from, &to, &[]).await;
+        assert!(provider.received.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1191,6 +1282,7 @@ mod tests {
                 _identifier: &str,
                 _from: &State,
                 _to: &Resource,
+                _changed_attributes: &[String],
             ) -> BoxFuture<'_, ProviderResult<State>> {
                 let id = id.clone();
                 Box::pin(async move { Ok(State::not_found(id)) })

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -478,16 +478,17 @@ impl WasmBindings {
         identifier: &str,
         from: &wit_types::State,
         to: &wit_types::ResourceDef,
+        changed_attributes: &[String],
     ) -> wasmtime::Result<Result<wit_types::State, String>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_update(store, id, identifier, from, to)
+                    .call_update(store, id, identifier, from, to, changed_attributes)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_update(store, id, identifier, from, to)
+                    .call_update(store, id, identifier, from, to, changed_attributes)
                     .await
             }
         }
@@ -1431,6 +1432,7 @@ impl Provider for WasmProvider {
         identifier: &str,
         from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
         let identifier = identifier.to_string();
@@ -1442,6 +1444,7 @@ impl Provider for WasmProvider {
             Ok(v) => v,
             Err(e) => return early_provider_err(e),
         };
+        let changed_attributes = changed_attributes.to_vec();
         let id = id.clone();
         Box::pin(async move {
             let mut store = self.instance.store.lock().await;
@@ -1449,7 +1452,14 @@ impl Provider for WasmProvider {
             let result = self
                 .instance
                 .bindings
-                .call_update(&mut store, &wit_id, &identifier, &wit_from, &wit_to)
+                .call_update(
+                    &mut store,
+                    &wit_id,
+                    &identifier,
+                    &wit_from,
+                    &wit_to,
+                    &changed_attributes,
+                )
                 .await
                 .map_err(|e| {
                     let msg = format!("{e}");

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -156,8 +156,15 @@ async fn test_wasm_mock_provider_update_and_delete() {
         ("size".into(), Value::Int(20)),
     ]);
 
+    let changed_attributes = vec!["color".to_string(), "size".to_string()];
     let updated = provider
-        .update(&id, "mock-id", &created, &updated_resource)
+        .update(
+            &id,
+            "mock-id",
+            &created,
+            &updated_resource,
+            &changed_attributes,
+        )
         .await
         .expect("update should succeed");
     assert_eq!(
@@ -165,6 +172,37 @@ async fn test_wasm_mock_provider_update_and_delete() {
         Some(&Value::String("blue".into()))
     );
     assert_eq!(updated.attributes.get("size"), Some(&Value::Int(20)));
+
+    // Issue #2565: the host MUST forward `changed_attributes` to the wasm
+    // guest verbatim (preserving order). The mock guest echoes the value it
+    // received back into state under the `__mock_changed_attributes__` key
+    // so this test can prove the WIT round-trip.
+    let echoed = updated
+        .attributes
+        .get("__mock_changed_attributes__")
+        .expect("mock should echo changed_attributes back into state");
+    assert_eq!(
+        echoed,
+        &Value::List(vec![
+            Value::String("color".into()),
+            Value::String("size".into()),
+        ]),
+        "wasm guest must observe the same list (and order) the host passed in"
+    );
+
+    // Empty `changed_attributes` must also round-trip (signals "nothing
+    // changed"; provider should leave the resource untouched). Verifies the
+    // host->guest channel does not silently drop empty vecs.
+    let empty_changed: Vec<String> = Vec::new();
+    let updated_empty = provider
+        .update(&id, "mock-id", &created, &updated_resource, &empty_changed)
+        .await
+        .expect("update with empty changed_attributes should succeed");
+    assert_eq!(
+        updated_empty.attributes.get("__mock_changed_attributes__"),
+        Some(&Value::List(Vec::new())),
+        "empty list semantics must be preserved across the WIT boundary"
+    );
 
     // Read to verify update persisted in memory
     let read_state = provider

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -102,13 +102,23 @@ pub trait CarinaProvider {
     /// Create a new resource.
     fn create(&self, resource: &Resource) -> Result<State, ProviderError>;
 
-    /// Update an existing resource.
+    /// Update an existing resource toward the desired `to` state.
+    ///
+    /// `changed_attributes` is the set of attribute keys the user explicitly
+    /// intends to add, replace, or remove on this update; fields not in this
+    /// list MUST be left untouched by the provider. Computed by the host
+    /// from the user's current desired configuration vs. the previously
+    /// recorded desired configuration in state. Providers that build
+    /// partial-update payloads (e.g. CloudControl JSON Patch) MUST gate
+    /// their patch operations on this list rather than comparing `from`
+    /// and `to` directly.
     fn update(
         &self,
         id: &ResourceId,
         identifier: &str,
         from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> Result<State, ProviderError>;
 
     /// Delete an existing resource.
@@ -295,7 +305,13 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.update(&params.id, &params.identifier, &params.from, &params.to) {
+            match provider.update(
+                &params.id,
+                &params.identifier,
+                &params.from,
+                &params.to,
+                &params.changed_attributes,
+            ) {
                 Ok(state) => Response::success(id, methods::UpdateResult { state }),
                 Err(e) => Response::error(id, -1, e.message),
             }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -316,6 +316,7 @@ macro_rules! export_provider {
                     identifier: String,
                     current: wit_types::State,
                     to: wit_types::ResourceDef,
+                    changed_attributes: Vec<String>,
                 ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
@@ -327,6 +328,7 @@ macro_rules! export_provider {
                         &identifier,
                         &proto_from,
                         &proto_to,
+                        &changed_attributes,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
                         Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
@@ -679,6 +681,7 @@ macro_rules! export_provider {
                     identifier: String,
                     current: wit_types::State,
                     to: wit_types::ResourceDef,
+                    changed_attributes: Vec<String>,
                 ) -> Result<wit_types::State, String> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
@@ -690,6 +693,7 @@ macro_rules! export_provider {
                         &identifier,
                         &proto_from,
                         &proto_to,
+                        &changed_attributes,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
                         Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -108,6 +108,7 @@ impl Provider for MockProvider {
         _identifier: &str,
         _from: &State,
         to: &Resource,
+        _changed_attributes: &[String],
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         let to = to.clone();

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -98,15 +98,30 @@ impl CarinaProvider for MockProcessProvider {
         _identifier: &str,
         _from: &State,
         to: &Resource,
+        changed_attributes: &[String],
     ) -> Result<State, ProviderError> {
         let mut states = self.states.lock().unwrap();
         let key = Self::resource_key(id);
         states.insert(key, to.attributes.clone());
 
+        // Echo the host-supplied `changed_attributes` back into state under a
+        // sentinel key so integration tests can verify the WIT round-trip
+        // (host -> guest -> host) preserves order and empty-vec semantics.
+        let mut attributes = to.attributes.clone();
+        attributes.insert(
+            "__mock_changed_attributes__".to_string(),
+            Value::List(
+                changed_attributes
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+
         Ok(State {
             id: id.clone(),
             identifier: Some("mock-id".into()),
-            attributes: to.attributes.clone(),
+            attributes,
             exists: true,
         })
     }

--- a/carina-provider-protocol/src/methods.rs
+++ b/carina-provider-protocol/src/methods.rs
@@ -76,6 +76,11 @@ pub struct UpdateParams {
     pub identifier: String,
     pub from: State,
     pub to: Resource,
+    /// Attribute keys the user explicitly intends to add, replace, or remove
+    /// on this update. Fields not in this list MUST be left untouched by the
+    /// provider. See `Provider::update` doc-comment for the full contract.
+    #[serde(default)]
+    pub changed_attributes: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Step 2 of `#2564`. Wire the differ's `Effect::Update.changed_attributes` list all the way through the `Provider::update` trait so providers can build precise partial-update payloads instead of re-deriving intent by comparing `from` and `to`.

The WIT contract change landed in `carina-rs/carina-plugin-wit#4`; this PR:

- **Bumps the `carina-plugin-wit` submodule** to the post-#4 commit (`dae2e79`) so the regenerated wasmtime/wit-bindgen output includes `changed-attributes`.
- **Extends `Provider::update`** in `carina-core/src/provider.rs` with a new `changed_attributes: &[String]` parameter, doc-commented with the same MUST contract as the WIT.
- **Threads the parameter** through:
  - the wasmtime host (`carina-plugin-host::wasm_factory`)
  - the wasm-guest SDK macro bridges (`carina-plugin-sdk::wasm_guest`, two macro arms: `Basic` and `Http`)
  - the JSON-RPC `UpdateParams` (`carina-provider-protocol::methods`) and its dispatch in `carina-plugin-sdk::run`
  - all executor call sites (`carina-core::executor::{basic, phased, replace}`)
  - the in-tree mock provider (host-side and wasm `main.rs`)
- **Cascade / rename paths** that don't have a planner-precomputed list:
  - Cascading updates (CBD finalization) call a new `compute_changed_attributes(&from, &to)` helper that diffs attribute keys.
  - Rename updates pass `[temp.attribute]` (only the rename target attribute changes).

No behavior change for end users in this PR; it is the channel that downstream provider repos will plug into. The mock provider records the host-supplied `changed_attributes` into a sentinel `__mock_changed_attributes__` attribute so the wasm integration test can prove the WIT round-trip preserves both list order and empty-vec semantics.

## Test plan

- [x] `cargo nextest run --workspace` (2923 passed, 74 skipped)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five)
- [x] `cargo build --release`
- [x] New unit test in `carina-core/src/provider.rs` asserts `Provider::update` receives `changed_attributes` verbatim (including empty-vec).
- [x] Updated wasm integration test in `carina-plugin-host/tests/wasm_integration_test.rs` round-trips a non-empty list and an empty list through the WIT boundary, asserting the guest observed exactly what the host sent.

## Notes

- This PR includes a `carina-plugin-wit` submodule bump (940b966 -> dae2e79).
- Downstream provider repos need follow-up PRs to adopt the new signature; those are the remaining steps of the meta tracker:
  - Step 3a: `carina-rs/carina-provider-aws` (separate issue / PR).
  - Step 3b: `carina-rs/carina-provider-awscc` — adapt impl AND fix `build_update_patches` to gate JSON Patch ops on `changed_attributes` (the bug fix that lands the user-visible regression in #2559).

Closes carina-rs/carina#2565
Refs carina-rs/carina#2564
Refs carina-rs/carina#2559