### PR TITLE
carina-core: directory-aware parse pipeline (PR1 of #2817)

### DIFF
--- a/carina-core/src/config_loader.rs
+++ b/carina-core/src/config_loader.rs
@@ -65,103 +65,71 @@ pub fn load_configuration_with_config(
             return Err(format!("No .crn files found in {}", path.display()));
         }
 
-        let empty_parsed = ParsedFile::default;
-        let mut merged = empty_parsed();
-        let mut unresolved_merged = empty_parsed();
-        let mut parse_errors = Vec::new();
-        let mut backend_file: Option<PathBuf> = None;
-
+        // Read every file once and run the directory-aware parse so
+        // each file's `ParseContext` is seeded with the binding-name
+        // union from sibling `.crn`s. Without this, e.g. an
+        // `arguments {}` in `main.crn` would be invisible to `${env}`
+        // interpolations in sibling `role.crn` (#2815, #2817).
+        let mut file_inputs: Vec<(PathBuf, String)> = Vec::with_capacity(files.len());
         for file in &files {
             let content = fs::read_to_string(file)
                 .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?;
-            match parser::parse(&content, config) {
-                Ok(mut parsed) => {
-                    // Stamp the full source path onto warnings and deferred
-                    // for-expressions. Bare filenames are ambiguous when a
-                    // project spans multiple `.crn` files (and identically
-                    // named files in sibling directories), and they break
-                    // editor jump-to-location.
-                    let file_path = Some(file.display().to_string());
-                    for w in &mut parsed.warnings {
-                        w.file = file_path.clone();
-                    }
-                    for d in &mut parsed.deferred_for_expressions {
-                        d.file = file_path.clone();
-                    }
+            file_inputs.push((file.clone(), content));
+        }
+        let parsed_files = match parse_directory_files(&file_inputs, config) {
+            Ok(v) => v,
+            Err(e) => return Err(format!("{}: {}", path.display(), e)),
+        };
 
-                    let unresolved = parsed.clone();
-                    if let Err(e) = parser::resolve_resource_refs_with_config(&mut parsed, config) {
-                        parse_errors.push(format!("{}: {}", file.display(), e));
-                        continue;
-                    }
+        let empty_parsed = ParsedFile::default;
+        let mut merged = empty_parsed();
+        let mut unresolved_merged = empty_parsed();
+        let mut parse_errors: Vec<String> = Vec::new();
+        let mut backend_file: Option<PathBuf> = None;
 
-                    // Merge unresolved
-                    unresolved_merged.providers.extend(unresolved.providers);
-                    unresolved_merged.resources.extend(unresolved.resources);
-                    unresolved_merged.variables.extend(unresolved.variables);
-                    unresolved_merged.uses.extend(unresolved.uses);
-                    unresolved_merged
-                        .module_calls
-                        .extend(unresolved.module_calls);
-                    unresolved_merged.arguments.extend(unresolved.arguments);
-                    unresolved_merged
-                        .attribute_params
-                        .extend(unresolved.attribute_params);
-                    unresolved_merged
-                        .export_params
-                        .extend(unresolved.export_params);
-                    unresolved_merged
-                        .state_blocks
-                        .extend(unresolved.state_blocks);
-                    unresolved_merged
-                        .user_functions
-                        .extend(unresolved.user_functions);
-                    unresolved_merged
-                        .upstream_states
-                        .extend(unresolved.upstream_states);
-                    unresolved_merged
-                        .structural_bindings
-                        .extend(unresolved.structural_bindings);
-                    unresolved_merged.warnings.extend(unresolved.warnings);
-                    unresolved_merged
-                        .deferred_for_expressions
-                        .extend(unresolved.deferred_for_expressions);
+        for (file, mut parsed) in parsed_files {
+            // Stamp the full source path onto warnings and deferred
+            // for-expressions. Bare filenames are ambiguous when a
+            // project spans multiple `.crn` files (and identically
+            // named files in sibling directories), and they break
+            // editor jump-to-location.
+            let file_path = Some(file.display().to_string());
+            for w in &mut parsed.warnings {
+                w.file = file_path.clone();
+            }
+            for d in &mut parsed.deferred_for_expressions {
+                d.file = file_path.clone();
+            }
 
-                    // Merge resolved
-                    merged.providers.extend(parsed.providers);
-                    merged.resources.extend(parsed.resources);
-                    merged.variables.extend(parsed.variables);
-                    merged.uses.extend(parsed.uses);
-                    merged.module_calls.extend(parsed.module_calls);
-                    merged.arguments.extend(parsed.arguments);
-                    merged.attribute_params.extend(parsed.attribute_params);
-                    merged.export_params.extend(parsed.export_params);
-                    merged.state_blocks.extend(parsed.state_blocks);
-                    merged.user_functions.extend(parsed.user_functions);
-                    merged.upstream_states.extend(parsed.upstream_states);
-                    merged.requires.extend(parsed.requires);
-                    merged
-                        .structural_bindings
-                        .extend(parsed.structural_bindings);
-                    merged.warnings.extend(parsed.warnings);
-                    merged
-                        .deferred_for_expressions
-                        .extend(parsed.deferred_for_expressions);
-                    // Merge backend (only one allowed)
-                    if let Some(backend) = parsed.backend {
-                        if merged.backend.is_some() {
-                            parse_errors.push(format!(
-                                "{}: multiple backend blocks defined",
-                                file.display()
-                            ));
-                        } else {
-                            merged.backend = Some(backend);
-                            backend_file = Some(file.clone());
-                        }
-                    }
-                }
-                Err(e) => {
-                    parse_errors.push(format!("{}: {}", file.display(), e));
+            let mut unresolved = parsed.clone();
+            if let Err(e) = parser::resolve_resource_refs_with_config(&mut parsed, config) {
+                parse_errors.push(format!("{}: {}", file.display(), e));
+                continue;
+            }
+
+            // The legacy form unrolled both `merge_parsed_file` calls
+            // because the match arm needed independent control over
+            // backend collision. Now that the match is gone, both
+            // merges can delegate to the same helper. Backend collision
+            // for `merged` is checked explicitly below (mirroring the
+            // legacy "multiple backend blocks defined" error); the
+            // unresolved copy only ever stored a single backend, so we
+            // strip it before merging to avoid accidentally overwriting
+            // `unresolved_merged.backend`.
+            unresolved.backend = None;
+            merge_parsed_file(&mut unresolved_merged, unresolved);
+
+            let backend = parsed.backend.take();
+            merge_parsed_file(&mut merged, parsed);
+            if let Some(backend) = backend {
+                if merged.backend.is_some() {
+                    parse_errors.push(format!(
+                        "{}: multiple backend blocks defined",
+                        file.display()
+                    ));
+                } else {
+                    merged.backend = Some(backend);
+                    backend_file = Some(file.clone());
                 }
             }
         }
@@ -252,34 +220,34 @@ pub fn parse_directory_with_overrides(
         return Err(format!("No .crn files found in {}", dir.display()));
     }
 
-    let mut merged = ParsedFile::default();
-    let mut parse_errors = Vec::new();
-
+    // Resolve every file's source text (disk or override) up front so
+    // the directory-aware parse helper sees the right inputs. #2817.
+    let mut file_inputs: Vec<(PathBuf, String)> = Vec::with_capacity(paths.len());
     for (file, name) in &paths {
         let content = match overrides.get(name) {
             Some(buffer) => buffer.clone(),
             None => fs::read_to_string(file)
                 .map_err(|e| format!("Failed to read {}: {}", file.display(), e))?,
         };
-        match parser::parse(&content, config) {
-            Ok(mut parsed) => {
-                let file_path = Some(file.display().to_string());
-                for w in &mut parsed.warnings {
-                    w.file = file_path.clone();
-                }
-                for d in &mut parsed.deferred_for_expressions {
-                    d.file = file_path.clone();
-                }
-                merge_parsed_file(&mut merged, parsed);
-            }
-            Err(e) => {
-                parse_errors.push(format!("{}: {}", file.display(), e));
-            }
-        }
+        file_inputs.push((file.clone(), content));
     }
 
-    if !parse_errors.is_empty() {
-        return Err(parse_errors.join("\n"));
+    let parsed_files = match parse_directory_files(&file_inputs, config) {
+        Ok(v) => v,
+        Err(e) => return Err(format!("{}: {}", dir.display(), e)),
+    };
+
+    let mut merged = ParsedFile::default();
+
+    for (file, mut parsed) in parsed_files {
+        let file_path = Some(file.display().to_string());
+        for w in &mut parsed.warnings {
+            w.file = file_path.clone();
+        }
+        for d in &mut parsed.deferred_for_expressions {
+            d.file = file_path.clone();
+        }
+        merge_parsed_file(&mut merged, parsed);
     }
 
     // Resolve cross-file references on the merged result
@@ -326,6 +294,58 @@ pub(crate) fn merge_parsed_file(target: &mut ParsedFile, source: ParsedFile) {
     if let Some(backend) = source.backend {
         target.backend = Some(backend);
     }
+}
+
+/// Parse every `(path, source)` pair as part of a single directory unit.
+///
+/// Two-pass implementation that addresses the sibling-scope class
+/// (#2817):
+///
+/// - **Pass 1** parses every input with an empty seed list. This is the
+///   legacy per-file parse — sibling-defined names are not in scope, so
+///   ResourceRef / String fallback paths fire as before. The Pass-1
+///   `ParsedFile`s are merged only to collect the *binding-name union*
+///   from sibling files; the merged result itself is discarded.
+/// - **Pass 2** parses every input again, this time seeding the per-file
+///   `ParseContext` with the binding-name union from Pass 1. Names that
+///   originate in *sibling* files now resolve through the normal
+///   `ctx.get_variable` / `ctx.is_resource_binding` paths, so an
+///   `arguments {}` block in `main.crn` is visible from `role.crn`,
+///   a `let` declared in `helpers.crn` is visible from `main.crn`,
+///   etc.
+///
+/// The returned vector preserves the input order. Any per-file parse
+/// error from Pass 2 short-circuits and is returned to the caller; Pass
+/// 1 swallows nothing — if Pass 1 fails on a file, Pass 2 will fail on
+/// the same file with the same error.
+///
+/// Pass-1 cost is paid once per directory load. Each call to
+/// `parse_with_seeded_bindings` with an empty seed list is a no-op
+/// in `seed_bindings`, so single-file callers (parser tests, the
+/// `parse(input, config)` wrapper) pay zero overhead.
+pub fn parse_directory_files(
+    files: &[(PathBuf, String)],
+    config: &ProviderContext,
+) -> Result<Vec<(PathBuf, ParsedFile)>, parser::ParseError> {
+    // Pass 1: collect the binding-name union from a regular per-file
+    // parse. Errors here propagate identically to Pass 2 (same input,
+    // same parser path), so don't try to be clever about saving them.
+    let mut union = ParsedFile::default();
+    for (_, content) in files {
+        let parsed = parser::parse(content, config)?;
+        merge_parsed_file(&mut union, parsed);
+    }
+    let seeds: Vec<&str> = parser::collect_known_bindings_merged(&union)
+        .into_iter()
+        .collect();
+
+    // Pass 2: re-parse each file with the union seeded into `ctx`.
+    let mut out = Vec::with_capacity(files.len());
+    for (path, content) in files {
+        let parsed = parser::parse_with_seeded_bindings(content, config, &seeds)?;
+        out.push((path.clone(), parsed));
+    }
+    Ok(out)
 }
 
 /// Get base directory for module resolution.

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -196,7 +196,17 @@ impl ModuleResolver<'_> {
             for (key, expr) in &new_resource.attributes {
                 let rewritten =
                     rewrite_intra_module_refs(expr, instance_prefix, &intra_module_bindings);
-                let substituted = substitute_arguments(&rewritten, &argument_values);
+                let mut substituted = substitute_arguments(&rewritten, &argument_values);
+                // After substitution, an `Interpolation` whose `${...}`
+                // parts collapsed to literal scalars must canonicalize
+                // back to a flat `String`. Without this, `role_name =
+                // "test-role-${env}"` keeps a single-arg `Interpolation`
+                // with `Expr(String("dev"))` instead of
+                // `String("test-role-dev")`, and downstream consumers
+                // that match on `Value::String` (state diff, plan
+                // rendering) miss the resolved value. Symmetric with
+                // the default-evaluation path above. #2815 / #2817.
+                substituted.canonicalize_in_place();
                 substituted_attrs.insert(key.clone(), substituted);
             }
             new_resource.attributes = substituted_attrs;
@@ -216,7 +226,10 @@ impl ModuleResolver<'_> {
                     // Rewrite intra-module refs and substitute arguments
                     let rewritten =
                         rewrite_intra_module_refs(value, instance_prefix, &intra_module_bindings);
-                    let substituted = substitute_arguments(&rewritten, &argument_values);
+                    let mut substituted = substitute_arguments(&rewritten, &argument_values);
+                    // Same post-substitution canonicalize as the
+                    // resource-attribute path above (#2815 / #2817).
+                    substituted.canonicalize_in_place();
                     virtual_attrs.insert(attr_param.name.clone(), substituted);
                 }
             }

--- a/carina-core/src/module_resolver/loader.rs
+++ b/carina-core/src/module_resolver/loader.rs
@@ -51,15 +51,24 @@ pub(super) fn sorted_crn_paths_in(dir_path: &Path) -> std::io::Result<Vec<PathBu
 ///
 /// Returns `None` if the directory cannot be read or contains no module
 /// definitions (no arguments/attributes).
+///
+/// Routed through [`crate::config_loader::parse_directory_files`] so
+/// every file's `ParseContext` is seeded with the binding-name union
+/// from sibling `.crn` files (#2817).
 pub fn load_directory_module(dir_path: &Path) -> Option<ParsedFile> {
-    let mut merged = ParsedFile::default();
-
-    for path in sorted_crn_paths_in(dir_path).ok()? {
-        if let Ok(content) = fs::read_to_string(&path)
-            && let Ok(parsed) = crate::parser::parse(&content, &ProviderContext::default())
-        {
-            crate::config_loader::merge_parsed_file(&mut merged, parsed);
+    let paths = sorted_crn_paths_in(dir_path).ok()?;
+    let mut files: Vec<(PathBuf, String)> = Vec::with_capacity(paths.len());
+    for path in paths {
+        if let Ok(content) = fs::read_to_string(&path) {
+            files.push((path, content));
         }
+    }
+    let parsed_files =
+        crate::config_loader::parse_directory_files(&files, &ProviderContext::default()).ok()?;
+
+    let mut merged = ParsedFile::default();
+    for (_, parsed) in parsed_files {
+        crate::config_loader::merge_parsed_file(&mut merged, parsed);
     }
 
     if merged.arguments.is_empty() && merged.attribute_params.is_empty() {
@@ -106,16 +115,26 @@ pub fn derive_module_name(path: &Path) -> String {
 ///
 /// Unlike [`load_directory_module`], this returns a `Result` with descriptive
 /// error messages and does not check for module definitions (inputs/outputs).
+///
+/// Routed through [`crate::config_loader::parse_directory_files`] for
+/// directory-aware parse (#2817).
 pub fn load_module_from_directory(dir: &Path) -> Result<ParsedFile, String> {
     let paths = sorted_crn_paths_in(dir)
         .map_err(|e| format!("Failed to read directory {}: {}", dir.display(), e))?;
 
-    let mut merged = ParsedFile::default();
+    let mut files: Vec<(PathBuf, String)> = Vec::with_capacity(paths.len());
     for path in paths {
         let content = fs::read_to_string(&path)
             .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-        let parsed = crate::parser::parse(&content, &ProviderContext::default())
-            .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))?;
+        files.push((path, content));
+    }
+
+    let parsed_files =
+        crate::config_loader::parse_directory_files(&files, &ProviderContext::default())
+            .map_err(|e| format!("Failed to parse directory {}: {}", dir.display(), e))?;
+
+    let mut merged = ParsedFile::default();
+    for (_, parsed) in parsed_files {
         crate::config_loader::merge_parsed_file(&mut merged, parsed);
     }
 

--- a/carina-core/src/module_resolver/resolver.rs
+++ b/carina-core/src/module_resolver/resolver.rs
@@ -114,15 +114,25 @@ impl<'cfg> ModuleResolver<'cfg> {
     }
 
     /// Load all .crn files from a directory and merge them into a single ParsedFile.
+    ///
+    /// Routed through [`crate::config_loader::parse_directory_files`] so
+    /// every file's `ParseContext` is seeded with the binding-name union
+    /// from sibling `.crn` files. Without this, `arguments {}` declared
+    /// in `main.crn` would be invisible to `${env}` interpolations in
+    /// sibling `role.crn` (#2815). #2817.
     fn load_directory_module(&self, dir_path: &Path) -> Result<ParsedFile, ModuleError> {
-        let mut merged = ParsedFile::default();
+        let paths = sorted_crn_paths_in(dir_path)?;
+        let mut files: Vec<(std::path::PathBuf, String)> = Vec::with_capacity(paths.len());
+        for path in paths {
+            let content = std::fs::read_to_string(&path)?;
+            files.push((path, content));
+        }
+        let parsed_files = crate::config_loader::parse_directory_files(&files, self.config)?;
 
-        for file_path in sorted_crn_paths_in(dir_path)? {
-            let content = std::fs::read_to_string(&file_path)?;
-            let parsed = crate::parser::parse(&content, self.config)?;
+        let mut merged = ParsedFile::default();
+        for (_, parsed) in parsed_files {
             crate::config_loader::merge_parsed_file(&mut merged, parsed);
         }
-
         Ok(merged)
     }
 

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -1242,8 +1242,6 @@ fn create_module_with_interpolation() -> ParsedFile {
 
 #[test]
 fn test_expand_module_call_with_interpolation() {
-    use crate::resource::InterpolationPart;
-
     let resolver = {
         let mut r = ModuleResolver::new(".");
         r.imported_modules
@@ -1277,13 +1275,14 @@ fn test_expand_module_call_with_interpolation() {
     );
     assert_eq!(vpc.get_attr("env"), Some(&Value::String("dev".to_string())));
 
-    // Interpolation with argument should have the argument value substituted
+    // Interpolation with argument substitutes and canonicalizes back to
+    // a flat `String` so downstream `Value::String` consumers (state
+    // diff, plan rendering) see the resolved value. Without the post-
+    // substitution canonicalize, this would stay as
+    // `Interpolation([Literal("test-"), Expr(String("dev"))])` (#2815, #2817).
     assert_eq!(
         vpc.get_attr("name"),
-        Some(&Value::Interpolation(vec![
-            InterpolationPart::Literal("test-".to_string()),
-            InterpolationPart::Expr(Value::String("dev".to_string())),
-        ]))
+        Some(&Value::String("test-dev".to_string())),
     );
 }
 
@@ -2669,13 +2668,23 @@ m {
     assert_eq!(policy_map.get("y_value"), Some(&Value::Int(42)));
 }
 
-// #2393 — argument defaults are resolved in declaration order; a default
-// that refers to a later-declared argument has no in-scope binding when its
-// expression is parsed and degrades to the literal identifier name. This
-// test pins the current behavior so any future change (e.g. moving to a
-// two-pass resolution that allows forward refs) is explicit.
+// #2393 — argument defaults are still resolved in strict declaration
+// order by `substitute_arguments` (see `expander.rs`). A forward-ref
+// default like `prefix = later` cannot pick up `later`'s value at
+// substitution time because `later` hasn't been processed yet.
+//
+// Before #2817, the parser also degraded the forward identifier `later`
+// to a literal `Value::String("later")`, hiding the order-sensitive
+// nature behind a wrong-but-plausible string. With the directory-aware
+// parse pipeline, every argument name is seeded into the per-file
+// `ParseContext`, so the forward identifier surfaces as a structured
+// `ResourceRef` placeholder. That is strictly more honest — downstream
+// scope / type checks now see the unresolved reference and can flag
+// it. Wiring a fixed-point or topological resolution that completes
+// the substitution is a separate follow-up; this test pins the new
+// surface behavior.
 #[test]
-fn test_argument_default_forward_ref_degrades_to_literal() {
+fn test_argument_default_forward_ref_stays_as_ref_under_seeded_parse() {
     let parsed = resolve_default_arg_fixture(
         r#"
 arguments {
@@ -2695,12 +2704,19 @@ m {}
 "#,
     );
 
-    assert_eq!(
-        role_attr(&parsed, "role_name"),
-        &Value::String("later".to_string()),
-        "forward-ref default falls back to the literal identifier name; \
-         resolution is order-sensitive (see #2393)"
-    );
+    let role_name = role_attr(&parsed, "role_name");
+    match role_name {
+        Value::ResourceRef { path } => {
+            assert_eq!(path.binding(), "later");
+            assert_eq!(path.attribute(), "");
+            assert!(path.field_path().is_empty());
+            assert!(path.subscripts().is_empty());
+        }
+        other => panic!(
+            "forward-ref default should surface as `ResourceRef(later)` post-seeding; \
+             got {other:?}"
+        ),
+    }
 }
 
 // #2393 — caller-supplied ResourceRefs (cross-module data flow) must NOT be
@@ -3375,5 +3391,121 @@ fn caller_side_value_in_string_literal_union_is_accepted() {
         result.is_ok(),
         "Caller passing 'prod' (in the declared union) must be accepted. Got: {:?}",
         result
+    );
+}
+
+/// Acceptance test for #2815 / #2817. An `arguments {}` block declared in
+/// `main.crn` must be visible to identifier references in *sibling* `.crn`
+/// files in the same module directory. Before #2817, the per-file
+/// `ParseContext` could not see sibling-defined symbols, so `${env}` in
+/// `role.crn` lowered to a literal `Value::String("env")` — `role_name`
+/// rendered as `"test-role-env"` instead of `"test-role-dev"`. The
+/// directory-aware parse pipeline seeds every file's `ParseContext` with
+/// the union of declared names from all sibling files, so the normal
+/// `ctx.get_variable` path resolves the reference uniformly.
+#[test]
+fn test_arguments_visible_to_sibling_crn_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let module_dir = tmp.path().join("modules/usecase");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        module_dir.join("main.crn"),
+        r#"
+arguments {
+  env: String
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        module_dir.join("role.crn"),
+        r#"
+let role = awscc.iam.Role {
+  role_name = "test-role-${env}"
+  assume_role_policy_document = {}
+}
+"#,
+    )
+    .unwrap();
+
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("main.crn"),
+        r#"
+let uc = use { source = '../modules/usecase' }
+let r  = uc { env = 'dev' }
+"#,
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+    resolve_modules(&mut parsed, &root_dir).expect("resolve_modules should succeed");
+
+    assert_eq!(
+        role_names(&parsed),
+        ["test-role-dev".to_string()]
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        "argument `env` declared in `main.crn` must substitute into `${{env}}` \
+         interpolation in sibling `role.crn`",
+    );
+}
+
+/// Regression for the seeding-vs-local-duplicate corner of #2817.
+///
+/// Inside the directory-aware Pass-2 parse, every binding name from
+/// the merged Pass-1 result is seeded into the per-file
+/// `ParseContext`. The seeded name MUST NOT mask a real in-file
+/// duplicate (`arguments { foo }` and `let foo = ...` in the same
+/// file). The shadow logic is to drop the seed mark the moment a
+/// local declaration overwrites it; if a *second* local declaration
+/// then appears, the regular duplicate-binding error must still
+/// trigger.
+#[test]
+fn test_local_duplicate_still_detected_under_seeded_parse() {
+    // The duplicate is `let foo = "y"` colliding with `arguments { foo }`,
+    // which both register `foo` as a binding. Seeding (a sibling file
+    // with `let foo = ...`) primed the seed mark; the `arguments` block
+    // must drop it so the subsequent `let foo` is still a duplicate.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let module_dir = tmp.path().join("modules/dup");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+        module_dir.join("main.crn"),
+        r#"
+arguments {
+  foo: String
+}
+
+let foo = "y"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        module_dir.join("sibling.crn"),
+        "# also has foo via let later\nlet foo_other = \"z\"\n",
+    )
+    .unwrap();
+
+    let root_dir = tmp.path().join("root");
+    fs::create_dir_all(&root_dir).unwrap();
+    fs::write(
+        root_dir.join("main.crn"),
+        r#"
+let m = use { source = '../modules/dup' }
+m { foo = 'x' }
+"#,
+    )
+    .unwrap();
+
+    let content = fs::read_to_string(root_dir.join("main.crn")).unwrap();
+    let mut parsed = crate::parser::parse(&content, &ProviderContext::default()).unwrap();
+    let err = resolve_modules(&mut parsed, &root_dir).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("DuplicateBinding") && msg.contains("foo"),
+        "expected DuplicateBinding for `foo`; got {msg}"
     );
 }

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -139,6 +139,10 @@ fn register_argument_binding(ctx: &mut ParseContext, name: &str) {
     ctx.set_variable(name.to_string(), placeholder_ref);
     let placeholder = Resource::new("_argument", name);
     ctx.set_resource_binding(name.to_string(), placeholder);
+    // The local declaration is the real one for this file; drop the
+    // seed mark (if any) so a later real duplicate (`let <name> = ...`
+    // in the same file) is still flagged. #2817.
+    ctx.unmark_seeded(name);
 }
 
 /// Parse attributes block

--- a/carina-core/src/parser/context.rs
+++ b/carina-core/src/parser/context.rs
@@ -40,6 +40,12 @@ pub(crate) struct ParseContext<'cfg> {
     pub(super) warnings: Vec<ParseWarning>,
     /// Deferred for-expressions collected during parsing
     pub(super) deferred_for_expressions: Vec<DeferredForExpression>,
+    /// Names pre-registered via the directory-aware seed pass
+    /// (`parse_with_seeded_bindings`). Excluded from local duplicate-
+    /// binding checks, so a `let role = ...` in this file does not
+    /// collide with the seed installed because the same name is
+    /// declared in a sibling `.crn`. See #2817.
+    pub(super) seeded_bindings: HashSet<String>,
 }
 
 impl<'cfg> ParseContext<'cfg> {
@@ -55,7 +61,25 @@ impl<'cfg> ParseContext<'cfg> {
             upstream_states: HashMap::new(),
             warnings: Vec::new(),
             deferred_for_expressions: Vec::new(),
+            seeded_bindings: HashSet::new(),
         }
+    }
+
+    /// True if `name` was pre-registered via the directory-aware seed
+    /// pass and not yet shadowed by a local declaration. Used by entry
+    /// points that perform duplicate-binding checks (`let`, `arguments`)
+    /// to allow a local declaration to overwrite the seeded placeholder
+    /// without falsely flagging a duplicate. See #2817.
+    pub(in crate::parser) fn is_seeded_binding(&self, name: &str) -> bool {
+        self.seeded_bindings.contains(name)
+    }
+
+    /// Drop `name` from the seeded set. Called as soon as a local
+    /// declaration overwrites the seeded placeholder, so subsequent
+    /// `let foo = ...` redeclarations within the same file *are* still
+    /// flagged as duplicates.
+    pub(in crate::parser) fn unmark_seeded(&mut self, name: &str) {
+        self.seeded_bindings.remove(name);
     }
 
     pub(super) fn set_variable(&mut self, name: String, value: impl Into<EvalValue>) {

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -35,7 +35,45 @@ use pest::Parser;
 ///
 /// The config allows injecting a decryptor function for `decrypt()` calls
 /// and custom type validators from provider crates.
+///
+/// **Single-file API.** Sibling-defined names (a `let` in another `.crn`,
+/// an `arguments {}` declared in `main.crn` and referenced from a
+/// sibling) are *not* in scope. Production code paths that read a
+/// directory of `.crn` files must go through
+/// [`crate::config_loader::parse_directory_files`], which collects the
+/// sibling binding-name union in Pass 1 and re-parses every file with
+/// the union seeded into `ParseContext` in Pass 2. See #2817
+/// (directory-aware parse) for the broader contract.
 pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseError> {
+    parse_with_seeded_bindings(input, config, &[])
+}
+
+/// Parse a .crn file with `seeds` pre-registered as lexical bindings.
+///
+/// Each name in `seeds` is registered in the per-file [`ParseContext`]
+/// the same way `register_argument_binding` does: a placeholder
+/// `Value::ResourceRef { binding: <name>, attribute: "", … }` is
+/// installed in `ctx.variables`, and a placeholder `Resource` is
+/// installed in `ctx.resource_bindings`. This means subsequent
+/// expressions resolve the name via the normal `ctx.get_variable` /
+/// `ctx.is_resource_binding` paths instead of degrading to the literal-
+/// string fallback in `primary.rs::variable_ref` / `parse_namespaced_id_value`.
+///
+/// The seed list is the directory aggregate: every binding declared in
+/// any sibling `.crn` (resource bindings, argument names, attribute
+/// names, export names, user-function names, `use` aliases,
+/// `upstream_state` bindings). The caller is responsible for collecting
+/// it via a Phase-1 unseeded parse and passing the union here.
+///
+/// Names already declared inside `input` itself (re-introduced by the
+/// regular parse) win over the seeded placeholder — the parser overwrites
+/// the seed entry the moment it processes the local `let` / `arguments`
+/// / etc. that introduces the name.
+pub fn parse_with_seeded_bindings(
+    input: &str,
+    config: &ProviderContext,
+    seeds: &[&str],
+) -> Result<ParsedFile, ParseError> {
     let preprocess_result =
         crate::heredoc::preprocess_heredocs(input).map_err(|e| ParseError::InvalidExpression {
             line: 0,
@@ -44,6 +82,7 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
     let pairs = CarinaParser::parse(Rule::file, &preprocess_result.source)?;
 
     let mut ctx = ParseContext::new(config);
+    seed_bindings(&mut ctx, seeds);
     let mut providers = Vec::new();
     let mut resources = Vec::new();
     let mut uses = Vec::new();
@@ -181,12 +220,36 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
                                 let is_discard = name == "_";
                                 let is_upstream_state = ctx.upstream_states.contains_key(&name);
                                 if !is_discard {
-                                    if ctx.variables.contains_key(&name)
-                                        || ctx.resource_bindings.contains_key(&name)
+                                    // A seeded placeholder (from a sibling-file
+                                    // declaration during the directory-aware
+                                    // Pass-2 parse, #2817) is not a real
+                                    // duplicate — the local declaration is the
+                                    // real one for *this* file. Drop the seed
+                                    // mark so subsequent in-file redeclarations
+                                    // still trip the duplicate check.
+                                    let shadows_seed = ctx.is_seeded_binding(&name);
+                                    if !shadows_seed
+                                        && (ctx.variables.contains_key(&name)
+                                            || ctx.resource_bindings.contains_key(&name))
                                     {
                                         return Err(ParseError::DuplicateBinding { name, line });
                                     }
-                                    if !is_upstream_state {
+                                    if shadows_seed {
+                                        ctx.unmark_seeded(&name);
+                                    }
+                                    if is_upstream_state {
+                                        // upstream_state lets do not bind a
+                                        // user-facing value; legacy semantics
+                                        // is "no entry in `variables`". When a
+                                        // seed pre-installed a placeholder
+                                        // under this name, drop it so the
+                                        // ParsedFile we hand back doesn't
+                                        // leak the seeded `ResourceRef` into
+                                        // downstream walkers (#2817).
+                                        if shadows_seed {
+                                            ctx.variables.shift_remove(&name);
+                                        }
+                                    } else {
                                         ctx.set_variable(name.clone(), value);
                                     }
                                 }
@@ -296,6 +359,23 @@ pub fn parse(input: &str, config: &ProviderContext) -> Result<ParsedFile, ParseE
         warnings: ctx.warnings,
         deferred_for_expressions: ctx.deferred_for_expressions,
     })
+}
+
+/// Pre-register `seeds` as lexical bindings in `ctx`. Mirrors the
+/// shape of `register_argument_binding` so seeded names resolve through
+/// the same `ctx.get_variable` / `ctx.is_resource_binding` paths that
+/// locally-declared `let` / `arguments` names use after parsing.
+///
+/// Empty seed list is a no-op — single-file callers (the legacy
+/// `parse(input, config)` wrapper, parser tests) pay no cost.
+fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[&str]) {
+    for &name in seeds {
+        let placeholder_ref = Value::resource_ref(name.to_string(), String::new(), vec![]);
+        ctx.set_variable(name.to_string(), placeholder_ref);
+        let placeholder = Resource::new("_seeded", name);
+        ctx.set_resource_binding(name.to_string(), placeholder);
+        ctx.seeded_bindings.insert(name.to_string());
+    }
 }
 
 /// Parse an expression. The result is a fully-reduced `Value`: any

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -24,6 +24,7 @@ pub use ast::{
     ValidateExpr, ValidationBlock,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
+pub(crate) use entry::parse_with_seeded_bindings;
 pub use entry::{parse, parse_and_resolve};
 pub(crate) use entry::{parse_expression, parse_expression_eval};
 pub use error::{ParseError, ParseWarning};

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -1636,7 +1636,8 @@ mod tests {
             "#,
         );
         let exports = mk_exports(&[("orgs", &["accounts"])]);
-        assert!(check_upstream_state_field_references(&parsed, &exports).is_empty());
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert!(errs.is_empty(), "got: {errs:?}");
     }
 
     #[test]


### PR DESCRIPTION
PR1 of #2817. Closes #2815.

## Summary

`carina_core::parser::parse(input: &str, ...)` is a per-file API. Its `ParseContext` only sees declarations from the file currently being parsed, so an `arguments {}` block in `main.crn` was invisible to a `${env}` interpolation in sibling `role.crn`, a `let` declared in `helpers.crn` was invisible to `main.crn`, and so on. Past per-site patches (#2435, #2447, #2462, and the closed PR #2816) handled the class case-by-case; this PR fixes the root primitive.

## Pipeline

- **Pass 1**: every `.crn` in the directory is parsed with the legacy per-file API. Results are merged only to collect the binding-name union via `collect_known_bindings_merged`.
- **Pass 2**: every file is re-parsed with `parse_with_seeded_bindings`, which pre-registers each union name in the per-file `ParseContext` as a placeholder `ResourceRef` (mirrors `register_argument_binding`). The normal `ctx.get_variable` / `ctx.is_resource_binding` paths in `primary.rs::variable_ref`, `parse_namespaced_id_value`, and the string-interpolation handler now resolve sibling-defined names uniformly.

Wired through `config_loader::parse_directory_files`, which all four production directory loaders now go through:
- `config_loader::load_configuration_with_config`
- `config_loader::parse_directory_with_overrides`
- `module_resolver::ModuleResolver::load_directory_module`
- `module_resolver::loader::load_directory_module`
- `module_resolver::loader::load_module_from_directory`

Also re-lands the symmetry fix from the closed PR #2816: a `canonicalize_in_place()` after `substitute_arguments` in the resource-attribute and virtual-resource paths in `expander.rs`. Without this, `role_name = "test-role-${env}"` keeps a single-arg `Interpolation` with `Expr(String("dev"))` instead of `String("test-role-dev")`, and downstream `Value::String` consumers (state diff, plan rendering) miss the resolved value.

## Out of scope (cleanup follow-ups for #2817)

- Removing the per-site placeholder fallbacks in `parse_namespaced_id_value` (#2435/#2447) and `try_evaluate_fn_value` (#2462).
- Making argument defaults forward-resolve. With seeding, `prefix: String = later` surfaces `later` as `ResourceRef("later")` instead of literal `"later"`, but `expander::substitute_arguments` still walks declaration order without a fix-point.
- Migrating the LSP fallback collectors (`collect_sibling_binding_names`, `collect_user_fn_names`).

## Notable edge cases

`register_argument_binding` and the `let` arm in `entry.rs` both call `unmark_seeded` so a real in-file duplicate (`arguments { foo }` plus `let foo = ...`) is still flagged. The `upstream_state` arm additionally `shift_remove`s the seeded `variables` entry to preserve the legacy "no entry in `variables` for `upstream_state` lets" invariant — without it, downstream walkers see a leaked seeded `ResourceRef` and mis-flag the binding.

## Test plan

- [x] `test_arguments_visible_to_sibling_crn_files` — the failing test from PR #2816 (closed), now green via the pipeline. Multi-file fixture: `arguments { env }` in `main.crn`, `${env}` in sibling `role.crn`.
- [x] `test_local_duplicate_still_detected_under_seeded_parse` — new regression test pinning the invariant that a seeded name does not mask in-file duplicates.
- [x] `test_expand_module_call_with_interpolation` — updated to assert the canonicalized `String("test-dev")` instead of the un-canonicalized `Interpolation([Literal, Expr(String("dev"))])`.
- [x] `test_argument_default_forward_ref_degrades_to_literal` renamed to `test_argument_default_forward_ref_stays_as_ref_under_seeded_parse`, updated expected.
- [x] `cargo nextest run -p carina-core` (1797 pass)
- [x] `cargo nextest run --workspace` (3035 pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all 5 pass)
- [x] `carina fmt --check` against 12 directories under `carina-rs/infra/` (real-infra smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
