### PR TITLE
parser: resolve+finalize provider attrs after module expansion + multi-file fixture

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -281,6 +281,25 @@ pub fn validate_and_resolve_errors_with_factories(
         return errors;
     }
 
+    // Module expansion produces virtual resources for module-call
+    // bindings (`carina-core/src/module_resolver/expander.rs`). Resolve
+    // deferred provider attributes that reference those bindings
+    // (`default_tags = mod.tags`), then finalize so the resolved values
+    // are promoted into the typed `default_tags` field. See #2717.
+    if let Err(e) =
+        carina_core::parser::resolve_provider_unresolved_attributes(parsed, &enriched_context)
+    {
+        errors.push(AppError::Config(format!(
+            "Provider attribute resolution error: {}",
+            e
+        )));
+        return errors;
+    }
+    if let Err(e) = carina_core::parser::finalize_provider_configs(parsed) {
+        errors.push(AppError::Config(format!("Finalize error: {}", e)));
+        return errors;
+    }
+
     // Resolve names (let bindings -> resource names) — must succeed
     // before per-resource schema checks can look up the renamed
     // attributes, so its failures gate the remaining pipeline.

--- a/carina-cli/tests/fixtures/share_provider_attrs/component/main.crn
+++ b/carina-cli/tests/fixtures/share_provider_attrs/component/main.crn
@@ -1,0 +1,2 @@
+# Empty component body. The acceptance test asserts on the resolved
+# `default_tags` produced from `providers.crn` + `modules/standard-tags`.

--- a/carina-cli/tests/fixtures/share_provider_attrs/component/providers.crn
+++ b/carina-cli/tests/fixtures/share_provider_attrs/component/providers.crn
@@ -1,0 +1,12 @@
+let st = use { source = '../modules/standard-tags' }
+
+let tags = st {
+  environment = 'dev'
+  component   = 'registry'
+}
+
+provider mock {
+  source       = 'github.com/carina-rs/carina-provider-mock'
+  version      = '~0.1.0'
+  default_tags = tags.tags
+}

--- a/carina-cli/tests/fixtures/share_provider_attrs/modules/standard-tags/main.crn
+++ b/carina-cli/tests/fixtures/share_provider_attrs/modules/standard-tags/main.crn
@@ -1,0 +1,14 @@
+arguments {
+  environment: String
+  component:   String
+}
+
+attributes {
+  tags: map(String) = {
+    ManagedBy   = 'carina'
+    Project     = 'carina-rs'
+    Repository  = 'carina-rs/infra'
+    Environment = environment
+    Component   = component
+  }
+}

--- a/carina-cli/tests/share_provider_attrs.rs
+++ b/carina-cli/tests/share_provider_attrs.rs
@@ -1,0 +1,68 @@
+//! Integration test for shared provider attributes (#2717).
+//!
+//! Reproduces the CLI pipeline (parse → load → resolve → module-expand →
+//! finalize) against a multi-file fixture that sources `default_tags`
+//! from a sibling module via `use` + module-call + field access.
+//! Asserts the resolved tag map matches what would be produced by a
+//! literal `default_tags = { ... }` map.
+
+use std::path::PathBuf;
+
+use carina_core::config_loader::load_configuration;
+use carina_core::resource::Value;
+
+#[test]
+fn share_provider_attrs_resolves_default_tags() {
+    let fixture: PathBuf = [
+        env!("CARGO_MANIFEST_DIR"),
+        "tests",
+        "fixtures",
+        "share_provider_attrs",
+        "component",
+    ]
+    .iter()
+    .collect();
+
+    let mut config = load_configuration(&fixture).expect("load_configuration");
+
+    // Run the CLI's full validate-and-resolve pipeline so module
+    // expansion + finalize happen. `skip_resource_validation = true`
+    // bypasses provider-plugin loading; the mock provider's WASM is not
+    // available in the test environment, but we only need pipeline
+    // semantics here.
+    carina_cli::commands::validate_and_resolve(&mut config.parsed, &fixture, true)
+        .expect("validate_and_resolve must succeed");
+
+    let provider = config
+        .parsed
+        .providers
+        .iter()
+        .find(|p| p.name == "mock")
+        .expect("provider mock present");
+
+    assert!(
+        provider.unresolved_attributes.is_empty(),
+        "finalize must drain unresolved_attributes; got: {:?}",
+        provider.unresolved_attributes,
+    );
+
+    let tags = &provider.default_tags;
+    assert_eq!(tags.get("ManagedBy"), Some(&Value::String("carina".into())),);
+    assert_eq!(
+        tags.get("Project"),
+        Some(&Value::String("carina-rs".into())),
+    );
+    assert_eq!(
+        tags.get("Repository"),
+        Some(&Value::String("carina-rs/infra".into())),
+    );
+    assert_eq!(
+        tags.get("Environment"),
+        Some(&Value::String("dev".into())),
+        "Environment must come from the module-call argument; got {tags:?}",
+    );
+    assert_eq!(
+        tags.get("Component"),
+        Some(&Value::String("registry".into())),
+    );
+}

--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -179,12 +179,12 @@ pub fn load_configuration_with_config(
             return Err(e.to_string());
         }
 
-        // Promote any deferred provider attributes (e.g. non-literal
-        // `default_tags`) into their typed fields now that resolution
-        // is complete. See `finalize_provider_configs` (#2717).
-        if let Err(e) = parser::finalize_provider_configs(&mut merged) {
-            return Err(e.to_string());
-        }
+        // `finalize_provider_configs` is intentionally NOT called here.
+        // The merged result is still pre-module-expansion, so deferred
+        // `default_tags = mod.tags` shapes cannot be resolved yet. The
+        // CLI calls finalize after `module_resolver::resolve_modules_with_config`
+        // (see `carina-cli/src/commands/mod.rs`); LSP follows the same
+        // contract. See #2717.
 
         // Identifier-scope checks are accumulated rather than short-
         // circuited so `carina validate` can keep going and report every
@@ -287,12 +287,12 @@ pub fn parse_directory_with_overrides(
         return Err(e.to_string());
     }
 
-    // Promote any deferred provider attributes (e.g. non-literal
-    // `default_tags`) into their typed fields now that resolution
-    // is complete. See `finalize_provider_configs` (#2717).
-    if let Err(e) = parser::finalize_provider_configs(&mut merged) {
-        return Err(e.to_string());
-    }
+    // `finalize_provider_configs` is intentionally NOT called here. The
+    // merged result is pre-module-expansion; deferred provider
+    // attributes that reference module-call bindings cannot be resolved
+    // until `module_resolver::resolve_modules_with_config` runs.
+    // Consumers (CLI, LSP) call finalize themselves after expansion.
+    // See #2717.
 
     // Identifier-scope validation is left to callers. LSP needs the
     // ParsedFile even when a reference is unresolved, so it can surface

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -23,7 +23,8 @@ use super::expressions::pipe::parse_coalesce_expr;
 use super::functions::parse_fn_def;
 use super::let_binding::parse_let_binding_extended;
 use super::resolve::{
-    finalize_provider_configs, resolve_forward_references, resolve_resource_refs,
+    finalize_provider_configs, resolve_forward_references, resolve_provider_unresolved_attributes,
+    resolve_resource_refs,
 };
 use crate::eval_value::EvalValue;
 use crate::resource::{Resource, Value};
@@ -330,10 +331,19 @@ pub(crate) fn parse_expression_eval(
     parse_coalesce_expr(inner, ctx)
 }
 
-/// Parse a .crn file and resolve resource references
+/// Parse a .crn file and resolve resource references.
+///
+/// `finalize_provider_configs` is called at the end so deferred
+/// `default_tags` (etc.) values are promoted into their typed fields.
+/// This works for single-string inputs without `module_call` expansion.
+/// Directory-scoped flows (`parse_directory_with_overrides`,
+/// `load_configuration_with_config`) finalize **after**
+/// `module_resolver::resolve_modules_with_config` so that virtual
+/// resources from module expansion are visible to the resolver pass.
 pub fn parse_and_resolve(input: &str) -> Result<ParsedFile, ParseError> {
     let mut parsed = parse(input, &ProviderContext::default())?;
     resolve_resource_refs(&mut parsed)?;
+    resolve_provider_unresolved_attributes(&mut parsed, &ProviderContext::default())?;
     finalize_provider_configs(&mut parsed)?;
     Ok(parsed)
 }

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -31,7 +31,8 @@ pub(crate) use functions::evaluate_user_function;
 pub use functions::{provider_context_lookup, validate_custom_type};
 pub use resolve::{
     check_identifier_scope, collect_known_bindings_merged, finalize_provider_configs,
-    resolve_resource_refs, resolve_resource_refs_with_config,
+    resolve_provider_unresolved_attributes, resolve_resource_refs,
+    resolve_resource_refs_with_config,
 };
 pub use types::parse_type_expr_str;
 pub(crate) use util::{eval_type_name, value_type_name};

--- a/carina-core/src/parser/resolve.rs
+++ b/carina-core/src/parser/resolve.rs
@@ -231,18 +231,11 @@ pub fn resolve_resource_refs_with_config(
         }
     }
 
-    // Resolve references inside provider blocks' deferred attributes
-    // (#2717). Without this, `default_tags = some_binding.field` would
-    // remain a `Value::ResourceRef` after resolve and `finalize_provider_configs`
-    // would reject it as "must resolve to a map".
-    for provider in &mut parsed.providers {
-        let mut resolved: IndexMap<String, Value> = IndexMap::new();
-        for (key, expr) in &provider.unresolved_attributes {
-            let r = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
-            resolved.insert(key.clone(), r);
-        }
-        provider.unresolved_attributes = resolved;
-    }
+    // Provider attribute resolution lives in
+    // `resolve_provider_unresolved_attributes` (generic over export-
+    // parameter shape so it works on both `ParsedFile` and `InferredFile`),
+    // and is called by consumers after `module_resolver::resolve_modules_with_config`
+    // produces virtual resources. See #2717.
 
     Ok(())
 }
@@ -534,17 +527,67 @@ fn resolve_function_calls_only(
     }
 }
 
+/// Resolve `ResourceRef` values inside provider blocks'
+/// `unresolved_attributes` against the merged binding map produced by
+/// `parsed.resources` + `parsed.arguments` + `parsed.module_calls` +
+/// `parsed.upstream_states`.
+///
+/// Call this **after** `module_resolver::resolve_modules_with_config`
+/// has produced virtual resources for module-call bindings, so that
+/// `default_tags = mod.tags` can see the module's exported attribute
+/// values. Then call [`finalize_provider_configs`] to drain the
+/// (now-literal) values into the typed `default_tags` field.
+///
+/// Generic over the export-parameter shape so callers can pass either
+/// `ParsedFile` or `InferredFile` — we only touch
+/// `provider.unresolved_attributes`, never `export_params`.
+pub fn resolve_provider_unresolved_attributes<E>(
+    parsed: &mut super::File<E>,
+    config: &ProviderContext,
+) -> Result<(), ParseError> {
+    let mut binding_map: HashMap<String, HashMap<String, Value>> = HashMap::new();
+    for resource in &parsed.resources {
+        if let Some(ref binding_name) = resource.binding {
+            binding_map.insert(binding_name.clone(), resource.resolved_attributes());
+        }
+    }
+    for arg in &parsed.arguments {
+        binding_map.entry(arg.name.clone()).or_default();
+    }
+    for call in &parsed.module_calls {
+        if let Some(ref name) = call.binding_name {
+            binding_map.entry(name.clone()).or_default();
+        }
+    }
+    for us in &parsed.upstream_states {
+        binding_map.entry(us.binding.clone()).or_default();
+    }
+    let mut fn_ctx = super::ParseContext::new(config);
+    fn_ctx.user_functions = parsed.user_functions.clone();
+
+    for provider in &mut parsed.providers {
+        let mut resolved: IndexMap<String, Value> = IndexMap::new();
+        for (key, expr) in &provider.unresolved_attributes {
+            let r = resolve_value_with_config(expr, &binding_map, &fn_ctx)?;
+            resolved.insert(key.clone(), r);
+        }
+        provider.unresolved_attributes = resolved;
+    }
+    Ok(())
+}
+
 /// Drain `ProviderConfig.unresolved_attributes` and promote resolved
 /// well-known attributes into their typed fields. Run **after**
-/// [`resolve_resource_refs`] so deferred references have a chance to
-/// resolve to literals first.
+/// [`resolve_resource_refs`] (and, for module-call deferrals,
+/// [`resolve_provider_unresolved_attributes`]) so deferred references
+/// have a chance to resolve to literals first.
 ///
 /// Today only `default_tags` is handled; `source` / `version` /
 /// `revision` peel sites still use the legacy parse-time shape (#2757).
 ///
 /// Errors when a resolved value has the wrong shape (e.g.
 /// `default_tags = "string"`).
-pub fn finalize_provider_configs(parsed: &mut ParsedFile) -> Result<(), ParseError> {
+pub fn finalize_provider_configs<E>(parsed: &mut super::File<E>) -> Result<(), ParseError> {
     for provider in parsed.providers.iter_mut() {
         if let Some(value) = provider.unresolved_attributes.shift_remove("default_tags") {
             match value {


### PR DESCRIPTION
Closes #2751. Task 5/7 of #2717.

## Summary

Move provider-attribute resolve+finalize to after module expansion in the CLI pipeline. Without this change, `default_tags = mod.tags` (i.e. a module-call binding's exported attribute) cannot be resolved because the virtual resource for the module call is only produced by `module_resolver::resolve_modules_with_config`. Add a multi-file fixture and integration test that exercises the full directory-scoped pipeline.

This was the key correctness gap noticed during Task 5: PR #2750 had `finalize_provider_configs` called inside `load_configuration_with_config`, which runs **before** module expansion. The new `resolve_provider_unresolved_attributes` + `finalize_provider_configs` call site sits **after** `module_resolver::resolve_modules_with_config` so the virtual resources from module-call expansion are visible to the resolver.

## Changes

- `carina-core/src/parser/resolve.rs`: split into two generic helpers
  - `resolve_provider_unresolved_attributes<E>` — resolves `Value::ResourceRef` inside `provider.unresolved_attributes` against the merged binding map (which now includes virtual resources from module expansion).
  - `finalize_provider_configs<E>` — drains and validates. Now generic over export-parameter shape.
  - Removed the inline provider-visit loop that #2765 added inside `resolve_resource_refs_with_config` — that logic is now the new helper.
- `carina-core/src/parser/mod.rs`: re-export the new helper.
- `carina-core/src/parser/entry.rs`: `parse_and_resolve` calls the new helper before finalize so single-string parser tests (no module expansion) keep working.
- `carina-core/src/config_loader.rs`: REMOVED finalize calls from `load_configuration_with_config` and `parse_directory_with_overrides`. They were too early — before module expansion. Doc comments updated to point at the new call site.
- `carina-cli/src/commands/mod.rs::validate_and_resolve_errors_with_factories`: after `module_resolver::resolve_modules_with_config`, call `resolve_provider_unresolved_attributes` then `finalize_provider_configs`.
- New multi-file fixture `carina-cli/tests/fixtures/share_provider_attrs/{component/{providers.crn,main.crn},modules/standard-tags/main.crn}`.
- New integration test `carina-cli/tests/share_provider_attrs.rs` that exercises the directory-scoped CLI pipeline and asserts the resolved `default_tags` matches the literal-map equivalent.

## Plan-vs-implementation note

Two divergences from the plan, both intentional:

1. **Module shape**: plan used `exports { tags = { ... } }`. Actual fixture uses `attributes { tags: map(String) = { ... } }`. Reason: `module_resolver::expander.rs` creates virtual resources for module calls from `attributes` blocks, not `exports`. `exports` is the cross-directory `upstream_state` mechanism (a different surface).

2. **Test entry point**: plan suggested `carina_core::load_directory(...)`. Actual test uses `carina_cli::commands::validate_and_resolve(&mut config.parsed, &fixture, true)`. That is the canonical CLI pipeline (load + module-expand + resolve_provider_attrs + finalize) where the new resolve+finalize live; `skip_resource_validation = true` bypasses provider-plugin loading.

## LSP parity

LSP currently does not call `resolve_provider_unresolved_attributes` + `finalize_provider_configs`. It uses `parse_directory_with_overrides`, which now intentionally does not finalize. **Task 7 (#2753)** brings LSP up to parity. This PR's `Closes #2751` does not close the umbrella #2717.

## Test plan

- [x] `cargo nextest run -p carina-cli share_provider_attrs` — new integration test passes
- [x] `cargo nextest run --workspace` — 3026 tests pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass
