### PR TITLE
state: append trailing newline to carina-backend.lock

### DIFF
--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -111,8 +111,12 @@ impl BackendLock {
     /// Persist this lock snapshot at the project root.
     pub fn save(&self, base_dir: &Path) -> BackendResult<()> {
         let path = Self::lock_path(base_dir);
-        let contents = serde_json::to_string_pretty(self)
+        let mut contents = serde_json::to_string_pretty(self)
             .map_err(|e| BackendError::Serialization(e.to_string()))?;
+        // Match the trailing-newline convention used by
+        // `carina-providers.lock` so POSIX tooling and "add final
+        // newline" editors agree on the file shape.
+        contents.push('\n');
         std::fs::write(&path, contents)
             .map_err(|e| BackendError::Io(format!("Failed to write {}: {}", path.display(), e)))?;
         Ok(())
@@ -220,6 +224,22 @@ mod tests {
         // Should be at root, not in .carina/
         assert!(tmp.path().join("carina-backend.lock").exists());
         assert!(!tmp.path().join(".carina/backend-lock.json").exists());
+    }
+
+    // Pin the byte-level shape so carina-backend.lock and
+    // carina-providers.lock stay consistent (both end with `\n`).
+    #[test]
+    fn lock_file_ends_with_trailing_newline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock = BackendLock::from_config(&make_config("b", "us-east-1")).unwrap();
+        lock.save(tmp.path()).unwrap();
+        let bytes = std::fs::read(tmp.path().join("carina-backend.lock")).unwrap();
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "carina-backend.lock must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2583.

`BackendLock::save` writes JSON via `serde_json::to_string_pretty` then `fs::write`. `to_string_pretty` does not emit a trailing newline, while the sibling `carina-providers.lock` (written by `toml::to_string_pretty`) already ends with `\n`. The asymmetry trips POSIX tooling (`tail`, `wc -l`), editors with "add final newline" enabled, and VCS auto-newline hooks.

## Fix

Append `\n` to the serialized contents before `fs::write` in `carina-state/src/backend_lock.rs::save`. Pin the byte-level shape with a new test that asserts `tail -c 1 carina-backend.lock` returns `\n`.

`load()` requires no change — `serde_json::from_str` is already whitespace-tolerant per the JSON spec, and the existing `lock_roundtrip_via_disk` test exercises the read-after-write path.

## Follow-ups (out of scope)

The 5-round review surfaced two more JSON write paths with the same bug class. Filed as separate issues per the "1 PR = 1 topic" rule:

- #2721 — `carina.state.json` (state file written by `LocalBackend::write_state`)
- #2722 — `plan.json` written by `carina plan --out`

Transient lock-coordination files (`acquire_lock`, `acquire_recovery_claim`, `renew_lock`) are deleted on release and not human-inspected, so excluded.

## Test plan

- [x] `cargo nextest run -p carina-state` (103 tests pass; new `lock_file_ends_with_trailing_newline` confirms the fix)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)