### PR TITLE
carina-core: make arguments {} visible to sibling .crn files

### DIFF
--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -196,7 +196,16 @@ impl ModuleResolver<'_> {
             for (key, expr) in &new_resource.attributes {
                 let rewritten =
                     rewrite_intra_module_refs(expr, instance_prefix, &intra_module_bindings);
-                let substituted = substitute_arguments(&rewritten, &argument_values);
+                let mut substituted = substitute_arguments(&rewritten, &argument_values);
+                // After substitution, an `Interpolation` whose `${...}`
+                // parts collapsed to literal scalars must canonicalize
+                // back to a flat `String`. Without this, `role_name =
+                // "test-role-${env}"` keeps a single-arg `Interpolation`
+                // with `Expr(String("dev"))` instead of `String("test-role-dev")`,
+                // and downstream consumers that match on `Value::String`
+                // (state diff, plan rendering) miss the resolved value.
+                // Symmetric with the default-evaluation path above. #2815.
+                substituted.canonicalize_in_place();
                 substituted_attrs.insert(key.clone(), substituted);
             }
             new_resource.attributes = substituted_attrs;
@@ -216,7 +225,12 @@ impl ModuleResolver<'_> {
                     // Rewrite intra-module refs and substitute arguments
                     let rewritten =
                         rewrite_intra_module_refs(value, instance_prefix, &intra_module_bindings);
-                    let substituted = substitute_arguments(&rewritten, &argument_values);
+                    let mut substituted = substitute_arguments(&rewritten, &argument_values);
+                    // Same post-substitution canonicalize as the resource
+                    // attribute path above — collapse `Interpolation`
+                    // whose `${arg}` slots resolved to scalars back to a
+                    // flat `String`. #2815.
+                    substituted.canonicalize_in_place();
                     virtual_attrs.insert(attr_param.name.clone(), substituted);
                 }
             }

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -1242,8 +1242,6 @@ fn create_module_with_interpolation() -> ParsedFile {
 
 #[test]
 fn test_expand_module_call_with_interpolation() {
-    use crate::resource::InterpolationPart;
-
     let resolver = {
         let mut r = ModuleResolver::new(".");
         r.imported_modules
@@ -1277,13 +1275,14 @@ fn test_expand_module_call_with_interpolation() {
     );
     assert_eq!(vpc.get_attr("env"), Some(&Value::String("dev".to_string())));
 
-    // Interpolation with argument should have the argument value substituted
+    // Interpolation with argument substitutes and canonicalizes back to
+    // a flat `String` so downstream `Value::String` consumers (state
+    // diff, plan rendering) see the resolved value. Without the post-
+    // substitution canonicalize, this would stay as
+    // `Interpolation([Literal("test-"), Expr(String("dev"))])` (#2815).
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::Interpolation(vec![
-            InterpolationPart::Literal("test-".to_string()),
-            InterpolationPart::Expr(Value::String("dev".to_string())),
-        ]))
+        Some(&Value::String("test-dev".to_string())),
     );
 }
 
@@ -3375,5 +3374,61 @@ fn caller_side_value_in_string_literal_union_is_accepted() {
         result.is_ok(),
         "Caller passing 'prod' (in the declared union) must be accepted. Got: {:?}",
         result
+    );
+}
+
+/// Regression for #2815: an `arguments {}` block declared in `main.crn`
+/// must be visible to identifier references in *sibling* `.crn` files in
+/// the same module directory. Before the fix, the argument name was only
+/// registered in the per-file `ParseContext`, so `${env}` in `role.crn`
+/// degraded to a literal `Value::String("env")` — `role_name` rendered as
+/// `"test-role-env"` instead of `"test-role-dev"`.
+#[test]
+fn test_arguments_visible_to_sibling_crn_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let module_dir = tmp.path().join("modules/usecase");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        module_dir.join("main.crn"),
+        r#"
+arguments {
+  env: String
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        module_dir.join("role.crn"),
+        r#"
+let role = awscc.iam.Role {
+  role_name = "test-role-${env}"
+  assume_role_policy_document = {}
+}
+"#,
+    )
+    .unwrap();
+
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("main.crn"),
+        r#"
+let uc = use { source = '../modules/usecase' }
+let r  = uc { env = 'dev' }
+"#,
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+    resolve_modules(&mut parsed, &root_dir).expect("resolve_modules should succeed");
+
+    assert_eq!(
+        role_names(&parsed),
+        ["test-role-dev".to_string()]
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        "argument `env` declared in `main.crn` must substitute into `${{env}}` \
+         interpolation in sibling `role.crn`",
     );
 }

--- a/carina-core/src/parser/expressions/string_literal.rs
+++ b/carina-core/src/parser/expressions/string_literal.rs
@@ -71,7 +71,7 @@ pub(crate) fn parse_string_value(
                     // — the LSP surfaces it as a diagnostic; downstream
                     // resolvers carry it as an unresolved value. See #2480.
                     let value = match inner.into_inner().next() {
-                        Some(expr_pair) => parse_expression(expr_pair, ctx)?,
+                        Some(expr_pair) => parse_interpolation_expr(expr_pair, ctx)?,
                         None => Value::Unknown(UnknownReason::EmptyInterpolation),
                     };
                     parts.push(InterpolationPart::Expr(value));
@@ -101,6 +101,66 @@ pub(crate) fn parse_string_value(
             .collect::<String>();
         Ok(Value::String(s))
     }
+}
+
+/// Parse the expression inside `${ ... }`. Mostly a thin wrapper around
+/// [`parse_expression`], with one carve-out: a bare identifier with no
+/// field/index access whose name is not bound in this file lowers to a
+/// `ResourceRef` placeholder rather than a `Value::String` literal.
+///
+/// `parse_expression` keeps the legacy "unknown bare identifier becomes
+/// `Value::String`" fallback because outside interpolation it covers
+/// schema enum shorthand (e.g. `instance_tenancy = dedicated`). Inside
+/// `${...}` an enum shorthand makes no sense, so the same fallback turns
+/// `${env}` into a literal `"env"` and module argument substitution
+/// downstream sees nothing to substitute. The placeholder shape lets
+/// `module_resolver::expander::substitute_arguments` and
+/// `parser::resolve_resource_refs_with_config` find and rewrite the
+/// reference at the directory aggregate, so an `arguments {}` block in
+/// `main.crn` is visible from sibling `.crn` files (#2815).
+fn parse_interpolation_expr(
+    pair: pest::iterators::Pair<Rule>,
+    ctx: &ParseContext,
+) -> Result<Value, ParseError> {
+    if let Some(name) = bare_variable_ref_name(&pair)
+        && ctx.get_variable(&name).is_none()
+    {
+        return Ok(Value::resource_ref(name, String::new(), vec![]));
+    }
+    parse_expression(pair, ctx)
+}
+
+/// If `pair` is an `expression` whose only payload is a bare
+/// `variable_ref` (no field or index access), return the identifier
+/// name. Otherwise return `None`. Used by the interpolation parser to
+/// decide whether the unbound-identifier fallback should be a
+/// `ResourceRef` placeholder instead of a `Value::String` literal.
+fn bare_variable_ref_name(pair: &pest::iterators::Pair<Rule>) -> Option<String> {
+    fn descend(pair: pest::iterators::Pair<Rule>) -> Option<String> {
+        match pair.as_rule() {
+            Rule::variable_ref => {
+                let mut inner = pair.into_inner();
+                let ident = inner.next()?;
+                if ident.as_rule() != Rule::identifier {
+                    return None;
+                }
+                let name = ident.as_str().to_string();
+                if inner.next().is_some() {
+                    return None;
+                }
+                Some(name)
+            }
+            _ => {
+                let mut iter = pair.into_inner();
+                let only = iter.next()?;
+                if iter.next().is_some() {
+                    return None;
+                }
+                descend(only)
+            }
+        }
+    }
+    descend(pair.clone())
 }
 
 /// Handle escape sequences in string literals


### PR DESCRIPTION
Closes #2815.

## Summary

`${env}` in a sibling `.crn` file degraded to a literal `Value::String("env")` because two paths combined to drop the binding:

1. The bare-identifier `variable_ref` fallback in `primary.rs` lowers an unbound name to `Value::String` to support schema enum shorthand (`instance_tenancy = dedicated`). Inside `${...}` an enum shorthand is meaningless, so the same fallback turned `${env}` into the literal `"env"`.
2. After module-argument substitution, the resulting `Interpolation([Literal, Expr(String)])` shape was never canonicalized, so downstream `Value::String` consumers (state diff, plan rendering) missed the resolved value even when substitution did fire.

## Fix

- New `parse_interpolation_expr` wrapper in `string_literal.rs` carves out the bare-`variable_ref`-no-access case: when unbound in this file, emit a `ResourceRef` placeholder instead of a `Value::String` literal. `module_resolver::expander::substitute_arguments` and `parser::resolve_resource_refs_with_config` then resolve it against the directory aggregate. Enum shorthand outside interpolation is unchanged.
- Post-substitution `canonicalize_in_place()` in `module_resolver::expander.rs` (both the resource-attribute and virtual-resource paths) collapses single-`Expr`-scalar interpolations back to a flat `String`, symmetric with the default-evaluation path already in this file.

Side effect: previously silent `${typo}` typos now surface through `check_identifier_scope` as "Undefined identifier" diagnostics, which matches the original report's call-out that the bug had no validate-time error.

## Test plan

- [x] `cargo nextest run -p carina-core` (1796 tests pass, includes new `test_arguments_visible_to_sibling_crn_files` multi-file fixture mirroring the issue's reproduction)
- [x] `cargo nextest run --workspace` (3034 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
