### PR TITLE
core: stamp bare upstream binding refs as Unknown for plan display

### DIFF
--- a/carina-core/src/identifier/mod.rs
+++ b/carina-core/src/identifier/mod.rs
@@ -209,6 +209,9 @@ fn deterministic_value_string(value: &Value) -> String {
                 UnknownReason::UpstreamRef { path } => {
                     format!("Unknown(UpstreamRef({}))", path.to_dot_string())
                 }
+                UnknownReason::UpstreamBareRef { binding } => {
+                    format!("Unknown(UpstreamBareRef({}))", binding)
+                }
                 UnknownReason::ForKey => "Unknown(ForKey)".to_string(),
                 UnknownReason::ForIndex => "Unknown(ForIndex)".to_string(),
                 UnknownReason::ForValue => "Unknown(ForValue)".to_string(),

--- a/carina-core/src/resolver.rs
+++ b/carina-core/src/resolver.rs
@@ -115,6 +115,9 @@ fn stamp_unresolved_upstream(
         Value::ResourceRef { path } if upstream_binding_names.contains(path.binding()) => {
             Value::Unknown(crate::resource::UnknownReason::UpstreamRef { path })
         }
+        Value::BindingRef { binding } if upstream_binding_names.contains(binding.as_str()) => {
+            Value::Unknown(crate::resource::UnknownReason::UpstreamBareRef { binding })
+        }
         Value::List(items) => Value::List(
             items
                 .into_iter()
@@ -1575,6 +1578,85 @@ mod tests {
             resources[0].get_attr("vpc_id"),
             Some(Value::ResourceRef { .. })
         ));
+    }
+
+    /// Bare-binding refs into an upstream_state binding must also be
+    /// stamped — `let v = bootstrap` (no `.attr`) parses as
+    /// `Value::BindingRef { binding: "bootstrap" }` since #2856.
+    /// Without a dedicated arm in `stamp_unresolved_upstream`, the
+    /// `BindingRef` would slip past the marker and surface in plan
+    /// display as a plain identifier instead of the
+    /// `(known after upstream apply: bootstrap)` form. #2876.
+    #[test]
+    fn test_resolve_refs_for_plan_stamps_bare_upstream_binding_ref() {
+        use crate::resource::UnknownReason;
+        let mut resources = vec![make_resource(
+            "consumer",
+            None,
+            vec![(
+                "raw",
+                Value::BindingRef {
+                    binding: "bootstrap".to_string(),
+                },
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("bootstrap".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        match resources[0].get_attr("raw") {
+            Some(Value::Unknown(UnknownReason::UpstreamBareRef { binding })) => {
+                assert_eq!(binding, "bootstrap");
+            }
+            other => panic!("expected Value::Unknown(UpstreamBareRef), got {:?}", other),
+        }
+    }
+
+    /// Bare upstream refs nested inside a `List` must reach the
+    /// stamping arm via the existing recursion. Locks in the recursive
+    /// contract symmetrically with the `UpstreamRef`-inside-list test
+    /// above. #2876.
+    #[test]
+    fn test_resolve_refs_for_plan_stamps_bare_upstream_inside_list() {
+        use crate::resource::UnknownReason;
+        let mut resources = vec![make_resource(
+            "consumer",
+            None,
+            vec![(
+                "raws",
+                Value::List(vec![
+                    Value::BindingRef {
+                        binding: "bootstrap".to_string(),
+                    },
+                    Value::BindingRef {
+                        binding: "secondary".to_string(),
+                    },
+                ]),
+            )],
+        )];
+        let mut remote_bindings: HashMap<String, HashMap<String, Value>> = HashMap::new();
+        remote_bindings.insert("bootstrap".to_string(), HashMap::new());
+        remote_bindings.insert("secondary".to_string(), HashMap::new());
+
+        resolve_refs_for_plan(&mut resources, &HashMap::new(), &remote_bindings).unwrap();
+
+        match resources[0].get_attr("raws") {
+            Some(Value::List(items)) => {
+                assert_eq!(items.len(), 2);
+                let bindings: Vec<&str> = items
+                    .iter()
+                    .map(|v| match v {
+                        Value::Unknown(UnknownReason::UpstreamBareRef { binding }) => {
+                            binding.as_str()
+                        }
+                        other => panic!("expected UpstreamBareRef, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(bindings, vec!["bootstrap", "secondary"]);
+            }
+            other => panic!("expected List, got {:?}", other),
+        }
     }
 
     /// Refs to non-upstream bindings must not be marked, so existing

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -475,6 +475,16 @@ pub enum UnknownReason {
     /// Holds the original `AccessPath` so display retains subscripts and
     /// chained field access (`network.accounts[0]`, `vpc.tags["Name"]`).
     UpstreamRef { path: AccessPath },
+    /// Plan-time reference into an `upstream_state` binding written
+    /// without an attribute selector — `let v = bootstrap` (since the
+    /// type-split in #2856 lowers a bare identifier to
+    /// `Value::BindingRef`). Renders as
+    /// `(known after upstream apply: <binding>)`. Parallel to
+    /// `UpstreamRef`; kept as a distinct variant so the type system
+    /// carries the "no attribute" condition rather than a runtime
+    /// `path.attribute().is_empty()` check inside `UpstreamRef`. See
+    /// #2876.
+    UpstreamBareRef { binding: String },
     /// Map-binding key in a deferred for-expression
     /// (`for (k, _) in iterable`). Substituted with the actual key when
     /// the iterable is later resolved.
@@ -876,6 +886,7 @@ impl Value {
                     // the `ResourceRef` arm above) — no per-call String
                     // allocation.
                     UnknownReason::UpstreamRef { path } => path.hash(hasher),
+                    UnknownReason::UpstreamBareRef { binding } => binding.hash(hasher),
                     // `For{Key,Index,Value}` and `EmptyInterpolation`
                     // carry no payload; the discriminant alone already
                     // distinguishes them.

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -107,6 +107,9 @@ impl std::fmt::Display for UnknownReason {
             UnknownReason::UpstreamRef { path } => {
                 write!(f, "upstream value {}", path.to_dot_string())
             }
+            UnknownReason::UpstreamBareRef { binding } => {
+                write!(f, "upstream value {}", binding)
+            }
             UnknownReason::ForKey => write!(f, "deferred for-binding key"),
             UnknownReason::ForIndex => write!(f, "deferred for-binding index"),
             UnknownReason::ForValue => write!(f, "deferred for-binding value"),
@@ -120,6 +123,9 @@ pub fn render_unknown(reason: &UnknownReason) -> String {
     match reason {
         UnknownReason::UpstreamRef { path } => {
             format!("(known after upstream apply: {})", path.to_dot_string())
+        }
+        UnknownReason::UpstreamBareRef { binding } => {
+            format!("(known after upstream apply: {})", binding)
         }
         UnknownReason::ForKey => "(known after upstream apply: key)".to_string(),
         UnknownReason::ForIndex => "(known after upstream apply: index)".to_string(),


### PR DESCRIPTION
## Summary

After #2856 split `Value::ResourceRef` into `ResourceRef + BindingRef`, `stamp_unresolved_upstream` in `carina-core/src/resolver.rs` only stamped `ResourceRef`. Bare upstream references — `let v = bootstrap` against `let bootstrap = upstream_state {...}` — bypassed the plan-time stamping pass. Plan display rendered the bare identifier instead of the `(known after upstream apply: …)` marker. Serialization boundaries already rejected the value via `UnresolvedResourceRef`, so apply-time safety was intact — this was a display-fidelity gap, not a correctness gap.

Adds a parallel `UnknownReason::UpstreamBareRef { binding: String }` variant and stamps `Value::BindingRef` whose binding name is in the upstream set.

## Design rationale (Option A over B)

Issue body listed two options. I picked A:

- **A (chosen)**: new `UnknownReason::UpstreamBareRef { binding }` variant parallel to `UpstreamRef { path }`.
- **B**: extend `UpstreamRef.path` to an inner `enum { Path(AccessPath) | Bare(String) }`.

Reasons:

- `UnknownReason` already follows "one variant per reason; payload carries exactly what that reason needs". `UpstreamRef` holds `AccessPath`; the bare form holds only a `String`. Splitting keeps the type system, not a runtime `path.attribute().is_empty()` predicate, in charge of the distinction.
- Stub measurement: A produces **5 non-exhaustive-match sites**, all under `match reason { … }`. B produces **~118 callsite breaks** because every `{ path }` destructure becomes `{ target: Path(p) | Bare(s) }`. The distinction has to live somewhere; the type-system-outside form costs less and keeps each callsite explicit.
- Future bare-only display logic (LSP hover, code action text, detail-row rendering) lands as one match arm rather than a nested inner enum dispatch.

## Wires

- `stamp_unresolved_upstream`: new `Value::BindingRef` arm emits `Unknown(UpstreamBareRef { binding })` when the binding is in the upstream set.
- Four exhaustive-match sites covered: `Display for UnknownReason`, `render_unknown`, `deterministic_value_string`, `hash_into`.
- Sibling variant-specific destructures (`backend_lock.rs`, `wasm_convert.rs`, `state_writeback.rs`, `plan.rs`) are intentionally `UpstreamRef`-only patterns and remain unchanged — non-exhaustive by design.

## Test plan

- [x] `cargo nextest run --workspace` — 3046 / 3046 pass
- [x] `cargo test --workspace --doc` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bash scripts/check-*.sh` — all OK
- [x] New regression tests: direct case (`BindingRef` at attribute root) and nested case (`List([BindingRef, BindingRef])`) — both stamp to `Unknown(UpstreamBareRef { … })`.
- [ ] Bare upstream refs are unusual (the user almost always writes `bootstrap.attr`); no `carina-rs/infra/` path exercises this. Real-infra smoke deliberately skipped.

Refs #2856 (the bug emerged because that PR introduced the `BindingRef` variant)
Closes #2876
