### PR TITLE
state: append trailing newline to S3 backend state body

### DIFF
--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -132,6 +132,17 @@ impl S3Backend {
         serde_json::to_vec_pretty(lock).map_err(|e| BackendError::Serialization(e.to_string()))
     }
 
+    fn state_body(state: &StateFile) -> BackendResult<Vec<u8>> {
+        let mut body = serde_json::to_vec_pretty(state)
+            .map_err(|e| BackendError::Serialization(e.to_string()))?;
+        // Match the trailing-newline convention used by the local
+        // backend's carina.state.json so POSIX tooling and "add final
+        // newline" editors agree on the file shape regardless of
+        // which backend stores it.
+        body.push(b'\n');
+        Ok(body)
+    }
+
     async fn write_lock_if_absent(&self, lock: &LockInfo) -> BackendResult<bool> {
         self.write_lock(lock, Some("*"), None).await
     }
@@ -248,8 +259,7 @@ impl StateBackend for S3Backend {
     }
 
     async fn write_state(&self, state: &StateFile) -> BackendResult<()> {
-        let body = serde_json::to_vec_pretty(state)
-            .map_err(|e| BackendError::Serialization(e.to_string()))?;
+        let body = Self::state_body(state)?;
 
         let mut request = self
             .client
@@ -604,6 +614,22 @@ mod tests {
             }
             other => panic!("expected Configuration error, got: {other:?}"),
         }
+    }
+
+    // Pin the byte-level shape so the S3-stored carina.state.json
+    // body matches the trailing-newline convention used by the local
+    // backend (#2721).
+    #[test]
+    fn state_body_ends_with_trailing_newline() {
+        let mut state = StateFile::new();
+        state.increment_serial();
+        let bytes = S3Backend::state_body(&state).unwrap();
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "S3 state body must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2754.

`S3Backend::write_state` serializes state via `serde_json::to_vec_pretty` and uploads the body to S3 without a trailing newline. The asymmetry with the local backend's `carina.state.json` (post #2721) and the lock files trips POSIX tooling (`tail`, `wc -l`), editors with "add final newline" enabled, and any pipeline that compares S3 state objects fetched via `aws s3 cp` to their local counterparts.

## Fix

Extract a private `state_body(state) -> BackendResult<Vec<u8>>` helper mirroring the existing `lock_body` shape, with `\n` appended after serialization. `write_state` calls the helper. The byte-level shape is pinned with a unit test that exercises the helper directly, avoiding the need for a real S3 client in tests.

`read_state` requires no change — `serde_json::from_slice` is whitespace-tolerant per the JSON spec.

## Why a helper this time

The prior trailing-newline fixes (#2583, #2721, #2722) all inlined `push('\n')` because the writer was directly testable. `S3Backend::write_state` is async and requires a real S3 client to drive end-to-end, so a private helper is the cleanest unit-test entry point. The shape mirrors the existing `lock_body` helper in the same file.

## Follow-ups (out of scope)

- #2758 — S3 backend `lock_body` (separate issue, untouched here)
- #2759 — `MockProvider::save_states` (separate issue)

The local-backend lock-coordination files (`acquire_lock`, `acquire_recovery_claim`, `lock_renew`) were intentionally excluded by #2721's issue body as transient.

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (pass; new `state_body_ends_with_trailing_newline` confirms the fix)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)