### PR TITLE
fmt: align `=` columns in `attributes {}` / `exports {}` blocks

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -859,6 +859,135 @@ mod tests {
         );
     }
 
+    // Regression for #2641: untyped `attributes {}` entries should align
+    // their `=` columns the same way resource attribute lists already do.
+    #[test]
+    fn issue_2641_attributes_block_aligns_equals_for_untyped_entries() {
+        let input = "attributes {\n  role_arn = role.arn\n  role_name = role.role_name\n}\n";
+        let config = FormatConfig {
+            align_attributes: true,
+            ..Default::default()
+        };
+        let result = format(input, &config).unwrap();
+
+        let lines: Vec<&str> = result.lines().collect();
+        let arn_eq = lines
+            .iter()
+            .find(|l| l.contains("role_arn"))
+            .unwrap()
+            .find('=');
+        let name_eq = lines
+            .iter()
+            .find(|l| l.contains("role_name"))
+            .unwrap()
+            .find('=');
+
+        assert_eq!(
+            arn_eq, name_eq,
+            "`=` columns must line up in `attributes {{}}` block. Got:\n{}",
+            result
+        );
+
+        // Idempotence
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
+    }
+
+    // Same alignment guarantee for `exports {}`, which shares the
+    // formatter path with `attributes {}` (NodeKind::ExportsBlock /
+    // ExportsParam).
+    #[test]
+    fn issue_2641_exports_block_aligns_equals_for_untyped_entries() {
+        let input = "exports {\n  role_arn = role.arn\n  role_name = role.role_name\n}\n";
+        let config = FormatConfig {
+            align_attributes: true,
+            ..Default::default()
+        };
+        let result = format(input, &config).unwrap();
+
+        let lines: Vec<&str> = result.lines().collect();
+        let arn_eq = lines
+            .iter()
+            .find(|l| l.contains("role_arn"))
+            .unwrap()
+            .find('=');
+        let name_eq = lines
+            .iter()
+            .find(|l| l.contains("role_name"))
+            .unwrap()
+            .find('=');
+
+        assert_eq!(
+            arn_eq, name_eq,
+            "`=` columns must line up in `exports {{}}` block. Got:\n{}",
+            result
+        );
+
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
+    }
+
+    // Degenerate shapes for the new alignment path: zero and one
+    // untyped entries. The guard's `align_to > 0` and `key_len <
+    // align_to` checks must skip padding so neither shape crashes or
+    // grows phantom whitespace.
+    #[test]
+    fn issue_2641_attributes_block_degenerate_shapes() {
+        let config = FormatConfig {
+            align_attributes: true,
+            ..Default::default()
+        };
+
+        // Empty block
+        let empty = format("attributes {\n}\n", &config).unwrap();
+        assert_eq!(format(&empty, &config).unwrap(), empty);
+
+        // Single entry — no peer to align to, padding must be skipped.
+        let single = format("attributes {\n  only_one = thing.value\n}\n", &config).unwrap();
+        assert!(
+            single.contains("only_one = thing.value"),
+            "single-entry block should not gain phantom padding. Got:\n{}",
+            single
+        );
+        assert_eq!(format(&single, &config).unwrap(), single);
+    }
+
+    // Mixed typed/untyped block: the new `!wrote_colon` guard in
+    // `format_attributes_param` only adds padding when no `:` was
+    // emitted, so typed entries still align at `:` (existing behavior)
+    // while untyped entries align at `=` against the same `align_to`
+    // (the longest key in the whole block).
+    #[test]
+    fn issue_2641_attributes_block_mixed_typed_and_untyped() {
+        let input = "attributes {\n  vpc_id: awscc.ec2.VpcId = vpc.vpc_id\n  security_group = sg.id\n  role_arn = role.arn\n}\n";
+        let config = FormatConfig {
+            align_attributes: true,
+            ..Default::default()
+        };
+        let result = format(input, &config).unwrap();
+
+        let lines: Vec<&str> = result.lines().collect();
+        let sg_eq = lines
+            .iter()
+            .find(|l| l.contains("security_group"))
+            .unwrap()
+            .find('=');
+        let role_eq = lines
+            .iter()
+            .find(|l| l.contains("role_arn"))
+            .unwrap()
+            .find('=');
+
+        assert_eq!(
+            sg_eq, role_eq,
+            "untyped `=` columns must line up across mixed block. Got:\n{}",
+            result
+        );
+
+        let second = format(&result, &config).unwrap();
+        assert_eq!(result, second, "format must be idempotent");
+    }
+
     #[test]
     fn test_format_index_access() {
         let input = "let x = items[0].name\n";

--- a/carina-core/src/formatter/rules/attributes.rs
+++ b/carina-core/src/formatter/rules/attributes.rs
@@ -335,6 +335,13 @@ impl Formatter {
                         self.write(": ");
                         wrote_colon = true;
                     } else if token.text == "=" && !wrote_equals {
+                        // Untyped form (no `:` seen): pad before `=` so
+                        // entries' `=` columns line up. Typed form has
+                        // already aligned at `:`, so no extra padding here.
+                        if !wrote_colon && align_to > 0 && key_len < align_to {
+                            let padding = align_to - key_len;
+                            self.write(&" ".repeat(padding));
+                        }
                         self.write(" = ");
                         wrote_equals = true;
                     } else if wrote_colon && !wrote_equals {


### PR DESCRIPTION
## Summary

`carina fmt` aligns `=` columns inside resource blocks, `tags = { ... }` literals, and other key-value forms — but **not** inside `attributes {}` / `exports {}` blocks for the untyped (`key = value`) form. Result: every other key-value block in a file lines up, then `attributes {}` at the bottom is visually inconsistent.

```crn
# Before
attributes {
  role_arn = role.arn
  role_name = role.role_name
}

# After
attributes {
  role_arn  = role.arn
  role_name = role.role_name
}
```

## Fix

`format_attributes_param` already had `align_to` (the longest key in the block) and used it to pad before `:` for typed entries. It just never applied the same padding before `=` for untyped entries.

The fix adds a guard inside the existing `=` token branch:

```rust
if !wrote_colon && align_to > 0 && key_len < align_to {
    let padding = align_to - key_len;
    self.write(&" ".repeat(padding));
}
self.write(" = ");
```

The `!wrote_colon` part is what keeps the typed branch's behavior unchanged — typed entries still align at `:` exactly as before. Same function handles `attributes {}` and `exports {}` (via `NodeKind::ExportsBlock` / `ExportsParam`), so both are fixed in one shot.

## Tests

Four new regression tests in `carina-core/src/formatter/format.rs`:

- `issue_2641_attributes_block_aligns_equals_for_untyped_entries` — base case + idempotence
- `issue_2641_exports_block_aligns_equals_for_untyped_entries` — `exports {}` parity
- `issue_2641_attributes_block_mixed_typed_and_untyped` — typed entries unaffected, untyped `=` columns line up against the same `align_to`
- `issue_2641_attributes_block_degenerate_shapes` — empty block + single-entry block don't crash and don't grow phantom whitespace

Real-infra smoke confirmed against `carina-rs/infra/usecases/bootstrap/main.crn` and `carina-rs/infra/modules/github-oidc/main.crn`.

## Follow-up

Filed #2660 to extract the `align_to > 0 && key_len < align_to` padding pattern into a `Formatter::write_alignment_padding` helper — surfaces six identical sites across the formatter (this PR adds the sixth). Out of scope for this fix per "1 PR = 1 topic".

Closes #2641
