### PR TITLE
parser: finalize_provider_configs drains deferred default_tags

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -179,6 +179,13 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
+        // Promote any deferred provider attributes (e.g. non-literal
+        // `default_tags`) into their typed fields now that resolution
+        // is complete. See `finalize_provider_configs` (#2717).
+        if let Err(e) = parser::finalize_provider_configs(&mut merged) {
+            return Err(e.to_string());
+        }
+
         // Identifier-scope checks are accumulated rather than short-
         // circuited so `carina validate` can keep going and report every
         // static error in one pass (#2102, #2126, #2138).
@@ -277,6 +284,13 @@ pub fn parse_directory_with_overrides(
 
     // Resolve cross-file references on the merged result
     if let Err(e) = parser::resolve_resource_refs_with_config(&mut merged, config) {
+        return Err(e.to_string());
+    }
+
+    // Promote any deferred provider attributes (e.g. non-literal
+    // `default_tags`) into their typed fields now that resolution
+    // is complete. See `finalize_provider_configs` (#2717).
+    if let Err(e) = parser::finalize_provider_configs(&mut merged) {
         return Err(e.to_string());
     }
 

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -22,7 +22,9 @@ use super::expressions::if_expr::parse_if_expr;
 use super::expressions::pipe::parse_coalesce_expr;
 use super::functions::parse_fn_def;
 use super::let_binding::parse_let_binding_extended;
-use super::resolve::{resolve_forward_references, resolve_resource_refs};
+use super::resolve::{
+    finalize_provider_configs, resolve_forward_references, resolve_resource_refs,
+};
 use crate::eval_value::EvalValue;
 use crate::resource::{Resource, Value};
 use indexmap::IndexMap;
@@ -332,5 +334,6 @@ pub(crate) fn parse_expression_eval(
 pub fn parse_and_resolve(input: &str) -> Result<ParsedFile, ParseError> {
     let mut parsed = parse(input, &ProviderContext::default())?;
     resolve_resource_refs(&mut parsed)?;
+    finalize_provider_configs(&mut parsed)?;
     Ok(parsed)
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -30,8 +30,8 @@ pub use error::{ParseError, ParseWarning};
 pub(crate) use functions::evaluate_user_function;
 pub use functions::{provider_context_lookup, validate_custom_type};
 pub use resolve::{
-    check_identifier_scope, collect_known_bindings_merged, resolve_resource_refs,
-    resolve_resource_refs_with_config,
+    check_identifier_scope, collect_known_bindings_merged, finalize_provider_configs,
+    resolve_resource_refs, resolve_resource_refs_with_config,
 };
 pub use types::parse_type_expr_str;
 pub(crate) use util::{eval_type_name, value_type_name};

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -231,6 +231,19 @@ pub fn resolve_resource_refs_with_config(
         }
     }
 
+    // Resolve references inside provider blocks' deferred attributes
+    // (#2717). Without this, `default_tags = some_binding.field` would
+    // remain a `Value::ResourceRef` after resolve and `finalize_provider_configs`
+    // would reject it as "must resolve to a map".
+    for provider in &mut parsed.providers {
+        let mut resolved: IndexMap<String, Value> = IndexMap::new();
+        for (key, expr) in &provider.unresolved_attributes {
+            let r = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
+            resolved.insert(key.clone(), r);
+        }
+        provider.unresolved_attributes = resolved;
+    }
+
     Ok(())
 }
 
@@ -519,4 +532,40 @@ fn resolve_function_calls_only(
         }
         _ => Ok(value.clone()),
     }
+}
+
+/// Drain `ProviderConfig.unresolved_attributes` and promote resolved
+/// well-known attributes into their typed fields. Run **after**
+/// [`resolve_resource_refs`] so deferred references have a chance to
+/// resolve to literals first.
+///
+/// Today only `default_tags` is handled; `source` / `version` /
+/// `revision` peel sites still use the legacy parse-time shape (#2757).
+///
+/// Errors when a resolved value has the wrong shape (e.g.
+/// `default_tags = "string"`).
+pub fn finalize_provider_configs(parsed: &mut ParsedFile) -> Result<(), ParseError> {
+    for provider in parsed.providers.iter_mut() {
+        if let Some(value) = provider.unresolved_attributes.shift_remove("default_tags") {
+            match value {
+                Value::Map(tags) => {
+                    provider.default_tags = tags;
+                }
+                other => {
+                    return Err(ParseError::InvalidExpression {
+                        line: 0,
+                        message: format!(
+                            "Provider '{}': default_tags must resolve to a map, got {other:?}",
+                            provider.name
+                        ),
+                    });
+                }
+            }
+        }
+        debug_assert!(
+            provider.unresolved_attributes.is_empty(),
+            "unresolved_attributes must be drained by finalize",
+        );
+    }
+    Ok(())
 }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -2382,6 +2382,107 @@ fn provider_block_undefined_let_reference_flagged() {
 }
 
 #[test]
+fn finalize_provider_configs_promotes_resolved_default_tags() {
+    // After parse + resolve, a non-literal `default_tags = some_let.field`
+    // must end up resolved into the typed `default_tags` field, with
+    // `unresolved_attributes` drained.
+    let input = r#"
+        let shared = { region = "ap-northeast-1", env = "dev" }
+
+        provider awscc {
+          source       = "github.com/carina-rs/carina-provider-awscc"
+          revision     = "main"
+          default_tags = shared
+        }
+    "#;
+
+    // `let shared = { ... }` is inlined by the parser at parse time, so
+    // `default_tags = shared` reaches the literal-Map peel directly and
+    // `unresolved_attributes` stays empty in this single-file test. The
+    // genuine ResourceRef path (`default_tags = mod.tags`) needs a
+    // multi-file fixture and is covered by Task 5 (#2751).
+    let parsed = parse_and_resolve(input).unwrap();
+    let pc = &parsed.providers[0];
+
+    assert!(
+        pc.unresolved_attributes.is_empty(),
+        "finalize must drain unresolved_attributes; got: {:?}",
+        pc.unresolved_attributes
+    );
+    assert_eq!(
+        pc.default_tags.get("region"),
+        Some(&Value::String("ap-northeast-1".to_string())),
+        "resolved default_tags must contain the literal map's entries; got: {:?}",
+        pc.default_tags
+    );
+    assert_eq!(
+        pc.default_tags.get("env"),
+        Some(&Value::String("dev".to_string())),
+    );
+}
+
+#[test]
+fn finalize_provider_configs_resolves_resource_ref_default_tags() {
+    // The genuine target shape: `default_tags = binding.attr` where the
+    // attribute is itself a literal map. The deferred ResourceRef must be
+    // resolved by `resolve_resource_refs` before `finalize_provider_configs`
+    // promotes it.
+    let input = r#"
+        let cfg = aws.s3.Bucket {
+          name = "x"
+          tags = { Project = "carina-rs", Env = "dev" }
+        }
+
+        provider awscc {
+          source       = "github.com/carina-rs/carina-provider-awscc"
+          revision     = "main"
+          default_tags = cfg.tags
+        }
+    "#;
+
+    let parsed = parse_and_resolve(input).unwrap();
+    let pc = &parsed.providers[0];
+
+    assert!(
+        pc.unresolved_attributes.is_empty(),
+        "finalize must drain unresolved_attributes; got: {:?}",
+        pc.unresolved_attributes
+    );
+    assert_eq!(
+        pc.default_tags.get("Project"),
+        Some(&Value::String("carina-rs".to_string())),
+        "ResourceRef default_tags must resolve to the referenced map; got: {:?}",
+        pc.default_tags
+    );
+    assert_eq!(
+        pc.default_tags.get("Env"),
+        Some(&Value::String("dev".to_string())),
+    );
+}
+
+#[test]
+fn finalize_provider_configs_rejects_non_map_default_tags() {
+    // `default_tags = "not a map"` must surface as a typed error after
+    // finalize, instead of silently producing an empty map.
+    let input = r#"
+        let bad = "not a map"
+
+        provider awscc {
+          source       = "github.com/carina-rs/carina-provider-awscc"
+          revision     = "main"
+          default_tags = bad
+        }
+    "#;
+
+    let err = parse_and_resolve(input).unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("default_tags"),
+        "error must mention default_tags; got: {msg}"
+    );
+}
+
+#[test]
 fn provider_config_carries_unresolved_attributes_field() {
     use crate::parser::ast::ProviderConfig;
     use indexmap::IndexMap;


### PR DESCRIPTION
Closes #2750. Task 4/7 of #2717. **Core implementation of #2717.**

## Summary

Add `finalize_provider_configs(parsed: &mut ParsedFile)` that drains `ProviderConfig.unresolved_attributes` (populated by Task 2 in #2761) and promotes resolved `default_tags` into the typed `default_tags` field. Errors when a resolved value is not a map, instead of silently producing an empty map.

Also extend `resolve_resource_refs_with_config` to visit `provider.unresolved_attributes`, so deferred `Value::ResourceRef` values (e.g. `default_tags = cfg.tags`) are resolved to literals before `finalize_provider_configs` runs.

Wire `finalize_provider_configs` into all three load paths:
- `parse_and_resolve` (library / doctest entry)
- `load_configuration_with_config` (CLI validate / plan / apply)
- `parse_directory_with_overrides` (LSP diagnostics)

After this PR, the issue's target shape works end-to-end:

```crn
let cfg = aws.s3.Bucket {
  name = "x"
  tags = { Project = "carina-rs", Env = "dev" }
}

provider awscc {
  source       = "github.com/carina-rs/carina-provider-awscc"
  revision     = "main"
  default_tags = cfg.tags    # resolves to the literal map at finalize
}
```

## Why both resolver extension AND finalize step?

A simpler approach was tried first: only add `finalize_provider_configs`, leaving `resolve_resource_refs` untouched. The 5-round review caught the gap: `resolve_resource_refs_with_config` only visits `parsed.resources`, `parsed.variables`, and `parsed.export_params` — it does NOT walk `provider.unresolved_attributes`. So a deferred `Value::ResourceRef` would remain unresolved at finalize time and trip the "must resolve to a map" error. The fix: extend the resolver to also visit provider unresolved attributes before finalize runs.

## Plan-vs-implementation note

Plan dictated the `finalize_provider_configs` body byte-for-byte; the resolver extension (~14 extra lines in `resolve_resource_refs_with_config`) is additional and was driven by the integration gap above. Test coverage extended to 3 tests: literal-Map drain, ResourceRef resolve + drain, non-Map reject.

## Out of scope

- `source` / `version` / `revision` peel sites — same silent-drop class, filed as #2757.
- LSP diagnostics surfacing — Task 7 (#2753).
- Multi-file directory fixture — Task 5 (#2751).

## Test plan

- [x] `cargo nextest run -p carina-core finalize_provider` — 3 new tests pass
- [x] `cargo nextest run --workspace` — 3024 tests pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass
