### PR TITLE
validation: accept Simple(name) into Union<plain String, ...non-scalars>

### DIFF
--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -1960,6 +1960,51 @@ mod tests {
         assert!(errs[0].location.contains("for"));
     }
 
+    // Issue #2663: a semantic-ARN refinement (e.g. `IamOidcProviderArn`)
+    // declared on an upstream export must be assignable to a
+    // `Union<Struct(Principal), String>` receiver — the canonical IAM
+    // policy `principal` slot. Before the fix, the Struct member made
+    // the union fall through to the catch-all reject so the arn was
+    // refused at the very position it was designed for.
+    #[test]
+    fn type_check_accepts_arn_refinement_into_principal_union() {
+        use crate::schema::{AttributeType, StructField};
+        let parsed = parse_project_with_provider(
+            r#"
+                let bootstrap = upstream_state { source = "../bootstrap" }
+                test.r.res {
+                    name = { federated = bootstrap.oidc_provider_arn }
+                }
+            "#,
+            "test",
+        );
+        let exports = mk_typed_exports(&[(
+            "bootstrap",
+            &[(
+                "oidc_provider_arn",
+                TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
+            )],
+        )]);
+        // Mirrors the canonical IAM `principal` slot shape:
+        // `Union<Struct(IamPolicyPrincipal), String>`. The map walker
+        // hits the Union catch-all and walks each value against the
+        // whole union, so the leaf `Simple(iam_oidc_provider_arn)`
+        // must be assignable to the union receiver directly.
+        let principal_union = AttributeType::Union(vec![
+            AttributeType::Struct {
+                name: "IamPolicyPrincipal".to_string(),
+                fields: vec![StructField::new("federated", AttributeType::String)],
+            },
+            AttributeType::String,
+        ]);
+        let schemas = schema_with_attr("name", principal_union);
+        let errs = check_upstream_state_field_types(&parsed, &exports, &schemas);
+        assert!(
+            errs.is_empty(),
+            "IamOidcProviderArn must be assignable into Union<Struct, String>, got: {errs:?}"
+        );
+    }
+
     #[test]
     fn type_check_accepts_custom_type_chain() {
         // Consumer attribute is `Custom { name: "KmsKeyArn", base: Arn }`;

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -429,7 +429,36 @@ pub fn is_type_expr_compatible_with_schema(
                     _ => break,
                 }
             }
-            is_plain_string_or_string_union(attr_type)
+            if is_plain_string_or_string_union(attr_type) {
+                return true;
+            }
+            // Issue #2663: a `Simple(name)` value is unambiguously
+            // string-shaped at runtime, so it can flow into a `Union`
+            // receiver as long as one member is plain `String` and
+            // every other member is shape-disjoint from a string —
+            // i.e. `List`/`Map`/`Struct`. The runtime dispatch on
+            // shape sends the value to the String branch with no
+            // ambiguity. Mixing in another scalar member (e.g.
+            // `Union<String, Int>`) keeps falling through here, so
+            // the existing `Simple → Union<String, Int>` rejection
+            // (`type_compat_simple_rejected_by_mixed_string_int_union_receiver`)
+            // is preserved.
+            if let AttributeType::Union(members) = attr_type {
+                let has_plain_string = members.iter().any(|m| matches!(m, AttributeType::String));
+                let others_shape_disjoint = members.iter().all(|m| {
+                    matches!(
+                        m,
+                        AttributeType::String
+                            | AttributeType::List { .. }
+                            | AttributeType::Map { .. }
+                            | AttributeType::Struct { .. }
+                    )
+                });
+                if has_plain_string && others_shape_disjoint {
+                    return true;
+                }
+            }
+            false
         }
         TypeExpr::List(inner) => match attr_type {
             AttributeType::List {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -1764,6 +1764,127 @@ fn type_compat_simple_subtypes_into_plain_string() {
     ));
 }
 
+// Issue #2663: a semantic-ARN refinement (`IamOidcProviderArn`) flowed
+// into a `Union<Struct(Principal), String>` receiver — the canonical
+// shape for IAM-style policy `principal` slots — was rejected because
+// the existing `Union<plain String>` rule required *every* member to
+// be a plain String. The Struct member made the union fall through to
+// the catch-all reject. The Simple value is unambiguously string-shaped
+// at runtime, and the Struct member only accepts map-shaped values, so
+// the two members are shape-disjoint and the assignment is safe.
+#[test]
+fn type_compat_simple_into_union_struct_or_string() {
+    use crate::schema::StructField;
+    let principal_union = AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "IamPolicyPrincipal".to_string(),
+            fields: vec![StructField::new("federated", AttributeType::String)],
+        },
+        AttributeType::String,
+    ]);
+    // Issue #2663 enumerates the full set of ARN refinements that
+    // should reach the principal slot; pin each one against the same
+    // receiver so the table is the spec.
+    for name in [
+        "arn",
+        "iam_role_arn",
+        "iam_policy_arn",
+        "iam_oidc_provider_arn",
+        "kms_key_arn",
+    ] {
+        assert!(
+            is_type_expr_compatible_with_schema(
+                &TypeExpr::Simple(name.to_string()),
+                &principal_union,
+            ),
+            "Simple({name}) should be assignable to Union<Struct, String>"
+        );
+    }
+}
+
+// Guards the boundary the new rule must not cross: if any non-String
+// member of the union is *also* scalar-shaped, the union receiver can
+// reinterpret the value down a non-string branch, which is the unsafe
+// case the original `Union<String, Int>` test pinned. A union mixing
+// Struct, String, and Int must still reject `Simple(name)` because the
+// Int branch competes for primitive values.
+#[test]
+fn type_compat_simple_rejected_when_union_has_other_scalar() {
+    use crate::schema::StructField;
+    let mixed = AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "Principal".to_string(),
+            fields: vec![StructField::new("federated", AttributeType::String)],
+        },
+        AttributeType::String,
+        AttributeType::Int,
+    ]);
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
+        &mixed,
+    ));
+}
+
+// A union without any plain-String member cannot accept a Simple value:
+// even a List<String> member shapes its values as a list, not a string.
+#[test]
+fn type_compat_simple_rejected_when_union_has_no_plain_string() {
+    use crate::schema::StructField;
+    let no_string = AttributeType::Union(vec![
+        AttributeType::Struct {
+            name: "Principal".to_string(),
+            fields: vec![StructField::new("federated", AttributeType::String)],
+        },
+        AttributeType::List {
+            inner: Box::new(AttributeType::String),
+            ordered: true,
+        },
+    ]);
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
+        &no_string,
+    ));
+}
+
+// `Custom` and `StringEnum` are deliberately excluded from the new
+// Union allow-list: both are string-shaped at runtime, so a `Simple`
+// value sharing a union with one of them is ambiguous about which
+// branch the consumer treats as the route. The Custom-chain walk
+// above already handles the *specific* "Simple subtypes of this
+// Custom" case at the top of the arm; the union escape hatch is for
+// shape-disjoint members only. If these arms are ever folded into the
+// allow-list, this test will fail and force a re-think.
+#[test]
+fn type_compat_simple_rejected_when_union_has_string_shaped_peer() {
+    let arn = AttributeType::Custom {
+        semantic_name: Some("Arn".to_string()),
+        base: Box::new(AttributeType::String),
+        pattern: None,
+        length: None,
+        validate: noop_validator(),
+        namespace: None,
+        to_dsl: None,
+    };
+    let with_custom = AttributeType::Union(vec![AttributeType::String, arn]);
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
+        &with_custom,
+    ));
+    let with_enum = AttributeType::Union(vec![
+        AttributeType::String,
+        AttributeType::StringEnum {
+            name: "Status".to_string(),
+            values: vec!["enabled".to_string(), "disabled".to_string()],
+            namespace: None,
+            to_dsl: None,
+        },
+    ]);
+    assert!(!is_type_expr_compatible_with_schema(
+        &TypeExpr::Simple("iam_oidc_provider_arn".to_string()),
+        &with_enum,
+    ));
+}
+
 #[test]
 fn validate_export_param_ref_types_map_accepts_compatible_types() {
     use crate::parser::InferredExportParam;


### PR DESCRIPTION
## Summary

Closes #2663.

A semantic-ARN refinement declared via `TypeExpr::Simple(name)` (e.g. `IamOidcProviderArn`) was rejected when assigned to the canonical IAM principal slot `Union<Struct(IamPolicyPrincipal), String>`. The Union arm of `is_type_expr_compatible_with_schema` only accepted unions whose members were *all* plain `String`, so the `Struct` member made every IAM-policy principal position reject every ARN refinement — defeating the whole point of the new semantic types.

## Fix

Extend the `Simple(name)` arm in `is_type_expr_compatible_with_schema` so a Union receiver passes when:

- one member is plain `String`, AND
- every other member is shape-disjoint from a string at runtime (`List` / `Map` / `Struct`).

A `Simple(name)` value is unambiguously string-shaped at runtime, and the non-scalar members only accept container-shaped values, so runtime dispatch is unambiguous.

`Custom` and `StringEnum` are deliberately excluded from the allow-list — both are string-shaped at runtime, so sharing a union with one of them would re-introduce the ambiguity the rule is trying to avoid. A boundary test (`type_compat_simple_rejected_when_union_has_string_shaped_peer`) pins this exclusion. The existing `Union<String, Int>` rejection is preserved.

## Test plan

- [x] `cargo nextest run --workspace` (3014 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)
- [x] Real-infra smoke: `carina validate carina-rs/infra/registry/dev/registry-deploy` — pre-fix reports the #2663 error, post-fix prints `✓ 3 resources validated successfully.`

New tests:

- `type_compat_simple_into_union_struct_or_string` — pins all 5 ARN refinements enumerated in the issue (`arn`, `iam_role_arn`, `iam_policy_arn`, `iam_oidc_provider_arn`, `kms_key_arn`)
- `type_compat_simple_rejected_when_union_has_other_scalar` — `Union<Struct, String, Int>` still rejects (Int competes)
- `type_compat_simple_rejected_when_union_has_no_plain_string` — `Union<Struct, List<String>>` rejects (no plain String member)
- `type_compat_simple_rejected_when_union_has_string_shaped_peer` — `Union<String, Custom>` and `Union<String, StringEnum>` reject (string-shaped peer ambiguity)
- `type_check_accepts_arn_refinement_into_principal_union` — full pipeline acceptance test through `check_upstream_state_field_types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)