### PR TITLE
parser: defer non-literal default_tags into unresolved_attributes

### DIFF
--- a/carina-core/src/parser/blocks/provider.rs
+++ b/carina-core/src/parser/blocks/provider.rs
@@ -38,11 +38,18 @@ pub(in crate::parser) fn parse_provider_block(
     }
 
     // `shift_remove` keeps the surviving attributes in source order.
-    // Extract default_tags from attributes if present
-    let default_tags = if let Some(Value::Map(tags)) = attributes.shift_remove("default_tags") {
-        tags
-    } else {
-        IndexMap::new()
+    // Extract default_tags from attributes if present. Non-literal values
+    // cannot be peeled at parse time — route them into `unresolved_attributes`
+    // for the post-resolver finalize step. Otherwise they would silently
+    // fall through to an empty map (#2717).
+    let mut unresolved_attributes: IndexMap<String, Value> = IndexMap::new();
+    let default_tags = match attributes.shift_remove("default_tags") {
+        Some(Value::Map(tags)) => tags,
+        Some(other) => {
+            unresolved_attributes.insert("default_tags".to_string(), other);
+            IndexMap::new()
+        }
+        None => IndexMap::new(),
     };
 
     // Extract source from attributes if present
@@ -91,7 +98,7 @@ pub(in crate::parser) fn parse_provider_block(
         source,
         version,
         revision,
-        unresolved_attributes: IndexMap::new(),
+        unresolved_attributes,
     })
 }
 

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2325,6 +2325,41 @@ fn parse_block_comment_with_all_comment_styles() {
 }
 
 #[test]
+fn parse_provider_block_defers_non_literal_default_tags() {
+    // `tags.tags` is a ResourceRef into a module-call binding — the parser
+    // cannot inline-resolve it (the module hasn't been loaded yet), so the
+    // value must travel through the resolver pass. Without deferral, the
+    // legacy peel pattern dropped this silently into an empty default_tags.
+    let input = r#"
+        let st = use { source = "./modules/standard-tags" }
+
+        let tags = st {
+          environment = "dev"
+        }
+
+        provider awscc {
+          source       = "github.com/carina-rs/carina-provider-awscc"
+          revision     = "main"
+          default_tags = tags.tags
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    let pc = &parsed.providers[0];
+
+    assert!(
+        pc.default_tags.is_empty(),
+        "default_tags must stay empty until the post-resolver finalize step \
+         resolves `tags.tags`"
+    );
+    assert!(
+        pc.unresolved_attributes.contains_key("default_tags"),
+        "non-literal default_tags must be deferred into unresolved_attributes, \
+         not dropped"
+    );
+}
+
+#[test]
 fn provider_config_carries_unresolved_attributes_field() {
     use crate::parser::ast::ProviderConfig;
     use indexmap::IndexMap;


### PR DESCRIPTION
Closes #2748. Task 2/7 of #2717.

## Summary

Replace `parse_provider_block`'s silent-empty fallback with a `match` that routes non-literal `default_tags` values into `ProviderConfig.unresolved_attributes` (the transit slot added in #2747). Literal `Value::Map(...)` continues to populate `default_tags` directly, so existing tests stay green.

## Why

The legacy peel pattern was:

```rust
let default_tags = if let Some(Value::Map(tags)) = attributes.shift_remove("default_tags") {
    tags
} else {
    IndexMap::new()
};
```

A `Value::ResourceRef` (what e.g. `default_tags = tags.tags` produces at parse time) silently fell into the `else` branch and `default_tags` became empty with no diagnostic — the bug behind #2717. Task 2 stops the silent drop. Task 4 (#2750) will drain `unresolved_attributes` and resolve the deferred values once the resolver pass has finished.

## Plan-vs-implementation note

The plan's failing test used `let shared = { ... }` + `default_tags = shared`, but the parser inline-evaluates `let`-bound literal maps at parse time, so that shape resolves to `Value::Map(...)` and never enters the deferral arm. The actual test uses `let st = use { source = "..." }` + `let tags = st { ... }` + `default_tags = tags.tags` — `tags.tags` parses as a `Value::ResourceRef` that is genuinely non-literal at parse time and exercises the new arm.

## End-user impact

None in this PR alone — `default_tags` still resolves to an empty map for non-literal references until Task 4 lands. This PR only populates the in-memory transit slot.

## Follow-up filed

#2757 — the same silent-drop pattern exists at `source` / `version` / `revision` / `lifecycle` peel sites; filed independently per the "audit the class" memory rule.

## Test plan

- [x] `cargo nextest run -p carina-core parse_provider_block_defers_non_literal_default_tags` — new test passes
- [x] `cargo nextest run -p carina-core parse_provider_block` — all 11 existing provider-block tests still pass
- [x] `cargo nextest run --workspace` — 3019 tests, all pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass
