### PR TITLE
arguments: support closed-set string types ('dev' | 'prod')

### DIFF
--- a/carina-core/src/formatter/carina_fmt.pest
+++ b/carina-core/src/formatter/carina_fmt.pest
@@ -137,8 +137,15 @@ exports_param = {
 }
 
 // Type expression: string, bool, int, cidr, arn, etc., list(type), map(type), aws.resource (resource ref), struct { field: type, ... }
-type_expr = {
-    type_struct | type_ref | type_list | type_map | type_primitive
+//
+// Closed-set string types (carina-rs/carina#2611) parse as
+// `type_expr_atom (PIPE type_expr_atom)*`. The atom layer carries
+// every shape including `type_string_literal` so unions like
+// `'dev' | 'prod'` round-trip through fmt without losing layout.
+type_expr = { type_expr_atom ~ (trivia* ~ pipe ~ trivia* ~ type_expr_atom)* }
+
+type_expr_atom = {
+    type_struct | type_ref | type_list | type_map | type_string_literal | type_primitive
 }
 
 type_primitive = @{ identifier }
@@ -150,6 +157,10 @@ type_map = { kw_map ~ trivia* ~ open_paren ~ trivia* ~ type_expr ~ trivia* ~ clo
 type_ref = { namespaced_id }
 
 type_struct = { kw_struct ~ trivia* ~ open_brace ~ trivia* ~ struct_field_list? ~ trivia* ~ close_brace }
+
+type_string_literal = { string }
+
+pipe = { "|" }
 
 struct_field_list = { struct_field ~ (trivia* ~ comma ~ trivia* ~ struct_field)* ~ (trivia* ~ comma)? }
 

--- a/carina-core/src/formatter/cst_builder.rs
+++ b/carina-core/src/formatter/cst_builder.rs
@@ -131,6 +131,16 @@ impl<'a> CstBuilder<'a> {
                 self.build_node(NodeKind::ExportsParam, pair),
             )),
             Rule::type_expr => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
+            // `type_expr_atom` is the new wrapper introduced for
+            // `'dev' | 'prod'`-style closed-set string types
+            // (carina-rs/carina#2611). The CST flattens it into the
+            // existing `TypeExpr` node so downstream formatters
+            // continue to see an unwrapped sequence of children.
+            Rule::type_expr_atom => Some(CstChild::Node(self.build_node(NodeKind::TypeExpr, pair))),
+            Rule::type_string_literal => {
+                Some(CstChild::Token(Token::new(pair.as_str().to_string(), span)))
+            }
+            Rule::pipe => Some(CstChild::Token(Token::new(pair.as_str().to_string(), span))),
             Rule::type_primitive => {
                 Some(CstChild::Token(Token::new(pair.as_str().to_string(), span)))
             }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -3279,3 +3279,101 @@ let prod = outer {
     let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
     resolve_modules(&mut parsed, &root_dir).expect("3-deep list pass-through should resolve");
 }
+
+// carina-rs/carina#2611: closed-set string types in `arguments`.
+// These tests cover the *caller* side — when a module is declared
+// with `env: 'dev' | 'prod' = 'dev'`, the call site
+// `mod_call { env = 'dpv' }` must be rejected by typecheck. Without
+// the StringLiteral/Union arms in `module_resolver::typecheck`, the
+// typo would slip through to plan because the parser's pre-#2611
+// fallback was `String`.
+
+fn create_module_with_environment_union() -> ParsedFile {
+    ParsedFile {
+        providers: vec![],
+        resources: vec![],
+        variables: IndexMap::new(),
+        uses: vec![],
+        module_calls: vec![],
+        arguments: vec![ArgumentParameter {
+            name: "environment".to_string(),
+            type_expr: TypeExpr::Union(vec![
+                TypeExpr::StringLiteral("dev".to_string()),
+                TypeExpr::StringLiteral("prod".to_string()),
+            ]),
+            default: Some(Value::String("dev".to_string())),
+            description: None,
+            validations: Vec::new(),
+        }],
+        attribute_params: vec![],
+        export_params: vec![],
+        backend: None,
+        state_blocks: vec![],
+        user_functions: HashMap::new(),
+        upstream_states: vec![],
+        requires: vec![],
+        structural_bindings: HashSet::new(),
+        warnings: vec![],
+        deferred_for_expressions: vec![],
+    }
+}
+
+#[test]
+fn caller_side_typo_against_string_literal_union_is_rejected() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert(
+            "env_module".to_string(),
+            create_module_with_environment_union(),
+        );
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "env_module".to_string(),
+        binding_name: Some("my_env".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            // Typo: 'dpv' is outside the declared 'dev' | 'prod' union.
+            args.insert("environment".to_string(), Value::String("dpv".to_string()));
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "my_env", None);
+    assert!(
+        matches!(result, Err(ModuleError::InvalidArgumentType { .. })),
+        "Caller passing 'dpv' to `'dev' | 'prod'` must be rejected — \
+         carina-rs/carina#2611. Got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn caller_side_value_in_string_literal_union_is_accepted() {
+    let resolver = {
+        let mut r = ModuleResolver::new(".");
+        r.imported_modules.insert(
+            "env_module".to_string(),
+            create_module_with_environment_union(),
+        );
+        r
+    };
+
+    let call = ModuleCall {
+        module_name: "env_module".to_string(),
+        binding_name: Some("my_env".to_string()),
+        arguments: {
+            let mut args = HashMap::new();
+            args.insert("environment".to_string(), Value::String("prod".to_string()));
+            args
+        },
+    };
+
+    let result = resolver.expand_module_call(&call, "my_env", None);
+    assert!(
+        result.is_ok(),
+        "Caller passing 'prod' (in the declared union) must be accepted. Got: {:?}",
+        result
+    );
+}

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -179,6 +179,27 @@ pub(super) fn check_type_match(
             }
             TypeCheckResult::Ok
         }
+        // Closed-set string literal type (`'dev'` etc., carina-rs/carina#2611).
+        // Only an exact-string `Value::String` match is accepted.
+        TypeExpr::StringLiteral(expected) => {
+            if matches!(value, Value::String(s) if s == expected) {
+                TypeCheckResult::Ok
+            } else {
+                TypeCheckResult::Mismatch
+            }
+        }
+        // Union: `T1 | T2 | ...` accepts the value if any member does.
+        TypeExpr::Union(members) => {
+            for m in members {
+                if matches!(
+                    check_type_match(m, value, config, enclosing_args),
+                    TypeCheckResult::Ok
+                ) {
+                    return TypeCheckResult::Ok;
+                }
+            }
+            TypeCheckResult::Mismatch
+        }
         // Sentinel for failed inference (#2360 stage 2). Module signatures
         // are user-declared and should never carry Unknown — reaching this
         // arm is a defensive fallthrough, treated as a mismatch.
@@ -195,7 +216,11 @@ fn type_expr_compatible(expected: &TypeExpr, actual: &TypeExpr) -> TypeCheckResu
     fn is_string_shaped(t: &TypeExpr) -> bool {
         matches!(
             t,
-            TypeExpr::String | TypeExpr::Simple(_) | TypeExpr::Ref(_) | TypeExpr::SchemaType { .. }
+            TypeExpr::String
+                | TypeExpr::Simple(_)
+                | TypeExpr::Ref(_)
+                | TypeExpr::SchemaType { .. }
+                | TypeExpr::StringLiteral(_)
         )
     }
 
@@ -220,6 +245,30 @@ fn type_expr_compatible(expected: &TypeExpr, actual: &TypeExpr) -> TypeCheckResu
                 }
             }
             TypeCheckResult::Ok
+        }
+        // Union compatibility: actual must satisfy *some* member of
+        // expected when expected is a union; expected actual union
+        // must satisfy expected on at least one member when actual is
+        // a union. See carina-rs/carina#2611.
+        (TypeExpr::Union(members), other) => {
+            if members
+                .iter()
+                .any(|m| matches!(type_expr_compatible(m, other), TypeCheckResult::Ok))
+            {
+                TypeCheckResult::Ok
+            } else {
+                TypeCheckResult::Mismatch
+            }
+        }
+        (other, TypeExpr::Union(members)) => {
+            if members
+                .iter()
+                .any(|m| matches!(type_expr_compatible(other, m), TypeCheckResult::Ok))
+            {
+                TypeCheckResult::Ok
+            } else {
+                TypeCheckResult::Mismatch
+            }
         }
         // Unknown is the failed-inference sentinel; anything paired with
         // it is a defensive mismatch.

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -126,6 +126,19 @@ pub enum TypeExpr {
     Struct {
         fields: Vec<(String, TypeExpr)>,
     },
+    /// Singleton string literal type: `'dev'` accepts only the value
+    /// `Value::String("dev")` (carina-rs/carina#2611). Composes with
+    /// [`TypeExpr::Union`] to produce closed-set string types like
+    /// `'dev' | 'prod'`, and with [`TypeExpr::List`] / `Map` to nest
+    /// (`list('dev' | 'prod')`).
+    StringLiteral(String),
+    /// Union of two or more types: `T1 | T2 | ...`. A value matches
+    /// the union if it matches at least one member type. Today the
+    /// only grammar-reachable shape is unions of [`TypeExpr::StringLiteral`]
+    /// — `'dev' | 'prod'` — but the AST shape stays general so future
+    /// additions (`String | Int`, nullable types via `T | none`) drop
+    /// in without another structural change. See carina-rs/carina#2611.
+    Union(Vec<TypeExpr>),
     /// Sentinel for inference failure: an unannotated export whose
     /// rhs could not be statically typed. Produced *only* by
     /// `apply_inference`, never by the parser. Type-comparison
@@ -195,6 +208,16 @@ impl std::fmt::Display for TypeExpr {
                     }
                     write!(f, " }}")
                 }
+            }
+            TypeExpr::StringLiteral(s) => write!(f, "'{}'", s),
+            TypeExpr::Union(members) => {
+                for (i, m) in members.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    write!(f, "{}", m)?;
+                }
+                Ok(())
             }
             TypeExpr::Unknown => write!(f, "<unknown>"),
         }

--- a/carina-core/src/parser/carina.pest
+++ b/carina-core/src/parser/carina.pest
@@ -91,7 +91,15 @@ exports_param = {
 }
 
 // Type expression: string, bool, int, float, cidr, arn, etc., list(type), map(type), aws.vpc (resource ref), struct { field: type, ... }
-type_expr = { type_struct | type_ref | type_generic | type_simple }
+//
+// `type_expr_atom` is a single non-union type. `type_expr` then chains
+// 1+ atoms with `|` so closed-set string types like `'dev' | 'prod'`
+// parse without breaking the existing single-atom forms — see
+// carina-rs/carina#2611. The `type_string_literal` atom uses the same
+// `string` rule as value-position string literals so
+// `arguments { env: 'dev' = 'dev' }` parses uniformly on both sides.
+type_expr = { type_expr_atom ~ ("|" ~ type_expr_atom)* }
+type_expr_atom = { type_struct | type_ref | type_generic | type_string_literal | type_simple }
 type_simple = @{ identifier }
 type_generic = { ("list" | "map") ~ "(" ~ type_expr ~ ")" }
 type_ref = { resource_type_path }
@@ -99,6 +107,7 @@ resource_type_path = @{ identifier ~ ("." ~ identifier)+ }
 type_struct = { "struct" ~ "{" ~ struct_field_list? ~ "}" }
 struct_field_list = { struct_field ~ ("," ~ struct_field)* ~ ","? }
 struct_field = { identifier ~ ":" ~ type_expr }
+type_string_literal = { string }
 
 // Use expression: use { source = "<path>" }
 // Loads a Carina module from the given source directory.

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -330,6 +330,29 @@ fn check_fn_arg_type(
             }
         }
         TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        // Closed-set string literal: only the exact string matches.
+        // Interpolations and ResourceRefs are rejected here because
+        // their runtime expansion is not knowable at parse time.
+        // See carina-rs/carina#2611.
+        TypeExpr::StringLiteral(expected) => {
+            matches!(value, Value::String(s) if s == expected)
+        }
+        // Union: matches if at least one member's structural-shape
+        // arm accepts the value. We only inspect literal/string-shape
+        // members here — that is what `'dev' | 'prod'`-style unions
+        // need today. Mixed unions (`String | Int`) become reachable
+        // when the grammar opens up further; this arm is the
+        // single point that needs updating then.
+        TypeExpr::Union(members) => members.iter().any(|m| match m {
+            TypeExpr::StringLiteral(expected) => {
+                matches!(value, Value::String(s) if s == expected)
+            }
+            TypeExpr::String => matches!(
+                value,
+                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+            ),
+            _ => false,
+        }),
         // Inference sentinel: never matches a concrete value.
         TypeExpr::Unknown => false,
     };
@@ -400,6 +423,24 @@ fn check_fn_return_type(
             }
         }
         TypeExpr::Struct { .. } => matches!(value, Value::Map(_)),
+        // Closed-set string literal: only the exact string matches.
+        // See carina-rs/carina#2611.
+        TypeExpr::StringLiteral(expected) => {
+            matches!(value, Value::String(s) if s == expected)
+        }
+        // Union: matches if at least one member accepts the value.
+        // Same shape as in `check_fn_arg_type` — only literal/string
+        // members are inspected today.
+        TypeExpr::Union(members) => members.iter().any(|m| match m {
+            TypeExpr::StringLiteral(expected) => {
+                matches!(value, Value::String(s) if s == expected)
+            }
+            TypeExpr::String => matches!(
+                value,
+                Value::String(_) | Value::Interpolation(_) | Value::ResourceRef { .. }
+            ),
+            _ => false,
+        }),
         // Inference sentinel: never matches a concrete value.
         TypeExpr::Unknown => false,
     };

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -8377,3 +8377,92 @@ fn parse_directory_truly_undefined_fn_in_let_list_still_errors() {
         "error should name the unknown fn, got: {err}"
     );
 }
+
+// carina-rs/carina#2611: closed-set string types in `arguments`.
+//
+// `env: 'dev' | 'prod' = 'dev'` parses as a `TypeExpr::Union` of two
+// `TypeExpr::StringLiteral` atoms; a default of `'dev'` matches the
+// declared type; a default of `'dpv'` (typo) is rejected at parse
+// time, not at plan time.
+
+#[test]
+fn arguments_param_accepts_string_literal_type() {
+    let src = r#"
+arguments {
+  env: 'dev' = 'dev'
+}
+"#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.arguments.len(), 1);
+    let arg = &parsed.arguments[0];
+    assert_eq!(arg.name, "env");
+    assert_eq!(arg.type_expr, TypeExpr::StringLiteral("dev".to_string()));
+}
+
+#[test]
+fn arguments_param_accepts_union_of_string_literals() {
+    let src = r#"
+arguments {
+  env: 'dev' | 'prod' = 'dev'
+}
+"#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    assert_eq!(parsed.arguments.len(), 1);
+    let arg = &parsed.arguments[0];
+    assert_eq!(
+        arg.type_expr,
+        TypeExpr::Union(vec![
+            TypeExpr::StringLiteral("dev".to_string()),
+            TypeExpr::StringLiteral("prod".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn arguments_param_three_way_union_round_trips_through_display() {
+    let src = r#"
+arguments {
+  region: 'tokyo' | 'osaka' | 'oregon' = 'tokyo'
+}
+"#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let arg = &parsed.arguments[0];
+    assert_eq!(arg.type_expr.to_string(), "'tokyo' | 'osaka' | 'oregon'");
+}
+
+#[test]
+fn arguments_param_string_literal_default_in_set_is_accepted() {
+    let src = r#"
+arguments {
+  env: 'dev' | 'prod' = 'prod'
+}
+"#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let arg = &parsed.arguments[0];
+    assert_eq!(
+        arg.default.as_ref().unwrap(),
+        &Value::String("prod".to_string())
+    );
+}
+
+#[test]
+fn arguments_param_list_of_union_parses() {
+    let src = r#"
+arguments {
+  envs: list('dev' | 'prod') = ['dev', 'prod']
+}
+"#;
+    let parsed = parse(src, &ProviderContext::default()).unwrap();
+    let arg = &parsed.arguments[0];
+    let inner = match &arg.type_expr {
+        TypeExpr::List(inner) => inner.as_ref(),
+        other => panic!("expected list type, got {:?}", other),
+    };
+    assert_eq!(
+        *inner,
+        TypeExpr::Union(vec![
+            TypeExpr::StringLiteral("dev".to_string()),
+            TypeExpr::StringLiteral("prod".to_string()),
+        ])
+    );
+}

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -8,8 +8,33 @@ use super::error::{ParseError, ParseWarning};
 use super::util::{pascal_to_snake, snake_to_pascal};
 use super::{ProviderContext, Rule, first_inner, next_pair};
 
-/// Parse type expression
+/// Parse type expression. Handles unions of atomic types
+/// (`'dev' | 'prod'`, see carina-rs/carina#2611) by collecting every
+/// `type_expr_atom` child and folding 2+ atoms into a [`TypeExpr::Union`];
+/// a single atom returns the atom unchanged so existing call sites
+/// keep their shape.
 pub(super) fn parse_type_expr(
+    pair: pest::iterators::Pair<Rule>,
+    config: &ProviderContext,
+    warnings: &mut Vec<ParseWarning>,
+) -> Result<TypeExpr, ParseError> {
+    // Top-level `type_expr` is one or more `type_expr_atom`s separated
+    // by `|`. Collect each atom; the `|` tokens are silent in pest, so
+    // pair iteration yields only `type_expr_atom` children.
+    let mut atoms: Vec<TypeExpr> = Vec::new();
+    for child in pair.into_inner() {
+        if child.as_rule() == Rule::type_expr_atom {
+            atoms.push(parse_type_expr_atom(child, config, warnings)?);
+        }
+    }
+    match atoms.len() {
+        0 => Ok(TypeExpr::String),
+        1 => Ok(atoms.into_iter().next().unwrap()),
+        _ => Ok(TypeExpr::Union(atoms)),
+    }
+}
+
+fn parse_type_expr_atom(
     pair: pest::iterators::Pair<Rule>,
     config: &ProviderContext,
     warnings: &mut Vec<ParseWarning>,
@@ -17,6 +42,23 @@ pub(super) fn parse_type_expr(
     let _ = warnings;
     let inner = first_inner(pair, "type", "type expression")?;
     match inner.as_rule() {
+        Rule::type_string_literal => {
+            // type_string_literal wraps a `string` rule. Unquote and
+            // strip interpolation: type-position string literals are
+            // by construction simple literals (the grammar accepts
+            // only the same `string` form, but interpolation in a
+            // type position has no semantics and is rejected as
+            // "unknown type" upstream rather than crashed on here).
+            let raw = inner.as_str();
+            let unquoted = if (raw.starts_with('\'') && raw.ends_with('\''))
+                || (raw.starts_with('"') && raw.ends_with('"'))
+            {
+                &raw[1..raw.len() - 1]
+            } else {
+                raw
+            };
+            Ok(TypeExpr::StringLiteral(unquoted.to_string()))
+        }
         Rule::type_simple => {
             let line = inner.as_span().start_pos().line_col().0;
             let text = inner.as_str();

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -396,6 +396,8 @@ impl CompletionProvider {
             }
             schema_type @ parser::TypeExpr::SchemaType { .. } => schema_type.to_string(),
             struct_type @ parser::TypeExpr::Struct { .. } => struct_type.to_string(),
+            literal @ parser::TypeExpr::StringLiteral(_) => literal.to_string(),
+            union @ parser::TypeExpr::Union(_) => union.to_string(),
             parser::TypeExpr::Unknown => "<unknown>".to_string(),
         }
     }


### PR DESCRIPTION
## Summary

Closes #2611.

`arguments {}` blocks could not constrain a `String` parameter to a closed set of literal values; authors who wanted `mode: 'dev' | 'prod'` had to fall back to plain `String` and rely on convention. A typo at the call site (`environment = 'dpv'` against a module declaring `environment: 'dev' | 'prod'`) only surfaced at plan or apply time, after IAM had already been touched.

This PR adds the type-system support for closed-set string types.

## Approach

Picked Option A from the issue (sum of literals) over Option B (`enum(...)` constructor): a literal-union grammar composes with `list(...)` / `map(...)` and sets up the syntax for future shapes (`String | Int`, `T | none`) without needing yet another constructor.

Two new `TypeExpr` variants:

- `StringLiteral(String)` — singleton string type. `'dev'` accepts only `Value::String("dev")`.
- `Union(Vec<TypeExpr>)` — `T1 | T2 | ...`. A value matches the union if some member matches.

The grammar is split into `type_expr = type_expr_atom ('|' type_expr_atom)*`. A single atom returns the atom unchanged so existing call sites' shape is preserved; two or more atoms fold into a `Union`. The formatter's mirror grammar (`carina_fmt.pest`) gets the same split so fmt stays parity-clean.

`TypeExpr::StringLiteral` plugs into the existing string-shape machinery (`is_string_shaped` includes it). `TypeExpr::Union` is matched member-wise in:

- `module_resolver::typecheck::check_type_match` — caller-side argument validation.
- `parser::functions::check_fn_arg_type` / `check_fn_return_type` — user-defined fn arg / return validation.

`type_expr_compatible` (structural compatibility between two declared types) gets symmetric `Union` arms.

## What now works

```crn
arguments {
  environment: 'dev' | 'prod' = 'dev'
  region: 'tokyo' | 'osaka' | 'oregon' = 'tokyo'
  envs: list('dev' | 'prod') = ['dev', 'prod']
}
```

A caller passing `environment = 'dpv'` against the module above is rejected with `InvalidArgumentType`; the parser-level `Display` round-trips `'dev' | 'prod'` exactly.

## Test plan

- [x] Five new parser tests (`carina-core/src/parser/tests.rs`): single `StringLiteral` type, two-way / three-way union, `list(union)` nesting, default literal in declared set.
- [x] Two new module-resolver tests (`carina-core/src/module_resolver/tests.rs`): caller-side `'dpv'` rejected; caller-side `'prod'` accepted. The first one is the regression guard for #2611.
- [x] `cargo nextest run --workspace`: 2961 passed (previously 2954; +7 new).
- [x] `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh` green.
- [x] `pest_grammar_parity::every_main_rule_has_a_formatter_counterpart` passes — formatter grammar tracks the new rules.

## Forward compatibility

The AST shape is general. Mixed unions (`String | Int`), nullable types (`T | none`), or future literal kinds (`Int` literals, `Bool` literals) drop in by adding atoms; the matching code already iterates over `members` generically, the only spot that today filters to string-shape members is `parser::functions::check_fn_arg_type`'s `Union` arm — comment in code points there as the single update point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
