### PR TITLE
lsp: surface let bindings at value position inside resource blocks

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -3766,3 +3766,148 @@ let role = test.nested.resource {
         labels
     );
 }
+
+// =====================================================================
+// Value-position bare-identifier completion for `let` bindings (#2642)
+//
+// At a top-level value position inside a resource block (`attr = ▉`),
+// `let X = ...` bindings declared earlier in the same file (or in a
+// sibling `.crn`) must appear as bare-identifier candidates. Before
+// this fix, only `arguments {}` declarations were surfaced; let
+// bindings only reached the popup as `<binding>.<attr>` REFERENCE
+// candidates and only when the target attribute's `Custom` semantic
+// type happened to match a binding-attr's semantic type.
+// =====================================================================
+
+#[test]
+fn top_level_value_position_offers_let_bindings() {
+    // Same-file `let helper = ...` should appear as a bare candidate
+    // when the cursor is inside another resource's `attr = ▉`. The
+    // current binding (`role`) is excluded — referencing it from
+    // inside its own body would be circular.
+    let provider = test_provider_single_attr();
+    let text = "\
+let helper = test.foo.bar {
+  attr = \"hello\"
+}
+
+let role = test.foo.bar {
+  attr =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"helper"),
+        "expected sibling `let` binding `helper` at value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"role"),
+        "current binding `role` must not appear inside its own body. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn top_level_value_position_offers_let_binding_in_anonymous_resource() {
+    // Anonymous resource (no enclosing `let`): every let binding still
+    // shows because there's no `current_binding` to filter on.
+    let provider = test_provider_single_attr();
+    let text = "\
+let helper = test.foo.bar {
+  attr = \"hello\"
+}
+
+test.foo.bar {
+  attr =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"helper"),
+        "expected `helper` even without enclosing `let`. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn top_level_value_position_emits_bare_binding_alongside_reference() {
+    // When the target attribute carries a `Custom` semantic type that
+    // matches a binding-attr's semantic type, the existing REFERENCE
+    // pass emits `<binding>.<attr>` (e.g. `vpc.vpc_id`). The new pass
+    // adds the bare binding name (`vpc`) alongside it. Both should
+    // appear — the user might want to type `vpc` then `.` to descend,
+    // or pick the dotted form directly.
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+let vpc = awscc.ec2.Vpc {
+  cidr_block = \"10.0.0.0/16\"
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  vpc_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"vpc"),
+        "expected bare `vpc` (let binding) at vpc_id value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"vpc.vpc_id"),
+        "expected REFERENCE `vpc.vpc_id` (Custom-type match) at vpc_id value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn top_level_value_position_offers_let_binding_from_sibling_file() {
+    // Cross-file: a `let` binding declared in a sibling `.crn` file
+    // must still surface — the directory-scoped invariant. Mirrors
+    // the real `infra/.../<dir>/main.crn` + `<dir>/helpers.crn` shape.
+    let provider = test_provider_single_attr();
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("helpers.crn"),
+        "let helper = test.foo.bar {\n  attr = \"hello\"\n}\n",
+    )
+    .unwrap();
+    let main = "\
+let role = test.foo.bar {
+  attr =
+}
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 1,
+        character: "  attr = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"helper"),
+        "expected sibling-file `let` binding `helper` at value position. Got: {:?}",
+        labels
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -261,18 +261,17 @@ impl CompletionProvider {
             }
         }
 
-        // Add argument parameter references (lexically scoped — direct name access).
-        // The shared `src` surfaces `arguments { ... }` even when split into
-        // a dedicated `arguments.crn`.
-        for (name, type_hint) in self.extract_argument_parameters(src) {
-            completions.push(CompletionItem {
-                label: name.clone(),
-                kind: Some(CompletionItemKind::VARIABLE),
-                detail: Some(format!("argument: {}", type_hint)),
-                insert_text: Some(name),
-                ..Default::default()
-            });
-        }
+        // Bare-identifier candidates: `let` bindings declared in this
+        // directory plus `arguments {}` parameters. Without the `let`
+        // half, a binding could only reach the popup as a REFERENCE
+        // (`<binding>.<attr>`), and only when the target attr's
+        // `Custom` semantic type happened to match a binding-attr's —
+        // a too-narrow filter that hid the most common intra-file
+        // reference style. See #2642.
+        completions.extend(self.in_scope_binding_completions_with_src(
+            src,
+            InScopeBindingMode::ValuePosition { current_binding },
+        ));
 
         // Add for-loop binding names in scope, filtered by inferred element
         // type where possible. When the iterable is an `upstream_state`
@@ -642,6 +641,21 @@ impl CompletionProvider {
         base_path: Option<&Path>,
         mode: InScopeBindingMode<'_>,
     ) -> Vec<CompletionItem> {
+        let mut src_buf = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
+        self.in_scope_binding_completions_with_src(src, mode)
+    }
+
+    /// Same as [`in_scope_binding_completions`] but reuses an
+    /// already-built [`DslSource`]. Hot-path callers (e.g.
+    /// [`value_completions_for_attr`]) build `src` once for several
+    /// passes; passing it in avoids re-reading every sibling `.crn`
+    /// file per keystroke.
+    pub(super) fn in_scope_binding_completions_with_src(
+        &self,
+        src: DslSource<'_>,
+        mode: InScopeBindingMode<'_>,
+    ) -> Vec<CompletionItem> {
         let current_binding = match &mode {
             InScopeBindingMode::ValuePosition { current_binding } => *current_binding,
             InScopeBindingMode::PartialReplace { .. } => None,
@@ -677,8 +691,6 @@ impl CompletionProvider {
             items.push(item);
         };
 
-        let mut src_buf = String::new();
-        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
         for (name, rhs) in Self::extract_let_bindings(src) {
             let detail = if rhs.starts_with("upstream_state") {
                 "upstream_state binding"


### PR DESCRIPTION
## Summary

- `value_completions_for_attr` only emitted `<binding>.<attr>` REFERENCE candidates (and only when the target attribute's `Custom` semantic type matched a binding-attr's), plus `arguments {}` parameters. Bare `let` binding names — the most common intra-file reference style — never reached the popup, so writing `role_name = role` had to be typed character-by-character without IDE help.
- Replace the inline `extract_argument_parameters` loop with a call to the existing `in_scope_binding_completions` helper (introduced in #2624 for the nested-struct case), which already surfaces both `let` bindings and `arguments {}` parameters and respects `current_binding` self-skip.
- Add an `in_scope_binding_completions_with_src` variant so this hot-path caller can reuse the `DslSource` it already built, instead of re-reading every sibling `.crn` from disk on each keystroke.

## Test plan

- [x] 4 new tests in `carina-lsp/src/completion/tests/extended.rs`:
  - same-file `let helper` is offered + current binding (`role`) is filtered out
  - anonymous resource (no enclosing `let`) — `helper` still appears
  - sibling-file `let` binding is offered (directory-scoped invariant)
  - bare `vpc` and REFERENCE `vpc.vpc_id` coexist (Custom-type match)
- [x] `cargo nextest run -p carina-lsp` — 484 / 484
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five)

## Relation to #2640 (parent tracker)

This is sub-issue 1/3 of #2640. The other two:

- #2643 (2/3) — type-aware ranking / filtering of value-position candidates.
- #2644 (3/3) — value-position completion is empty inside `attributes { }` block.

Each lands in its own PR. Please do not auto-close #2640 from this PR — that issue stays open as a tracker until all three sub-issues close.

Closes #2642
Refs #2640
