### PR TITLE
docs: update awscc provider reference

### DIFF
--- a/docs/src/content/docs/reference/providers/awscc/iam/oidc_provider.md
+++ b/docs/src/content/docs/reference/providers/awscc/iam/oidc_provider.md
@@ -35,7 +35,7 @@ Resource Type definition for AWS::IAM::OIDCProvider
 
 ### `arn`
 
-- **Type:** Arn
+- **Type:** IamOidcProviderArn
 
 Amazon Resource Name (ARN) of the OIDC provider
 


### PR DESCRIPTION
Auto-generated from carina-provider-awscc.

Triggered by https://github.com/carina-rs/carina-provider-awscc/commit/d855312c12fafb2a72a9ff6be6331a83c316564b