### PR TITLE
state: append trailing newline to S3 backend lock body

### DIFF
--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -128,19 +128,25 @@ impl S3Backend {
         Ok(self.read_lock_with_etag().await?.map(|(lock, _)| lock))
     }
 
+    /// Serialize `value` as pretty JSON with a trailing newline, ready
+    /// to upload as the body of an S3 PutObject. Matches the
+    /// trailing-newline convention used by the local backend's
+    /// `carina.state.json` (#2721) and `carina-backend.lock` (#2583)
+    /// so POSIX tooling and "add final newline" editors agree on the
+    /// file shape regardless of which backend stores the artifact.
+    fn pretty_body_with_newline<T: serde::Serialize>(value: &T) -> BackendResult<Vec<u8>> {
+        let mut body = serde_json::to_vec_pretty(value)
+            .map_err(|e| BackendError::Serialization(e.to_string()))?;
+        body.push(b'\n');
+        Ok(body)
+    }
+
     fn lock_body(lock: &LockInfo) -> BackendResult<Vec<u8>> {
-        serde_json::to_vec_pretty(lock).map_err(|e| BackendError::Serialization(e.to_string()))
+        Self::pretty_body_with_newline(lock)
     }
 
     fn state_body(state: &StateFile) -> BackendResult<Vec<u8>> {
-        let mut body = serde_json::to_vec_pretty(state)
-            .map_err(|e| BackendError::Serialization(e.to_string()))?;
-        // Match the trailing-newline convention used by the local
-        // backend's carina.state.json so POSIX tooling and "add final
-        // newline" editors agree on the file shape regardless of
-        // which backend stores it.
-        body.push(b'\n');
-        Ok(body)
+        Self::pretty_body_with_newline(state)
     }
 
     async fn write_lock_if_absent(&self, lock: &LockInfo) -> BackendResult<bool> {
@@ -614,6 +620,21 @@ mod tests {
             }
             other => panic!("expected Configuration error, got: {other:?}"),
         }
+    }
+
+    // Pin the byte-level shape so the S3-stored lock body matches
+    // the trailing-newline convention used by the state body (#2754)
+    // and the local backend (#2721, #2583).
+    #[test]
+    fn lock_body_ends_with_trailing_newline() {
+        let lock = LockInfo::new("apply");
+        let bytes = S3Backend::lock_body(&lock).unwrap();
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "S3 lock body must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
+        );
     }
 
     // Pin the byte-level shape so the S3-stored carina.state.json


### PR DESCRIPTION
## Summary

Closes #2758.

`S3Backend::lock_body` (used by `acquire_lock` and `renew_lock` writes to the S3 lock object) was producing JSON without a trailing newline, unlike the now-fixed sibling `state_body` (#2754) and the local backend's `carina-backend.lock` (#2583).

## Fix

Append `\n` to the serialized contents in `lock_body`, and consolidate `lock_body` + `state_body` into a private `pretty_body_with_newline<T: Serialize>` helper now that both helpers are byte-identical structurally. The newline contract is pinned in one place; the two wrappers are thin type-disambiguators.

Workspace-wide consolidation across `carina-state` / `carina-cli` is deferred — the four sites outside this file diverge on return type (`String` vs `Vec<u8>`) and error type (`BackendResult` vs `Result<_, String>`).

`read_lock` requires no change — `serde_json::from_slice` is whitespace-tolerant per the JSON spec. ETag-based conditional writes are unaffected because S3 computes ETags server-side over the uploaded bytes.

## Follow-ups

- #2759 — `MockProvider::save_states` (low priority, mock-only)

The local backend's lock-coordination files (`acquire_lock`, `acquire_recovery_claim`, `renew_lock`) were explicitly classified by #2721's issue body as transient and out-of-scope. A follow-up Issue #2766 was auto-filed during 5-round review and immediately closed for the same reason.

## Test plan

- [x] `cargo nextest run -p carina-state -p carina-cli` (pass; new `lock_body_ends_with_trailing_newline` confirms the fix; existing `state_body_ends_with_trailing_newline` confirms parity preserved through the helper)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --doc`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)