### PR TITLE
Preserve user's list layout in carina fmt

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -1727,4 +1727,137 @@ require   port >= 1 && port <= 65535  , "port must be valid"
         let second = format(&result, &config).unwrap();
         assert_eq!(result, second, "must be idempotent");
     }
+
+    // carina-rs/carina#2586: fmt must preserve the user's list layout —
+    // a multi-line list (with a newline between `[` and `]`) stays
+    // multi-line, and a single-line list stays single-line. The
+    // formatter only normalizes indentation and the comma-space
+    // between elements; it never reflows for line width.
+
+    #[test]
+    fn test_format_preserves_multiline_list_layout() {
+        let input = "\
+aws.s3.Bucket {
+  action = [
+    's3:GetObject',
+    's3:PutObject',
+    's3:DeleteObject',
+  ]
+}
+";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(
+            result, input,
+            "multi-line list must round-trip unchanged. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_format_preserves_singleline_list_layout() {
+        let input = "aws.s3.Bucket {\n  action = ['s3:GetObject', 's3:PutObject']\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(
+            result, input,
+            "single-line list must stay single-line. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_format_does_not_collapse_long_multiline_list() {
+        // Reproduces the carina#2586 bug: long multi-line lists were
+        // being collapsed onto a single ~1100-character line. The
+        // formatter must leave the multi-line shape alone.
+        let input = "\
+aws.s3.Bucket {
+  action = [
+    's3:CreateBucket',
+    's3:DeleteBucket',
+    's3:GetBucketAcl',
+    's3:GetBucketCORS',
+    's3:GetBucketLocation',
+    's3:GetBucketLogging',
+    's3:GetBucketObjectLockConfiguration',
+    's3:GetBucketOwnershipControls',
+    's3:GetBucketPolicy',
+    's3:GetBucketPolicyStatus',
+    's3:GetBucketPublicAccessBlock',
+    's3:GetBucketRequestPayment',
+    's3:GetBucketTagging',
+    's3:GetBucketVersioning',
+    's3:GetBucketWebsite',
+  ]
+}
+";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(
+            result, input,
+            "long multi-line list must NOT be collapsed to a single line. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_format_normalizes_singleline_list_spacing() {
+        // Single-line stays single-line, but commas without spaces
+        // must be normalized to comma-space.
+        let input = "aws.s3.Bucket {\n  action = ['a','b','c']\n}\n";
+        let expected = "aws.s3.Bucket {\n  action = ['a', 'b', 'c']\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(
+            result, expected,
+            "single-line list spacing must normalize to ', '. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_format_normalizes_multiline_list_indentation() {
+        // Multi-line stays multi-line, but mis-indented elements get
+        // normalized to the correct indent level.
+        let input = "\
+aws.s3.Bucket {
+  action = [
+        's3:GetObject',
+   's3:PutObject',
+  ]
+}
+";
+        let expected = "\
+aws.s3.Bucket {
+  action = [
+    's3:GetObject',
+    's3:PutObject',
+  ]
+}
+";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(
+            result, expected,
+            "multi-line list indentation must normalize. Got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_format_multiline_list_is_idempotent() {
+        let input = "\
+aws.s3.Bucket {
+  action = [
+    's3:GetObject',
+    's3:PutObject',
+  ]
+}
+";
+        let config = FormatConfig::default();
+        let first = format(input, &config).unwrap();
+        let second = format(&first, &config).unwrap();
+        assert_eq!(first, second, "multi-line list fmt must be idempotent");
+    }
 }

--- a/carina-core/src/formatter/rules/values.rs
+++ b/carina-core/src/formatter/rules/values.rs
@@ -190,36 +190,57 @@ impl Formatter {
     }
 
     pub(in crate::formatter) fn format_list(&mut self, node: &CstNode) {
+        // carina-rs/carina#2586: preserve the user's list layout.
+        // If the source had any newline between `[` and `]`, render
+        // multi-line (one element per line, trailing comma); otherwise
+        // stay on a single line. Indentation and the comma-space
+        // between elements are normalized either way; we never reflow
+        // for line width.
+        let multiline = list_is_multiline(node);
+
         self.write("[");
-        let mut first = true;
-
-        for child in &node.children {
-            match child {
-                CstChild::Token(token) => {
-                    if token.text == "[" || token.text == "]" {
-                        continue;
-                    }
-                    if token.text == "," {
-                        continue;
-                    }
-                    // String or other literal
-                    if !first {
-                        self.write(", ");
-                    }
-                    self.write_token(&token.text);
-                    first = false;
-                }
-                CstChild::Node(n) => {
-                    if !first {
-                        self.write(", ");
-                    }
-                    self.format_node(n);
-                    first = false;
-                }
-                CstChild::Trivia(_) => {}
-            }
+        if multiline {
+            self.write_newline();
+            self.current_indent += 1;
         }
-
+        let mut first = true;
+        for child in &node.children {
+            let is_element = match child {
+                CstChild::Token(token) => !matches!(token.text.as_str(), "[" | "]" | ","),
+                CstChild::Node(_) => true,
+                CstChild::Trivia(_) => false,
+            };
+            if !is_element {
+                continue;
+            }
+            if !first {
+                if multiline {
+                    self.write(",");
+                    self.write_newline();
+                } else {
+                    self.write(", ");
+                }
+            }
+            if multiline {
+                self.write_indent();
+            }
+            match child {
+                CstChild::Token(token) => self.write_token(&token.text),
+                CstChild::Node(n) => self.format_node(n),
+                CstChild::Trivia(_) => unreachable!(),
+            }
+            first = false;
+        }
+        if multiline {
+            if !first {
+                // Trailing comma after the last element, then newline
+                // before the closing bracket at the parent indent.
+                self.write(",");
+                self.write_newline();
+            }
+            self.current_indent -= 1;
+            self.write_indent();
+        }
         self.write("]");
     }
 
@@ -410,4 +431,16 @@ impl Formatter {
 
         self.write_newline();
     }
+}
+
+/// Was this list written across multiple lines in the source?
+///
+/// True iff any `Trivia::Newline` appears among the list node's
+/// children (i.e. between `[` and `]`). Used by `format_list` to
+/// preserve the user's layout instead of forcing every list onto
+/// one line — see carina-rs/carina#2586.
+fn list_is_multiline(node: &CstNode) -> bool {
+    node.children
+        .iter()
+        .any(|c| matches!(c, CstChild::Trivia(Trivia::Newline)))
 }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -6485,6 +6485,10 @@ exports {
 
 #[test]
 fn parse_exports_block_list_round_trips_through_formatter() {
+    // carina-rs/carina#2586: a multi-line list in source must round-trip
+    // through the formatter as a multi-line list (one element per line,
+    // trailing comma, normalized indentation). The formatter never
+    // collapses multi-line layouts onto a single line.
     let input = r#"
 provider awscc {
   region = awscc.Region.ap_northeast_1
@@ -6517,7 +6521,9 @@ let vpc = awscc.ec2.Vpc {
 }
 
 exports {
-  vpc_ids: list(String) = [vpc.vpc_id]
+  vpc_ids: list(String) = [
+    vpc.vpc_id,
+  ]
 }
 "#
     );

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -1882,7 +1882,12 @@ fn exports_type_warning_survives_formatter_round_trip() {
         .find(|d| d.message.contains("expected Bool, got string"))
         .map(|d| d.message.clone());
 
-    assert_eq!(formatted, "exports {\n  values: list(Bool) = ['nope']\n}\n");
+    // carina-rs/carina#2586: source list is multi-line, so the
+    // formatter preserves the multi-line shape.
+    assert_eq!(
+        formatted,
+        "exports {\n  values: list(Bool) = [\n    'nope',\n  ]\n}\n"
+    );
     assert_eq!(before_warning, after_warning);
     assert!(
         after_warning.is_some(),
@@ -1925,9 +1930,12 @@ exports {
         .find(|d| d.message.contains("export 'values': type mismatch"))
         .map(|d| d.message.clone());
 
+    // carina-rs/carina#2586: the source list is multi-line, so the
+    // formatter preserves the multi-line layout (one element per line,
+    // trailing comma, normalized indentation).
     assert_eq!(
         formatted,
-        "let item = test.sample.resource {\n  enabled = true\n}\n\nexports {\n  values: list(String) = [item.enabled]\n}\n"
+        "let item = test.sample.resource {\n  enabled = true\n}\n\nexports {\n  values: list(String) = [\n    item.enabled,\n  ]\n}\n"
     );
     assert_eq!(before_warning, after_warning);
     assert!(


### PR DESCRIPTION
## Summary

Closes #2586.

`carina fmt` collapsed every list literal onto a single line, regardless of length, producing 1100+ character lines for IAM policy `action` lists and similar configurations. This PR makes the formatter preserve the user's layout instead.

```crn
# multi-line in source → multi-line in output
action = [
  's3:GetObject',
  's3:ListBucket',
]

# single-line in source → single-line in output (with `, ` normalized)
action = ['s3:GetObject', 's3:ListBucket']
```

The same approach `terraform fmt` and Black take: the user's choice of layout is the source of truth; the formatter normalizes indentation and the comma-space between elements but never reflows for line width.

## Implementation

`format_list` in `carina-core/src/formatter/rules/values.rs` now checks whether any `Trivia::Newline` appears between `[` and `]` in the CST. If so, it emits one element per line with a trailing comma at the parent indent level + 1; otherwise it stays on one line. The two existing round-trip tests that asserted the old "always collapse" behavior have been updated to assert the new shape.

## Test plan

- [x] Six new unit tests in `carina-core/src/formatter/format.rs` covering: multi-line preservation, single-line preservation, the long-list repro from the issue, multi-line indentation normalization, single-line spacing normalization, multi-line idempotence.
- [x] `cargo nextest run --workspace`: 2941 passed (previously 2935; +6 new).
- [x] `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh`: green.
- [x] Real-infra smoke against `infra/aws/management/{carina-state, github-oidc, identity-center, organizations, route53}` — `carina fmt` reports "All files are already properly formatted" (idempotent, no spurious churn).
- [x] Synthesized the issue's long-list reproduction in a temp directory; confirmed the multi-line shape is preserved end-to-end after the fix.

## Follow-up

A pre-existing bug surfaced during this work: line comments inside list literals are silently dropped by `format_list`. That sits outside the scope of #2586 and is filed separately as #2588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)