### PR TITLE
docs: spec example must use `attributes`, not `exports` (#2773)

### DIFF
--- a/docs/plans/2026-05-09-share-provider-attributes.md
+++ b/docs/plans/2026-05-09-share-provider-attributes.md
@@ -404,12 +404,12 @@ Fixture content:
 `modules/standard-tags/main.crn`:
 ```crn
 arguments {
-  environment: string
-  component:   string
+  environment: String
+  component:   String
 }
 
-exports {
-  tags = {
+attributes {
+  tags: map(String) = {
     ManagedBy   = 'carina'
     Project     = 'carina-rs'
     Repository  = 'carina-rs/infra'

--- a/docs/specs/2026-05-09-share-provider-attributes-design.md
+++ b/docs/specs/2026-05-09-share-provider-attributes-design.md
@@ -76,12 +76,12 @@ provider awscc {
 ```crn
 # infra/.../modules/standard-tags/main.crn
 arguments {
-  environment: string
-  component:   string
+  environment: String
+  component:   String
 }
 
-exports {
-  tags = {
+attributes {
+  tags: map(String) = {
     ManagedBy   = 'carina'
     Project     = 'carina-rs'
     Repository  = 'carina-rs/infra'
@@ -90,6 +90,23 @@ exports {
   }
 }
 ```
+
+The module exposes its tag map via the `attributes { ... }` block,
+not `exports { ... }`. The two surfaces are unrelated:
+
+- `attributes { ... }` declares a module's **return-value fields** —
+  the things a call-site binding (`let st = standard_tags { ... }`)
+  carries on `st.tags`. `module_resolver::expander` turns each entry
+  into a virtual-resource attribute at module-call time, so the value
+  is resolvable as soon as the module call is expanded.
+- `exports { ... }` declares **state values** that another
+  configuration directory can read via `upstream_state { source = '...' }`.
+  The exports are evaluated against the directory's *applied state*
+  (post-plan/apply), not against parse-time DSL values.
+
+A module's return value is `attributes`. `exports` is the
+state-export surface — using it for module return values does not
+work, because the call-site binding only sees `attributes` entries.
 
 ### Why Option 1, not Options 2/3
 
@@ -117,7 +134,10 @@ the grammar today:
   `collect_known_bindings_merged` (`carina-core/src/parser/resolve.rs:262`)
   already includes `parsed.uses[].alias` in the binding name set, so
   the `st` module name resolves.
-- Module `arguments { ... }` and `exports { ... }` blocks — existing.
+- Module `arguments { ... }` and `attributes { ... }` blocks —
+  existing. (`exports { ... }` is the state-export surface read by
+  `upstream_state { source }` and is unrelated to module-call return
+  values; the call-site binding carries `attributes` entries.)
 
 The only place that breaks is the parse-time extraction of `default_tags`
 in `parse_provider_block`.


### PR DESCRIPTION
Closes #2773.

## Summary

Fix a spec-doc bug introduced in #2746. The shared-provider-attributes design and plan used `exports { tags = ... }` in the module example, but Carina's `module_resolver::expander.rs` only consumes `attributes { ... }` blocks when expanding a module call into a virtual resource.

The user-visible field on the call-site binding (`st.tags` in `let st = standard_tags { ... }`) is the `attributes` entry, not `exports`. `exports` is a different surface — it serves cross-directory `upstream_state { source = '...' }` reads.

## Why this PR exists

#2773 reported that `default_tags = st.tags` failed at finalize with `must resolve to a map, got ResourceRef`. Investigation revealed the user faithfully copied the spec's example, which is wrong: it tells the reader to write `exports { tags = ... }`, but the parser/resolver path only finds `tags` if it lives in `attributes { tags: map(String) = ... }`.

The fixture used by Task 5's integration test (`carina-cli/tests/fixtures/share_provider_attrs/modules/standard-tags/main.crn`) already uses `attributes` — only the spec and plan documents were stale.

## Diff

Only `docs/`:

- `docs/specs/2026-05-09-share-provider-attributes-design.md`: example block changed from `exports { tags = ... }` to `attributes { tags: map(String) = ... }`. Added a paragraph distinguishing the two block types.
- `docs/plans/2026-05-09-share-provider-attributes.md`: same change in the plan's "Test" section.

## User-side action

Users hitting the same error should change their module's `exports { tags = ... }` to `attributes { tags: map(String) = ... }`. The call-site binding then resolves correctly through the `module_resolver::resolve_modules_with_config` -> `resolve_provider_unresolved_attributes` -> `finalize_provider_configs` pipeline introduced in the #2717 series.

## Test plan

- [x] `bash scripts/check-docs-use-new-spellings.sh` — docs OK
- [x] `git diff main` shows only `docs/` changes
- [x] Three-way consistency between spec, plan, and the merged Task 5 fixture verified

