### PR TITLE
docs: design + plan for shareable provider attributes (#2717)

### DIFF
--- a/docs/plans/2026-05-09-share-provider-attributes.md
+++ b/docs/plans/2026-05-09-share-provider-attributes.md
@@ -1,0 +1,650 @@
+# Implementation plan: shareable provider attributes
+
+<!-- derived-from ../specs/2026-05-09-share-provider-attributes-design.md -->
+
+Issue: [#2717](https://github.com/carina-rs/carina/issues/2717)
+
+Spec: `docs/specs/2026-05-09-share-provider-attributes-design.md`
+
+This plan decomposes the design into 7 TDD-sized tasks. Each task is
+independently verifiable and produces a single failing test before
+implementation. Tasks are ordered so each builds on the previous one.
+
+The work splits cleanly into two PRs:
+
+- **PR 1 — language change** (Tasks 1–6): make `default_tags`
+  accept resolved `let`-binding references in `carina-core`.
+- **PR 2 — LSP follow-through** (Task 7): bring `carina-lsp`
+  diagnostics in line so editor warnings stay in parity with CLI
+  validate.
+
+Both PRs need to land before the rule
+"validate and LSP warnings must reach parity"
+(memory) is satisfied; the issue is closed only after Task 7 ships.
+
+## Files
+
+### Modified
+- `carina-core/src/parser/ast.rs` — `ProviderConfig` gains a transient
+  field for unresolved well-known attributes.
+- `carina-core/src/parser/blocks/provider.rs` — stops peeling
+  `default_tags` at parse time; collects it into the new transient
+  field instead.
+- `carina-core/src/parser/resolve.rs` — new post-resolver step
+  `finalize_provider_configs`, plus an extension to
+  `accumulate_undefined_reference_errors` that visits provider
+  attribute values.
+- `carina-core/src/parser/tests.rs` — existing
+  `parse_provider_block_with_default_tags`,
+  `parse_provider_block_without_default_tags`,
+  `provider_config_default_tags_preserve_insertion_order` may need to
+  be invoked through the post-resolver path. New tests cover the
+  reference-form input.
+- `carina-cli/tests/fixtures/` — new multi-file fixture
+  `share_provider_attrs/` with `providers.crn` + `modules/standard-tags/`.
+- `carina-cli/tests/` — integration test that loads the fixture and
+  asserts the resolved `default_tags`.
+- `carina-lsp/src/diagnostics/mod.rs` (or sibling) — keep
+  diagnostics in parity with CLI after the peel moves.
+
+### Created
+- `carina-cli/tests/fixtures/share_provider_attrs/component/providers.crn`
+- `carina-cli/tests/fixtures/share_provider_attrs/component/main.crn`
+- `carina-cli/tests/fixtures/share_provider_attrs/modules/standard-tags/main.crn`
+
+## Verification commands
+
+Per CLAUDE.md verify protocol — crate-scoped first, workspace before PR:
+
+```bash
+cargo check -p carina-core
+cargo nextest run -p carina-core
+cargo nextest run -p carina-cli
+cargo nextest run -p carina-lsp        # only for Task 7
+cargo test --workspace --doc           # before PR
+cargo clippy --workspace --all-targets -- -D warnings
+bash scripts/check-*.sh
+```
+
+---
+
+## Task 1 — Add transient `unresolved_attributes` field to `ProviderConfig`
+
+### Goal
+Give `ProviderConfig` a place to carry un-peeled attribute values
+through the resolver. This is the type-level prerequisite for moving
+the peel; no behaviour change yet.
+
+### Files
+- `carina-core/src/parser/ast.rs`
+
+### Test
+Add a unit test asserting that the field exists, defaults to empty,
+and survives `Clone`/`Debug`/`PartialEq` (the existing derives on
+`ProviderConfig`):
+
+```rust
+// carina-core/src/parser/tests.rs
+#[test]
+fn provider_config_carries_unresolved_attributes_field() {
+    use crate::parser::ast::ProviderConfig;
+    use indexmap::IndexMap;
+
+    let pc = ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+    };
+    assert!(pc.unresolved_attributes.is_empty());
+}
+```
+
+### Implementation
+In `carina-core/src/parser/ast.rs`, add the field to `ProviderConfig`:
+
+```rust
+pub struct ProviderConfig {
+    pub name: String,
+    pub attributes: IndexMap<String, Value>,
+    pub default_tags: IndexMap<String, Value>,
+    pub source: Option<String>,
+    pub version: Option<VersionConstraint>,
+    pub revision: Option<String>,
+
+    /// Well-known attributes whose values were not literal at parse
+    /// time (e.g. `default_tags = some_let.field`). Populated by the
+    /// parser; drained and validated by `finalize_provider_configs`
+    /// after the resolver pass. Always empty after finalization.
+    pub unresolved_attributes: IndexMap<String, Value>,
+}
+```
+
+`parse_provider_block` continues to populate `unresolved_attributes`
+with `IndexMap::new()` for now (no peel change yet); other
+construction sites in tests get the same `IndexMap::new()`.
+
+### Verification
+```bash
+cargo nextest run -p carina-core provider_config_carries_unresolved_attributes_field
+```
+Expected: passes after the field is added.
+
+---
+
+## Task 2 — Parse defers `default_tags` when its value is not a literal map
+
+### Goal
+Stop the silent-empty fallback. When `parse_provider_block` sees
+`default_tags = some_reference`, route the value to
+`unresolved_attributes` instead of dropping it on the floor. Literal
+`default_tags = { ... }` continues to populate
+`ProviderConfig.default_tags` directly so existing tests keep passing.
+
+### Files
+- `carina-core/src/parser/blocks/provider.rs`
+
+### Test
+```rust
+// carina-core/src/parser/tests.rs
+#[test]
+fn parse_provider_block_defers_non_literal_default_tags() {
+    let input = r#"
+        let shared = { Env = 'dev', Team = 'infra' }
+
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = shared
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    let pc = &parsed.providers[0];
+
+    // Not silently dropped: held in unresolved_attributes for the
+    // resolver to finish.
+    assert!(pc.default_tags.is_empty(), "literal-only field stays empty");
+    assert!(
+        pc.unresolved_attributes.contains_key("default_tags"),
+        "non-literal default_tags must be deferred, not dropped"
+    );
+}
+```
+
+### Implementation
+In `carina-core/src/parser/blocks/provider.rs`, replace the
+silent-empty fallback:
+
+```rust
+let mut unresolved_attributes: IndexMap<String, Value> = IndexMap::new();
+
+let default_tags = match attributes.shift_remove("default_tags") {
+    Some(Value::Map(tags)) => tags,
+    Some(other) => {
+        unresolved_attributes.insert("default_tags".to_string(), other);
+        IndexMap::new()
+    }
+    None => IndexMap::new(),
+};
+```
+
+Pass `unresolved_attributes` into the constructed `ProviderConfig`.
+Existing `default_tags = { ... }` literal tests keep passing because
+the `Value::Map` arm is unchanged.
+
+### Verification
+```bash
+cargo nextest run -p carina-core parse_provider_block_defers_non_literal_default_tags
+cargo nextest run -p carina-core parse_provider_block_with_default_tags
+cargo nextest run -p carina-core parse_provider_block_without_default_tags
+cargo nextest run -p carina-core provider_config_default_tags_preserve_insertion_order
+```
+Expected: new test passes, existing literal-form tests keep passing.
+
+---
+
+## Task 3 — Identifier-scope check visits provider attribute values
+
+### Goal
+A typo in a `let`-reference inside a provider block must surface as
+`UndefinedIdentifier`, not a silent runtime miss. Today
+`accumulate_undefined_reference_errors` walks resources, attribute
+params, module-call args, and export params; provider attributes are
+not in the list.
+
+### Files
+- `carina-core/src/parser/resolve.rs`
+
+### Test
+```rust
+// carina-core/src/parser/tests.rs
+#[test]
+fn provider_block_undefined_let_reference_flagged() {
+    let input = r#"
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = nonexistent_binding
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    let errs = check_identifier_scope(&parsed);
+    assert!(
+        errs.iter().any(|e| format!("{e}").contains("nonexistent_binding")),
+        "expected UndefinedIdentifier for `nonexistent_binding`, got: {errs:?}"
+    );
+}
+```
+
+### Implementation
+In `accumulate_undefined_reference_errors`
+(`carina-core/src/parser/resolve.rs:296`), add a pass over provider
+configs:
+
+```rust
+for provider in &parsed.providers {
+    for value in provider.attributes.values() {
+        check(value);
+    }
+    for value in provider.unresolved_attributes.values() {
+        check(value);
+    }
+}
+```
+
+The closure `check` already calls `value.visit_refs` and uses the
+shared `known` binding set, so this is a one-loop addition.
+
+### Verification
+```bash
+cargo nextest run -p carina-core provider_block_undefined_let_reference_flagged
+cargo nextest run -p carina-core check_identifier_scope
+```
+Expected: new test passes; existing identifier-scope tests stay
+green.
+
+---
+
+## Task 4 — `finalize_provider_configs` resolves deferred provider attributes
+
+### Goal
+After the resolver substitutes `Value::ResourceRef`s with concrete
+values, walk every `ProviderConfig`, drain
+`unresolved_attributes["default_tags"]`, validate it as a map of
+strings, and write it into `ProviderConfig.default_tags`. Emit a
+typed error if the resolved value is not a map.
+
+### Files
+- `carina-core/src/parser/resolve.rs`
+- `carina-core/src/parser/error.rs` (if a new error variant is the
+  cleanest fit; otherwise reuse `InvalidExpression`)
+
+### Test
+```rust
+// carina-core/src/parser/tests.rs
+#[test]
+fn finalize_provider_configs_promotes_resolved_default_tags() {
+    let input = r#"
+        let shared = { Env = 'dev', Team = 'infra' }
+
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = shared
+        }
+    "#;
+
+    // Full pipeline: parse -> resolve refs -> finalize providers.
+    let parsed = parse_and_resolve(input).unwrap();
+
+    let pc = &parsed.providers[0];
+    assert!(pc.unresolved_attributes.is_empty(),
+            "finalize must drain unresolved_attributes");
+    assert_eq!(pc.default_tags.len(), 2);
+    assert_eq!(
+        pc.default_tags.get("Env"),
+        Some(&Value::String("dev".to_string())),
+    );
+    assert_eq!(
+        pc.default_tags.get("Team"),
+        Some(&Value::String("infra".to_string())),
+    );
+}
+
+#[test]
+fn finalize_provider_configs_rejects_non_map_default_tags() {
+    let input = r#"
+        let bad = "not a map"
+
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = bad
+        }
+    "#;
+
+    let err = parse_and_resolve(input).unwrap_err();
+    assert!(format!("{err}").contains("default_tags"),
+            "error must mention default_tags; got: {err}");
+}
+```
+
+(`parse_and_resolve` is the existing or new helper that runs parse +
+resolver + finalize. If it doesn't exist, expose a thin wrapper in
+`carina-core/src/parser/mod.rs` that the tests can call.)
+
+### Implementation
+In `carina-core/src/parser/resolve.rs`, add:
+
+```rust
+pub fn finalize_provider_configs(parsed: &mut ParsedFile) -> Result<(), ParseError> {
+    for provider in parsed.providers.iter_mut() {
+        if let Some(value) = provider.unresolved_attributes.shift_remove("default_tags") {
+            match value {
+                Value::Map(tags) => {
+                    provider.default_tags = tags;
+                }
+                other => {
+                    return Err(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "Provider '{}': default_tags must resolve to a map, got {other:?}",
+                            provider.name
+                        ),
+                    });
+                }
+            }
+        }
+        // Future: source / version / revision peel land here.
+        debug_assert!(
+            provider.unresolved_attributes.is_empty(),
+            "unresolved_attributes must be drained by finalize",
+        );
+    }
+    Ok(())
+}
+```
+
+Wire `finalize_provider_configs` into the existing post-parse pipeline
+(the place where `check_identifier_scope` and friends are already
+invoked — typically `carina-core/src/parser/mod.rs::parse` or the CLI
+load path).
+
+### Verification
+```bash
+cargo nextest run -p carina-core finalize_provider_configs_promotes_resolved_default_tags
+cargo nextest run -p carina-core finalize_provider_configs_rejects_non_map_default_tags
+cargo nextest run -p carina-core             # full crate
+```
+Expected: both new tests pass; the full carina-core suite stays green.
+
+---
+
+## Task 5 — Multi-file fixture for shared `default_tags`
+
+### Goal
+Codify the directory-scoped acceptance shape from the design doc as a
+fixture, and add an integration test that drives the same path
+`carina validate` would.
+
+### Files
+- `carina-cli/tests/fixtures/share_provider_attrs/component/providers.crn` (new)
+- `carina-cli/tests/fixtures/share_provider_attrs/component/main.crn` (new)
+- `carina-cli/tests/fixtures/share_provider_attrs/modules/standard-tags/main.crn` (new)
+- `carina-cli/tests/share_provider_attrs.rs` (new) — integration test
+
+### Test
+Fixture content:
+
+`modules/standard-tags/main.crn`:
+```crn
+arguments {
+  environment: string
+  component:   string
+}
+
+exports {
+  tags = {
+    ManagedBy   = 'carina'
+    Project     = 'carina-rs'
+    Repository  = 'carina-rs/infra'
+    Environment = environment
+    Component   = component
+  }
+}
+```
+
+`component/providers.crn`:
+```crn
+let st = use { source = '../modules/standard-tags' }
+
+let tags = st {
+  environment = 'dev'
+  component   = 'registry'
+}
+
+provider mock {
+  source       = 'github.com/carina-rs/carina-provider-mock'
+  version      = '~0.1.0'
+  default_tags = tags.tags
+}
+```
+
+`component/main.crn`: a single mock resource so the directory parses
+as a complete component (use the existing mock-resource shape from
+other fixtures, e.g. `version_constraint`).
+
+Integration test:
+
+```rust
+// carina-cli/tests/share_provider_attrs.rs
+use std::path::PathBuf;
+
+#[test]
+fn share_provider_attrs_resolves_default_tags() {
+    let fixture: PathBuf = ["tests", "fixtures", "share_provider_attrs", "component"]
+        .iter()
+        .collect();
+
+    // Loads the directory through the same path the CLI uses.
+    let parsed = carina_core::load_directory(&fixture).expect("parse + resolve");
+    let provider = parsed
+        .providers
+        .iter()
+        .find(|p| p.name == "mock")
+        .expect("provider mock present");
+
+    let tags = &provider.default_tags;
+    assert_eq!(tags.get("ManagedBy"), Some(&carina_core::Value::String("carina".into())));
+    assert_eq!(tags.get("Environment"), Some(&carina_core::Value::String("dev".into())));
+    assert_eq!(tags.get("Component"),   Some(&carina_core::Value::String("registry".into())));
+}
+```
+
+(If `carina_core::load_directory` is not the public entry point, swap
+to whatever `carina-cli` uses today — `ModuleResolver::load_module` or
+similar. The test must run the *full* directory-scoped pipeline, not
+a single-string parse.)
+
+### Implementation
+Drop the three fixture files; write the integration test against the
+public entry point currently used by `carina validate`.
+
+### Verification
+```bash
+cargo nextest run -p carina-cli share_provider_attrs_resolves_default_tags
+```
+Expected: passes — and proves end-to-end that directory-scoped resolve
++ finalize produces the exact tag map we want.
+
+---
+
+## Task 6 — Real-infra smoke verification
+
+### Goal
+The design doc requires a real-infra smoke test. Confirm `carina
+validate` on a `carina-rs/infra` component using a shared
+`standard-tags` module produces the same effective tags as a literal
+map.
+
+### Files
+- None checked into this repo.
+- A throwaway scratch directory under `carina-rs/infra` (the user's
+  working copy) with a `standard-tags/` module and one component
+  using it via `let st = use { ... }` + `default_tags = tags.tags`.
+
+### Test
+Run sequentially against the user's `carina-rs/infra` working copy:
+
+```bash
+# Build the worktree's binary (no cargo install side effects)
+cargo build -p carina-cli
+
+CARINA=$(pwd)/target/debug/carina
+
+# Baseline: literal default_tags variant — capture the rendered plan
+aws-vault exec mizzy -- "$CARINA" plan /path/to/literal-variant > /tmp/plan-literal.txt
+
+# New shape: same directory rewritten to use the shared module
+aws-vault exec mizzy -- "$CARINA" plan /path/to/shared-variant > /tmp/plan-shared.txt
+
+# Effective tags must match
+diff /tmp/plan-literal.txt /tmp/plan-shared.txt
+```
+
+Acceptance: tag-bearing diff lines (`ManagedBy`, `Project`,
+`Repository`, `Environment`, `Component`) are identical between
+literal and shared variants.
+
+### Implementation
+Run the steps above. Capture the output in a comment on the issue or
+PR description so reviewers can see the smoke result. No code change
+in this repo.
+
+### Verification
+- Both `plan` invocations exit `0`.
+- `diff` shows no difference in the rendered tag set.
+
+---
+
+## Task 7 — LSP diagnostics parity for provider attributes
+
+### Goal
+When the user writes `default_tags = nonexistent_binding` in a
+provider block, the editor must show the same `UndefinedIdentifier`
+warning that `carina validate` shows. Same for "resolved value is not
+a map." Today LSP diagnostics drive off the same parse pipeline as
+the CLI; after Task 4 the validation site moved to a post-resolver
+pass, so the LSP entry point needs to invoke that pass too.
+
+### Files
+- `carina-lsp/src/diagnostics/mod.rs` (or sibling — wherever the LSP
+  invokes `parse`)
+- `carina-lsp/src/diagnostics/checks.rs` (if module-loading interacts
+  with finalize)
+
+### Test
+```rust
+// carina-lsp/src/diagnostics/tests.rs (or the existing diagnostics
+// test module)
+#[test]
+fn lsp_flags_undefined_let_reference_in_provider_block() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("providers.crn"),
+        r#"
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = nonexistent_binding
+        }
+        "#,
+    ).unwrap();
+
+    let diags = run_diagnostics(dir.path());
+    assert!(
+        diags.iter().any(|d| d.message.contains("nonexistent_binding")),
+        "LSP must surface UndefinedIdentifier for nonexistent_binding; got: {diags:?}"
+    );
+}
+
+#[test]
+fn lsp_flags_non_map_default_tags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("providers.crn"),
+        r#"
+        let bad = "not a map"
+
+        provider awscc {
+          source       = 'github.com/carina-rs/carina-provider-awscc'
+          revision     = 'main'
+          default_tags = bad
+        }
+        "#,
+    ).unwrap();
+
+    let diags = run_diagnostics(dir.path());
+    assert!(
+        diags.iter().any(|d| d.message.contains("default_tags")),
+        "LSP must surface non-map default_tags error; got: {diags:?}"
+    );
+}
+```
+
+`run_diagnostics` is the existing test helper (or a thin wrapper over
+the public diagnostics entry point). If it doesn't yet support
+multi-file directories, extend it minimally.
+
+### Implementation
+Audit the LSP entry that today produces parser diagnostics — typically
+`carina-lsp/src/diagnostics/mod.rs` in the `analyze`/`diagnose`
+function — and ensure it calls the same post-parse pipeline used by
+the CLI: `parse` → resolve → `check_identifier_scope` →
+`finalize_provider_configs`. If the LSP has its own slimmer pipeline,
+add the new step there too.
+
+`finalize_provider_configs` returns a `ParseError`; the LSP already
+has machinery for converting `ParseError` to a `Diagnostic` — use it.
+
+### Verification
+```bash
+cargo nextest run -p carina-lsp lsp_flags_undefined_let_reference_in_provider_block
+cargo nextest run -p carina-lsp lsp_flags_non_map_default_tags
+cargo nextest run -p carina-lsp                    # full crate
+cargo test --workspace --doc
+cargo clippy --workspace --all-targets -- -D warnings
+bash scripts/check-*.sh
+```
+Expected: both new LSP tests pass; full carina-lsp suite stays green;
+workspace doctests, clippy, and repo invariant scripts are clean.
+
+---
+
+## Self-review checklist
+
+- [x] Every task has a concrete failing test before implementation.
+- [x] No "implement similar to Task N" — each task's
+      Implementation block names the exact file lines / function /
+      structural change.
+- [x] Each task is independently verifiable with a runnable command.
+- [x] Task order respects dependencies: AST field (1) → parser
+      defers (2) → identifier scope (3) → finalize (4) → fixture (5)
+      → real infra (6) → LSP (7).
+- [x] Existing tests (`parse_provider_block_with_default_tags`,
+      `parse_provider_block_without_default_tags`,
+      `provider_config_default_tags_preserve_insertion_order`) are
+      either preserved or explicitly migrated; the design's "user-
+      facing diagnostic doesn't regress" contract is upheld in Task 4.
+- [x] Multi-file fixture covers the directory-scoped invariant from
+      CLAUDE.md.
+- [x] LSP/CLI parity (memory rule) is reached before the issue is
+      closed.
+- [x] `merge` DSL function and `source`/`version`/`revision`
+      reference-form support are *out of scope* per the design doc;
+      not in any task.

--- a/docs/specs/2026-05-09-share-provider-attributes-design.md
+++ b/docs/specs/2026-05-09-share-provider-attributes-design.md
@@ -1,0 +1,312 @@
+# Sharing provider attributes across components
+
+<!-- derived-from ../../CLAUDE.md#directory-scoped-never-single-file -->
+
+Issue: [#2717](https://github.com/carina-rs/carina/issues/2717)
+
+## Goal
+
+Make it possible to factor out a shared set of provider-block attributes
+— most concretely `default_tags` — and reuse it across multiple
+component directories without copy-pasting the literal map.
+
+The driver is `carina-rs/infra`. The next several PRs (`registry/dev/registry-deploy/`,
+`registry/dev/registry/`, `registry/prod/registry-deploy/`,
+`registry/prod/registry/`, etc.) all want the same five-key
+`default_tags` set with one or two values flipped per environment /
+component. Today every `providers.crn` has to repeat the literal map.
+We want a first-class way to share it.
+
+## Background
+
+`provider <name> { ... }` is currently a closed shape:
+
+- The pest grammar accepts `attribute*` inside the block, where each
+  `attribute = identifier "=" expression`.
+- `parse_provider_block` in `carina-core/src/parser/blocks/provider.rs`
+  evaluates each attribute via `parse_expression` and stuffs the
+  results into an `IndexMap<String, Value>`.
+- A handful of attributes are pulled out of that map by name with
+  pattern matches that **assume a literal value at parse time**:
+
+  ```rust
+  let default_tags = if let Some(Value::Map(tags)) =
+      attributes.shift_remove("default_tags") {
+      tags
+  } else {
+      IndexMap::new()
+  };
+  ```
+
+  The same pattern applies to `source` (`Value::String`), `version`,
+  and `revision`. If the right-hand side resolves to a `Value::ResourceRef`
+  — which is what a `let`-binding reference produces at parse time —
+  the pattern does not match and the attribute silently becomes empty
+  / `None`. No diagnostic, no error.
+
+That silent-empty behaviour is the concrete blocker for
+`default_tags = tags.tags`.
+
+## Chosen approach
+
+**Option 1** from the issue: allow the right-hand side of provider-block
+attribute values to be an arbitrary expression, including a reference
+to a top-level `let` binding. Source the shared values via the existing
+module + `exports` + `use` mechanism. No new vocabulary.
+
+The end-user shape:
+
+```crn
+# infra/.../registry/dev/registry-deploy/providers.crn
+let st = use { source = '../../../modules/standard-tags' }
+
+let tags = st {
+  environment = 'dev'
+  component   = 'registry'
+}
+
+provider awscc {
+  source       = 'github.com/carina-rs/carina-provider-awscc'
+  revision     = 'main'
+  region       = awscc.Region.ap_northeast_1
+  default_tags = tags.tags
+}
+```
+
+```crn
+# infra/.../modules/standard-tags/main.crn
+arguments {
+  environment: string
+  component:   string
+}
+
+exports {
+  tags = {
+    ManagedBy   = 'carina'
+    Project     = 'carina-rs'
+    Repository  = 'carina-rs/infra'
+    Environment = environment
+    Component   = component
+  }
+}
+```
+
+### Why Option 1, not Options 2/3
+
+| Axis | Option 1 (let + use) | Option 2 (`tag_set` module type) | Option 3 (parent-dir inheritance) |
+| ---- | -------------------- | -------------------------------- | --------------------------------- |
+| Language surface | None added (grammar already permits `expression`) | New module kind, new grammar, new LSP/diagnostics paths | New parent-walk semantics, new file convention |
+| Repetition removal | Full | Full | Full |
+| Greppability | Explicit reference at the use site | Explicit | Implicit; can't see the source from the call site |
+| Reuse beyond `default_tags` | `region`, `allowed_account_ids`, `revision` etc. all benefit | Per-attribute new types needed | Same parent-walk, but every attribute opts into implicit inheritance |
+
+Option 2 is rejected because it adds vocabulary for a problem the
+existing module system already solves. Option 3 is rejected because
+the issue itself flags it as "implicit; less greppable" and the
+project's `directory-scoped, never single-file` discipline does not
+extend to *parent*-directory walking.
+
+### What is already in place
+
+A test fixture written during this design pass parses cleanly through
+the grammar today:
+
+- `let st = use { source = '...' }` — existing
+- `let tags = st { environment = 'dev', component = 'registry' }`
+  parses as a `module_call` whose `module_name` is the alias `st`.
+  `collect_known_bindings_merged` (`carina-core/src/parser/resolve.rs:262`)
+  already includes `parsed.uses[].alias` in the binding name set, so
+  the `st` module name resolves.
+- Module `arguments { ... }` and `exports { ... }` blocks — existing.
+
+The only place that breaks is the parse-time extraction of `default_tags`
+in `parse_provider_block`.
+
+## Key design decisions
+
+### D1. Defer extraction of well-known provider attributes until after the resolver pass
+
+The pattern-match strip in `parse_provider_block` runs *during* parsing.
+The resolver runs *after* parsing. To accept references in
+`default_tags`, the strip needs to move past the resolver — or the
+provider config needs to carry an unresolved `Value` through the
+resolver and only get its well-known attributes peeled off at the end.
+
+Two viable shapes:
+
+- **D1a — Parse keeps everything in `attributes`; a post-resolver pass
+  peels off `default_tags` / `source` / `version` / `revision`.**
+  `ProviderConfig` stops carrying typed `default_tags`, `source`, etc.
+  fields at parse time; instead it carries the raw `attributes` map
+  plus a small post-resolver step that interprets the well-known keys
+  once their values have been resolved to literals.
+
+- **D1b — Parse keeps the typed fields, but their type widens to
+  accept unresolved values; the resolver visits provider configs and
+  rewrites them in place.** `default_tags: IndexMap<String, Value>`
+  stays, but the entry "value is `Value::ResourceRef`" is now
+  legitimate, and a new resolver step replaces it with the resolved
+  literal map.
+
+D1a is preferred. It keeps the resolver as the single source of truth
+for "when does a `ResourceRef` become a literal" and prevents new
+`Value`-shape assumptions from leaking into provider-aware code paths
+elsewhere (state, plan display, the WIT bridge).
+
+The implementation issue gets to pick the precise shape, but the
+design contract is: **after the resolver pass completes, `ProviderConfig`
+exposes typed `default_tags` / `source` / `version` / `revision`
+that look exactly like today's, and downstream consumers (provider
+plugin host, `merge_default_tags_for_provider`, plan display) keep
+working unchanged.**
+
+### D2. Validate the well-known attributes once they are resolved
+
+Type validation of `default_tags` (must resolve to a map of strings),
+`source` (string), `version` (string parseable as a version
+constraint), and `revision` (string) is currently inlined in
+`parse_provider_block` and emitted as a `ParseError`. After D1, those
+checks have to move to the post-resolver pass and surface as the same
+parse-class error so existing tests (e.g.
+`parse_provider_block_with_default_tags`,
+`parse_provider_version_revision_mutually_exclusive`) continue to
+catch the same shapes. The error site moves; the user-facing message
+doesn't.
+
+### D3. `merge` is out of scope for this PR
+
+Issue #2717's example shows `standard_tags { environment = 'dev', component = 'registry' }`
+overlaying a base set. The chosen approach handles per-instance overrides
+**through module arguments** (the `st { ... }` call), so `merge`
+itself is not on the critical path for solving the issue. A `merge`
+DSL function may still be desirable as a separate utility — for
+mixing default tags with per-resource tags, for example — but it is
+deferred to a follow-up issue. This document does not specify it.
+
+### D4. No new grammar
+
+The pest grammar already allows arbitrary `expression` in
+`attribute = identifier "=" expression`, which is what
+`provider_block` uses (`"provider" identifier "{" attribute* "}"`).
+No grammar change is needed; the change is entirely in
+`parse_provider_block` and the resolver.
+
+### D5. Scope of well-known attributes covered by this work
+
+The issue lists `default_tags` as the immediate need and mentions
+`allowed_account_ids`, `region`, and similar as future targets. This
+PR's design covers `default_tags` end-to-end (extraction site moved
+past resolver, validation moved, fixtures, real-infra smoke). The
+same mechanism transparently unlocks the other attributes once they
+go through the same post-resolver peel — but expanding the test
+coverage / docs / LSP completion to call them out is **not in scope**
+for this design. They become "free" once `default_tags` works, and
+each can be promoted in a follow-up issue when there's a concrete
+driver.
+
+## File structure / architecture
+
+Touched components:
+
+- **`carina-core/src/parser/blocks/provider.rs`** — main change. Parse
+  collects all attributes into `IndexMap<String, Value>` without
+  peeling. Mutual-exclusion check for `version` + `revision` either
+  stays here (still works on the raw values when both are literals,
+  errors for the resolved case after D1) or moves to the post-resolver
+  pass — implementer's choice.
+- **`carina-core/src/parser/ast.rs`** — `ProviderConfig`'s typed fields
+  (`default_tags`, `source`, `version`, `revision`) keep their types
+  and stay public. Internal storage may grow a transient
+  `unresolved_attributes` field (or equivalent) used only between
+  parse and resolver.
+- **`carina-core/src/parser/resolve.rs`** (or a sibling module) — new
+  post-resolver step that walks each `ProviderConfig`, looks up the
+  reserved keys in the unresolved map, validates their resolved
+  shapes, and writes them into the typed fields. Existing identifier-
+  scope checks (`accumulate_undefined_reference_errors`,
+  `check_identifier_scope`) already know how to chase `ResourceRef`
+  roots; they just need to be told to also visit provider attribute
+  values.
+- **Diagnostics in `carina-lsp/src/diagnostics/`** — must continue to
+  catch invalid shapes (e.g., `default_tags = "string"`,
+  `version = some_resource_ref`) with the same severity and message
+  class as today. The error sites move from parse to post-resolver
+  but the user-visible behaviour does not regress.
+- **`carina-cli/tests/fixtures/`** — at least one multi-file fixture
+  matching the `infra/aws/management/<dir>/` shape:
+  `main.crn` + `providers.crn` + a sibling `modules/standard-tags/`
+  directory. The fixture asserts that `default_tags` resolved through
+  `let` + `use` produces the same effective map as a literal
+  `default_tags = { ... }`.
+
+Untouched:
+
+- WIT bridge to provider plugins (provider host receives the same
+  resolved `IndexMap<String, Value>` it does today).
+- `merge_default_tags_for_provider` and the `Provider` trait's
+  `merge_default_tags` hook (`carina-core/src/provider.rs`). These see
+  resolved values and don't care how the values reached them.
+- State persistence and plan display (their input is the
+  resource-level merged tag map, after the provider host applies
+  `default_tags`).
+
+## Edge cases and constraints
+
+- **Silent-empty regression risk.** Today, a syntactically-valid but
+  type-wrong `default_tags = "string"` falls into the `else` branch
+  and silently produces an empty map. The post-resolver peel must
+  raise an error in that case rather than continuing the silent-empty
+  behaviour. A regression test pinning the diagnostic is required.
+- **Unknown reference at provider attribute.** A reference to an
+  undefined binding inside a provider attribute must surface via the
+  existing `UndefinedIdentifier` flow. `accumulate_undefined_reference_errors`
+  currently iterates `parsed.resources`, `parsed.attribute_params`,
+  `parsed.module_calls`, `parsed.export_params`, and deferred for-iterables.
+  A new arm for `parsed.providers[].attributes` (and the unresolved
+  default_tags / source / etc., if those live separately) is required.
+- **Directory-scoped, never single-file.** Per the
+  `directory-scoped, never single-file` rule (CLAUDE.md), the
+  acceptance fixture for this work is multi-file:
+  `providers.crn` + a `modules/standard-tags/` directory at minimum.
+  Adding a single-string unit test is fine *in addition*, never
+  *instead*.
+- **`use` + same-name `let` collision.** `let st = use { ... }` already
+  reserves `st` as the alias. If the user then writes
+  `let st = "literal"` later in the same directory, that is an
+  existing duplicate-binding error and remains so — the design does
+  not change collision semantics.
+- **Module call as RHS.** `let tags = st { environment = 'dev' }`
+  parses as a `module_call`. `parse_module_call` rejects
+  `module_name == "remote_state"` for migration reasons; no other
+  reserved names exist. The alias-equals-`module_name` resolution path
+  was added when `use` was introduced and is exercised by existing
+  tests.
+- **Empty `default_tags` after resolution.** If the resolved value is
+  an empty map (`{}`), preserve the existing behaviour: empty default
+  tags is allowed and equivalent to omitting the attribute.
+
+## Out of scope
+
+- A `merge` DSL function (D3).
+- Auto-migration of existing `providers.crn` files in `carina-rs/infra`.
+- Promoting `allowed_account_ids` / `region` / `revision` /
+  `region`-list to formally-tested shared-attribute targets (D5).
+- LSP completion suggesting `let` bindings inside provider blocks. The
+  identifier scope already includes them; `value_completions_for_attr`
+  may need a follow-up to surface them in completion lists, but that's
+  polish, not correctness.
+
+## Acceptance
+
+- `default_tags = some_let_binding.field` produces the same effective
+  resource-level tag map as a literal `default_tags = { ... }` with
+  the same contents, in plan, apply, and round-trip state.
+- Fixture demonstrating the multi-component shape from `Goal`.
+- Real-infra smoke: `aws-vault exec mizzy -- carina validate <one
+  registry/* component using a shared standard-tags module>`
+  succeeds, and `aws-vault exec mizzy -- carina plan ...` shows the
+  same effective tags it would have shown for the literal-map version.
+- All existing `parse_provider_block_*` tests continue to pass with
+  their current assertions; if any need to be replaced with
+  post-resolver equivalents, the replacement keeps the same
+  user-facing diagnostic.


### PR DESCRIPTION
Refs #2717.

Brainstorming output: a design document and an implementation plan
for letting `provider <name> { ... }` blocks reference shared
attribute values (concretely `default_tags`) via top-level `let`
bindings, sourced through the existing module + `exports` + `use`
mechanism.

## What this PR contains

- `docs/specs/2026-05-09-share-provider-attributes-design.md`
- `docs/plans/2026-05-09-share-provider-attributes.md`

No code changes. The implementation lands as a follow-up series of
issues (Tasks 1–7 in the plan).

## Chosen direction

Option 1 from the issue: allow provider-block attribute values to be
arbitrary expressions and reference top-level `let` bindings. No new
language vocabulary; sharing is sourced through `module + exports + use`.

End-user shape:

```crn
let st = use { source = '../../../modules/standard-tags' }

let tags = st {
  environment = 'dev'
  component   = 'registry'
}

provider awscc {
  source       = 'github.com/carina-rs/carina-provider-awscc'
  revision     = 'main'
  default_tags = tags.tags
}
```

Options 2 (dedicated `tag_set` module type) and 3 (parent-directory
inheritance) are rejected — the design doc records the rationale.

## Core implementation insight

The grammar already permits this shape; what breaks is that
`parse_provider_block` peels `default_tags` at parse time with a
pattern that only matches literal `Value::Map(...)`. A
`Value::ResourceRef` (what a `let` reference produces at parse time)
falls into the silent `else` branch and `default_tags` becomes empty
with no diagnostic. The implementation moves this peel past the
resolver pass and adds a `finalize_provider_configs` step.

## Task breakdown

PR 1 (carina-core / cli) — Tasks 1–6:
1. Add `ProviderConfig.unresolved_attributes` transient field
2. Defer non-literal `default_tags` at parse
3. `check_identifier_scope` visits provider attributes
4. `finalize_provider_configs` resolver-completion step
5. Multi-file fixture + integration test
6. Real-infra smoke against `carina-rs/infra`

PR 2 (carina-lsp) — Task 7:
7. LSP diagnostics parity for the new error sites

The work splits into 2 PRs to respect the validate↔LSP parity rule
without bundling unrelated crates.

## Out of scope

- A `merge` DSL function (handled via module `arguments` instead)
- Reference-form support for `source` / `version` / `revision`
- Auto-migration of existing `providers.crn` files in `carina-rs/infra`