### PR TITLE
carina-core: add pretty_with_newline JSON helpers, migrate all callers

### DIFF
--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -382,13 +382,8 @@ pub async fn run_plan(
     if let Some(out_path) = out {
         let plan_file = build_plan_file(path, &parsed, &state_file, &ctx)
             .map_err(|e| format_plan_save_error(&e, "--out"))?;
-        let mut json_out = serde_json::to_string_pretty(&plan_file)
+        let json_out = carina_core::utils::pretty_with_newline(&plan_file)
             .map_err(|e| format!("Failed to serialize plan: {}", e))?;
-        // Match the trailing-newline convention used by
-        // carina-backend.lock, carina.state.json, and
-        // carina-providers.lock so POSIX tooling and "add final
-        // newline" editors agree on the file shape.
-        json_out.push('\n');
         fs::write(out_path, json_out).map_err(|e| format!("Failed to write plan file: {}", e))?;
 
         println!();

--- a/carina-core/src/utils.rs
+++ b/carina-core/src/utils.rs
@@ -615,6 +615,29 @@ pub fn is_identifier_safe(s: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Serialize `value` as pretty JSON terminated with `\n`. Matches the
+/// trailing-newline convention enforced across all durable JSON
+/// artifacts Carina writes (#2583, #2721, #2722, #2754, #2758, #2759)
+/// so POSIX tooling and "add final newline" editors agree on the file
+/// shape regardless of the writer.
+///
+/// Each caller maps the returned `serde_json::Error` to its local
+/// error type as before; the helper does no error wrapping itself.
+pub fn pretty_with_newline<T: serde::Serialize>(value: &T) -> serde_json::Result<String> {
+    let mut s = serde_json::to_string_pretty(value)?;
+    s.push('\n');
+    Ok(s)
+}
+
+/// Byte-oriented variant of [`pretty_with_newline`] for callers (e.g.
+/// the S3 backend's `PutObject`) that consume `Vec<u8>` directly and
+/// want to avoid an intermediate `String`.
+pub fn pretty_with_newline_bytes<T: serde::Serialize>(value: &T) -> serde_json::Result<Vec<u8>> {
+    let mut v = serde_json::to_vec_pretty(value)?;
+    v.push(b'\n');
+    Ok(v)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1285,5 +1308,38 @@ mod tests {
             canonicalize_map_key_address("explicit-name-with-hyphens"),
             "explicit-name-with-hyphens"
         );
+    }
+
+    #[test]
+    fn pretty_with_newline_appends_single_trailing_newline() {
+        let value = serde_json::json!({"a": 1});
+        let s = pretty_with_newline(&value).unwrap();
+        assert!(s.ends_with("}\n"), "expected `...}}\\n`, got: {s:?}");
+        // Exactly one newline, not two.
+        assert!(!s.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn pretty_with_newline_bytes_appends_single_trailing_newline() {
+        let value = serde_json::json!({"a": 1});
+        let v = pretty_with_newline_bytes(&value).unwrap();
+        assert_eq!(v.last().copied(), Some(b'\n'));
+        let len = v.len();
+        // Last char is `\n`, second-to-last is `}` — not a double newline.
+        assert_eq!(v.get(len - 2).copied(), Some(b'}'));
+    }
+
+    #[test]
+    fn pretty_with_newline_propagates_serialize_error() {
+        // serde_json refuses non-string keys in maps because the JSON
+        // spec only allows string keys. A `BTreeMap<Vec<i32>, _>` key
+        // would serialize to a JSON array, so the serializer fails.
+        // The helper must surface that error, not swallow it.
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(vec![1, 2], "x");
+        let err = pretty_with_newline(&map).unwrap_err();
+        // The exact message is serde_json's; we only assert that a
+        // serialization failure surfaces as an Err.
+        assert!(!err.to_string().is_empty());
     }
 }

--- a/carina-provider-mock/src/lib.rs
+++ b/carina-provider-mock/src/lib.rs
@@ -35,12 +35,7 @@ impl MockProvider {
         if let Some(parent) = self.state_file.parent() {
             fs::create_dir_all(parent)?;
         }
-        let mut content = serde_json::to_string_pretty(states)?;
-        // Match the trailing-newline convention used by
-        // carina.state.json (#2721) and carina-backend.lock (#2583)
-        // so POSIX tooling and "add final newline" editors agree on
-        // the file shape.
-        content.push('\n');
+        let content = carina_core::utils::pretty_with_newline(states)?;
         fs::write(&self.state_file, content)
     }
 

--- a/carina-state/src/backend_lock.rs
+++ b/carina-state/src/backend_lock.rs
@@ -111,12 +111,8 @@ impl BackendLock {
     /// Persist this lock snapshot at the project root.
     pub fn save(&self, base_dir: &Path) -> BackendResult<()> {
         let path = Self::lock_path(base_dir);
-        let mut contents = serde_json::to_string_pretty(self)
+        let contents = carina_core::utils::pretty_with_newline(self)
             .map_err(|e| BackendError::Serialization(e.to_string()))?;
-        // Match the trailing-newline convention used by
-        // `carina-providers.lock` so POSIX tooling and "add final
-        // newline" editors agree on the file shape.
-        contents.push('\n');
         std::fs::write(&path, contents)
             .map_err(|e| BackendError::Io(format!("Failed to write {}: {}", path.display(), e)))?;
         Ok(())

--- a/carina-state/src/backends/local.rs
+++ b/carina-state/src/backends/local.rs
@@ -242,14 +242,9 @@ impl StateBackend for LocalBackend {
     }
 
     async fn write_state(&self, state: &StateFile) -> BackendResult<()> {
-        let mut content = serde_json::to_string_pretty(state).map_err(|e| {
+        let content = carina_core::utils::pretty_with_newline(state).map_err(|e| {
             BackendError::Serialization(format!("Failed to serialize state: {}", e))
         })?;
-        // Match the trailing-newline convention used by
-        // carina-backend.lock and carina-providers.lock so POSIX
-        // tooling and "add final newline" editors agree on the
-        // file shape.
-        content.push('\n');
 
         // Write to a temp file in the same directory, then rename atomically
         let tmp_path = self.state_path.with_extension("json.tmp");

--- a/carina-state/src/backends/s3.rs
+++ b/carina-state/src/backends/s3.rs
@@ -128,25 +128,14 @@ impl S3Backend {
         Ok(self.read_lock_with_etag().await?.map(|(lock, _)| lock))
     }
 
-    /// Serialize `value` as pretty JSON with a trailing newline, ready
-    /// to upload as the body of an S3 PutObject. Matches the
-    /// trailing-newline convention used by the local backend's
-    /// `carina.state.json` (#2721) and `carina-backend.lock` (#2583)
-    /// so POSIX tooling and "add final newline" editors agree on the
-    /// file shape regardless of which backend stores the artifact.
-    fn pretty_body_with_newline<T: serde::Serialize>(value: &T) -> BackendResult<Vec<u8>> {
-        let mut body = serde_json::to_vec_pretty(value)
-            .map_err(|e| BackendError::Serialization(e.to_string()))?;
-        body.push(b'\n');
-        Ok(body)
-    }
-
     fn lock_body(lock: &LockInfo) -> BackendResult<Vec<u8>> {
-        Self::pretty_body_with_newline(lock)
+        carina_core::utils::pretty_with_newline_bytes(lock)
+            .map_err(|e| BackendError::Serialization(e.to_string()))
     }
 
     fn state_body(state: &StateFile) -> BackendResult<Vec<u8>> {
-        Self::pretty_body_with_newline(state)
+        carina_core::utils::pretty_with_newline_bytes(state)
+            .map_err(|e| BackendError::Serialization(e.to_string()))
     }
 
     async fn write_lock_if_absent(&self, lock: &LockInfo) -> BackendResult<bool> {


### PR DESCRIPTION
## Summary

Closes #2769.

The trailing-newline series (#2583, #2721, #2722, #2754, #2758, #2759) left FIVE production sites open-coding the same pattern:

```rust
let mut s = serde_json::to_string_pretty(value)?;
s.push('\n');
```

Centralize the convention behind two helpers in `carina-core::utils`:

- `pretty_with_newline<T: Serialize>(&T) -> serde_json::Result<String>`
- `pretty_with_newline_bytes<T: Serialize>(&T) -> serde_json::Result<Vec<u8>>`

The `Vec<u8>` variant exists so the S3 backend's `PutObject` path keeps its byte factoring without paying for an intermediate `String` allocation + UTF-8 validation. The split mirrors `serde_json`'s own `to_string_pretty` / `to_vec_pretty` API.

Each helper returns `serde_json::Error` unwrapped; callers preserve their existing error mappings (`BackendError::Serialization`, `format!`-into-`String`, `?`-into-`io::Error`). Pure refactor — byte-for-byte output of all five writers is unchanged.

## Migrated call sites

- `carina-state/src/backend_lock.rs::save`
- `carina-state/src/backends/local.rs::write_state`
- `carina-state/src/backends/s3.rs::lock_body` + `state_body` (drops the local `pretty_body_with_newline` helper)
- `carina-cli/src/commands/plan.rs::run_plan --out`
- `carina-provider-mock/src/lib.rs::save_states`

## Why this shape

Per-writer regression tests stay intact: each writer's `*_ends_with_trailing_newline` test still pins its byte-level shape independently of the helper, so a future writer that drops the helper call regresses loudly. The helper is the *positive* reinforcement; the per-writer tests are the *negative* one.

## Test plan

- [x] `cargo nextest run --workspace` (3031 tests pass; new `pretty_with_newline_*` helper tests + all per-writer regression tests still green)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build -p carina-provider-mock --target wasm32-wasip2`
- [x] `bash scripts/check-*.sh` (all 5 scripts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)