### PR TITLE
expander: fix-point loop for argument default substitution

### DIFF
--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -66,10 +66,18 @@ impl ModuleResolver<'_> {
         // The parser registers each argument as a placeholder ResourceRef
         // binding while parsing the block, so the default lands here as a
         // tree containing `Value::ResourceRef { binding: "<other_arg>" }`
-        // nodes. Resolve those against arguments processed so far, in
-        // declaration order, before storing — that way every downstream
-        // consumer (type check, validate, require, attribute substitution)
-        // sees a fully-resolved value.
+        // nodes.
+        //
+        // **Initial pass** seeds each entry with either the caller-
+        // supplied value or the raw default. **Fix-point loop** then
+        // re-substitutes every entry against the current map until an
+        // iteration produces no change — this lets a forward-ref
+        // default like `prefix: String = later` (where `later` is
+        // declared after `prefix`) resolve to `later`'s value once
+        // `later` itself is resolved. A hard iteration cap (one round
+        // per argument plus one) bounds genuinely cyclic shapes
+        // (`a = b`, `b = a`); leftover unresolved refs surface to the
+        // post-merge scope check as undefined identifiers. #2817.
         let mut argument_values: HashMap<String, Value> = HashMap::new();
         for arg in &module.arguments {
             let value = call
@@ -78,13 +86,28 @@ impl ModuleResolver<'_> {
                 .cloned()
                 .or_else(|| arg.default.clone())
                 .unwrap();
-            let mut resolved = substitute_arguments(&value, &argument_values);
-            // Substitution may turn an `Interpolation` whose parts now hold
-            // only literal scalars into a flat `String`; canonicalize so
-            // downstream consumers (type check, validate, plan rendering)
-            // see the collapsed form rather than a single-Expr Interpolation.
-            resolved.canonicalize_in_place();
-            argument_values.insert(arg.name.clone(), resolved);
+            argument_values.insert(arg.name.clone(), value);
+        }
+        let max_iterations = module.arguments.len() + 1;
+        for _ in 0..max_iterations {
+            let mut changed = false;
+            // Snapshot the current map so each entry resolves against
+            // the same generation — without this, the order in which
+            // we iterate `module.arguments` would silently re-introduce
+            // declaration-order coupling.
+            let snapshot = argument_values.clone();
+            for arg in &module.arguments {
+                let current = argument_values.get(&arg.name).expect("seeded above");
+                let mut next = substitute_arguments(current, &snapshot);
+                next.canonicalize_in_place();
+                if &next != current {
+                    argument_values.insert(arg.name.clone(), next);
+                    changed = true;
+                }
+            }
+            if !changed {
+                break;
+            }
         }
 
         // Type-check argument values against declared types

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -2668,23 +2668,21 @@ m {
     assert_eq!(policy_map.get("y_value"), Some(&Value::Int(42)));
 }
 
-// #2393 — argument defaults are still resolved in strict declaration
-// order by `substitute_arguments` (see `expander.rs`). A forward-ref
-// default like `prefix = later` cannot pick up `later`'s value at
-// substitution time because `later` hasn't been processed yet.
+// #2393 — argument defaults whose RHS references *another* argument
+// (`prefix: String = later`) used to be resolved in strict declaration
+// order by `substitute_arguments` in `expander.rs`. A forward
+// reference therefore degraded — first to a literal
+// `Value::String("later")` (pre-#2817), then to an unresolved
+// `Value::ResourceRef("later")` (post-#2817 PR1).
 //
-// Before #2817, the parser also degraded the forward identifier `later`
-// to a literal `Value::String("later")`, hiding the order-sensitive
-// nature behind a wrong-but-plausible string. With the directory-aware
-// parse pipeline, every argument name is seeded into the per-file
-// `ParseContext`, so the forward identifier surfaces as a structured
-// `ResourceRef` placeholder. That is strictly more honest — downstream
-// scope / type checks now see the unresolved reference and can flag
-// it. Wiring a fixed-point or topological resolution that completes
-// the substitution is a separate follow-up; this test pins the new
-// surface behavior.
+// This pass adds a fixed-point loop around `substitute_arguments`
+// (#2817 follow-up): each iteration replaces every `ResourceRef`
+// whose binding matches an already-resolved argument; the loop
+// terminates when an iteration produces no changes. Cycles
+// (`a = b`, `b = a`) hit a hard iteration cap and leave the still-
+// unresolved refs in place for the post-merge scope check to flag.
 #[test]
-fn test_argument_default_forward_ref_stays_as_ref_under_seeded_parse() {
+fn test_argument_default_forward_ref_resolves_under_fixpoint() {
     let parsed = resolve_default_arg_fixture(
         r#"
 arguments {
@@ -2704,18 +2702,55 @@ m {}
 "#,
     );
 
+    assert_eq!(
+        role_attr(&parsed, "role_name"),
+        &Value::String("L".to_string()),
+        "forward-ref default `prefix = later` resolves to `later`'s value `'L'` \
+         once the fix-point loop runs in `expander.rs::substitute_arguments`"
+    );
+}
+
+/// Argument-default fix-point loop must terminate even when the
+/// dependency graph is cyclic. With `a: String = b` and `b: String = a`
+/// neither side ever reduces, so each iteration leaves both as
+/// `ResourceRef`. The hard iteration cap stops the loop and surfaces
+/// the unresolved refs to the scope check.
+#[test]
+fn test_argument_default_cycle_terminates_with_unresolved_refs() {
+    let parsed = resolve_default_arg_fixture(
+        r#"
+arguments {
+  a: String = b
+  b: String = a
+}
+
+let role = awscc.iam.Role {
+  role_name                   = a
+  assume_role_policy_document = {}
+}
+"#,
+        r#"
+let m = use { source = '../modules/m' }
+
+m {}
+"#,
+    );
+
     let role_name = role_attr(&parsed, "role_name");
     match role_name {
         Value::ResourceRef { path } => {
-            assert_eq!(path.binding(), "later");
-            assert_eq!(path.attribute(), "");
-            assert!(path.field_path().is_empty());
-            assert!(path.subscripts().is_empty());
+            // The cycle leaves both `a` and `b` as ResourceRef; which one
+            // surfaces as `role_name` depends on substitute_arguments's
+            // walk order. Either is fine — the contract is that the
+            // loop terminates without panicking and produces a
+            // structured ref the scope check can flag.
+            assert!(
+                path.binding() == "a" || path.binding() == "b",
+                "expected cyclic ref to point at `a` or `b`, got: {:?}",
+                path.binding()
+            );
         }
-        other => panic!(
-            "forward-ref default should surface as `ResourceRef(later)` post-seeding; \
-             got {other:?}"
-        ),
+        other => panic!("expected unresolved ResourceRef from cycle; got {other:?}"),
     }
 }
 


### PR DESCRIPTION
Refs #2817 (cleanup follow-up after #2819 directory-aware parse).

## Summary

`expander.rs::substitute_arguments` walked `module.arguments` in declaration order, so a default whose RHS referred to a *later-declared* argument never resolved — e.g. `prefix: String = later` with `later: String = 'L'` declared after `prefix` would surface `role_name = prefix` as `Value::ResourceRef("later")` instead of `Value::String("L")`.

Pre-#2819 the per-site fallback in `parse_namespaced_id_value` hid the order-sensitivity behind a literal `Value::String("later")` (wrong but plausible). Post-#2819 the unresolved `ResourceRef` was honest but useless. This PR completes the resolution.

## Implementation

Switch to a fix-point loop:

1. **Initial pass**: seed `argument_values` with each entry's caller-supplied value or raw default (no substitution yet).
2. **Fix-point**: re-substitute every entry against a snapshot of the current map. Stop when an iteration produces no change. The snapshot prevents intra-iteration order from coupling back into the result.
3. **Iteration cap**: `module.arguments.len() + 1` rounds. Genuinely cyclic shapes (`a = b`, `b = a`) hit the cap; leftover unresolved `ResourceRef`s surface to the post-merge scope check as undefined identifiers — the loop terminates without panicking.

## Test plan

- [x] `test_argument_default_forward_ref_resolves_under_fixpoint`: renamed from `test_argument_default_forward_ref_stays_as_ref_under_seeded_parse` and updated to assert the resolved `Value::String("L")`.
- [x] `test_argument_default_cycle_terminates_with_unresolved_refs`: new test pinning that `a = b`, `b = a` doesn't loop forever and leaves the unresolved ref in place.
- [x] `cargo nextest run --workspace` (3036 pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
