### PR TITLE
Adopt Level 3 Provider trait, request records, and provider-error enum

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -13,7 +13,7 @@ use carina_core::differ::{cascade_dependent_updates, create_plan};
 use carina_core::effect::Effect;
 use carina_core::executor::{ExecutionInput, ExecutionResult};
 use carina_core::plan::Plan;
-use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer};
+use carina_core::provider::{self as provider_mod, Provider, ProviderNormalizer, ReadRequest};
 use carina_core::resolver::resolve_refs_with_state_and_remote;
 use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::format_value;
@@ -373,7 +373,7 @@ pub async fn detect_drift(
         let identifier = planned_state.and_then(|s| s.identifier.as_deref());
 
         let actual_state = provider
-            .read(&resource.id, identifier)
+            .read(&resource.id, identifier.unwrap_or(""), ReadRequest)
             .await
             .map_err(AppError::Provider)?;
 
@@ -541,7 +541,15 @@ pub async fn run_apply(
                     .unwrap_or_default();
                 let bucket_provider = factory.create_provider(&provider_config_attrs).await?;
 
-                match bucket_provider.create(bucket_resource).await {
+                match bucket_provider
+                    .create(
+                        &bucket_resource.id,
+                        carina_core::provider::CreateRequest {
+                            resource: bucket_resource.clone(),
+                        },
+                    )
+                    .await
+                {
                     Ok(_) => {
                         println!("  {} Created state bucket: {}", "✓".green(), bucket_name);
                     }

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -687,7 +687,13 @@ async fn run_destroy_locked(
             in_flight.push(async move {
                 let started = Instant::now();
                 let delete_result = provider_ref
-                    .delete(&resource_id, &identifier, &lifecycle)
+                    .delete(
+                        &resource_id,
+                        &identifier,
+                        carina_core::provider::DeleteRequest {
+                            lifecycle: lifecycle.clone(),
+                        },
+                    )
                     .await;
                 (
                     idx,
@@ -792,7 +798,7 @@ async fn run_destroy_locked(
                 success_count += 1;
                 destroyed_ids.push(resource_id);
             }
-            Err(e) if e.is_timeout => {
+            Err(carina_core::provider::ProviderError::Timeout(_)) => {
                 let msg = format!(
                     "{} {} - Operation timed out, waiting for completion...",
                     "⏳".yellow(),
@@ -931,7 +937,6 @@ async fn run_destroy_locked(
 mod tests {
     use super::*;
     use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
-    use carina_core::resource::LifecycleConfig;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// A mock provider whose `read()` returns a sequence of results.
@@ -959,7 +964,8 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: Option<&str>,
+            _identifier: &str,
+            _request: carina_core::provider::ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
             let id = id.clone();
@@ -968,7 +974,7 @@ mod tests {
                     // Recreate the result since ProviderResult is not Clone
                     match &self.responses[idx] {
                         Ok(state) => Ok(state.clone()),
-                        Err(e) => Err(ProviderError::new(e.message.clone())),
+                        Err(e) => Err(ProviderError::api_error(e.message().to_string())),
                     }
                 } else {
                     Ok(State::not_found(id))
@@ -977,10 +983,14 @@ mod tests {
         }
 
         fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            self.read(&resource.id, None)
+            self.read(&resource.id, "", carina_core::provider::ReadRequest)
         }
 
-        fn create(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: carina_core::provider::CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { unreachable!() })
         }
 
@@ -988,8 +998,7 @@ mod tests {
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _from: &State,
-            _to: &Resource,
+            _request: carina_core::provider::UpdateRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { unreachable!() })
         }
@@ -998,7 +1007,7 @@ mod tests {
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _lifecycle: &LifecycleConfig,
+            _request: carina_core::provider::DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { unreachable!() })
         }
@@ -1006,7 +1015,7 @@ mod tests {
 
     #[test]
     fn is_retryable_detects_dependency_violation() {
-        let err = ProviderError::new(
+        let err = ProviderError::api_error(
             "DependencyViolation: Network vpc-xxx has some mapped public address(es)",
         );
         assert!(is_retryable_delete_error(&err));
@@ -1014,19 +1023,19 @@ mod tests {
 
     #[test]
     fn is_retryable_detects_has_dependent_object() {
-        let err = ProviderError::new("resource has a dependent object");
+        let err = ProviderError::api_error("resource has a dependent object");
         assert!(is_retryable_delete_error(&err));
     }
 
     #[test]
     fn is_retryable_returns_false_for_generic_error() {
-        let err = ProviderError::new("AccessDenied: not authorized");
+        let err = ProviderError::api_error("AccessDenied: not authorized");
         assert!(!is_retryable_delete_error(&err));
     }
 
     #[test]
     fn is_retryable_returns_false_for_timeout() {
-        let err = ProviderError::new("DependencyViolation: something").timeout();
+        let err = ProviderError::timeout("DependencyViolation: something");
         assert!(!is_retryable_delete_error(&err));
     }
 
@@ -1071,7 +1080,7 @@ mod tests {
     #[tokio::test]
     async fn wait_for_deletion_returns_read_error_on_provider_error() {
         let id = ResourceId::new("s3.Bucket", "test");
-        let provider = SequenceProvider::new(vec![Err(ProviderError::new("auth expired"))]);
+        let provider = SequenceProvider::new(vec![Err(ProviderError::api_error("auth expired"))]);
 
         let result = wait_for_deletion(
             &provider,
@@ -1099,7 +1108,7 @@ mod tests {
         // deletion, causing live infrastructure to be orphaned while the user
         // was told it was destroyed.
         let id = ResourceId::new("s3.Bucket", "test");
-        let provider = SequenceProvider::new(vec![Err(ProviderError::new("network timeout"))]);
+        let provider = SequenceProvider::new(vec![Err(ProviderError::timeout("network timeout"))]);
 
         let result = wait_for_deletion(
             &provider,

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -3,7 +3,7 @@
 use carina_core::effect::Effect;
 use carina_core::executor::ExecutionResult;
 use carina_core::plan::Plan;
-use carina_core::provider::Provider;
+use carina_core::provider::{Provider, ReadRequest};
 use colored::Colorize;
 
 /// Execute import effects by reading the resource from the provider.
@@ -19,7 +19,7 @@ pub(crate) async fn execute_import_effects(
     for effect in plan.effects() {
         if let Effect::Import { id, identifier } = effect {
             println!("  {} Importing {} (id: {})...", "<-".cyan(), id, identifier);
-            match provider.read(id, Some(identifier)).await {
+            match provider.read(id, identifier, ReadRequest).await {
                 Ok(state) => {
                     if state.exists {
                         println!("  {} Imported {}", "✓".green(), id);

--- a/carina-cli/src/commands/shared/retry.rs
+++ b/carina-cli/src/commands/shared/retry.rs
@@ -1,6 +1,6 @@
 //! Retry helpers for `destroy`: delete-error classification and deletion polling.
 
-use carina_core::provider::Provider;
+use carina_core::provider::{Provider, ReadRequest};
 use carina_core::resource::ResourceId;
 
 /// Check if a delete error is retryable due to implicit dependency ordering.
@@ -10,7 +10,7 @@ use carina_core::resource::ResourceId;
 /// ResourceRef dependency. These errors are retryable: once the blocker is
 /// deleted, the retry will succeed.
 pub(crate) fn is_retryable_delete_error(e: &carina_core::provider::ProviderError) -> bool {
-    if e.is_timeout {
+    if matches!(e, carina_core::provider::ProviderError::Timeout(_)) {
         return false;
     }
     let msg = e.to_string();
@@ -53,7 +53,7 @@ pub(crate) async fn wait_for_deletion(
 ) -> WaitResult {
     for _ in 0..max_attempts {
         tokio::time::sleep(poll_interval).await;
-        match provider.read(id, Some(identifier)).await {
+        match provider.read(id, identifier, ReadRequest).await {
             Ok(state) if !state.exists => return WaitResult::Deleted,
             Ok(_) => {
                 // Still exists, keep waiting

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -551,7 +551,7 @@ async fn run_state_bucket_delete(
         .delete(
             &bucket_id,
             bucket_name,
-            &carina_core::resource::LifecycleConfig::default(),
+            carina_core::provider::DeleteRequest::default(),
         )
         .await
     {
@@ -680,7 +680,11 @@ pub(crate) async fn run_state_refresh_locked(
         }
 
         let fresh_state = provider
-            .read(&resource.id, identifier.as_deref())
+            .read(
+                &resource.id,
+                identifier.as_deref().unwrap_or(""),
+                carina_core::provider::ReadRequest,
+            )
             .await
             .map_err(AppError::Provider)?;
         current_states.insert(resource.id.clone(), fresh_state);
@@ -706,7 +710,7 @@ pub(crate) async fn run_state_refresh_locked(
 
     for (id, identifier) in &orphan_ids {
         let fresh_state = provider
-            .read(id, Some(identifier.as_str()))
+            .read(id, identifier.as_str(), carina_core::provider::ReadRequest)
             .await
             .map_err(AppError::Provider)?;
         current_states.insert(id.clone(), fresh_state);

--- a/carina-cli/src/error.rs
+++ b/carina-cli/src/error.rs
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn from_provider_error() {
-        let provider_err = ProviderError::new("timeout");
+        let provider_err = ProviderError::timeout("timeout");
         let app_err: AppError = provider_err.into();
         assert!(matches!(app_err, AppError::Provider(_)));
         assert!(app_err.to_string().contains("timeout"));

--- a/carina-cli/src/main.rs
+++ b/carina-cli/src/main.rs
@@ -472,8 +472,10 @@ fn render_app_error(e: &error::AppError) -> AppErrorRendering {
             exit_code: 130,
         },
         error::AppError::Provider(pe) => {
-            let body = error::format_account_guard_error(&pe.message, pe.provider_name.as_deref())
-                .unwrap_or_else(|| e.to_string());
+            let detail = pe.detail();
+            let body =
+                error::format_account_guard_error(&detail.message, detail.provider_name.as_deref())
+                    .unwrap_or_else(|| e.to_string());
             AppErrorRendering {
                 stderr: format_error_lines(&body),
                 exit_code: 1,
@@ -531,7 +533,7 @@ mod error_format_tests {
     #[test]
     fn provider_account_guard_renders_structured_block() {
         colored::control::set_override(false);
-        let pe = carina_core::provider::ProviderError::new(
+        let pe = carina_core::provider::ProviderError::invalid_input(
             "Provider initialization failed: AWS account ID '019115212452' \
              is not in the provider's allowed_account_ids [\"151116838382\"]. \
              Refusing to operate against this account. \
@@ -585,7 +587,7 @@ mod error_format_tests {
         // credentials chain, etc.) must still be surfaced — just not
         // through the structured account-guard renderer.
         colored::control::set_override(false);
-        let pe = carina_core::provider::ProviderError::new(
+        let pe = carina_core::provider::ProviderError::invalid_input(
             "Provider initialization failed: failed to load AWS credentials \
              from the environment",
         );
@@ -621,7 +623,7 @@ mod error_format_tests {
         // it instead of the "aws" default. Catches awscc-vs-aws
         // mislabeling.
         colored::control::set_override(false);
-        let pe = carina_core::provider::ProviderError::new(
+        let pe = carina_core::provider::ProviderError::invalid_input(
             "Provider initialization failed: AWS account ID '019115212452' \
              is not in the provider's allowed_account_ids [\"151116838382\"]. \
              Refusing to operate against this account.",

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -59,42 +59,46 @@ impl Provider for TestProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        let key = (id.to_string(), identifier.unwrap_or_default().to_string());
+        let key = (id.to_string(), identifier.to_string());
         let result = self
             .read_results
             .get(&key)
             .cloned()
             .unwrap_or_else(|| panic!("missing read state for {:?}", key));
-        Box::pin(async move { result.map_err(ProviderError::new) })
+        Box::pin(async move { result.map_err(ProviderError::internal) })
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
+        self.read(&resource.id, "", carina_core::provider::ReadRequest)
     }
 
-    fn create(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("unexpected create")) })
+    fn create(
+        &self,
+        _id: &ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        Box::pin(async { Err(ProviderError::internal("unexpected create")) })
     }
 
     fn update(
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        _to: &Resource,
+        _request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("unexpected update")) })
+        Box::pin(async { Err(ProviderError::internal("unexpected update")) })
     }
 
     fn delete(
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        Box::pin(async { Err(ProviderError::new("unexpected delete")) })
+        Box::pin(async { Err(ProviderError::internal("unexpected delete")) })
     }
 }
 
@@ -1567,26 +1571,29 @@ impl Provider for RecordingProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         Box::pin(async move { Ok(State::not_found(id)) })
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
+        self.read(&resource.id, "", carina_core::provider::ReadRequest)
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
         // Return a state with a new identifier to simulate resource creation
-        let mut attrs = resource.attributes.clone();
+        let mut attrs = request.resource.attributes.clone();
         // Simulate AWS returning a new ID
         attrs.insert("vpc_id".to_string(), Value::String("vpc-NEW".to_string()));
-        let state = State::existing(
-            resource.id.clone(),
-            carina_core::resource::attrs_to_hashmap(&attrs),
-        )
-        .with_identifier("vpc-NEW");
+        let id = id.clone();
+        let state = State::existing(id, carina_core::resource::attrs_to_hashmap(&attrs))
+            .with_identifier("vpc-NEW");
         Box::pin(async move { Ok(state) })
     }
 
@@ -1594,15 +1601,30 @@ impl Provider for RecordingProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        to: &Resource,
+        request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        self.update_calls
-            .lock()
-            .unwrap()
-            .push((id.to_string(), to.clone()));
-        let state =
-            State::existing(id.clone(), to.resolved_attributes()).with_identifier("subnet-123");
+        // Reconstruct a Resource view of the desired post-update state for
+        // existing tests that introspect the recorded `to`.
+        let mut attrs = request.from.attributes.clone();
+        for op in &request.patch.ops {
+            match op.kind {
+                carina_core::provider::PatchOpKind::Add
+                | carina_core::provider::PatchOpKind::Replace => {
+                    if let Some(v) = op.value.clone() {
+                        attrs.insert(op.key.clone(), v);
+                    }
+                }
+                carina_core::provider::PatchOpKind::Remove => {
+                    attrs.remove(&op.key);
+                }
+            }
+        }
+        let mut to = Resource::with_provider(&id.provider, &id.resource_type, id.name_str());
+        for (k, v) in &attrs {
+            to.set_attr(k.clone(), v.clone());
+        }
+        self.update_calls.lock().unwrap().push((id.to_string(), to));
+        let state = State::existing(id.clone(), attrs).with_identifier("subnet-123");
         Box::pin(async move { Ok(state) })
     }
 
@@ -1610,7 +1632,7 @@ impl Provider for RecordingProvider {
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Ok(()) })
     }
@@ -1627,18 +1649,23 @@ impl Provider for RenameFailProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         Box::pin(async move { Ok(State::not_found(id)) })
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
+        self.read(&resource.id, "", carina_core::provider::ReadRequest)
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let state = State::existing(resource.id.clone(), resource.resolved_attributes())
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let state = State::existing(id.clone(), request.resource.resolved_attributes())
             .with_identifier("temp-name-abc");
         Box::pin(async move { Ok(state) })
     }
@@ -1647,17 +1674,16 @@ impl Provider for RenameFailProvider {
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        _to: &Resource,
+        _request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("rename failed: API error")) })
+        Box::pin(async { Err(ProviderError::api_error("rename failed: API error")) })
     }
 
     fn delete(
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         Box::pin(async { Ok(()) })
     }

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1609,7 +1609,14 @@ pub async fn read_with_retry(
 ) -> Result<State, ProviderError> {
     let max_retries = 3;
     for attempt in 0..=max_retries {
-        match provider.read(id, identifier).await {
+        match provider
+            .read(
+                id,
+                identifier.unwrap_or(""),
+                carina_core::provider::ReadRequest,
+            )
+            .await
+        {
             Ok(state) => return Ok(state),
             Err(e) if attempt < max_retries && is_throttling_error(&e) => {
                 let delay = Duration::from_secs(1 << attempt); // 1s, 2s, 4s

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -208,7 +208,8 @@ impl Provider for NoopProvider {
     fn read(
         &self,
         _id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
@@ -218,15 +219,18 @@ impl Provider for NoopProvider {
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
-    fn create(&self, _r: &Resource) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
+    fn create(
+        &self,
+        _id: &ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
     fn update(
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        _to: &Resource,
+        _request: carina_core::provider::UpdateRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }
@@ -234,7 +238,7 @@ impl Provider for NoopProvider {
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &carina_core::resource::LifecycleConfig,
+        _request: carina_core::provider::DeleteRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<()>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })
     }

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -7,7 +7,9 @@ use std::time::Instant;
 
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
-use crate::provider::Provider;
+use crate::provider::{
+    CreateRequest, DeleteRequest, Provider, ReadRequest, UpdateRequest, build_update_patch,
+};
 use crate::resolver::resolve_ref_value;
 use crate::resource::{Resource, ResourceId, State, Value};
 
@@ -76,7 +78,7 @@ pub(super) async fn refresh_pending_states(
     let mut failed_refreshes = std::collections::HashSet::new();
 
     for (id, identifier) in refreshes {
-        match provider.read(id, Some(identifier)).await {
+        match provider.read(id, identifier, ReadRequest).await {
             Ok(state) => {
                 observer.on_event(&ExecutionEvent::RefreshSucceeded { id });
                 current_states.insert(id.clone(), state);
@@ -231,7 +233,15 @@ pub(super) async fn execute_basic_effect<'a>(
                     };
                 }
             };
-            match provider.create(&resolved).await {
+            match provider
+                .create(
+                    &resource.id,
+                    CreateRequest {
+                        resource: resolved.clone(),
+                    },
+                )
+                .await
+            {
                 Ok(state) => {
                     observer.on_event(&ExecutionEvent::EffectSucceeded {
                         effect,
@@ -261,7 +271,12 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             }
         }
-        Effect::Update { id, from, to, .. } => {
+        Effect::Update {
+            id,
+            from,
+            to,
+            changed_attributes,
+        } => {
             let resolve_source = unresolved.get(id).unwrap_or(to);
             let resolved_to = match resolve_resource_with_source(to, resolve_source, bindings) {
                 Ok(r) => r,
@@ -279,7 +294,31 @@ pub(super) async fn execute_basic_effect<'a>(
                 }
             };
             let identifier = from.identifier.as_deref().unwrap_or("");
-            match provider.update(id, identifier, from, &resolved_to).await {
+            // Augment plan-time `changed_attributes` with any
+            // ResourceRef-derived attributes whose resolved value at
+            // apply time differs from `from`. This catches the case
+            // where a dependency was just replaced (and the binding
+            // map flipped to a new computed value) but the plan-time
+            // diff did not see the change because both the old and
+            // new ResourceRef expressions are syntactically identical.
+            // Without this, the patch would omit the changed
+            // reference value and the provider would never be told
+            // to update it.
+            let mut effective_changed: Vec<String> = changed_attributes.clone();
+            for (key, new_value) in &resolved_to.attributes {
+                if effective_changed.iter().any(|k| k == key) {
+                    continue;
+                }
+                if from.attributes.get(key) != Some(new_value) {
+                    effective_changed.push(key.clone());
+                }
+            }
+            let patch = build_update_patch(&effective_changed, &resolved_to, from);
+            let request = UpdateRequest {
+                from: (**from).clone(),
+                patch,
+            };
+            match provider.update(id, identifier, request).await {
                 Ok(state) => {
                     observer.on_event(&ExecutionEvent::EffectSucceeded {
                         effect,
@@ -314,7 +353,16 @@ pub(super) async fn execute_basic_effect<'a>(
             identifier,
             lifecycle,
             ..
-        } => match provider.delete(id, identifier, lifecycle).await {
+        } => match provider
+            .delete(
+                id,
+                identifier,
+                DeleteRequest {
+                    lifecycle: lifecycle.clone(),
+                },
+            )
+            .await
+        {
             Ok(()) => {
                 observer.on_event(&ExecutionEvent::EffectSucceeded {
                     effect,

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -8,7 +8,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 
 use crate::deps::{find_failed_dependency, get_resource_dependencies};
 use crate::effect::Effect;
-use crate::provider::Provider;
+use crate::provider::{CreateRequest, DeleteRequest, Provider, UpdateRequest};
 use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::basic::{
@@ -16,6 +16,7 @@ use super::basic::{
     process_basic_result, queue_state_refresh, refresh_pending_states, resolve_resource,
     resolve_resource_with_source,
 };
+use super::replace::{compute_full_diff_patch, single_attribute_patch};
 use super::{ExecutionEvent, ExecutionInput, ExecutionObserver, ExecutionResult, ProgressInfo};
 
 /// Check if the plan contains multiple Replace effects that depend on each other.
@@ -526,7 +527,15 @@ pub(super) async fn execute_effects_phased(
                             }
                         };
 
-                        match provider.create(&resolved).await {
+                        match provider
+                            .create(
+                                &to.id,
+                                CreateRequest {
+                                    resource: resolved.clone(),
+                                },
+                            )
+                            .await
+                        {
                             Ok(state) => {
                                 let mut local_bindings = binding_snapshot.clone();
                                 local_bindings.record_applied(
@@ -564,13 +573,14 @@ pub(super) async fn execute_effects_phased(
                                         };
                                     let cascade_identifier =
                                         cascade.from.identifier.as_deref().unwrap_or("");
+                                    let cascade_patch =
+                                        compute_full_diff_patch(&cascade.from, &resolved_to);
+                                    let cascade_request = UpdateRequest {
+                                        from: (*cascade.from).clone(),
+                                        patch: cascade_patch,
+                                    };
                                     match provider
-                                        .update(
-                                            &cascade.id,
-                                            cascade_identifier,
-                                            &cascade.from,
-                                            &resolved_to,
-                                        )
+                                        .update(&cascade.id, cascade_identifier, cascade_request)
                                         .await
                                     {
                                         Ok(cascade_state) => {
@@ -840,7 +850,16 @@ pub(super) async fn execute_effects_phased(
                     } = effect
                     {
                         let identifier = from.identifier.as_deref().unwrap_or("");
-                        match provider.delete(id, identifier, lifecycle).await {
+                        match provider
+                            .delete(
+                                id,
+                                identifier,
+                                DeleteRequest {
+                                    lifecycle: lifecycle.clone(),
+                                },
+                            )
+                            .await
+                        {
                             Ok(()) => (idx, PhaseEffectResult::ReplaceDeleteSuccess),
                             Err(e) => {
                                 let error_str = e.to_string();
@@ -979,15 +998,15 @@ pub(super) async fn execute_effects_phased(
                                 && temp.can_rename
                             {
                                 let new_identifier = state.identifier.as_deref().unwrap_or("");
-                                let mut rename_to = to.clone();
-                                rename_to.set_attr(
+                                let rename_patch = single_attribute_patch(
                                     temp.attribute.clone(),
                                     Value::String(temp.original_value.clone()),
                                 );
-                                match provider
-                                    .update(&id, new_identifier, &state, &rename_to)
-                                    .await
-                                {
+                                let rename_request = UpdateRequest {
+                                    from: state.clone(),
+                                    patch: rename_patch,
+                                };
+                                match provider.update(&id, new_identifier, rename_request).await {
                                     Ok(renamed_state) => {
                                         observer.on_event(&ExecutionEvent::RenameSucceeded {
                                             id: &id,
@@ -1099,7 +1118,15 @@ pub(super) async fn execute_effects_phased(
                                     }
                                 };
 
-                                match provider.create(&resolved).await {
+                                match provider
+                                    .create(
+                                        &to.id,
+                                        CreateRequest {
+                                            resource: resolved.clone(),
+                                        },
+                                    )
+                                    .await
+                                {
                                     Ok(state) => {
                                         observer.on_event(&ExecutionEvent::EffectSucceeded {
                                             effect,

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -5,11 +5,49 @@ use std::time::Instant;
 
 use crate::binding_index::ResolvedBindings;
 use crate::effect::Effect;
-use crate::provider::Provider;
+use crate::provider::{
+    CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, UpdatePatch, UpdateRequest,
+    build_update_patch,
+};
 use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::basic::{BasicEffectResult, resolve_resource, resolve_resource_with_source};
 use super::{ExecutionEvent, ExecutionObserver, ProgressInfo};
+
+/// Build a full attribute-diff [`UpdatePatch`] between an existing
+/// `from` state and a desired `to` resource, used by the cascade
+/// path of replacements (cascade has no precomputed
+/// `changed_attributes` list, so the patch is derived from the
+/// from/to comparison directly).
+pub(super) fn compute_full_diff_patch(from: &State, to: &Resource) -> UpdatePatch {
+    use std::collections::HashSet;
+
+    let mut keys: HashSet<&str> = HashSet::new();
+    keys.extend(from.attributes.keys().map(String::as_str));
+    keys.extend(to.attributes.keys().map(String::as_str));
+    let mut sorted_keys: Vec<&str> = keys.into_iter().collect();
+    sorted_keys.sort();
+
+    let changed: Vec<String> = sorted_keys
+        .into_iter()
+        .filter(|k| from.attributes.get(*k) != to.attributes.get(*k))
+        .map(|k| k.to_string())
+        .collect();
+    build_update_patch(&changed, to, from)
+}
+
+/// Build a single-attribute [`UpdatePatch`] for the rename path of
+/// CBD replace, where exactly one attribute is being flipped from
+/// the temporary value back to the original.
+pub(super) fn single_attribute_patch(key: String, value: Value) -> UpdatePatch {
+    UpdatePatch {
+        ops: vec![PatchOp {
+            kind: PatchOpKind::Replace,
+            key,
+            value: Some(value),
+        }],
+    }
+}
 
 /// Result of executing a single effect.
 pub(super) enum SingleEffectResult {
@@ -85,7 +123,15 @@ pub(super) async fn execute_cbd_replace_parallel(
     };
     let mut refreshes = Vec::new();
 
-    match provider.create(&resolved).await {
+    match provider
+        .create(
+            &ctx.to.id,
+            CreateRequest {
+                resource: resolved.clone(),
+            },
+        )
+        .await
+    {
         Ok(state) => {
             // Build a local bindings clone for cascade resolution
             let mut local_bindings = ctx.bindings.clone();
@@ -112,8 +158,13 @@ pub(super) async fn execute_cbd_replace_parallel(
                     }
                 };
                 let cascade_identifier = cascade.from.identifier.as_deref().unwrap_or("");
+                let cascade_patch = compute_full_diff_patch(&cascade.from, &resolved_to);
+                let cascade_request = UpdateRequest {
+                    from: (*cascade.from).clone(),
+                    patch: cascade_patch,
+                };
                 match provider
-                    .update(&cascade.id, cascade_identifier, &cascade.from, &resolved_to)
+                    .update(&cascade.id, cascade_identifier, cascade_request)
                     .await
                 {
                     Ok(cascade_state) => {
@@ -156,7 +207,16 @@ pub(super) async fn execute_cbd_replace_parallel(
 
             // Delete the old resource
             let identifier = ctx.from.identifier.as_deref().unwrap_or("");
-            match provider.delete(ctx.id, identifier, ctx.lifecycle).await {
+            match provider
+                .delete(
+                    ctx.id,
+                    identifier,
+                    DeleteRequest {
+                        lifecycle: ctx.lifecycle.clone(),
+                    },
+                )
+                .await
+            {
                 Ok(()) => {
                     // Handle rename
                     let mut permanent_overrides = None;
@@ -167,13 +227,16 @@ pub(super) async fn execute_cbd_replace_parallel(
                         && temp.can_rename
                     {
                         let new_identifier = state.identifier.as_deref().unwrap_or("");
-                        let mut rename_to = ctx.to.clone();
-                        rename_to.set_attr(
+                        let rename_patch = single_attribute_patch(
                             temp.attribute.clone(),
                             Value::String(temp.original_value.clone()),
                         );
+                        let rename_request = UpdateRequest {
+                            from: state.clone(),
+                            patch: rename_patch,
+                        };
                         match provider
-                            .update(ctx.id, new_identifier, &state, &rename_to)
+                            .update(ctx.id, new_identifier, rename_request)
                             .await
                         {
                             Ok(renamed_state) => {
@@ -293,7 +356,16 @@ pub(super) async fn execute_dbd_replace_parallel(
     let identifier = ctx.from.identifier.as_deref().unwrap_or("");
     let mut refreshes = Vec::new();
 
-    match provider.delete(ctx.id, identifier, ctx.lifecycle).await {
+    match provider
+        .delete(
+            ctx.id,
+            identifier,
+            DeleteRequest {
+                lifecycle: ctx.lifecycle.clone(),
+            },
+        )
+        .await
+    {
         Ok(()) => {
             let resolve_source = ctx.unresolved.get(&ctx.to.id).unwrap_or(ctx.to);
             let resolved = match resolve_resource_with_source(ctx.to, resolve_source, ctx.bindings)
@@ -318,7 +390,15 @@ pub(super) async fn execute_dbd_replace_parallel(
                     };
                 }
             };
-            match provider.create(&resolved).await {
+            match provider
+                .create(
+                    &ctx.to.id,
+                    CreateRequest {
+                        resource: resolved.clone(),
+                    },
+                )
+                .await
+            {
                 Ok(state) => {
                     observer.on_event(&ExecutionEvent::EffectSucceeded {
                         effect: ctx.effect,

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::plan::Plan;
-use crate::provider::{BoxFuture, ProviderError, ProviderResult};
+use crate::provider::{
+    BoxFuture, CreateRequest, DeleteRequest, ProviderError, ProviderResult, ReadRequest,
+    UpdateRequest,
+};
 use crate::resource::{LifecycleConfig, Resource, Value};
 use parallel::{build_dependency_levels, build_dependency_map};
 use std::sync::{Arc, Mutex};
@@ -61,7 +64,8 @@ impl Provider for MockProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
         self.call_log
@@ -73,11 +77,15 @@ impl Provider for MockProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
+        self.read(&resource.id, "", ReadRequest)
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let id_str = resource.id.to_string();
+    fn create(
+        &self,
+        id: &ResourceId,
+        _request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id_str = id.to_string();
         self.call_log
             .lock()
             .unwrap()
@@ -90,8 +98,7 @@ impl Provider for MockProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        _to: &Resource,
+        _request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
         self.call_log
@@ -106,7 +113,7 @@ impl Provider for MockProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let id_str = id.to_string();
         self.call_log
@@ -288,7 +295,7 @@ async fn test_failed_effect_propagates_to_dependent() {
     plan.add(Effect::Create(rb));
 
     // First create fails
-    provider.push_create(Err(ProviderError::new("create failed")));
+    provider.push_create(Err(ProviderError::api_error("create failed")));
 
     let input = ExecutionInput {
         plan: &plan,
@@ -663,7 +670,7 @@ async fn test_parallel_failure_skips_dependents() {
 
     provider.push_create(Ok(ok_state(&vpc_id)));
     // subnet_a fails, subnet_b succeeds
-    provider.push_create(Err(ProviderError::new("create failed")));
+    provider.push_create(Err(ProviderError::api_error("create failed")));
     provider.push_create(Ok(ok_state(&subnet_b_id)));
 
     let input = ExecutionInput {
@@ -857,18 +864,23 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
         fn read(
             &self,
             _id: &ResourceId,
-            _identifier: Option<&str>,
+            _identifier: &str,
+            _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
-            Box::pin(async { Err(ProviderError::new("not implemented")) })
+            Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
 
         fn read_data_source(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            Box::pin(async { Err(ProviderError::new("not implemented")) })
+            Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
 
-        fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            let id = resource.id.clone();
-            let name = resource.id.name_str().to_string();
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id_clone = id.clone();
+            let name = id.name_str().to_string();
             let delay = self.delays.get(&name).copied().unwrap_or(Duration::ZERO);
             let log = self.call_log.clone();
             Box::pin(async move {
@@ -876,7 +888,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
                 log.lock()
                     .unwrap()
                     .push(("create".to_string(), name, Instant::now()));
-                Ok(State::existing(id, HashMap::new()).with_identifier("id-123"))
+                Ok(State::existing(id_clone, HashMap::new()).with_identifier("id-123"))
             })
         }
 
@@ -884,19 +896,18 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _from: &State,
-            _to: &Resource,
+            _request: UpdateRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
-            Box::pin(async { Err(ProviderError::new("not implemented")) })
+            Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
 
         fn delete(
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _lifecycle: &LifecycleConfig,
+            _request: DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
-            Box::pin(async { Err(ProviderError::new("not implemented")) })
+            Box::pin(async { Err(ProviderError::internal("not implemented")) })
         }
     }
 
@@ -1286,18 +1297,23 @@ impl Provider for RecordingMockProvider {
     fn read(
         &self,
         _id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("not implemented")) })
+        Box::pin(async { Err(ProviderError::internal("not implemented")) })
     }
 
     fn read_data_source(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("not implemented")) })
+        Box::pin(async { Err(ProviderError::internal("not implemented")) })
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let id_str = resource.id.to_string();
-        let attrs = resource.resolved_attributes();
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id_str = id.to_string();
+        let attrs = request.resource.resolved_attributes();
         self.create_log.lock().unwrap().push((id_str, attrs));
         let result = self.create_results.lock().unwrap().remove(0);
         Box::pin(async move { result })
@@ -1307,19 +1323,18 @@ impl Provider for RecordingMockProvider {
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        _to: &Resource,
+        _request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        Box::pin(async { Err(ProviderError::new("not implemented")) })
+        Box::pin(async { Err(ProviderError::internal("not implemented")) })
     }
 
     fn delete(
         &self,
         _id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        Box::pin(async { Err(ProviderError::new("not implemented")) })
+        Box::pin(async { Err(ProviderError::internal("not implemented")) })
     }
 }
 

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -12,29 +12,63 @@ use std::pin::Pin;
 use crate::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use crate::schema::SchemaRegistry;
 
-/// Error type for Provider operations
-#[derive(Debug)]
-pub struct ProviderError {
+/// Contextual metadata attached to every [`ProviderError`] variant.
+///
+/// Mirrors `error-detail` in `wit/types.wit`. The `cause` chain stays
+/// host-side (boxed `dyn Error`) and is flattened to a string when the
+/// error crosses the WIT boundary.
+#[derive(Debug, Default)]
+pub struct ErrorDetail {
+    /// Human-readable message.
     pub message: String,
+    /// Resource the error pertains to, if known.
     pub resource_id: Option<Box<ResourceId>>,
+    /// Underlying cause chain. Lost when the error crosses the WIT
+    /// boundary — flattened to a string there.
     pub cause: Option<Box<dyn std::error::Error + Send + Sync>>,
-    pub is_timeout: bool,
-    /// Optional provider name (e.g. `"aws"`, `"awscc"`) attached when
-    /// the error is raised at provider boundary points where the name
-    /// is known but no specific resource is in scope (e.g. provider
-    /// init / `create_provider`). Display ignores this field; CLI
-    /// renderers can read it to label structured output.
+    /// Provider name (e.g. `"aws"`, `"awscc"`) attached when the error
+    /// is raised at provider-init / `create_provider` boundary points
+    /// where the name is known but no specific resource is in scope.
+    /// Display ignores this field; CLI renderers can read it to label
+    /// structured output.
     pub provider_name: Option<String>,
+}
+
+/// Structured error returned by every provider operation.
+///
+/// Variants mirror `provider-error` in `wit/types.wit`. Host-side code
+/// can match exhaustively to dispatch retry / abort / not-found /
+/// escalate strategies in a type-safe way.
+#[derive(Debug)]
+pub enum ProviderError {
+    /// User-supplied input is invalid (bad attribute value, schema
+    /// violation, configuration mismatch). Not retriable.
+    InvalidInput(ErrorDetail),
+    /// The cloud API rejected the request (HTTP 4xx/5xx, server-side
+    /// error). May be retriable depending on the cause.
+    ApiError(ErrorDetail),
+    /// Resource was not found at the cloud API. `read` returns this
+    /// instead of an empty state when the underlying resource has been
+    /// deleted out-of-band. `delete` returns this when the resource is
+    /// already gone.
+    NotFound(ErrorDetail),
+    /// Operation timed out before completing. Retriable with backoff.
+    Timeout(ErrorDetail),
+    /// Provider-internal failure (panic, unexpected state, missing
+    /// schema entry, etc.). Should be escalated as a bug rather than
+    /// retried.
+    Internal(ErrorDetail),
 }
 
 impl std::fmt::Display for ProviderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ref id) = self.resource_id {
-            write!(f, "[{}.{}] {}", id.resource_type, id.name, self.message)?;
+        let detail = self.detail();
+        if let Some(ref id) = detail.resource_id {
+            write!(f, "[{}.{}] {}", id.resource_type, id.name, detail.message)?;
         } else {
-            write!(f, "{}", self.message)?;
+            write!(f, "{}", detail.message)?;
         }
-        if let Some(ref cause) = self.cause {
+        if let Some(ref cause) = detail.cause {
             write!(f, ": {}", cause)?;
         }
         Ok(())
@@ -43,35 +77,86 @@ impl std::fmt::Display for ProviderError {
 
 impl std::error::Error for ProviderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.cause
+        self.detail()
+            .cause
             .as_ref()
             .map(|e| e.as_ref() as &dyn std::error::Error)
     }
 }
 
 impl ProviderError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            resource_id: None,
-            cause: None,
-            is_timeout: false,
-            provider_name: None,
+    /// Borrow the inner [`ErrorDetail`] regardless of variant.
+    pub fn detail(&self) -> &ErrorDetail {
+        match self {
+            ProviderError::InvalidInput(d)
+            | ProviderError::ApiError(d)
+            | ProviderError::NotFound(d)
+            | ProviderError::Timeout(d)
+            | ProviderError::Internal(d) => d,
         }
     }
 
+    /// Mutably borrow the inner [`ErrorDetail`] regardless of variant.
+    pub fn detail_mut(&mut self) -> &mut ErrorDetail {
+        match self {
+            ProviderError::InvalidInput(d)
+            | ProviderError::ApiError(d)
+            | ProviderError::NotFound(d)
+            | ProviderError::Timeout(d)
+            | ProviderError::Internal(d) => d,
+        }
+    }
+
+    /// Variant name as a static string (used by serialization layers).
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            ProviderError::InvalidInput(_) => "invalid_input",
+            ProviderError::ApiError(_) => "api_error",
+            ProviderError::NotFound(_) => "not_found",
+            ProviderError::Timeout(_) => "timeout",
+            ProviderError::Internal(_) => "internal",
+        }
+    }
+
+    /// Convenience accessor for the human-readable message.
+    pub fn message(&self) -> &str {
+        &self.detail().message
+    }
+
+    /// User-supplied input is invalid.
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        ProviderError::InvalidInput(ErrorDetail::new(message))
+    }
+
+    /// The cloud API rejected the request.
+    pub fn api_error(message: impl Into<String>) -> Self {
+        ProviderError::ApiError(ErrorDetail::new(message))
+    }
+
+    /// Resource was not found at the cloud API.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        ProviderError::NotFound(ErrorDetail::new(message))
+    }
+
+    /// Operation timed out.
+    pub fn timeout(message: impl Into<String>) -> Self {
+        ProviderError::Timeout(ErrorDetail::new(message))
+    }
+
+    /// Provider-internal failure / unexpected state.
+    pub fn internal(message: impl Into<String>) -> Self {
+        ProviderError::Internal(ErrorDetail::new(message))
+    }
+
+    /// Attach a resource id to the inner detail.
     pub fn for_resource(mut self, id: ResourceId) -> Self {
-        self.resource_id = Some(Box::new(id));
+        self.detail_mut().resource_id = Some(Box::new(id));
         self
     }
 
+    /// Attach a cause chain to the inner detail.
     pub fn with_cause(mut self, cause: impl std::error::Error + Send + Sync + 'static) -> Self {
-        self.cause = Some(Box::new(cause));
-        self
-    }
-
-    pub fn timeout(mut self) -> Self {
-        self.is_timeout = true;
+        self.detail_mut().cause = Some(Box::new(cause));
         self
     }
 
@@ -80,12 +165,153 @@ impl ProviderError {
     /// `create_provider` / provider init failures). Used by the CLI
     /// renderer to label structured account-guard output.
     pub fn for_provider(mut self, provider_name: impl Into<String>) -> Self {
-        self.provider_name = Some(provider_name.into());
+        self.detail_mut().provider_name = Some(provider_name.into());
         self
     }
 }
 
+impl ErrorDetail {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            resource_id: None,
+            cause: None,
+            provider_name: None,
+        }
+    }
+}
+
 pub type ProviderResult<T> = Result<T, ProviderError>;
+
+/// Per-operation request record for [`Provider::create`].
+///
+/// Mirrors `create-request` in `wit/types.wit`.
+#[derive(Debug, Clone)]
+pub struct CreateRequest {
+    /// Full desired state for the new resource.
+    pub resource: Resource,
+}
+
+/// Per-operation request record for [`Provider::read`].
+///
+/// Mirrors `read-request` in `wit/types.wit`. Has no operationally
+/// meaningful fields today; the record exists so future fields (e.g.
+/// a freshness hint or an attribute projection) can be added without
+/// breaking the `read` signature.
+#[derive(Debug, Clone, Default)]
+pub struct ReadRequest;
+
+/// Per-operation request record for [`Provider::update`].
+///
+/// Mirrors `update-request` in `wit/types.wit`. `from` is the current
+/// provider-side state; `patch` carries only the user's intended
+/// changes. The patch is the sole source of truth for what the
+/// provider should write — there is no separate `to: Resource`
+/// because exposing the full desired resource invites providers to
+/// touch fields the user never specified (the root cause of
+/// `carina-rs/carina#2559`).
+#[derive(Debug, Clone)]
+pub struct UpdateRequest {
+    /// Current provider-side state. May be used for read-modify-write
+    /// paths or for resolving server-assigned identifiers; MUST NOT be
+    /// used to derive additional fields to write back.
+    pub from: State,
+    /// Structured description of the user's intended change.
+    pub patch: UpdatePatch,
+}
+
+/// Per-operation request record for [`Provider::delete`].
+///
+/// Mirrors `delete-request` in `wit/types.wit`.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteRequest {
+    /// Lifecycle policy for the resource.
+    pub lifecycle: LifecycleConfig,
+}
+
+/// A structured description of the user's intended change to a resource.
+///
+/// Mirrors `update-patch` in `wit/types.wit`. Each [`PatchOp`]
+/// corresponds to a key the user explicitly specified or removed in
+/// the desired state. Fields the user has never specified do not
+/// appear in the patch.
+///
+/// Providers MUST NOT modify any attribute that is not represented in
+/// `ops`.
+#[derive(Debug, Clone, Default)]
+pub struct UpdatePatch {
+    pub ops: Vec<PatchOp>,
+}
+
+/// A single operation inside an [`UpdatePatch`].
+///
+/// Mirrors `patch-op` in `wit/types.wit`.
+#[derive(Debug, Clone)]
+pub struct PatchOp {
+    pub kind: PatchOpKind,
+    /// Top-level attribute name. Nested-field patches are a future
+    /// extension.
+    pub key: String,
+    /// `Some(_)` for `Add` and `Replace`; `None` for `Remove`.
+    pub value: Option<Value>,
+}
+
+/// Kind of a single [`PatchOp`].
+///
+/// Mirrors `patch-op-kind` in `wit/types.wit`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchOpKind {
+    /// User added a key that did not previously appear in the desired state.
+    Add,
+    /// User changed the value of an existing key in the desired state.
+    Replace,
+    /// User removed a key that previously appeared in the desired state.
+    Remove,
+}
+
+/// Build an [`UpdatePatch`] from a list of changed attribute names plus
+/// the desired (`to`) and current (`from`) views.
+///
+/// For each `key` in `changed_attributes`:
+/// - present in `to` but missing in `from` → [`PatchOpKind::Add`]
+/// - present in both                       → [`PatchOpKind::Replace`]
+/// - missing in `to` but present in `from` → [`PatchOpKind::Remove`]
+///
+/// `Remove` ops carry `value: None`; others carry a clone of the
+/// value from `to`.
+pub fn build_update_patch(
+    changed_attributes: &[String],
+    to: &Resource,
+    from: &State,
+) -> UpdatePatch {
+    let ops = changed_attributes
+        .iter()
+        .map(|key| {
+            let in_to = to.attributes.contains_key(key);
+            let in_from = from.attributes.contains_key(key);
+            let kind = match (in_to, in_from) {
+                (true, false) => PatchOpKind::Add,
+                (true, true) => PatchOpKind::Replace,
+                (false, true) => PatchOpKind::Remove,
+                // Neither side has it. Treat as Replace with None value;
+                // this should not happen with well-formed inputs but the
+                // provider will see a no-op-ish entry rather than a panic.
+                (false, false) => PatchOpKind::Remove,
+            };
+            let value = if matches!(kind, PatchOpKind::Remove) {
+                None
+            } else {
+                to.attributes.get(key).cloned()
+            };
+            PatchOp {
+                kind,
+                key: key.clone(),
+                value,
+            }
+        })
+        .collect();
+    UpdatePatch { ops }
+}
 
 /// Return type for async operations
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -100,18 +326,27 @@ pub type SavedAttrs = HashMap<ResourceId, HashMap<String, Value>>;
 ///
 /// Each infrastructure provider (AWS, GCP, etc.) implements this trait
 /// to perform actual API calls against its infrastructure.
+///
+/// Every CRUD op (except [`Provider::read_data_source`]) takes a
+/// per-operation `*Request` record. Request records mirror the
+/// records of the same name in `wit/types.wit`; future per-op
+/// parameters become non-breaking record-field additions instead of
+/// trait-signature churn.
 pub trait Provider: Send + Sync {
     /// Name of this Provider (e.g., "aws")
     fn name(&self) -> &str;
 
-    /// Get the current state of a resource
+    /// Read the current provider-side state of an existing resource.
     ///
-    /// If identifier is provided, use it to read the resource directly.
-    /// Returns `State::not_found()` if no identifier is provided or the resource does not exist.
+    /// `identifier` is the cloud-side identifier (e.g. `vpc-0abc...`).
+    /// `request` carries no operationally meaningful fields today; it
+    /// exists so future fields (e.g. a freshness hint or an attribute
+    /// projection) can be added without breaking the signature.
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>>;
 
     /// Read a data source resource.
@@ -123,33 +358,49 @@ pub trait Provider: Send + Sync {
     ///
     /// Each provider must implement this explicitly. For zero-input data
     /// sources (e.g. `aws.sts.caller_identity`), the implementation can
-    /// simply delegate to `self.read(&resource.id, None)`.
+    /// simply delegate to a state-only read against `resource.id`.
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>>;
 
-    /// Create a resource
-    ///
-    /// Returns State with identifier set to the AWS internal ID (e.g., vpc-xxx)
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>>;
+    /// Create the resource described by `request.resource` and return
+    /// the resulting state (with `identifier` set to the cloud-side
+    /// internal ID, e.g. `vpc-xxx`).
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>>;
 
-    /// Update a resource
+    /// Update an existing resource by applying `request.patch`.
     ///
-    /// The identifier is the AWS internal ID (e.g., vpc-xxx)
+    /// Each [`PatchOp`] corresponds to a key the user explicitly
+    /// specified or removed in the desired state. Fields the user has
+    /// never specified do not appear in the patch.
+    ///
+    /// **Providers MUST NOT modify any attribute that is not
+    /// represented in `request.patch.ops`.** The patch is the sole
+    /// source of truth for the update payload.
+    ///
+    /// `request.from` is the current provider-side state and may be
+    /// used for read-modify-write paths or for resolving
+    /// server-assigned identifiers; it MUST NOT be used to derive
+    /// additional fields to write back.
     fn update(
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>>;
 
-    /// Delete a resource
+    /// Delete an existing resource. `identifier` is the cloud-side
+    /// internal ID (e.g. `vpc-xxx`).
     ///
-    /// The identifier is the AWS internal ID (e.g., vpc-xxx)
+    /// `request.lifecycle` carries the resource's lifecycle policy
+    /// (force-delete, create-before-destroy, prevent-destroy).
     fn delete(
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>>;
 }
 
@@ -315,7 +566,7 @@ impl ProviderRouter {
         self.providers
             .get(provider_name)
             .map(|p| p.as_ref())
-            .ok_or_else(|| ProviderError::new(format!("Unknown provider: {}", provider_name)))
+            .ok_or_else(|| ProviderError::internal(format!("Unknown provider: {}", provider_name)))
     }
 }
 
@@ -327,10 +578,11 @@ impl Provider for ProviderRouter {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         match self.get_provider_or_error(&id.provider) {
-            Ok(provider) => provider.read(id, identifier),
+            Ok(provider) => provider.read(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -342,9 +594,13 @@ impl Provider for ProviderRouter {
         }
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        match self.get_provider_or_error(&resource.id.provider) {
-            Ok(provider) => provider.create(resource),
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        match self.get_provider_or_error(&id.provider) {
+            Ok(provider) => provider.create(id, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -353,11 +609,10 @@ impl Provider for ProviderRouter {
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         match self.get_provider_or_error(&id.provider) {
-            Ok(provider) => provider.update(id, identifier, from, to),
+            Ok(provider) => provider.update(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -366,10 +621,10 @@ impl Provider for ProviderRouter {
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         match self.get_provider_or_error(&id.provider) {
-            Ok(provider) => provider.delete(id, identifier, lifecycle),
+            Ok(provider) => provider.delete(id, identifier, request),
             Err(e) => Box::pin(async move { Err(e) }),
         }
     }
@@ -664,36 +919,40 @@ impl Provider for Box<dyn Provider> {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        (**self).read(id, identifier)
+        (**self).read(id, identifier, request)
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         (**self).read_data_source(resource)
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        (**self).create(resource)
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        (**self).create(id, request)
     }
 
     fn update(
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        (**self).update(id, identifier, from, to)
+        (**self).update(id, identifier, request)
     }
 
     fn delete(
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
-        (**self).delete(id, identifier, lifecycle)
+        (**self).delete(id, identifier, request)
     }
 }
 
@@ -712,19 +971,25 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: Option<&str>,
+            _identifier: &str,
+            _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
             Box::pin(async move { Ok(State::not_found(id)) })
         }
 
         fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            self.read(&resource.id, None)
+            let id = resource.id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
         }
 
-        fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            let id = resource.id.clone();
-            let attrs = resource.attributes.clone();
+        fn create(
+            &self,
+            id: &ResourceId,
+            request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            let attrs = request.resource.attributes.clone();
             Box::pin(async move {
                 Ok(
                     State::existing(id, crate::resource::attrs_to_hashmap(&attrs))
@@ -737,24 +1002,32 @@ mod tests {
             &self,
             id: &ResourceId,
             _identifier: &str,
-            _from: &State,
-            to: &Resource,
+            request: UpdateRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
-            let attrs = to.attributes.clone();
-            Box::pin(async move {
-                Ok(State::existing(
-                    id,
-                    crate::resource::attrs_to_hashmap(&attrs),
-                ))
-            })
+            // Apply the patch on top of `from` so the test sees the
+            // user-specified changes round-tripped into State.
+            let mut attrs = request.from.attributes.clone();
+            for op in request.patch.ops {
+                match op.kind {
+                    PatchOpKind::Add | PatchOpKind::Replace => {
+                        if let Some(v) = op.value {
+                            attrs.insert(op.key, v);
+                        }
+                    }
+                    PatchOpKind::Remove => {
+                        attrs.remove(&op.key);
+                    }
+                }
+            }
+            Box::pin(async move { Ok(State::existing(id, attrs)) })
         }
 
         fn delete(
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _lifecycle: &LifecycleConfig,
+            _request: DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
@@ -764,7 +1037,7 @@ mod tests {
     async fn mock_provider_read_returns_not_found() {
         let provider = MockProvider;
         let id = ResourceId::new("test", "example");
-        let state = provider.read(&id, None).await.unwrap();
+        let state = provider.read(&id, "", ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
 
@@ -782,14 +1055,15 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: Option<&str>,
+            _identifier: &str,
+            _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
             // Intentionally fails if the data source path doesn't deliver
-            // the full Resource — the legacy `read(&id, None)` route has no
-            // access to input attributes.
+            // the full Resource — the regular `read` route has no access
+            // to input attributes.
             Box::pin(async move {
-                Err(ProviderError::new("read(&id, None) cannot see inputs").for_resource(id))
+                Err(ProviderError::internal("read cannot see inputs").for_resource(id))
             })
         }
 
@@ -806,25 +1080,28 @@ mod tests {
             })
         }
 
-        fn create(&self, _resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            Box::pin(async { Err(ProviderError::new("not supported")) })
+        fn create(
+            &self,
+            _id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async { Err(ProviderError::internal("not supported")) })
         }
 
         fn update(
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _from: &State,
-            _to: &Resource,
+            _request: UpdateRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
-            Box::pin(async { Err(ProviderError::new("not supported")) })
+            Box::pin(async { Err(ProviderError::internal("not supported")) })
         }
 
         fn delete(
             &self,
             _id: &ResourceId,
             _identifier: &str,
-            _lifecycle: &LifecycleConfig,
+            _request: DeleteRequest,
         ) -> BoxFuture<'_, ProviderResult<()>> {
             Box::pin(async { Ok(()) })
         }
@@ -906,7 +1183,11 @@ mod tests {
     async fn mock_provider_create_returns_existing() {
         let provider = MockProvider;
         let resource = Resource::new("test", "example");
-        let state = provider.create(&resource).await.unwrap();
+        let id = resource.id.clone();
+        let state = provider
+            .create(&id, CreateRequest { resource })
+            .await
+            .unwrap();
         assert!(state.exists);
         assert_eq!(state.identifier, Some("mock-id-123".to_string()));
     }
@@ -917,7 +1198,7 @@ mod tests {
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
         let id = ResourceId::with_provider("mock", "test", "example");
-        let state = router.read(&id, None).await.unwrap();
+        let state = router.read(&id, "", ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
 
@@ -927,7 +1208,11 @@ mod tests {
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
         let resource = Resource::with_provider("mock", "test", "example");
-        let state = router.create(&resource).await.unwrap();
+        let id = resource.id.clone();
+        let state = router
+            .create(&id, CreateRequest { resource })
+            .await
+            .unwrap();
         assert!(state.exists);
         assert_eq!(state.identifier, Some("mock-id-123".to_string()));
     }
@@ -936,7 +1221,7 @@ mod tests {
     fn provider_error_source_returns_cause() {
         use std::error::Error;
         let cause = std::io::Error::other("connection refused");
-        let err = ProviderError::new("Failed to create resource").with_cause(cause);
+        let err = ProviderError::api_error("Failed to create resource").with_cause(cause);
         let source = err.source().expect("source should be Some");
         assert_eq!(source.to_string(), "connection refused");
     }
@@ -944,7 +1229,7 @@ mod tests {
     #[test]
     fn provider_error_display_includes_cause() {
         let cause = std::io::Error::other("connection refused");
-        let err = ProviderError::new("Failed to create resource").with_cause(cause);
+        let err = ProviderError::api_error("Failed to create resource").with_cause(cause);
         let display = format!("{}", err);
         assert!(
             display.contains("connection refused"),
@@ -955,7 +1240,7 @@ mod tests {
 
     #[test]
     fn provider_error_display_without_cause() {
-        let err = ProviderError::new("simple error");
+        let err = ProviderError::internal("simple error");
         let display = format!("{}", err);
         assert_eq!(display, "simple error");
     }
@@ -964,7 +1249,7 @@ mod tests {
     fn provider_error_display_with_resource_id_and_cause() {
         let cause = std::io::Error::other("timeout");
         let id = ResourceId::new("s3.Bucket", "my-bucket");
-        let err = ProviderError::new("Failed to read")
+        let err = ProviderError::api_error("Failed to read")
             .with_cause(cause)
             .for_resource(id);
         let display = format!("{}", err);
@@ -980,6 +1265,54 @@ mod tests {
         );
     }
 
+    #[test]
+    fn provider_error_variant_constructors() {
+        let inv = ProviderError::invalid_input("bad");
+        assert!(matches!(inv, ProviderError::InvalidInput(_)));
+        assert_eq!(inv.message(), "bad");
+
+        let api = ProviderError::api_error("rejected");
+        assert!(matches!(api, ProviderError::ApiError(_)));
+
+        let nf = ProviderError::not_found("missing");
+        assert!(matches!(nf, ProviderError::NotFound(_)));
+
+        let to = ProviderError::timeout("slow");
+        assert!(matches!(to, ProviderError::Timeout(_)));
+
+        let intl = ProviderError::internal("bug");
+        assert!(matches!(intl, ProviderError::Internal(_)));
+    }
+
+    #[test]
+    fn build_update_patch_classifies_ops() {
+        let id = ResourceId::new("test", "example");
+        let mut from_attrs = HashMap::new();
+        from_attrs.insert("a".to_string(), Value::String("old".into()));
+        from_attrs.insert("c".to_string(), Value::String("removed".into()));
+        let from = State::existing(id.clone(), from_attrs);
+
+        let mut to = Resource::new("test", "example");
+        to.set_attr("a".to_string(), Value::String("new".into()));
+        to.set_attr("b".to_string(), Value::String("added".into()));
+
+        let changed = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let patch = build_update_patch(&changed, &to, &from);
+        assert_eq!(patch.ops.len(), 3);
+
+        let by_key: HashMap<&str, &PatchOp> =
+            patch.ops.iter().map(|op| (op.key.as_str(), op)).collect();
+        let a = by_key["a"];
+        assert_eq!(a.kind, PatchOpKind::Replace);
+        assert_eq!(a.value, Some(Value::String("new".into())));
+        let b = by_key["b"];
+        assert_eq!(b.kind, PatchOpKind::Add);
+        assert_eq!(b.value, Some(Value::String("added".into())));
+        let c = by_key["c"];
+        assert_eq!(c.kind, PatchOpKind::Remove);
+        assert_eq!(c.value, None);
+    }
+
     #[tokio::test]
     async fn provider_router_dispatches_update_by_provider_name() {
         let mut router = ProviderRouter::new();
@@ -987,8 +1320,11 @@ mod tests {
 
         let id = ResourceId::with_provider("mock", "test", "example");
         let from = State::existing(id.clone(), HashMap::new());
-        let to = Resource::with_provider("mock", "test", "example");
-        let state = router.update(&id, "mock-id-123", &from, &to).await.unwrap();
+        let request = UpdateRequest {
+            from,
+            patch: UpdatePatch::default(),
+        };
+        let state = router.update(&id, "mock-id-123", request).await.unwrap();
         assert!(state.exists);
     }
 
@@ -998,8 +1334,8 @@ mod tests {
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
         let id = ResourceId::with_provider("mock", "test", "example");
-        let lifecycle = crate::resource::LifecycleConfig::default();
-        let result = router.delete(&id, "mock-id-123", &lifecycle).await;
+        let request = DeleteRequest::default();
+        let result = router.delete(&id, "mock-id-123", request).await;
         assert!(result.is_ok());
     }
 
@@ -1007,14 +1343,11 @@ mod tests {
     async fn provider_router_returns_error_for_unknown_provider() {
         let router = ProviderRouter::new();
         let id = ResourceId::with_provider("nonexistent", "test", "example");
-        let result = router.read(&id, None).await;
+        let result = router.read(&id, "", ReadRequest).await;
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .message
-                .contains("Unknown provider: nonexistent")
-        );
+        let err = result.unwrap_err();
+        assert!(matches!(err, ProviderError::Internal(_)));
+        assert!(err.message().contains("Unknown provider: nonexistent"));
     }
 
     #[tokio::test]
@@ -1050,7 +1383,7 @@ mod tests {
                 _attrs: &IndexMap<String, Value>,
             ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
                 Box::pin(async {
-                    Err(ProviderError::new(
+                    Err(ProviderError::invalid_input(
                         "AWS account ID '019115212452' is not in the provider's \
                          allowed_account_ids [\"151116838382\"]. Refusing to operate \
                          against this account. Check the AWS credentials in your environment.",
@@ -1069,7 +1402,7 @@ mod tests {
             Err(e) => e,
         };
         // Inner message must be preserved verbatim; no implementation-detail wrapper.
-        let msg = err.message;
+        let msg = err.message().to_string();
         assert!(
             msg.contains("019115212452"),
             "actual account missing: {msg}"
@@ -1166,7 +1499,8 @@ mod tests {
             fn read(
                 &self,
                 id: &ResourceId,
-                _identifier: Option<&str>,
+                _identifier: &str,
+                _request: ReadRequest,
             ) -> BoxFuture<'_, ProviderResult<State>> {
                 let id = id.clone();
                 Box::pin(async move { Ok(State::not_found(id)) })
@@ -1180,8 +1514,12 @@ mod tests {
                 Box::pin(async move { Ok(State::not_found(id)) })
             }
 
-            fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-                let id = resource.id.clone();
+            fn create(
+                &self,
+                id: &ResourceId,
+                _request: CreateRequest,
+            ) -> BoxFuture<'_, ProviderResult<State>> {
+                let id = id.clone();
                 Box::pin(async move { Ok(State::not_found(id)) })
             }
 
@@ -1189,8 +1527,7 @@ mod tests {
                 &self,
                 id: &ResourceId,
                 _identifier: &str,
-                _from: &State,
-                _to: &Resource,
+                _request: UpdateRequest,
             ) -> BoxFuture<'_, ProviderResult<State>> {
                 let id = id.clone();
                 Box::pin(async move { Ok(State::not_found(id)) })
@@ -1200,7 +1537,7 @@ mod tests {
                 &self,
                 _id: &ResourceId,
                 _identifier: &str,
-                _lifecycle: &LifecycleConfig,
+                _request: DeleteRequest,
             ) -> BoxFuture<'_, ProviderResult<()>> {
                 Box::pin(async { Ok(()) })
             }

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -2,6 +2,12 @@
 
 use std::collections::HashMap;
 
+use carina_core::provider::{
+    CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest,
+    ErrorDetail as CoreErrorDetail, PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind,
+    ProviderError as CoreProviderError, ReadRequest as CoreReadRequest,
+    UpdatePatch as CoreUpdatePatch, UpdateRequest as CoreUpdateRequest,
+};
 use carina_core::resource::{
     LifecycleConfig, Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
     Value as CoreValue,
@@ -300,30 +306,169 @@ pub fn lifecycle_to_json(lifecycle: &LifecycleConfig) -> String {
     serde_json::to_string(lifecycle).unwrap_or_else(|_| "{}".to_string())
 }
 
-/// Deserialize a JSON error string to a core ProviderError.
-pub fn json_to_provider_error(json: &str) -> carina_core::provider::ProviderError {
-    if let Ok(proto_err) = serde_json::from_str::<proto::ProviderError>(json) {
-        carina_core::provider::ProviderError {
-            message: proto_err.message,
-            resource_id: proto_err.resource_id.map(|pid| {
-                Box::new(CoreResourceId::with_provider(
-                    &pid.provider,
-                    &pid.resource_type,
-                    &pid.name,
-                ))
-            }),
-            cause: None,
-            is_timeout: proto_err.is_timeout,
-            provider_name: None,
-        }
-    } else {
-        carina_core::provider::ProviderError {
-            message: json.to_string(),
-            resource_id: None,
-            cause: None,
-            is_timeout: false,
-            provider_name: None,
-        }
+// -- ProviderError --
+
+/// Convert a host-side core [`CoreProviderError`] into the WIT
+/// `provider-error` variant. The boxed `cause` chain is flattened to a
+/// string because WIT cannot represent `dyn std::error::Error`.
+pub fn core_to_wit_provider_error(err: &CoreProviderError) -> wit::ProviderError {
+    let detail = err.detail();
+    let wit_detail = wit::ErrorDetail {
+        message: detail.message.clone(),
+        resource_id: detail
+            .resource_id
+            .as_ref()
+            .map(|id| core_to_wit_resource_id(id)),
+        cause: detail.cause.as_ref().map(|c| c.to_string()),
+        provider_name: detail.provider_name.clone(),
+    };
+    match err {
+        CoreProviderError::InvalidInput(_) => wit::ProviderError::InvalidInput(wit_detail),
+        CoreProviderError::ApiError(_) => wit::ProviderError::ApiError(wit_detail),
+        CoreProviderError::NotFound(_) => wit::ProviderError::NotFound(wit_detail),
+        CoreProviderError::Timeout(_) => wit::ProviderError::Timeout(wit_detail),
+        CoreProviderError::Internal(_) => wit::ProviderError::Internal(wit_detail),
+    }
+}
+
+/// Convert a WIT [`wit::ProviderError`] into the host-side core
+/// [`CoreProviderError`]. The variant is preserved exactly; the
+/// `cause` string is rehydrated as an `Option<String>` inside
+/// [`CoreErrorDetail`].
+pub fn wit_to_core_provider_error(err: wit::ProviderError) -> CoreProviderError {
+    let (detail, ctor): (wit::ErrorDetail, fn(CoreErrorDetail) -> CoreProviderError) = match err {
+        wit::ProviderError::InvalidInput(d) => (d, CoreProviderError::InvalidInput),
+        wit::ProviderError::ApiError(d) => (d, CoreProviderError::ApiError),
+        wit::ProviderError::NotFound(d) => (d, CoreProviderError::NotFound),
+        wit::ProviderError::Timeout(d) => (d, CoreProviderError::Timeout),
+        wit::ProviderError::Internal(d) => (d, CoreProviderError::Internal),
+    };
+    let core_detail = CoreErrorDetail {
+        message: detail.message,
+        resource_id: detail
+            .resource_id
+            .map(|id| Box::new(wit_to_core_resource_id(&id))),
+        cause: detail
+            .cause
+            .map(|s| Box::new(FlattenedCause(s)) as Box<dyn std::error::Error + Send + Sync>),
+        provider_name: detail.provider_name,
+    };
+    ctor(core_detail)
+}
+
+/// Synthetic `Error` wrapping a flattened-cause string from the WIT
+/// boundary. We can't rehydrate a real cause chain across WIT
+/// (`dyn Error` doesn't fit through a record), so we wrap the string
+/// in a minimal `Error` shape so callers reading
+/// `ProviderError::source()` still see a non-empty message.
+#[derive(Debug)]
+struct FlattenedCause(String);
+
+impl std::fmt::Display for FlattenedCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for FlattenedCause {}
+
+// -- Update request and patch --
+
+/// Build a [`wit::UpdateRequest`] from the host-side core
+/// [`CoreUpdateRequest`]. Patch op order is preserved.
+pub fn core_to_wit_update_request(
+    request: &CoreUpdateRequest,
+) -> Result<wit::UpdateRequest, SerializationError> {
+    Ok(wit::UpdateRequest {
+        current: core_to_wit_state(&request.from)?,
+        patch: core_to_wit_update_patch(&request.patch)?,
+    })
+}
+
+/// Build a [`wit::CreateRequest`] from the host-side core
+/// [`CoreCreateRequest`].
+pub fn core_to_wit_create_request(
+    request: &CoreCreateRequest,
+) -> Result<wit::CreateRequest, SerializationError> {
+    Ok(wit::CreateRequest {
+        res: core_to_wit_resource(&request.resource)?,
+    })
+}
+
+/// Build a [`wit::ReadRequest`].
+///
+/// `ReadRequest` carries no operationally meaningful fields; the
+/// `reserved` placeholder exists because the wasm component model
+/// rejects records with zero fields.
+pub fn core_to_wit_read_request(_request: &CoreReadRequest) -> wit::ReadRequest {
+    wit::ReadRequest { reserved: false }
+}
+
+/// Build a [`wit::DeleteRequest`] from the host-side core
+/// [`CoreDeleteRequest`].
+pub fn core_to_wit_delete_request(request: &CoreDeleteRequest) -> wit::DeleteRequest {
+    wit::DeleteRequest {
+        lifecycle: core_to_wit_lifecycle_config(&request.lifecycle),
+    }
+}
+
+/// Convert a [`LifecycleConfig`] to a [`wit::LifecycleConfig`].
+pub fn core_to_wit_lifecycle_config(lifecycle: &LifecycleConfig) -> wit::LifecycleConfig {
+    wit::LifecycleConfig {
+        force_delete: lifecycle.force_delete,
+        create_before_destroy: lifecycle.create_before_destroy,
+        prevent_destroy: lifecycle.prevent_destroy,
+    }
+}
+
+/// Convert a host-side [`CoreUpdatePatch`] to a [`wit::UpdatePatch`].
+/// Op order is preserved.
+pub fn core_to_wit_update_patch(
+    patch: &CoreUpdatePatch,
+) -> Result<wit::UpdatePatch, SerializationError> {
+    let ops = patch
+        .ops
+        .iter()
+        .map(core_to_wit_patch_op)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(wit::UpdatePatch { ops })
+}
+
+/// Convert a host-side [`CorePatchOp`] to a [`wit::PatchOp`].
+pub fn core_to_wit_patch_op(op: &CorePatchOp) -> Result<wit::PatchOp, SerializationError> {
+    let value = match &op.value {
+        Some(v) => Some(core_to_wit_value(v)?),
+        None => None,
+    };
+    Ok(wit::PatchOp {
+        kind: match op.kind {
+            CorePatchOpKind::Add => wit::PatchOpKind::Add,
+            CorePatchOpKind::Replace => wit::PatchOpKind::Replace,
+            CorePatchOpKind::Remove => wit::PatchOpKind::Remove,
+        },
+        key: op.key.clone(),
+        value,
+    })
+}
+
+/// Convert a [`wit::UpdatePatch`] back to a host-side
+/// [`CoreUpdatePatch`]. Used by tests and round-trip verification.
+pub fn wit_to_core_update_patch(patch: &wit::UpdatePatch) -> CoreUpdatePatch {
+    CoreUpdatePatch {
+        ops: patch.ops.iter().map(wit_to_core_patch_op).collect(),
+    }
+}
+
+/// Convert a [`wit::PatchOp`] to a host-side [`CorePatchOp`].
+pub fn wit_to_core_patch_op(op: &wit::PatchOp) -> CorePatchOp {
+    CorePatchOp {
+        kind: match op.kind {
+            wit::PatchOpKind::Add => CorePatchOpKind::Add,
+            wit::PatchOpKind::Replace => CorePatchOpKind::Replace,
+            wit::PatchOpKind::Remove => CorePatchOpKind::Remove,
+        },
+        key: op.key.clone(),
+        value: op.value.as_ref().map(wit_to_core_value),
     }
 }
 
@@ -883,20 +1028,101 @@ mod tests {
     }
 
     #[test]
-    fn test_json_to_provider_error_valid() {
-        let json = r#"{"message":"something failed","resource_id":{"provider":"aws","resource_type":"s3.Bucket","name":"test"},"is_timeout":true}"#;
-        let err = json_to_provider_error(json);
-        assert_eq!(err.message, "something failed");
-        assert!(err.is_timeout);
-        assert_eq!(err.resource_id.as_ref().unwrap().provider, "aws");
+    fn test_provider_error_variant_round_trip_through_wit() {
+        // Build host-side core errors of every variant, convert them
+        // to the WIT shape, then back. The variant tag must be
+        // preserved exactly so host code matching on the variant
+        // still works after a round trip across the WIT boundary.
+        type VariantCheck = fn(&CoreProviderError) -> bool;
+        let cases: Vec<(CoreProviderError, VariantCheck)> = vec![
+            (CoreProviderError::invalid_input("bad input"), |e| {
+                matches!(e, CoreProviderError::InvalidInput(_))
+            }),
+            (CoreProviderError::api_error("rejected"), |e| {
+                matches!(e, CoreProviderError::ApiError(_))
+            }),
+            (CoreProviderError::not_found("missing"), |e| {
+                matches!(e, CoreProviderError::NotFound(_))
+            }),
+            (CoreProviderError::timeout("slow"), |e| {
+                matches!(e, CoreProviderError::Timeout(_))
+            }),
+            (CoreProviderError::internal("bug"), |e| {
+                matches!(e, CoreProviderError::Internal(_))
+            }),
+        ];
+
+        for (err, is_variant) in cases {
+            let wit_err = core_to_wit_provider_error(&err);
+            let back = wit_to_core_provider_error(wit_err);
+            assert!(is_variant(&back), "variant lost for {}", err.variant_name());
+            assert_eq!(back.message(), err.message(), "message lost");
+        }
     }
 
     #[test]
-    fn test_json_to_provider_error_plain_string() {
-        let err = json_to_provider_error("some error message");
-        assert_eq!(err.message, "some error message");
-        assert!(!err.is_timeout);
-        assert!(err.resource_id.is_none());
+    fn test_provider_error_detail_fields_round_trip() {
+        // Resource id, cause string, and provider name must all
+        // survive a host -> WIT -> host round trip. cause is
+        // flattened to a string at the boundary because WIT cannot
+        // carry `dyn std::error::Error`.
+        let cause = std::io::Error::other("inner io error");
+        let id = CoreResourceId::with_provider("aws", "s3.Bucket", "my-bucket");
+        let err = CoreProviderError::api_error("Failed to read")
+            .with_cause(cause)
+            .for_resource(id.clone())
+            .for_provider("aws");
+
+        let wit_err = core_to_wit_provider_error(&err);
+        let back = wit_to_core_provider_error(wit_err);
+        assert!(matches!(back, CoreProviderError::ApiError(_)));
+        let detail = back.detail();
+        assert_eq!(detail.message, "Failed to read");
+        assert_eq!(detail.provider_name.as_deref(), Some("aws"));
+        let rid = detail.resource_id.as_ref().expect("resource_id preserved");
+        assert_eq!(rid.provider, "aws");
+        assert_eq!(rid.resource_type, "s3.Bucket");
+        assert_eq!(rid.name_str(), "my-bucket");
+        let cause_str = detail
+            .cause
+            .as_ref()
+            .map(|c| c.to_string())
+            .expect("cause preserved as string");
+        assert_eq!(cause_str, "inner io error");
+    }
+
+    #[test]
+    fn test_update_patch_round_trip_preserves_op_order_and_kinds() {
+        use carina_core::resource::Value as CV;
+        let patch = CoreUpdatePatch {
+            ops: vec![
+                CorePatchOp {
+                    kind: CorePatchOpKind::Add,
+                    key: "a".to_string(),
+                    value: Some(CV::String("alpha".into())),
+                },
+                CorePatchOp {
+                    kind: CorePatchOpKind::Replace,
+                    key: "b".to_string(),
+                    value: Some(CV::Int(42)),
+                },
+                CorePatchOp {
+                    kind: CorePatchOpKind::Remove,
+                    key: "c".to_string(),
+                    value: None,
+                },
+            ],
+        };
+        let wit_patch = core_to_wit_update_patch(&patch).unwrap();
+        let back = wit_to_core_update_patch(&wit_patch);
+        assert_eq!(back.ops.len(), 3);
+        assert_eq!(back.ops[0].kind, CorePatchOpKind::Add);
+        assert_eq!(back.ops[0].key, "a");
+        assert_eq!(back.ops[1].kind, CorePatchOpKind::Replace);
+        assert_eq!(back.ops[1].key, "b");
+        assert_eq!(back.ops[2].kind, CorePatchOpKind::Remove);
+        assert_eq!(back.ops[2].key, "c");
+        assert!(back.ops[2].value.is_none(), "Remove must carry None");
     }
 
     #[test]

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -21,10 +21,10 @@ use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
 
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
-    SavedAttrs,
+    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
+    ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
 };
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::{CompletionValue, ResourceSchema};
 use carina_core::value::SerializationError;
 
@@ -38,7 +38,7 @@ use crate::wasm_convert;
 /// async block so the future is `'static`.
 fn early_provider_err<T: 'static>(e: SerializationError) -> BoxFuture<'static, ProviderResult<T>> {
     let msg = e.to_string();
-    Box::pin(async move { Err(ProviderError::new(msg)) })
+    Box::pin(async move { Err(ProviderError::internal(msg)) })
 }
 
 /// Unwrap a `core_to_wit_*` result that **must** succeed by invariant.
@@ -359,7 +359,7 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         attrs: &[(String, wit_types::Value)],
-    ) -> wasmtime::Result<Result<(), String>> {
+    ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -379,7 +379,7 @@ impl WasmBindings {
         store: &mut Store<HostState>,
         type_name: &str,
         value: &str,
-    ) -> wasmtime::Result<Result<(), String>> {
+    ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -398,7 +398,7 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         attrs: &[(String, wit_types::Value)],
-    ) -> wasmtime::Result<Result<(), String>> {
+    ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -417,17 +417,18 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
-        identifier: Option<&str>,
-    ) -> wasmtime::Result<Result<wit_types::State, String>> {
+        identifier: &str,
+        request: wit_types::ReadRequest,
+    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_read(store, id, identifier)
+                    .call_read(store, id, identifier, request)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_read(store, id, identifier)
+                    .call_read(store, id, identifier, request)
                     .await
             }
         }
@@ -437,7 +438,7 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         resource: &wit_types::ResourceDef,
-    ) -> wasmtime::Result<Result<wit_types::State, String>> {
+    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
@@ -455,17 +456,18 @@ impl WasmBindings {
     async fn call_create(
         &self,
         store: &mut Store<HostState>,
-        resource: &wit_types::ResourceDef,
-    ) -> wasmtime::Result<Result<wit_types::State, String>> {
+        id: &wit_types::ResourceId,
+        request: &wit_types::CreateRequest,
+    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_create(store, resource)
+                    .call_create(store, id, request)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_create(store, resource)
+                    .call_create(store, id, request)
                     .await
             }
         }
@@ -476,18 +478,17 @@ impl WasmBindings {
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
         identifier: &str,
-        from: &wit_types::State,
-        to: &wit_types::ResourceDef,
-    ) -> wasmtime::Result<Result<wit_types::State, String>> {
+        request: &wit_types::UpdateRequest,
+    ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_update(store, id, identifier, from, to)
+                    .call_update(store, id, identifier, request)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_update(store, id, identifier, from, to)
+                    .call_update(store, id, identifier, request)
                     .await
             }
         }
@@ -498,17 +499,17 @@ impl WasmBindings {
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
         identifier: &str,
-        options: &str,
-    ) -> wasmtime::Result<Result<(), String>> {
+        request: wit_types::DeleteRequest,
+    ) -> wasmtime::Result<Result<(), wit_types::ProviderError>> {
         match self {
             WasmBindings::Basic(b) => {
                 b.carina_provider_provider()
-                    .call_delete(store, id, identifier, options)
+                    .call_delete(store, id, identifier, request)
                     .await
             }
             WasmBindings::Http(b) => {
                 b.carina_provider_provider()
-                    .call_delete(store, id, identifier, options)
+                    .call_delete(store, id, identifier, request)
                     .await
             }
         }
@@ -1131,7 +1132,10 @@ impl WasmProviderFactory {
             .call_initialize(&mut store, &wit_attrs)
             .await
             .map_err(|e| format!("Failed to call initialize(): {e}"))?
-            .map_err(|e| format!("Provider initialization failed: {e}"))?;
+            .map_err(|e| {
+                let core_err = wasm_convert::wit_to_core_provider_error(e);
+                format!("Provider initialization failed: {}", core_err.message())
+            })?;
 
         Ok((store, bindings))
     }
@@ -1212,6 +1216,11 @@ impl ProviderFactory for WasmProviderFactory {
                     .call_validate_config(store, &wit_attrs)
                     .await
                     .map_err(|e| format!("Failed to call validate_config(): {e}"))?
+                    .map_err(|e| {
+                        wasm_convert::wit_to_core_provider_error(e)
+                            .message()
+                            .to_string()
+                    })
             })
         })
     }
@@ -1226,6 +1235,11 @@ impl ProviderFactory for WasmProviderFactory {
                     .call_validate_custom_type(store, type_name, value)
                     .await
                     .map_err(|e| format!("Failed to call validate_custom_type(): {e}"))?
+                    .map_err(|e| {
+                        wasm_convert::wit_to_core_provider_error(e)
+                            .message()
+                            .to_string()
+                    })
             })
         })
     }
@@ -1276,7 +1290,7 @@ impl ProviderFactory for WasmProviderFactory {
             let instance = self
                 .get_or_create_shared_instance(&attrs)
                 .await
-                .map_err(ProviderError::new)?;
+                .map_err(ProviderError::invalid_input)?;
             Ok(Box::new(WasmProvider {
                 instance,
                 name: self.name.clone(),
@@ -1327,34 +1341,35 @@ impl Provider for WasmProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
+        let wit_request = wasm_convert::core_to_wit_read_request(&request);
+        let identifier = identifier.to_string();
         let id = id.clone();
-        let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
             let mut store = self.instance.store.lock().await;
             store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
             let result = self
                 .instance
                 .bindings
-                .call_read(&mut store, &wit_id, identifier.as_deref())
+                .call_read(&mut store, &wit_id, &identifier, wit_request)
                 .await
                 .map_err(|e| {
                     let msg = format!("{e}");
                     if is_epoch_trap_message(&msg) {
-                        ProviderError::new(format!(
+                        ProviderError::timeout(format!(
                             "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in read \
                              (check AWS credentials)"
                         ))
-                        .timeout()
                     } else {
-                        ProviderError::new(format!("WASM trap in read: {e}"))
+                        ProviderError::internal(format!("WASM trap in read: {e}"))
                     }
                 })?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
+                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
             }
         })
     }
@@ -1376,69 +1391,28 @@ impl Provider for WasmProvider {
                 .map_err(|e| {
                     let msg = format!("{e}");
                     if is_epoch_trap_message(&msg) {
-                        ProviderError::new(format!(
+                        ProviderError::timeout(format!(
                             "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in \
                              read_data_source (check AWS credentials)"
                         ))
-                        .timeout()
                     } else {
-                        ProviderError::new(format!("WASM trap in read_data_source: {e}"))
+                        ProviderError::internal(format!("WASM trap in read_data_source: {e}"))
                     }
                 })?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
+                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
             }
         })
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let wit_resource = match wasm_convert::core_to_wit_resource(resource) {
-            Ok(v) => v,
-            Err(e) => return early_provider_err(e),
-        };
-        let id = resource.id.clone();
-        Box::pin(async move {
-            let mut store = self.instance.store.lock().await;
-            store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
-            let result = self
-                .instance
-                .bindings
-                .call_create(&mut store, &wit_resource)
-                .await
-                .map_err(|e| {
-                    let msg = format!("{e}");
-                    if is_epoch_trap_message(&msg) {
-                        ProviderError::new(format!(
-                            "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in create \
-                             (check AWS credentials)"
-                        ))
-                        .timeout()
-                    } else {
-                        ProviderError::new(format!("WASM trap in create: {e}"))
-                    }
-                })?;
-            match result {
-                Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
-            }
-        })
-    }
-
-    fn update(
+    fn create(
         &self,
         id: &ResourceId,
-        identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: CreateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
-        let identifier = identifier.to_string();
-        let wit_from = match wasm_convert::core_to_wit_state(from) {
-            Ok(v) => v,
-            Err(e) => return early_provider_err(e),
-        };
-        let wit_to = match wasm_convert::core_to_wit_resource(to) {
+        let wit_request = match wasm_convert::core_to_wit_create_request(&request) {
             Ok(v) => v,
             Err(e) => return early_provider_err(e),
         };
@@ -1449,23 +1423,61 @@ impl Provider for WasmProvider {
             let result = self
                 .instance
                 .bindings
-                .call_update(&mut store, &wit_id, &identifier, &wit_from, &wit_to)
+                .call_create(&mut store, &wit_id, &wit_request)
                 .await
                 .map_err(|e| {
                     let msg = format!("{e}");
                     if is_epoch_trap_message(&msg) {
-                        ProviderError::new(format!(
-                            "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in update \
+                        ProviderError::timeout(format!(
+                            "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in create \
                              (check AWS credentials)"
                         ))
-                        .timeout()
                     } else {
-                        ProviderError::new(format!("WASM trap in update: {e}"))
+                        ProviderError::internal(format!("WASM trap in create: {e}"))
                     }
                 })?;
             match result {
                 Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
-                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
+                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
+            }
+        })
+    }
+
+    fn update(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        request: UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let wit_id = wasm_convert::core_to_wit_resource_id(id);
+        let identifier = identifier.to_string();
+        let wit_request = match wasm_convert::core_to_wit_update_request(&request) {
+            Ok(v) => v,
+            Err(e) => return early_provider_err(e),
+        };
+        let id = id.clone();
+        Box::pin(async move {
+            let mut store = self.instance.store.lock().await;
+            store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
+            let result = self
+                .instance
+                .bindings
+                .call_update(&mut store, &wit_id, &identifier, &wit_request)
+                .await
+                .map_err(|e| {
+                    let msg = format!("{e}");
+                    if is_epoch_trap_message(&msg) {
+                        ProviderError::timeout(format!(
+                            "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in update \
+                             (check AWS credentials)"
+                        ))
+                    } else {
+                        ProviderError::internal(format!("WASM trap in update: {e}"))
+                    }
+                })?;
+            match result {
+                Ok(wit_state) => Ok(wasm_convert::wit_to_core_state(&wit_state, &id)),
+                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
             }
         })
     }
@@ -1474,34 +1486,33 @@ impl Provider for WasmProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
         let identifier = identifier.to_string();
-        let options_json = wasm_convert::lifecycle_to_json(lifecycle);
+        let wit_request = wasm_convert::core_to_wit_delete_request(&request);
         Box::pin(async move {
             let mut store = self.instance.store.lock().await;
             store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
             let result = self
                 .instance
                 .bindings
-                .call_delete(&mut store, &wit_id, &identifier, &options_json)
+                .call_delete(&mut store, &wit_id, &identifier, wit_request)
                 .await
                 .map_err(|e| {
                     let msg = format!("{e}");
                     if is_epoch_trap_message(&msg) {
-                        ProviderError::new(format!(
+                        ProviderError::timeout(format!(
                             "WASM plugin timed out after {WASM_OPERATION_TIMEOUT_SECS}s in delete \
                              (check AWS credentials)"
                         ))
-                        .timeout()
                     } else {
-                        ProviderError::new(format!("WASM trap in delete: {e}"))
+                        ProviderError::internal(format!("WASM trap in delete: {e}"))
                     }
                 })?;
             match result {
                 Ok(()) => Ok(()),
-                Err(err_json) => Err(wasm_convert::json_to_provider_error(&err_json)),
+                Err(wit_err) => Err(wasm_convert::wit_to_core_provider_error(wit_err)),
             }
         })
     }

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use carina_core::provider::{Provider, ProviderFactory};
+use carina_core::provider::{
+    CreateRequest, DeleteRequest, PatchOp, PatchOpKind, Provider, ProviderFactory, ReadRequest,
+    UpdatePatch, UpdateRequest,
+};
 use carina_core::resource::{Resource, ResourceId, Value};
 use carina_plugin_host::WasmProviderFactory;
 
@@ -76,7 +79,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     // Read before create - should return a state with no identifier and empty attributes
     let id = ResourceId::with_provider("mock", "test.resource", "my-resource");
     let state = provider
-        .read(&id, None)
+        .read(&id, "", ReadRequest)
         .await
         .expect("read should not error");
     assert!(state.identifier.is_none());
@@ -91,7 +94,12 @@ async fn test_wasm_mock_provider_create_and_read() {
     ]);
 
     let created = provider
-        .create(&resource)
+        .create(
+            &id,
+            CreateRequest {
+                resource: resource.clone(),
+            },
+        )
         .await
         .expect("create should succeed");
     assert_eq!(created.identifier, Some("mock-id".into()));
@@ -107,7 +115,7 @@ async fn test_wasm_mock_provider_create_and_read() {
 
     // Read back - should return the created state
     let read_state = provider
-        .read(&id, Some("mock-id"))
+        .read(&id, "mock-id", ReadRequest)
         .await
         .expect("read should not error");
     assert_eq!(read_state.identifier, Some("mock-id".into()));
@@ -141,7 +149,12 @@ async fn test_wasm_mock_provider_update_and_delete() {
     ]);
 
     let created = provider
-        .create(&resource)
+        .create(
+            &id,
+            CreateRequest {
+                resource: resource.clone(),
+            },
+        )
         .await
         .expect("create should succeed");
     assert_eq!(
@@ -149,15 +162,33 @@ async fn test_wasm_mock_provider_update_and_delete() {
         Some(&Value::String("red".into()))
     );
 
-    // Update with new attributes
-    let mut updated_resource = Resource::with_provider("mock", "test.resource", "updatable");
-    updated_resource.attributes = indexmap::IndexMap::from([
-        ("color".into(), Value::String("blue".into())),
-        ("size".into(), Value::Int(20)),
-    ]);
+    // Build an UpdatePatch describing the user's intended changes
+    // (color: red→blue, size: 10→20). Both ops are Replace because
+    // they exist in `from`.
+    let patch = UpdatePatch {
+        ops: vec![
+            PatchOp {
+                kind: PatchOpKind::Replace,
+                key: "color".to_string(),
+                value: Some(Value::String("blue".into())),
+            },
+            PatchOp {
+                kind: PatchOpKind::Replace,
+                key: "size".to_string(),
+                value: Some(Value::Int(20)),
+            },
+        ],
+    };
 
     let updated = provider
-        .update(&id, "mock-id", &created, &updated_resource)
+        .update(
+            &id,
+            "mock-id",
+            UpdateRequest {
+                from: created.clone(),
+                patch,
+            },
+        )
         .await
         .expect("update should succeed");
     assert_eq!(
@@ -165,10 +196,23 @@ async fn test_wasm_mock_provider_update_and_delete() {
         Some(&Value::String("blue".into()))
     );
     assert_eq!(updated.attributes.get("size"), Some(&Value::Int(20)));
+    // The mock echoes the applied patch op kinds + keys as a sentinel
+    // attribute so we can verify the patch round-tripped through the
+    // WIT boundary in op order.
+    let echoed = updated
+        .attributes
+        .get("__mock_patch_ops__")
+        .expect("mock should echo patch ops");
+    let Value::List(ops) = echoed else {
+        panic!("__mock_patch_ops__ should be a list, got {echoed:?}");
+    };
+    assert_eq!(ops.len(), 2);
+    assert_eq!(ops[0], Value::String("replace:color".into()));
+    assert_eq!(ops[1], Value::String("replace:size".into()));
 
     // Read to verify update persisted in memory
     let read_state = provider
-        .read(&id, Some("mock-id"))
+        .read(&id, "mock-id", ReadRequest)
         .await
         .expect("read should not error");
     assert_eq!(
@@ -177,15 +221,14 @@ async fn test_wasm_mock_provider_update_and_delete() {
     );
 
     // Delete
-    let lifecycle = Default::default();
     provider
-        .delete(&id, "mock-id", &lifecycle)
+        .delete(&id, "mock-id", DeleteRequest::default())
         .await
         .expect("delete should succeed");
 
     // Read after delete - should return empty state (no identifier, no attributes)
     let deleted_state = provider
-        .read(&id, None)
+        .read(&id, "", ReadRequest)
         .await
         .expect("read should not error");
     assert!(deleted_state.identifier.is_none());

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -52,6 +52,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
 /// Trait that provider authors implement.
+#[allow(clippy::result_large_err)]
 pub trait CarinaProvider {
     /// Return provider name and display name.
     fn info(&self) -> ProviderInfo;
@@ -86,7 +87,12 @@ pub trait CarinaProvider {
     }
 
     /// Read current state of a resource.
-    fn read(&self, id: &ResourceId, identifier: Option<&str>) -> Result<State, ProviderError>;
+    fn read(
+        &self,
+        id: &ResourceId,
+        identifier: &str,
+        request: ReadRequest,
+    ) -> Result<State, ProviderError>;
 
     /// Read a data source resource.
     ///
@@ -96,19 +102,22 @@ pub trait CarinaProvider {
     ///
     /// Each provider must implement this explicitly. For zero-input data
     /// sources (e.g. `aws.sts.caller_identity`), the implementation can
-    /// simply delegate to `self.read(&resource.id, None)`.
+    /// delegate to a state-only read against `resource.id`.
     fn read_data_source(&self, resource: &Resource) -> Result<State, ProviderError>;
 
     /// Create a new resource.
-    fn create(&self, resource: &Resource) -> Result<State, ProviderError>;
+    fn create(&self, id: &ResourceId, request: CreateRequest) -> Result<State, ProviderError>;
 
     /// Update an existing resource.
+    ///
+    /// Providers MUST NOT modify any attribute that is not represented in
+    /// `request.patch.ops`. The patch is the sole source of truth for the
+    /// update payload.
     fn update(
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> Result<State, ProviderError>;
 
     /// Delete an existing resource.
@@ -116,7 +125,7 @@ pub trait CarinaProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> Result<(), ProviderError>;
 
     /// Return provider config attribute completions.
@@ -273,7 +282,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.read(&params.id, params.identifier.as_deref()) {
+            match provider.read(&params.id, &params.identifier, params.request) {
                 Ok(state) => Response::success(id, methods::ReadResult { state }),
                 Err(e) => Response::error(id, -1, e.message),
             }
@@ -284,7 +293,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.create(&params.resource) {
+            match provider.create(&params.id, params.request) {
                 Ok(state) => Response::success(id, methods::CreateResult { state }),
                 Err(e) => Response::error(id, -1, e.message),
             }
@@ -295,7 +304,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.update(&params.id, &params.identifier, &params.from, &params.to) {
+            match provider.update(&params.id, &params.identifier, params.request) {
                 Ok(state) => Response::success(id, methods::UpdateResult { state }),
                 Err(e) => Response::error(id, -1, e.message),
             }
@@ -306,7 +315,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.delete(&params.id, &params.identifier, &params.lifecycle) {
+            match provider.delete(&params.id, &params.identifier, params.request) {
                 Ok(()) => Response::success(id, methods::DeleteResult { ok: true }),
                 Err(e) => Response::error(id, -1, e.message),
             }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -234,6 +234,92 @@ macro_rules! export_provider {
                 }
             }
 
+            fn proto_to_wit_provider_error(err: proto::ProviderError) -> wit_types::ProviderError {
+                let detail = wit_types::ErrorDetail {
+                    message: err.message,
+                    resource_id: err.resource_id.as_ref().map(proto_to_wit_resource_id),
+                    cause: err.cause,
+                    provider_name: err.provider_name,
+                };
+                match err.kind {
+                    proto::ProviderErrorKind::InvalidInput => {
+                        wit_types::ProviderError::InvalidInput(detail)
+                    }
+                    proto::ProviderErrorKind::ApiError => {
+                        wit_types::ProviderError::ApiError(detail)
+                    }
+                    proto::ProviderErrorKind::NotFound => {
+                        wit_types::ProviderError::NotFound(detail)
+                    }
+                    proto::ProviderErrorKind::Timeout => {
+                        wit_types::ProviderError::Timeout(detail)
+                    }
+                    proto::ProviderErrorKind::Internal => {
+                        wit_types::ProviderError::Internal(detail)
+                    }
+                }
+            }
+
+            fn validate_string_to_provider_error(
+                msg: String,
+            ) -> wit_types::ProviderError {
+                wit_types::ProviderError::InvalidInput(wit_types::ErrorDetail {
+                    message: msg,
+                    resource_id: None,
+                    cause: None,
+                    provider_name: None,
+                })
+            }
+
+            fn wit_to_proto_patch_op_kind(k: wit_types::PatchOpKind) -> proto::PatchOpKind {
+                match k {
+                    wit_types::PatchOpKind::Add => proto::PatchOpKind::Add,
+                    wit_types::PatchOpKind::Replace => proto::PatchOpKind::Replace,
+                    wit_types::PatchOpKind::Remove => proto::PatchOpKind::Remove,
+                }
+            }
+
+            fn wit_to_proto_update_request(
+                req: wit_types::UpdateRequest,
+                proto_id: &proto::ResourceId,
+            ) -> proto::UpdateRequest {
+                let from = wit_to_proto_state(proto_id, &req.current);
+                let ops = req
+                    .patch
+                    .ops
+                    .into_iter()
+                    .map(|op| proto::PatchOp {
+                        kind: wit_to_proto_patch_op_kind(op.kind),
+                        key: op.key,
+                        value: op.value.as_ref().map(wit_to_proto_value),
+                    })
+                    .collect();
+                proto::UpdateRequest {
+                    from,
+                    patch: proto::UpdatePatch { ops },
+                }
+            }
+
+            fn wit_to_proto_create_request(
+                req: wit_types::CreateRequest,
+            ) -> proto::CreateRequest {
+                proto::CreateRequest {
+                    resource: wit_to_proto_resource(&req.res),
+                }
+            }
+
+            fn wit_to_proto_delete_request(
+                req: wit_types::DeleteRequest,
+            ) -> proto::DeleteRequest {
+                proto::DeleteRequest {
+                    lifecycle: proto::LifecycleConfig {
+                        force_delete: req.lifecycle.force_delete,
+                        create_before_destroy: req.lifecycle.create_before_destroy,
+                        prevent_destroy: req.lifecycle.prevent_destroy,
+                    },
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -259,97 +345,99 @@ macro_rules! export_provider {
 
                 fn validate_config(
                     attrs: Vec<(String, wit_types::Value)>,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let map = wit_to_proto_value_map(&attrs);
                     $crate::CarinaProvider::validate_config(&*provider, &map)
+                        .map_err(validate_string_to_provider_error)
                 }
 
                 fn initialize(
                     attrs: Vec<(String, wit_types::Value)>,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let mut provider = get_provider().lock().unwrap();
                     let map = wit_to_proto_value_map(&attrs);
                     $crate::CarinaProvider::initialize(&mut *provider, &map)
+                        .map_err(validate_string_to_provider_error)
                 }
 
                 fn read(
                     id: wit_types::ResourceId,
-                    identifier: Option<String>,
-                ) -> Result<wit_types::State, String> {
+                    identifier: String,
+                    _request: wit_types::ReadRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     match $crate::CarinaProvider::read(
                         &*provider,
                         &proto_id,
-                        identifier.as_deref(),
+                        &identifier,
+                        proto::ReadRequest,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn read_data_source(
                     res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_res = wit_to_proto_resource(&res);
                     match $crate::CarinaProvider::read_data_source(&*provider, &proto_res) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn create(
-                    res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                    id: wit_types::ResourceId,
+                    request: wit_types::CreateRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
-                    let proto_res = wit_to_proto_resource(&res);
-                    match $crate::CarinaProvider::create(&*provider, &proto_res) {
+                    let proto_id = wit_to_proto_resource_id(&id);
+                    let proto_request = wit_to_proto_create_request(request);
+                    match $crate::CarinaProvider::create(&*provider, &proto_id, proto_request) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn update(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    current: wit_types::State,
-                    to: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                    request: wit_types::UpdateRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let proto_from = wit_to_proto_state(&proto_id, &current);
-                    let proto_to = wit_to_proto_resource(&to);
+                    let proto_request = wit_to_proto_update_request(request, &proto_id);
                     match $crate::CarinaProvider::update(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &proto_from,
-                        &proto_to,
+                        proto_request,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn delete(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    options: String,
-                ) -> Result<(), String> {
+                    request: wit_types::DeleteRequest,
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let lifecycle: proto::LifecycleConfig =
-                        serde_json::from_str(&options).unwrap_or_default();
+                    let proto_request = wit_to_proto_delete_request(request);
                     match $crate::CarinaProvider::delete(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &lifecycle,
+                        proto_request,
                     ) {
                         Ok(()) => Ok(()),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
@@ -367,13 +455,14 @@ macro_rules! export_provider {
                 fn validate_custom_type(
                     type_name: String,
                     value: String,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     $crate::CarinaProvider::validate_custom_type(
                         &*provider,
                         &type_name,
                         &value,
                     )
+                    .map_err(validate_string_to_provider_error)
                 }
 
                 fn get_enum_aliases() -> String {
@@ -597,6 +686,92 @@ macro_rules! export_provider {
 
             // -- Guest trait implementation --
 
+            fn proto_to_wit_provider_error(err: proto::ProviderError) -> wit_types::ProviderError {
+                let detail = wit_types::ErrorDetail {
+                    message: err.message,
+                    resource_id: err.resource_id.as_ref().map(proto_to_wit_resource_id),
+                    cause: err.cause,
+                    provider_name: err.provider_name,
+                };
+                match err.kind {
+                    proto::ProviderErrorKind::InvalidInput => {
+                        wit_types::ProviderError::InvalidInput(detail)
+                    }
+                    proto::ProviderErrorKind::ApiError => {
+                        wit_types::ProviderError::ApiError(detail)
+                    }
+                    proto::ProviderErrorKind::NotFound => {
+                        wit_types::ProviderError::NotFound(detail)
+                    }
+                    proto::ProviderErrorKind::Timeout => {
+                        wit_types::ProviderError::Timeout(detail)
+                    }
+                    proto::ProviderErrorKind::Internal => {
+                        wit_types::ProviderError::Internal(detail)
+                    }
+                }
+            }
+
+            fn validate_string_to_provider_error(
+                msg: String,
+            ) -> wit_types::ProviderError {
+                wit_types::ProviderError::InvalidInput(wit_types::ErrorDetail {
+                    message: msg,
+                    resource_id: None,
+                    cause: None,
+                    provider_name: None,
+                })
+            }
+
+            fn wit_to_proto_patch_op_kind(k: wit_types::PatchOpKind) -> proto::PatchOpKind {
+                match k {
+                    wit_types::PatchOpKind::Add => proto::PatchOpKind::Add,
+                    wit_types::PatchOpKind::Replace => proto::PatchOpKind::Replace,
+                    wit_types::PatchOpKind::Remove => proto::PatchOpKind::Remove,
+                }
+            }
+
+            fn wit_to_proto_update_request(
+                req: wit_types::UpdateRequest,
+                proto_id: &proto::ResourceId,
+            ) -> proto::UpdateRequest {
+                let from = wit_to_proto_state(proto_id, &req.current);
+                let ops = req
+                    .patch
+                    .ops
+                    .into_iter()
+                    .map(|op| proto::PatchOp {
+                        kind: wit_to_proto_patch_op_kind(op.kind),
+                        key: op.key,
+                        value: op.value.as_ref().map(wit_to_proto_value),
+                    })
+                    .collect();
+                proto::UpdateRequest {
+                    from,
+                    patch: proto::UpdatePatch { ops },
+                }
+            }
+
+            fn wit_to_proto_create_request(
+                req: wit_types::CreateRequest,
+            ) -> proto::CreateRequest {
+                proto::CreateRequest {
+                    resource: wit_to_proto_resource(&req.res),
+                }
+            }
+
+            fn wit_to_proto_delete_request(
+                req: wit_types::DeleteRequest,
+            ) -> proto::DeleteRequest {
+                proto::DeleteRequest {
+                    lifecycle: proto::LifecycleConfig {
+                        force_delete: req.lifecycle.force_delete,
+                        create_before_destroy: req.lifecycle.create_before_destroy,
+                        prevent_destroy: req.lifecycle.prevent_destroy,
+                    },
+                }
+            }
+
             struct WasmGuest;
 
             impl exports::carina::provider::provider::Guest for WasmGuest {
@@ -622,97 +797,99 @@ macro_rules! export_provider {
 
                 fn validate_config(
                     attrs: Vec<(String, wit_types::Value)>,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let map = wit_to_proto_value_map(&attrs);
                     $crate::CarinaProvider::validate_config(&*provider, &map)
+                        .map_err(validate_string_to_provider_error)
                 }
 
                 fn initialize(
                     attrs: Vec<(String, wit_types::Value)>,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let mut provider = get_provider().lock().unwrap();
                     let map = wit_to_proto_value_map(&attrs);
                     $crate::CarinaProvider::initialize(&mut *provider, &map)
+                        .map_err(validate_string_to_provider_error)
                 }
 
                 fn read(
                     id: wit_types::ResourceId,
-                    identifier: Option<String>,
-                ) -> Result<wit_types::State, String> {
+                    identifier: String,
+                    _request: wit_types::ReadRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
                     match $crate::CarinaProvider::read(
                         &*provider,
                         &proto_id,
-                        identifier.as_deref(),
+                        &identifier,
+                        proto::ReadRequest,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn read_data_source(
                     res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_res = wit_to_proto_resource(&res);
                     match $crate::CarinaProvider::read_data_source(&*provider, &proto_res) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn create(
-                    res: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                    id: wit_types::ResourceId,
+                    request: wit_types::CreateRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
-                    let proto_res = wit_to_proto_resource(&res);
-                    match $crate::CarinaProvider::create(&*provider, &proto_res) {
+                    let proto_id = wit_to_proto_resource_id(&id);
+                    let proto_request = wit_to_proto_create_request(request);
+                    match $crate::CarinaProvider::create(&*provider, &proto_id, proto_request) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn update(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    current: wit_types::State,
-                    to: wit_types::ResourceDef,
-                ) -> Result<wit_types::State, String> {
+                    request: wit_types::UpdateRequest,
+                ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let proto_from = wit_to_proto_state(&proto_id, &current);
-                    let proto_to = wit_to_proto_resource(&to);
+                    let proto_request = wit_to_proto_update_request(request, &proto_id);
                     match $crate::CarinaProvider::update(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &proto_from,
-                        &proto_to,
+                        proto_request,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
                 fn delete(
                     id: wit_types::ResourceId,
                     identifier: String,
-                    options: String,
-                ) -> Result<(), String> {
+                    request: wit_types::DeleteRequest,
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     let proto_id = wit_to_proto_resource_id(&id);
-                    let lifecycle: proto::LifecycleConfig =
-                        serde_json::from_str(&options).unwrap_or_default();
+                    let proto_request = wit_to_proto_delete_request(request);
                     match $crate::CarinaProvider::delete(
                         &*provider,
                         &proto_id,
                         &identifier,
-                        &lifecycle,
+                        proto_request,
                     ) {
                         Ok(()) => Ok(()),
-                        Err(e) => Err(serde_json::to_string(&e).unwrap_or_else(|_| e.message.clone())),
+                        Err(e) => Err(proto_to_wit_provider_error(e)),
                     }
                 }
 
@@ -730,13 +907,14 @@ macro_rules! export_provider {
                 fn validate_custom_type(
                     type_name: String,
                     value: String,
-                ) -> Result<(), String> {
+                ) -> Result<(), wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
                     $crate::CarinaProvider::validate_custom_type(
                         &*provider,
                         &type_name,
                         &value,
                     )
+                    .map_err(validate_string_to_provider_error)
                 }
 
                 fn get_enum_aliases() -> String {

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -2,8 +2,11 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use carina_core::provider::{BoxFuture, Provider, ProviderError, ProviderResult};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::provider::{
+    BoxFuture, CreateRequest, DeleteRequest, PatchOpKind, Provider, ProviderError, ProviderResult,
+    ReadRequest, UpdateRequest,
+};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::value::{json_to_dsl_value, value_to_json};
 
 pub struct MockProvider {
@@ -55,7 +58,8 @@ impl Provider for MockProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: Option<&str>,
+        _identifier: &str,
+        _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
         Box::pin(async move {
@@ -75,30 +79,32 @@ impl Provider for MockProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
+        self.read(&resource.id, "", ReadRequest)
     }
 
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        let resource = resource.clone();
+    fn create(
+        &self,
+        id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        let id = id.clone();
+        let resource = request.resource;
         Box::pin(async move {
             let mut states = self.load_states();
-            let key = Self::resource_key(&resource.id);
+            let key = Self::resource_key(&id);
 
             let attrs: HashMap<String, serde_json::Value> = resource
                 .attributes
                 .iter()
                 .map(|(k, v)| value_to_json(v).map(|jv| (k.clone(), jv)))
                 .collect::<Result<_, _>>()
-                .map_err(|e| ProviderError::new(format!("Failed to convert value: {}", e)))?;
+                .map_err(|e| ProviderError::internal(format!("Failed to convert value: {}", e)))?;
 
             states.insert(key, attrs);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
+                .map_err(|e| ProviderError::internal("Failed to save state").with_cause(e))?;
 
-            Ok(
-                State::existing(resource.id.clone(), resource.resolved_attributes())
-                    .with_identifier("mock-id"),
-            )
+            Ok(State::existing(id, resource.resolved_attributes()).with_identifier("mock-id"))
         })
     }
 
@@ -106,27 +112,41 @@ impl Provider for MockProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
-        let to = to.clone();
         Box::pin(async move {
+            // Apply the patch on top of `from` to construct the post-update
+            // attribute map. The mock writes only what the user changed —
+            // matching the Level 3 contract that providers MUST NOT touch
+            // unspecified fields.
+            let mut attributes = request.from.attributes.clone();
+            for op in request.patch.ops {
+                match op.kind {
+                    PatchOpKind::Add | PatchOpKind::Replace => {
+                        if let Some(value) = op.value {
+                            attributes.insert(op.key, value);
+                        }
+                    }
+                    PatchOpKind::Remove => {
+                        attributes.remove(&op.key);
+                    }
+                }
+            }
+
             let mut states = self.load_states();
             let key = Self::resource_key(&id);
-
-            let attrs: HashMap<String, serde_json::Value> = to
-                .attributes
+            let attrs: HashMap<String, serde_json::Value> = attributes
                 .iter()
                 .map(|(k, v)| value_to_json(v).map(|jv| (k.clone(), jv)))
                 .collect::<Result<_, _>>()
-                .map_err(|e| ProviderError::new(format!("Failed to convert value: {}", e)))?;
+                .map_err(|e| ProviderError::internal(format!("Failed to convert value: {}", e)))?;
 
             states.insert(key, attrs);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
+                .map_err(|e| ProviderError::internal("Failed to save state").with_cause(e))?;
 
-            Ok(State::existing(id, to.resolved_attributes()))
+            Ok(State::existing(id, attributes))
         })
     }
 
@@ -134,7 +154,7 @@ impl Provider for MockProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         let id = id.clone();
         Box::pin(async move {
@@ -143,7 +163,7 @@ impl Provider for MockProvider {
 
             states.remove(&key);
             self.save_states(&states)
-                .map_err(|e| ProviderError::new("Failed to save state").with_cause(e))?;
+                .map_err(|e| ProviderError::internal("Failed to save state").with_cause(e))?;
 
             Ok(())
         })

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -43,7 +43,12 @@ impl CarinaProvider for MockProcessProvider {
         Ok(())
     }
 
-    fn read(&self, id: &ResourceId, _identifier: Option<&str>) -> Result<State, ProviderError> {
+    fn read(
+        &self,
+        id: &ResourceId,
+        _identifier: &str,
+        _request: ReadRequest,
+    ) -> Result<State, ProviderError> {
         let states = self.states.lock().unwrap();
         let key = Self::resource_key(id);
 
@@ -79,15 +84,16 @@ impl CarinaProvider for MockProcessProvider {
         })
     }
 
-    fn create(&self, resource: &Resource) -> Result<State, ProviderError> {
+    fn create(&self, id: &ResourceId, request: CreateRequest) -> Result<State, ProviderError> {
         let mut states = self.states.lock().unwrap();
-        let key = Self::resource_key(&resource.id);
+        let key = Self::resource_key(id);
+        let resource = request.resource;
         states.insert(key, resource.attributes.clone());
 
         Ok(State {
-            id: resource.id.clone(),
+            id: id.clone(),
             identifier: Some("mock-id".into()),
-            attributes: resource.attributes.clone(),
+            attributes: resource.attributes,
             exists: true,
         })
     }
@@ -96,17 +102,48 @@ impl CarinaProvider for MockProcessProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> Result<State, ProviderError> {
+        // Apply the patch on top of `from` to construct the post-update
+        // attribute map. Also echo the patch op kinds into a sentinel
+        // attribute so integration tests can assert the patch
+        // round-tripped through the WIT boundary.
+        let mut attributes = request.from.attributes.clone();
+        let mut applied_op_kinds: Vec<Value> = Vec::with_capacity(request.patch.ops.len());
+        for op in &request.patch.ops {
+            applied_op_kinds.push(Value::String(format!(
+                "{}:{}",
+                match op.kind {
+                    PatchOpKind::Add => "add",
+                    PatchOpKind::Replace => "replace",
+                    PatchOpKind::Remove => "remove",
+                },
+                op.key,
+            )));
+            match op.kind {
+                PatchOpKind::Add | PatchOpKind::Replace => {
+                    if let Some(value) = op.value.clone() {
+                        attributes.insert(op.key.clone(), value);
+                    }
+                }
+                PatchOpKind::Remove => {
+                    attributes.remove(&op.key);
+                }
+            }
+        }
+        attributes.insert(
+            "__mock_patch_ops__".to_string(),
+            Value::List(applied_op_kinds),
+        );
+
         let mut states = self.states.lock().unwrap();
         let key = Self::resource_key(id);
-        states.insert(key, to.attributes.clone());
+        states.insert(key, attributes.clone());
 
         Ok(State {
             id: id.clone(),
             identifier: Some("mock-id".into()),
-            attributes: to.attributes.clone(),
+            attributes,
             exists: true,
         })
     }
@@ -115,7 +152,7 @@ impl CarinaProvider for MockProcessProvider {
         &self,
         id: &ResourceId,
         _identifier: &str,
-        _lifecycle: &LifecycleConfig,
+        _request: DeleteRequest,
     ) -> Result<(), ProviderError> {
         let mut states = self.states.lock().unwrap();
         let key = Self::resource_key(id);

--- a/carina-provider-protocol/src/methods.rs
+++ b/carina-provider-protocol/src/methods.rs
@@ -48,7 +48,12 @@ pub struct InitializeResult {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReadParams {
     pub id: ResourceId,
-    pub identifier: Option<String>,
+    pub identifier: String,
+    /// Per-operation request record. Present so future fields (e.g.
+    /// freshness hint) can be added without breaking existing
+    /// providers. Defaults to an empty record on the wire.
+    #[serde(default)]
+    pub request: ReadRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,7 +65,8 @@ pub struct ReadResult {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateParams {
-    pub resource: Resource,
+    pub id: ResourceId,
+    pub request: CreateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,8 +80,7 @@ pub struct CreateResult {
 pub struct UpdateParams {
     pub id: ResourceId,
     pub identifier: String,
-    pub from: State,
-    pub to: Resource,
+    pub request: UpdateRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -89,8 +94,7 @@ pub struct UpdateResult {
 pub struct DeleteParams {
     pub id: ResourceId,
     pub identifier: String,
-    #[serde(default)]
-    pub lifecycle: LifecycleConfig,
+    pub request: DeleteRequest,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/carina-provider-protocol/src/types.rs
+++ b/carina-provider-protocol/src/types.rs
@@ -103,6 +103,63 @@ pub struct State {
     pub exists: bool,
 }
 
+/// Kind of a single [`PatchOp`]. Mirrors `patch-op-kind` in
+/// `wit/types.wit`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatchOpKind {
+    Add,
+    Replace,
+    Remove,
+}
+
+/// One operation inside an [`UpdatePatch`]. Mirrors `patch-op` in
+/// `wit/types.wit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchOp {
+    pub kind: PatchOpKind,
+    pub key: String,
+    /// `Some(_)` for `Add`/`Replace`; `None` for `Remove`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+}
+
+/// Structured description of the user's intended change to a resource.
+/// Mirrors `update-patch` in `wit/types.wit`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UpdatePatch {
+    #[serde(default)]
+    pub ops: Vec<PatchOp>,
+}
+
+/// Per-operation request record for `read`. Mirrors `read-request`
+/// in `wit/types.wit`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReadRequest;
+
+/// Per-operation request record for `create`. Mirrors
+/// `create-request` in `wit/types.wit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateRequest {
+    pub resource: Resource,
+}
+
+/// Per-operation request record for `update`. Mirrors
+/// `update-request` in `wit/types.wit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateRequest {
+    pub from: State,
+    pub patch: UpdatePatch,
+}
+
+/// Per-operation request record for `delete`. Mirrors
+/// `delete-request` in `wit/types.wit`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeleteRequest {
+    #[serde(default)]
+    pub lifecycle: LifecycleConfig,
+}
+
 /// Lifecycle configuration for a resource.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LifecycleConfig {
@@ -141,14 +198,41 @@ pub struct CompletionValue {
     pub description: String,
 }
 
+/// Variant tag of [`ProviderError`].
+///
+/// Mirrors `provider-error` in `wit/types.wit`. Carried as a separate
+/// `kind` field so the wire format stays a flat record (easier to
+/// inspect than a serde-tagged enum, and matches the WIT variant
+/// directly).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderErrorKind {
+    InvalidInput,
+    ApiError,
+    NotFound,
+    Timeout,
+    #[default]
+    Internal,
+}
+
 /// Provider error returned from operations.
+///
+/// Mirrors `(provider-error, error-detail)` in `wit/types.wit`. The
+/// variant lives in [`ProviderErrorKind`]; the metadata fields mirror
+/// `error-detail`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderError {
+    #[serde(default)]
+    pub kind: ProviderErrorKind,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_id: Option<ResourceId>,
-    #[serde(default)]
-    pub is_timeout: bool,
+    /// Flattened representation of the underlying cause chain, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cause: Option<String>,
+    /// Provider name (e.g. `"aws"`, `"awscc"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_name: Option<String>,
 }
 
 /// Serializable validator types that can cross the WASM boundary.


### PR DESCRIPTION
## Summary

Step 2 of meta tracker `carina-rs/carina#2564`. Bumps the
`carina-plugin-wit` submodule to the post-`#7` Level 3 contract and
propagates the new shape end-to-end through `Provider` trait,
request records, error enum, wasm/json-rpc bindings, executor, and
the mock provider.

The Level 3 contract makes "providers touching unspecified fields"
structurally impossible by replacing `update`'s `to: Resource`
parameter with a structured `UpdatePatch` that carries only what
the user actually changed. This is the type-system fix for the
class of bug behind `carina-rs/carina#2559`.

## Trait shape

```rust
trait Provider: Send + Sync {
    fn create(&self, id: &ResourceId, request: CreateRequest)
        -> BoxFuture<'_, ProviderResult<State>>;
    fn read(&self, id: &ResourceId, identifier: &str, request: ReadRequest)
        -> BoxFuture<'_, ProviderResult<State>>;
    fn read_data_source(&self, resource: &Resource)  // unchanged
        -> BoxFuture<'_, ProviderResult<State>>;
    fn update(&self, id: &ResourceId, identifier: &str, request: UpdateRequest)
        -> BoxFuture<'_, ProviderResult<State>>;
    fn delete(&self, id: &ResourceId, identifier: &str, request: DeleteRequest)
        -> BoxFuture<'_, ProviderResult<()>>;
}
```

`UpdateRequest { from: State, patch: UpdatePatch }` is the source
of truth for an update; `to: Resource` is gone. `read_data_source`
is unchanged because it sits outside the CRUD surface this plan
reshapes.

## ProviderError refactor

`ProviderError` becomes an enum:

```rust
pub enum ProviderError {
    InvalidInput(ErrorDetail),
    ApiError(ErrorDetail),
    NotFound(ErrorDetail),
    Timeout(ErrorDetail),
    Internal(ErrorDetail),
}
```

`ErrorDetail` carries `message`, `resource_id`, `cause` (boxed
`dyn Error` host-side, flattened to `Option<String>` across the
WIT boundary), and `provider_name`. Builder methods
(`for_resource`, `with_cause`, `for_provider`) all apply to the
inner detail. The legacy `is_timeout: bool` flag is gone; sites
that read it (`destroy.rs`, `retry.rs`) now match the variant via
`matches!(e, ProviderError::Timeout(_))`.

### Migrated `ProviderError::new` call sites (50 total)

By picked variant, with the rationale for the judgment calls:

- **`invalid_input`** (5): provider init / config failures. Picks
  this variant because the message is user-actionable
  (e.g. `allowed_account_ids` mismatch). Sites: the three
  `main.rs` rendering tests, the `WasmProviderFactory` shared-
  instance `get_or_create` boundary, and the
  `provider_factory_create_provider_propagates_error` test in
  `carina-core::provider`.
- **`api_error`** (8): simulated cloud-side errors in
  `executor::tests`, `destroy::tests` retry classifiers, the
  recording mocks in `carina-cli/src/tests.rs`, and the
  `SequenceProvider::read` error pass-through.
- **`not_found`** (0): no host-side call site needed it in this
  PR. Provider implementations will use it as they adopt the
  contract in step 3a / 3b.
- **`timeout`** (3): the host-side WASM-trap timeout paths in
  `wasm_factory` (read / read_data_source / create / update /
  delete) and the legacy `error.rs` `"timeout"` test seed.
- **`internal`** (the rest): every "should not happen" boundary
  &mdash; router unknown-provider, mock storage failures, "not
  implemented" test stubs, serialization-failure shims.

When in doubt, `internal` was the safe default per the issue
spec.

## Wasm and JSON-RPC bindings

Host (`carina-plugin-host/src/wasm_convert.rs`) gains
`core_to_wit_provider_error` / `wit_to_core_provider_error` plus
matching `core_to_wit_*_request` / `wit_to_core_update_patch`
helpers. SDK guest macro mirrors the same shape for both Basic
and Http worlds. Round-trip unit tests cover:

- Every `ProviderError` variant preserved across host -> WIT ->
  host.
- `ErrorDetail` fields (`resource_id` + flattened `cause` +
  `provider_name`) preserved.
- `UpdatePatch` op order and kinds preserved, with `Remove`
  carrying `None` for `value`.

JSON-RPC `methods.rs` reshapes `Update/Create/Delete/ReadParams`
to carry per-op `*Request` records, and `ProviderError` gains a
`kind` field plus flattened `cause` and `provider_name`.

## Executor

`Effect::Update` execution builds the patch from plan-time
`changed_attributes` plus an apply-time augmentation that picks
up `ResourceRef`-derived attributes whose resolved value flipped
after a dependency was replaced (existing regression test
`update_effect_resolves_refs_against_post_replacement_binding_map`
keeps passing). Cascade (CBD finalize) and rename paths build
their own patches via two new helpers
(`compute_full_diff_patch`, `single_attribute_patch`) shared
between `replace.rs` and `phased.rs`.

## Mock provider

The WASM mock applies the patch on top of `from` (matching the
contract: write only what the user changed) and echoes the
applied patch op kinds + keys via `__mock_patch_ops__` so
integration tests can verify the patch round-tripped through the
WIT boundary in op order. The integration test in
`wasm_integration_test::test_wasm_mock_provider_update_and_delete`
asserts both the post-update attributes and the echoed op order.

## Submodule bump

`carina-plugin-wit` is bumped from `940b966` to `1f8c4b9`,
picking up:

- `a6a3441` feat: wrap every CRUD operation in a dedicated request record (Level 3)
- `fc41143` feat: add provider-error variant and lifecycle-config record

No backward-compat shims were introduced &mdash; this is a clean
break consistent with the project's no-back-compat policy.

## Downstream impact

Provider repos need follow-up PRs to adopt the new signature:

- `carina-rs/carina-provider-aws` (step 3a) &mdash; adapt impl
  signatures. The aws provider can convert `(from, patch)` back
  to a full `Resource` internally for full-replace API paths; no
  behavior change required.
- `carina-rs/carina-provider-awscc` (step 3b) &mdash; adapt impl
  signatures and map `patch.ops` directly to CloudControl JSON
  Patch. This step carries the actual fix for
  `carina-rs/carina#2559`.

## Test plan

- [x] `cargo nextest run --workspace` &mdash; 2925 passed
- [x] `cargo test --workspace --doc` &mdash; all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five)
- [x] `cargo build --release`
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2`
- [x] WASM round-trip integration test
  (`test_wasm_mock_provider_update_and_delete`) verifies
  `UpdatePatch` ops preserved across the WIT boundary in order.
- [x] `provider_error_variant_round_trip_through_wit` and
  `provider_error_detail_fields_round_trip` cover every variant
  + ErrorDetail fields across the boundary.

Closes carina-rs/carina#2568
Refs carina-rs/carina#2564 (meta tracker)
Refs carina-rs/carina#2559 (user-visible bug)