### PR TITLE
cli: append trailing newline to plan files written by plan --out

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -382,8 +382,13 @@ pub async fn run_plan(
     if let Some(out_path) = out {
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx)
             .map_err(|e| format_plan_save_error(&e, "--out"))?;
-        let json_out = serde_json::to_string_pretty(&plan_file)
+        let mut json_out = serde_json::to_string_pretty(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
+        // Match the trailing-newline convention used by
+        // carina-backend.lock, carina.state.json, and
+        // carina-providers.lock so POSIX tooling and "add final
+        // newline" editors agree on the file shape.
+        json_out.push('\n');
         fs::write(out_path, json_out).map_err(|e| format!("Failed to write plan file: {}", e))?;
 
         println!();
@@ -1196,6 +1201,50 @@ exports { region: String = "ap-northeast-1" }"#,
         assert_eq!(
             bindings["a"]["region"],
             Value::String("ap-northeast-1".to_string())
+        );
+    }
+}
+
+#[cfg(test)]
+mod run_plan_out_tests {
+    use super::*;
+    use std::fs;
+
+    // Pin the byte-level shape so plan files written by `plan --out`
+    // match the trailing-newline convention used by carina-backend.lock,
+    // carina.state.json, and carina-providers.lock (#2583).
+    #[tokio::test]
+    async fn run_plan_out_file_ends_with_trailing_newline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        fs::write(
+            dir.join("main.crn"),
+            r#"exports { region: String = "ap-northeast-1" }"#,
+        )
+        .unwrap();
+
+        crate::commands::ensure_backend_lock(dir, None).unwrap();
+
+        let plan_path = dir.join("plan.json");
+        run_plan(
+            dir,
+            Some(&plan_path),
+            DetailLevel::None,
+            false,
+            false,
+            true,
+            false,
+            &ProviderContext::default(),
+        )
+        .await
+        .expect("run_plan should succeed");
+
+        let bytes = fs::read(&plan_path).expect("plan file written");
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "plan --out file must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #2722.

`run_plan`'s `--out` branch writes JSON via `serde_json::to_string_pretty` then `fs::write`. `to_string_pretty` does not emit a trailing newline, while the sibling `carina-backend.lock` (post #2583), `carina.state.json` (post #2721), and `carina-providers.lock` already end with `\n`. The asymmetry trips POSIX tooling (`tail`, `wc -l`), editors with "add final newline" enabled, and VCS auto-newline hooks. `--out` plan files are intended for `carina apply` later and are sometimes committed or attached to CI artifacts, so the spurious-diff cost matters.

## Fix

Append `\n` to the serialized contents before `fs::write` in `run_plan`. Pin the byte-level shape with a regression test in a dedicated `run_plan_out_tests` module that drives `run_plan` end-to-end via a tempdir fixture.

`apply --plan` requires no change — `serde_json::from_str` is whitespace-tolerant per the JSON spec.

## Follow-ups (out of scope)

The 5-round review surfaced two more sibling sites. Filed as separate issues per the "1 PR = 1 topic" rule:

- #2758 — S3 backend `write_lock` body
- #2759 — `MockProvider::save_states` (low priority — mock-only)

## Test plan

- [x] `cargo nextest run -p carina-cli` (381 tests pass; new `run_plan_out_file_ends_with_trailing_newline` confirms the fix)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)