### PR TITLE
plugin-host: dispatch merge_default_tags via the WIT bridge

### DIFF
--- a/carina-core/src/provider.rs
+++ b/carina-core/src/provider.rs
@@ -471,7 +471,23 @@ pub trait ProviderNormalizer: Send + Sync {
     /// Records which tag keys came from defaults in the `_default_tag_keys` internal
     /// metadata attribute.
     ///
-    /// Default implementation is a no-op for providers without tag support.
+    /// No default: an implicit no-op silently swallowed
+    /// `WasmProviderNormalizer`'s missing dispatch in
+    /// carina-rs/carina-provider-awscc#192. Every implementation now picks
+    /// explicitly between [`merge_default_tags_for_provider`], a custom
+    /// merge, or [`NoopNormalizer`]'s deliberate no-op.
+    fn merge_default_tags(
+        &self,
+        resources: &mut [Resource],
+        default_tags: &IndexMap<String, Value>,
+        registry: &SchemaRegistry,
+    );
+}
+
+/// A no-op normalizer for providers that don't need plan-time normalization.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopNormalizer;
+impl ProviderNormalizer for NoopNormalizer {
     fn merge_default_tags(
         &self,
         _resources: &mut [Resource],
@@ -480,11 +496,6 @@ pub trait ProviderNormalizer: Send + Sync {
     ) {
     }
 }
-
-/// A no-op normalizer for providers that don't need plan-time normalization.
-#[derive(Debug, Clone, Copy)]
-pub struct NoopNormalizer;
-impl ProviderNormalizer for NoopNormalizer {}
 
 /// Shared implementation for merging default tags into resources.
 ///
@@ -1525,6 +1536,14 @@ mod tests {
                     }
                 }
             }
+
+            fn merge_default_tags(
+                &self,
+                _resources: &mut [Resource],
+                _default_tags: &IndexMap<String, Value>,
+                _registry: &SchemaRegistry,
+            ) {
+            }
         }
 
         // Test normalize_desired
@@ -1625,6 +1644,14 @@ mod tests {
                         }
                     }
                 }
+            }
+
+            fn merge_default_tags(
+                &self,
+                _resources: &mut [Resource],
+                _default_tags: &IndexMap<String, Value>,
+                _registry: &SchemaRegistry,
+            ) {
             }
         }
 

--- a/carina-plugin-host/src/wasm_factory.rs
+++ b/carina-plugin-host/src/wasm_factory.rs
@@ -572,6 +572,26 @@ impl WasmBindings {
             }
         }
     }
+
+    async fn call_merge_default_tags(
+        &self,
+        store: &mut Store<HostState>,
+        resources: &[wit_types::ResourceDef],
+        default_tags: &[(String, wit_types::Value)],
+    ) -> wasmtime::Result<Vec<wit_types::ResourceDef>> {
+        match self {
+            WasmBindings::Basic(b) => {
+                b.carina_provider_provider()
+                    .call_merge_default_tags(store, resources, default_tags)
+                    .await
+            }
+            WasmBindings::Http(b) => {
+                b.carina_provider_provider()
+                    .call_merge_default_tags(store, resources, default_tags)
+                    .await
+            }
+        }
+    }
 }
 
 /// Build `StoreLimits` used for every WASM plugin store.
@@ -1655,6 +1675,64 @@ impl ProviderNormalizer for WasmProviderNormalizer {
                 }
             }
             Err(e) => log::error!("WASM trap in hydrate_read_state: {e}"),
+        }
+    }
+
+    fn merge_default_tags(
+        &self,
+        resources: &mut [Resource],
+        default_tags: &IndexMap<String, Value>,
+        _registry: &carina_core::schema::SchemaRegistry,
+    ) {
+        if default_tags.is_empty() {
+            return;
+        }
+
+        let wit_resources: Vec<_> = expect_unresolvable_absent(
+            resources
+                .iter()
+                .map(wasm_convert::core_to_wit_resource)
+                .collect::<Result<Vec<_>, _>>(),
+            "merge_default_tags",
+        );
+
+        // Per-key skip on serialize failure (vs. `core_to_wit_value_map`'s
+        // all-or-nothing) — one bad default tag must not nuke the whole
+        // merge for a multi-resource plan.
+        let wit_default_tags: Vec<(String, wit_types::Value)> = default_tags
+            .iter()
+            .filter_map(|(k, v)| match wasm_convert::core_to_wit_value(v) {
+                Ok(wit_value) => Some((k.clone(), wit_value)),
+                Err(e) => {
+                    log::error!("Skipping default_tag '{k}' with unresolvable value: {e}");
+                    None
+                }
+            })
+            .collect();
+
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                let mut store = self.instance.store.lock().await;
+                store.set_epoch_deadline(WASM_OPERATION_TIMEOUT_SECS);
+                self.instance
+                    .bindings
+                    .call_merge_default_tags(&mut store, &wit_resources, &wit_default_tags)
+                    .await
+            })
+        });
+
+        match result {
+            Ok(result) => {
+                // Guest preserves resource order; zip and overwrite
+                // attributes (merge may add `tags` and `_default_tag_keys`).
+                for (core_res, wit_res) in resources.iter_mut().zip(result.iter()) {
+                    let resolved = wasm_convert::wit_to_core_value_map(&wit_res.attributes);
+                    for (key, value) in resolved {
+                        core_res.attributes.insert(key, value);
+                    }
+                }
+            }
+            Err(e) => log::error!("WASM trap in merge_default_tags: {e}"),
         }
     }
 }

--- a/carina-plugin-host/tests/wasm_integration_test.rs
+++ b/carina-plugin-host/tests/wasm_integration_test.rs
@@ -265,6 +265,89 @@ async fn test_wasm_mock_provider_normalizer() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_wasm_mock_provider_merge_default_tags_dispatches_through_wit() {
+    // Regression test for carina-rs/carina-provider-awscc#192 and
+    // carina-rs/carina-provider-aws#242. Before the WIT contract gained
+    // `merge-default-tags`, the host's `WasmProviderNormalizer` had no
+    // way to dispatch the call to the guest, so provider-level
+    // `default_tags` silently never reached resources. The mock guest
+    // echoes the host-supplied `default_tags` into a sentinel attribute;
+    // its presence proves the WIT bridge round-tripped.
+    let path = skip_if_no_wasm!();
+    let (factory, _cache) = load_factory(&path).await;
+    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+
+    let registry = carina_core::schema::SchemaRegistry::new();
+    let mut resources = vec![Resource::with_provider("mock", "test.resource", "tag-test")];
+    let default_tags = indexmap::IndexMap::from([
+        ("Env".to_string(), Value::String("dev".to_string())),
+        ("Owner".to_string(), Value::String("platform".to_string())),
+    ]);
+
+    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+
+    let echoed = resources[0]
+        .get_attr("__mock_merged_default_tags__")
+        .expect("guest's merge_default_tags must run via the WIT bridge");
+    let Value::List(items) = echoed else {
+        panic!("expected list, got {echoed:?}");
+    };
+    assert_eq!(items.len(), 2, "both default_tags should arrive at guest");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wasm_mock_provider_merge_default_tags_empty_short_circuits() {
+    // Empty `default_tags` must skip the WIT round-trip entirely; if it
+    // didn't, the mock guest would still write its sentinel attribute.
+    let path = skip_if_no_wasm!();
+    let (factory, _cache) = load_factory(&path).await;
+    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+
+    let registry = carina_core::schema::SchemaRegistry::new();
+    let mut resources = vec![Resource::with_provider("mock", "test.resource", "no-tags")];
+    let default_tags: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+
+    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+
+    assert!(
+        resources[0]
+            .get_attr("__mock_merged_default_tags__")
+            .is_none(),
+        "empty default_tags must short-circuit before reaching the guest"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wasm_mock_provider_merge_default_tags_preserves_order() {
+    // Multi-resource ordering: the host zips the guest's response by
+    // index, so the guest must return resources in input order.
+    let path = skip_if_no_wasm!();
+    let (factory, _cache) = load_factory(&path).await;
+    let normalizer = factory.create_normalizer(&indexmap::IndexMap::new()).await;
+
+    let registry = carina_core::schema::SchemaRegistry::new();
+    let mut resources = vec![
+        Resource::with_provider("mock", "test.resource", "alpha"),
+        Resource::with_provider("mock", "test.resource", "beta"),
+        Resource::with_provider("mock", "test.resource", "gamma"),
+    ];
+    let default_tags =
+        indexmap::IndexMap::from([("Env".to_string(), Value::String("dev".to_string()))]);
+
+    normalizer.merge_default_tags(&mut resources, &default_tags, &registry);
+
+    assert_eq!(resources[0].id.name.as_str(), "alpha");
+    assert_eq!(resources[1].id.name.as_str(), "beta");
+    assert_eq!(resources[2].id.name.as_str(), "gamma");
+    for r in &resources {
+        assert!(
+            r.get_attr("__mock_merged_default_tags__").is_some(),
+            "every resource should receive the merged sentinel"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_mock_provider_read_data_source_dispatches_override() {
     // Regression test for carina-rs/carina#1677: the plugin boundary must
     // route `read_data_source` through to the guest's implementation so

--- a/carina-plugin-sdk/src/wasm_guest.rs
+++ b/carina-plugin-sdk/src/wasm_guest.rs
@@ -527,6 +527,27 @@ macro_rules! export_provider {
                         .map(|(k, s)| (k, proto_to_wit_state(&s)))
                         .collect()
                 }
+
+                fn merge_default_tags(
+                    resources: Vec<wit_types::ResourceDef>,
+                    default_tags: Vec<(String, wit_types::Value)>,
+                ) -> Vec<wit_types::ResourceDef> {
+                    let provider = get_provider().lock().unwrap();
+                    let mut proto_resources: Vec<_> =
+                        resources.iter().map(wit_to_proto_resource).collect();
+                    let proto_tags: HashMap<String, proto::Value> = default_tags
+                        .iter()
+                        .map(|(k, v)| (k.clone(), wit_to_proto_value(v)))
+                        .collect();
+                    let schemas = $crate::CarinaProvider::schemas(&*provider);
+                    $crate::CarinaProvider::merge_default_tags(
+                        &*provider,
+                        &mut proto_resources,
+                        &proto_tags,
+                        &schemas,
+                    );
+                    proto_resources.iter().map(proto_to_wit_resource).collect()
+                }
             }
 
             export!(WasmGuest);
@@ -978,6 +999,27 @@ macro_rules! export_provider {
                         .into_iter()
                         .map(|(k, s)| (k, proto_to_wit_state(&s)))
                         .collect()
+                }
+
+                fn merge_default_tags(
+                    resources: Vec<wit_types::ResourceDef>,
+                    default_tags: Vec<(String, wit_types::Value)>,
+                ) -> Vec<wit_types::ResourceDef> {
+                    let provider = get_provider().lock().unwrap();
+                    let mut proto_resources: Vec<_> =
+                        resources.iter().map(wit_to_proto_resource).collect();
+                    let proto_tags: HashMap<String, proto::Value> = default_tags
+                        .iter()
+                        .map(|(k, v)| (k.clone(), wit_to_proto_value(v)))
+                        .collect();
+                    let schemas = $crate::CarinaProvider::schemas(&*provider);
+                    $crate::CarinaProvider::merge_default_tags(
+                        &*provider,
+                        &mut proto_resources,
+                        &proto_tags,
+                        &schemas,
+                    );
+                    proto_resources.iter().map(proto_to_wit_resource).collect()
                 }
             }
 

--- a/carina-provider-mock/src/main.rs
+++ b/carina-provider-mock/src/main.rs
@@ -159,6 +159,34 @@ impl CarinaProvider for MockProcessProvider {
         states.remove(&key);
         Ok(())
     }
+
+    /// Echo the host-provided `default_tags` back into each resource's
+    /// attributes under a sentinel `__mock_merged_default_tags__` key so
+    /// integration tests can verify the WIT bridge dispatched the call.
+    /// Real providers would call `merge_default_tags_for_provider` here;
+    /// the mock provider's job is just to prove the call landed.
+    fn merge_default_tags(
+        &self,
+        resources: &mut Vec<Resource>,
+        default_tags: &HashMap<String, Value>,
+        _schemas: &Vec<ResourceSchema>,
+    ) {
+        let snapshot: Vec<Value> = default_tags
+            .iter()
+            .map(|(k, v)| {
+                Value::Map(HashMap::from([
+                    ("k".to_string(), Value::String(k.clone())),
+                    ("v".to_string(), v.clone()),
+                ]))
+            })
+            .collect();
+        for r in resources.iter_mut() {
+            r.attributes.insert(
+                "__mock_merged_default_tags__".to_string(),
+                Value::List(snapshot.clone()),
+            );
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

Stage 2/4 of the chain that closes carina-rs/carina-provider-awscc#192 and carina-rs/carina-provider-aws#242. Plumbs the new `merge-default-tags` WIT export (carina-rs/carina-plugin-wit#11) through:

- `carina-plugin-sdk` — adds the `merge_default_tags` guest binding to both `wit_bindgen::generate!` arms.
- `carina-plugin-host` — adds `WasmBindings::call_merge_default_tags` and `WasmProviderNormalizer::merge_default_tags`, which dispatch through the new WIT export.
- `carina-core` — drops the `ProviderNormalizer::merge_default_tags` trait default (a silent no-op was the original bug source) and adds explicit bodies on every in-tree impl.
- `carina-provider-mock` — instrumented `merge_default_tags` echoes the host-supplied tags into a sentinel attribute so the WIT bridge has a regression test.

Closes #2620.

## Why drop the trait default

The whole reason awscc#192 and aws#242 exist is that `WasmProviderNormalizer` silently inherited the trait's no-op default and never dispatched the merge into the WASM guest. Making the method required forces every implementation to choose explicitly between [`merge_default_tags_for_provider`], a custom merge, or [`NoopNormalizer`]'s deliberate no-op — what would otherwise be a silent regression now becomes a compile error.

## Test plan

3 new integration tests in `carina-plugin-host/tests/wasm_integration_test.rs`:

- `test_wasm_mock_provider_merge_default_tags_dispatches_through_wit` — proves the WIT bridge round-trips (sentinel attribute appears with both host-supplied tags).
- `test_wasm_mock_provider_merge_default_tags_empty_short_circuits` — proves the empty-`default_tags` early-return at the host avoids the round-trip.
- `test_wasm_mock_provider_merge_default_tags_preserves_order` — proves the multi-resource zip-by-index pattern lines up with the guest's order-preserving response.

Verify gates:

- [x] `cargo nextest run --workspace` (2969 tests, all pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] All `scripts/check-*.sh` pass
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2 --release` (CI's Test job builds this)

## Downstream impact

This PR makes `merge_default_tags` required on `ProviderNormalizer`. The out-of-tree `AwsccNormalizer` (carina-rs/carina-provider-awscc) and `AwsNormalizer` (carina-rs/carina-provider-aws) already implement it, so no source change is needed in those repos — but their git-dep `rev=` on `carina` must bump past this commit before stages 3/4 of the chain can pick up the new WIT export.

## Chain status

- Stage 1/4 ✅ carina-rs/carina-plugin-wit#11 (merged 2c34419d)
- Stage 2/4 ⬅️ this PR
- Stage 3/4 ⏸ carina-rs/carina-provider-awscc — bump submodule + git-dep, expose `merge_default_tags` via the new WIT export. Closes carina-rs/carina-provider-awscc#192.
- Stage 4/4 ⏸ carina-rs/carina-provider-aws — same. Closes carina-rs/carina-provider-aws#242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
