### PR TITLE
lsp: regression guard for attributes-block value-position completion

### DIFF
--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -4166,3 +4166,107 @@ attributes {
         labels
     );
 }
+
+// =====================================================================
+// `attributes { }` block value-position completion (#2644)
+//
+// Inside an `attributes { name = ▉ }` block the right-hand side is a
+// value expression — the popup must surface in-scope identifiers
+// (arguments, `let` bindings) just like inside any other resource
+// block. The reporter saw an empty popup pre-#2649; the
+// schema-unknown fallback in `value_completions_for_attr` no longer
+// suppresses the in-scope pass after PR #2649. Lock the behavior
+// here so a future tightening can't silently regress to the empty
+// popup the original report described.
+// =====================================================================
+
+#[test]
+fn attributes_block_value_position_offers_arguments() {
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+arguments {
+  oidc_provider_arn: String
+  environment: String
+}
+
+attributes {
+  role_arn =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 6,
+        character: "  role_arn = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"oidc_provider_arn"),
+        "argument `oidc_provider_arn` must appear at attributes-block value position. Got: {:?}",
+        labels
+    );
+    assert!(
+        labels.contains(&"environment"),
+        "argument `environment` must appear at attributes-block value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn attributes_block_value_position_offers_let_bindings() {
+    let provider = test_provider_with_vpc_and_security_group();
+    let text = "\
+let vpc = awscc.ec2.Vpc {
+  cidr_block = \"10.0.0.0/16\"
+}
+
+attributes {
+  vpc_arn =
+}
+";
+    let doc = create_document(text);
+    let position = Position {
+        line: 5,
+        character: "  vpc_arn = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, None);
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"vpc"),
+        "let binding `vpc` must appear at attributes-block value position. Got: {:?}",
+        labels
+    );
+}
+
+#[test]
+fn attributes_block_value_position_offers_arguments_from_sibling_file() {
+    // Directory-scoped invariant: `arguments` declared in a sibling
+    // `.crn` (the `arguments.crn` + `main.crn` shape) must still
+    // surface at an attributes-block cursor in `main.crn`.
+    let provider = test_provider_with_vpc_and_security_group();
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path().to_path_buf();
+    std::fs::write(
+        base.join("arguments.crn"),
+        "arguments {\n  oidc_provider_arn: String\n}\n",
+    )
+    .unwrap();
+    let main = "\
+attributes {
+  role_arn =
+}
+";
+    std::fs::write(base.join("main.crn"), main).unwrap();
+    let doc = create_document(main);
+    let position = Position {
+        line: 1,
+        character: "  role_arn = ".chars().count() as u32,
+    };
+    let completions = provider.complete(&doc, position, Some(&base));
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"oidc_provider_arn"),
+        "sibling-file `arguments` must reach an attributes-block value position. Got: {:?}",
+        labels
+    );
+}


### PR DESCRIPTION
## Summary

The reporter saw an empty popup at `attributes { name = ▉ }` (#2644). The report predated PR #2649; the schema-unknown fallback in `value_completions_for_attr` — which `attributes {}` cursors hit because they reach the handler with `resource_type = ""` — used to emit only `builtin_function_completions()`, so when those were suppressed the popup would have gone dark.

PR #2649 reshaped the same fallback path to fall through to the `in_scope_binding_completions_with_src` pass introduced in PR #2645. That pass surfaces `let` bindings + `arguments {}` parameters regardless of whether the schema lookup succeeded, so attributes blocks now share the same popup behavior as resource blocks. **Real-infra smoke (VS Code at `awscc.iam.RolePolicy { ... }` and `attributes { ... }` cursors) confirmed the popup is populated.**

This PR contributes only **regression tests** — no production code changes. The three tests lock the behavior so a future tightening can't silently regress to the empty popup the original report described.

## Test plan

- [x] 3 new tests in `carina-lsp/src/completion/tests/extended.rs`:
  - same-file `arguments {}` declarations surface at attributes-block value position
  - same-file `let` bindings surface at attributes-block value position
  - sibling-file `arguments` (the `arguments.crn` + `main.crn` shape) surface (directory-scoped invariant)
- [x] `cargo nextest run -p carina-lsp` (494 / 494 pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] **Real-infra smoke**: VS Code popup populated at `attributes {}` cursor in `usecases/registry-deploy/main.crn`.

## Relation to #2640 (parent tracker)

Sub-issue 3/3, the last open sibling. With this PR landing, all three sub-issues resolve:

- ✅ #2642 (1/3) — `let` bindings at value position. PR #2645 (merged).
- ✅ #2643 (2/3) — value-position type narrowing + builtin suppression. PR #2649 (merged).
- ✅ #2644 (3/3) — attributes-block value position popup populated. **This PR.**

The parent tracker #2640 can close once this lands. Per the convention established earlier in the series, the PR keeps a `Refs #2640` rather than `Closes #2640` so the tracker doesn't auto-close from this PR alone — the user closes it manually after confirming all three sub-issues are done.

Closes #2644
Refs #2640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
