### PR TITLE
lsp: bring provider-attribute diagnostics to parity with validate

### DIFF
--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -392,6 +392,14 @@ impl DiagnosticEngine {
     /// Run a directory-scoped parse with the current editor buffer substituted
     /// for its on-disk copy, so diagnostics that need cross-file context
     /// (upstream-state exports, for-iterable bindings) update on keystrokes.
+    ///
+    /// After the directory parse, run module expansion +
+    /// `resolve_provider_unresolved_attributes` + `finalize_provider_configs`
+    /// so deferred provider attributes (e.g. `default_tags = mod.tags`) reach
+    /// their typed fields and the LSP catches the same errors `carina validate`
+    /// would (#2717). A finalize error is non-fatal here: the merged parse is
+    /// still returned so identifier-scope and other diagnostics keep running;
+    /// the error itself surfaces via [`Self::finalize_provider_diagnostic`].
     pub(super) fn parse_merged_with_buffer(
         &self,
         doc: &Document,
@@ -402,12 +410,63 @@ impl DiagnosticEngine {
         if let Some(name) = current_file_name {
             overrides.insert(name.to_string(), doc.text());
         }
-        carina_core::config_loader::parse_directory_with_overrides(
+        let mut merged = carina_core::config_loader::parse_directory_with_overrides(
             base_path,
             &self.provider_context,
             &overrides,
         )
-        .ok()
+        .ok()?;
+        // Module expansion is a no-op for configs without `module_call`, and
+        // safe to ignore-if-fails for module-loading errors (sibling LSP
+        // checks like `check_module_calls` already report those). We only
+        // care about reaching finalize on the typical case.
+        let _ = carina_core::module_resolver::resolve_modules_with_config(
+            &mut merged,
+            base_path,
+            &self.provider_context,
+        );
+        let _ = carina_core::parser::resolve_provider_unresolved_attributes(
+            &mut merged,
+            &self.provider_context,
+        );
+        let _ = carina_core::parser::finalize_provider_configs(&mut merged);
+        Some(merged)
+    }
+
+    /// Run finalize-against-a-buffer in isolation so the engine can surface
+    /// `default_tags must resolve to a map` etc. as diagnostics. The merged
+    /// parse + module-expansion + resolve pair is rebuilt here intentionally:
+    /// `parse_merged_with_buffer` swallows the finalize error to keep
+    /// identifier-scope diagnostics running, but that error must surface
+    /// somewhere (#2717 / #2753).
+    pub(super) fn finalize_provider_diagnostic(
+        &self,
+        doc: &Document,
+        current_file_name: Option<&str>,
+        base_path: &std::path::Path,
+    ) -> Option<carina_core::parser::ParseError> {
+        let mut overrides: HashMap<String, String> = HashMap::new();
+        if let Some(name) = current_file_name {
+            overrides.insert(name.to_string(), doc.text());
+        }
+        let mut merged = carina_core::config_loader::parse_directory_with_overrides(
+            base_path,
+            &self.provider_context,
+            &overrides,
+        )
+        .ok()?;
+        let _ = carina_core::module_resolver::resolve_modules_with_config(
+            &mut merged,
+            base_path,
+            &self.provider_context,
+        );
+        if let Err(e) = carina_core::parser::resolve_provider_unresolved_attributes(
+            &mut merged,
+            &self.provider_context,
+        ) {
+            return Some(e);
+        }
+        carina_core::parser::finalize_provider_configs(&mut merged).err()
     }
 
     /// Collect every binding name declared anywhere in `base_path` by

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -147,6 +147,17 @@ impl DiagnosticEngine {
             diagnostics.extend(self.check_for_iterable_bindings(doc, merged, current_file_name));
         }
 
+        // Provider-attribute finalize diagnostic (#2717 / #2753): if a
+        // non-literal `default_tags` (or future deferred attribute) does
+        // not resolve to the expected shape, surface that error as a
+        // diagnostic so editors flag it the same way `carina validate`
+        // does.
+        if let Some(base) = base_path
+            && let Some(err) = self.finalize_provider_diagnostic(doc, current_file_name, base)
+        {
+            diagnostics.push(parse_error_to_diagnostic(&err));
+        }
+
         // `known_bindings` for the text-scan undefined-reference check.
         // When the merged parse succeeds, `BindingNameSet::from_parsed`
         // yields every binding declared anywhere in the directory. When

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3685,3 +3685,61 @@ fn empty_interpolation_diagnostic_is_warning_not_error() {
         "empty interpolation is a mid-edit hint, not a hard error"
     );
 }
+
+#[test]
+fn lsp_flags_undefined_let_reference_in_provider_block() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    let file = base.join("providers.crn");
+    std::fs::write(
+        &file,
+        r#"
+provider awscc {
+  source       = "github.com/carina-rs/carina-provider-awscc"
+  revision     = "main"
+  default_tags = nonexistent.tags
+}
+"#,
+    )
+    .unwrap();
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(&file).unwrap();
+    let diags = analyze_with_buffer(&engine, base, "providers.crn", &buffer);
+
+    assert!(
+        diags.iter().any(|d| d.message.contains("nonexistent")),
+        "LSP must surface UndefinedIdentifier for `nonexistent`; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn lsp_flags_non_map_default_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    let file = base.join("providers.crn");
+    std::fs::write(
+        &file,
+        r#"
+let bad = "not a map"
+
+provider awscc {
+  source       = "github.com/carina-rs/carina-provider-awscc"
+  revision     = "main"
+  default_tags = bad
+}
+"#,
+    )
+    .unwrap();
+
+    let engine = test_engine();
+    let buffer = std::fs::read_to_string(&file).unwrap();
+    let diags = analyze_with_buffer(&engine, base, "providers.crn", &buffer);
+
+    assert!(
+        diags.iter().any(|d| d.message.contains("default_tags")),
+        "LSP must surface non-map default_tags error; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}


### PR DESCRIPTION
Closes #2753. Closes #2717. Task 7/7 of #2717 — final task in the series.

## Summary

Extend the LSP's directory-scoped parse to mirror the CLI pipeline introduced in #2768:

```
parse_directory_with_overrides
  -> module_resolver::resolve_modules_with_config
  -> resolve_provider_unresolved_attributes
  -> finalize_provider_configs
```

Errors from the first three steps are swallowed (sibling LSP checks like `check_module_calls` and `check_undefined_references` already cover their failure modes). Finalize errors surface as a new diagnostic via the new helper `finalize_provider_diagnostic`.

After this PR, an editor flags

```crn
provider awscc { default_tags = bad }
let bad = "not a map"
```

with the same `default_tags must resolve to a map` error that `carina validate` produces, satisfying the validate-LSP parity rule.

## Changes

- `carina-lsp/src/diagnostics/checks.rs::parse_merged_with_buffer`: invokes module expand + resolve provider attrs + finalize. Errors swallowed so other diagnostics keep running.
- `carina-lsp/src/diagnostics/checks.rs::finalize_provider_diagnostic` (new): re-runs the pipeline and returns the finalize error so the engine can surface it.
- `carina-lsp/src/diagnostics/mod.rs::analyze_with_filename`: pushes the finalize error (if any) as a Diagnostic.
- 2 new tests:
  - `lsp_flags_undefined_let_reference_in_provider_block` — undefined ref via field access form (Task 3 already covers this; regression guard).
  - `lsp_flags_non_map_default_tags` — non-map `default_tags` produces a "default_tags" diagnostic.

## Performance note

`finalize_provider_diagnostic` re-builds the directory parse on every keystroke (the merged parse is also built by `parse_merged_with_buffer`). Pragmatic for now — the alternative is widening the `parse_merged_with_buffer` return shape to `(Option<ParsedFile>, Option<ParseError>)`, which touches every caller. If editor latency becomes a concern, that refactor is the obvious follow-up.

## Real-infra smoke

Task 6 (#2752) — real-infra plan diff against `carina-rs/infra` — is left for the user to run manually since it requires AWS credentials and the user's `infra/` working copy.

## Test plan

- [x] `cargo nextest run -p carina-lsp lsp_flags` — 2 new tests pass
- [x] `cargo nextest run -p carina-lsp` — full suite green (no regression)
- [x] `cargo nextest run --workspace` — 3029 tests pass
- [x] `cargo test --workspace --doc` — doctests green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts pass

