### PR TITLE
core: split bare-binding refs into Value::BindingRef

### DIFF
--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -189,6 +189,10 @@ pub(crate) fn dsl_value_to_json(
             path: path.to_dot_string(),
             context: ctx,
         }),
+        Value::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
+            path: binding.clone(),
+            context: ctx,
+        }),
         Value::Interpolation(_) => {
             Err(SerializationError::UnresolvedInterpolation { context: ctx })
         }

--- a/carina-core/src/builtins/mod.rs
+++ b/carina-core/src/builtins/mod.rs
@@ -420,6 +420,7 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::StringList(_) => "StringList",
         Value::Map(_) => "Map",
         Value::ResourceRef { .. } => "ResourceRef",
+        Value::BindingRef { .. } => "BindingRef",
         Value::Interpolation(_) => "Interpolation",
         Value::FunctionCall { .. } => "FunctionCall",
         Value::Secret(_) => "Secret",

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -32,11 +32,43 @@ pub fn get_resource_dependencies(resource: &Resource) -> HashSet<String> {
     deps
 }
 
-/// Recursively collect resource reference dependencies from a value
+/// Recursively collect resource reference dependencies from a value.
+///
+/// Both attribute references (`vpc.vpc_id`) and bare-binding refs
+/// (`vpc_id` standing alone) record the same dependency edge: the
+/// resource depends on the named binding. The two parse to different
+/// `Value` variants since #2847 (`ResourceRef` vs. `BindingRef`), so
+/// the walker visits both forms here.
 fn collect_dependencies(value: &Value, deps: &mut HashSet<String>) {
-    value.visit_refs(&mut |path| {
-        deps.insert(path.binding().to_string());
-    });
+    fn walk(value: &Value, deps: &mut HashSet<String>) {
+        match value {
+            Value::ResourceRef { path } => {
+                deps.insert(path.binding().to_string());
+            }
+            Value::BindingRef { binding } => {
+                deps.insert(binding.clone());
+            }
+            Value::List(items) => items.iter().for_each(|v| walk(v, deps)),
+            Value::Map(map) => map.values().for_each(|v| walk(v, deps)),
+            Value::Interpolation(parts) => {
+                use crate::resource::InterpolationPart;
+                for part in parts {
+                    if let InterpolationPart::Expr(v) = part {
+                        walk(v, deps);
+                    }
+                }
+            }
+            Value::FunctionCall { args, .. } => args.iter().for_each(|v| walk(v, deps)),
+            Value::Secret(inner) => walk(inner, deps),
+            Value::String(_)
+            | Value::Int(_)
+            | Value::Float(_)
+            | Value::Bool(_)
+            | Value::StringList(_)
+            | Value::Unknown(_) => {}
+        }
+    }
+    walk(value, deps);
 }
 
 /// Sort resources topologically based on dependencies.

--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -180,6 +180,9 @@ fn deterministic_value_string(value: &Value) -> String {
         Value::ResourceRef { path } => {
             format!("ResourceRef({})", path.to_dot_string())
         }
+        Value::BindingRef { binding } => {
+            format!("BindingRef({})", binding)
+        }
         Value::Interpolation(parts) => {
             use crate::resource::InterpolationPart;
             let strs: Vec<String> = parts

--- a/carina-core/src/module.rs
+++ b/carina-core/src/module.rs
@@ -163,12 +163,9 @@ fn format_value(value: &Value) -> String {
             }
         }
         Value::ResourceRef { path } => {
-            if path.attribute().is_empty() {
-                path.binding().to_string()
-            } else {
-                format!("{}.{}", path.binding(), path.attribute())
-            }
+            format!("{}.{}", path.binding(), path.attribute())
         }
+        Value::BindingRef { binding } => binding.clone(),
         Value::Interpolation(parts) => {
             use crate::resource::InterpolationPart;
             let inner: String = parts
@@ -456,6 +453,22 @@ impl RootConfigSignature {
                         target: path.binding().to_string(),
                         target_type,
                         attribute: path.attribute().to_string(),
+                        used_in: attr_key.to_string(),
+                    },
+                );
+            }
+            // Bare-binding refs (e.g. `vpc_id` standing alone, since
+            // #2847) are dependencies just like attribute refs; the
+            // displayed `attribute` slot stays empty so
+            // `format_dep_detail` renders `target (via used_in)`.
+            Value::BindingRef { binding } => {
+                let target_type = binding_types.get(binding).cloned();
+                graph.add_edge(
+                    from.to_string(),
+                    TypedDependency {
+                        target: binding.clone(),
+                        target_type,
+                        attribute: String::new(),
                         used_in: attr_key.to_string(),
                     },
                 );
@@ -874,6 +887,29 @@ impl ModuleSignature {
                         target: binding_name.to_string(),
                         target_type,
                         attribute: path.attribute().to_string(),
+                        used_in: attr_key.to_string(),
+                    },
+                );
+            }
+            // Bare-binding refs (`vpc_id = vpc` referencing argument
+            // `vpc`, since #2847) — same dependency edge, empty
+            // attribute slot.
+            Value::BindingRef { binding } => {
+                let target_type = if let Some(arg_type) = argument_types.get(binding) {
+                    if let TypeExpr::Ref(p) = arg_type {
+                        Some(p.clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    binding_types.get(binding).cloned()
+                };
+                graph.add_edge(
+                    from.to_string(),
+                    TypedDependency {
+                        target: binding.clone(),
+                        target_type,
+                        attribute: String::new(),
                         used_in: attr_key.to_string(),
                     },
                 );

--- a/carina-core/src/module_resolver/expander.rs
+++ b/carina-core/src/module_resolver/expander.rs
@@ -280,11 +280,17 @@ impl ModuleResolver<'_> {
 
 /// Substitute arguments references with actual values.
 ///
-/// Argument parameter names are registered as lexical bindings in the parser,
-/// so they appear as `ResourceRef { binding_name: "<param_name>", attribute_name: ... }`.
-/// We match when `binding_name` is one of the argument keys.
+/// Argument parameter names are registered as lexical bindings in the
+/// parser. A bare-name reference (`source_arn`) parses as
+/// [`Value::BindingRef`]; an attribute access (`source_arn.field`)
+/// parses as [`Value::ResourceRef`]. Both forms can target an argument
+/// parameter, so substitution covers both.
 pub(super) fn substitute_arguments(value: &Value, arguments: &HashMap<String, Value>) -> Value {
     match value {
+        Value::BindingRef { binding } if arguments.contains_key(binding) => arguments
+            .get(binding)
+            .cloned()
+            .unwrap_or_else(|| value.clone()),
         Value::ResourceRef { path } if arguments.contains_key(path.binding()) => arguments
             .get(path.binding())
             .cloned()
@@ -334,6 +340,11 @@ pub(super) fn rewrite_intra_module_refs(
     intra_module_bindings: &HashSet<String>,
 ) -> Value {
     match value {
+        Value::BindingRef { binding } if intra_module_bindings.contains(binding) => {
+            Value::BindingRef {
+                binding: format!("{}.{}", instance_prefix, binding),
+            }
+        }
         Value::ResourceRef { path } if intra_module_bindings.contains(path.binding()) => {
             Value::ResourceRef {
                 path: crate::resource::AccessPath::with_fields_and_subscripts(

--- a/carina-core/src/module_resolver/tests.rs
+++ b/carina-core/src/module_resolver/tests.rs
@@ -25,7 +25,9 @@ fn create_test_module() -> ParsedFile {
                 attrs.insert("name".to_string(), Value::String("sg".to_string()));
                 attrs.insert(
                     "vpc_id".to_string(),
-                    Value::resource_ref("vpc_id".to_string(), String::new(), vec![]),
+                    Value::BindingRef {
+                        binding: "vpc_id".to_string(),
+                    },
                 );
                 attrs.insert(
                     "_type".to_string(),
@@ -79,7 +81,9 @@ fn test_substitute_arguments() {
     inputs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
 
     // Argument params are lexically scoped: binding_name is the param name itself
-    let value = Value::resource_ref("vpc_id".to_string(), String::new(), vec![]);
+    let value = Value::BindingRef {
+        binding: "vpc_id".to_string(),
+    };
     let result = substitute_arguments(&value, &inputs);
 
     assert_eq!(result, Value::String("vpc-123".to_string()));
@@ -91,7 +95,9 @@ fn test_substitute_arguments_nested() {
     inputs.insert("port".to_string(), Value::Int(8080));
 
     let value = Value::List(vec![
-        Value::resource_ref("port".to_string(), String::new(), vec![]),
+        Value::BindingRef {
+            binding: "port".to_string(),
+        },
         Value::Int(443),
     ]);
     let result = substitute_arguments(&value, &inputs);
@@ -244,7 +250,9 @@ fn create_module_with_intra_refs() -> ParsedFile {
                     let mut attrs = HashMap::new();
                     attrs.insert(
                         "cidr_block".to_string(),
-                        Value::resource_ref("cidr".to_string(), String::new(), vec![]),
+                        Value::BindingRef {
+                            binding: "cidr".to_string(),
+                        },
                     );
                     attrs.into_iter().collect()
                 },
@@ -1088,11 +1096,9 @@ fn test_substitute_arguments_interpolation() {
     // Interpolation like "prefix-${env_name}-suffix" where env_name is a module argument
     let value = Value::Interpolation(vec![
         InterpolationPart::Literal("prefix-".to_string()),
-        InterpolationPart::Expr(Value::resource_ref(
-            "env_name".to_string(),
-            String::new(),
-            vec![],
-        )),
+        InterpolationPart::Expr(Value::BindingRef {
+            binding: "env_name".to_string(),
+        }),
         InterpolationPart::Literal("-suffix".to_string()),
     ]);
     let result = substitute_arguments(&value, &inputs);
@@ -1149,7 +1155,9 @@ fn test_substitute_arguments_function_call() {
     let value = Value::FunctionCall {
         name: "cidr_subnet".to_string(),
         args: vec![
-            Value::resource_ref("cidr".to_string(), String::new(), vec![]),
+            Value::BindingRef {
+                binding: "cidr".to_string(),
+            },
             Value::Int(8),
             Value::Int(0),
         ],
@@ -1181,22 +1189,24 @@ fn create_module_with_interpolation() -> ParsedFile {
                 let mut attrs = HashMap::new();
                 attrs.insert(
                     "cidr_block".to_string(),
-                    Value::resource_ref("cidr_block".to_string(), String::new(), vec![]),
+                    Value::BindingRef {
+                        binding: "cidr_block".to_string(),
+                    },
                 );
                 attrs.insert(
                     "name".to_string(),
                     Value::Interpolation(vec![
                         InterpolationPart::Literal("test-".to_string()),
-                        InterpolationPart::Expr(Value::resource_ref(
-                            "env_name".to_string(),
-                            String::new(),
-                            vec![],
-                        )),
+                        InterpolationPart::Expr(Value::BindingRef {
+                            binding: "env_name".to_string(),
+                        }),
                     ]),
                 );
                 attrs.insert(
                     "env".to_string(),
-                    Value::resource_ref("env_name".to_string(), String::new(), vec![]),
+                    Value::BindingRef {
+                        binding: "env_name".to_string(),
+                    },
                 );
                 attrs.into_iter().collect()
             },
@@ -2738,19 +2748,19 @@ m {}
 
     let role_name = role_attr(&parsed, "role_name");
     match role_name {
-        Value::ResourceRef { path } => {
-            // The cycle leaves both `a` and `b` as ResourceRef; which one
-            // surfaces as `role_name` depends on substitute_arguments's
-            // walk order. Either is fine — the contract is that the
-            // loop terminates without panicking and produces a
-            // structured ref the scope check can flag.
+        // The cycle leaves both `a` and `b` as bare-binding refs; which
+        // one surfaces as `role_name` depends on substitute_arguments's
+        // walk order. Either is fine — the contract is that the loop
+        // terminates without panicking and produces a structured ref
+        // the scope check can flag. Since #2847 these bare refs are
+        // `BindingRef`, not `ResourceRef` with empty attribute.
+        Value::BindingRef { binding } => {
             assert!(
-                path.binding() == "a" || path.binding() == "b",
-                "expected cyclic ref to point at `a` or `b`, got: {:?}",
-                path.binding()
+                binding == "a" || binding == "b",
+                "expected cyclic ref to point at `a` or `b`, got: {binding:?}"
             );
         }
-        other => panic!("expected unresolved ResourceRef from cycle; got {other:?}"),
+        other => panic!("expected unresolved BindingRef from cycle; got {other:?}"),
     }
 }
 

--- a/carina-core/src/module_resolver/typecheck.rs
+++ b/carina-core/src/module_resolver/typecheck.rs
@@ -41,26 +41,24 @@ pub(super) enum TypeCheckResult {
     ValidationError(String),
 }
 
-/// If `value` is a bare reference to a binding in `enclosing_args`
-/// (no attribute / field path / subscripts), return that arg's declared
-/// type. Bare-binding refs are how the parser represents arguments-block
-/// names that propagate into nested module calls (#2549).
+/// If `value` is a bare reference to a binding in `enclosing_args`,
+/// return that arg's declared type. Bare-binding refs are how the
+/// parser represents arguments-block names that propagate into nested
+/// module calls (#2549).
+///
+/// `Value::BindingRef` is the canonical representation since #2847;
+/// the type system guarantees no attribute/field/subscript can hide
+/// inside it.
 fn enclosing_arg_type<'a>(
     value: &Value,
     enclosing_args: Option<&'a [ArgumentParameter]>,
 ) -> Option<&'a TypeExpr> {
-    let Value::ResourceRef { path } = value else {
+    let Value::BindingRef { binding } = value else {
         return None;
     };
-    if !path.attribute().is_empty()
-        || !path.field_path().is_empty()
-        || !path.subscripts().is_empty()
-    {
-        return None;
-    }
     enclosing_args?
         .iter()
-        .find(|a| a.name == path.binding())
+        .find(|a| a.name == binding.as_str())
         .map(|a| &a.type_expr)
 }
 
@@ -80,7 +78,17 @@ pub(super) fn check_type_match(
 
     match type_expr {
         // Deferred-resolution values: type unknown at this checkpoint.
-        _ if matches!(value, Value::FunctionCall { .. } | Value::Unknown(_)) => TypeCheckResult::Ok,
+        // `BindingRef` falls through here only when it is not an
+        // enclosing-arg ref (the early return above handles that case);
+        // those leftover bare refs are unresolved sibling/forward refs
+        // and behave like `Unknown` for typecheck purposes.
+        _ if matches!(
+            value,
+            Value::FunctionCall { .. } | Value::Unknown(_) | Value::BindingRef { .. }
+        ) =>
+        {
+            TypeCheckResult::Ok
+        }
         TypeExpr::String => {
             if matches!(
                 value,

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -131,11 +131,20 @@ pub(in crate::parser) fn parse_arguments_block(
 
 /// Register an argument name as a lexical binding so subsequent expressions
 /// (later argument defaults, resource bodies, etc.) resolve it as a
-/// `ResourceRef` placeholder rather than a literal string. Without this
+/// `BindingRef` placeholder rather than a literal string. Without this
 /// incremental registration, `${other_arg}` inside a default would have no
 /// in-scope binding and degrade to the literal string `"other_arg"` (#2393).
+///
+/// `BindingRef` (not `ResourceRef`) is correct here: an `arguments {}`
+/// declaration introduces a name without an attribute. When a later
+/// expression writes `other_arg.attr`, the parser composes a fresh
+/// `ResourceRef`. Storing the placeholder as `ResourceRef` with an
+/// empty `attribute` would be a type-level lie — the same shape that
+/// produced the empty-field diagnostic in #2847.
 fn register_argument_binding(ctx: &mut ParseContext, name: &str) {
-    let placeholder_ref = Value::resource_ref(name.to_string(), String::new(), vec![]);
+    let placeholder_ref = Value::BindingRef {
+        binding: name.to_string(),
+    };
     ctx.set_variable(name.to_string(), placeholder_ref);
     let placeholder = Resource::new("_argument", name);
     ctx.set_resource_binding(name.to_string(), placeholder);

--- a/carina-core/src/parser/entry.rs
+++ b/carina-core/src/parser/entry.rs
@@ -366,11 +366,22 @@ pub fn parse_with_seeded_bindings(
 /// the same `ctx.get_variable` / `ctx.is_resource_binding` paths that
 /// locally-declared `let` / `arguments` names use after parsing.
 ///
+/// Each seed is installed as a [`Value::BindingRef`] — a bare-binding
+/// reference with no attribute slot. This is intentional: a seed
+/// represents "a name exists in scope; we know nothing more about it".
+/// When a downstream expression accesses `name.attr`, the parser
+/// composes a fresh [`Value::ResourceRef`] with the real attribute
+/// instead of mutating the seed. Storing the seed as `ResourceRef`
+/// with an empty `attribute` field would be a type-level lie and
+/// previously surfaced as the empty-field diagnostic in #2847.
+///
 /// Empty seed list is a no-op — single-file callers (the legacy
 /// `parse(input, config)` wrapper, parser tests) pay no cost.
 fn seed_bindings(ctx: &mut ParseContext<'_>, seeds: &[&str]) {
     for &name in seeds {
-        let placeholder_ref = Value::resource_ref(name.to_string(), String::new(), vec![]);
+        let placeholder_ref = Value::BindingRef {
+            binding: name.to_string(),
+        };
         ctx.set_variable(name.to_string(), placeholder_ref);
         let placeholder = Resource::new("_seeded", name);
         ctx.set_resource_binding(name.to_string(), placeholder);

--- a/carina-core/src/parser/expressions/primary.rs
+++ b/carina-core/src/parser/expressions/primary.rs
@@ -376,13 +376,17 @@ pub(crate) fn parse_primary_eval(
                     // construction (the post-field bucket only fills
                     // after a field). Pre-field subscripts have already
                     // been folded into binding_name above.
+                    //
+                    // No attribute selector → emit `BindingRef`. The
+                    // legacy "ResourceRef with empty attribute" shape
+                    // was the source of the empty-field diagnostic in
+                    // #2847; the new variant makes that representation
+                    // unrepresentable.
                     match ctx.get_variable(&binding_name) {
                         Some(val) => Ok(val.clone()),
-                        None => Ok(EvalValue::from_value(Value::resource_ref(
-                            binding_name,
-                            String::new(),
-                            vec![],
-                        ))),
+                        None => Ok(EvalValue::from_value(Value::BindingRef {
+                            binding: binding_name,
+                        })),
                     }
                 } else {
                     let attribute_name = field_names.remove(0);

--- a/carina-core/src/parser/static_eval.rs
+++ b/carina-core/src/parser/static_eval.rs
@@ -20,7 +20,10 @@ pub(crate) fn is_static_value(value: &Value) -> bool {
         Value::List(items) => items.iter().all(is_static_value),
         Value::Map(map) => map.values().all(is_static_value),
         Value::FunctionCall { args, .. } => args.iter().all(is_static_value),
-        Value::ResourceRef { .. } | Value::Interpolation(_) | Value::Unknown(_) => false,
+        Value::ResourceRef { .. }
+        | Value::BindingRef { .. }
+        | Value::Interpolation(_)
+        | Value::Unknown(_) => false,
         Value::Secret(inner) => is_static_value(inner),
     }
 }

--- a/carina-core/src/parser/tests.rs
+++ b/carina-core/src/parser/tests.rs
@@ -580,11 +580,9 @@ fn parse_directory_module() {
     let sg = &result.resources[0];
     assert_eq!(
         sg.get_attr("vpc_id"),
-        Some(&Value::resource_ref(
-            "vpc_id".to_string(),
-            String::new(),
-            vec![]
-        ))
+        Some(&Value::BindingRef {
+            binding: "vpc_id".to_string(),
+        })
     );
 }
 

--- a/carina-core/src/parser/util.rs
+++ b/carina-core/src/parser/util.rs
@@ -57,6 +57,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         Value::StringList(_) => "list",
         Value::Map(_) => "map",
         Value::ResourceRef { .. } => "resource reference",
+        Value::BindingRef { .. } => "binding reference",
         Value::Interpolation(_) => "string",
         Value::FunctionCall { .. } => "function call",
         Value::Secret(_) => "secret",

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -255,24 +255,46 @@ pub struct AccessPath {
 
 impl AccessPath {
     /// Create an `AccessPath` referring to a top-level attribute of a binding.
+    ///
+    /// `attribute` must be non-empty. A bare-binding reference (no
+    /// `.attr`) is represented by [`Value::BindingRef`], not by an
+    /// `AccessPath` with an empty attribute.
     pub fn new(binding: impl Into<String>, attribute: impl Into<String>) -> Self {
+        let binding = binding.into();
+        let attribute = attribute.into();
+        assert!(
+            !attribute.is_empty(),
+            "AccessPath::new with empty attribute for binding {:?}; \
+             use Value::BindingRef instead (#2847)",
+            binding
+        );
         Self {
-            binding: binding.into(),
-            attribute: attribute.into(),
+            binding,
+            attribute,
             field_path: Vec::new(),
             subscripts: Vec::new(),
         }
     }
 
     /// Create an `AccessPath` with a nested field path (e.g., `web.network.vpc_id`).
+    ///
+    /// `attribute` must be non-empty. See [`AccessPath::new`].
     pub fn with_fields(
         binding: impl Into<String>,
         attribute: impl Into<String>,
         field_path: Vec<String>,
     ) -> Self {
+        let binding = binding.into();
+        let attribute = attribute.into();
+        assert!(
+            !attribute.is_empty(),
+            "AccessPath::with_fields with empty attribute for binding {:?}; \
+             use Value::BindingRef instead (#2847)",
+            binding
+        );
         Self {
-            binding: binding.into(),
-            attribute: attribute.into(),
+            binding,
+            attribute,
             field_path,
             subscripts: Vec::new(),
         }
@@ -281,15 +303,25 @@ impl AccessPath {
     /// Create an `AccessPath` with both a field chain and trailing
     /// `[index]` subscripts. Used by the parser when source contains
     /// `binding.field[idx]` or `binding.field.subfield[idx]…`.
+    ///
+    /// `attribute` must be non-empty. See [`AccessPath::new`].
     pub fn with_fields_and_subscripts(
         binding: impl Into<String>,
         attribute: impl Into<String>,
         field_path: Vec<String>,
         subscripts: Vec<Subscript>,
     ) -> Self {
+        let binding = binding.into();
+        let attribute = attribute.into();
+        assert!(
+            !attribute.is_empty(),
+            "AccessPath::with_fields_and_subscripts with empty attribute for binding {:?}; \
+             use Value::BindingRef instead (#2847)",
+            binding
+        );
         Self {
-            binding: binding.into(),
-            attribute: attribute.into(),
+            binding,
+            attribute,
             field_path,
             subscripts,
         }
@@ -375,8 +407,32 @@ pub enum Value {
     /// - segment 0: binding name (e.g., "vpc")
     /// - segment 1: attribute name (e.g., "vpc_id")
     /// - segments 2+: nested field path
+    ///
+    /// `AccessPath` carries a non-empty `attribute`; the type system
+    /// guarantees this — see [`AccessPath`]. A reference to a binding
+    /// without any attribute access (`bootstrap` standalone, the
+    /// directory-aware Pass-2 seed for sibling-defined names) is
+    /// represented as [`Value::BindingRef`] instead.
     ResourceRef {
         path: AccessPath,
+    },
+    /// Reference to a binding without an attribute selector.
+    ///
+    /// Two producer sites:
+    /// - [`crate::parser::parse_with_seeded_bindings`] seeds every
+    ///   sibling-defined name (#2817) so in-file expressions resolve
+    ///   `name.attr` correctly; the seed itself carries no attribute.
+    /// - The parser's `variable_ref` rule emits `BindingRef` for a bare
+    ///   `let arn = bootstrap` (no `.attr` chain).
+    ///
+    /// `BindingRef` is invisible to attribute-walking code paths
+    /// (`visit_refs`, `check_upstream_state_field_references`, etc.) by
+    /// construction: there is no `attribute` slot for them to read. This
+    /// makes the empty-field diagnostic class (#2847) unrepresentable —
+    /// a sibling-only seed cannot synthesize a fake attribute reference
+    /// because the type carries none.
+    BindingRef {
+        binding: String,
     },
     /// String interpolation: `"prefix-${expr}-suffix"`
     /// Parts are evaluated and concatenated into a final String.
@@ -465,6 +521,7 @@ impl PartialEq for Value {
             (Value::StringList(a), Value::StringList(b)) => a == b,
             (Value::Map(a), Value::Map(b)) => a == b,
             (Value::ResourceRef { path: a }, Value::ResourceRef { path: b }) => a == b,
+            (Value::BindingRef { binding: a }, Value::BindingRef { binding: b }) => a == b,
             (Value::Interpolation(a), Value::Interpolation(b)) => a == b,
             (
                 Value::FunctionCall { name: an, args: aa },
@@ -592,8 +649,10 @@ impl Value {
 
     /// Create a `ResourceRef` from binding name, attribute name, and optional field path.
     ///
-    /// This is the primary constructor for `ResourceRef` values, replacing direct
-    /// struct literal construction.
+    /// `attribute_name` must be non-empty. A bare-binding reference (no
+    /// `.attr`) is a [`Value::BindingRef`], not a `ResourceRef` with an
+    /// empty attribute — see #2847 for the regression that motivated
+    /// the type-level split.
     pub fn resource_ref(
         binding_name: impl Into<String>,
         attribute_name: impl Into<String>,
@@ -660,6 +719,11 @@ impl Value {
             | Value::Float(_)
             | Value::Bool(_)
             | Value::StringList(_) => {}
+            // `BindingRef` carries no attribute, so attribute-walking
+            // visitors have nothing to do. Callers that *do* care about
+            // bare-binding references walk them explicitly via
+            // `visit_binding_refs`.
+            Value::BindingRef { .. } => {}
             // `Value::Unknown` is what a previously-unresolved
             // `ResourceRef` was *replaced with* by `stamp_unresolved_upstream`.
             // It carries an `AccessPath` for display, but it is no longer
@@ -766,6 +830,9 @@ impl Value {
             }
             Value::ResourceRef { path } => {
                 path.hash(hasher);
+            }
+            Value::BindingRef { binding } => {
+                binding.hash(hasher);
             }
             Value::Interpolation(parts) => {
                 parts.len().hash(hasher);

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1706,6 +1706,7 @@ impl Value {
             Value::ResourceRef { path } => {
                 format!("ResourceRef({})", path.to_dot_string())
             }
+            Value::BindingRef { binding } => format!("BindingRef({})", binding),
             Value::Interpolation(_) => "Interpolation".to_string(),
             Value::FunctionCall { name, .. } => format!("FunctionCall({})", name),
             Value::Secret(_) => "Secret".to_string(),

--- a/carina-core/src/upstream_exports.rs
+++ b/carina-core/src/upstream_exports.rs
@@ -675,6 +675,11 @@ fn walk_value_against_type(
         | Value::Bool(_)
         | Value::StringList(_)
         | Value::Unknown(_) => {}
+        // `BindingRef` carries no attribute, so there is nothing to
+        // type-check at a "field reference" position. The same applies
+        // to all other walkers in this module: a bare-binding seed
+        // cannot stand in for an attribute reference. (#2847)
+        Value::BindingRef { .. } => {}
     }
 }
 
@@ -1693,6 +1698,50 @@ mod tests {
         assert_eq!(errs.len(), 1, "got: {errs:?}");
         assert_eq!(errs[0].field, "acc");
         assert!(errs[0].location.contains("let"));
+    }
+
+    #[test]
+    fn upstream_state_sibling_reference_no_empty_export_error() {
+        // Regression: #2847. `bootstrap` declared in `backend.crn`,
+        // referenced from `main.crn`. Pre-fix the seeded placeholder
+        // surfaced as a `ResourceRef { attribute: "" }` and tripped the
+        // walker into emitting `does not export ``.`. Type-split makes
+        // the offending shape unrepresentable: a sibling-only seed is a
+        // `Value::BindingRef`, which has no attribute slot for the
+        // walker to read, so the empty-field diagnostic class is
+        // statically eliminated.
+        let tmp = tempfile::tempdir().unwrap();
+        write_crn(
+            tmp.path(),
+            "backend.crn",
+            r#"
+            let bootstrap = upstream_state { source = "../bootstrap" }
+            "#,
+        );
+        write_crn(
+            tmp.path(),
+            "main.crn",
+            r#"
+            let arn = bootstrap.oidc_provider_arn
+            "#,
+        );
+        let parsed = parse_directory(tmp.path(), &ctx()).expect("parse_directory");
+        // Whitebox: the bare-binding seed surfaces as `BindingRef`,
+        // not `ResourceRef`. The type itself proves the seeded shape
+        // can no longer impersonate an attribute reference.
+        let bootstrap_var = parsed.variables.get("bootstrap");
+        assert!(
+            matches!(bootstrap_var, Some(Value::BindingRef { .. }) | None),
+            "sibling-only `bootstrap` must be either absent or a \
+             BindingRef, got: {bootstrap_var:?}"
+        );
+        let exports = mk_exports(&[("bootstrap", &["oidc_provider_arn"])]);
+        let errs = check_upstream_state_field_references(&parsed, &exports);
+        assert!(
+            errs.is_empty(),
+            "consumer-only sibling reference must not synthesize an \
+             empty-field error, got: {errs:?}"
+        );
     }
 
     #[test]

--- a/carina-core/src/validation/inference.rs
+++ b/carina-core/src/validation/inference.rs
@@ -310,6 +310,12 @@ fn infer_type_from_value_with_visiting(
             schemas,
             visiting,
         ),
+        // `BindingRef` is a bare-binding placeholder with no attribute
+        // and therefore no inferable position. Inference treats it as
+        // "type unknown until accessed" — same shape as `Unknown(_)`.
+        Value::BindingRef { .. } => Err(InferenceError::UnknownType {
+            reason: "bare binding reference has no attribute to infer".to_string(),
+        }),
         Value::FunctionCall { name, .. } => infer_function_call(name),
         Value::Unknown(_) => Err(InferenceError::UnknownType {
             reason: "value not yet known at plan time (unresolved upstream)".to_string(),

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -244,6 +244,15 @@ pub fn value_to_json_with_context(
             path: path.to_dot_string(),
             context: ctx,
         }),
+        Value::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
+            // A bare-binding reference is by construction never a
+            // resolved value — it must be substituted by the resolver
+            // pass before reaching any serialization boundary. Report
+            // through the same channel as `ResourceRef` so the same
+            // diagnostic path covers both producer kinds.
+            path: binding.clone(),
+            context: ctx,
+        }),
         Value::Interpolation(_) => {
             Err(SerializationError::UnresolvedInterpolation { context: ctx })
         }
@@ -459,6 +468,7 @@ pub(crate) fn format_value_into<S: FormatSink>(
             sink.write_str("}")
         }
         Value::ResourceRef { path } => sink.write_str(&path.to_dot_string()),
+        Value::BindingRef { binding } => sink.write_str(binding),
         Value::Interpolation(parts) => {
             sink.write_str("\"")?;
             for part in parts {

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -1029,20 +1029,30 @@ impl DiagnosticEngine {
 
         for attr_param in &parsed.attribute_params {
             if let Some(value) = &attr_param.value {
-                // Check for undefined binding references
-                if let Value::ResourceRef { path } = value
-                    && !defined_bindings.contains(path.binding())
+                // Check for undefined binding references — both shapes
+                // (`Value::ResourceRef` for `name.attr`, `Value::BindingRef`
+                // for bare `name`, since #2847).
+                let undefined_binding = match value {
+                    Value::ResourceRef { path } if !defined_bindings.contains(path.binding()) => {
+                        Some(path.binding().to_string())
+                    }
+                    Value::BindingRef { binding } if !defined_bindings.contains(binding) => {
+                        Some(binding.clone())
+                    }
+                    _ => None,
+                };
+                if let Some(undefined) = undefined_binding
                     && let Some((line, col)) =
                         self.find_attributes_value_position(doc, &attr_param.name)
                 {
                     diagnostics.push(carina_diagnostic(
                         line,
                         col,
-                        col + path.binding().len() as u32,
+                        col + undefined.len() as u32,
                         DiagnosticSeverity::ERROR,
                         format!(
                             "Undefined resource '{}' in attributes '{}'. Define it with 'let {} = ...'",
-                            path.binding(), attr_param.name, path.binding()
+                            undefined, attr_param.name, undefined
                         ),
                     ));
                 }
@@ -1212,6 +1222,11 @@ impl DiagnosticEngine {
                 )
             }
             (_, Value::ResourceRef { .. }) => None,
+            // Bare-binding ref (#2847): no attribute selector means we
+            // cannot localize the type at this checkpoint without a
+            // separate let/argument lookup. Skip rather than false-flag
+            // — same policy as the `ResourceRef` fallthrough above.
+            (_, Value::BindingRef { .. }) => None,
             // List: recurse into elements
             (TypeExpr::List(inner), Value::List(items)) => {
                 for (i, item) in items.iter().enumerate() {

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -607,9 +607,16 @@ impl DiagnosticEngine {
                                         .err()
                                         .map(|e| e.with_attribute(attr_name).to_string())
                                 }
-                                // Validate Union static values (non-ResourceRef)
+                                // Validate Union static values (non-ResourceRef, non-BindingRef).
+                                // Ref-shaped values are unresolved at this
+                                // checkpoint and must not be type-checked
+                                // against Union members here — see #2847
+                                // for the bare-binding (`BindingRef`) form.
                                 (carina_core::schema::AttributeType::Union(_), value)
-                                    if !matches!(value, Value::ResourceRef { .. }) =>
+                                    if !matches!(
+                                        value,
+                                        Value::ResourceRef { .. } | Value::BindingRef { .. }
+                                    ) =>
                                 {
                                     attr_schema
                                         .attr_type

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -88,6 +88,10 @@ pub fn core_to_wit_value(v: &CoreValue) -> Result<wit::Value, SerializationError
             path: path.to_dot_string(),
             context: SerializationContext::WasmBoundary,
         }),
+        CoreValue::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
+            path: binding.clone(),
+            context: SerializationContext::WasmBoundary,
+        }),
         CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {
             context: SerializationContext::WasmBoundary,
         }),
@@ -175,6 +179,10 @@ fn core_value_to_json(v: &CoreValue) -> Result<serde_json::Value, SerializationE
         }),
         CoreValue::ResourceRef { path } => Err(SerializationError::UnresolvedResourceRef {
             path: path.to_dot_string(),
+            context: SerializationContext::WasmBoundary,
+        }),
+        CoreValue::BindingRef { binding } => Err(SerializationError::UnresolvedResourceRef {
+            path: binding.clone(),
             context: SerializationContext::WasmBoundary,
         }),
         CoreValue::Interpolation(_) => Err(SerializationError::UnresolvedInterpolation {


### PR DESCRIPTION
## Summary

Replaces the bogus `upstream_state ``bootstrap`` does not export ````.` diagnostic with a type-level guarantee that the offending shape can no longer be constructed.

**Root cause**: the directory-aware Pass-2 parse (#2817) seeded sibling-defined names into `ctx.variables` as a `Value::ResourceRef { binding, attribute: "" }` placeholder. The empty-string `attribute` was a sentinel meaning "bare binding, no attribute selector"; `AccessPath`'s docstring already promised "binding + attribute is mandatory — enforced by the type system", but the runtime allowed it anyway. The placeholder leaked into `parsed.variables`, was walked by `check_upstream_state_field_references`, and the empty-string `attribute` produced the bogus diagnostic.

**Fix**: split the variant.

- New `Value::BindingRef { binding: String }` for bare-binding refs. No `attribute` slot — the type cannot impersonate an attribute reference.
- `Value::ResourceRef { path: AccessPath }` keeps `AccessPath` and the constructors now `assert!(!attribute.is_empty())` (hard `assert!`, not `debug_assert!` — release builds must catch a future regression).
- Three producer sites switched from `Value::resource_ref(name, "", vec![])` to `Value::BindingRef`:
  - `parse_with_seeded_bindings::seed_bindings` (#2817 sibling-name seed)
  - `register_argument_binding` (`arguments {}` block)
  - parser `variable_ref` rule no-fields fallback
- The Rust compiler's exhaustiveness checker drove the rest: every `match Value` got a `BindingRef` arm. Walkers update where behavior changes:
  - `module_resolver::expander::{substitute_arguments, rewrite_intra_module_refs}` substitute bare-binding refs.
  - `module.rs::collect_typed_dependencies` (both copies) records `BindingRef` as a dependency edge with empty `attribute` — preserves TUI `depends on: vpc (via vpc_id)` rendering.
  - `deps::collect_dependencies` recognizes both variants for topological sort.
  - `module_resolver::typecheck::enclosing_arg_type` matches `Value::BindingRef` directly. The pre-fix predicate (`ResourceRef + empty attribute + empty field_path + empty subscripts`) becomes a one-line variant match.
  - LSP undefined-binding diagnostic in `attribute_params` covers both variants. Type-validation `Union` arm guard skips `BindingRef` alongside `ResourceRef`.
  - WIT / state / JSON serialization boundaries reject `BindingRef` the same way they reject `ResourceRef` (unresolved → error).

The new `upstream_state_sibling_reference_no_empty_export_error` test asserts both the symptom (empty-field diagnostic gone) **and** the mechanism (sibling-only `bootstrap` is `BindingRef` or absent in `parsed.variables`, never `ResourceRef` with empty attribute). The whitebox check pins the type-level guarantee so a future regression in the variant choice fails loudly.

## Test plan

- [x] `cargo nextest run --workspace` — 3045 / 3045 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all OK
- [x] New regression test mirrors the real `infra/registry/dev/registry-deploy/` shape (multi-file `backend.crn` + `main.crn`).
- [ ] **User must run** `aws-vault exec mizzy -- carina plan` against `carina-rs/infra/registry/dev/registry-deploy/` to confirm the regression diagnostic is gone in the real-infra path. Per memory rule, real-infra AWS-touching commands are user-driven.

## Cross-repo

No coordinated provider PR needed. `carina-provider-aws` and `carina-provider-awscc` consume `Value` only through wildcard arms in `convert.rs`, so the new variant flows through unchanged.

## Follow-up

- #2876 — `stamp_unresolved_upstream` does not yet emit `Unknown(UpstreamRef)` for bare-binding upstream refs. Display-fidelity gap, not a correctness gap (serialization still rejects). Filed as follow-up rather than expanding this PR.

Closes #2847
