### PR TITLE
parser: extend identifier-scope check to provider attributes

### DIFF
--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -330,6 +330,14 @@ fn accumulate_undefined_reference_errors(
             check(value);
         }
     }
+    for provider in &parsed.providers {
+        for value in provider.attributes.values() {
+            check(value);
+        }
+        for value in provider.unresolved_attributes.values() {
+            check(value);
+        }
+    }
 }
 
 fn accumulate_deferred_iterable_errors(

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2360,6 +2360,28 @@ fn parse_provider_block_defers_non_literal_default_tags() {
 }
 
 #[test]
+fn provider_block_undefined_let_reference_flagged() {
+    // `nonexistent.tags` is a ResourceRef (bare identifiers without field
+    // access parse to Value::String per parser/expressions/primary.rs and
+    // are intentionally not scope-checked). The `.tags` access is what
+    // upgrades the value into a ResourceRef whose root must resolve.
+    let input = r#"
+        provider awscc {
+          source       = "github.com/carina-rs/carina-provider-awscc"
+          revision     = "main"
+          default_tags = nonexistent.tags
+        }
+    "#;
+
+    let parsed = parse(input, &ProviderContext::default()).unwrap();
+    let errs = check_identifier_scope(&parsed);
+    assert!(
+        errs.iter().any(|e| format!("{e}").contains("nonexistent")),
+        "expected UndefinedIdentifier for `nonexistent`, got: {errs:?}"
+    );
+}
+
+#[test]
 fn provider_config_carries_unresolved_attributes_field() {
     use crate::parser::ast::ProviderConfig;
     use indexmap::IndexMap;


### PR DESCRIPTION
Closes #2749. Task 3/7 of #2717.

## Summary

Extend `accumulate_undefined_reference_errors` (in `carina-core/src/parser/resolve.rs`) to walk `provider.attributes` and `provider.unresolved_attributes` in addition to the existing `resources`/`attribute_params`/`module_calls`/`export_params`/`deferred_for_expressions` passes.

## Why

Before this change, a typo in a `let` reference inside a `provider {}` block silently passed validation — `check_identifier_scope` did not visit provider attributes. After this change, `provider awscc { default_tags = nonexistent.tags }` produces an `UndefinedIdentifier` diagnostic for `nonexistent`.

## Plan-vs-implementation note

The plan's failing test used `default_tags = nonexistent_binding` (bare identifier). Bare identifiers without an access chain parse to `Value::String` per `parser/expressions/primary.rs:286-293` and are intentionally not scope-checked. The actual test uses `default_tags = nonexistent.tags` — the `.tags` field access upgrades the value into a `Value::ResourceRef` whose root binding `nonexistent` is then visited by the scope check. Comment in the test documents this.

## Order-of-operations note

After Task 4 (#2750) lands, `finalize_provider_configs` will drain `unresolved_attributes` before scope check runs, making the second loop a no-op for the post-finalize state. The current design is "scope check before finalize" so `unresolved_attributes` is populated when `check_identifier_scope` is called. Code remains correct in either order (an empty `IndexMap` iter is a no-op).

## Follow-up filed

#2762 — `accumulate_undefined_reference_errors` still does not visit `arguments[*].default`, `variables`, `backend.attributes`, `state_blocks`, `requires`, `user_functions`, or values inside literal-map peeled fields. Filed as a follow-up per the "audit the class" memory rule; out of scope for #2717.

## Test plan

- [x] `cargo nextest run -p carina-core provider_block_undefined_let_reference_flagged` — new test passes
- [x] `cargo nextest run -p carina-core check_identifier_scope` — existing scope tests still pass
- [x] `cargo nextest run --workspace` — 3020 tests pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass
