### PR TITLE
lsp: offer in-scope identifiers at value position inside nested struct blocks

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use dsl_source::DslSource;
 use std::path::Path;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Command, CompletionItem, CompletionItemKind, Position};
+use tower_lsp::lsp_types::{Command, CompletionItem, CompletionItemKind, Position, Range};
 
 use crate::document::Document;
 use carina_core::schema::{
@@ -108,7 +108,13 @@ impl CompletionProvider {
         // suppresses completion entirely — the value-position path
         // declines once `after_eq` starts with a double quote.
         if let Some(partial) = detect_interpolation_bare_partial(&text, position) {
-            return self.in_scope_binding_completions(&text, position, &partial, base_path);
+            return self.in_scope_binding_completions(
+                &text,
+                base_path,
+                values::InScopeBindingMode::PartialReplace {
+                    range: range_for_partial(position, &partial),
+                },
+            );
         }
 
         let context = self.get_completion_context(&text, position);
@@ -151,7 +157,15 @@ impl CompletionProvider {
                 resource_type,
                 attr_path,
                 field_name,
-            } => self.value_completions_for_struct_field(&resource_type, &attr_path, &field_name),
+                current_binding,
+            } => self.value_completions_for_struct_field(
+                &resource_type,
+                &attr_path,
+                &field_name,
+                &text,
+                current_binding.as_deref(),
+                base_path,
+            ),
             CompletionContext::InsideProviderBlock { .. } => self.provider_block_completions(),
             CompletionContext::AfterProviderRegion { provider_name } => {
                 self.region_completions_for_provider(&provider_name)
@@ -163,9 +177,13 @@ impl CompletionProvider {
             CompletionContext::InsideUpstreamStateSource { partial_path } => {
                 self.upstream_state_source_completions(&partial_path, position, base_path)
             }
-            CompletionContext::ForIterable { partial } => {
-                self.in_scope_binding_completions(&text, position, &partial, base_path)
-            }
+            CompletionContext::ForIterable { partial } => self.in_scope_binding_completions(
+                &text,
+                base_path,
+                values::InScopeBindingMode::PartialReplace {
+                    range: range_for_partial(position, &partial),
+                },
+            ),
             CompletionContext::None => vec![],
         }
     }
@@ -437,6 +455,7 @@ impl CompletionProvider {
                         resource_type: resource_type.clone(),
                         attr_path: nested_block_names,
                         field_name,
+                        current_binding: current_binding.clone(),
                     };
                 }
             }
@@ -741,21 +760,34 @@ impl CompletionProvider {
         }
     }
 
-    /// Provide value completions for a specific struct field
+    /// Provide value completions for a specific struct field — both
+    /// type-driven candidates from the field's `AttributeType` and
+    /// in-scope identifiers (arguments, `let` bindings) reachable at
+    /// this cursor. The in-scope half closes #2624 — without it a
+    /// deeply-nested struct value position offered nothing beyond the
+    /// type's literal values.
     fn value_completions_for_struct_field(
         &self,
         resource_type: &str,
         attr_path: &[String],
         field_name: &str,
+        text: &str,
+        current_binding: Option<&str>,
+        base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
+        let mut completions = Vec::new();
         if let Some(schema) = self.lookup_schema(resource_type)
             && let Some(fields) = self.resolve_struct_fields_for_path(schema, attr_path)
             && let Some(field) = fields.iter().find(|f| f.name == field_name)
         {
-            self.completions_for_type(&field.field_type, Some(resource_type))
-        } else {
-            vec![]
+            completions.extend(self.completions_for_type(&field.field_type, Some(resource_type)));
         }
+        completions.extend(self.in_scope_binding_completions(
+            text,
+            base_path,
+            values::InScopeBindingMode::ValuePosition { current_binding },
+        ));
+        completions
     }
 }
 
@@ -804,6 +836,10 @@ enum CompletionContext {
         resource_type: String,
         attr_path: Vec<String>,
         field_name: String,
+        /// Name of the enclosing `let <binding> = <resource> { ... }` if any.
+        /// Used to skip self-references when offering in-scope identifiers
+        /// at value position inside a nested struct body (#2624).
+        current_binding: Option<String>,
     },
     InsideProviderBlock {
         provider_name: String,
@@ -1105,6 +1141,19 @@ fn parse_trailing_dotted_segments(prefix: &str, n: usize) -> Option<Vec<&str>> {
 
 fn is_identifier(s: &str) -> bool {
     carina_core::utils::is_identifier_safe(s)
+}
+
+/// Range covering the trailing `partial` characters at `position` —
+/// what `text_edit` should replace when the editor accepts a candidate.
+fn range_for_partial(position: Position, partial: &str) -> Range {
+    let partial_chars = partial.chars().count() as u32;
+    Range {
+        start: Position {
+            line: position.line,
+            character: position.character.saturating_sub(partial_chars),
+        },
+        end: position,
+    }
 }
 
 /// Look up the `source = '...'` path for `binding` declared in any

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -136,6 +136,7 @@ outer {
                 ref resource_type,
                 ref attr_path,
                 ref field_name,
+                ..
             } if resource_type == "test.nested.resource"
                 && attr_path == &["outer".to_string(), "inner".to_string()]
                 && field_name == "leaf_field"
@@ -3497,6 +3498,271 @@ aws.s3.BucketPolicy {
     assert!(
         labels.contains(&"orgs"),
         "expected `orgs` inside deeply-nested `${{o`, got: {:?}",
+        labels
+    );
+}
+
+// =====================================================================
+// Value-position in-scope identifier completion (#2624)
+//
+// Inside a value position — the right-hand side of `attr =` whether at
+// a top-level resource attribute or deep inside a nested struct block —
+// the LSP must offer arguments declared in `arguments {}`, `let`
+// bindings declared elsewhere in scope, and `<binding>.<export>`
+// references to `upstream_state` exports. The struct-nested case
+// previously yielded only type-driven candidates, so the user got no
+// help typing identifiers that were perfectly in scope.
+// =====================================================================
+
+#[test]
+fn nested_struct_value_position_offers_argument_parameters() {
+    // The repro from #2624: a `let` binding wraps a deeply-nested struct
+    // body and an `arguments { ... }` block declares parameters that
+    // should be reachable as bare identifiers inside the body.
+    let provider = test_provider_with_nested_structs();
+    let text = "\
+arguments {
+  oidc_provider_arn: String
+  environment: String
+}
+
+let role = test.nested.resource {
+  outer {
+    inner {
+      leaf_field =
+    }
+  }
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 8,
+        character: "      leaf_field = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"oidc_provider_arn"),
+        "expected `oidc_provider_arn` (argument) at nested struct value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"environment"),
+        "expected `environment` (argument) at nested struct value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn nested_struct_value_position_offers_let_bindings() {
+    // Sibling `let` bindings in the same file should appear as
+    // candidates at a value position deep inside another resource's
+    // nested struct body. The current binding (`role`) itself is
+    // intentionally excluded because referencing it from inside its own
+    // body makes no sense.
+    let provider = test_provider_with_nested_structs();
+    let text = "\
+let helper = test.nested.resource {
+  outer {
+    inner {
+      leaf_field = \"hello\"
+    }
+  }
+}
+
+let role = test.nested.resource {
+  outer {
+    inner {
+      leaf_field =
+    }
+  }
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 11,
+        character: "      leaf_field = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"helper"),
+        "expected sibling `let` binding `helper` at nested struct value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"role"),
+        "current binding `role` must not appear inside its own body. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn nested_struct_value_position_offers_upstream_state_references() {
+    // Cross-file: an `upstream_state` binding declared in a sibling
+    // file should surface as the bare binding name (`orgs`) at a value
+    // position inside a nested struct body. Once the user types the
+    // trailing dot, the depth-1 detector takes over and offers the
+    // upstream's exports — covered separately by
+    // `nested_struct_value_position_dot_after_upstream_state_offers_exports`.
+    let provider = test_provider_with_nested_structs();
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    let main = "\
+let role = test.nested.resource {
+  outer {
+    inner {
+      leaf_field =
+    }
+  }
+}
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 3,
+        character: "      leaf_field = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    // The bare binding name (`orgs`) is also useful so the user can
+    // tab-trigger it and then type `.` to descend into exports.
+    assert!(
+        labels.contains(&"orgs"),
+        "expected upstream_state binding `orgs` at nested struct value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn nested_struct_value_position_dot_after_upstream_state_offers_exports() {
+    // Once the user types `orgs.` at the value position, the dot
+    // detector takes over from `AfterEqualsInStruct` and offers the
+    // upstream's exports — the same depth-1 detector used in flatter
+    // contexts works just as well inside a nested struct body. Without
+    // this, completing through to e.g. `<binding>.<export>` (item 3 in
+    // #2624's expected sources) would still fail.
+    let provider = test_provider_with_nested_structs();
+    let tmp = tempfile::tempdir().unwrap();
+    let upstream = tmp.path().join("organizations");
+    std::fs::create_dir(&upstream).unwrap();
+    std::fs::write(
+        upstream.join("exports.crn"),
+        "exports {\n  accounts: map(String) = \"x\"\n}\n",
+    )
+    .unwrap();
+    let base = tmp.path().join("downstream");
+    std::fs::create_dir(&base).unwrap();
+    std::fs::write(
+        base.join("backend.crn"),
+        "let orgs = upstream_state { source = '../organizations' }\n",
+    )
+    .unwrap();
+    let main = "\
+let role = test.nested.resource {
+  outer {
+    inner {
+      leaf_field = orgs.
+    }
+  }
+}
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 3,
+        character: "      leaf_field = orgs.".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"accounts"),
+        "expected upstream export `accounts` after `orgs.` at nested struct value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn nested_struct_value_position_in_anonymous_resource() {
+    // Anonymous resource (no enclosing `let`): `current_binding` is
+    // `None`, so the self-skip is a no-op and all in-scope identifiers
+    // still surface. Locks in the behavior so a future tightening of
+    // the filter can't silently break the bare-resource case.
+    let provider = test_provider_with_nested_structs();
+    let text = "\
+arguments {
+  oidc_provider_arn: String
+}
+
+test.nested.resource {
+  outer {
+    inner {
+      leaf_field =
+    }
+  }
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 7,
+        character: "      leaf_field = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"oidc_provider_arn"),
+        "expected `oidc_provider_arn` even without enclosing `let`. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn nested_struct_value_position_argument_from_sibling_file() {
+    // The `arguments {}` block lives in a sibling `.crn` file from the
+    // file the user is editing — a directory-scoped feature must merge
+    // sibling files before scanning for arguments. Mirrors the real
+    // `arguments.crn` + `main.crn` shape.
+    let provider = test_provider_with_nested_structs();
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("arguments.crn"),
+        "arguments {\n  oidc_provider_arn: String\n}\n",
+    )
+    .unwrap();
+    let main = "\
+let role = test.nested.resource {
+  outer {
+    inner {
+      leaf_field =
+    }
+  }
+}
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 3,
+        character: "      leaf_field = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"oidc_provider_arn"),
+        "expected sibling-file argument `oidc_provider_arn` at nested struct value position. Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -23,6 +23,25 @@ struct BindingDotContext {
     resource_type: String,
 }
 
+/// Caller mode for [`CompletionProvider::in_scope_binding_completions`].
+///
+/// The two arms reflect the two real call sites — partial-replacing
+/// (for-iterable / interpolation) and value-position (resource / nested
+/// struct attribute = ▉). Splitting them keeps illegal mixes (e.g.
+/// `range: Some(_)` *and* `current_binding: Some(_)`) unrepresentable.
+pub(super) enum InScopeBindingMode<'a> {
+    /// `for ... in <HERE>` and `"${<HERE>}"` — accepting a candidate
+    /// replaces the partial the user has already typed, so emit a
+    /// `text_edit` covering that range.
+    PartialReplace { range: Range },
+    /// Value position inside a resource block (`attr = ▉`). No partial
+    /// to replace; emit `insert_text` and skip self-references via
+    /// `current_binding`. The fuller `argument: <type>` detail is
+    /// surfaced here because compatibility with the surrounding
+    /// attribute is part of the popup's job.
+    ValuePosition { current_binding: Option<&'a str> },
+}
+
 fn type_completion_item(label: String, detail: String, range: Range) -> CompletionItem {
     CompletionItem {
         label: label.clone(),
@@ -604,52 +623,58 @@ impl CompletionProvider {
         ]
     }
 
-    /// Surface every binding that `check_deferred_for_iterables` treats
-    /// as in-scope at a bare-identifier expression position: `let`,
-    /// `upstream_state`, module calls, imports, and argument parameters.
-    /// Used by the `for ... in <HERE>` iterable detector and by the
-    /// `"${<HERE>"` interpolation detector — both want the same
-    /// candidates.
-    ///
-    /// Bindings commonly live in sibling `.crn` files (e.g.
+    /// Surface every in-scope identifier — `let` bindings (resource,
+    /// module use, upstream_state) and `arguments {}` parameters — as
+    /// candidates. Bindings commonly live in sibling `.crn` files (e.g.
     /// `let orgs = upstream_state { ... }` in `backend.crn` referenced
-    /// from `main.crn`), so we read every `.crn` in `base_path`, not
-    /// just the current buffer.
+    /// from `main.crn`), so we read every `.crn` in `base_path`.
+    ///
+    /// Two callers share this:
+    ///   - `for ... in <HERE>` and `"${<HERE>"` (partial-replacing): a
+    ///     `Range` is supplied so accepting a candidate replaces the
+    ///     already-typed prefix.
+    ///   - Value position inside a resource / nested struct (#2624):
+    ///     `range = None`, `current_binding = Some(...)` to skip
+    ///     self-references.
     pub(super) fn in_scope_binding_completions(
         &self,
         text: &str,
-        position: Position,
-        partial: &str,
         base_path: Option<&Path>,
+        mode: InScopeBindingMode<'_>,
     ) -> Vec<CompletionItem> {
-        let partial_chars = partial.chars().count() as u32;
-        let range = Range {
-            start: Position {
-                line: position.line,
-                character: position.character.saturating_sub(partial_chars),
-            },
-            end: position,
+        let current_binding = match &mode {
+            InScopeBindingMode::ValuePosition { current_binding } => *current_binding,
+            InScopeBindingMode::PartialReplace { .. } => None,
         };
 
         let mut items = Vec::new();
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let push = |items: &mut Vec<CompletionItem>,
-                    seen: &mut std::collections::HashSet<String>,
-                    name: String,
-                    detail: &str| {
+        let mut push = |name: String, detail: String| {
+            if current_binding.is_some_and(|cb| cb == name) {
+                return;
+            }
             if !seen.insert(name.clone()) {
                 return;
             }
-            items.push(CompletionItem {
+            let mut item = CompletionItem {
                 label: name.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
-                detail: Some(detail.to_string()),
-                text_edit: Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
-                    range,
-                    new_text: name,
-                })),
+                detail: Some(detail),
                 ..Default::default()
-            });
+            };
+            match &mode {
+                InScopeBindingMode::PartialReplace { range } => {
+                    item.text_edit =
+                        Some(tower_lsp::lsp_types::CompletionTextEdit::Edit(TextEdit {
+                            range: *range,
+                            new_text: name,
+                        }));
+                }
+                InScopeBindingMode::ValuePosition { .. } => {
+                    item.insert_text = Some(name);
+                }
+            }
+            items.push(item);
         };
 
         let mut src_buf = String::new();
@@ -662,10 +687,14 @@ impl CompletionProvider {
             } else {
                 "binding"
             };
-            push(&mut items, &mut seen, name, detail);
+            push(name, detail.to_string());
         }
-        for (name, _) in self.extract_argument_parameters(src) {
-            push(&mut items, &mut seen, name, "argument");
+        for (name, type_hint) in self.extract_argument_parameters(src) {
+            let detail = match mode {
+                InScopeBindingMode::ValuePosition { .. } => format!("argument: {}", type_hint),
+                InScopeBindingMode::PartialReplace { .. } => "argument".to_string(),
+            };
+            push(name, detail);
         }
 
         items


### PR DESCRIPTION
## Summary

- `AfterEqualsInStruct` only emitted type-driven candidates (enum literals, `true`/`false`), so deep inside a struct body the user got nothing for `arguments`, `let` bindings, or `upstream_state` binding names that were in scope. The non-struct `AfterEquals` path already surfaced these — only the struct branch was broken.
- Extended `value_completions_for_struct_field` to also call `in_scope_binding_completions`, and unified that helper with the former `in_scope_identifier_completions` via an `InScopeBindingMode` enum (`PartialReplace { range }` for for-iterable / interpolation, `ValuePosition { current_binding }` for the new struct-nested caller). The enum split keeps illegal combinations unrepresentable.
- `AfterEqualsInStruct` now carries `current_binding` like `AfterEquals` already does, so a binding can't suggest itself inside its own body.
- Honors the directory-scoped invariant: `arguments` / `let` declared in a sibling `.crn` are merged before scanning, mirroring the real `arguments.crn` + `main.crn` shape.

## Test plan

- [x] 6 new tests in `carina-lsp/src/completion/tests/extended.rs`:
  - arguments visible at nested struct value position (single-file)
  - sibling `let` binding visible (+ self-reference excluded)
  - cross-file `upstream_state` binding (`orgs`) visible
  - depth-1 dot detector still fires (`orgs.` → `accounts`) inside a nested struct body
  - sibling-file `arguments.crn` (directory-scoped)
  - anonymous resource (no enclosing `let`) — locks in that the self-skip is a no-op
- [x] `cargo nextest run -p carina-lsp` (480 / 480)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five)

## Out of scope

- **Type-aware ranking / filtering** of in-scope candidates. Issue body explicitly defers this — "minimum useful behavior is: offer them at all". Worth a follow-up issue.
- **Full parity with `AfterEquals`**: the new struct path doesn't preflight `<binding>.<export>` REFERENCE candidates the way `value_completions_for_attr` does. Users still reach exports via the depth-1 dot detector once they type `binding.`. Worth a follow-up.
- **Real-infra smoke test**: the issue references `carina-rs/infra/usecases/registry-deploy/main.crn`, which lives on PR #42 and isn't on `main` yet. The test fixture (`test_provider_with_nested_structs`) reproduces the same depth-2 struct shape (`outer.inner.leaf_field`) the real `awscc.iam.Role` case hits.

Closes #2624

🤖 Generated with [Claude Code](https://claude.com/claude-code)