### PR TITLE
mock provider: append trailing newline to MockProvider state file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "carina-plugin-sdk",
  "carina-provider-protocol",
  "serde_json",
+ "tempfile",
  "wit-bindgen 0.51.0",
 ]
 

--- a/carina-provider-mock/Cargo.toml
+++ b/carina-provider-mock/Cargo.toml
@@ -18,5 +18,8 @@ carina-plugin-sdk = { path = "../carina-plugin-sdk" }
 carina-provider-protocol = { path = "../carina-provider-protocol" }
 serde_json = "1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wit-bindgen = { version = "0.51", default-features = false, features = ["macros"] }

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -35,7 +35,12 @@ impl MockProvider {
         if let Some(parent) = self.state_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        let content = serde_json::to_string_pretty(states)?;
+        let mut content = serde_json::to_string_pretty(states)?;
+        // Match the trailing-newline convention used by
+        // carina.state.json (#2721) and carina-backend.lock (#2583)
+        // so POSIX tooling and "add final newline" editors agree on
+        // the file shape.
+        content.push('\n');
         fs::write(&self.state_file, content)
     }
 
@@ -167,5 +172,34 @@ impl Provider for MockProvider {
 
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the byte-level shape so MockProvider's state file matches
+    // the trailing-newline convention used by carina.state.json
+    // (#2721) and carina-backend.lock (#2583).
+    #[test]
+    fn state_file_ends_with_trailing_newline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_file = tmp.path().join("mock-state.json");
+        let provider = MockProvider {
+            state_file: state_file.clone(),
+        };
+        let mut states = HashMap::new();
+        let mut entry = HashMap::new();
+        entry.insert("k".to_string(), serde_json::json!("v"));
+        states.insert("aws.s3.Bucket.b".to_string(), entry);
+        provider.save_states(&states).unwrap();
+        let bytes = fs::read(&state_file).unwrap();
+        assert_eq!(
+            bytes.last().copied(),
+            Some(b'\n'),
+            "MockProvider state file must end with a trailing newline; got {:?}",
+            bytes.last().map(|b| *b as char),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #2759.

`MockProvider::save_states` writes JSON via `serde_json::to_string_pretty` + `fs::write` without a trailing newline. Final issue in the trailing-newline series (#2583, #2721, #2722, #2754, #2758) — brings the mock provider into convention parity so example/test artifacts read by humans match the rest of carina's durable JSON shape.

## Fix

Append `\n` to the serialized contents in `save_states`. Pin the byte-level shape with a regression test in a new `mod tests` block (placed at end of `lib.rs` to satisfy clippy's `items_after_test_module` lint).

`tempfile` is added as a dev-dependency, mirroring `carina-state` and `carina-cli`. The dev-dep is excluded from the `wasm32-wasip2` build target (verified locally).

`load_states` requires no change — `serde_json::from_str` is whitespace-tolerant per the JSON spec.

## Follow-up filed

- #2769 — extract a `pretty_with_newline<T>` helper in `carina-core` to consolidate the now-five sites that open-code the same pattern. Pure refactor; no behavior change.

## Test plan

- [x] `cargo nextest run -p carina-provider-mock` (pass; new `state_file_ends_with_trailing_newline` confirms the fix)
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2` (dev-dep correctly excluded)
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)