### PR TITLE
Provider::read identifier: use Option<&str> instead of empty-string sentinel

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -373,7 +373,7 @@ pub async fn detect_drift(
         let identifier = planned_state.and_then(|s| s.identifier.as_deref());
 
         let actual_state = provider
-            .read(&resource.id, identifier.unwrap_or(""), ReadRequest)
+            .read(&resource.id, identifier, ReadRequest)
             .await
             .map_err(AppError::Provider)?;
 

--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -964,7 +964,7 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: &str,
+            _identifier: Option<&str>,
             _request: carina_core::provider::ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let idx = self.call_count.fetch_add(1, Ordering::SeqCst);
@@ -983,7 +983,7 @@ mod tests {
         }
 
         fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-            self.read(&resource.id, "", carina_core::provider::ReadRequest)
+            self.read(&resource.id, None, carina_core::provider::ReadRequest)
         }
 
         fn create(

--- a/carina-cli/src/commands/shared/effect_execution.rs
+++ b/carina-cli/src/commands/shared/effect_execution.rs
@@ -19,7 +19,10 @@ pub(crate) async fn execute_import_effects(
     for effect in plan.effects() {
         if let Effect::Import { id, identifier } = effect {
             println!("  {} Importing {} (id: {})...", "<-".cyan(), id, identifier);
-            match provider.read(id, identifier, ReadRequest).await {
+            match provider
+                .read(id, Some(identifier.as_str()), ReadRequest)
+                .await
+            {
                 Ok(state) => {
                     if state.exists {
                         println!("  {} Imported {}", "✓".green(), id);

--- a/carina-cli/src/commands/shared/retry.rs
+++ b/carina-cli/src/commands/shared/retry.rs
@@ -53,7 +53,7 @@ pub(crate) async fn wait_for_deletion(
 ) -> WaitResult {
     for _ in 0..max_attempts {
         tokio::time::sleep(poll_interval).await;
-        match provider.read(id, identifier, ReadRequest).await {
+        match provider.read(id, Some(identifier), ReadRequest).await {
             Ok(state) if !state.exists => return WaitResult::Deleted,
             Ok(_) => {
                 // Still exists, keep waiting

--- a/carina-cli/src/commands/state.rs
+++ b/carina-cli/src/commands/state.rs
@@ -682,7 +682,7 @@ pub(crate) async fn run_state_refresh_locked(
         let fresh_state = provider
             .read(
                 &resource.id,
-                identifier.as_deref().unwrap_or(""),
+                identifier.as_deref(),
                 carina_core::provider::ReadRequest,
             )
             .await
@@ -710,7 +710,11 @@ pub(crate) async fn run_state_refresh_locked(
 
     for (id, identifier) in &orphan_ids {
         let fresh_state = provider
-            .read(id, identifier.as_str(), carina_core::provider::ReadRequest)
+            .read(
+                id,
+                Some(identifier.as_str()),
+                carina_core::provider::ReadRequest,
+            )
             .await
             .map_err(AppError::Provider)?;
         current_states.insert(id.clone(), fresh_state);

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -59,10 +59,10 @@ impl Provider for TestProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
-        let key = (id.to_string(), identifier.to_string());
+        let key = (id.to_string(), identifier.unwrap_or("").to_string());
         let result = self
             .read_results
             .get(&key)
@@ -72,7 +72,7 @@ impl Provider for TestProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, "", carina_core::provider::ReadRequest)
+        self.read(&resource.id, None, carina_core::provider::ReadRequest)
     }
 
     fn create(
@@ -1571,7 +1571,7 @@ impl Provider for RecordingProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
@@ -1579,7 +1579,7 @@ impl Provider for RecordingProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, "", carina_core::provider::ReadRequest)
+        self.read(&resource.id, None, carina_core::provider::ReadRequest)
     }
 
     fn create(
@@ -1649,7 +1649,7 @@ impl Provider for RenameFailProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
@@ -1657,7 +1657,7 @@ impl Provider for RenameFailProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, "", carina_core::provider::ReadRequest)
+        self.read(&resource.id, None, carina_core::provider::ReadRequest)
     }
 
     fn create(

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1607,14 +1607,19 @@ pub async fn read_with_retry(
     id: &ResourceId,
     identifier: Option<&str>,
 ) -> Result<State, ProviderError> {
+    // carina-rs/carina#2594: when no prior identifier exists for this
+    // resource (a fresh component, or a newly added resource on top
+    // of an existing component), there is nothing to refresh — short-
+    // circuit to `not_found` and let the planner emit a Create. The
+    // earlier shape passed `""` through to the provider, which AWS
+    // CloudControl rejected with `ValidationException`.
+    if identifier.is_none() {
+        return Ok(State::not_found(id.clone()));
+    }
     let max_retries = 3;
     for attempt in 0..=max_retries {
         match provider
-            .read(
-                id,
-                identifier.unwrap_or(""),
-                carina_core::provider::ReadRequest,
-            )
+            .read(id, identifier, carina_core::provider::ReadRequest)
             .await
         {
             Ok(state) => return Ok(state),

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -1074,3 +1074,117 @@ fn validate_passes_when_no_empty_interpolation() {
         errors
     );
 }
+
+// carina-rs/carina#2594 / #2596: read_with_retry must short-circuit
+// to State::not_found when the identifier is None. This guarantees a
+// fresh component (no saved state) does not produce an empty-string
+// `GetResource` call against the provider.
+#[cfg(test)]
+mod read_with_retry_identifier_tests {
+    use super::*;
+    use carina_core::provider::{ProviderResult, ReadRequest};
+    use carina_core::resource::{Resource, State};
+    use futures::future::BoxFuture;
+    use std::sync::Mutex;
+
+    /// A provider whose `read` records every invocation. Used to verify
+    /// that `read_with_retry` does *not* call into the provider when
+    /// `identifier` is None.
+    struct RecordingProvider {
+        calls: Mutex<Vec<(ResourceId, Option<String>)>>,
+    }
+
+    impl RecordingProvider {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Provider for RecordingProvider {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        fn read(
+            &self,
+            id: &ResourceId,
+            identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((id.clone(), identifier.map(|s| s.to_string())));
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, std::collections::HashMap::new())) })
+        }
+
+        fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = resource.id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: carina_core::provider::CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+
+        fn update(
+            &self,
+            id: &ResourceId,
+            _identifier: &str,
+            _request: carina_core::provider::UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::not_found(id)) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: carina_core::provider::DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn read_with_retry_short_circuits_when_identifier_is_none() {
+        let provider = RecordingProvider::new();
+        let id = ResourceId::with_provider("awscc", "iam.Role", "fresh");
+
+        let state = read_with_retry(&provider, &id, None).await.unwrap();
+
+        assert!(
+            !state.exists,
+            "missing identifier must yield not_found state, not a real read"
+        );
+        assert_eq!(
+            provider.calls.lock().unwrap().len(),
+            0,
+            "provider.read must NOT be called when identifier is None \
+             (regression guard for carina#2594)"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_with_retry_forwards_when_identifier_is_some() {
+        let provider = RecordingProvider::new();
+        let id = ResourceId::with_provider("awscc", "iam.Role", "existing");
+
+        let _state = read_with_retry(&provider, &id, Some("AROABC123"))
+            .await
+            .unwrap();
+
+        let calls = provider.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "provider.read must be called exactly once");
+        assert_eq!(calls[0].1.as_deref(), Some("AROABC123"));
+    }
+}

--- a/carina-cli/tests/e2e_typecheck_parity.rs
+++ b/carina-cli/tests/e2e_typecheck_parity.rs
@@ -208,7 +208,7 @@ impl Provider for NoopProvider {
     fn read(
         &self,
         _id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: carina_core::provider::ReadRequest,
     ) -> BoxFuture<'_, carina_core::provider::ProviderResult<State>> {
         Box::pin(async { unimplemented!("e2e parity tests do not exercise apply") })

--- a/carina-core/src/executor/basic.rs
+++ b/carina-core/src/executor/basic.rs
@@ -78,7 +78,10 @@ pub(super) async fn refresh_pending_states(
     let mut failed_refreshes = std::collections::HashSet::new();
 
     for (id, identifier) in refreshes {
-        match provider.read(id, identifier, ReadRequest).await {
+        match provider
+            .read(id, Some(identifier.as_str()), ReadRequest)
+            .await
+        {
             Ok(state) => {
                 observer.on_event(&ExecutionEvent::RefreshSucceeded { id });
                 current_states.insert(id.clone(), state);

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -64,7 +64,7 @@ impl Provider for MockProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id_str = id.to_string();
@@ -77,7 +77,7 @@ impl Provider for MockProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, "", ReadRequest)
+        self.read(&resource.id, None, ReadRequest)
     }
 
     fn create(
@@ -864,7 +864,7 @@ async fn test_fine_grained_scheduling_starts_dependent_before_slow_peer_complete
         fn read(
             &self,
             _id: &ResourceId,
-            _identifier: &str,
+            _identifier: Option<&str>,
             _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             Box::pin(async { Err(ProviderError::internal("not implemented")) })
@@ -1297,7 +1297,7 @@ impl Provider for RecordingMockProvider {
     fn read(
         &self,
         _id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         Box::pin(async { Err(ProviderError::internal("not implemented")) })

--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -338,14 +338,23 @@ pub trait Provider: Send + Sync {
 
     /// Read the current provider-side state of an existing resource.
     ///
-    /// `identifier` is the cloud-side identifier (e.g. `vpc-0abc...`).
+    /// `identifier` is the cloud-side identifier (e.g. `vpc-0abc...`),
+    /// or `None` when no prior identifier exists for this resource —
+    /// typically because the saved state has no entry for it yet (a
+    /// fresh component or a newly added resource). When `identifier`
+    /// is `None` the provider MUST return [`State::not_found`]
+    /// without contacting any external API. Encoding presence in the
+    /// type lets the compiler enforce that contract on every
+    /// implementation, replacing the earlier `&str` shape that used
+    /// `""` as a sentinel and produced carina-rs/carina#2594.
+    ///
     /// `request` carries no operationally meaningful fields today; it
     /// exists so future fields (e.g. a freshness hint or an attribute
     /// projection) can be added without breaking the signature.
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>>;
 
@@ -578,7 +587,7 @@ impl Provider for ProviderRouter {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         match self.get_provider_or_error(&id.provider) {
@@ -919,7 +928,7 @@ impl Provider for Box<dyn Provider> {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         (**self).read(id, identifier, request)
@@ -971,7 +980,7 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: &str,
+            _identifier: Option<&str>,
             _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
@@ -1037,7 +1046,7 @@ mod tests {
     async fn mock_provider_read_returns_not_found() {
         let provider = MockProvider;
         let id = ResourceId::new("test", "example");
-        let state = provider.read(&id, "", ReadRequest).await.unwrap();
+        let state = provider.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
 
@@ -1055,7 +1064,7 @@ mod tests {
         fn read(
             &self,
             id: &ResourceId,
-            _identifier: &str,
+            _identifier: Option<&str>,
             _request: ReadRequest,
         ) -> BoxFuture<'_, ProviderResult<State>> {
             let id = id.clone();
@@ -1198,7 +1207,7 @@ mod tests {
         router.add_provider("mock".to_string(), Box::new(MockProvider));
 
         let id = ResourceId::with_provider("mock", "test", "example");
-        let state = router.read(&id, "", ReadRequest).await.unwrap();
+        let state = router.read(&id, None, ReadRequest).await.unwrap();
         assert!(!state.exists);
     }
 
@@ -1343,7 +1352,7 @@ mod tests {
     async fn provider_router_returns_error_for_unknown_provider() {
         let router = ProviderRouter::new();
         let id = ResourceId::with_provider("nonexistent", "test", "example");
-        let result = router.read(&id, "", ReadRequest).await;
+        let result = router.read(&id, None, ReadRequest).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, ProviderError::Internal(_)));
@@ -1499,7 +1508,7 @@ mod tests {
             fn read(
                 &self,
                 id: &ResourceId,
-                _identifier: &str,
+                _identifier: Option<&str>,
                 _request: ReadRequest,
             ) -> BoxFuture<'_, ProviderResult<State>> {
                 let id = id.clone();

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -417,7 +417,7 @@ impl WasmBindings {
         &self,
         store: &mut Store<HostState>,
         id: &wit_types::ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: wit_types::ReadRequest,
     ) -> wasmtime::Result<Result<wit_types::State, wit_types::ProviderError>> {
         match self {
@@ -1341,12 +1341,12 @@ impl Provider for WasmProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let wit_id = wasm_convert::core_to_wit_resource_id(id);
         let wit_request = wasm_convert::core_to_wit_read_request(&request);
-        let identifier = identifier.to_string();
+        let identifier = identifier.map(|s| s.to_string());
         let id = id.clone();
         Box::pin(async move {
             let mut store = self.instance.store.lock().await;
@@ -1354,7 +1354,7 @@ impl Provider for WasmProvider {
             let result = self
                 .instance
                 .bindings
-                .call_read(&mut store, &wit_id, &identifier, wit_request)
+                .call_read(&mut store, &wit_id, identifier.as_deref(), wit_request)
                 .await
                 .map_err(|e| {
                     let msg = format!("{e}");

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -79,7 +79,7 @@ async fn test_wasm_mock_provider_create_and_read() {
     // Read before create - should return a state with no identifier and empty attributes
     let id = ResourceId::with_provider("mock", "test.resource", "my-resource");
     let state = provider
-        .read(&id, "", ReadRequest)
+        .read(&id, None, ReadRequest)
         .await
         .expect("read should not error");
     assert!(state.identifier.is_none());
@@ -115,7 +115,7 @@ async fn test_wasm_mock_provider_create_and_read() {
 
     // Read back - should return the created state
     let read_state = provider
-        .read(&id, "mock-id", ReadRequest)
+        .read(&id, Some("mock-id"), ReadRequest)
         .await
         .expect("read should not error");
     assert_eq!(read_state.identifier, Some("mock-id".into()));
@@ -212,7 +212,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 
     // Read to verify update persisted in memory
     let read_state = provider
-        .read(&id, "mock-id", ReadRequest)
+        .read(&id, Some("mock-id"), ReadRequest)
         .await
         .expect("read should not error");
     assert_eq!(
@@ -228,7 +228,7 @@ async fn test_wasm_mock_provider_update_and_delete() {
 
     // Read after delete - should return empty state (no identifier, no attributes)
     let deleted_state = provider
-        .read(&id, "", ReadRequest)
+        .read(&id, None, ReadRequest)
         .await
         .expect("read should not error");
     assert!(deleted_state.identifier.is_none());

--- a/carina-plugin-sdk/src/lib.rs
+++ b/carina-plugin-sdk/src/lib.rs
@@ -87,10 +87,18 @@ pub trait CarinaProvider {
     }
 
     /// Read current state of a resource.
+    ///
+    /// `identifier` is `None` when no prior identifier exists (a fresh
+    /// component, or a newly added resource on top of an existing
+    /// component). In that case the provider MUST return
+    /// [`State::not_found`] without contacting any external API.
+    /// Encoding presence in the type — instead of using `""` as a
+    /// sentinel — makes that contract enforceable at compile time
+    /// (carina-rs/carina#2594 / #2596).
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         request: ReadRequest,
     ) -> Result<State, ProviderError>;
 
@@ -282,7 +290,7 @@ fn dispatch(provider: &mut impl CarinaProvider, request: &Request) -> Response {
                 Ok(p) => p,
                 Err(e) => return Response::error(id, -32602, e),
             };
-            match provider.read(&params.id, &params.identifier, params.request) {
+            match provider.read(&params.id, params.identifier.as_deref(), params.request) {
                 Ok(state) => Response::success(id, methods::ReadResult { state }),
                 Err(e) => Response::error(id, -1, e.message),
             }

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -363,7 +363,7 @@ macro_rules! export_provider {
 
                 fn read(
                     id: wit_types::ResourceId,
-                    identifier: String,
+                    identifier: Option<String>,
                     _request: wit_types::ReadRequest,
                 ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
@@ -371,7 +371,7 @@ macro_rules! export_provider {
                     match $crate::CarinaProvider::read(
                         &*provider,
                         &proto_id,
-                        &identifier,
+                        identifier.as_deref(),
                         proto::ReadRequest,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),
@@ -815,7 +815,7 @@ macro_rules! export_provider {
 
                 fn read(
                     id: wit_types::ResourceId,
-                    identifier: String,
+                    identifier: Option<String>,
                     _request: wit_types::ReadRequest,
                 ) -> Result<wit_types::State, wit_types::ProviderError> {
                     let provider = get_provider().lock().unwrap();
@@ -823,7 +823,7 @@ macro_rules! export_provider {
                     match $crate::CarinaProvider::read(
                         &*provider,
                         &proto_id,
-                        &identifier,
+                        identifier.as_deref(),
                         proto::ReadRequest,
                     ) {
                         Ok(state) => Ok(proto_to_wit_state(&state)),

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -58,7 +58,7 @@ impl Provider for MockProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         let id = id.clone();
@@ -79,7 +79,7 @@ impl Provider for MockProvider {
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, "", ReadRequest)
+        self.read(&resource.id, None, ReadRequest)
     }
 
     fn create(

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -46,7 +46,7 @@ impl CarinaProvider for MockProcessProvider {
     fn read(
         &self,
         id: &ResourceId,
-        _identifier: &str,
+        _identifier: Option<&str>,
         _request: ReadRequest,
     ) -> Result<State, ProviderError> {
         let states = self.states.lock().unwrap();

--- a/carina-provider-protocol/src/methods.rs
+++ b/carina-provider-protocol/src/methods.rs
@@ -48,7 +48,11 @@ pub struct InitializeResult {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReadParams {
     pub id: ResourceId,
-    pub identifier: String,
+    /// `None` when no prior identifier exists for this resource.
+    /// Mirrors the `option<string>` shape in the WIT contract; see
+    /// carina-rs/carina#2596.
+    #[serde(default)]
+    pub identifier: Option<String>,
     /// Per-operation request record. Present so future fields (e.g.
     /// freshness hint) can be added without breaking existing
     /// providers. Defaults to an empty record on the wire.


### PR DESCRIPTION
## Summary

Closes #2594.
Refs #2596 (cross-repo migration meta tracker).

`Provider::read` previously took `identifier: &str`, with `""` overloaded as the sentinel for "no prior identifier exists for this resource" (a fresh component, or a newly added resource on top of an existing component). The convention had no compile-time enforcement: `read_with_retry` collapsed `Option<&str>` to `""`, and the empty string was forwarded all the way to AWS CloudControl, which rejected the call with `ValidationException: identifier must have length >= 1`. Every fresh component crashed at "Refreshing state...".

The fix is a type-level one: encode presence in the type, so the compiler enforces the contract at every consumer instead of relying on a docstring convention.

## What changes

- **WIT** (`carina-rs/carina-plugin-wit#9`, already merged): `read.identifier` is now `option<string>`. Submodule pin bumped here.
- **Provider trait** in `carina-core`: `identifier: &str` → `Option<&str>`. Doc comment makes the "None ⇒ provider MUST return `not_found` without contacting any external API" contract explicit.
- **`read_with_retry`** in `carina-cli`: short-circuit to `State::not_found` when `identifier` is `None` instead of mapping it onto `""`. This is what fixes the symptom in #2594.
- **All other call sites and `Provider::read` implementations** (`ProviderRouter`, `Box<dyn Provider>`, `WasmProvider` host adapter, `CarinaProvider` SDK trait, JSON-RPC `ReadParams`, in-tree mocks, tests) follow the type change. Most are mechanical `&str` → `Option<&str>` flips.

## Why a type-level fix and not a defensive `is_empty()` check

A defensive check inside one consumer would not eliminate the class of bug — any new caller can still pass `""` and reproduce the failure. The same philosophy as #2564 (Level 3 `Provider` trait) and RFC #2371 (`Value::Unknown` variant): when a stringly-typed sentinel is creeping into a public contract, the cure is a type-level change, not yet another set of defensive checks scattered across consumers.

## Test plan

- [x] Two new unit tests for `read_with_retry` (`carina-cli/src/wiring/tests.rs`):
  - `read_with_retry_short_circuits_when_identifier_is_none` — provider's `read` is **not** called when identifier is `None`; result is `not_found`.
  - `read_with_retry_forwards_when_identifier_is_some` — regression guard: provider is called exactly once with the supplied identifier.
- [x] `cargo nextest run --workspace`: 2948 tests passed (previously 2946; +2 new).
- [x] `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh` green.
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` succeeds end-to-end with the new WIT contract.

## Cross-repo follow-up

The provider implementations in `carina-rs/carina-provider-aws` (#240) and `carina-rs/carina-provider-awscc` (#189) bump the carina + WIT git pins and adopt the new `Option<&str>` shape. They will be opened in separate PRs after this one merges, since they depend on the new core API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)