### PR TITLE
lsp: type-narrow value-position popup, suppress builtins, accept Simple → String

### DIFF
--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -33,6 +33,7 @@ pub use resolve::{
     check_identifier_scope, collect_known_bindings_merged, resolve_resource_refs,
     resolve_resource_refs_with_config,
 };
+pub use types::parse_type_expr_str;
 pub(crate) use util::{eval_type_name, value_type_name};
 pub use util::{pascal_to_snake, snake_to_pascal};
 

--- a/carina-core/src/parser/types.rs
+++ b/carina-core/src/parser/types.rs
@@ -3,10 +3,40 @@
 //!
 //! Extracted from `parser/mod.rs` per #2263 (part 2/2).
 
+use pest::Parser;
+
 use super::ast::{ResourceTypePath, TypeExpr};
 use super::error::{ParseError, ParseWarning};
 use super::util::{pascal_to_snake, snake_to_pascal};
 use super::{ProviderContext, Rule, first_inner, next_pair};
+
+/// Parse a standalone type-expression text snippet (e.g. `"String"`,
+/// `"List(Int)"`, `"'dev' | 'prod'"`) into a [`TypeExpr`].
+///
+/// Returns `None` when the input doesn't match the type-expression
+/// grammar — callers can use this to short-circuit type-aware
+/// behavior (e.g. LSP completion ranking) without aborting; an
+/// unparseable type hint just falls back to the un-typed path.
+///
+/// The full trimmed input must match — trailing tokens cause `None`
+/// rather than a silent prefix match. This matters for mid-edit
+/// buffers like `param: Bool foo` where pest's default greedy
+/// behavior would otherwise accept `Bool` and drop ` foo`, producing
+/// a wrong type that would then drive completion filtering.
+///
+/// This wraps the internal pest entry point so consumers outside
+/// the parser module (LSP, tests, tooling) can lift textual type
+/// hints into the type system without re-implementing pest plumbing.
+pub fn parse_type_expr_str(input: &str, config: &ProviderContext) -> Option<TypeExpr> {
+    let trimmed = input.trim();
+    let mut pairs = super::CarinaParser::parse(super::Rule::type_expr, trimmed).ok()?;
+    let pair = pairs.next()?;
+    if pair.as_span().end() != trimmed.len() {
+        return None;
+    }
+    let mut warnings: Vec<ParseWarning> = Vec::new();
+    parse_type_expr(pair, config, &mut warnings).ok()
+}
 
 /// Parse type expression. Handles unions of atomic types
 /// (`'dev' | 'prod'`, see carina-rs/carina#2611) by collecting every
@@ -170,5 +200,61 @@ fn parse_type_expr_atom(
             Ok(TypeExpr::Struct { fields })
         }
         _ => Ok(TypeExpr::String),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_type_expr_str_accepts_primitive() {
+        let ctx = ProviderContext::default();
+        assert!(matches!(
+            parse_type_expr_str("Bool", &ctx),
+            Some(TypeExpr::Bool)
+        ));
+        assert!(matches!(
+            parse_type_expr_str("String", &ctx),
+            Some(TypeExpr::String)
+        ));
+    }
+
+    #[test]
+    fn parse_type_expr_str_trims_surrounding_whitespace() {
+        let ctx = ProviderContext::default();
+        assert!(matches!(
+            parse_type_expr_str("  String  ", &ctx),
+            Some(TypeExpr::String)
+        ));
+    }
+
+    #[test]
+    fn parse_type_expr_str_rejects_trailing_junk() {
+        // Without the end-of-input check this would silently match
+        // `Bool` and drop ` foo`, producing a wrong type. Mid-edit
+        // buffers where the user has typed past the type need the
+        // bypass — `None` here lets the completion filter fall
+        // through to "show everything".
+        let ctx = ProviderContext::default();
+        assert_eq!(parse_type_expr_str("Bool foo", &ctx), None);
+    }
+
+    #[test]
+    fn parse_type_expr_str_pascal_simple() {
+        let ctx = ProviderContext::default();
+        // PascalCase identifier → TypeExpr::Simple(snake_case)
+        assert!(matches!(
+            parse_type_expr_str("IamOidcProviderArn", &ctx),
+            Some(TypeExpr::Simple(ref s)) if s == "iam_oidc_provider_arn"
+        ));
+    }
+
+    #[test]
+    fn parse_type_expr_str_rejects_unparseable() {
+        let ctx = ProviderContext::default();
+        assert_eq!(parse_type_expr_str("!!!", &ctx), None);
+        assert_eq!(parse_type_expr_str("List(", &ctx), None);
+        assert_eq!(parse_type_expr_str("", &ctx), None);
     }
 }

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -712,14 +712,16 @@ fn check_resource_ref_at_position(
     if crate::validation::is_type_expr_compatible_with_schema(&narrowed, expected) {
         return;
     }
-    // Narrowed-string-shape vs string-receiver: a `Simple("aws_account_id")`
-    // (or any other string-compatible scalar identity) can sit in any
-    // string-compatible position. The strict compat check rejects this
-    // direction (it walks the receiver's `Custom` chain looking for the
-    // exact identity; `String` carries no chain), but the runtime
-    // value is a string, so the position is satisfiable. The reverse
-    // direction (`String → Custom{Specific}`) stays strict via
-    // `attr_type_demands_specific_custom`. #2475.
+    // String-shaped value into a string-compatible receiver. The
+    // strict compat check above accepts `Simple(name) → String` /
+    // `Union<plain Strings>` directly via subtyping (#2643), so this
+    // fallback only handles the receivers it doesn't yet cover —
+    // `Custom { semantic_name: None }`-shaped wrappers and
+    // `StringEnum` receivers — and the non-`Simple` string-shaped
+    // values (e.g. `SchemaType` / scalar `String` literal) the
+    // strict path also doesn't recognise. The reverse direction
+    // (`String → Custom { semantic_name: Some(_) }`) stays strict
+    // via `attr_type_demands_specific_custom`. #2475 / #2643.
     if narrowed.is_string_shaped() && crate::validation::is_string_compatible_type(expected) {
         return;
     }

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -401,8 +401,23 @@ pub fn is_type_expr_compatible_with_schema(
         TypeExpr::Int => matches!(attr_type, AttributeType::Int),
         TypeExpr::Float => matches!(attr_type, AttributeType::Float),
         TypeExpr::Simple(name) => {
-            // Walk the base chain: if any type in the chain matches, it's compatible.
-            // e.g., Simple("arn") accepts KmsKeyArn (chain: KmsKeyArn → Arn ✓)
+            // Two compatibility directions both succeed:
+            //
+            // 1. Receiver more specific than value. Walk the
+            //    receiver's `Custom` chain looking for a level whose
+            //    `type_name()` matches `name`. `Simple("arn")` is
+            //    accepted by `Custom { KmsKeyArn → Arn }` because
+            //    the chain contains `Arn`. Sibling Customs
+            //    (`kms_key_arn` vs `IamRoleArn`) stay rejected
+            //    because no chain level matches. Issue #1874.
+            //
+            // 2. Value more specific than receiver (subtyping into
+            //    plain string). `Simple(name)` represents a
+            //    particular kind of string; flowing it into a plain
+            //    `String` receiver erases nothing. The reverse
+            //    direction (`String` value into a Custom-with-
+            //    semantic-name receiver) stays rejected by
+            //    `attr_type_demands_specific_custom`.
             let mut current = attr_type;
             loop {
                 let type_snake = crate::parser::pascal_to_snake(&current.type_name());
@@ -411,9 +426,10 @@ pub fn is_type_expr_compatible_with_schema(
                 }
                 match current {
                     AttributeType::Custom { base, .. } => current = base,
-                    _ => return false,
+                    _ => break,
                 }
             }
+            is_plain_string_or_string_union(attr_type)
         }
         TypeExpr::List(inner) => match attr_type {
             AttributeType::List {
@@ -476,6 +492,19 @@ pub fn is_string_compatible_type(attr_type: &AttributeType) -> bool {
             true
         }
         AttributeType::Union(types) => types.iter().all(is_string_compatible_type),
+        _ => false,
+    }
+}
+
+/// Returns `true` only for receivers that name no specific identity:
+/// plain `String` or a `Union` of plain Strings. The wider sibling
+/// [`is_string_compatible_type`] also accepts `Custom` and `StringEnum`
+/// receivers, but those carry constraints (specific identity / fixed
+/// value set) that would be erased by accepting a `Simple(name)` value.
+fn is_plain_string_or_string_union(attr_type: &AttributeType) -> bool {
+    match attr_type {
+        AttributeType::String => true,
+        AttributeType::Union(types) => types.iter().all(is_plain_string_or_string_union),
         _ => false,
     }
 }

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1738,9 +1738,27 @@ fn type_compat_exact_match() {
 }
 
 #[test]
-fn type_compat_plain_string_rejected_for_simple() {
-    // Simple("aws_account_id") rejects plain String
+fn type_compat_simple_rejected_by_mixed_string_int_union_receiver() {
+    // The subtyping branch only fires when *every* member of a
+    // `Union` receiver is plain String. A receiver typed
+    // `Union<[String, Int]>` cannot accept a `Simple(name)` value
+    // because the Int member would silently reinterpret the data.
+    let mixed = AttributeType::Union(vec![AttributeType::String, AttributeType::Int]);
     assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Simple("aws_account_id".to_string()),
+        &mixed,
+    ));
+}
+
+#[test]
+fn type_compat_simple_subtypes_into_plain_string() {
+    // `Simple("aws_account_id")` is a particular kind of string;
+    // the plain-`String` receiver wants any string, so the value
+    // satisfies it. The reverse direction (plain `String` value
+    // into a `Custom { semantic_name: AwsAccountId }` receiver) is
+    // rejected by `attr_type_demands_specific_custom`. See #1874
+    // and #2643.
+    assert!(is_type_expr_compatible_with_schema(
         &TypeExpr::Simple("aws_account_id".to_string()),
         &AttributeType::String,
     ));

--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -82,6 +82,7 @@ impl CompletionProvider {
         base_path: Option<&Path>,
     ) -> Vec<CompletionItem> {
         let text = doc.text();
+        let provider_ctx = doc.provider_context();
 
         // `<binding>.<key>.<partial>` (depth-2) is checked first because
         // its prefix shape also matches the depth-1 walker's tail (which
@@ -140,6 +141,7 @@ impl CompletionProvider {
                 current_binding.as_deref(),
                 position,
                 base_path,
+                provider_ctx,
             ),
             CompletionContext::AfterEqualsInExports {
                 type_expr_text,

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -1263,8 +1263,11 @@ fn unknown_attribute_fallback_has_no_type_pollution() {
     // When value completion cannot resolve the attribute's type (the
     // attribute isn't in the schema), the fallback must not inject
     // concrete values of arbitrary types. `true`/`false` belong to Bool;
-    // `aws.Region.*` belong to Region. Built-in functions are fine —
-    // they're type-neutral.
+    // `aws.Region.*` belong to Region. Built-in functions are no longer
+    // emitted at the bare value position either (#2643) — their return
+    // types are too coarse to honor a Custom-typed receiver, and a
+    // popup full of builtins crowded out the in-scope reference
+    // candidates that the user was actually after.
     use carina_core::schema::{AttributeSchema, AttributeType, CompletionValue, ResourceSchema};
     use std::sync::Arc;
 
@@ -1302,10 +1305,13 @@ fn unknown_attribute_fallback_has_no_type_pollution() {
         "Region values must not leak into unknown-attribute fallback. Got: {:?}",
         labels
     );
-    // Sanity: built-in functions are still offered (type-neutral).
+    // Built-ins are intentionally suppressed at the bare value
+    // position (#2643). The pre-existing precedents in `971f1b78`
+    // (struct attrs hide builtins) and `45f9d0b6` (post-`binding.`
+    // hides builtins) extend here.
     assert!(
-        labels.contains(&"join"),
-        "Built-in functions should still appear. Got: {:?}",
+        !labels.contains(&"join"),
+        "Built-in functions should not appear at bare value position (#2643). Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -612,7 +612,18 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 }
 
 #[test]
-fn builtin_function_completions_in_value_position() {
+fn builtin_function_completions_suppressed_at_value_position() {
+    // Built-in functions are intentionally NOT emitted at the bare
+    // value position. The return-type filter in
+    // `builtin_function_completions_for_type` is too coarse to honor
+    // `Custom { semantic_name: ... }` receivers, so a popup including
+    // every String-returning builtin promised correctness it couldn't
+    // deliver and crowded out the in-scope reference candidates.
+    // Builtins remain reachable by typing the function name directly;
+    // a follow-up can add a `<id>(`-triggered surface if explicit
+    // function-call completion is wanted. Pre-existing precedents:
+    // `971f1b78` (Struct attrs hide builtins) and `45f9d0b6`
+    // (post-`binding.` hides builtins). #2643.
     let provider = test_provider();
     let doc = create_document(
         r#"awscc.ec2.Vpc {
@@ -627,22 +638,14 @@ fn builtin_function_completions_in_value_position() {
     let completions = provider.complete(&doc, position, None);
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
 
-    // Should include built-in function names
-    assert!(
-        labels.contains(&"join"),
-        "Should suggest 'join' function. Got: {:?}",
-        labels
-    );
-    assert!(
-        labels.contains(&"upper"),
-        "Should suggest 'upper' function. Got: {:?}",
-        labels
-    );
-    assert!(
-        labels.contains(&"cidr_subnet"),
-        "Should suggest 'cidr_subnet' function. Got: {:?}",
-        labels
-    );
+    for builtin in ["join", "upper", "cidr_subnet", "lower", "lookup", "length"] {
+        assert!(
+            !labels.contains(&builtin),
+            "Built-in `{}` must NOT appear at bare value position. Got: {:?}",
+            builtin,
+            labels
+        );
+    }
 }
 
 #[test]
@@ -2348,10 +2351,14 @@ fn namespaced_enum_completions_offer_full_form_not_bare_tail() {
     );
 }
 
-/// A plain `String` attribute still sees string-returning built-ins, and
-/// list-returning ones stay filtered out — guards against over-filtering.
+/// Builtins are intentionally suppressed at the bare value position
+/// (#2643): the return-type filter is too coarse to honor Custom
+/// receivers, and a popup full of String-returning helpers crowded
+/// out the in-scope identifiers users actually wanted. Even on a
+/// plain `String` attribute, no builtin should reach the popup —
+/// users who want to call one type the name directly.
 #[test]
-fn string_returning_builtins_still_offered_for_plain_string_attr() {
+fn builtins_suppressed_at_plain_string_value_position() {
     let provider = test_provider_single_attr();
     let doc = create_document(
         r#"test.foo.bar {
@@ -2365,19 +2372,14 @@ fn string_returning_builtins_still_offered_for_plain_string_attr() {
     };
     let completions = provider.complete(&doc, position, None);
     let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
-    for builtin in ["join", "upper", "lower"] {
+    for builtin in ["join", "upper", "lower", "concat", "length", "keys"] {
         assert!(
-            labels.contains(&builtin),
-            "string-returning '{}' must appear at plain String attr. Got: {:?}",
+            !labels.contains(&builtin),
+            "builtin '{}' must NOT appear at plain String value position. Got: {:?}",
             builtin,
             labels
         );
     }
-    assert!(
-        !labels.contains(&"concat"),
-        "list-returning 'concat' must not appear at String attr. Got: {:?}",
-        labels
-    );
 }
 
 #[test]
@@ -3908,6 +3910,259 @@ let role = test.foo.bar {
     assert!(
         labels.contains(&"helper"),
         "expected sibling-file `let` binding `helper` at value position. Got: {:?}",
+        labels
+    );
+}
+
+// =====================================================================
+// Type-aware filtering of value-position candidates (#2643)
+//
+// At a typed value position (`attr = ▉` where the schema declares a
+// concrete type), arguments and builtin functions whose declared
+// return type is incompatible with the target attribute's type must
+// not appear in the popup. The filter uses
+// `carina_core::validation::is_type_expr_compatible_with_schema`,
+// already used elsewhere in the same handler for `for-loop` bindings
+// and `upstream_state` exports.
+//
+// Bare `let` binding names stay unfiltered (they have no scalar
+// value type — `<binding>.<attr>` REFERENCE candidates remain the
+// type-precise way to reach them, and that path already filters by
+// `Custom` semantic-name match).
+//
+// When the target attribute's type can't be resolved (schema lookup
+// missed, no attr_name matched, etc.), the filter is bypassed —
+// "show everything" is the safer fallback than "show nothing."
+// =====================================================================
+
+#[test]
+fn value_position_excludes_type_incompatible_argument() {
+    // `cidr_block` is typed `String`. An argument typed `bool` cannot
+    // produce a String, so it must not appear at this cursor.
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+arguments {
+  cidr: String
+  enabled: Bool
+}
+
+awscc.ec2.Vpc {
+  cidr_block =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 6,
+        character: "  cidr_block = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"cidr"),
+        "type-compatible argument `cidr` (String) must appear at String cursor. Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"enabled"),
+        "type-incompatible argument `enabled` (bool) must not appear at String cursor. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn value_position_suppresses_all_builtins() {
+    // Builtins are intentionally NOT emitted at the bare value
+    // position regardless of target type. Even String-returning
+    // helpers like `lower` / `upper` / `join` are suppressed —
+    // their return types are too coarse to honor a Custom-typed
+    // receiver, and the popup noise crowded out the in-scope
+    // reference candidates that are the real point. Users who
+    // want to call a builtin type the name directly. (#2643)
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+awscc.ec2.Vpc {
+  cidr_block =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 1,
+        character: "  cidr_block = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for builtin in ["lower", "upper", "join", "env", "length", "keys", "flatten"] {
+        assert!(
+            !labels.contains(&builtin),
+            "builtin `{}` must NOT appear at value position. Got: {:?}",
+            builtin,
+            labels
+        );
+    }
+}
+
+#[test]
+fn value_position_suppresses_builtins_when_target_type_unknown() {
+    // Cursor inside an `attributes {}` block — schema lookup fails
+    // so the target type is unknown. Builtins are still suppressed
+    // (#2643): when the receiver type can't be resolved, every
+    // builtin would be ungrounded noise. The popup can be empty
+    // here; that's the safer signal than a list of candidates with
+    // no type backing.
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+attributes {
+  whatever =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 1,
+        character: "  whatever = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for builtin in ["length", "lower", "upper", "join"] {
+        assert!(
+            !labels.contains(&builtin),
+            "builtin `{}` must NOT appear when target type is unresolved. Got: {:?}",
+            builtin,
+            labels
+        );
+    }
+}
+
+#[test]
+fn value_position_let_binding_name_kept_when_target_typed() {
+    // The bare `let` binding name (`vpc`) has no scalar value type to
+    // judge against the target. It must still appear regardless of
+    // the target attr's type — typing `vpc.` then descends into the
+    // schema-precise REFERENCE pass, which already filters by Custom
+    // semantic-name match. Removing the bare name would break the
+    // tab-trigger UX delivered by #2642.
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+let vpc = awscc.ec2.Vpc {
+  cidr_block = \"10.0.0.0/16\"
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  vpc_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"vpc"),
+        "bare `let` binding `vpc` must remain regardless of target type. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn value_position_filters_generic_string_arg_against_specific_custom_target() {
+    // Motivating case from #2640's report: `vpc_id` is a
+    // `Custom { semantic_name: Some("VpcId"), base: String }`. A
+    // generic-`String` argument cannot satisfy that — the receiver
+    // names a specific identity, and any `String` value would erase
+    // that proof. Conversely, an argument typed `vpc_id` (Simple) is
+    // structurally compatible.
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+arguments {
+  generic: String
+  the_vpc: VpcId
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 6,
+        character: "  vpc_id = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"the_vpc"),
+        "argument `the_vpc: VpcId` must appear at `vpc_id` cursor (Custom semantic match). Got: {:?}",
+        labels
+    );
+    assert!(
+        !labels.contains(&"generic"),
+        "generic `String` argument must NOT appear at a `Custom {{ semantic_name: VpcId }}` cursor — the type system rejects this narrowing. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn value_position_keeps_argument_when_type_hint_unparseable() {
+    // Mid-edit safety: when an argument's type hint fails to parse
+    // (the buffer is partway through a refactor, or grammar evolved),
+    // `parse_type_expr_str` returns `None`. The filter must let that
+    // argument through rather than silently hide it — "show
+    // everything" beats "show nothing" when type info is missing.
+    let provider = test_provider_with_vpc_and_security_group();
+    // `!!!` isn't a valid type expression. The argument should still
+    // appear at a typed cursor.
+    let text = "\
+arguments {
+  broken: !!!
+}
+
+awscc.ec2.Vpc {
+  cidr_block =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  cidr_block = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"broken"),
+        "argument with unparseable type hint must remain (mid-edit fallback). Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn value_position_no_filter_keeps_argument_when_target_type_unknown() {
+    // Companion to `value_position_no_filter_when_target_type_unknown`
+    // — that one only proves builtins are emitted unfiltered; this
+    // one proves the *argument*-filter branch also bypasses when
+    // the target type is unresolved (here: cursor inside an
+    // `attributes {}` block, so `value_completions_for_attr` receives
+    // `resource_type = ""` and the schema lookup fails).
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+arguments {
+  enabled: Bool
+}
+
+attributes {
+  whatever =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  whatever = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"enabled"),
+        "argument `enabled: Bool` must remain when target type is unresolved (filter bypassed). Got: {:?}",
         labels
     );
 }

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -108,6 +108,10 @@ impl CompletionProvider {
         completions
     }
 
+    // 8 args is over clippy's 7-default; bundling them into a context
+    // struct is a worthwhile cleanup but out of scope for #2643. Track
+    // it as a follow-up if the param list grows again.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn value_completions_for_attr(
         &self,
         resource_type: &str,
@@ -116,6 +120,7 @@ impl CompletionProvider {
         current_binding: Option<&str>,
         position: Position,
         base_path: Option<&Path>,
+        provider_ctx: &carina_core::parser::ProviderContext,
     ) -> Vec<CompletionItem> {
         let mut completions = Vec::new();
 
@@ -261,17 +266,54 @@ impl CompletionProvider {
             }
         }
 
-        // Bare-identifier candidates: `let` bindings declared in this
-        // directory plus `arguments {}` parameters. Without the `let`
-        // half, a binding could only reach the popup as a REFERENCE
-        // (`<binding>.<attr>`), and only when the target attr's
-        // `Custom` semantic type happened to match a binding-attr's —
-        // a too-narrow filter that hid the most common intra-file
-        // reference style. See #2642.
-        completions.extend(self.in_scope_binding_completions_with_src(
+        // Target attribute type, if the schema knows about this
+        // (resource_type, attr_name) pair. Used by both the arguments
+        // filter just below and the for-binding filter further down.
+        let target_attr_type = self
+            .lookup_schema(resource_type)
+            .and_then(|s| s.attributes.get(attr_name))
+            .map(|a| &a.attr_type);
+
+        // In-scope bare identifiers: `let` bindings + `arguments {}`
+        // parameters (#2624 / #2642). When the target attribute's
+        // type resolves, drop arguments whose declared `TypeExpr`
+        // can't produce that type — a `Bool` argument can't satisfy
+        // a `String` cursor, a generic `String` can't satisfy a
+        // `Custom { semantic_name: Some(_) }`. Bare `let` names are
+        // never filtered (no scalar value type to judge), and the
+        // filter is bypassed when the target type is unknown or the
+        // argument's type hint fails to parse — "show everything"
+        // is safer than "show nothing" mid-edit. (#2643)
+        let in_scope = self.in_scope_binding_completions_with_src(
             src,
             InScopeBindingMode::ValuePosition { current_binding },
-        ));
+        );
+        match target_attr_type {
+            None => completions.extend(in_scope),
+            Some(attr_type) => {
+                // Argument count is small (usually < 10), so a Vec
+                // walked linearly is cheaper than a HashMap.
+                let typed_arguments: Vec<(String, carina_core::parser::TypeExpr)> = self
+                    .extract_argument_parameters(src)
+                    .into_iter()
+                    .filter_map(|(name, type_hint)| {
+                        carina_core::parser::parse_type_expr_str(&type_hint, provider_ctx)
+                            .map(|t| (name, t))
+                    })
+                    .collect();
+                completions.extend(in_scope.into_iter().filter(|item| {
+                    let Some((_, arg_type_expr)) =
+                        typed_arguments.iter().find(|(n, _)| n == &item.label)
+                    else {
+                        return true;
+                    };
+                    carina_core::validation::is_type_expr_compatible_with_schema(
+                        arg_type_expr,
+                        attr_type,
+                    )
+                }));
+            }
+        }
 
         // Add for-loop binding names in scope, filtered by inferred element
         // type where possible. When the iterable is an `upstream_state`
@@ -281,10 +323,7 @@ impl CompletionProvider {
         // no schema for the target attribute) falls back to an
         // unconditional suggest so the user still gets autocomplete on
         // the bare name.
-        let attr_type_for_for_filter = self
-            .lookup_schema(resource_type)
-            .and_then(|s| s.attributes.get(attr_name))
-            .map(|a| &a.attr_type);
+        let attr_type_for_for_filter = target_attr_type;
         let for_bindings = super::top_level::extract_for_bindings_in_scope(text, position);
         for binding in &for_bindings {
             if let Some(attr_type) = attr_type_for_for_filter
@@ -328,13 +367,20 @@ impl CompletionProvider {
                 return completions;
             }
 
-            // Built-in function completions filtered by return-type fit.
-            // Offering every built-in at e.g. an `aws_account_id` cursor
-            // would pollute the popup with suggestions that can't produce
-            // the right value.
-            completions.extend(Self::builtin_function_completions_for_type(
-                &attr_schema.attr_type,
-            ));
+            // Built-in functions are intentionally NOT emitted at the
+            // bare value position. The return-type filter is too coarse
+            // to honor `Custom { semantic_name: ... }` receivers — it
+            // lets `lower(x): String` reach a `Custom { IamRoleName }`
+            // cursor even though no String can satisfy that identity.
+            // Continuing to surface them at every typed position taught
+            // "anything goes" and crowded out the in-scope reference
+            // candidates that are the real point of the popup. The
+            // pre-existing precedents are `971f1b78` (Struct attrs hide
+            // builtins) and `45f9d0b6` (post-`binding.` hides builtins) —
+            // this extends the same principle to bare value position.
+            // Builtins are still reachable by typing the function name
+            // directly; a future PR can add a `<id>(`-triggered surface
+            // if we want explicit completion for that intent. (#2643)
 
             // First check if schema defines completions for this attribute
             if let Some(schema_completions) = &attr_schema.completions {
@@ -353,11 +399,11 @@ impl CompletionProvider {
             return completions;
         }
 
-        // No schema found — offer only type-neutral candidates. Built-in
-        // functions are safe (their concrete value types depend on use),
-        // but injecting `true`/`false` or every region would pollute the
-        // list with values that can't possibly fit an unknown attribute.
-        completions.extend(self.builtin_function_completions());
+        // No schema found — return whatever in-scope identifiers the
+        // earlier passes already pushed. Builtins are intentionally
+        // suppressed here too: when the receiver type is unknown we
+        // cannot honor it, and the noise drowns out the actual scope
+        // candidates. See the comment on the typed branch above.
         completions
     }
 
@@ -959,7 +1005,13 @@ impl CompletionProvider {
             .collect()
     }
 
-    /// Provide completions for built-in function names.
+    /// Provide completions for built-in function names. No callers
+    /// in production after #2643 (builtin suppression at value
+    /// position). Kept available for unit tests that assert label /
+    /// signature shape and full coverage of the builtin registry,
+    /// and as the hook for a future `<id>(`-triggered completion
+    /// surface. Remove once that surface lands or the tests move.
+    #[allow(dead_code)]
     pub(super) fn builtin_function_completions(&self) -> Vec<CompletionItem> {
         Self::builtin_completions_matching(|_| true)
     }


### PR DESCRIPTION
## Summary

Three coordinated changes solve the noise the user reported on `awscc.iam.RolePolicy { policy_name = ▉ }` — a popup full of builtins (`cidr_subnet`, `lower`, ...), type-incompatible arguments, and unhelpful generic suggestions:

1. **LSP value-position arguments are type-filtered.** Drop arguments whose declared `TypeExpr` cannot produce the target attribute's type — a `Bool` argument can't satisfy a `String` cursor; a sibling `Custom` can't satisfy a different `Custom`. Bare `let` names stay unfiltered (no scalar value type to judge); the filter is bypassed when the target type can't be resolved or the argument's type hint fails to parse, so "show everything" remains the safe fallback during mid-edit.
2. **Builtins no longer reach the bare value-position popup.** Their return-type filter is too coarse to honor `Custom { semantic_name: ... }` receivers — `lower(x): String` was reaching `Custom { IamRoleName }` cursors regardless. Builtins remain reachable by typing the function name directly. Precedents: `971f1b78` (Struct attrs hide builtins) and `45f9d0b6` (post-`binding.` hides builtins).
3. **`is_type_expr_compatible_with_schema`'s `Simple` arm now accepts `Simple(name) → plain String` (subtyping).** This direction was previously rejected as a side effect of #1874's chain-walk implementation, whose design intent was Custom-vs-Custom *sibling* rejection. Subtyping a specific value into a generic string receiver erases nothing; the symmetric direction (`String → Custom { semantic_name: Some(_) }`) stays strict via `attr_type_demands_specific_custom`.

Adds public `parse_type_expr_str` in carina-core so the LSP can lift the textual type hint recovered by `extract_argument_parameters` back into a structured `TypeExpr`. End-of-input check rejects trailing tokens (mid-edit safety).

## Test plan

- [x] 11 new tests in `carina-lsp/src/completion/tests/extended.rs` covering the typed/untyped/let/argument matrix, plus the inverted assertions for two pre-existing tests that locked in the old "all builtins at value position" behavior.
- [x] 6 new tests in `carina-core/src/parser/types.rs` for `parse_type_expr_str` (primitive accept, whitespace trim, trailing-junk reject, unparseable reject, PascalCase Simple).
- [x] 2 new tests in `carina-core/src/validation/tests.rs` (`Simple → plain String` subtyping accepted, `Simple → Union<[String, Int]>` rejected).
- [x] One pre-existing test renamed and inverted (`type_compat_plain_string_rejected_for_simple` → `type_compat_simple_subtypes_into_plain_string`).
- [x] `cargo nextest run -p carina-core -p carina-lsp` (2268 / 2268 pass).
- [x] `cargo test --workspace --doc`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `bash scripts/check-*.sh`.
- [x] **Real-infra smoke**: `~/.cargo/bin/carina-lsp` rebuilt; user confirmed in VS Code that `policy_name = ▉` cursor in the registry-deploy fixture now yields a clean popup (builtins suppressed, `oidc_provider_arn: IamOidcProviderArn` correctly retained).

## Side-effects worth flagging at review

- **`is_type_expr_compatible_with_schema` is a shared core helper.** The widening reaches every caller — `validate_export_param_ref_types_map`, `validate_for_iterable_type`, `check_cross_file_ref_type` (carina-lsp diagnostics), the upstream-export fallback in `carina-core/src/upstream_exports.rs`, and the LSP completion filters. None previously relied on the rejection being strict; the diff only flips false-rejections into correct accepts. The `upstream_exports.rs` fallback comment that documented the old rejection was refreshed in this PR.
- **One pre-existing test was renamed *and inverted*.** Anyone grepping for `type_compat_plain_string_rejected_for_simple` will not find it — see commit message footer for the rationale.

## Out of scope

- **Primitive-arm asymmetry**: `TypeExpr::Bool/Int/Float` still use bare `matches!` against the receiver and reject `Custom { base: Bool/Int/Float, semantic_name: Some(_) }` receivers. Worth a follow-up issue mirroring the `Simple` arm's two-direction logic.
- **`extract_argument_parameters` returning text instead of `TypeExpr`**: threading parsed types end-to-end is a cleaner refactor than the per-keystroke `parse_type_expr_str` walk this PR introduces, but a non-trivial change to the helper's signature and its other callers. Worth a follow-up.
- **`<id>(`-triggered builtin completion**: hiding builtins from the bare value position is correct, but the `pub(super) fn builtin_function_completions` hook is now production-dead. A future PR could surface builtins under a `<name>(`-trigger context where the user has clearly asked for one. Marked `#[allow(dead_code)]` with a follow-up comment.
- **Union/StringLiteral catchall** in `is_type_expr_compatible_with_schema` (filed as #2648). Touches the same helper but in different arms; out of scope for this PR.

## Relation to #2640 (parent tracker)

Sub-issue 2/3. Siblings:

- #2642 (1/3) — `let` bindings at value position. Merged via PR #2645.
- #2644 (3/3) — `attributes { }` block popup is empty. Open.

Closes #2643
Refs #2640 (parent tracker, do not auto-close)
Refs #1874 (Simple-arm chain walk this loosens)
Refs #2475 (upstream-export fallback this comment refreshes)
Refs #2648 (Union/StringLiteral catchall, related but separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
