### PR TITLE
Surface AWS error context with operation, bucket/key, and source chain

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -68,8 +68,18 @@ impl std::fmt::Display for ProviderError {
         } else {
             write!(f, "{}", detail.message)?;
         }
+        // carina-rs/carina#2603: walk the entire `source()` chain
+        // rather than printing only the first level. AWS SDK errors
+        // typically carry the actionable detail (error code, raw
+        // response message, request id) two or three levels deep;
+        // a single `: {cause}` would still hide e.g. "AccessDenied"
+        // behind a generic "service error" wrapper.
         if let Some(ref cause) = detail.cause {
-            write!(f, ": {}", cause)?;
+            let mut current: Option<&(dyn std::error::Error + 'static)> = Some(cause.as_ref());
+            while let Some(c) = current {
+                write!(f, ": {}", c)?;
+                current = c.source();
+            }
         }
         Ok(())
     }
@@ -1252,6 +1262,56 @@ mod tests {
         let err = ProviderError::internal("simple error");
         let display = format!("{}", err);
         assert_eq!(display, "simple error");
+    }
+
+    /// carina-rs/carina#2603: AWS SDK errors typically carry the
+    /// actionable detail (error code, message, request id) wrapped
+    /// two or three levels deep behind `source()`. A `Display` impl
+    /// that prints only the first level hides the part the user
+    /// actually needs. Walk the whole chain.
+    #[test]
+    fn provider_error_display_walks_entire_source_chain() {
+        #[derive(Debug)]
+        struct ChainErr {
+            msg: &'static str,
+            source: Option<Box<dyn std::error::Error + Send + Sync>>,
+        }
+        impl std::fmt::Display for ChainErr {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.msg)
+            }
+        }
+        impl std::error::Error for ChainErr {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.source
+                    .as_deref()
+                    .map(|e| e as &(dyn std::error::Error + 'static))
+            }
+        }
+
+        let inner = ChainErr {
+            msg: "AccessDenied: User is not authorized to perform: s3:HeadBucket",
+            source: None,
+        };
+        let outer = ChainErr {
+            msg: "service error",
+            source: Some(Box::new(inner)),
+        };
+        let err = ProviderError::api_error("AWS error").with_cause(outer);
+
+        let rendered = format!("{}", err);
+        assert!(
+            rendered.contains("service error"),
+            "outer cause must surface, got: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("AccessDenied"),
+            "deeper source-chain text (the part the user actually needs) \
+             must surface — single-level Display is the carina#2603 bug. \
+             Got: {}",
+            rendered
+        );
     }
 
     #[test]

--- a/carina-state/src/backend.rs
+++ b/carina-state/src/backend.rs
@@ -57,13 +57,98 @@ pub enum BackendError {
     #[error("I/O error: {0}")]
     Io(String),
 
-    /// AWS SDK error
-    #[error("AWS error: {0}")]
-    Aws(String),
+    /// AWS SDK error with structured context.
+    ///
+    /// The bucket/key/operation labels and the full source-chain
+    /// rendering of `source` (e.g. AWS error `code`, message,
+    /// request id) make the failure actionable at first glance —
+    /// see carina-rs/carina#2603. The earlier `Aws(String)` shape
+    /// flattened SDK errors via `.to_string()`, which collapses to
+    /// the literal `"service error"` for most `SdkError::ServiceError`
+    /// values and drops the entire context chain on the floor.
+    #[error("{}", aws_err_display(.0))]
+    Aws(Box<AwsError>),
 
     /// Serialization/deserialization error
     #[error("Serialization error: {0}")]
     Serialization(String),
+}
+
+/// Structured context attached to a [`BackendError::Aws`].
+///
+/// Each AWS SDK call site populates `operation` (e.g. `"s3.HeadObject"`)
+/// and the relevant resource fields (`bucket`, `key`); `source` keeps
+/// the underlying SDK error so the `Display` impl can walk the full
+/// chain and surface the AWS error code, message, and request id.
+#[derive(Debug)]
+pub struct AwsError {
+    /// Service-qualified API operation, e.g. `"s3.HeadObject"`,
+    /// `"s3.GetObject"`. Always present; chosen by the call site.
+    pub operation: &'static str,
+    /// S3 bucket the call targeted, when applicable.
+    pub bucket: Option<String>,
+    /// S3 object key the call targeted, when applicable.
+    pub key: Option<String>,
+    /// The underlying SDK error chain.
+    pub source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl AwsError {
+    /// Build a new structured AWS error. Use the `bucket`/`key`
+    /// builders to attach resource context.
+    pub fn new(
+        operation: &'static str,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            operation,
+            bucket: None,
+            key: None,
+            source: Box::new(source),
+        }
+    }
+
+    pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+        self.bucket = Some(bucket.into());
+        self
+    }
+
+    pub fn key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+}
+
+/// Render an [`AwsError`] as a multi-line, fully-expanded message:
+/// service/operation, the targeted bucket/key (if known), and the
+/// full source-chain text from the SDK error. Used by
+/// `BackendError::Aws`'s `Display` impl.
+fn aws_err_display(err: &AwsError) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "AWS error");
+    let _ = writeln!(out, "  operation: {}", err.operation);
+    if let Some(bucket) = &err.bucket {
+        let _ = writeln!(out, "  bucket: {}", bucket);
+    }
+    if let Some(key) = &err.key {
+        let _ = writeln!(out, "  key: {}", key);
+    }
+    // Walk the source chain so the AWS error code, message, request
+    // id, and any wrapped causes all surface.
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err.source.as_ref());
+    let mut depth = 0usize;
+    while let Some(e) = current {
+        let _ = writeln!(out, "  cause[{}]: {}", depth, e);
+        depth += 1;
+        current = e.source();
+    }
+    // Drop the trailing newline so the formatter ("Error: {}") does
+    // not emit a blank line at the very end.
+    while out.ends_with('\n') {
+        out.pop();
+    }
+    out
 }
 
 impl BackendError {
@@ -258,5 +343,116 @@ mod tests {
         assert_eq!(state_config.backend_type, "s3");
         assert_eq!(state_config.get_string("bucket"), Some("my-bucket"));
         assert_eq!(state_config.get_string("key"), Some("state.json"));
+    }
+
+    // carina-rs/carina#2603: BackendError::Aws must surface the
+    // operation, bucket/key context, and the entire source-error
+    // chain (AWS code, message, request id, ...) — not collapse to
+    // the literal `"AWS error: service error"` that hid every clue
+    // the user needed when CI failures happened in OIDC-assumed
+    // roles where reproducing locally is awkward.
+
+    /// Stand-in for an SDK error chain. Wrapped causes flow through
+    /// `source()`, mirroring how `aws-smithy-runtime` exposes the
+    /// underlying response/code/message.
+    #[derive(Debug)]
+    struct ChainErr {
+        msg: &'static str,
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    }
+
+    impl std::fmt::Display for ChainErr {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.msg)
+        }
+    }
+
+    impl std::error::Error for ChainErr {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.source.as_deref().map(|e| e as &dyn std::error::Error)
+        }
+    }
+
+    #[test]
+    fn aws_error_display_renders_operation_and_source_chain() {
+        let inner = ChainErr {
+            msg: "AccessDenied: User: arn:aws:sts::… is not authorized to perform: s3:HeadBucket",
+            source: None,
+        };
+        let outer = ChainErr {
+            msg: "service error",
+            source: Some(Box::new(inner)),
+        };
+        let aws = AwsError::new("s3.HeadBucket", outer).bucket("carina-registry-state-dev");
+        let err = BackendError::Aws(Box::new(aws));
+
+        let rendered = err.to_string();
+        assert!(rendered.starts_with("AWS error\n"), "got:\n{}", rendered);
+        assert!(
+            rendered.contains("operation: s3.HeadBucket"),
+            "operation must be visible. got:\n{}",
+            rendered
+        );
+        assert!(
+            rendered.contains("bucket: carina-registry-state-dev"),
+            "bucket must be visible. got:\n{}",
+            rendered
+        );
+        assert!(
+            rendered.contains("cause[0]: service error"),
+            "outer cause must be visible. got:\n{}",
+            rendered
+        );
+        assert!(
+            rendered.contains("AccessDenied"),
+            "the deeper source chain (AWS error code) must surface. got:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn aws_error_display_includes_key_when_set() {
+        let aws = AwsError::new(
+            "s3.GetObject",
+            ChainErr {
+                msg: "NoSuchKey",
+                source: None,
+            },
+        )
+        .bucket("my-bucket")
+        .key("path/to/state.json");
+        let err = BackendError::Aws(Box::new(aws));
+
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("operation: s3.GetObject")
+                && rendered.contains("bucket: my-bucket")
+                && rendered.contains("key: path/to/state.json"),
+            "operation/bucket/key must all be present. got:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn aws_error_display_omits_optional_fields_when_unset() {
+        // Some operations (e.g. HeadBucket) have no key; a future
+        // operation may also have no bucket. The renderer should
+        // simply skip those lines instead of writing empty stubs.
+        let aws = AwsError::new(
+            "s3.HeadBucket",
+            ChainErr {
+                msg: "AccessDenied",
+                source: None,
+            },
+        )
+        .bucket("my-bucket");
+        let err = BackendError::Aws(Box::new(aws));
+        let rendered = err.to_string();
+        assert!(rendered.contains("bucket: my-bucket"));
+        assert!(
+            !rendered.contains("key:"),
+            "no key was set; the key line must be omitted. got:\n{}",
+            rendered
+        );
     }
 }

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -9,7 +9,7 @@ use aws_sdk_s3::types::{PublicAccessBlockConfiguration, ServerSideEncryption};
 
 use carina_core::utils::convert_region_value;
 
-use crate::backend::{BackendConfig, BackendError, BackendResult, StateBackend};
+use crate::backend::{AwsError, BackendConfig, BackendError, BackendResult, StateBackend};
 use crate::lock::LockInfo;
 use crate::state::{self, StateFile};
 
@@ -92,10 +92,13 @@ impl S3Backend {
 
         match result {
             Ok(output) => {
-                let etag = output
-                    .e_tag()
-                    .map(ToOwned::to_owned)
-                    .ok_or_else(|| BackendError::Aws("Lock object missing ETag".to_string()))?;
+                let etag = output.e_tag().map(ToOwned::to_owned).ok_or_else(|| {
+                    BackendError::Configuration(format!(
+                        "Lock object {}/{} missing ETag",
+                        self.bucket,
+                        self.lock_key()
+                    ))
+                })?;
                 let body = output
                     .body
                     .collect()
@@ -111,7 +114,11 @@ impl S3Backend {
                 if is_not_found_error(&err) {
                     Ok(None)
                 } else {
-                    Err(BackendError::Aws(err.to_string()))
+                    Err(BackendError::Aws(Box::new(
+                        AwsError::new("s3.GetObject", err)
+                            .bucket(&self.bucket)
+                            .key(self.lock_key()),
+                    )))
                 }
             }
         }
@@ -165,19 +172,30 @@ impl S3Backend {
         match request.send().await {
             Ok(_) => Ok(true),
             Err(err) if is_conditional_write_conflict(&err) => Ok(false),
-            Err(err) => Err(BackendError::Aws(err.to_string())),
+            Err(err) => Err(BackendError::Aws(Box::new(
+                AwsError::new("s3.PutObject", err)
+                    .bucket(&self.bucket)
+                    .key(self.lock_key()),
+            ))),
         }
     }
 
     /// Delete the lock file from S3
     async fn delete_lock(&self) -> BackendResult<()> {
+        let lock_key = self.lock_key();
         self.client
             .delete_object()
             .bucket(&self.bucket)
-            .key(self.lock_key())
+            .key(&lock_key)
             .send()
             .await
-            .map_err(|e| BackendError::Aws(e.to_string()))?;
+            .map_err(|e| {
+                BackendError::Aws(Box::new(
+                    AwsError::new("s3.DeleteObject", e)
+                        .bucket(&self.bucket)
+                        .key(&lock_key),
+                ))
+            })?;
 
         Ok(())
     }
@@ -219,7 +237,11 @@ impl StateBackend for S3Backend {
                 if is_not_found_error(&err) {
                     Ok(None)
                 } else {
-                    Err(BackendError::Aws(err.to_string()))
+                    Err(BackendError::Aws(Box::new(
+                        AwsError::new("s3.GetObject", err)
+                            .bucket(&self.bucket)
+                            .key(&self.key),
+                    )))
                 }
             }
         }
@@ -241,10 +263,13 @@ impl StateBackend for S3Backend {
             request = request.server_side_encryption(ServerSideEncryption::Aes256);
         }
 
-        request
-            .send()
-            .await
-            .map_err(|e| BackendError::Aws(e.to_string()))?;
+        request.send().await.map_err(|e| {
+            BackendError::Aws(Box::new(
+                AwsError::new("s3.PutObject", e)
+                    .bucket(&self.bucket)
+                    .key(&self.key),
+            ))
+        })?;
 
         Ok(())
     }
@@ -376,7 +401,9 @@ impl StateBackend for S3Backend {
                 if is_missing_head_bucket_response(&err) {
                     Ok(false)
                 } else {
-                    Err(BackendError::Aws(err.to_string()))
+                    Err(BackendError::Aws(Box::new(
+                        AwsError::new("s3.HeadBucket", err).bucket(&self.bucket),
+                    )))
                 }
             }
         }
@@ -427,7 +454,11 @@ impl StateBackend for S3Backend {
             .public_access_block_configuration(public_access_block)
             .send()
             .await
-            .map_err(|e| BackendError::Aws(format!("Failed to block public access: {}", e)))?;
+            .map_err(|e| {
+                BackendError::Aws(Box::new(
+                    AwsError::new("s3.PutPublicAccessBlock", e).bucket(&self.bucket),
+                ))
+            })?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes #2603.

`carina plan` / `apply` previously collapsed every AWS-side failure to the literal three-word string `Error: AWS error: service error`. The actual context — service, operation, AWS error code, message, request id, resource — was lost both in carina-state's S3 backend wrapper (`BackendError::Aws(String)` flattened SDK errors via `.to_string()`) and in `ProviderError`'s `Display` impl (which printed only the first level of `source()` chain). CI failures in OIDC-assumed-role environments — exactly where the underlying error matters most — were effectively undebuggable without local admin reproduction.

This PR surfaces the context end-to-end through two type-level changes.

## What changes

**`carina-state`**

- `BackendError::Aws(String)` → `Aws(Box<AwsError>)`.
- New `AwsError` struct: `operation: &'static str` (e.g. `"s3.HeadBucket"`), `bucket: Option<String>`, `key: Option<String>`, `source: Box<dyn Error + Send + Sync>`. Builder API (`AwsError::new(op, e).bucket(...).key(...)`).
- All six S3 backend call sites populate the fields they know.
- `Display` walks the full source chain so the AWS error code/message/request id render as `cause[0]:` / `cause[1]:` lines underneath an `operation:` header.

**`carina-core`**

- `ProviderError`'s `Display` impl now walks the entire `source()` chain rather than printing only the first level. AWS SDK errors carry the actionable text (e.g. `AccessDenied: User … is not authorized to perform: s3:HeadBucket`) two or three levels deep behind a generic `service error` wrapper; a single-level `: {cause}` would still hide it.

## Effect

Before:

```
Error: AWS error: service error
```

After (example):

```
Error: AWS error
  operation: s3.HeadBucket
  bucket: carina-registry-state-dev
  cause[0]: service error
  cause[1]: AccessDenied: User: arn:aws:sts::… is not authorized to perform: s3:HeadBucket
```

## Why a structured `AwsError` and not just `Error::aws("s3.HeadBucket", e)`

The issue's suggested fix kept `String` as the carrier and added an operation label. That removes the immediate symptom but leaves the same shape that produced the bug — the next caller can still drop the source chain on the floor by calling `.to_string()`. Encoding operation/bucket/key as fields, and the source as `Box<dyn Error>`, makes the contract type-checked: the formatter walks `source()` on every `AwsError`, and there is no escape hatch for a partial render.

## Test plan

- [x] Three new unit tests on `AwsError` (`carina-state/src/backend.rs`): operation + bucket + chain rendering; key inclusion; optional-field omission.
- [x] One new unit test on `ProviderError` (`carina-core/src/provider.rs`): chain walk surfaces the deeper-level AWS error code that the previous single-level `Display` hid.
- [x] `cargo nextest run --workspace`: 2952 passed (previously 2948; +4 new).
- [x] `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh` green.

## Out of scope

The `carina-provider-aws` and `carina-provider-awscc` repositories construct `ProviderError::api_error(...).with_cause(sdk_err)` already; this PR is sufficient for those errors to surface end-to-end via the new `Display` walk. No provider repo changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
