### PR TITLE
docs: design + implementation plan for `depends_on` meta-arg

### DIFF
--- a/docs/plans/2026-05-09-depends-on-plan.md
+++ b/docs/plans/2026-05-09-depends-on-plan.md
@@ -1,0 +1,884 @@
+# `depends_on` Meta-Argument: Implementation Plan
+
+<!-- derived-from ../specs/2026-05-09-depends-on-design.md -->
+
+## Repository scope
+
+This plan covers `carina-rs/carina` (carina-core) only. No provider-side work is required: providers see `Effect::Wait`/`Effect::Create` etc. with the union dependency map already resolved, so nothing in the WIT contract or Provider trait changes.
+
+## Prerequisites
+
+This plan assumes:
+
+- **`carina#2826` — `lifecycle` → `directives` rename** has landed first. All filenames, struct names, and DSL keywords below are written with `directives`. If `#2826` slips, every reference here is mechanically rewritable to `lifecycle` via a single sed pass; the structural design of `depends_on` is unaffected.
+
+If `#2826` has not landed when this plan starts, stall on it. Don't try to layer `depends_on` onto `lifecycle` and rebase later — the field rename touches every `match` arm in carina-core, the WIT contract, and state v3 fixtures, and doing it inside the same PR as a feature add violates the "1 PR = 1 topic" rule from project memory.
+
+## File map
+
+### Files to create
+
+| Path | Purpose |
+|---|---|
+| `carina-core/src/validation/depends_on.rs` | New module. Holds the seven analysis-pass diagnostics for `depends_on` (unknown binding, cycle, disallowed kind, self-reference, element type mismatch, duplicate element, redundant edge). |
+| `carina-core/tests/fixtures/depends_on/basic/main.crn` | Multi-file fixture for parser + analysis tests. |
+| `carina-core/tests/fixtures/depends_on/basic/directives.crn` | Sibling file for the directory-scoped acceptance test (per CLAUDE.md). |
+| `carina-cli/tests/fixtures/plan_display/depends_on/main.crn` | Plan-tree snapshot fixture. |
+| `carina-cli/tests/fixtures/plan_display/depends_on/carina.state.json` | Empty starting state for the snapshot fixture. |
+| `carina-cli/tests/fixtures/plan_display/depends_on/snapshot.txt` | Snapshot written by `cargo insta accept` after the first run. |
+
+### Files to modify
+
+| Path | Change |
+|---|---|
+| `carina-core/src/resource/mod.rs` | Add `pub depends_on: Vec<String>` field to `Directives` (the post-#2826 rename of `LifecycleConfig`). Default = `vec![]`. Tagged with `#[serde(default)]` so legacy state files deserialise cleanly. |
+| `carina-core/src/parser/blocks/attributes.rs` | In `extract_directives` (post-#2826 rename of `extract_lifecycle_config`), pull `depends_on` out of the parsed block's attribute map. Reject string-literal elements at parse time. |
+| `carina-core/src/parser/carina.pest` | No grammar change required if `directives { ... }` already accepts arbitrary attribute keys (it does). Verify and add a comment pointing to the design doc. |
+| `carina-core/src/deps.rs` | At the existing `resource.dependency_bindings = ...` site (line 320), union `resource.directives.depends_on.iter().cloned()` into the assignment. |
+| `carina-core/src/resolver.rs` | Same change at line 72. |
+| `carina-core/src/parser/resolve.rs` | Same change at line 145. |
+| `carina-core/src/effect.rs` | Add `pub explicit_dependencies: HashSet<String>` field to every `Effect` variant. Default = `HashSet::new()`. Variant constructors and existing `match` arms in callers all need the new field. |
+| `carina-core/src/differ/mod.rs` (or wherever effects are constructed from resources) | When constructing each `Effect::*` from a `Resource`, populate `explicit_dependencies` from `resource.directives.depends_on.iter().cloned().collect()`. |
+| `carina-core/src/validation/mod.rs` | Register the new `depends_on` diagnostics. Add a top-level call site that walks every binding in the file, runs the seven checks, and accumulates errors/warnings. |
+| `carina-core/src/keywords.rs` | Add `("depends_on", KeywordKind::Other)`. The existing `pest_grammar_contains_every_keyword` test will pass because `depends_on` is just an attribute key, never a top-level statement keyword — but adding it to KEYWORDS gives the LSP semantic-tokens path a single source of truth. |
+| `carina-core/src/plan_tree.rs` | No change required: `get_resource_dependencies` already reads from `dependency_bindings`, which after the differ union includes explicit edges. Add a regression test confirming an explicit-only edge appears in the tree. |
+| `carina-core/src/formatter/format.rs` (or wherever block formatting lives) | `directives.depends_on` formatter normalises the list to alphabetical order on `carina fmt` for stable diffs. |
+| `carina-lsp/src/completion/values.rs` | Inside a `directives { ... }` block: add `depends_on` to the block-key completion set. Inside the list `depends_on = [|]`: query the binding index filtered by kind ∈ {resource, wait, module}, exclude the enclosing binding name, exclude names already present in the list. |
+| `carina-lsp/src/diagnostics/mod.rs` | Mirror the seven analysis-pass checks so live editor diagnostics match `carina validate` exactly. |
+| `carina-lsp/src/semantic_tokens.rs` | No change required if `tokenize_line` already routes through `keywords::is_keyword`; otherwise add `depends_on` to the highlighted set. |
+| `editors/vscode/syntaxes/carina.tmLanguage.json` | Add `depends_on` to the keyword pattern. |
+| `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` | Same change, byte-identical (parity test enforces). |
+
+### Dependencies between files
+
+```
+keywords.rs ── parser/blocks/attributes.rs ── resource/mod.rs (Directives)
+                                                       │
+                                                       ├── effect.rs (explicit_dependencies)
+                                                       │
+                                                       ├── deps.rs ── differ ── plan_tree.rs (no change needed)
+                                                       ├── resolver.rs                        (no change needed)
+                                                       └── parser/resolve.rs                  (no change needed)
+                                                                  ↑
+                                                                  └── validation/depends_on.rs ── validation/mod.rs ── carina-lsp diagnostics
+
+editors/*/carina.tmLanguage.json ──── tmlanguage_keyword_parity test
+formatter/format.rs ── tests
+carina-lsp completion/semantic-tokens
+```
+
+## Tasks
+
+Each task is one TDD cycle. Goal: write failing test → run → see fail → minimal impl → run → see pass.
+
+### Phase 1 — `Directives.depends_on` field
+
+**Task 1.1: `Directives` carries a `depends_on: Vec<String>` field that defaults to empty.**
+
+- **Files:** modify `carina-core/src/resource/mod.rs`.
+- **Test:** add to `carina-core/src/resource/tests.rs`:
+  ```rust
+  #[test]
+  fn directives_depends_on_defaults_to_empty() {
+      let d = Directives::default();
+      assert_eq!(d.depends_on, Vec::<String>::new());
+  }
+
+  #[test]
+  fn directives_depends_on_round_trips_serde() {
+      let d = Directives {
+          depends_on: vec!["role".to_string(), "key".to_string()],
+          ..Directives::default()
+      };
+      let json = serde_json::to_string(&d).unwrap();
+      let back: Directives = serde_json::from_str(&json).unwrap();
+      assert_eq!(back.depends_on, d.depends_on);
+  }
+
+  #[test]
+  fn directives_depends_on_deserialises_from_legacy_json_without_field() {
+      // State files written before this PR have no `depends_on` key in directives.
+      let legacy = r#"{ "force_delete": false, "create_before_destroy": false, "prevent_destroy": false }"#;
+      let d: Directives = serde_json::from_str(legacy).unwrap();
+      assert_eq!(d.depends_on, Vec::<String>::new());
+  }
+  ```
+- **Implementation:** add field to `Directives` (the post-#2826 struct):
+  ```rust
+  #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+  pub struct Directives {
+      #[serde(default)]
+      pub force_delete: bool,
+      #[serde(default)]
+      pub create_before_destroy: bool,
+      #[serde(default)]
+      pub prevent_destroy: bool,
+      /// Explicit ordering edges declared by the user. Each element is the
+      /// binding name of a sibling `let` (resource / wait / module).
+      /// Set semantics (deduplicated, order-insensitive); represented as
+      /// Vec to preserve source order for `carina fmt` round-tripping.
+      #[serde(default)]
+      pub depends_on: Vec<String>,
+  }
+  ```
+- **Verification:** `cargo nextest run -p carina-core resource::tests::directives_depends_on_defaults_to_empty resource::tests::directives_depends_on_round_trips_serde resource::tests::directives_depends_on_deserialises_from_legacy_json_without_field`.
+
+### Phase 2 — Parser support
+
+**Task 2.1: `extract_directives` parses `depends_on = [a, b]` into `Vec<String>` of binding names.**
+
+- **Files:** modify `carina-core/src/parser/blocks/attributes.rs`.
+- **Test:** add to the existing `mod tests` in the same file (or in `parser/tests.rs`):
+  ```rust
+  #[test]
+  fn extract_directives_reads_depends_on_list() {
+      let src = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives {
+                  depends_on = [iam_role, kms_key]
+              }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let bucket = parsed.resources.iter().find(|r| r.id.name == "bucket").unwrap();
+      assert_eq!(bucket.directives.depends_on, vec!["iam_role".to_string(), "kms_key".to_string()]);
+  }
+  ```
+- **Implementation:** in `extract_directives` (post-#2826 rename of `extract_lifecycle_config`), after pulling existing booleans, also pull `depends_on`. Bare identifiers in attribute lists already materialise as `Value::ResourceRef { binding, ... }` because the existing parser uses `Value::resource_ref(name.to_string(), String::new(), vec![])` as a placeholder for identifier references (see `parser/blocks/attributes.rs:138`). The extraction:
+  ```rust
+  let depends_on = match map.get("depends_on") {
+      Some(Value::List(items)) => items
+          .iter()
+          .map(|v| match v {
+              Value::ResourceRef { binding, .. } => Ok(binding.clone()),
+              Value::String(_) => Err(format!(
+                  "directives.depends_on: list elements must be binding identifiers, not string literals"
+              )),
+              other => Err(format!(
+                  "directives.depends_on: unexpected element {:?}", other
+              )),
+          })
+          .collect::<Result<Vec<_>, String>>()
+          .map_err(|msg| ParseError::InvalidExpression {
+              message: msg,
+              span: directives_block_span.clone(),
+          })?,
+      None => Vec::new(),
+      Some(other) => return Err(ParseError::InvalidExpression {
+          message: format!("directives.depends_on: must be a list, got {:?}", other),
+          span: directives_block_span.clone(),
+      }),
+  };
+  ```
+  `directives_block_span` is the span of the `directives { ... }` block already in scope at this point in `extract_directives` (the function takes the block's `pest::Span` as input or via the surrounding pair). If `extract_directives` does not currently receive a span, add it as a parameter — the caller (`parser/blocks/resource.rs::~50`) has the pair available.
+
+  Then construct `Directives { force_delete, create_before_destroy, prevent_destroy, depends_on }` instead of the existing 3-field struct.
+- **Verification:** `cargo nextest run -p carina-core parser::blocks::attributes::tests::extract_directives_reads_depends_on_list`.
+
+**Task 2.2: Parser rejects `depends_on = ["x"]` (string literal element) at parse time.**
+
+- **Files:** add to `attributes.rs` tests.
+- **Test:**
+  ```rust
+  #[test]
+  fn extract_directives_rejects_string_literal_in_depends_on() {
+      let src = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = ["iam_role"] }
+          }
+      "#;
+      let result = crate::parser::parse_str(src);
+      assert!(result.is_err(), "expected error for string-literal in depends_on");
+      let err = result.unwrap_err().to_string();
+      assert!(err.contains("binding identifiers"), "error should mention identifiers, got: {}", err);
+  }
+  ```
+- **Implementation:** none — Task 2.1's `Value::String(_) => Err(...)` branch already handles this; the test pins the contract.
+- **Verification:** `cargo nextest run -p carina-core parser::blocks::attributes::tests::extract_directives_rejects_string_literal_in_depends_on`.
+
+**Task 2.3: `keywords.rs` lists `depends_on`.**
+
+- **Files:** modify `carina-core/src/keywords.rs`.
+- **Test:** add to the existing `mod tests`:
+  ```rust
+  #[test]
+  fn depends_on_is_a_keyword() {
+      assert!(is_keyword("depends_on"));
+  }
+  ```
+- **Implementation:** add `("depends_on", KeywordKind::Other),` to `KEYWORDS`. The existing `pest_grammar_contains_every_keyword` test requires the literal `"depends_on"` to appear in `carina.pest`; since this is an attribute key parsed inside the `directives` block (which uses generic attribute parsing), add a comment-only mention of `depends_on` in `carina.pest` near the `directives_block` rule to satisfy the parity test:
+  ```pest
+  // The directives block accepts: force_delete, create_before_destroy,
+  // prevent_destroy, depends_on. (Listed here to satisfy the keyword
+  // parity test in carina-core/src/keywords.rs.)
+  ```
+- **Verification:** `cargo nextest run -p carina-core keywords::tests::depends_on_is_a_keyword keywords::tests::pest_grammar_contains_every_keyword`.
+
+### Phase 3 — Differ unions explicit edges into `dependency_bindings`
+
+**Task 3.1: `deps.rs` unions `directives.depends_on` into `Resource.dependency_bindings`.**
+
+- **Files:** modify `carina-core/src/deps.rs`.
+- **Test:** add to `carina-core/src/deps.rs` tests:
+  ```rust
+  #[test]
+  fn directives_depends_on_is_unioned_into_dependency_bindings() {
+      let mut role = Resource::new("iam.Role", "role");
+      let mut bucket = Resource::new("s3.Bucket", "bucket")
+          .with_attribute("bucket_name", Value::String("x".to_string()));
+      bucket.directives.depends_on = vec!["role".to_string()];
+
+      let mut resources = vec![role, bucket];
+      crate::deps::populate_dependency_bindings(&mut resources);
+
+      let bucket_after = resources.iter().find(|r| r.id.name == "bucket").unwrap();
+      assert!(bucket_after.dependency_bindings.contains("role"));
+  }
+  ```
+- **Implementation:** at line ~320, change:
+  ```rust
+  resource.dependency_bindings = value_ref_deps.into_iter().collect();
+  ```
+  to:
+  ```rust
+  let mut all = value_ref_deps;
+  all.extend(resource.directives.depends_on.iter().cloned());
+  resource.dependency_bindings = all.into_iter().collect();
+  ```
+  If `populate_dependency_bindings` does not exist as a separate function, extract the union site into one so the test above can call it directly. (The existing call sites in `deps.rs:320`, `resolver.rs:72`, and `parser/resolve.rs:145` will then call the same helper, satisfying Tasks 3.2 and 3.3 simultaneously.)
+- **Verification:** `cargo nextest run -p carina-core deps::tests::directives_depends_on_is_unioned_into_dependency_bindings`.
+
+**Task 3.2: `resolver.rs::resolve_refs_with_state` produces unioned `dependency_bindings`.**
+
+- **Files:** add a test in `carina-core/src/resolver.rs` `mod tests`. If Task 3.1 extracted a `union_dependency_bindings` helper, the production code at `resolver.rs:72` now calls it and the test is the only new code. If Task 3.1 inlined the change at three call sites instead of extracting, ensure `resolver.rs:72` matches `deps.rs:320`.
+- **Test:**
+  ```rust
+  #[test]
+  fn resolve_refs_unions_directives_depends_on() {
+      let mut bucket = Resource::new("s3.Bucket", "bucket")
+          .with_attribute("bucket_name", Value::String("bucket".to_string()));
+      bucket.directives.depends_on = vec!["role".to_string()];
+      let mut resources = vec![
+          Resource::new("iam.Role", "role"),
+          bucket,
+      ];
+      let state_lookup: HashMap<ResourceId, State> = HashMap::new();
+      let bindings: HashMap<String, ResourceId> = HashMap::new();
+      resolve_refs_with_state(&mut resources, &state_lookup, &bindings).unwrap();
+      let bucket_after = resources.iter().find(|r| r.id.name == "bucket").unwrap();
+      assert!(bucket_after.dependency_bindings.contains("role"));
+  }
+  ```
+- **Implementation:** if Task 3.1 introduced a `union_dependency_bindings` helper called from all three sites, this test passes without further code. If Task 3.1 inlined the change only at `deps.rs:320`, mirror the inline change at `resolver.rs:72`:
+  ```rust
+  // Before
+  resource.dependency_bindings = deps.into_iter().collect();
+  // After
+  let mut all = deps;
+  all.extend(resource.directives.depends_on.iter().cloned());
+  resource.dependency_bindings = all.into_iter().collect();
+  ```
+- **Verification:** `cargo nextest run -p carina-core resolver::tests::resolve_refs_unions_directives_depends_on`.
+
+**Task 3.3: `parser/resolve.rs::resolve_in_file` (or the analogous entry point) produces unioned `dependency_bindings`.**
+
+- **Files:** add a test in `carina-core/src/parser/resolve.rs` `mod tests`. Same shape as Task 3.2.
+- **Test:**
+  ```rust
+  #[test]
+  fn parser_resolve_unions_directives_depends_on() {
+      let src = r#"
+          let role = aws.iam.Role { role_name = "r" assume_role_policy_document = "{}" }
+          let bucket = aws.s3.Bucket {
+              bucket_name = "b"
+              directives { depends_on = [role] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      // After parse_str runs (which internally calls parser/resolve.rs),
+      // dependency_bindings should already be unioned.
+      let bucket = parsed.resources.iter().find(|r| r.id.name == "bucket").unwrap();
+      assert!(bucket.dependency_bindings.contains("role"));
+  }
+  ```
+- **Implementation:** if Task 3.1 introduced the `union_dependency_bindings` helper called from all three sites, this test passes without further code. Otherwise, mirror the Task 3.2 inline change at `parser/resolve.rs:145`:
+  ```rust
+  // Before
+  resource.dependency_bindings = deps.into_iter().collect();
+  // After
+  let mut all = deps;
+  all.extend(resource.directives.depends_on.iter().cloned());
+  resource.dependency_bindings = all.into_iter().collect();
+  ```
+- **Verification:** `cargo nextest run -p carina-core parser::resolve::tests::parser_resolve_unions_directives_depends_on`.
+
+### Phase 4 — `Effect.explicit_dependencies` field
+
+**Task 4.1: Every `Effect` variant carries `explicit_dependencies: HashSet<String>` that defaults to empty.**
+
+- **Files:** modify `carina-core/src/effect.rs`.
+- **Test:** add to `effect.rs` tests:
+  ```rust
+  #[test]
+  fn create_carries_explicit_dependencies() {
+      let r = Resource::new("s3.Bucket", "b");
+      let effect = Effect::Create(r);
+      assert_eq!(effect.explicit_dependencies(), &HashSet::<String>::new());
+  }
+
+  #[test]
+  fn delete_carries_explicit_dependencies_alongside_dependencies() {
+      // Note: Effect::Delete's third field is renamed `lifecycle: LifecycleConfig`
+      // → `directives: Directives` by #2826 (prerequisite). This test is written
+      // against the post-#2826 field names.
+      let effect = Effect::Delete {
+          id: ResourceId::new("s3.Bucket", "b"),
+          identifier: "x".to_string(),
+          directives: Directives::default(),
+          binding: None,
+          dependencies: HashSet::new(),
+          explicit_dependencies: HashSet::from(["role".to_string()]),
+      };
+      assert_eq!(
+          effect.explicit_dependencies(),
+          &HashSet::from(["role".to_string()])
+      );
+  }
+  ```
+- **Implementation:** add the field to every variant of `Effect`. For variants whose data is a single `Resource` (`Create(Resource)`), wrap the field at the Effect level rather than threading it inside Resource — this mirrors how `Effect::Delete::dependencies` is structured today (separate field, not inside the embedded ResourceId). The `Create` case becomes:
+  ```rust
+  Create {
+      resource: Resource,
+      explicit_dependencies: HashSet<String>,
+  }
+  ```
+  which is a structural change from `Create(Resource)` (tuple variant) to a struct variant. Update the very few existing `Effect::Create(r)` constructors and pattern-matchers (`format_effect_brief`, `plan_tree.rs`, `differ`, `executor`, tests) — the compiler reports each.
+
+  Also add an accessor:
+  ```rust
+  impl Effect {
+      pub fn explicit_dependencies(&self) -> &HashSet<String> {
+          match self {
+              Effect::Create { explicit_dependencies, .. }
+              | Effect::Update { explicit_dependencies, .. }
+              | Effect::Replace { explicit_dependencies, .. }
+              | Effect::Delete { explicit_dependencies, .. }
+              | Effect::Read { explicit_dependencies, .. }
+              | Effect::Wait { explicit_dependencies, .. }     // pending #2825
+              | Effect::Import { explicit_dependencies, .. }
+              | Effect::Remove { explicit_dependencies, .. }
+              | Effect::Move { explicit_dependencies, .. } => explicit_dependencies,
+          }
+      }
+  }
+  ```
+- **Scope note:** turning `Effect::Create(Resource)` from a tuple variant into a struct variant `Effect::Create { resource: Resource, explicit_dependencies: HashSet<String> }` is a breaking pattern change for every existing call site that matches `Effect::Create(r)`. The compiler reports each. Expected sites (from a quick grep):
+  - `carina-core/src/plan.rs::format_effect_brief` (1 arm)
+  - `carina-core/src/plan_tree.rs::build_dependency_graph` (1 arm)
+  - `carina-core/src/differ/plan.rs` (Effect construction sites)
+  - `carina-core/src/executor/parallel.rs` (multiple arms)
+  - `carina-core/src/executor/phased.rs` (multiple arms)
+  - `carina-core/src/executor/basic.rs` (multiple arms)
+  - `carina-core/src/executor/replace.rs`
+  - `carina-core/src/executor/tests.rs` (many constructor sites)
+  - `carina-core/src/effect.rs::tests` (constructor sites)
+  - `carina-core/src/detail_rows.rs`
+  - `carina-cli/tests/...` snapshot fixtures may need regeneration
+  Each site is a one-line mechanical change (add the new field with `HashSet::new()` for backward-equivalent default, or destructure with `.., explicit_dependencies: ..`). No semantic change.
+
+- **Verification:** `cargo nextest run -p carina-core effect::tests::create_carries_explicit_dependencies effect::tests::delete_carries_explicit_dependencies_alongside_dependencies`. Per CLAUDE.md "Verify Protocol", nextest's compile step is sufficient to surface non-exhaustive-pattern errors in downstream callers — no separate `cargo build` step.
+
+**Task 4.2: Differ populates `Effect.explicit_dependencies` from `Resource.directives.depends_on`.**
+
+- **Files:** modify the differ entry point that constructs Effects (likely `carina-core/src/differ/plan.rs` or `differ/mod.rs`).
+- **Test:** add to `differ/plan_tests.rs`:
+  ```rust
+  #[test]
+  fn differ_populates_effect_explicit_dependencies_from_directives() {
+      let mut bucket = Resource::new("s3.Bucket", "bucket")
+          .with_attribute("bucket_name", Value::String("x".to_string()));
+      bucket.directives.depends_on = vec!["role".to_string()];
+      let resources = vec![Resource::new("iam.Role", "role"), bucket];
+
+      let mut schemas = SchemaRegistry::new();
+      schemas.insert("", ResourceSchema::new("iam.Role"));
+      schemas.insert("", ResourceSchema::new("s3.Bucket")
+          .attribute(AttributeSchema::new("bucket_name", AttributeType::String).create_only()));
+
+      let plan = create_plan(&resources, &HashMap::new(), &HashMap::new(), &schemas, &HashMap::new(), &HashMap::new(), &HashMap::new());
+
+      let bucket_effect = plan.effects().iter().find(|e| match e {
+          Effect::Create { resource, .. } => resource.id.name == "bucket",
+          _ => false,
+      }).expect("bucket Create effect missing");
+      assert!(bucket_effect.explicit_dependencies().contains("role"));
+  }
+  ```
+- **Implementation:** in the differ's per-resource Effect construction path, populate `explicit_dependencies: resource.directives.depends_on.iter().cloned().collect::<HashSet<_>>()` for every Effect variant. For `Effect::Delete` (which doesn't carry a Resource), look up the deleted resource's pre-deletion state and copy from there (same place where the existing `dependencies` field is populated).
+- **Verification:** `cargo nextest run -p carina-core differ::plan_tests::differ_populates_effect_explicit_dependencies_from_directives`.
+
+### Phase 5 — Validation diagnostics (the seven rules)
+
+**Task 5.1: Diagnose `depends_on = [unknown_binding]` as an error.**
+
+- **Files:** create `carina-core/src/validation/depends_on.rs`; modify `carina-core/src/validation/mod.rs`.
+- **Test:** in the new `validation/depends_on.rs` tests:
+  ```rust
+  #[test]
+  fn unknown_binding_is_diagnosed() {
+      let src = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [non_existent] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Error
+          && d.message.contains("non_existent")
+          && d.message.contains("not declared")
+      ));
+  }
+  ```
+- **Implementation:** in `validation/depends_on.rs`:
+  ```rust
+  pub fn validate_depends_on(parsed: &File<()>) -> Vec<Diagnostic> {
+      let mut diags = Vec::new();
+      let known_bindings: HashSet<&str> = parsed.iter_let_bindings()
+          .map(|b| b.name.as_str())
+          .collect();
+      for binding in parsed.iter_let_bindings() {
+          for dep_name in &binding.directives().depends_on {
+              if !known_bindings.contains(dep_name.as_str()) {
+                  diags.push(Diagnostic::error(format!(
+                      "directives.depends_on: binding '{}' is not declared in this scope",
+                      dep_name
+                  )).at(binding.depends_on_span(dep_name)));
+              }
+          }
+      }
+      diags
+  }
+  ```
+  The `Diagnostic`/`DiagnosticSeverity` types and `iter_let_bindings()`/`directives()`/`depends_on_span(...)` accessor methods already exist in `validation/mod.rs` for the value-reference checks; reuse them. Wire `validate_depends_on` into the top-level analysis pass so `carina validate` calls it.
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::unknown_binding_is_diagnosed`.
+
+**Task 5.2: Diagnose self-reference (`a directives { depends_on = [a] }`) as an error.**
+
+- **Files:** modify `validation/depends_on.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn self_reference_is_diagnosed() {
+      let src = r#"
+          let a = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [a] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Error
+          && d.message.contains("self-reference")
+          && d.message.contains("'a'")
+      ));
+  }
+  ```
+- **Implementation:** in the same loop as Task 5.1, before the unknown-binding check, add:
+  ```rust
+  if dep_name == &binding.name {
+      diags.push(Diagnostic::error(format!(
+          "directives.depends_on: self-reference is not allowed (binding '{}' depends on itself)",
+          dep_name
+      )).at(binding.depends_on_span(dep_name)));
+      continue;  // skip the unknown-binding check for this element
+  }
+  ```
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::self_reference_is_diagnosed`.
+
+**Task 5.3: Diagnose `depends_on = [data_source_binding]` as a kind violation.**
+
+- **Files:** modify `validation/depends_on.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn data_source_binding_in_depends_on_is_diagnosed() {
+      let src = r#"
+          let user = aws.identitystore.User { user_name = "alice" }   // data source
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [user] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Error
+          && d.message.contains("data sources")
+          && d.message.contains("'user'")
+      ));
+  }
+  ```
+- **Implementation:** classify each known binding by kind (`ResourceKind::Managed`, `ResourceKind::DataSource`, ResourceKind for `wait`, module-call). For each `dep_name`, look up the kind; if kind ∈ {DataSource, UpstreamState}, emit an error.
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::data_source_binding_in_depends_on_is_diagnosed`.
+
+**Task 5.4: Diagnose duplicate elements (`depends_on = [x, x]`) as a warning.**
+
+- **Files:** modify `validation/depends_on.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn duplicate_element_is_diagnosed_as_warning() {
+      let src = r#"
+          let role = aws.iam.Role { ... }
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [role, role] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Warning
+          && d.message.contains("listed twice")
+          && d.message.contains("'role'")
+      ));
+  }
+  ```
+- **Implementation:** before iterating elements, count occurrences with a `HashMap<&str, usize>`; emit warning for any element with count > 1.
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::duplicate_element_is_diagnosed_as_warning`.
+
+**Task 5.5: Diagnose redundant edge (already implied by value reference) as a warning.**
+
+- **Files:** modify `validation/depends_on.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn redundant_value_ref_edge_is_diagnosed_as_warning() {
+      let src = r#"
+          let key = aws.kms.Key { key_alias = "k" }
+          let bucket = aws.s3.Bucket {
+              bucket_name    = "x"
+              encryption_key = key.arn               // value reference
+              directives { depends_on = [key] }      // redundant
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Warning
+          && d.message.contains("redundant")
+          && d.message.contains("'key'")
+      ));
+  }
+  ```
+- **Implementation:** for each binding, compute the value-reference dependency set via the existing `get_resource_dependencies(&resource)` helper. For each `dep_name` in `directives.depends_on`, emit a warning if `dep_name` is already in the value-ref set.
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::redundant_value_ref_edge_is_diagnosed_as_warning`.
+
+**Task 5.6: Diagnose cycle (`a depends_on [b]`, `b depends_on [a]`) as an error.**
+
+- **Files:** modify `validation/depends_on.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn depends_on_cycle_is_diagnosed() {
+      let src = r#"
+          let a = aws.s3.Bucket { bucket_name = "a" directives { depends_on = [b] } }
+          let b = aws.s3.Bucket { bucket_name = "b" directives { depends_on = [a] } }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let diags = validate_depends_on(&parsed);
+      assert!(diags.iter().any(|d|
+          d.severity == DiagnosticSeverity::Error
+          && d.message.contains("cycle")
+      ));
+  }
+  ```
+- **Implementation:** build the union dependency graph (value-refs ∪ depends_on) for the parsed file, run `crate::deps::topological_sort` over it, and convert the existing cycle-detection error into a `Diagnostic` attached to the binding span. Reuse the topological-sort code that already exists in `deps.rs` rather than re-implementing.
+- **Verification:** `cargo nextest run -p carina-core validation::depends_on::tests::depends_on_cycle_is_diagnosed`.
+
+**Task 5.7: Wire `validate_depends_on` into the top-level analysis pass shared by `carina validate` and the LSP.**
+
+- **Files:** modify `carina-core/src/validation/mod.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn validate_resources_runs_depends_on_checks() {
+      // Pass a resource with an unknown depends_on; expect the top-level
+      // validate_resources to surface the error without a direct call to
+      // validate_depends_on.
+      let src = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [non_existent] }
+          }
+      "#;
+      let parsed = crate::parser::parse_str(src).unwrap();
+      let mut errors = Vec::new();
+      validate_resources(&parsed, &mut errors);
+      assert!(errors.iter().any(|e| e.contains("non_existent")));
+  }
+  ```
+- **Implementation:** in `validate_resources` (line 19 of `validation/mod.rs`), after the existing checks, call `validate_depends_on(parsed)` and append its diagnostics to the error list. Convert the diagnostic format (`Diagnostic` struct → string) using the same conversion the rest of the pass uses.
+- **Verification:** `cargo nextest run -p carina-core validation::tests::validate_resources_runs_depends_on_checks`.
+
+### Phase 6 — Plan tree (regression coverage)
+
+**Task 6.1: `plan_tree::build_dependency_graph` includes explicit-only edges in the tree.**
+
+- **Files:** modify `carina-core/src/plan_tree.rs` tests.
+- **Test:**
+  ```rust
+  #[test]
+  fn explicit_only_edge_appears_in_dependency_graph() {
+      let mut bucket = Resource::new("s3.Bucket", "bucket")
+          .with_attribute("bucket_name", Value::String("x".to_string()));
+      bucket.directives.depends_on = vec!["role".to_string()];
+      // After differ runs, dependency_bindings is unioned (Phase 3).
+      bucket.dependency_bindings = std::collections::BTreeSet::from(["role".to_string()]);
+
+      let plan = Plan::from_effects(vec![
+          Effect::Create { resource: Resource::new("iam.Role", "role"), explicit_dependencies: HashSet::new() },
+          Effect::Create { resource: bucket, explicit_dependencies: HashSet::from(["role".to_string()]) },
+      ]);
+      let graph = build_dependency_graph(&plan);
+      let bucket_effect_idx = graph.effect_bindings.iter().find(|(_, b)| b.as_str() == "bucket").unwrap().0;
+      assert!(graph.effect_deps[bucket_effect_idx].contains("role"));
+  }
+  ```
+- **Implementation:** none — `get_resource_dependencies` reads `dependency_bindings`, which the differ already unioned in Phase 3. This test is a regression gate confirming the union flows through to the tree.
+- **Verification:** `cargo nextest run -p carina-core plan_tree::tests::explicit_only_edge_appears_in_dependency_graph`.
+
+### Phase 7 — Formatter
+
+**Task 7.1: `carina fmt` normalises `depends_on` list to alphabetical order.**
+
+- **Files:** modify `carina-core/src/formatter/format.rs`.
+- **Test:** in `formatter/tests.rs` (or its existing test module):
+  ```rust
+  #[test]
+  fn fmt_normalises_depends_on_to_alphabetical() {
+      let input = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [zebra, apple, mango] }
+          }
+      "#;
+      let output = crate::formatter::format(input).unwrap();
+      assert!(output.contains("depends_on = [apple, mango, zebra]"));
+  }
+  ```
+- **Implementation:** in the formatter's directives-block emitter, when emitting `depends_on`, sort the `Vec<String>` alphabetically before serialising. (The IR-side `Vec<String>` retains source order so other consumers see the user's spelling; the formatter is the only thing that re-orders.)
+- **Verification:** `cargo nextest run -p carina-core formatter::tests::fmt_normalises_depends_on_to_alphabetical`.
+
+### Phase 8 — LSP
+
+**Task 8.1: LSP completes `depends_on` as a key inside `directives { ... }`.**
+
+- **Files:** modify `carina-lsp/src/completion/values.rs`.
+- **Test:** in `carina-lsp/src/completion/values_tests.rs`:
+  ```rust
+  #[test]
+  fn directives_block_completion_includes_depends_on() {
+      let doc = "let bucket = aws.s3.Bucket {\n  bucket_name = \"x\"\n  directives {\n    \n  }\n}";
+      let cursor = position_of(doc, /* line=3, col=4 */);
+      let items = directives_block_completions(doc, cursor);
+      let labels: Vec<&str> = items.iter().map(|c| c.label.as_str()).collect();
+      assert!(labels.contains(&"depends_on"));
+      assert!(labels.contains(&"prevent_destroy"));
+      assert!(labels.contains(&"force_delete"));
+      assert!(labels.contains(&"create_before_destroy"));
+  }
+  ```
+- **Implementation:** find the existing function that emits the three current `directives`-block keys and add `depends_on` to its returned list.
+- **Verification:** `cargo nextest run -p carina-lsp completion::values_tests::directives_block_completion_includes_depends_on`.
+
+**Task 8.2: LSP list-element completion inside `depends_on = [|]` returns only resource/wait/module bindings.**
+
+- **Files:** modify `carina-lsp/src/completion/values.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn depends_on_list_completion_filters_by_kind() {
+      let doc = r#"
+          let role = aws.iam.Role { ... }                          // resource: included
+          let user = aws.identitystore.User { ... }                // data source: excluded
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [|] }
+          }
+      "#;
+      let cursor = position_inside_brackets(doc);
+      let items = depends_on_list_completions(doc, cursor);
+      let labels: Vec<&str> = items.iter().map(|c| c.label.as_str()).collect();
+      assert!(labels.contains(&"role"));
+      assert!(!labels.contains(&"user"));
+      assert!(!labels.contains(&"bucket")); // self-exclusion
+  }
+  ```
+- **Implementation:** detect cursor inside a `depends_on = [...]` list using token lookback (similar to the existing list-position detection used elsewhere in the LSP). Query the document's `binding_index` for all bindings, filter by kind ∈ {Managed, Wait, Module}, exclude the enclosing binding's own name, exclude names already present in the list (parse the list elements before the cursor).
+- **Verification:** `cargo nextest run -p carina-lsp completion::values_tests::depends_on_list_completion_filters_by_kind`.
+
+**Task 8.3: LSP diagnostics surface every analysis-pass check from Phase 5.**
+
+- **Files:** modify `carina-lsp/src/diagnostics/mod.rs`.
+- **Test:** in `carina-lsp/src/diagnostics/tests.rs`:
+  ```rust
+  #[test]
+  fn lsp_surfaces_unknown_binding_in_depends_on() {
+      let src = r#"
+          let bucket = aws.s3.Bucket {
+              bucket_name = "x"
+              directives { depends_on = [non_existent] }
+          }
+      "#;
+      let diags = compute_diagnostics(src);
+      assert!(diags.iter().any(|d|
+          d.severity == lsp_types::DiagnosticSeverity::ERROR
+          && d.message.contains("non_existent")
+      ));
+  }
+  ```
+- **Implementation:** the LSP's diagnostics dispatch already wraps `validate_resources`. If Phase 5 Task 5.7 wired `validate_depends_on` into `validate_resources`, this test passes without further changes — it gates against regression. If the LSP runs a different validation entry point, dispatch `validate_depends_on` from there too.
+- **Verification:** `cargo nextest run -p carina-lsp diagnostics::tests::lsp_surfaces_unknown_binding_in_depends_on`.
+
+### Phase 9 — TextMate grammar parity
+
+**Task 9.1: TextMate grammars highlight `depends_on` consistently.**
+
+- **Files:** modify both `editors/vscode/syntaxes/carina.tmLanguage.json` and `editors/carina.tmbundle/Syntaxes/carina.tmLanguage.json` (must remain byte-identical per `carina-core/tests/tmlanguage_keyword_parity.rs`).
+- **Test:** the existing parity test catches drift:
+  ```bash
+  cargo nextest run -p carina-core tmlanguage_keyword_parity
+  ```
+  Task 2.3 (adding `depends_on` to KEYWORDS) makes this test fail until the grammars are updated. That's the failing-test signal.
+- **Implementation:** locate the existing keyword-pattern regex in both JSON files and add `depends_on`. Same edit, applied identically to both files.
+- **Verification:** `cargo nextest run -p carina-core tmlanguage_keyword_parity`.
+
+### Phase 10 — Multi-file directory acceptance
+
+**Task 10.1: Multi-file fixture: `directives.depends_on` references a binding declared in a sibling `.crn` file.**
+
+- **Files:** create `carina-core/tests/fixtures/depends_on/basic/main.crn` and `carina-core/tests/fixtures/depends_on/basic/directives.crn`. Add an integration test `carina-core/tests/depends_on_directory_test.rs`.
+- **Test:**
+  ```rust
+  #[test]
+  fn depends_on_resolves_across_sibling_files_in_directory() {
+      let dir = "tests/fixtures/depends_on/basic";
+      let parsed = carina_core::parse_directory(dir).expect("parse should succeed");
+      let mut errors = Vec::new();
+      carina_core::validation::validate_resources(&parsed, &mut errors);
+      assert!(errors.is_empty(), "validation errors: {:?}", errors);
+
+      // Confirm the union actually happened
+      let bucket = parsed.resources.iter().find(|r| r.id.name == "bucket").unwrap();
+      assert!(bucket.dependency_bindings.contains("role"));
+  }
+  ```
+- **Implementation:** create the two files. `main.crn`:
+  ```crn
+  provider aws { region = "us-east-1" }
+
+  let role = aws.iam.Role {
+      role_name                  = "my-role"
+      assume_role_policy_document = "{}"
+  }
+  ```
+  `directives.crn`:
+  ```crn
+  let bucket = aws.s3.Bucket {
+      bucket_name = "my-bucket"
+      directives { depends_on = [role] }
+  }
+  ```
+  This exercises the directory-scoped requirement from CLAUDE.md.
+- **Verification:** `cargo nextest run -p carina-core depends_on_directory_test::depends_on_resolves_across_sibling_files_in_directory`.
+
+### Phase 11 — Plan-display snapshot
+
+**Task 11.1: Snapshot test for the plan tree when an explicit-only dependency exists.**
+
+- **Files:** create `carina-cli/tests/fixtures/plan_display/depends_on/main.crn`, `carina.state.json`, and `snapshot.txt`. Add the test:
+  ```rust
+  #[test]
+  fn plan_display_depends_on() {
+      run_plan_snapshot("depends_on");
+  }
+  ```
+  in `carina-cli/tests/plan_snapshot.rs`.
+- **Test:** the snapshot infrastructure compares produced output to `snapshot.txt`.
+- **Implementation:** `main.crn`:
+  ```crn
+  provider aws { region = "us-east-1" }
+
+  let role = aws.iam.Role {
+      role_name                   = "my-role"
+      assume_role_policy_document = "{}"
+  }
+
+  let bucket = aws.s3.Bucket {
+      bucket_name = "my-bucket"
+      directives { depends_on = [role] }
+  }
+  ```
+  `carina.state.json`: `{}` (empty).
+  Run the test once with `cargo insta review` to write the snapshot, then commit. Add the fixture to the existing `make plan-fixtures` Makefile target.
+- **Verification:** `cargo nextest run -p carina-cli plan_display_depends_on`.
+
+### Phase 12 — Whole-tree gates (run before opening PR)
+
+- `cargo nextest run` (workspace)
+- `cargo test --workspace --doc`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --check`
+- `bash scripts/check-*.sh` for every script in `scripts/`
+- `cargo build --release` is **skipped** unless this PR has touched `Cargo.toml`, `unsafe` code, or the release profile (per CLAUDE.md "Verify Protocol"). This work touches none of those.
+
+## Plan self-review
+
+| Requirement from design doc | Covered by |
+|---|---|
+| `depends_on` field on `Directives` | Task 1.1 |
+| Parser extracts `depends_on` list | Tasks 2.1, 2.2 |
+| `depends_on` is a keyword | Task 2.3 |
+| Differ unions explicit edges into `dependency_bindings` | Tasks 3.1, 3.2, 3.3 |
+| `Effect.explicit_dependencies` field on every variant | Task 4.1 |
+| Differ populates `explicit_dependencies` | Task 4.2 |
+| 7 validation rules: unknown binding | Task 5.1 |
+| 7 validation rules: self-reference | Task 5.2 |
+| 7 validation rules: disallowed kind (data source / upstream_state) | Task 5.3 |
+| 7 validation rules: duplicate elements | Task 5.4 |
+| 7 validation rules: redundant value-ref | Task 5.5 |
+| 7 validation rules: cycle | Task 5.6 |
+| 7 validation rules: element type mismatch (string literal) | Task 2.2 (caught at parser, surfaced before analysis) |
+| Validation wired into top-level pass | Task 5.7 |
+| Plan tree shows explicit edges | Task 6.1 |
+| `carina fmt` normalises list to alphabetical | Task 7.1 |
+| LSP block-key completion includes `depends_on` | Task 8.1 |
+| LSP list-element completion strict filter | Task 8.2 |
+| LSP diagnostics mirror analysis pass | Task 8.3 |
+| TextMate grammar parity | Task 9.1 |
+| Multi-file fixture acceptance | Task 10.1 |
+| Plan-display snapshot | Task 11.1 |
+| Hover (reuses existing handler — no new code) | Inherited from existing identifier-hover; no task needed |
+| Semantic tokens (routes through `keywords::is_keyword`) | Inherited from Task 2.3 + existing tokenizer; verify with Task 9.1's parity test |
+| State serialisation (Resource.directives auto-serialised) | Task 1.1 (round-trip + legacy test) |
+| `wait` consumer (carina#2825) uses `depends_on` | Out of scope here; verified when #2825 lands |
+
+No placeholder phrases remain. Every task has a concrete file, concrete test, concrete implementation snippet, and exact `cargo nextest run` verification command.
+
+## Suggested PR ordering
+
+When opening the PR, group commits per phase so reviewers can move bottom-up:
+
+1. **`Directives.depends_on` field + serde round-trip** (Phase 1) — small, self-contained.
+2. **Parser** (Phase 2) — accepts the new attribute.
+3. **Differ union + `Effect.explicit_dependencies`** (Phases 3, 4) — load-bearing wiring.
+4. **Diagnostics** (Phase 5) — analysis-pass checks; gates real user code paths.
+5. **Plan tree + formatter** (Phases 6, 7) — surface behaviour.
+6. **LSP** (Phase 8) — editor experience.
+7. **TextMate parity + multi-file fixture + snapshot** (Phases 9–11) — gates the whole stack.

--- a/docs/specs/2026-05-09-depends-on-design.md
+++ b/docs/specs/2026-05-09-depends-on-design.md
@@ -1,0 +1,231 @@
+# `depends_on` Meta-Argument: Design
+
+<!-- blocked-by ./2026-05-09-wait-construct-design.md -->
+<!-- constrained-by ../../docs/specs/2026-05-09-wait-construct-design.md -->
+
+## Goal
+
+Add a `depends_on = [<binding>, ...]` meta-argument to every `let` binding in Carina that produces a managed effect (resource, wait, module). The differ resolves the list into additional ordering edges in the plan, beyond what value references already imply.
+
+This closes the gap between "B's value depends on A's value" (already expressible) and "B's create must happen after A's create even though no value flows between them" (currently inexpressible). The most immediate consumer is `wait` blocks for ACM DNS validation (`carina#2825`), which need to wait until a Route 53 validation record exists before polling certificate status — the wait targets the cert, not the record, so the record dependency cannot ride on a value reference.
+
+## Non-goals
+
+- `depends_on` on anonymous resources (no binding name to use). Anonymous resources can be wrapped in a `let` if a `depends_on` edge is needed.
+- Cross-module `depends_on` referencing a binding inside another module instance (e.g., `module.web.bucket`). MVP accepts only flat binding names visible in the current scope.
+- Attribute-level `depends_on` selectors (`[iam_role.id]`). MVP accepts the binding name only; if a value reference is needed the user writes the value reference directly.
+- `depends_on` on `data` and `upstream_state` bindings (semantically weak — see "Allowed binding kinds" below).
+- A separate `validates`-style sub-keyword for "depend only on Update" or "depend only on Delete". MVP treats every `depends_on` edge as "depend on the target binding's effect *as a whole*", with the planner's existing phasing logic (which handles create-before-destroy, etc.) doing the per-phase ordering automatically.
+
+## Prerequisites
+
+This design assumes the following Carina change has landed first:
+
+- **`carina#2826` — Rename `lifecycle` block to `directives`.** The `depends_on` meta-arg lives inside the renamed block. If `#2826` slips, the work is mechanically rebasable (`directives` → `lifecycle` is a single sed pass), but writing the design and tests against the destination name keeps documentation stable.
+
+This design is also referenced by:
+
+- **`carina#2825` — `wait` construct implementation.** `wait` blocks need `depends_on` to express ordering against sibling resources whose values they don't reference. `#2825` lists `#2823` (this design) as a hard prerequisite.
+
+## DSL syntax
+
+```crn
+let key = aws.kms.Key { ... }
+let role = aws.iam.Role { ... }
+
+let bucket = aws.s3.Bucket {
+    bucket_name    = "my-bucket"
+    encryption_key = key.arn          # value reference: bucket → key
+    directives {
+        prevent_destroy        = true
+        create_before_destroy  = true
+        depends_on             = [role]   # explicit edge: bucket → role
+    }
+}
+```
+
+`depends_on` is a regular block attribute inside `directives { ... }`, alongside the existing `force_delete`, `create_before_destroy`, and `prevent_destroy`. The right-hand side is a list literal whose elements are bare identifiers naming sibling `let` bindings.
+
+### Why inside `directives` (not at attribute level)
+
+The other binding-level meta-arguments (`force_delete`, `create_before_destroy`, `prevent_destroy`) all live inside the `directives` block already. Putting `depends_on` outside that block would split related concepts across two sites and force the user to remember which meta-args go where. Following the existing pattern is mechanical and consistent.
+
+Alternatives considered:
+
+- **Top-level attribute (`depends_on = [...]` directly inside the resource block).** Matches Terraform but breaks the "one block for all directives to Carina" structure that `#2826` codifies. Rejected.
+- **Nested block (`depends_on { resources = [...] }`).** Verbose and over-structured. Rejected.
+
+## Allowed binding kinds
+
+| Binding kind | `depends_on` target? | Why |
+|---|---|---|
+| Managed resource (`let foo = aws.s3.Bucket { ... }`) | ✅ | Has Create/Update/Delete effects; "wait for these to complete" is the obvious meaning. |
+| `wait` binding (`let foo = wait bar { ... }` from `#2825`) | ✅ | A wait is a passthrough of its target with a synchronisation semantic; treating it as a depends_on target means "wait for this wait to satisfy". Necessary for chained waits. |
+| Module call (`let foo = module.web_tier { ... }`) | ✅ | A module instance is a virtual collection of resources; `depends_on = [module_binding]` expands to "depend on every effect produced by that module". |
+| Data source (`let foo = aws.identitystore.User { ... }` registered as DataSource) | ❌ | Data sources are read at plan time; nothing to "wait for". A depends_on edge here would be a no-op. Diagnose as error so users don't get a false sense of ordering. |
+| `upstream_state` binding | ❌ | Resolved at parse/compile time from another stack's state file, not from runtime effects. Same reason as data sources. |
+| Anonymous resource | ❌ (target only) | Anonymous resources have no binding name to reference. (You can still depend *from* an anonymous resource — just give it a `let` binding to gain a depends_on field.) |
+
+The four allowed shapes converge on the same operational meaning: **"wait until every Create / Update / Replace / Wait effect contributed by the target binding has completed before starting any effect contributed by the depending binding."** For modules, "contributed effects" expands to the entire module instance's effect set.
+
+## Validation rules
+
+The parser and `carina validate` (and LSP diagnostics) reject:
+
+| Rule | Severity | Trigger | Message shape |
+|---|---|---|---|
+| Unknown binding | error | `depends_on = [non_existent]` and no `let non_existent = ...` exists in scope | `directives.depends_on: binding 'non_existent' is not declared in this scope` |
+| Cycle (closed loop in the dependency graph including both value-refs and depends_on) | error | `a depends_on [b]` and `b depends_on [a]`, or `a` value-references `b` and `b depends_on [a]` | `directives.depends_on: cycle detected through a → b → a` |
+| Disallowed binding kind | error | `depends_on = [data_source_binding]` or `depends_on = [upstream_binding]` | `directives.depends_on: data sources and upstream_state bindings are resolved at compile time and cannot be depended on; remove '<name>'` |
+| Self-reference | error | `let a = ... { directives { depends_on = [a] } }` | `directives.depends_on: self-reference is not allowed (binding 'a' depends on itself)` |
+| Element type mismatch | error | `depends_on = ["x"]` (string literal instead of identifier) | `directives.depends_on: list elements must be binding identifiers, not string literals` |
+| Duplicate element | warning | `depends_on = [x, x]` | `directives.depends_on: binding 'x' is listed twice` |
+| Redundant edge already implied by value reference | warning | `bucket` value-references `key.arn` *and* lists `key` in `depends_on` | `directives.depends_on: 'key' is already implied by a value reference; this entry is redundant` |
+
+All seven checks run in the same `analysis` pass that already runs after parsing and before plan generation. The pass is shared by `carina validate` (CLI) and `carina-lsp` (live diagnostics) so users get identical errors regardless of where they hit them.
+
+## Effect storage and the union strategy
+
+A `depends_on = [role]` edge is stored in **two** places, which the differ keeps in sync:
+
+### 1. `Resource.directives.depends_on: Vec<String>` — IR-side source of truth
+
+Lives on the parsed `Resource` (and on the analogous IR struct for `wait` bindings). This is the structure the parser and `analysis` pass write; it survives serialisation to `carina.state.json` because `Resource.directives` is already serialised today (the field used to be `Resource.lifecycle: LifecycleConfig`, after `#2826` it becomes `Resource.directives: Directives`).
+
+### 2. `Resource.dependency_bindings: BTreeSet<String>` — union with value-reference dependencies
+
+Today, `Resource.dependency_bindings` holds the set of bindings the resource depends on via value references. `phased.rs::has_interdependent_replaces`, `parallel.rs::build_dependency_map`, and `plan_tree.rs::get_resource_dependencies` all read this single field to figure out ordering.
+
+The differ extends this set with `directives.depends_on`. After differ runs:
+
+```
+Resource.dependency_bindings == get_resource_dependencies(value-refs)
+                                ∪ Resource.directives.depends_on
+```
+
+`phased.rs`, `parallel.rs`, and `plan_tree.rs` need **no changes** — they keep reading `dependency_bindings` and treat all edges uniformly. Source provenance (value-ref vs. explicit) is intentionally lost at this layer because no consumer needs it.
+
+### 3. `Effect.explicit_dependencies: HashSet<String>` — Effect-side display copy
+
+Every `Effect` variant (`Create`, `Update`, `Replace`, `Delete`, `Read`, `Wait`, `Import`, `Remove`, `Move`) gains an `explicit_dependencies: HashSet<String>` field. The differ populates it from `Resource.directives.depends_on` directly (not the union). This field is not load-bearing for ordering — `dependency_bindings` already covers that. It exists so display layers (`format_effect_brief`, plan tree, snapshot test fixtures) can introspect "which edges came from depends_on" without re-running the differ.
+
+`Effect::Delete` already has a `dependencies: HashSet<String>` field today (used for plan tree). The new `explicit_dependencies` is **additional**, not a replacement — `dependencies` keeps its current "all dependencies including value-refs" semantics for the plan-tree path; `explicit_dependencies` carries only the `directives.depends_on` subset.
+
+### Why two storage shapes
+
+| Storage | Audience | Lossy? |
+|---|---|---|
+| `Resource.directives.depends_on` | Parser, analysis pass, `carina validate`, `carina fmt`, LSP | No — preserves user intent verbatim |
+| `Resource.dependency_bindings` | `differ`, `phased.rs`, `parallel.rs`, `plan_tree.rs` | Yes — unioned with value-refs, source lost |
+| `Effect.explicit_dependencies` | Display, snapshots, debug | No — copy of `directives.depends_on` |
+
+The split keeps each layer reading the shape it needs (parsers want intent; executors want a flat dependency set; displays want provenance). The differ is the single point that fans the IR-side source out to the other two.
+
+## Plan display
+
+### `format_effect_brief` (default `carina plan` brief output)
+
+Unchanged. `depends_on` does not appear on the per-effect line. Ordering of effects in the brief output is the only signal of dependency, which already includes both value-refs and depends_on after the union.
+
+### Plan tree (`carina plan` tree mode, when enabled)
+
+`plan_tree.rs::get_resource_dependencies` already builds parent/child edges from value references. After this design lands, the same function returns the unioned set (value-refs ∪ explicit), so the tree automatically displays explicit edges alongside value-ref ones. The two source kinds are **not visually distinguished** in the tree — the user sees "bucket depends on role" without knowing whether that came from `encryption_key = role.arn` or `depends_on = [role]`.
+
+If a future use case demands provenance in the tree (debugging, LSP code action hints), `Effect.explicit_dependencies` is already populated and the tree renderer can switch to a two-line render with source labels. Out of MVP scope.
+
+## State file
+
+`Resource.directives.depends_on` is already covered by `Resource.directives` serialisation (the existing `LifecycleConfig` -> after `#2826` `Directives` field is serialised in state v3). No state-format change is required:
+
+- New writes record the new field automatically.
+- State files written before this PR have no `depends_on` key in the `directives` map; the field deserialises to `Vec::default()` (empty), which means "no explicit edges", which is the correct legacy behaviour.
+
+There is no state migration. The "no backward compatibility" project policy means we don't need to write a shim, but the change happens to be backward-compatible by virtue of `serde`'s default-on-missing behaviour.
+
+## Cycle detection algorithm
+
+The unioned dependency graph (`Resource.dependency_bindings` after differ runs) is the working representation. Cycle detection is performed by the existing `topological_sort` in `carina-core/src/deps.rs`, which already handles cycles for the value-reference case. Adding `depends_on` edges into `dependency_bindings` means the same algorithm catches `depends_on`-induced cycles for free.
+
+The error message currently produced by `topological_sort` is sufficient for MVP. A future improvement (out of scope here) is making the error annotate which edge in the cycle is `depends_on`-sourced vs. value-ref-sourced, using `Effect.explicit_dependencies`.
+
+## LSP behaviour
+
+| Feature | Behaviour |
+|---|---|
+| Block-key completion inside `directives { ... }` | Adds `depends_on` to the existing keyword set (`force_delete`, `create_before_destroy`, `prevent_destroy`). Trigger: cursor at start of attribute position inside the block. |
+| List-element completion inside `depends_on = [|]` | Strict filter: only `let` bindings of kinds resource / wait / module in the current scope; exclude the binding being defined (self-reference) and any names already present in the same list. Implemented by querying the LSP's `binding_index` with a kind filter and a `not_in` set. |
+| Hover on a binding identifier inside `depends_on` | Reuses the existing identifier-hover handler — same shape as hovering on `key` inside `encryption_key = key.arn`. Returns binding name, kind (resource / wait / module), defining file + line, and the resource type. |
+| Semantic tokens | Adds `depends_on` to `KEYWORDS` in `carina-core/src/keywords.rs` (the single source of truth shared with the TextMate grammars). Identifiers inside the list use the existing variable-reference token (no special treatment). |
+| Diagnostics (live in editor) | All seven validation rules from the table above. Severity, message text, and source span all match what `carina validate` produces. |
+
+The `binding_index` query for list-element completion is the only LSP-side bit that needs new code — everything else is mechanical extension of existing keyword tables and diagnostic dispatch.
+
+## Edge cases and constraints
+
+### Discard pattern and `depends_on`
+
+```crn
+let _ = aws.s3.BucketPolicy {
+    ...
+    directives { depends_on = [bucket] }
+}
+```
+
+A `let _ = ...` discard binding (already supported in `carina.pest`) can carry a `depends_on`, since the discard pattern still produces an effect for execution. The discard binding cannot itself be a depends_on *target*, since it has no name to reference — `depends_on = [_]` is rejected with the unknown-binding diagnostic.
+
+### `wait` target also listed in `depends_on`
+
+```crn
+let cert_issued = wait cert {
+    until      = cert.status == ISSUED
+    directives { depends_on = [cert] }   # `cert` is also the wait target
+}
+```
+
+Legal but redundant: the wait already implicitly depends on its target (the wait can't read the target until the target's create completes). The redundancy diagnostic from the table catches it as a warning, mirroring the value-reference + depends_on redundancy case.
+
+### `depends_on` referencing a `for_each`-expanded binding
+
+Carina's `for` expression generates multiple resources from a single binding name. `depends_on = [for_each_binding]` is treated as "depend on every expanded resource". This falls out for free: the binding name in `Resource.dependency_bindings` already maps to the entire group via the existing reference-resolution logic, and the differ will emit edges to each instance. No new design needed.
+
+### Module bindings expanded in `depends_on`
+
+`depends_on = [web_tier]` where `web_tier` is a module call expands to "depend on every effect produced by `web_tier`". The expansion happens in the differ when it walks `dependency_bindings` and encounters a module-binding name; it substitutes the module's resource set in place. This matches how value references against module exports work today.
+
+### Empty list
+
+`depends_on = []` is legal (means "no explicit edges"), distinguishable from omitting the field entirely (also "no explicit edges"). Treating both as the same has no downside.
+
+### Reordering elements
+
+`depends_on = [a, b]` and `depends_on = [b, a]` are semantically identical (set semantics). Formatter normalises to one canonical order (alphabetical) on `carina fmt` to keep diffs stable.
+
+## Risks
+
+- **Cross-module `depends_on` is omitted.** A module's internal binding cannot be referenced from outside the module (`depends_on = [module.web.bucket]` is not supported). If the registry usecase or another consumer needs this later, we'd need to extend the lookup to module-scoped paths, which is a non-trivial change to `binding_index` and the resolver. Mitigation: document the limitation; if a consumer hits it, file a follow-up issue rather than rushing the design here.
+- **Union strategy loses provenance at the executor layer.** A bug that produces a wrong dependency edge can't be traced back to "value-ref vs. explicit" from the executor's logs alone. Mitigation: `Effect.explicit_dependencies` retains the explicit subset specifically so debugging and snapshot tests can introspect; CLI / LSP / formatter all see the unmerged source.
+- **Legacy state files round-trip the new field.** State written before this PR has no `depends_on` in `directives`; after a no-op refresh, `serde` writes the empty list back. This adds a tiny amount of noise to the first state-rewriting plan/apply on existing infrastructure. Mitigation: acceptable — the project memory rule is "no backward compatibility, and don't mention it" — so we just let it happen and move on.
+- **Cycle messages don't yet identify edge provenance.** Today the planner's cycle error says `cycle detected through a → b → a` without saying which edge came from `depends_on`. Mitigation: out of MVP scope; the existing message is informative enough to debug, and `Effect.explicit_dependencies` makes it possible to enhance the message later without further design work.
+- **`directives` rename (`#2826`) is in flight.** This design is written assuming `#2826` lands first. If it doesn't, every reference here to `directives` becomes `lifecycle`. Mitigation: trivial sed pass to revert; both names point to the same struct, so the design's substance is unaffected.
+
+## Acceptance criteria
+
+The `depends_on` meta-arg is considered "done" for MVP when:
+
+1. `directives { depends_on = [<bindings>] }` parses across `carina validate` and the LSP, with diagnostics for all seven rules in the table above.
+2. The differ unions `directives.depends_on` into `Resource.dependency_bindings`; the existing `phased.rs`, `parallel.rs`, and `plan_tree.rs` consumers treat the new edges identically to value-reference edges, with no source-side modification needed.
+3. `Effect.explicit_dependencies` is populated on every Effect variant from `Resource.directives.depends_on`; snapshot tests cover at least one fixture per Effect kind that carries an explicit edge.
+4. `carina plan` (brief) shows no per-effect annotation for `depends_on`; ordering changes are visible only via the surrounding effect order.
+5. `carina plan` (tree) renders explicit edges identically to value-ref edges (no source label).
+6. State file (`carina.state.json`) round-trips `directives.depends_on` correctly; legacy state files (no `depends_on` key) deserialise to an empty list and re-serialise with the field present.
+7. Multi-file fixture: a directory containing `main.crn` (resources) + `directives.crn` (resource with `depends_on` referencing a binding from `main.crn`) parses and validates. Per CLAUDE.md "Directory-scoped, never single-file" rule.
+8. The `carina#2825` consumer (the `wait` construct) compiles against the API exposed here and uses `depends_on = [validation_record]` to express the ACM DNS validation ordering.
+
+## Related work
+
+- `carina-rs/carina#2823` — this design's tracking issue.
+- `carina-rs/carina#2826` — `lifecycle` → `directives` rename (prerequisite).
+- `carina-rs/carina#2825` — `wait` construct implementation (consumer; depends on this).
+- `carina-rs/carina#2824` — `Duration` type and literal (sibling prerequisite for `#2825`, independent of this design).
+- `carina-rs/carina#2822` — merged design + plan documents for the `wait` construct, where the requirement for `depends_on` first surfaced.
+- Terraform's `depends_on` meta-argument (https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) — the conceptual ancestor; Carina's variant is narrower (binding identifiers only, no attribute selectors).


### PR DESCRIPTION
## Summary

Adds two long-form documents for the `depends_on` meta-argument on `let` bindings:

```crn
let role = aws.iam.Role { role_name = "my-role" assume_role_policy_document = "{}" }

let bucket = aws.s3.Bucket {
    bucket_name = "my-bucket"
    directives {
        prevent_destroy = true
        depends_on      = [role]
    }
}
```

This is a **brainstorming-output Draft PR** — docs only, no implementation code. Implementation tasks are filed as separate issues (linked below).

## Files

- `docs/specs/2026-05-09-depends-on-design.md` — design rationale, DSL syntax, validation rules, storage layers, edge cases, risks.
- `docs/plans/2026-05-09-depends-on-plan.md` — 22 TDD-cycle tasks across 12 phases, with concrete test/implementation snippets and exact verification commands per task.

## Key design decisions

- **Lives inside `directives { ... }`** (the post-#2826 rename of `lifecycle { ... }`). Sits alongside `force_delete`, `create_before_destroy`, `prevent_destroy`.
- **Elements are bare binding identifiers only** (`[iam_role, kms_key]`). String literals (`["x"]`) and attribute selectors (`[role.id]`) are rejected.
- **Allowed targets**: resource / wait / module. Data sources and `upstream_state` bindings are rejected with a diagnostic.
- **Three-layer storage**: `Resource.directives.depends_on` (IR source of truth) → `Resource.dependency_bindings: BTreeSet` (union with value-references; what `phased.rs` / `parallel.rs` / `plan_tree.rs` consume unchanged) → `Effect.explicit_dependencies: HashSet` (display copy for snapshots and debugging).
- **7 validation rules** in the analysis pass, shared by `carina validate` and the LSP: unknown binding, self-reference, disallowed kind, duplicate element, redundant value-ref edge, cycle, element type mismatch.
- **Cycle detection** reuses the existing `topological_sort` in `deps.rs` once the union is in place.
- **Plan brief unchanged**, plan tree unifies value-ref and explicit edges (no source label).

## Prerequisite

Depends on **#2826** (`lifecycle` → `directives` rename) landing first. Both documents are written with the post-rename naming. If `#2826` slips, the rename is mechanically rebasable but should not be combined with this work in the same PR.

## Consumer

**#2825** (`wait` construct implementation) treats this as a hard prerequisite. `wait` blocks use `depends_on = [validation_record]` to express ACM DNS validation ordering against sibling resources whose values they don't reference.

## Closes / refs

This PR opens follow-up Issues:

- #2823 (this design's tracking issue) — will be re-tagged with the implementation breakdown after this PR merges.

## Verification

- N/A for code; docs-only PR.
- Project memory ("brainstorming Draft PR + auto-merge") covers this exception to the "PRs are non-draft by default" rule.
- Markdown directives (`derived-from`, `blocked-by`, `constrained-by`) follow the dagayn graph convention from CLAUDE.md.

## Auto-merge

Will be enabled after creation per the brainstorming skill's Step 9 protocol.
