### PR TITLE
parser: clarify post-#2817 status of #2435/#2447/#2462 fallbacks

### DIFF
--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -74,12 +74,19 @@ fn parse_namespaced_id_value(
     }
 
     // Subscripts (`a.b['k']`, `a.b[0]`) unambiguously mean binding
-    // access — no enum shorthand uses `[...]`. So when the head is not
-    // yet known as a resource binding in this file, emit a structured
-    // `ResourceRef` anyway and let cross-file resolution / scope checks
-    // either confirm the binding (e.g. an `upstream_state` declared in
-    // a sibling `.crn`) or surface an undefined-identifier diagnostic
-    // post-merge. Issue #2435.
+    // access — no enum shorthand uses `[...]`. When the head is not a
+    // resource binding in this file, emit a structured `ResourceRef`
+    // and let `check_identifier_scope` flag genuine typos post-merge.
+    //
+    // Under the directory-aware parse pipeline (#2817), sibling-defined
+    // bindings are seeded into `ctx.resource_bindings` so the early
+    // return at the top of this function covers the cross-file case
+    // directly. This branch retained as a safety net for the truly-
+    // undefined identifier path (typos, mid-edit references in the LSP
+    // single-file fallback parses) — without it, an unknown subscripted
+    // ID would fall through to the enum-shorthand `Value::String`
+    // fallback below and silently mistype as a string. Originally added
+    // for #2435.
     if !subscripts.is_empty() {
         return Ok(as_resource_ref(subscripts));
     }
@@ -97,10 +104,16 @@ fn parse_namespaced_id_value(
         });
     }
 
-    // Dotted IDs that aren't an enum shorthand are binding refs; the
-    // head may live in a sibling `.crn`, so emit a structured
-    // `ResourceRef` and let `check_identifier_scope` flag genuine typos
-    // post-merge. Symmetric with the subscript fallback above. #2447.
+    // Dotted IDs that aren't an enum shorthand are binding refs; emit
+    // a structured `ResourceRef` and let `check_identifier_scope` flag
+    // genuine typos post-merge.
+    //
+    // Symmetric with the subscript fallback above, and with the same
+    // post-#2817 status: the directory-aware parse pipeline seeds every
+    // sibling-defined binding into `ctx.resource_bindings`, so the
+    // cross-file case is covered by the top-of-function early return.
+    // Branch retained as a safety net for typos and LSP single-file
+    // fallback parses. Originally added for #2447.
     if crate::utils::NamespacedId::parse(full_str).is_none() {
         return Ok(as_resource_ref(Vec::new()));
     }

--- a/carina-core/src/parser/functions.rs
+++ b/carina-core/src/parser/functions.rs
@@ -601,6 +601,13 @@ fn try_evaluate_fn_value(value: Value, ctx: &ParseContext) -> Result<Value, Pars
                         // names are caught at the post-merge resolver
                         // pass (`resolve_value_with_config`), which has
                         // the full directory's `user_functions`.
+                        //
+                        // The directory-aware parse pipeline (#2817)
+                        // does not seed `user_functions` into the
+                        // per-file `ctx` — only `variables` and
+                        // `resource_bindings` are seeded — so this
+                        // defer path remains the route by which a
+                        // sibling-defined user fn becomes resolvable.
                         Ok(Value::FunctionCall {
                             name: name.clone(),
                             args: evaluated_args,


### PR DESCRIPTION
Refs #2817 (cleanup follow-up after directory-aware parse pipeline landed in #2819).

## Summary

Audited three legacy fallback / defer paths called out in #2817's "Cleanup follow-ups" list. **Conclusion: keep all three; comment-only update.**

- **`parse_namespaced_id_value`'s subscript fallback (#2435)** and **`!NamespacedId::parse` fallback (#2447)** in `parser/expressions/primary.rs` — the cross-file case is now covered by the top-of-function early return (sibling-defined bindings are seeded into `ctx.resource_bindings`), but both branches remain load-bearing as safety nets for typos and LSP single-file fallback parses. Removing them would let unknown dotted IDs slip through to the enum-shorthand `Value::String(full_str)` fallback and silently mistype as strings instead of surfacing an Undefined-identifier diagnostic via `check_identifier_scope`.

- **`try_evaluate_fn_value`'s deferred-FunctionCall path (#2462 / #2444)** in `parser/functions.rs` — still the route by which sibling-defined user-fns get resolved. The pipeline only seeds `variables` and `resource_bindings`, not `user_functions`, so `let v = sibling_fn()` in `main.crn` still needs the defer-then-post-merge-resolve flow.

Comments updated to call out the post-#2817 status (cross-file case covered upstream, branch retained for typos / LSP fallback / sibling user-fns) so future readers don't strip the safety net.

## Test plan

- [x] `cargo nextest run -p carina-core` (1797 pass — comment-only diff, no behavior change)
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
