### PR TITLE
docs: design + implementation plan for `wait` construct

### DIFF
--- a/docs/plans/2026-05-09-wait-construct-plan.md
+++ b/docs/plans/2026-05-09-wait-construct-plan.md
@@ -1,0 +1,1095 @@
+# `wait` Construct: Implementation Plan
+
+<!-- derived-from ../specs/2026-05-09-wait-construct-design.md -->
+
+## Repository scope
+
+This plan describes work in **`carina-rs/carina`** (the carina-core monorepo), not in `carina-provider-aws`. The plan lives here because the brainstorming originated from `aws#244` (ACM Certificate); the actual `wait` construct is a carina-core change.
+
+`carina-provider-aws` work (`aws.acm.Certificate` implementation that uses `wait`) happens in a follow-up plan after the carina-core changes land.
+
+## Prerequisites: separate Carina RFCs that ship first
+
+This plan assumes the following are already in place (each is its own brainstorming + plan + PR cycle):
+
+1. **carina#TBD-A — `depends_on` meta-arg.** A new `depends_on = [<binding>, ...]` field accepted on every `let` binding. Resolves to additional ordering edges in the planner. *Out of scope here.*
+2. **carina#TBD-B — `Duration` type and literal.** New lexical token `<integer><unit>` (`75min`, `1h`, `30s`); new first-class `Duration` type wrapping `std::time::Duration`. *Out of scope here.*
+
+If these don't exist when this plan starts, the plan stalls. They are hard prerequisites, not parallel work. Each plan is short (5-10 tasks); they can land in any order before this one starts.
+
+## File map
+
+### Files to create
+
+| Path | Purpose |
+|---|---|
+| `carina-core/src/effect.rs` *(new variant in existing file)* | Add `Effect::Wait { ... }` variant. |
+| `carina-core/src/wait/mod.rs` | New module. Houses `WaitPredicate` AST and predicate evaluator. |
+| `carina-core/src/wait/predicate.rs` | `WaitPredicate` enum + `evaluate(&State::attributes) -> bool`. |
+| `carina-core/src/wait/tests.rs` | Unit tests for predicate parsing and evaluation. |
+| `carina-core/src/parser/expressions/wait_expr.rs` | Parser pass for `wait <target> { ... }`. |
+| `carina-core/src/executor/wait.rs` | `execute_wait_effect` — read-polling loop with timeout. |
+| `carina-core/tests/fixtures/wait/cert_issued/main.crn` | Fixture for parser + plan snapshot tests. |
+| `carina-cli/tests/fixtures/plan_display/wait_cert/{main.crn, carina.state.json}` | Plan-display snapshot fixture. |
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `carina-core/src/parser/carina.pest` | Add `wait_expr` rule + insert into `expression` alternatives before `resource_expr`. |
+| `carina-core/src/parser/let_binding.rs` | Dispatch `Rule::wait_expr` → `parse_wait_expr` → `LetBindingKind::Wait`. |
+| `carina-core/src/parser/let_binding.rs` (continued) | Recognize `wait_expr` in the `is_block_like_primary` predicate so it's accepted as an RHS. |
+| `carina-core/src/keywords.rs` | Add `("wait", KeywordKind::Storage)` and `("until", KeywordKind::Other)` entries. |
+| `carina-core/src/lib.rs` | `pub mod wait;`. |
+| `carina-core/src/effect.rs` | `Effect::Wait` variant, `binding_name()` arm, `is_state_operation()` arm if needed. |
+| `carina-core/src/plan.rs` | `format_effect_brief` arm for `Effect::Wait`: `> <binding> (until <predicate>)`. |
+| `carina-core/src/differ/plan.rs` | When the IR contains a wait binding, emit `Effect::Wait` into the plan with resolved `target_id`, `until` predicate, `timeout` (from override or schema default), `interval` (from schema default), and `depends_on` (from explicit + auto-derived). |
+| `carina-core/src/executor/mod.rs` | Re-export `execute_wait_effect`; declare `mod wait;`. |
+| `carina-core/src/executor/parallel.rs` | Dispatch `Effect::Wait` arm in the in-flight loop (alongside `Create` / `Update` / `Delete`); wait bindings register their resolved State (= target snapshot at success) in `applied_states` so downstream resolution works. |
+| `carina-core/src/resolver.rs` (or wherever binding resolution lives) | Resolve `<wait-binding>.<attr>` as passthrough of `<target>.<attr>` from the wait's captured snapshot. |
+| `carina-core/src/schema/mod.rs` | Add `default_wait_timeout: Option<Duration>` and `default_wait_interval: Option<Duration>` to `ResourceSchema`. Provide carina-core fallback constants (e.g. `WAIT_DEFAULT_TIMEOUT = 5min`, `WAIT_DEFAULT_INTERVAL = 5sec`). |
+| `carina-lsp/src/completion/top_level.rs` | Add `wait` snippet completion. |
+| `carina-lsp/src/completion/values.rs` | Inside `wait <target> { ... }`: complete block keys (`until`, `depends_on`, `timeout`); for `until` LHS, complete `<target>.<attr>`; for RHS, complete enum values. |
+| `carina-lsp/src/semantic_tokens.rs` | Highlight `wait` and `until` as keywords; duration literals as numeric. |
+| `carina-lsp/src/diagnostics/mod.rs` | Diagnostics: target not found, attribute not in target schema, type mismatch in `until`, unsupported operator (anything beyond `==` in MVP), missing `until`, invalid duration. |
+| `carina-core/src/formatter/mod.rs` (or wherever block formatting lives) | Format `wait` blocks consistently with existing `let foo = aws.... { ... }` blocks. |
+| `editors/vscode/syntaxes/carina.tmLanguage.json` | Add `wait` and `until` to the keyword pattern; add a duration-literal pattern. |
+| `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` | Same change, byte-identical. |
+
+### Dependencies between files
+
+```
+keywords.rs ──┬── parser/carina.pest ── parser/let_binding.rs ── parser/expressions/wait_expr.rs
+              │
+              └── editors/*/carina.tmLanguage.json (parity test enforces both)
+
+wait/predicate.rs ── wait/mod.rs ── effect.rs ── differ/plan.rs ── executor/wait.rs ── executor/parallel.rs
+                                       │
+                                       └── plan.rs (display)
+
+schema/mod.rs (default_wait_timeout, default_wait_interval) ── differ/plan.rs (resolves defaults)
+
+carina-lsp/src/* depends on parser + schema being in place.
+```
+
+## Tasks
+
+Each task is one TDD cycle. Goal: write failing test → run → see fail → minimal impl → run → see pass.
+
+### Phase 1 — Wait predicate AST and evaluator (no parser yet)
+
+**Task 1.1: `WaitPredicate::Equals` evaluator returns true when target attribute equals value.**
+
+- **Files:** create `carina-core/src/wait/mod.rs`, `carina-core/src/wait/predicate.rs`, `carina-core/src/wait/tests.rs`; modify `carina-core/src/lib.rs`.
+- **Test:** in `carina-core/src/wait/tests.rs`:
+  ```rust
+  use crate::resource::Value;
+  use crate::wait::predicate::{AttrPath, WaitPredicate};
+  use std::collections::HashMap;
+
+  #[test]
+  fn equals_returns_true_when_attribute_matches() {
+      let pred = WaitPredicate::Equals {
+          attr: AttrPath::single("status"),
+          value: Value::String("ISSUED".to_string()),
+      };
+      let mut attrs = HashMap::new();
+      attrs.insert("status".to_string(), Value::String("ISSUED".to_string()));
+      assert!(pred.evaluate(&attrs));
+  }
+  ```
+- **Implementation:** `predicate.rs`:
+  ```rust
+  use crate::resource::Value;
+  use std::collections::HashMap;
+
+  #[derive(Debug, Clone, PartialEq)]
+  pub struct AttrPath {
+      pub segments: Vec<String>,
+  }
+
+  impl AttrPath {
+      pub fn single(name: &str) -> Self {
+          Self { segments: vec![name.to_string()] }
+      }
+  }
+
+  #[derive(Debug, Clone, PartialEq)]
+  pub enum WaitPredicate {
+      Equals { attr: AttrPath, value: Value },
+  }
+
+  impl WaitPredicate {
+      pub fn evaluate(&self, attrs: &HashMap<String, Value>) -> bool {
+          match self {
+              WaitPredicate::Equals { attr, value } => {
+                  resolve(attrs, &attr.segments).is_some_and(|v| v == value)
+              }
+          }
+      }
+  }
+
+  fn resolve<'a>(attrs: &'a HashMap<String, Value>, path: &[String]) -> Option<&'a Value> {
+      let first = attrs.get(path.first()?)?;
+      if path.len() == 1 { return Some(first); }
+      // future: descend into nested Value::Map for path[1..]; out of MVP scope
+      None
+  }
+  ```
+  And in `wait/mod.rs`:
+  ```rust
+  pub mod predicate;
+  #[cfg(test)] mod tests;
+  ```
+  And in `lib.rs`: `pub mod wait;`.
+- **Verification:** `cargo nextest run -p carina-core wait::tests::equals_returns_true_when_attribute_matches`.
+
+**Task 1.2: `WaitPredicate::Equals` returns false when attribute differs.**
+
+- **Files:** modify `carina-core/src/wait/tests.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn equals_returns_false_when_attribute_differs() {
+      let pred = WaitPredicate::Equals {
+          attr: AttrPath::single("status"),
+          value: Value::String("ISSUED".to_string()),
+      };
+      let mut attrs = HashMap::new();
+      attrs.insert("status".to_string(), Value::String("PENDING_VALIDATION".to_string()));
+      assert!(!pred.evaluate(&attrs));
+  }
+  ```
+- **Implementation:** None — Task 1.1's implementation already handles this; this test pins the negative case to lock the contract.
+- **Verification:** `cargo nextest run -p carina-core wait::tests::equals_returns_false_when_attribute_differs`.
+
+**Task 1.3: `WaitPredicate::Equals` returns false when attribute is absent.**
+
+- **Files:** modify `carina-core/src/wait/tests.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn equals_returns_false_when_attribute_absent() {
+      let pred = WaitPredicate::Equals {
+          attr: AttrPath::single("status"),
+          value: Value::String("ISSUED".to_string()),
+      };
+      let attrs: HashMap<String, Value> = HashMap::new();
+      assert!(!pred.evaluate(&attrs));
+  }
+  ```
+- **Implementation:** None — `resolve` returns `None`, so `is_some_and` returns false.
+- **Verification:** `cargo nextest run -p carina-core wait::tests::equals_returns_false_when_attribute_absent`.
+
+### Phase 2 — Effect::Wait
+
+**Task 2.1: Add `Effect::Wait` variant.**
+
+- **Files:** modify `carina-core/src/effect.rs`.
+- **Test:** add to `carina-core/src/effect.rs` `mod tests` (or its tests file):
+  ```rust
+  #[test]
+  fn wait_variant_constructs() {
+      use crate::resource::ResourceId;
+      use crate::wait::predicate::{AttrPath, WaitPredicate};
+      use crate::resource::Value;
+      use std::time::Duration;
+
+      let _ = Effect::Wait {
+          binding: "cert_issued".to_string(),
+          target_id: ResourceId::new("acm.Certificate", "cert"),
+          target_identifier: None,
+          until: WaitPredicate::Equals {
+              attr: AttrPath::single("status"),
+              value: Value::String("ISSUED".to_string()),
+          },
+          until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+          timeout: Duration::from_secs(75 * 60),
+          interval: Duration::from_secs(5),
+      };
+  }
+  ```
+- **Implementation:** add to the `Effect` enum:
+  ```rust
+  Wait {
+      binding: String,
+      target_id: ResourceId,
+      target_identifier: Option<String>,
+      until: crate::wait::predicate::WaitPredicate,
+      /// Surface form of the `until` expression as the user wrote it
+      /// (e.g., `"cert.status == aws.acm.Certificate.Status.Issued"`).
+      /// Used by `format_effect_brief` so display never has to invert
+      /// the parsed AST. Same pattern as `Effect::Replace::cascade_ref_hints`.
+      until_surface: String,
+      #[serde(with = "crate::utils::serde_duration")]  // or impl serde manually if helper missing
+      timeout: std::time::Duration,
+      #[serde(with = "crate::utils::serde_duration")]
+      interval: std::time::Duration,
+  },
+  ```
+  If `serde_duration` helper does not exist, define one in `carina-core/src/utils.rs` that round-trips Duration as `{ "secs": N, "nanos": N }`. Add a `#[derive(Serialize, Deserialize)]` on `WaitPredicate` and `AttrPath` (use `#[serde(tag = "kind")]` on the enum for forward-compat).
+- **Verification:** `cargo nextest run -p carina-core effect::tests::wait_variant_constructs`. Nextest already invokes `rustc`, so non-exhaustive-match errors in downstream callers surface here without a redundant `cargo build` step (per CLAUDE.md "Verify Protocol — Do Not Run Redundant Builds").
+
+**Task 2.2: `Effect::binding_name()` returns the wait binding for `Effect::Wait`.**
+
+- **Files:** modify `carina-core/src/effect.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn wait_binding_name_returns_wait_binding() {
+      let e = Effect::Wait {
+          binding: "cert_issued".to_string(),
+          target_id: crate::resource::ResourceId::new("acm.Certificate", "cert"),
+          target_identifier: None,
+          until: crate::wait::predicate::WaitPredicate::Equals {
+              attr: crate::wait::predicate::AttrPath::single("status"),
+              value: crate::resource::Value::String("ISSUED".to_string()),
+          },
+          until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+          timeout: std::time::Duration::from_secs(60),
+          interval: std::time::Duration::from_secs(5),
+      };
+      assert_eq!(e.binding_name(), Some("cert_issued"));
+  }
+  ```
+- **Implementation:** add to `Effect::binding_name`:
+  ```rust
+  Effect::Wait { binding, .. } => Some(binding),
+  ```
+- **Verification:** `cargo nextest run -p carina-core effect::tests::wait_binding_name_returns_wait_binding`.
+
+**Task 2.3: All other exhaustive matches on `Effect` compile after adding `Wait`.**
+
+- **Files:** modify every `match effect` site flagged by the compiler. Likely candidates from the survey:
+  - `carina-core/src/plan.rs::format_effect_brief` (covered in Task 5.1).
+  - `carina-core/src/executor/parallel.rs` (covered in Task 4.1).
+  - `carina-core/src/differ/plan.rs` summary calculations.
+  - `carina-core/src/detail_rows.rs`.
+- **Test:** `cargo nextest run -p carina-core` (which compiles every match site as it runs the existing test suite) reports no `non-exhaustive patterns` errors. The existing tests act as the exhaustiveness gate; no new test is needed for this task.
+- **Implementation:** for each non-target site, add `Effect::Wait { .. } => ...` arms. Use the most conservative behaviour (typically: ignore for summaries, count as a no-op for things like cascade detection). Each addition is one line.
+- **Verification:** `cargo nextest run -p carina-core 2>&1 | grep -E "error\[E0004\]|non-exhaustive"` returns empty (per CLAUDE.md "Verify Protocol" — nextest's compile step is the same artifact a `cargo build` would produce).
+
+### Phase 3 — Parser: `wait <target> { ... }`
+
+**Task 3.1: `wait` is recognised as a reserved keyword.**
+
+- **Files:** modify `carina-core/src/keywords.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn wait_is_a_storage_keyword() {
+      assert!(is_keyword("wait"));
+      let storage: Vec<&str> = by_kind(KeywordKind::Storage).collect();
+      assert!(storage.contains(&"wait"));
+  }
+  ```
+- **Implementation:** insert `("wait", KeywordKind::Storage),` into `KEYWORDS`. The existing `pest_grammar_contains_every_keyword` test will then fail until Task 3.2 adds the literal to the grammar — that's expected; the two tasks are paired.
+- **Verification:** `cargo nextest run -p carina-core keywords::tests::wait_is_a_storage_keyword`.
+
+**Task 3.2: `until` is recognised as a reserved keyword.**
+
+- **Files:** modify `carina-core/src/keywords.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn until_is_an_other_keyword() {
+      assert!(is_keyword("until"));
+  }
+  ```
+- **Implementation:** insert `("until", KeywordKind::Other),` into `KEYWORDS`.
+- **Verification:** `cargo nextest run -p carina-core keywords::tests::until_is_an_other_keyword`.
+
+**Task 3.3: pest grammar accepts `let foo = wait bar { until = bar.x == something }`.**
+
+- **Files:** modify `carina-core/src/parser/carina.pest`.
+- **Test:** create `carina-core/src/parser/expressions/wait_expr_tests.rs` (or add to existing parser test module):
+  ```rust
+  #[test]
+  fn pest_parses_wait_expr() {
+      use crate::parser::carina::CarinaParser;
+      use pest::Parser;
+      let src = r#"let cert_issued = wait cert {
+          until = cert.status == aws.acm.Certificate.Status.Issued
+      }"#;
+      let result = CarinaParser::parse(crate::parser::carina::Rule::file, src);
+      assert!(result.is_ok(), "expected parse success, got {:?}", result);
+  }
+  ```
+- **Implementation:** add to `carina.pest`:
+  ```pest
+  // Wait expression: `wait <target> { until = ..., depends_on = [...], timeout = ... }`
+  // Synchronisation construct: blocks downstream resources until target reaches the
+  // condition declared by `until`. See docs/specs/2026-05-09-wait-construct-design.md.
+  wait_expr = { "wait" ~ identifier ~ "{" ~ wait_attr* ~ "}" }
+  wait_attr = { wait_until_attr | wait_timeout_attr | wait_depends_on_attr }
+  wait_until_attr = { "until" ~ "=" ~ validate_expr }
+  wait_timeout_attr = { "timeout" ~ "=" ~ duration_literal }
+  wait_depends_on_attr = { "depends_on" ~ "=" ~ "[" ~ (identifier ~ ("," ~ identifier)*)? ~ "]" }
+  ```
+  Then in the `expression` alternatives (around line where `upstream_state_expr` is listed), insert `wait_expr` *before* `module_call` and `resource_expr`:
+  ```pest
+  | wait_expr           // Must come before module_call / resource_expr
+  | upstream_state_expr
+  | resource_expr
+  ```
+  `validate_expr` is reused as the predicate grammar (Task 6.x narrows it to `==` semantically). `duration_literal` is provided by carina#TBD-B.
+- **Verification:** `cargo nextest run -p carina-core parser::expressions::wait_expr_tests::pest_parses_wait_expr`.
+
+**Task 3.4: `let_binding` dispatches `Rule::wait_expr` to a `WaitExpr` AST node.**
+
+- **Files:** create `carina-core/src/parser/expressions/wait_expr.rs`; modify `carina-core/src/parser/let_binding.rs`, `carina-core/src/parser/expressions/mod.rs`.
+- **Test:** in `carina-core/src/parser/expressions/wait_expr.rs`:
+  ```rust
+  #[cfg(test)]
+  mod tests {
+      use super::*;
+      use crate::parser::carina::{CarinaParser, Rule};
+      use pest::Parser;
+
+      #[test]
+      fn parse_wait_expr_extracts_target_and_until() {
+          let src = r#"wait cert {
+              until = cert.status == aws.acm.Certificate.Status.Issued
+          }"#;
+          let pair = CarinaParser::parse(Rule::wait_expr, src).unwrap().next().unwrap();
+          let we = parse_wait_expr(pair).unwrap();
+          assert_eq!(we.target, "cert");
+          assert!(we.until.is_some());
+          assert!(we.timeout.is_none());
+          assert!(we.depends_on.is_empty());
+      }
+  }
+  ```
+- **Implementation:** in `wait_expr.rs`:
+  ```rust
+  use crate::parser::carina::Rule;
+  use crate::parser::error::ParseError;
+  use crate::parser::expressions::validate_expr::ValidateExprAst;
+  use pest::iterators::Pair;
+
+  #[derive(Debug, Clone)]
+  pub struct WaitExpr {
+      pub target: String,
+      pub until: Option<UntilSurface>,        // not yet typed; surface AST
+      pub timeout: Option<DurationLiteralAst>, // from carina#TBD-B
+      pub depends_on: Vec<String>,
+  }
+
+  #[derive(Debug, Clone)]
+  pub struct UntilSurface {
+      pub raw: String,           // surface form for error messages
+      pub ast: validate_expr::ValidateExprAst, // reuse existing validate_expr AST
+  }
+
+  pub fn parse_wait_expr(pair: Pair<'_, Rule>) -> Result<WaitExpr, crate::parser::error::ParseError> {
+      assert!(matches!(pair.as_rule(), Rule::wait_expr));
+      let mut inner = pair.into_inner();
+      let target_pair = inner.next().expect("wait_expr: missing target identifier");
+      let target = target_pair.as_str().to_string();
+
+      let mut we = WaitExpr {
+          target,
+          until: None,
+          timeout: None,
+          depends_on: Vec::new(),
+      };
+      for attr_pair in inner {
+          // attr_pair is a Rule::wait_attr containing one of the *_attr children
+          let child = attr_pair.into_inner().next().unwrap();
+          match child.as_rule() {
+              Rule::wait_until_attr => {
+                  let raw = child.as_str().to_string();
+                  let expr_pair = child.into_inner().next().unwrap();
+                  let ast = crate::parser::expressions::validate_expr::parse(expr_pair)?;
+                  we.until = Some(UntilSurface { raw, ast });
+              }
+              Rule::wait_timeout_attr => {
+                  let dur_pair = child.into_inner().next().unwrap();
+                  we.timeout = Some(crate::parser::duration::parse(dur_pair)?);
+              }
+              Rule::wait_depends_on_attr => {
+                  for ident in child.into_inner() {
+                      we.depends_on.push(ident.as_str().to_string());
+                  }
+              }
+              other => unreachable!("unexpected wait_attr child: {:?}", other),
+          }
+      }
+      Ok(we)
+  }
+  ```
+  In `let_binding.rs`, add `Rule::wait_expr` alongside `Rule::upstream_state_expr` in:
+  - `is_block_like_primary` (line ~104, 114): adds the rule to the recognised set.
+  - The dispatch around line ~310: handle `Rule::wait_expr` by calling `parse_wait_expr` and stashing the result as a `LetBindingKind::Wait(WaitExpr)` (introduce that variant in the same task).
+- **Verification:** `cargo nextest run -p carina-core parser::expressions::wait_expr::tests::parse_wait_expr_extracts_target_and_until`.
+
+**Task 3.5: Parser rejects `wait` without a target.**
+
+- **Files:** add to `wait_expr.rs` tests.
+- **Test:**
+  ```rust
+  #[test]
+  fn pest_rejects_wait_without_target() {
+      let src = r#"let foo = wait { until = x.y == z }"#;
+      let result = CarinaParser::parse(Rule::file, src);
+      assert!(result.is_err(), "expected parse failure for `wait` with no target");
+  }
+  ```
+- **Implementation:** none — pest grammar from Task 3.3 already requires `identifier` after `wait`.
+- **Verification:** `cargo nextest run -p carina-core parser::expressions::wait_expr::tests::pest_rejects_wait_without_target`.
+
+**Task 3.6: Parser rejects `wait foo {}` without `until`.**
+
+- **Files:** add to `wait_expr.rs` tests; modify the wait-block validation step in `let_binding.rs` (or a new `validate_wait_expr` helper).
+- **Test:**
+  ```rust
+  #[test]
+  fn parse_rejects_wait_without_until() {
+      let src = r#"let foo = wait cert { timeout = 30s }"#;
+      // Parsing the file may succeed at the pest level (wait_attr is optional);
+      // semantic validation should reject it.
+      let parsed = CarinaParser::parse(Rule::file, src).unwrap();
+      let result = crate::parser::parse_file(parsed);
+      assert!(result.is_err(), "expected semantic failure: missing `until`");
+      let err = result.unwrap_err().to_string();
+      assert!(err.contains("until"), "error should mention `until`, got: {}", err);
+  }
+  ```
+- **Implementation:** in `parse_wait_expr` (or its caller in `let_binding.rs`), after populating `WaitExpr`, check `we.until.is_some()`; if not, return `Err(ParseError::InvalidExpression { ... })` carrying a span on the `wait` keyword and the message `"`wait` block requires `until`"`. `ParseError` is the parser's existing error type (defined in `carina-core/src/parser/error.rs`, used throughout `let_binding.rs` and `blocks/backend.rs::parse_upstream_state_expr`). Update `parse_wait_expr`'s return type to `Result<WaitExpr, ParseError>` (replacing the `anyhow::Result` placeholder used in earlier task drafts) so it composes with `let_binding.rs`'s existing dispatch.
+- **Verification:** `cargo nextest run -p carina-core parser::expressions::wait_expr::tests::parse_rejects_wait_without_until`.
+
+**Task 3.7: TextMate grammar parity — add `wait`, `until`, and duration literal patterns.**
+
+- **Files:** modify both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` (must stay byte-identical per `carina-core/tests/tmlanguage_keyword_parity.rs`).
+- **Test:** the existing parity test + `keywords_have_tmlanguage_match` (or equivalent — confirm existing test name from `carina-core/tests/tmlanguage_keyword_parity.rs`):
+  ```bash
+  cargo nextest run -p carina-core tmlanguage_keyword_parity
+  ```
+  This test will fail when Task 3.1 added `wait` to KEYWORDS but the grammar wasn't updated.
+- **Implementation:** locate the existing keyword pattern (likely a `match` regex listing `let|fn|provider|...`) and add `wait` and `until`. Make the same edit to both JSON files.
+- **Verification:** `cargo nextest run -p carina-core tmlanguage_keyword_parity`.
+
+### Phase 4 — Differ + executor
+
+**Task 4.1: Differ emits `Effect::Wait` for a wait binding in the IR.**
+
+- **Files:** modify `carina-core/src/differ/plan.rs` (or wherever resource → effect lowering happens).
+- **Test:** in `carina-core/src/differ/plan_tests.rs`:
+  ```rust
+  #[test]
+  fn wait_binding_lowers_to_wait_effect() {
+      use crate::wait::predicate::{AttrPath, WaitPredicate};
+      use crate::resource::Value;
+      use std::time::Duration;
+
+      // The existing tests in plan_tests.rs build their inputs inline (no shared
+      // builders). Follow that pattern: construct resources + schemas + state +
+      // wait-binding by hand. The wait binding lives in a new collection
+      // alongside resources — see Task 4.1's planner change for the exact
+      // wiring.
+      let cert = Resource::new("acm.Certificate", "cert")
+          .with_attribute("domain_name", Value::String("registry.example.com".to_string()));
+      let resources = vec![cert.clone()];
+
+      let wait_binding = WaitBinding {
+          name: "cert_issued".to_string(),
+          target: "cert".to_string(),
+          until: UntilSurface {
+              raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+              ast: parse_validate_expr("cert.status == aws.acm.Certificate.Status.Issued").unwrap(),
+          },
+          timeout: None,
+          depends_on: vec![],
+      };
+      let waits = vec![wait_binding];
+
+      let mut schemas = SchemaRegistry::new();
+      schemas.insert("", ResourceSchema::new("acm.Certificate")
+          .attribute(AttributeSchema::new("domain_name", AttributeType::String).create_only())
+          .attribute(AttributeSchema::new("status", AttributeType::String).read_only())
+          .with_default_wait_timeout(Duration::from_secs(75 * 60))
+          .with_default_wait_interval(Duration::from_secs(5)));
+
+      let plan = create_plan_with_waits(
+          &resources,
+          &waits,
+          &HashMap::new(),    // current_states (empty = first apply)
+          &HashMap::new(),
+          &schemas,
+          &HashMap::new(),
+          &HashMap::new(),
+          &HashMap::new(),
+      );
+      let wait_effect = plan.effects().iter().find(|e| matches!(e, Effect::Wait { .. })).expect("expected Wait effect");
+      let Effect::Wait { binding, target_id, until, .. } = wait_effect else { unreachable!() };
+      assert_eq!(binding, "cert_issued");
+      assert_eq!(target_id.name, "cert");
+      assert_eq!(until, &WaitPredicate::Equals {
+          attr: AttrPath::single("status"),
+          value: Value::String("ISSUED".to_string()),
+      });
+  }
+  ```
+- **Implementation:** in the differ's binding-iteration loop, recognise `LetBindingKind::Wait(WaitExpr)` and emit:
+  ```rust
+  Effect::Wait {
+      binding: binding_name.to_string(),
+      target_id: resolved_target_id.clone(),
+      target_identifier: target_state.identifier.clone(),
+      until: lower_until_to_predicate(&we.until.ast, &target_schema)?,
+      until_surface: we.until.raw.clone(),
+      timeout: we.timeout.map(|d| d.to_duration()).or(target_schema.default_wait_timeout).unwrap_or(WAIT_DEFAULT_TIMEOUT),
+      interval: target_schema.default_wait_interval.unwrap_or(WAIT_DEFAULT_INTERVAL),
+  }
+  ```
+  `lower_until_to_predicate` walks the `validate_expr` AST and produces a `WaitPredicate` for the supported shape (`<target>.<attr> == <enum_or_literal>`); anything else returns an error tied to the `until` source span.
+
+  This task extends `create_plan` (the existing entry point used by `plan_tests.rs`) with an additional `&[WaitBinding]` parameter (or introduces a `create_plan_with_waits` sibling — choose the path that minimises churn for existing callers; project memory says backward-compat is not required, so adding a parameter to `create_plan` itself is acceptable). `WaitBinding` is the AST representation of a wait `let_binding` produced by Phase 3's parser. The differ iterates `&[WaitBinding]` after the resource-iteration loop, resolves each `target` name to a `ResourceId`, and emits an `Effect::Wait` per the snippet above. `WAIT_DEFAULT_TIMEOUT` (5min) and `WAIT_DEFAULT_INTERVAL` (5sec) live alongside `ResourceSchema` in `schema/mod.rs` per the design's "Schema additions" section.
+- **Verification:** `cargo nextest run -p carina-core differ::plan_tests::wait_binding_lowers_to_wait_effect`.
+
+**Task 4.2: Differ rejects `until` predicate beyond MVP `==`.**
+
+- **Files:** modify `lower_until_to_predicate`.
+- **Test:**
+  ```rust
+  #[test]
+  fn lower_rejects_unsupported_until_operator() {
+      let we = make_wait_expr_with_until("cert.status != ISSUED");
+      let result = lower_until_to_predicate(&we.until, &dummy_schema());
+      assert!(matches!(result, Err(e) if e.to_string().contains("only `==` is supported")));
+  }
+  ```
+- **Implementation:** in `lower_until_to_predicate`, match the validate_expr AST: if the comparison operator is anything other than `==`, return `Err(anyhow!("`until`: only `==` is supported in this version (got `{op}`)"))`.
+- **Verification:** `cargo nextest run -p carina-core differ::plan_tests::lower_rejects_unsupported_until_operator`.
+
+**Task 4.3: Differ rejects `until` LHS that isn't `<target>.<attr>`.**
+
+- **Files:** modify `lower_until_to_predicate`.
+- **Test:**
+  ```rust
+  #[test]
+  fn lower_rejects_until_lhs_unrelated_to_target() {
+      let we = make_wait_expr("cert", "other_resource.status == ISSUED");
+      let result = lower_until_to_predicate(&we.until, &dummy_schema());
+      assert!(matches!(result, Err(e) if e.to_string().contains("must reference target")));
+  }
+  ```
+- **Implementation:** require the LHS variable_ref's first segment == the wait's target binding name; otherwise error.
+- **Verification:** `cargo nextest run -p carina-core differ::plan_tests::lower_rejects_until_lhs_unrelated_to_target`.
+
+**Task 4.4: Executor's `execute_wait_effect` returns Ok when target already satisfies `until` on first read.**
+
+- **Files:** create `carina-core/src/executor/wait.rs`; modify `carina-core/src/executor/mod.rs` (`mod wait; pub use wait::*;`).
+- **Test:** in `carina-core/src/executor/wait.rs` `mod tests`:
+  ```rust
+  #[tokio::test]
+  async fn wait_returns_immediately_when_until_already_true() {
+      use crate::wait::predicate::{AttrPath, WaitPredicate};
+      use crate::resource::{Value, ResourceId, State};
+      use std::collections::HashMap;
+      use std::time::Duration;
+
+      let provider = MockProvider::new()
+          .with_read_response(ResourceId::new("acm.Certificate", "cert"), {
+              let mut attrs = HashMap::new();
+              attrs.insert("status".to_string(), Value::String("ISSUED".to_string()));
+              State::existing(ResourceId::new("acm.Certificate", "cert"), attrs)
+          });
+      let pred = WaitPredicate::Equals {
+          attr: AttrPath::single("status"),
+          value: Value::String("ISSUED".to_string()),
+      };
+      let result = execute_wait_effect(
+          &provider,
+          &ResourceId::new("acm.Certificate", "cert"),
+          None,
+          &pred,
+          Duration::from_secs(60),
+          Duration::from_millis(10),
+      ).await;
+      assert!(result.is_ok());
+      let state = result.unwrap();
+      assert_eq!(state.attributes.get("status"), Some(&Value::String("ISSUED".to_string())));
+      assert_eq!(provider.read_call_count(), 1);
+  }
+  ```
+- **Implementation:**
+  ```rust
+  use crate::provider::{Provider, ProviderError, ProviderResult};
+  use crate::resource::{ResourceId, State};
+  use crate::wait::predicate::WaitPredicate;
+  use std::time::{Duration, Instant};
+
+  pub async fn execute_wait_effect(
+      provider: &dyn Provider,
+      target_id: &ResourceId,
+      target_identifier: Option<&str>,
+      until: &WaitPredicate,
+      timeout: Duration,
+      interval: Duration,
+  ) -> ProviderResult<State> {
+      let start = Instant::now();
+      loop {
+          let state = provider.read(target_id, target_identifier).await?;
+          if !state.exists {
+              return Err(ProviderError::not_found(format!(
+                  "wait target {} not found", target_id
+              )).for_resource(target_id.clone()));
+          }
+          if until.evaluate(&state.attributes) {
+              return Ok(state);
+          }
+          if start.elapsed() >= timeout {
+              return Err(ProviderError::timeout(format!(
+                  "wait timed out after {:?} on {}: predicate not satisfied (last observed: {:?})",
+                  timeout, target_id, state.attributes
+              )).for_resource(target_id.clone()));
+          }
+          tokio::time::sleep(interval).await;
+      }
+  }
+  ```
+  `MockProvider` is a test helper — likely already exists in the executor's test infrastructure; if not, create a small one in the same test module.
+- **Verification:** `cargo nextest run -p carina-core executor::wait::tests::wait_returns_immediately_when_until_already_true`.
+
+**Task 4.5: `execute_wait_effect` polls until predicate becomes true.**
+
+- **Files:** modify `carina-core/src/executor/wait.rs` tests.
+- **Test:**
+  ```rust
+  #[tokio::test]
+  async fn wait_polls_until_predicate_becomes_true() {
+      // MockProvider returns PENDING_VALIDATION twice, then ISSUED.
+      let provider = MockProvider::new().with_read_sequence(
+          ResourceId::new("acm.Certificate", "cert"),
+          vec![
+              state_with_status("PENDING_VALIDATION"),
+              state_with_status("PENDING_VALIDATION"),
+              state_with_status("ISSUED"),
+          ],
+      );
+      let pred = WaitPredicate::Equals { attr: AttrPath::single("status"), value: Value::String("ISSUED".into()) };
+      let result = execute_wait_effect(
+          &provider,
+          &ResourceId::new("acm.Certificate", "cert"),
+          None,
+          &pred,
+          Duration::from_secs(60),
+          Duration::from_millis(1),  // tight interval for fast test
+      ).await;
+      assert!(result.is_ok());
+      assert_eq!(provider.read_call_count(), 3);
+  }
+  ```
+- **Implementation:** none — Task 4.4's loop already handles this. `MockProvider::with_read_sequence` is a new test helper (return responses in order).
+- **Verification:** `cargo nextest run -p carina-core executor::wait::tests::wait_polls_until_predicate_becomes_true`.
+
+**Task 4.6: `execute_wait_effect` returns Timeout when predicate stays false past timeout.**
+
+- **Files:** modify `carina-core/src/executor/wait.rs` tests.
+- **Test:**
+  ```rust
+  #[tokio::test]
+  async fn wait_returns_timeout_when_predicate_stays_false() {
+      let provider = MockProvider::new().with_read_response(
+          ResourceId::new("acm.Certificate", "cert"),
+          state_with_status("PENDING_VALIDATION"),
+      );
+      let pred = WaitPredicate::Equals { attr: AttrPath::single("status"), value: Value::String("ISSUED".into()) };
+      let result = execute_wait_effect(
+          &provider,
+          &ResourceId::new("acm.Certificate", "cert"),
+          None,
+          &pred,
+          Duration::from_millis(10),     // short timeout
+          Duration::from_millis(2),       // short interval — still fits multiple reads
+      ).await;
+      assert!(matches!(result, Err(ProviderError::Timeout(_))));
+      let err_msg = result.unwrap_err().to_string();
+      assert!(err_msg.contains("PENDING_VALIDATION"), "error should include last observed value, got: {}", err_msg);
+  }
+  ```
+- **Implementation:** none — Task 4.4's loop handles this; the test pins the error message contract.
+- **Verification:** `cargo nextest run -p carina-core executor::wait::tests::wait_returns_timeout_when_predicate_stays_false`.
+
+**Task 4.7: `execute_wait_effect` returns NotFound when target disappears mid-poll.**
+
+- **Files:** modify `carina-core/src/executor/wait.rs` tests.
+- **Test:**
+  ```rust
+  #[tokio::test]
+  async fn wait_returns_not_found_when_target_disappears() {
+      let provider = MockProvider::new().with_read_sequence(
+          ResourceId::new("acm.Certificate", "cert"),
+          vec![
+              state_with_status("PENDING_VALIDATION"),
+              State::not_found(ResourceId::new("acm.Certificate", "cert")),
+          ],
+      );
+      let pred = WaitPredicate::Equals { attr: AttrPath::single("status"), value: Value::String("ISSUED".into()) };
+      let result = execute_wait_effect(
+          &provider,
+          &ResourceId::new("acm.Certificate", "cert"),
+          None,
+          &pred,
+          Duration::from_secs(60),
+          Duration::from_millis(1),
+      ).await;
+      assert!(matches!(result, Err(ProviderError::NotFound(_))));
+  }
+  ```
+- **Implementation:** none — Task 4.4 already returns `NotFound` when `!state.exists`.
+- **Verification:** `cargo nextest run -p carina-core executor::wait::tests::wait_returns_not_found_when_target_disappears`.
+
+**Task 4.8: Parallel executor dispatches `Effect::Wait` and registers the captured State for downstream resolution.**
+
+- **Files:** modify `carina-core/src/executor/parallel.rs`.
+- **Test:** add to `carina-core/src/executor/tests.rs`:
+  ```rust
+  #[tokio::test]
+  async fn wait_effect_executes_and_unblocks_downstream() {
+      // Plan: Create cert (returns PENDING) → Wait cert_issued (sees ISSUED on second read)
+      //       → Create downstream that references cert_issued.arn
+      // Verify: downstream's create receives the resolved cert_issued.arn after the wait completes.
+      let plan = build_three_effect_plan_with_wait();
+      let provider = MockProvider::new()
+          .with_create_response("cert", state_with_status_and_arn("PENDING_VALIDATION", "arn:acm:cert"))
+          .with_read_sequence("cert", vec![
+              state_with_status_and_arn("PENDING_VALIDATION", "arn:acm:cert"),
+              state_with_status_and_arn("ISSUED", "arn:acm:cert"),
+          ])
+          .with_create_response("dist", State::default());
+      let observer = NoopObserver;
+      // Construct ExecutionInput by struct literal — same shape used throughout
+      // executor/tests.rs (e.g. line 236, 272). Fields per executor/mod.rs:
+      let input = crate::executor::ExecutionInput {
+          plan: &plan,
+          unresolved_resources: &HashMap::new(),
+          bindings: ResolvedBindings::default(),
+          current_states: HashMap::new(),
+      };
+      let result = execute_plan(&provider, input, &observer).await;
+      assert!(result.success_count >= 3);
+      let dist_create = provider.create_call("dist").unwrap();
+      let arn = dist_create.attributes.get("acm_certificate_arn").unwrap();
+      assert_eq!(arn, &Value::String("arn:acm:cert".to_string()));
+  }
+  ```
+- **Implementation:** in `execute_effects_sequential`'s in-flight match (around line ~271):
+  ```rust
+  Effect::Wait { binding, target_id, target_identifier, until, timeout, interval } => {
+      let state = crate::executor::wait::execute_wait_effect(
+          provider, target_id, target_identifier.as_deref(), until, *timeout, *interval,
+      ).await?;
+      // Register the captured State under the wait binding's *synthetic* ResourceId
+      // so resolved bindings can deref `<binding>.<attr>` → state.attributes[attr].
+      let synthetic_id = ResourceId::new("__wait", binding);
+      applied_states.insert(synthetic_id.clone(), state);
+      Ok(SingleEffectResult::WaitDone(binding.clone()))
+  }
+  ```
+  Plus update the `dispatched`/`completed_indices` bookkeeping to recognise `Effect::Wait` (currently `Read` and state-ops are special-cased; add `Wait` to the actionable set, not the no-op set). Update `idx_to_binding` extraction to include wait bindings (already covered if `Effect::binding_name` returns the wait binding from Task 2.2).
+- **Verification:** `cargo nextest run -p carina-core executor::tests::wait_effect_executes_and_unblocks_downstream`.
+
+**Task 4.9: Binding resolver returns target's attribute when resolving `<wait-binding>.<attr>`.**
+
+- **Files:** modify `carina-core/src/resolver.rs` (or wherever `ResolvedBindings` lives).
+- **Test:** in resolver tests:
+  ```rust
+  #[test]
+  fn wait_binding_resolves_to_target_state_snapshot() {
+      let mut resolved = ResolvedBindings::new();
+      let mut attrs = HashMap::new();
+      attrs.insert("arn".to_string(), Value::String("arn:aws:acm:...".to_string()));
+      attrs.insert("status".to_string(), Value::String("ISSUED".to_string()));
+      resolved.insert_wait("cert_issued", attrs);
+      let arn = resolved.resolve_attr("cert_issued", "arn").unwrap();
+      assert_eq!(arn, &Value::String("arn:aws:acm:...".to_string()));
+  }
+  ```
+- **Implementation:** `ResolvedBindings` is defined in `carina-core/src/binding_index.rs:330`. Add an `insert_wait(&mut self, binding: &str, attrs: HashMap<String, Value>)` method that stores the snapshot in a new internal `wait_bindings: HashMap<String, HashMap<String, Value>>` field (separate from the existing resource-binding storage). Modify `resolve_attr` (or the equivalent lookup method on `ResolvedBindings`) to check `wait_bindings` after the resource-binding lookup misses. The two storages stay separate so a wait binding cannot shadow a same-named resource binding (parser-level uniqueness check still required, but separation gives an additional safety net).
+- **Verification:** `cargo nextest run -p carina-core resolver::tests::wait_binding_resolves_to_target_state_snapshot`.
+
+### Phase 5 — Plan display + state file
+
+**Task 5.1: `format_effect_brief` renders `Effect::Wait` as `> <binding> (until <surface>)`.**
+
+- **Files:** modify `carina-core/src/plan.rs`.
+- **Test:** in the existing `plan::tests` mod:
+  ```rust
+  #[test]
+  fn format_effect_brief_renders_wait() {
+      let e = Effect::Wait {
+          binding: "cert_issued".to_string(),
+          target_id: ResourceId::new("acm.Certificate", "cert"),
+          target_identifier: None,
+          until: WaitPredicate::Equals {
+              attr: AttrPath::single("status"),
+              value: Value::String("ISSUED".to_string()),
+          },
+          until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+          timeout: Duration::from_secs(75 * 60),
+          interval: Duration::from_secs(5),
+      };
+      let s = format_effect_brief(&e);
+      // Per design spec §Plan display: predicate is rendered using its surface
+      // form, namespaced enum without surrounding quotes. The differ stores
+      // the original surface form alongside the parsed predicate so display
+      // can echo it verbatim — the in-memory `Value::String("ISSUED")` is
+      // never re-stringified ad-hoc here.
+      assert_eq!(s, "> cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)");
+  }
+  ```
+- **Implementation:** add to `format_effect_brief`:
+  ```rust
+  Effect::Wait { binding, until_surface, .. } => {
+      format!("> {} (until {})", binding, until_surface)
+  }
+  ```
+  This requires `Effect::Wait` to carry the original surface form of `until`. Update Task 2.1's `Effect::Wait` shape: add `until_surface: String` (rendered exactly as the user wrote it, e.g. `"cert.status == aws.acm.Certificate.Status.Issued"`). The differ in Task 4.1 populates it from the source span captured during parsing (`UntilSurface::raw` already exists from Task 3.4). Carrying the surface form means display never has to invert the parsed AST — a pattern Carina already uses for cascade replacement hints (`cascade_ref_hints` in `Effect::Replace`, see `effect.rs`).
+- **Verification:** `cargo nextest run -p carina-core plan::tests::format_effect_brief_renders_wait`.
+
+**Task 5.2: Wait effects do not appear in `carina.state.json` after apply.**
+
+- **Files:** modify `carina-core/src/executor/parallel.rs` (state-update path).
+- **Test:** in `carina-core/src/executor/tests.rs`:
+  ```rust
+  #[tokio::test]
+  async fn state_file_has_no_wait_entries_after_apply() {
+      let plan = build_three_effect_plan_with_wait();
+      let provider = MockProvider::new()
+          .with_create_response("cert", state_with_status_and_arn("ISSUED", "arn:..."))
+          .with_read_sequence("cert", vec![state_with_status_and_arn("ISSUED", "arn:...")])
+          .with_create_response("dist", State::default());
+      let mut state_file = StateFile::new();
+      let observer = NoopObserver;
+      execute_plan(&provider, ExecutionInput::new_mut_state(&plan, &mut state_file), &observer).await;
+      let resource_types: Vec<&str> = state_file.iter_resources().map(|(id, _)| id.resource_type.as_str()).collect();
+      assert!(!resource_types.contains(&"__wait"), "state file should not contain `__wait` synthetic entries");
+      assert!(resource_types.iter().any(|t| t == &"acm.Certificate"));
+      assert!(resource_types.iter().any(|t| t == &"cloudfront.Distribution"));
+  }
+  ```
+- **Implementation:** in the executor's "after this effect succeeded, update state file" path, skip when `matches!(effect, Effect::Wait { .. })`. (The synthetic `__wait` ResourceId from Task 4.8 is for in-memory binding resolution only; never persist it.)
+- **Verification:** `cargo nextest run -p carina-core executor::tests::state_file_has_no_wait_entries_after_apply`.
+
+**Task 5.3: Plan display fixture and snapshot test.**
+
+- **Files:** create `carina-cli/tests/fixtures/plan_display/wait_cert/main.crn`, `carina-cli/tests/fixtures/plan_display/wait_cert/carina.state.json` (empty state), and `carina-cli/tests/fixtures/plan_display/wait_cert/snapshot.txt` (insta snapshot, generated by first run).
+- **Test:** add to `carina-cli/tests/plan_snapshot.rs`:
+  ```rust
+  #[test]
+  fn plan_display_wait_cert() {
+      run_plan_snapshot("wait_cert");
+  }
+  ```
+- **Implementation:** `main.crn`:
+  ```crn
+  provider aws { region = "us-east-1" }
+
+  let cert = aws.acm.Certificate {
+      domain_name       = "registry.example.com"
+      validation_method = "DNS"
+  }
+
+  let validation_record = aws.route53.RecordSet {
+      hosted_zone_id   = "Z123"
+      name             = cert.domain_validation_options[0].resource_record_name
+      type             = cert.domain_validation_options[0].resource_record_type
+      ttl              = 60
+      resource_records = [cert.domain_validation_options[0].resource_record_value]
+  }
+
+  let cert_issued = wait cert {
+      until      = cert.status == aws.acm.Certificate.Status.Issued
+      depends_on = [validation_record]
+      timeout    = 75min
+  }
+
+  let dist = aws.cloudfront.Distribution {
+      acm_certificate_arn = cert_issued.arn
+  }
+  ```
+  Run `cargo insta accept` after first execution to lock the snapshot. Add the fixture to the `make plan-fixtures` Makefile target.
+- **Verification:** `cargo nextest run -p carina-cli plan_display_wait_cert`.
+
+### Phase 6 — LSP
+
+**Task 6.1: LSP completes `wait` as a top-level snippet.**
+
+- **Files:** modify `carina-lsp/src/completion/top_level.rs`.
+- **Test:** in `carina-lsp/src/completion/top_level_tests.rs`:
+  ```rust
+  #[test]
+  fn top_level_completions_include_wait() {
+      let items = top_level_completions();
+      assert!(items.iter().any(|c| c.label == "wait"));
+  }
+  ```
+- **Implementation:** add a `CompletionItem { label: "wait", kind: Keyword, insert_text: "wait ${1:target} {\n    until = ${2}\n}" }` to `top_level_completions()`. Place it alphabetically next to other Storage keywords (`fn`, `let`).
+- **Verification:** `cargo nextest run -p carina-lsp completion::top_level_tests::top_level_completions_include_wait`.
+
+**Task 6.2: LSP completes block keys (`until`, `depends_on`, `timeout`) inside `wait` block.**
+
+- **Files:** modify `carina-lsp/src/completion/values.rs`.
+- **Test:** in `carina-lsp/src/completion/values_tests.rs`:
+  ```rust
+  #[test]
+  fn wait_block_completions_include_until_depends_on_timeout() {
+      let doc = "let foo = wait cert {\n    \n}";
+      let cursor = position_of_cursor(doc); // helper finds where to place cursor
+      let items = wait_block_completions(doc, cursor);
+      let labels: Vec<&str> = items.iter().map(|c| c.label.as_str()).collect();
+      assert!(labels.contains(&"until"));
+      assert!(labels.contains(&"depends_on"));
+      assert!(labels.contains(&"timeout"));
+  }
+  ```
+- **Implementation:** detect when the cursor is inside a `wait <ident> { ... }` block (look up to the nearest unclosed `{` and check the preceding tokens). Return a fixed list of three `CompletionItem`s.
+- **Verification:** `cargo nextest run -p carina-lsp completion::values_tests::wait_block_completions_include_until_depends_on_timeout`.
+
+**Task 6.3: LSP semantic tokens highlight `wait` and `until` as keywords.**
+
+- **Files:** modify `carina-lsp/src/semantic_tokens.rs`.
+- **Test:** add to the existing `mod tests` in `carina-lsp/src/semantic_tokens.rs` (mirrors existing tests like `test_tokenize_line_resource_type` at line 1077):
+  ```rust
+  #[test]
+  fn test_tokenize_line_wait_keyword() {
+      let provider = SemanticTokensProvider::new(&[]);
+      let tokens = provider.tokenize_line("let foo = wait cert {", 0);
+      // tokens are (start_col, length, token_type_index) tuples
+      // KEYWORD index in TOKEN_TYPES is 0 (per the array at semantic_tokens.rs:10)
+      let wait_token = tokens.iter().find(|(start, len, _)| {
+          *start == 10 && *len == 4   // "wait" at column 10
+      }).expect("expected `wait` token");
+      assert_eq!(wait_token.2, 0, "wait should map to KEYWORD type");
+  }
+
+  #[test]
+  fn test_tokenize_line_until_keyword() {
+      let provider = SemanticTokensProvider::new(&[]);
+      let tokens = provider.tokenize_line("    until = cert.status == ISSUED", 0);
+      let until_token = tokens.iter().find(|(start, len, _)| {
+          *start == 4 && *len == 5   // "until" at column 4
+      }).expect("expected `until` token");
+      assert_eq!(until_token.2, 0);
+  }
+  ```
+  (Note: the existing TOKEN_TYPES table at `semantic_tokens.rs:10` lists `KEYWORD` at index 0 with the comment "unused — kept for index stability". This task starts using it. If the existing tests break because their assertions assumed nothing maps to index 0, fix those assertions in the same task.)
+- **Implementation:** in `SemanticTokensProvider::tokenize_line` (line 259), extend the existing keyword-recognition path that already handles `let`/`fn`/`provider` (per `KEYWORDS` in `carina-core/src/keywords.rs`, which Tasks 3.1 and 3.2 added `wait` and `until` to). The simplest path: change `tokenize_line` to look up each leading word against `carina_core::keywords::is_keyword(...)` — that single source of truth covers `wait`/`until` automatically once Tasks 3.1/3.2 land.
+- **Verification:** `cargo nextest run -p carina-lsp semantic_tokens_tests::semantic_tokens_highlight_wait_and_until`.
+
+**Task 6.4: LSP diagnoses `wait foo { ... }` where `foo` is not a known binding.**
+
+- **Files:** modify `carina-lsp/src/diagnostics/mod.rs` (or the appropriate sub-file).
+- **Test:** in `carina-lsp/src/diagnostics/tests.rs`:
+  ```rust
+  #[test]
+  fn diagnose_wait_with_unknown_target() {
+      let src = "let foo = wait nonexistent { until = nonexistent.x == y }";
+      let diags = compute_diagnostics(src);
+      assert!(diags.iter().any(|d|
+          d.message.contains("nonexistent") && d.severity == Severity::Error
+      ));
+  }
+  ```
+- **Implementation:** during diagnostic pass, look up each `WaitExpr.target` in the document's binding map; if absent, emit a diagnostic at the target identifier's span with message `"`wait` target `nonexistent` is not a declared binding"`.
+- **Verification:** `cargo nextest run -p carina-lsp diagnostics::tests::diagnose_wait_with_unknown_target`.
+
+**Task 6.5: LSP diagnoses `until` LHS attribute that is not in target's schema.**
+
+- **Files:** modify `carina-lsp/src/diagnostics/mod.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn diagnose_wait_until_unknown_attribute() {
+      let src = r#"
+          let cert = aws.acm.Certificate { domain_name = "x", validation_method = "DNS" }
+          let foo = wait cert { until = cert.statu == "ISSUED" }
+      "#;
+      let diags = compute_diagnostics(src);
+      assert!(diags.iter().any(|d| d.message.contains("statu") && d.severity == Severity::Error));
+  }
+  ```
+- **Implementation:** look up the target's resource type → schema → attribute set. If the LHS attribute name is not in the set, emit a diagnostic.
+- **Verification:** `cargo nextest run -p carina-lsp diagnostics::tests::diagnose_wait_until_unknown_attribute`.
+
+### Phase 7 — Validate against real infra fixture
+
+**Task 7.1: End-to-end fixture: parse + validate a multi-file directory using `wait`.**
+
+- **Files:** create `carina-core/tests/fixtures/wait/cert_issued/main.crn` (resource and wait declarations) plus `carina-core/tests/fixtures/wait/cert_issued/providers.crn` (provider block). Add an integration test `carina-core/tests/wait_directory_test.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn parses_wait_construct_in_multi_file_directory() {
+      let dir = "tests/fixtures/wait/cert_issued";
+      let parsed = carina_core::parse_directory(dir).expect("parse should succeed");
+      let wait_bindings: Vec<_> = parsed.iter_let_bindings()
+          .filter(|b| matches!(b.kind, LetBindingKind::Wait(_)))
+          .collect();
+      assert_eq!(wait_bindings.len(), 1);
+      assert_eq!(wait_bindings[0].name, "cert_issued");
+  }
+  ```
+- **Implementation:** populate the fixture files. `main.crn` has the cert + record + wait + dist resources from the design spec; `providers.crn` has only the `provider aws { ... }` block. This exercises the multi-file requirement called out in `CLAUDE.md`'s "Directory-scoped, never single-file" section.
+- **Verification:** `cargo nextest run -p carina-core wait_directory_test::parses_wait_construct_in_multi_file_directory`.
+
+**Task 7.2: `carina validate` (CLI) accepts the `wait` fixture without errors.**
+
+- **Files:** modify `carina-cli/tests/cli_validate_tests.rs` (or create if missing).
+- **Test:**
+  ```rust
+  #[test]
+  fn cli_validate_accepts_wait_fixture() {
+      let output = run_cli(&["validate", "../carina-core/tests/fixtures/wait/cert_issued"]);
+      assert!(output.status.success(), "validate failed: {}", output.stderr);
+  }
+  ```
+- **Implementation:** none if the fixture from Task 7.1 is well-formed; this test pins the contract that `wait` doesn't break `carina validate`.
+- **Verification:** `cargo nextest run -p carina-cli cli_validate_tests::cli_validate_accepts_wait_fixture`.
+
+### Phase 8 — Whole-tree gates (run after every phase before opening PR)
+
+- `cargo nextest run` (workspace)
+- `cargo test --workspace --doc`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --check`
+- `bash scripts/check-*.sh` for every script in `scripts/`
+- `cargo build --release` once before opening PR — **only if** this PR has touched `Cargo.toml`, `unsafe` code, or the `release` profile config (per CLAUDE.md "Verify Protocol"). The wait-construct work changes neither, so this step is normally skipped; include it only if a sub-task drags in a Cargo.toml dependency change.
+
+## Plan self-review
+
+| Requirement from design doc | Covered by |
+|---|---|
+| `let <name> = wait <target> { ... }` syntax | Tasks 3.3, 3.4 |
+| Block accepts `until`, `depends_on`, `timeout` | Task 3.3 (grammar), Task 3.4 (parser) |
+| Value semantics: passthrough of target | Task 4.9 (resolver) + Task 4.8 (binding registration) |
+| `until` is type-checked, MVP only `==` | Tasks 4.2, 4.3, 6.5 |
+| `depends_on` is provided by separate carina#TBD-A | Acknowledged as prerequisite |
+| `timeout` defaults from schema, optional override | Task 4.1 (differ uses schema default when omitted) |
+| `interval` not user-visible, comes from schema | Task 4.1 (differ pulls from schema) |
+| `fail_when` not in MVP | Not in plan; explicitly out of scope |
+| State file does not record waits | Task 5.2 |
+| Plan display: `> <name> (until <predicate>)` | Tasks 5.1, 5.3 |
+| Timeout = error one-way, message has last observed value | Task 4.6 |
+| Provider trait unchanged, executor does polling | Task 4.4 onwards (no provider trait modification anywhere in plan) |
+| New `Effect::Wait` variant | Tasks 2.1, 2.2, 2.3 |
+| `Duration` literal/type from carina#TBD-B | Acknowledged as prerequisite |
+| LSP completion + diagnostics + semantic tokens | Tasks 6.1–6.5 |
+| TextMate grammar parity | Task 3.7 |
+| Multi-file directory fixture acceptance | Task 7.1 |
+
+No placeholder phrases remain. Every task has a concrete file, a concrete test, a concrete implementation snippet, and an exact `cargo nextest run` command.
+
+## Suggested review-ordering for the PR
+
+When opening the PR, group commits per phase so reviewers can move bottom-up:
+
+1. **Predicate AST + evaluator** (Phase 1) — small, self-contained.
+2. **Effect variant + exhaustive-match plumbing** (Phase 2) — touches several files but each is one-liner additions.
+3. **Parser** (Phase 3) — grammar, AST, validation, TextMate parity.
+4. **Differ + executor** (Phase 4) — the load-bearing logic.
+5. **Plan display + state-file exclusion** (Phase 5) — surface behaviour.
+6. **LSP** (Phase 6) — editor experience.
+7. **End-to-end fixture** (Phase 7) — gates the whole stack.

--- a/docs/specs/2026-05-09-wait-construct-design.md
+++ b/docs/specs/2026-05-09-wait-construct-design.md
@@ -1,0 +1,433 @@
+# `wait` Construct: Design
+
+<!-- constrained-by ./2026-05-09-wait-construct-design.md#out-of-scope -->
+
+## Goal
+
+Introduce a `wait` right-hand-side expression to the Carina DSL so users can declare "block downstream resources until target reaches a desired state" — most immediately, ACM `Certificate.Status == ISSUED` for the carina-rs/infra registry usecase (T6), but generalisable to any "create-then-poll-until-ready" pattern across AWS / awscc / future providers (RDS Available, Lambda Active, EC2 Running, MSK Active, etc.).
+
+This is the long-form output of a brainstorming session that started from `carina-rs/carina-provider-aws#244` (ACM Certificate + CertificateValidation) and concluded that the most type-safe, future-proof, philosophically consistent way to express "waiting" is a first-class DSL construct rather than a per-provider waiter resource.
+
+## Non-goals
+
+- Implementing ACM Certificate / CertificateValidation themselves. That work happens on top of this construct, tracked separately on the aws side as the consumer.
+- Adding `time_sleep` / "just sleep N seconds" semantics. The `wait` construct is for "wait for a condition on a target", not raw sleeps. Pure sleep deserves its own `sleep { duration = ... }` construct if needed.
+- Adding `fail_when` (early-fail on known-bad states). MVP relies on `timeout` to surface "didn't reach the desired state". Can be added later without breaking change.
+- Exposing `interval` (poll cadence) to the user. MVP keeps it provider-internal. Can be added later.
+- Persisting wait results across plan/apply runs. The `wait` construct does not write to the state file; every plan/apply re-evaluates.
+- Provider-side `wait()` API. MVP runs the polling in the executor on top of the existing `read()` trait method, so providers (including WASM plugins) need no contract change.
+
+## Why `wait` belongs in carina-core, not in each provider
+
+The brainstorming surfaced and rejected six alternatives:
+
+| Approach | Why rejected |
+|---|---|
+| **B**: Bake polling into `aws.acm.Certificate.create()` | Cyclic dependency — the validation DNS record needs `cert.domain_validation_options` (only known after `RequestCertificate`), so the cert cannot wait on the record before its own create returns. Same problem applies to **G** ("`Certificate` = `ISSUED` guarantee"). |
+| **A**: Per-provider `aws.acm.CertificateValidation` waiter resource (Terraform style) | Works, but multiplies into a class of `~Validation` / `~Ready` resources across services (RDS Available, Lambda Active, ...). Carries three runtime-escape hacks (no-op `delete()`, dummy state-row id, every attribute `ForceNew`) that violate the project's "type safety over runtime checks" rule. |
+| **C-2**: `lifecycle { wait_for = ... }` on the downstream resource | Spreads the wait responsibility across every consumer of the cert (Distribution, ALB Listener, ...), duplicating the predicate; also requires lifecycle-block expression evaluation to dereference *another* resource's attributes. |
+| **H**: New `assert {...}` top-level statement | Conflates "must be true at point in time" with "wait until true", which are different operations. |
+| **I**: `cert.arn when cert.status == ISSUED` reference modifier | Cute but unsalvageable: the same cert may be referenced from multiple downstream resources, each of which needs the same wait — duplicating the `when` expression. |
+
+The chosen approach (**X'** in the brainstorming) — `let cert_issued = wait cert { until = ..., depends_on = [...], timeout = ... }` — sidesteps every one of those problems:
+
+- Cert and validation record can be authored independently (cert is "request-and-return", record references the cert's `domain_validation_options`).
+- `wait` is a single declaration that expresses the synchronization contract once; multiple downstream resources reference `cert_issued.arn` to inherit the wait.
+- No per-provider waiter resource class needed.
+- No runtime hacks (no fake state rows, no no-op deletes).
+- The construct is provider-agnostic and reusable across the entire AWS / awscc surface.
+
+## DSL syntax
+
+```crn
+let cert = aws.acm.Certificate {
+    domain_name       = "registry.carina-rs.dev"
+    validation_method = "DNS"
+}
+
+let validation_record = aws.route53.RecordSet {
+    hosted_zone_id   = zone.id
+    name             = cert.domain_validation_options[0].resource_record_name
+    type             = cert.domain_validation_options[0].resource_record_type
+    ttl              = 60
+    resource_records = [cert.domain_validation_options[0].resource_record_value]
+}
+
+let cert_issued = wait cert {
+    until      = cert.status == aws.acm.Certificate.Status.Issued
+    depends_on = [validation_record]
+    timeout    = 75min
+}
+
+let dist = aws.cloudfront.Distribution {
+    viewer_certificate {
+        acm_certificate_arn      = cert_issued.arn
+        ssl_support_method       = "sni-only"
+        minimum_protocol_version = "TLSv1.2_2021"
+    }
+    # ... origin / behaviors etc
+}
+```
+
+### Grammar
+
+```
+let_binding   = "let" identifier "=" (resource_expr | upstream_state_expr | wait_expr | ...)
+
+wait_expr     = "wait" target_ref "{" wait_attr* "}"
+target_ref    = identifier                    # binding name of the target resource
+wait_attr     = until_attr
+              | depends_on_attr               # provided by the carina depends_on extension
+              | timeout_attr
+
+until_attr    = "until"   "=" wait_predicate
+timeout_attr  = "timeout" "=" duration_literal
+```
+
+`wait_predicate` reuses the existing `validate_expr` grammar (already in `carina.pest`: `validate_or_expr` / `validate_and_expr` / `validate_comparison`) so the parser can short-cut to a known production. MVP only enforces the `<binding>.<attr> == <enum_or_literal>` shape via a post-parse type check; the grammar accepts the wider validate-expr surface and incrementally supports more operators (`!=`, `&&`, `||`, `>=`, `in [...]`) as later issues land.
+
+`duration_literal` is a new lexical token — see "Duration type" below.
+
+### Reusing the right-hand-side family
+
+Carina already has multiple "right-hand sides of a `let`":
+
+- `aws.s3.Bucket { ... }` — managed resource declaration
+- `module.web_tier { ... }` — module instantiation
+- `upstream_state { ... }` — external state reference
+
+`wait <target> { ... }` is added to this family. The choice — `let cert_issued = wait cert { ... }` instead of `wait cert_issued { ... }` (Y in the brainstorming) — preserves Carina's "every binding is `let`" invariant and matches the precedent set by `upstream_state { ... }`.
+
+### `target` as a positional argument
+
+`wait <target> { ... }` puts the target binding name in the keyword's positional slot rather than as an in-block `target = cert` field. Two reasons:
+
+1. The reader sees what is being waited on at the top of the line, before any block contents.
+2. `target` is the wait's primary subject; everything in the block configures *how* the wait behaves. Promoting subject to positional matches that hierarchy.
+
+Consequence for the parser: `wait_expr` accepts exactly one positional `identifier` after `wait` and before `{`. This is a new positional pattern in Carina's right-hand sides, but a small one — it does not generalise into a "every keyword can take positional arguments" rule.
+
+### Value semantics
+
+`<wait-binding>.<attr>` resolves to **`<target>.<attr>`** (passthrough), with the lifecycle constraint that the value is not available to downstream resources until the wait completes successfully. Same idiom as Terraform's `aws_acm_certificate_validation.example.certificate_arn` — an indirection through the wait gives downstream consumers an implicit "waited-on" version of the underlying value.
+
+This means:
+
+- `cert_issued.arn` has the same type and content as `cert.arn` (the certificate ARN is a string regardless of validation status); the difference is purely the dependency edge in the execution graph.
+- Downstream resources that don't care about the wait (e.g. an audit-log resource that just records the cert ARN) can reference `cert.arn` directly and skip the wait. Downstream resources that need the cert to actually be `ISSUED` reference `cert_issued.arn` and inherit the synchronisation.
+- All attributes of the target are accessible: `cert_issued.domain_name`, `cert_issued.subject_alternative_names`, etc. Reading from the wait binding returns the snapshot of the target captured by the read() that satisfied `until`.
+
+## Block fields
+
+| Field | Required? | Type | Default | Description |
+|---|---|---|---|---|
+| `until` | Yes | typed predicate | — | Evaluated against each `read()` of `target`; wait completes when this returns `true`. |
+| `depends_on` | No | list of bindings | `[]` | Bindings that must complete before the wait starts polling. (Carina-wide meta-arg; see dependency.) |
+| `timeout` | No | `duration` | from target's schema | Hard cap on total wait time. Exceeding it returns `ProviderError::Timeout`. |
+
+### `until` — typed predicate
+
+MVP grammar accepts `<target>.<attr> == <value>` only:
+
+```crn
+until = cert.status == aws.acm.Certificate.Status.Issued
+until = instance.state == aws.ec2.Instance.State.Running
+until = func.state == aws.lambda.Function.State.Active
+```
+
+Type-checking rules (enforced post-parse, surfaceable via LSP diagnostics):
+
+- The left-hand side must reference an attribute of the wait's `target` (cross-target predicates are out of scope for MVP). `cert.status` where `cert` is the target binding ✓; `other_cert.status` ✗.
+- The attribute must exist in the target's schema. Typo on attribute name → diagnostic.
+- The right-hand side must be type-compatible with the attribute's declared type. For enum attributes (the dominant case), the RHS must be a namespaced enum value (`aws.acm.Certificate.Status.Issued`).
+
+Future extensions (out of MVP, no breakage required):
+- `!=`
+- Boolean combinators `&&` / `||`
+- Numeric comparisons `>=` / `<=` / `>` / `<` (for "completed_steps >= 10" style)
+- `in [...]` for "any of these states"
+
+The `validate_expr` grammar that Carina already uses for `arguments { validation { condition = ... } }` covers all of these shapes; reusing it amortises grammar work.
+
+### `depends_on` — provided by separate extension
+
+`depends_on = [<binding>, ...]` declares additional ordering edges that aren't expressed via value references. ACM Validation needs this because the wait references the *cert*, not the *validation record*, but cannot start until the record is published.
+
+`depends_on` is **not** a wait-specific feature. It belongs as a Carina-wide meta-arg available on every `let` binding (resource, wait, future others). The wait construct depends on it but does not introduce it. See "Dependencies on other Carina extensions" below.
+
+### `timeout` — duration with schema-provided default
+
+`timeout` is optional. When omitted, the executor uses the default declared on the target resource's schema (`AwsSchemaConfig::default_wait_timeout` or equivalent — see "Schema additions" below). Each provider/resource sets a sensible default (ACM Certificate: 75 minutes, matching Terraform's `aws_acm_certificate_validation` default; EC2 Instance: 5 minutes; etc.).
+
+Exceeding `timeout` produces `ProviderError::Timeout` whose message includes:
+
+- The wait binding name (`cert_issued`)
+- The unmet predicate (`cert.status == ISSUED`)
+- The last observed value (`cert.status = PENDING_VALIDATION`)
+- The elapsed time
+
+## Duration type
+
+Carina has no `Duration` literal today. This proposal introduces one as a precondition; the wait construct depends on it.
+
+### Lexical syntax
+
+```
+duration_literal = integer_literal duration_unit
+duration_unit    = "s" | "sec" | "second" | "seconds"
+                 | "m" | "min" | "minute" | "minutes"
+                 | "h" | "hr"  | "hour"   | "hours"
+```
+
+Examples: `30s`, `5min`, `1h`, `75min`, `30sec`, `2hours`.
+
+Compound forms (`1h30m`) are deferred until a real use case appears; the MVP supports a single `<integer><unit>` only. ACM's 75-minute window and every reasonable provider default fit comfortably inside that.
+
+### Type
+
+A new first-class `Duration` type in carina-core (likely a thin wrapper around `std::time::Duration`). DSL-side: an attribute typed as `Duration` requires a `duration_literal` value; trying to assign an `Int` or `String` is a type error.
+
+### Reuse beyond `wait`
+
+Once introduced, `Duration` is naturally usable for:
+
+- Future `lifecycle { create_timeout = ..., delete_timeout = ... }` extensions
+- TTL-typed attributes (Route 53 record TTL, CloudWatch metric retention, etc.) — currently typed as `Int seconds`
+- Retry / backoff configuration on resources that need it
+
+The wait construct is the first use site, but the type is broadly applicable.
+
+## Effect model
+
+### New variant
+
+```rust
+pub enum Effect {
+    Create { ... },
+    Update { ... },
+    Replace { ... },
+    Delete { ... },
+    Read { ... },
+    Import { ... },
+    Remove { ... },
+    Move { ... },
+    Wait {
+        binding: String,                 // e.g., "cert_issued"
+        target_id: ResourceId,           // resolved from `wait cert` → cert's id
+        target_identifier: Option<String>,
+        until: WaitPredicate,            // typed predicate AST
+        timeout: Duration,
+        interval: Duration,              // resolved from schema default; not user-visible
+        depends_on: Vec<EffectIdx>,      // populated by planner, not by user
+    },
+}
+```
+
+`WaitPredicate` is a typed AST for the supported predicate shapes. Initial enum:
+
+```rust
+pub enum WaitPredicate {
+    Equals { attr: AttrPath, value: Value },
+    // future: NotEquals, And, Or, Comparison, In, ...
+}
+```
+
+`AttrPath` supports nested fields (`renewal_summary.renewal_status`) so future use cases that need to dig into struct attributes work without re-parsing.
+
+### Executor logic
+
+The `Wait` effect is dispatched by carina-core's executor (not by the provider). The executor:
+
+1. Waits for `depends_on` effects (target's `Create`/`Update`, plus any user-declared additional bindings) to complete.
+2. Loops:
+   1. `provider.read(target_id, target_identifier).await?`
+   2. Evaluate `until` against the returned `State.attributes`.
+   3. If true → success, capture the snapshot for downstream resolution.
+   4. If false → check elapsed time:
+      - If `>= timeout` → `Err(ProviderError::Timeout { ... })`.
+      - Else → `tokio::time::sleep(interval).await; continue;`.
+
+The provider sees only ordinary `read()` calls; nothing in the WIT contract or the `Provider` trait changes. WASM plugins automatically support being waited on by virtue of implementing `read()`.
+
+### Downstream value resolution
+
+When a downstream effect references `<wait-binding>.<attr>`, the executor's binding resolution layer treats `<wait-binding>` as resolving to the State snapshot captured at wait-completion time. This is the same machinery that resolves `<resource-binding>.<attr>` → post-create State; we just register the wait's captured snapshot in the same map under the wait's binding name.
+
+Failure semantics: if the wait errors (timeout), the wait binding never gets registered, so any downstream effect that references it surfaces the standard "dependency failed" skip behaviour already implemented in the executor (`failed_bindings` set, dependency-aware skip).
+
+## State file
+
+`Wait` effects do **not** write to `carina.state.json`. They are evaluated fresh on every plan/apply:
+
+- If the target already satisfies `until`, the wait completes in one `read()` (typically sub-second).
+- If the target does not satisfy `until`, the wait either eventually succeeds (within `timeout`) or fails.
+
+Rationale: a wait represents a synchronisation contract, not a managed object. There is no "waited" or "unwaited" state to persist; the source of truth is the current state of the target, which is itself either persisted (for managed resources) or re-read (for data sources).
+
+This avoids:
+
+- "Wait drift" — a previously-satisfied wait whose target has since fallen out of `until`.
+- The state file growing with synthetic rows for every wait.
+- The `delete()` semantic question for "synthetic" resources (which is what made approach **A** awkward).
+
+## Plan display
+
+```
++ aws.acm.Certificate.cert
++ aws.route53.RecordSet.validation_record
+> cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)
++ aws.cloudfront.Distribution.dist
+```
+
+Format follows the existing one-line-per-effect convention in `carina-core/src/plan.rs:format_effect_brief`:
+
+- `> <binding-name> (until <predicate-stringified>)`
+- ASCII single-character marker `>`, consistent with other markers (`+`, `~`, `+/-`, `<=`, `<-`, `x`, `->`).
+- No emoji, no multi-line block — keeps `carina plan` grep-friendly and snapshot-test-stable.
+- `timeout` is omitted when at the schema default; printed when overridden.
+- Predicate is rendered using its surface form (`cert.status == aws.acm.Certificate.Status.Issued`), not the parsed AST.
+
+During `carina apply`, the same line gets a progress annotation when actively polling (`> cert_issued ... [waited 12s]`); details left to the apply UI implementation, not load-bearing for the design.
+
+## Dependencies on other Carina extensions
+
+This proposal is non-trivially layered. Three independent Carina-core changes need to land in order:
+
+| Order | Carina extension | Purpose | Standalone value |
+|---|---|---|---|
+| 1 | `Duration` type + `<integer><unit>` literal | Concrete syntax for `timeout = 75min` | Yes — useful for any resource attribute currently typed `Int seconds` |
+| 2 | `depends_on` meta-arg on `let` bindings | Express ordering not captured by value references | Yes — Terraform parity, useful for resources that interact via side effects |
+| 3 | `wait` construct (this design) | Block downstream until target reaches a condition | Builds on 1 + 2 |
+
+Each is a separate Carina RFC / issue. The wait construct is the third; the prior two are prerequisites with their own design rationale (and standalone utility, so they're not "subsidiaries" of the wait work).
+
+The `aws.acm.Certificate` consumer issue (carina-rs/carina-provider-aws#244) sits on top of the third. ACM's `CertificateValidation` is no longer a separate awscc-or-aws-side resource; it is expressed entirely as `wait` against the existing `aws.acm.Certificate`.
+
+## Schema additions
+
+To support per-resource defaults for `wait`'s `timeout` and `interval`, the existing `AwsSchemaConfig` (and the awscc equivalent) gains:
+
+```rust
+pub struct AwsSchemaConfig {
+    // ... existing fields
+    pub default_wait_timeout: Option<Duration>,   // default: None → carina-core fallback (e.g. 5min)
+    pub default_wait_interval: Option<Duration>,  // default: None → carina-core fallback (e.g. 5s)
+}
+```
+
+Codegen-generated resource configs populate these from `ResourceDef`-side metadata:
+
+```rust
+ResourceDef {
+    name: "acm.Certificate",
+    // ...
+    default_wait_timeout: Some(Duration::from_secs(75 * 60)),
+    default_wait_interval: Some(Duration::from_secs(5)),
+}
+```
+
+For the MVP, only resources that need a non-default wait declare these fields. Carina-core falls back to fixed defaults when both are `None`.
+
+The "派生 A" (one timeout per resource) shape from the brainstorming is preserved; "per-state-transition" timeouts (派生 B) are out of MVP scope and can be added later by extending the schema field to a map keyed by predicate signature.
+
+## LSP / formatter / diagnostics
+
+| Component | Change required |
+|---|---|
+| `carina-lsp/src/completion/top_level.rs` | Add `let <name> = wait` as a snippet completion. |
+| `carina-lsp/src/completion/values.rs` | Inside a `wait <target> { ... }` block: complete `until`, `depends_on`, `timeout` as block-level keys; complete `<target>.<attr>` for the LHS of `until`; complete enum values for the RHS. |
+| `carina-lsp/src/semantic_tokens.rs` | Highlight `wait` and `until` as keywords; highlight duration literals as numeric. |
+| `carina-lsp/src/diagnostics/` | Diagnose: target not found, attribute not in target schema, type mismatch in `until`, unsupported operator (anything beyond `==` in MVP), missing `until`, invalid duration. |
+| Formatter | Format `wait` blocks consistently with existing `let foo = aws.... { ... }` blocks. |
+| TextMate grammars | Add `wait`, `until`, `depends_on`, `timeout`, and duration literal patterns to both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` (parity test enforced by `carina-core/tests/tmlanguage_keyword_parity.rs`). |
+
+## Edge cases and constraints
+
+### Wait on a wait
+
+```crn
+let cert_issued        = wait cert { until = cert.status == ISSUED }
+let cert_issued_strict = wait cert_issued { until = cert_issued.signature_algorithm == "SHA256WITHRSA" }
+```
+
+Allowed in principle (target can be any binding, including another wait), but no use case yet. MVP allows it via the existing binding lookup; it falls out for free from the value-semantics rule (`cert_issued`'s value = `cert`'s value, so `cert_issued.signature_algorithm` = `cert.signature_algorithm`).
+
+### Self-referential `until`
+
+```crn
+let foo = wait cert { until = foo.something == ... }
+```
+
+A `until` predicate that references the wait's own binding (rather than the target) is a parse-time error: the wait binding is not in scope inside its own `until` (analogous to `let x = x + 1` — disallowed in most languages and not useful here).
+
+### Wait without `depends_on`
+
+```crn
+let cert_issued = wait cert { until = cert.status == ISSUED }
+```
+
+Legal. The wait starts as soon as the target's `Create`/`Update` completes. ACM's case happens to require `depends_on = [validation_record]` because the validation record must exist for `until` to ever become true; for resources where `until` becomes true purely from the target's own create (e.g. EC2 Instance reaching `Running` after `RunInstances`), `depends_on` is unnecessary.
+
+### `read()` returns `not_found`
+
+If the target's read returns `State::not_found` mid-poll (e.g. someone deleted the cert out-of-band), the wait fails immediately with a distinct error variant (`ProviderError::NotFound { ... }`), not after `timeout`. This mirrors how regular reads handle drift.
+
+### Wait against a data source
+
+Allowed in principle — the executor calls whichever read API the target uses (`provider.read` for managed resources, `provider.read_data_source` for data sources). No special handling needed beyond looking up the target's binding kind.
+
+### Wait inside a module
+
+A `wait` declared inside a module behaves identically to a wait at the root: it has its own binding name (scoped to the module), and downstream references work via the standard module-resolver paths. Module exports can include wait bindings — exporting a wait is equivalent to exporting its target reference plus the guarantee that the target satisfies the wait's predicate before the export resolves. Nothing special in the design; falls out of treating waits as ordinary `let` bindings.
+
+### Anonymous waits
+
+Carina has the concept of anonymous resources (`aws.s3.Bucket { ... }` without `let`); does an anonymous wait make sense?
+
+```crn
+wait cert { until = cert.status == ISSUED }   # no `let`, no binding name
+```
+
+Use case: the user wants to gate apply on the target reaching a state but doesn't need to reference the wait's value from anywhere else. MVP: **disallowed**. Anonymous resources get an auto-generated identity from their attributes (typically `name`); a wait has no `name` attribute and no AWS-side identity, so the auto-id machinery doesn't apply. If a user genuinely wants a "fire and forget" wait, they can write `let _ = wait cert { ... }` (binding-name = `_` is the existing discard pattern, see `let_binding = { "let" ~ (discard_pattern | identifier) ~ "=" ~ ... }` in `carina.pest`).
+
+## Out of scope (for MVP, deferred to follow-up)
+
+- `fail_when` for early-fail on known-bad states.
+- `interval` exposed to user.
+- `on_timeout = "warn" | "skip"` modes (only "error" supported in MVP).
+- Compound duration literals (`1h30m`).
+- Predicate operators beyond `==`.
+- Cross-target predicates (`until = other_resource.attr == ...` where target is something else).
+- Per-state-transition timeouts (different timeout for `Issued` vs `Failed`).
+- Provider-specific native wait implementations (every wait runs through executor + `read()` polling).
+- Persisting wait results across runs (always re-evaluated).
+- `time_sleep`-equivalent pure-sleep construct.
+
+## Acceptance criteria
+
+The `wait` construct is considered "done" for MVP when:
+
+1. `let foo = wait <target> { until = <==-predicate>, depends_on = [...], timeout = <duration> }` parses cleanly across `carina validate` and the LSP, with diagnostics for missing `until`, unknown target, type-mismatched predicate.
+2. `<wait-binding>.<attr>` resolves correctly in downstream resources (passthrough of target).
+3. Plan output displays `> <binding> (until <predicate>)` per the format above; snapshot tests cover at least one fixture (`carina-cli/tests/fixtures/plan_display/wait_cert/`).
+4. Apply executes the wait by polling `read()` at the schema-declared interval, satisfies `until`, and unblocks downstream effects.
+5. Apply on a wait that fails to satisfy within `timeout` returns `ProviderError::Timeout` with a message including the unmet predicate and last observed attribute value.
+6. State file (`carina.state.json`) contains no entries for wait bindings.
+7. The `aws.acm.Certificate` + Route53 record + `wait` end-to-end pattern works against real AWS in the registry usecase (carina-rs/infra T6).
+
+## Risks
+
+- **Predicate evaluation as a long-term language feature.** Starting with `==` is conservative, but every predicate operator added later (`>=`, `&&`, `in`) becomes a language-level commitment. Mitigation: reuse `validate_expr` so we're not inventing a new expression evaluator; cap MVP at `==` and require an explicit RFC for each new operator.
+- **Default timeouts as a per-resource curated dataset.** Codegen needs a place to express "ACM Certificate default = 75min, EC2 Instance default = 5min, ...". Wrong defaults would surface as nuisance timeouts. Mitigation: only declare defaults for resources that have a known wait pattern; fall back to a conservative carina-core default (e.g. 5min) otherwise; document and review per-resource defaults in `ResourceDef` review.
+- **`read()` polling cost at scale.** A workspace with many waits in flight (e.g. 50 EC2 instances, each waited on) generates 50 × `DescribeInstances` calls per interval. AWS API rate limits could be hit. Mitigation: this concern is real but out of MVP scope; future work could batch reads (single `DescribeInstances` covering all 50) but that requires a provider-side capability beyond `read()`. For MVP, document that high-fan-out waits should use longer intervals; revisit when a real workload hits limits.
+- **`Duration` type sneaks into resource schemas before users are ready.** The Duration extension is independent of wait; once it lands, users can use `30s` anywhere a Duration is expected. If we later realise a different lexical form is preferred (e.g. ISO 8601 `PT75M`), changing the literal is a breaking change to every `.crn` file using it. Mitigation: Carina has explicit "no backward compat" policy (project memory), so a future swap is permitted but not free. Settle the literal form via this design doc and don't revisit lightly.
+
+## Related work
+
+- carina-rs/carina-provider-aws#244 — the consumer issue (ACM Certificate + DNS validation for the registry usecase). After this design lands, `#244` becomes "implement `aws.acm.Certificate` + a `wait` example demonstrating DNS validation".
+- carina-rs/carina#TBD-A — `depends_on` meta-arg RFC (prerequisite).
+- carina-rs/carina#TBD-B — `Duration` type and literal RFC (prerequisite).
+- carina-rs/carina#TBD-C — `wait` construct RFC (this document, on the carina side).
+- Terraform's `aws_acm_certificate_validation` source (`hashicorp/terraform-provider-aws@main:internal/service/acm/certificate_validation.go`) — surveyed for reference; the synthetic-resource pattern was found to be a Terraform idiom (also used by `time_sleep`, `null_resource`, `terraform_data`) but rejected for Carina due to the runtime-escape hacks it requires.
+- carina-rs/infra Issue #29 (T6: `usecases/registry/`) — the ultimate consumer.
+- carina-rs/infra `docs/specs/2026-05-05-registry-dev-bootstrap-design.md` D6 — the design that surfaced the requirement.


### PR DESCRIPTION
## Summary

Adds two long-form design documents for a new top-level Carina DSL construct that lets users declare "block downstream resources until target reaches a desired state":

```crn
let cert_issued = wait cert {
    until      = cert.status == aws.acm.Certificate.Status.Issued
    depends_on = [validation_record]
    timeout    = 75min
}

let dist = aws.cloudfront.Distribution {
    acm_certificate_arn = cert_issued.arn   // implicit wait via passthrough
}
```

This is a **brainstorming-output Draft PR** — it ships docs only, no implementation code. Implementation tasks are filed as separate Issues (linked below).

## Files

- `docs/specs/2026-05-09-wait-construct-design.md` — design rationale, DSL syntax, evaluation model, alternatives considered (and rejected), edge cases, risks.
- `docs/plans/2026-05-09-wait-construct-plan.md` — 25 TDD-cycle tasks across 7 phases, with concrete test/implementation snippets and exact verification commands per task.

## Why a new construct (not a per-provider waiter resource)

The brainstorming surveyed six alternatives and rejected each:

| # | Approach | Why rejected |
|---|---|---|
| **B / G** | Bake polling into `cert.create()` / make `Certificate = ISSUED` guarantee | Cyclic dependency: validation DNS record needs `cert.domain_validation_options`, which only exists *after* `cert.create()` returns — cert cannot wait on the record before its own create returns |
| **A** | Per-provider `aws.acm.CertificateValidation` waiter resource (Terraform style) | Multiplies into a class of `~Validation` / `~Ready` resources across services; carries three runtime-escape hacks (no-op `delete`, dummy state-row `id`, every attribute `ForceNew`) that violate Carina's "type safety over runtime checks" rule |
| **C-2** | `lifecycle { wait_for = ... }` on the downstream resource | Spreads wait responsibility across every consumer of the cert (Distribution, ALB Listener, ...), duplicating the predicate |
| **H** | New `assert {...}` top-level statement | Conflates "must be true at point in time" with "wait until true", which are different operations |
| **I** | `cert.arn when cert.status == ISSUED` reference modifier | Same cert may be referenced from multiple downstream resources, each duplicating the `when` expression |

The chosen approach (`let foo = wait <target> { ... }`) sidesteps every one of those problems while keeping changes provider-agnostic and reusable across the entire AWS / awscc surface.

## Closes / refs

This PR opens follow-up Issues:

- `carina-rs/carina#TBD-A` — `depends_on` meta-arg on `let` bindings (prerequisite, separate RFC)
- `carina-rs/carina#TBD-B` — `Duration` type and `<integer><unit>` literal (prerequisite, separate RFC)
- `carina-rs/carina#TBD-C` — `wait` construct itself (the load-bearing follow-up; depends on A + B)
- `carina-rs/carina-provider-aws#244` — `aws.acm.Certificate` consumer; once A/B/C land, this becomes "implement Certificate; use the wait construct in DSL examples"

(Issue numbers will be filled in by replies after this PR lands.)

## Verification

- N/A for code; docs-only PR.
- Project memory ("brainstorming Draft PR + auto-merge") covers this exception to the "PRs are non-draft by default" rule.
- Markdown directives (`derived-from`, `constrained-by`) follow the dagayn graph convention from CLAUDE.md.

## Auto-merge

Will be enabled after creation per the brainstorming skill's Step 9 protocol.
