### PR TITLE
parser: add unresolved_attributes transit field to ProviderConfig

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -566,6 +566,7 @@ mod tests {
             default_tags: IndexMap::new(),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
         });
 
         let base_dir = std::path::Path::new("/tmp/nonexistent-carina-test");
@@ -598,6 +599,7 @@ mod tests {
             default_tags: IndexMap::new(),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
         });
 
         let base_dir = std::path::Path::new("/tmp/nonexistent-carina-test");

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -297,6 +297,7 @@ fn plan_file_serde_round_trip() {
             source: None,
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
         }],
         backend_config: Some(BackendConfig {
             backend_type: "s3".to_string(),
@@ -567,6 +568,7 @@ fn make_awscc_provider(region_dsl: &str) -> ProviderConfig {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }
 }
 

--- a/carina-core/src/identifier/tests.rs
+++ b/carina-core/src/identifier/tests.rs
@@ -206,6 +206,7 @@ fn test_reconcile_anonymous_id_partial_create_only_match() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -385,6 +386,7 @@ fn test_anonymous_resource_inside_module_keeps_instance_prefix() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -437,6 +439,7 @@ fn test_anonymous_resource_no_create_only_properties() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -470,6 +473,7 @@ fn test_anonymous_resource_no_create_only_deterministic() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -501,6 +505,7 @@ fn test_anonymous_resource_no_create_only_collision() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -541,6 +546,7 @@ fn test_identity_attribute_prevents_collision() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -663,6 +669,7 @@ fn test_reconcile_anonymous_id_no_create_only_hamming_match() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -753,6 +760,7 @@ fn test_reconcile_anonymous_id_create_only_exists_but_none_set() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -934,6 +942,7 @@ fn test_reconcile_no_create_only_picks_closest_among_multiple_state_entries() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1029,6 +1038,7 @@ fn test_reconcile_no_create_only_same_id_in_state_no_change() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1085,6 +1095,7 @@ fn test_compute_anonymous_id_uses_simhash_for_no_create_only() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1139,6 +1150,7 @@ fn test_compute_anonymous_id_simhash_vs_create_only_hash_independent() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1224,6 +1236,7 @@ fn test_compute_anonymous_id_stable_with_prefixed_create_only_attribute() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1266,6 +1279,7 @@ fn test_compute_anonymous_id_different_prefix_produces_different_id() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -1445,6 +1459,7 @@ fn test_reconcile_eip_tag_update_with_unset_create_only_props() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec!["region".to_string()] };
 
@@ -2017,6 +2032,7 @@ fn anonymous_identifier_includes_provider_prefix() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -2049,6 +2065,7 @@ fn anonymous_identifier_provider_prefix_for_aws_provider() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 
@@ -2080,6 +2097,7 @@ fn reconcile_simhash_match_keeps_new_format_identifier_and_emits_rename() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }];
     let identity_fn = |_: &str| -> Vec<String> { vec![] };
 

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -419,6 +419,11 @@ pub struct ProviderConfig {
     /// Mutually exclusive with `version`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<String>,
+    /// Non-literal well-known attributes (e.g. `default_tags = some_let.field`)
+    /// drained and validated by the post-resolver finalize step. Invariant:
+    /// empty after finalization. In-memory transit only — never serialized.
+    #[serde(skip)]
+    pub unresolved_attributes: IndexMap<String, Value>,
 }
 
 /// Backend configuration for state storage

--- a/carina-core/src/parser/blocks/provider.rs
+++ b/carina-core/src/parser/blocks/provider.rs
@@ -91,6 +91,7 @@ pub(in crate::parser) fn parse_provider_block(
         source,
         version,
         revision,
+        unresolved_attributes: IndexMap::new(),
     })
 }
 

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2325,6 +2325,23 @@ fn parse_block_comment_with_all_comment_styles() {
 }
 
 #[test]
+fn provider_config_carries_unresolved_attributes_field() {
+    use crate::parser::ast::ProviderConfig;
+    use indexmap::IndexMap;
+
+    let pc = ProviderConfig {
+        name: "awscc".to_string(),
+        attributes: IndexMap::new(),
+        default_tags: IndexMap::new(),
+        source: None,
+        version: None,
+        revision: None,
+        unresolved_attributes: IndexMap::new(),
+    };
+    assert!(pc.unresolved_attributes.is_empty());
+}
+
+#[test]
 fn parse_provider_block_with_default_tags() {
     let input = r#"
         provider awscc {

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -602,6 +602,7 @@ fn provider_in_module_with_arguments_errors() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     });
     parsed.arguments.push(crate::parser::ArgumentParameter {
         name: "vpc_cidr".to_string(),
@@ -629,6 +630,7 @@ fn provider_in_module_with_attributes_errors() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     });
     parsed
         .attribute_params
@@ -652,6 +654,7 @@ fn provider_without_module_markers_ok() {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     });
 
     let result = validate_no_provider_in_module(&parsed);
@@ -693,6 +696,7 @@ fn provider(name: &str) -> crate::parser::ProviderConfig {
         source: None,
         version: None,
         revision: None,
+        unresolved_attributes: IndexMap::new(),
     }
 }
 

--- a/carina-lsp/src/backend.rs
+++ b/carina-lsp/src/backend.rs
@@ -971,6 +971,7 @@ mod tests {
             source: Some("github.com/carina-rs/stub".into()),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes,
             default_tags: IndexMap::new(),
         };
@@ -1003,6 +1004,7 @@ mod tests {
             source: None,
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         };
@@ -1031,6 +1033,7 @@ mod reload_skip_tests {
             source: source.map(String::from),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
         }
     }
 

--- a/carina-provider-resolver/src/provider_resolver.rs
+++ b/carina-provider-resolver/src/provider_resolver.rs
@@ -1034,6 +1034,7 @@ mod tests {
             revision: revision.map(|r| r.into()),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
+            unresolved_attributes: IndexMap::new(),
         }
     }
 
@@ -1381,6 +1382,7 @@ sha256 = "abc"
             source: Some(source.clone()),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }];
@@ -1406,6 +1408,7 @@ sha256 = "abc"
             source: Some("file:///nonexistent/path.wasm".into()),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }];
@@ -1503,6 +1506,7 @@ sha256 = "abc"
                 carina_core::version_constraint::VersionConstraint::parse(constraint).unwrap(),
             ),
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         }
@@ -1674,6 +1678,7 @@ sha256 = "abc"
             source: Some("file:///tmp/provider.wasm".into()),
             version: None,
             revision: None,
+            unresolved_attributes: IndexMap::new(),
             attributes: IndexMap::new(),
             default_tags: IndexMap::new(),
         };


### PR DESCRIPTION
Closes #2747. Task 1/7 of #2717.

## Summary

- Add `unresolved_attributes: IndexMap<String, Value>` to `ProviderConfig` (`#[serde(skip)]`), holding non-literal well-known attribute values until the post-resolver finalize step drains and validates them.
- Initialize the field to `IndexMap::new()` in `parse_provider_block`.
- Update every existing `ProviderConfig { ... }` literal across the workspace to set the new field. No `..Default::default()` shortcut introduced; `ProviderConfig` does not derive `Default`.

No behavioural change. Tasks 2–7 build on top of this slot.

## Why

`parse_provider_block` currently peels `default_tags` at parse time with a pattern that only matches literal `Value::Map(...)`. A `Value::ResourceRef` (what a `let`-binding reference produces at parse time) silently falls into the `else` branch and `default_tags` becomes empty with no diagnostic. The fix is to defer the peel past the resolver pass — Task 4 will introduce `finalize_provider_configs` that drains this new field and writes the resolved map. Task 1 is the type-level prerequisite.

See `docs/specs/2026-05-09-share-provider-attributes-design.md` for the full design.

## Test plan

- [x] `cargo nextest run -p carina-core provider_config_carries_unresolved_attributes_field` — new test passes
- [x] `cargo nextest run --workspace` — all 3017 tests pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass
