### PR TITLE
plan: render added/removed list-of-maps elements as multi-line blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ plan-map-diff:
 	$(PLAN_FIXTURE) map_key_diff
 plan-nested-map-diff:
 	$(PLAN_FIXTURE) nested_map_diff
+plan-list-diff-added-struct:
+	$(PLAN_FIXTURE) list_diff_added_struct
+plan-list-diff-removed-struct:
+	$(PLAN_FIXTURE) list_diff_removed_struct
 plan-enum-display:
 	$(PLAN_FIXTURE) enum_display
 plan-no-changes-enum:
@@ -73,6 +77,10 @@ plan-fixtures:
 	@echo ""
 	@echo "=== nested_map_diff ==="
 	@$(MAKE) plan-nested-map-diff
+	@echo "---"
+	@$(MAKE) plan-list-diff-added-struct
+	@echo "---"
+	@$(MAKE) plan-list-diff-removed-struct
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display
@@ -174,7 +182,8 @@ plan-provider-prefix:
 plan-module-anonymous-resource:
 	$(PLAN_FIXTURE) module_anonymous_resource
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
-        plan-map-diff plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
+        plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
+        plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \
         plan-upstream-state plan-upstream-state-unresolved plan-upstream-state-empty-exports \

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -4,7 +4,8 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use carina_core::detail_rows::{
-    DetailRow, ListOfMapsDiffField, ListOfMapsDiffModified, MapDiffEntryIR, build_detail_rows,
+    DetailRow, ListOfMapsDiffField, ListOfMapsDiffItem, ListOfMapsDiffItemKind,
+    ListOfMapsDiffModified, MapDiffEntryIR, build_detail_rows,
 };
 #[cfg(test)]
 use carina_core::diff_helpers::compute_map_diff;
@@ -1329,8 +1330,8 @@ fn render_list_of_maps_diff(
     out: &mut String,
     unchanged: &[String],
     modified: &[ListOfMapsDiffModified],
-    added: &[String],
-    removed: &[String],
+    added: &[ListOfMapsDiffItem],
+    removed: &[ListOfMapsDiffItem],
     attr_prefix: &str,
 ) {
     for item in unchanged {
@@ -1381,18 +1382,61 @@ fn render_list_of_maps_diff(
         }
     }
     for item in added {
-        writeln!(out, "{}  {} {}", attr_prefix, "+".green().bold(), item).unwrap();
+        render_added_removed_block(out, item, attr_prefix, ListOfMapsDiffItemKind::Added);
     }
     for item in removed {
-        writeln!(
-            out,
-            "{}  {} {}",
-            attr_prefix,
-            "-".red().bold().strikethrough(),
-            item.red().strikethrough()
-        )
-        .unwrap();
+        render_added_removed_block(out, item, attr_prefix, ListOfMapsDiffItemKind::Removed);
     }
+}
+
+/// Render a wholly added or removed list-of-maps element as a multi-line
+/// block (#2877). Mirrors the modified-with-nested layout
+/// (`~ {\n  key: value\n  ...\n}`) so all three diff markers (`+`, `-`,
+/// `~`) share the same visual shape.
+///
+/// Each field's value is laid out via `format_value_pretty` so nested
+/// long lists / maps wrap to multiple indented lines instead of dumping
+/// inline. The pre-fix path stringified the whole element with
+/// `format_value` and emitted it on one line (`+ {action: [...], ...}`),
+/// which produced unreadable ~500-column lines for IAM policy statements.
+fn render_added_removed_block(
+    out: &mut String,
+    item: &ListOfMapsDiffItem,
+    attr_prefix: &str,
+    kind: ListOfMapsDiffItemKind,
+) {
+    let marker = match kind {
+        ListOfMapsDiffItemKind::Added => "+".green().bold().to_string(),
+        ListOfMapsDiffItemKind::Removed => "-".red().bold().strikethrough().to_string(),
+    };
+    writeln!(out, "{}  {} {{", attr_prefix, marker).unwrap();
+    // Fields render at `attr_prefix.cols + 6`: 2 leading spaces, "+ {" is 3
+    // chars, then 1 more for the inner `  ` padding before the key — same
+    // column the modified-with-nested branch above uses for its
+    // `Unchanged` arm at `{attr_prefix}      `.
+    let field_indent_cols = attr_prefix.chars().count() + 6;
+    let field_indent = " ".repeat(field_indent_cols);
+    let mut prev_needs_separator = false;
+    for (key, value) in &item.fields {
+        // Mirror `format_map_vertical` / `MapExpanded`: a multi-element
+        // list-of-maps child needs a blank line before the next sibling
+        // key so the boundary stays visible (#2555).
+        if prev_needs_separator {
+            writeln!(out).unwrap();
+        }
+        prev_needs_separator = carina_core::value::needs_trailing_separator(value);
+        let layout = carina_core::value::PrettyLayout {
+            parent_indent_cols: field_indent_cols,
+            key,
+        };
+        let pretty = format_value_pretty(value, layout);
+        let cv = match kind {
+            ListOfMapsDiffItemKind::Added => colored_value(&pretty, false),
+            ListOfMapsDiffItemKind::Removed => pretty.red().strikethrough().to_string(),
+        };
+        writeln!(out, "{}{}: {}", field_indent, key, cv).unwrap();
+    }
+    writeln!(out, "{}    }}", attr_prefix).unwrap();
 }
 
 /// Render modified fields from structured IR into colored output.

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -911,6 +911,52 @@ fn snapshot_nested_map_diff() {
     insta::assert_snapshot!(output);
 }
 
+// #2877 acceptance: a struct element added to a list-of-maps attribute
+// must render with one field per line (multi-line `+ { ... }` block),
+// not as an inline single-line dump. The pre-fix path collapsed the
+// added element to a `+ {action: [...], effect: "...", ...}` line that
+// blew past 500 columns for IAM policy statements.
+#[test]
+fn snapshot_list_diff_added_struct() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_added_struct");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "added struct element should not render as a single very wide line; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
+// Mirror of the added-struct test for the removed path.
+#[test]
+fn snapshot_list_diff_removed_struct() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_removed_struct");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "removed struct element should not render as a single very wide line; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_deferred_for() {
     let fp = build_plan_from_fixture_name("deferred_for");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_added_struct.snap
@@ -1,0 +1,26 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+          {action: "s3:GetObject", effect: "Allow", resource: "arn:aws:s3:::example/*", sid: "AllowS3Read"}
+        + {
+            action: [
+              "cloudformation:CancelResourceRequest",
+              "cloudformation:CreateResource",
+              "cloudformation:DeleteResource",
+              "cloudformation:GetResource",
+              "cloudformation:GetResourceRequestStatus",
+              "cloudformation:ListResources",
+              "cloudformation:UpdateResource",
+            ]
+            effect: "Allow"
+            resource: ["*"]
+            sid: "CloudControl"
+          }
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_removed_struct.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_removed_struct.snap
@@ -1,0 +1,26 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+          {action: "s3:GetObject", effect: "Allow", resource: "arn:aws:s3:::example/*", sid: "AllowS3Read"}
+        - {
+            action: [
+              "cloudformation:CancelResourceRequest",
+              "cloudformation:CreateResource",
+              "cloudformation:DeleteResource",
+              "cloudformation:GetResource",
+              "cloudformation:GetResourceRequestStatus",
+              "cloudformation:ListResources",
+              "cloudformation:UpdateResource",
+            ]
+            effect: "Allow"
+            resource: ["*"]
+            sid: "CloudControl"
+          }
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
@@ -1,0 +1,33 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-added-struct",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/main.crn
@@ -1,0 +1,40 @@
+# Update plan that adds a struct element to a list-of-maps attribute
+# (issue #2877). The first statement is unchanged from state; the second
+# is a freshly added struct that contains a long list of strings — the
+# kind of element that previously rendered collapsed onto a single very
+# wide line.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid      = 'AllowS3Read'
+      effect   = 'Allow'
+      action   = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+    {
+      sid    = 'CloudControl'
+      effect = 'Allow'
+      action = [
+        'cloudformation:CancelResourceRequest',
+        'cloudformation:CreateResource',
+        'cloudformation:DeleteResource',
+        'cloudformation:GetResource',
+        'cloudformation:GetResourceRequestStatus',
+        'cloudformation:ListResources',
+        'cloudformation:UpdateResource',
+      ]
+      resource = ['*']
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
@@ -1,0 +1,47 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-removed-struct",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*"
+          },
+          {
+            "sid": "CloudControl",
+            "effect": "Allow",
+            "action": [
+              "cloudformation:CancelResourceRequest",
+              "cloudformation:CreateResource",
+              "cloudformation:DeleteResource",
+              "cloudformation:GetResource",
+              "cloudformation:GetResourceRequestStatus",
+              "cloudformation:ListResources",
+              "cloudformation:UpdateResource"
+            ],
+            "resource": ["*"]
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/main.crn
@@ -1,0 +1,24 @@
+# Update plan that removes a struct element from a list-of-maps attribute
+# (issue #2877). State has two statements; only one survives in main.crn,
+# so the other is rendered as a removed `- { ... }` block.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid      = 'AllowS3Read'
+      effect   = 'Allow'
+      action   = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -64,8 +64,8 @@ pub enum DetailRow {
         key: String,
         unchanged: Vec<String>,
         modified: Vec<ListOfMapsDiffModified>,
-        added: Vec<String>,
-        removed: Vec<String>,
+        added: Vec<ListOfMapsDiffItem>,
+        removed: Vec<ListOfMapsDiffItem>,
     },
     /// An attribute that was removed (for Update effects)
     Removed { key: String, old: String },
@@ -92,8 +92,8 @@ pub enum DetailRow {
         key: String,
         unchanged: Vec<String>,
         modified: Vec<ListOfMapsDiffModified>,
-        added: Vec<String>,
-        removed: Vec<String>,
+        added: Vec<ListOfMapsDiffItem>,
+        removed: Vec<ListOfMapsDiffItem>,
     },
     /// A map diff that forces replacement
     ReplaceMapDiff {
@@ -157,9 +157,32 @@ pub enum MapDiffEntryIR {
     NestedListOfMapsDiff {
         key: String,
         modified: Vec<ListOfMapsDiffModified>,
-        added: Vec<String>,
-        removed: Vec<String>,
+        added: Vec<ListOfMapsDiffItem>,
+        removed: Vec<ListOfMapsDiffItem>,
     },
+}
+
+/// A wholly added or removed item in a list-of-maps diff (#2877).
+///
+/// Fields carry the raw `Value` rather than a pre-stringified form so the
+/// renderer can supply the actual indent column when calling
+/// `format_value_pretty`. Pre-stringifying at build time would force
+/// nested complex values (long string lists, nested maps) onto a single
+/// line because a `String` carries no indentation context — that was
+/// exactly the bug fixed in #2877.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ListOfMapsDiffItem {
+    /// Map fields in the order they should be rendered (alphabetical).
+    pub fields: Vec<(String, Value)>,
+}
+
+/// Whether a `ListOfMapsDiffItem` is a wholly-added or wholly-removed
+/// element. Lives in `carina-core` so both the CLI and TUI renderers can
+/// share the discriminant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListOfMapsDiffItemKind {
+    Added,
+    Removed,
 }
 
 /// A modified item in a list-of-maps diff
@@ -737,8 +760,8 @@ fn compute_list_of_maps_diff_parts(
 ) -> (
     Vec<String>,
     Vec<ListOfMapsDiffModified>,
-    Vec<String>,
-    Vec<String>,
+    Vec<ListOfMapsDiffItem>,
+    Vec<ListOfMapsDiffItem>,
 ) {
     let new_items = match new_value {
         Value::List(items) => items,
@@ -876,33 +899,33 @@ fn compute_list_of_maps_diff_parts(
         }
     }
 
-    let mut added = Vec::new();
-    for &ni in &added_indices {
-        if let Value::Map(map) = &new_items[ni] {
-            let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            added.push(format!("{{{}}}", fields.join(", ")));
-        }
-    }
-
-    let mut removed = Vec::new();
-    for &oi in &removed_indices {
-        if let Value::Map(map) = &old_items[oi] {
-            let mut keys: Vec<_> = map.keys().collect();
-            keys.sort();
-            let fields: Vec<String> = keys
-                .iter()
-                .map(|k| format!("{}: {}", k, format_value(&map[*k])))
-                .collect();
-            removed.push(format!("{{{}}}", fields.join(", ")));
-        }
-    }
+    let added = collect_added_removed_items(&added_indices, new_items);
+    let removed = collect_added_removed_items(&removed_indices, old_items);
 
     (unchanged, modified, added, removed)
+}
+
+/// Build alphabetically-sorted `ListOfMapsDiffItem`s from a list of map
+/// indices into `items`. Non-map entries at the listed indices are silently
+/// skipped — only `Value::Map` items contribute fields. This is what the
+/// renderer consumes for the added/removed slots of a list-of-maps diff.
+fn collect_added_removed_items(indices: &[usize], items: &[Value]) -> Vec<ListOfMapsDiffItem> {
+    indices
+        .iter()
+        .filter_map(|&i| {
+            if let Value::Map(map) = &items[i] {
+                let mut entries: Vec<(&String, &Value)> = map.iter().collect();
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+                let fields = entries
+                    .into_iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                Some(ListOfMapsDiffItem { fields })
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Check if both old and new values are `Value::Map`.

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -1,6 +1,10 @@
 //! Map and list-of-maps diff rendering.
 
-use carina_core::detail_rows::{ListOfMapsDiffField, ListOfMapsDiffModified, MapDiffEntryIR};
+use carina_core::detail_rows::{
+    ListOfMapsDiffField, ListOfMapsDiffItem, ListOfMapsDiffItemKind, ListOfMapsDiffModified,
+    MapDiffEntryIR,
+};
+use carina_core::value::{PrettyLayout, format_value_pretty, needs_trailing_separator};
 use ratatui::prelude::*;
 
 /// Render map diff entries into TUI lines.
@@ -98,8 +102,8 @@ pub(super) fn render_list_of_maps_diff(
     key: &str,
     unchanged: &[String],
     modified: &[ListOfMapsDiffModified],
-    added: &[String],
-    removed: &[String],
+    added: &[ListOfMapsDiffItem],
+    removed: &[ListOfMapsDiffItem],
     is_selected: bool,
 ) {
     let mut first_line = Line::from(Span::raw(format!("  {}: [", key)));
@@ -152,18 +156,67 @@ pub(super) fn render_list_of_maps_diff(
         lines.push(Line::from(spans));
     }
     for item in added {
-        lines.push(Line::from(Span::styled(
-            format!("    {}", item),
-            Style::default().fg(Color::Green),
-        )));
+        push_added_removed_block(lines, item, ListOfMapsDiffItemKind::Added);
     }
     for item in removed {
-        lines.push(Line::from(Span::styled(
-            format!("    {}", item),
-            Style::default()
-                .fg(Color::Red)
-                .add_modifier(Modifier::CROSSED_OUT),
-        )));
+        push_added_removed_block(lines, item, ListOfMapsDiffItemKind::Removed);
     }
     lines.push(Line::from(Span::raw("  ]")));
+}
+
+/// Render a wholly added or removed list-of-maps element as a multi-line
+/// `+ {` / `- {` block (#2877). Mirrors the CLI display in
+/// `carina-cli/src/display/mod.rs::render_added_removed_block`. Each
+/// field's value goes through `format_value_pretty` so nested long lists
+/// or maps wrap to multiple indented lines instead of dumping inline.
+fn push_added_removed_block(
+    lines: &mut Vec<Line>,
+    item: &ListOfMapsDiffItem,
+    kind: ListOfMapsDiffItemKind,
+) {
+    let (marker, color, modifier) = match kind {
+        ListOfMapsDiffItemKind::Added => ("+", Color::Green, Modifier::empty()),
+        ListOfMapsDiffItemKind::Removed => ("-", Color::Red, Modifier::CROSSED_OUT),
+    };
+    let style = Style::default().fg(color).add_modifier(modifier);
+
+    lines.push(Line::from(vec![
+        Span::raw("    "),
+        Span::styled(format!("{} {{", marker), style),
+    ]));
+
+    // Constant indent — nesting (e.g. `NestedListOfMapsDiff`) is handled by
+    // the outer wrapper that prepends `"    "` to every line, shifting first-
+    // line key and continuation indent together. So we don't need to thread a
+    // dynamic prefix through here the way the CLI side does.
+    let field_indent_cols = 6;
+    let field_indent = " ".repeat(field_indent_cols);
+    let mut prev_needs_separator = false;
+    for (key, value) in &item.fields {
+        // Mirror `format_map_vertical`: insert a blank line before the
+        // next sibling key when the previous value was a multi-element
+        // list-of-maps so the boundary stays visible (#2555).
+        if prev_needs_separator {
+            lines.push(Line::from(Span::raw("")));
+        }
+        prev_needs_separator = needs_trailing_separator(value);
+        let layout = PrettyLayout {
+            parent_indent_cols: field_indent_cols,
+            key,
+        };
+        let pretty = format_value_pretty(value, layout);
+        for (i, vline) in pretty.split('\n').enumerate() {
+            let line = if i == 0 {
+                format!("{}{}: {}", field_indent, key, vline)
+            } else {
+                vline.to_string()
+            };
+            lines.push(Line::from(Span::styled(line, style)));
+        }
+    }
+
+    lines.push(Line::from(vec![
+        Span::raw("    "),
+        Span::styled("}".to_string(), style),
+    ]));
 }


### PR DESCRIPTION
## Summary

- Fix `carina plan` collapsing each added/removed struct element inside a list-of-maps diff to a single ~550-column line (closes #2877).
- Render those elements as multi-line `+ { ... }` / `- { ... }` blocks, mirroring the existing modified-with-nested `~ { ... }` layout so all three diff markers share the same visual shape.
- Carry the raw `Value` in the IR for added/removed items rather than a pre-stringified form so the renderer can supply the actual indent column when calling `format_value_pretty` — pre-stringifying at IR build time was the root cause: a `String` carries no indentation context, so nested long lists / maps got dumped inline.

### Before / after

Before (one ~500-column line):

`````
~ awscc.iam.RolePolicy rd.awscc_iam_role_policy_02942703
    policy_document:
        statement:
          + {action: ["cloudformation:CreateResource", "cloudformation:GetResource", "cloudformation:UpdateResource", "cloudformation:DeleteResource", "cloudformation:ListResources", "cloudformation:GetResourceRequestStatus", "cloudformation:CancelResourceRequest"], effect: "Allow", resource: ["*"], sid: "CloudControl"}
`````

After:

`````
~ awscc.iam.RolePolicy policy
    statement:
        {action: "s3:GetObject", effect: "Allow", resource: "arn:aws:s3:::example/*", sid: "AllowS3Read"}
      + {
          action: [
            "cloudformation:CancelResourceRequest",
            "cloudformation:CreateResource",
            "cloudformation:DeleteResource",
            "cloudformation:GetResource",
            "cloudformation:GetResourceRequestStatus",
            "cloudformation:ListResources",
            "cloudformation:UpdateResource",
          ]
          effect: "Allow"
          resource: ["*"]
          sid: "CloudControl"
        }
`````

(Field order is alphabetical, matching the existing modified / unchanged paths.)

## Implementation notes

- `DetailRow::ListOfMapsDiff` and `ReplaceListOfMapsDiff` `added`/`removed` field types changed from `Vec<String>` to `Vec<ListOfMapsDiffItem>`. `MapDiffEntryIR::NestedListOfMapsDiff` got the same treatment.
- New `ListOfMapsDiffItem { fields: Vec<(String, Value)> }` and `ListOfMapsDiffItemKind { Added, Removed }` live in `carina-core::detail_rows` so both CLI and TUI renderers share them.
- CLI: new `render_added_removed_block` in `carina-cli/src/display/mod.rs` mirrors the modified-with-nested branch layout.
- TUI: new `push_added_removed_block` in `carina-tui/src/ui/diff.rs` mirrors the CLI structure.
- Both renderers consult `needs_trailing_separator` for the multi-element list-of-maps blank-line rule (#2555).
- `ReplaceListOfMapsDiff` (forces-replacement variant) flows through the same renderer, so it picks up the new layout for free.

## Follow-ups (out of scope, will file separately)

The same "value pre-stringified at IR build time → collapses inline" pattern exists in three other places, but each is a distinct surface and the issue only asked for the added/removed list-element case:

- `MapDiffEntryIR::Added`/`Removed` carry `value: String`, so a wholly-added map key whose value is a `Value::Map` or list-of-maps still collapses inline.
- `ListOfMapsDiffField::Unchanged`/`Changed` carry pre-stringified values, so a long list/struct inside a *modified* list element still renders inline.
- `ListOfMapsDiff.unchanged: Vec<String>` is also pre-stringified — unchanged peer elements alongside added/removed ones still render single-line.

## Test plan

- [x] `cargo nextest run --workspace` (3047 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh` (all five gates green)
- [x] New snapshot tests `snapshot_list_diff_added_struct` / `snapshot_list_diff_removed_struct` cover both code paths and assert no line exceeds 200 columns (regression guard).
- [x] New fixtures wired into `Makefile` (`plan-list-diff-added-struct`, `plan-list-diff-removed-struct`) so `scripts/check-plan-fixtures.sh` is satisfied.

Closes #2877.