### PR TITLE
fmt: add spaces around | in string-literal union types

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -1078,6 +1078,55 @@ mod tests {
     }
 
     #[test]
+    fn format_arguments_string_literal_union_adds_spaces() {
+        let input = "arguments {\n  environment: 'dev'|'prod' = 'dev'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        let expected = "arguments {\n  environment: 'dev' | 'prod' = 'dev'\n}\n";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn format_arguments_string_literal_union_three_members() {
+        let input = "arguments {\n  region: 'us-east-1'|'ap-northeast-1'|'eu-west-1' = 'ap-northeast-1'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        let expected = "arguments {\n  region: 'us-east-1' | 'ap-northeast-1' | 'eu-west-1' = 'ap-northeast-1'\n}\n";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn format_arguments_string_literal_union_idempotent() {
+        let input = "arguments {\n  environment: 'dev' | 'prod' = 'dev'\n}\n";
+        let config = FormatConfig::default();
+        let first = format(input, &config).unwrap();
+        let second = format(&first, &config).unwrap();
+        assert_eq!(first, input);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn format_arguments_single_string_literal_no_pipe() {
+        // The grammar folds 0/1 atoms back to a plain TypeExpr, so a
+        // single-literal annotation must not emit a stray ` | `.
+        let input = "arguments {\n  environment: 'dev' = 'dev'\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn format_arguments_string_literal_union_inside_list() {
+        // The grammar permits `list('a' | 'b')`; the union arm must apply
+        // recursively inside generic type constructors.
+        let input = "arguments {\n  envs: list('dev'|'prod') = ['dev']\n}\n";
+        let config = FormatConfig::default();
+        let result = format(input, &config).unwrap();
+        let expected = "arguments {\n  envs: list('dev' | 'prod') = ['dev']\n}\n";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn format_arguments_mixed_simple_and_block_form() {
         let input = r#"arguments {
   enable_https: Bool = true

--- a/carina-core/src/formatter/rules/values.rs
+++ b/carina-core/src/formatter/rules/values.rs
@@ -68,6 +68,11 @@ impl Formatter {
                         self.write("(");
                     } else if token.text == ")" {
                         self.write(")");
+                    } else if token.text == "|" {
+                        // Closed-set string type union separator: surface as
+                        // ` | ` so unions read as cleanly as the surrounding
+                        // ` = ` (#2615).
+                        self.write(" | ");
                     } else {
                         self.write_token(&token.text);
                     }


### PR DESCRIPTION
## Summary

- `carina fmt` now renders the closed-set string type from #2611 with ` | ` (single space on each side) between members, consistent with `TypeExpr::Union`'s existing `Display` impl in `parser/ast.rs:213-220`.
- Single-arm change in `format_type_expr` (`carina-core/src/formatter/rules/values.rs`) — when the token is `|`, write `" | "` instead of `write_token`.
- Canonicalizes every input variant (`a|b`, `a |b`, `a| b`, `a | b`) to the same output, so the rule is also a stable normalizer.

Closes #2615.

## Coverage

5 new unit tests in `carina-core/src/formatter/format.rs`:

1. `format_arguments_string_literal_union_adds_spaces` — `'dev'|'prod'` → `'dev' | 'prod'`
2. `format_arguments_string_literal_union_three_members` — three-member unions
3. `format_arguments_string_literal_union_idempotent` — already-spaced source round-trips
4. `format_arguments_single_string_literal_no_pipe` — single-literal annotations don't grow a stray `|`
5. `format_arguments_string_literal_union_inside_list` — `list('a'|'b')` recurses correctly

Multi-line splitting (e.g. `'a'` newline `| 'b'`) is explicitly out of scope per the issue.

## Test plan

- [x] `cargo nextest run --workspace` (2966 tests, all pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] All `scripts/check-*.sh` pass
- [x] Manual `cargo run -- fmt` smoke against a tempdir with 2- and 3-member unions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
