### PR TITLE
state: append trailing newline to carina.state.json

### DIFF
--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -242,9 +242,14 @@ impl StateBackend for LocalBackend {
     }
 
     async fn write_state(&self, state: &StateFile) -> BackendResult<()> {
-        let content = serde_json::to_string_pretty(state).map_err(|e| {
+        let mut content = serde_json::to_string_pretty(state).map_err(|e| {
             BackendError::Serialization(format!("Failed to serialize state: {}", e))
         })?;
+        // Match the trailing-newline convention used by
+        // carina-backend.lock and carina-providers.lock so POSIX
+        // tooling and "add final newline" editors agree on the
+        // file shape.
+        content.push('\n');
 
         // Write to a temp file in the same directory, then rename atomically
         let tmp_path = self.state_path.with_extension("json.tmp");
@@ -568,6 +573,26 @@ mod tests {
         assert!(read_state.is_some());
         let read_state = read_state.unwrap();
         assert_eq!(read_state.serial, 1);
+    }
+
+    // Pin the byte-level shape so carina.state.json matches the
+    // trailing-newline convention used by carina-backend.lock and
+    // carina-providers.lock (#2583).
+    #[tokio::test]
+    async fn state_file_ends_with_trailing_newline() {
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("test.state.json");
+        let backend = LocalBackend::with_path(state_path.clone());
+        let mut state_file = StateFile::new();
+        state_file.increment_serial();
+        backend.write_state(&state_file).await.unwrap();
+        let bytes = std::fs::read(&state_path).unwrap();
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "carina.state.json must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #2721.

`LocalBackend::write_state` writes JSON via `serde_json::to_string_pretty` then `tokio::fs::write`. `to_string_pretty` does not emit a trailing newline, while the sibling `carina-backend.lock` (post #2583) and `carina-providers.lock` already end with `\n`. The asymmetry trips POSIX tooling (`tail`, `wc -l`), editors with "add final newline" enabled, and VCS auto-newline hooks. State files are inspected/diffed more often than the lock files, so the impact is arguably higher.

## Fix

Append `\n` to the serialized contents before the atomic tmp-file write in `carina-state/src/backends/local.rs::write_state`. The newline is part of the in-memory String before tmp-file write → fsync → rename, so durability and atomicity semantics are unchanged.

`read_state` requires no change — `serde_json::from_str` is already whitespace-tolerant per the JSON spec, and `test_local_backend_read_write` exercises the round-trip.

## Follow-ups (out of scope)

The 5-round review surfaced one more sibling: the S3 backend's `write_state` (`carina-state/src/backends/s3.rs:251`) has the same bug class. Filed as #2754. Lock-coordination files (`acquire_lock`, `acquire_recovery_claim`, `renew_lock`) are deliberately excluded — the issue body marks them as transient and not worth the same treatment.

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (484 tests pass; new `state_file_ends_with_trailing_newline` confirms the fix; existing `test_local_backend_read_write` confirms round-trip is unaffected)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)