### PR TITLE
cli: emit per-effect apply progress in non-TTY (CI) sessions

### DIFF
--- a/carina-cli/src/commands/shared/observer.rs
+++ b/carina-cli/src/commands/shared/observer.rs
@@ -1,4 +1,14 @@
 //! CLI observer that prints colored progress output using `indicatif`.
+//!
+//! Two output modes:
+//!
+//! * **TTY mode** (default when stdout or stderr is a terminal): renders
+//!   per-effect spinners through `indicatif::MultiProgress`.
+//! * **Plain mode** (both stdout and stderr non-TTY, e.g. CI logs): emits
+//!   one line per event via `println!` / `eprintln!`. This is necessary
+//!   because `indicatif` suppresses all drawing on non-TTY targets, which
+//!   otherwise leaves CI logs blank between "Applying changes..." and
+//!   "Apply complete!" (#2883).
 
 use std::collections::HashMap;
 use std::io::IsTerminal;
@@ -15,173 +25,346 @@ use crate::display::format_effect;
 
 use super::progress::format_duration;
 
-/// CLI observer that prints colored progress output using `indicatif`.
-///
-/// Uses dynamic display: resources appear only when they start executing or
-/// complete. No upfront tree is shown. Spinners are created lazily on
-/// `EffectStarted` and finished on `EffectSucceeded`/`EffectFailed`.
+enum Backend {
+    Tty {
+        multi: MultiProgress,
+        bars: Mutex<HashMap<String, ProgressBar>>,
+    },
+    Plain,
+}
+
+/// CLI observer that prints colored progress output.
 pub(crate) struct CliObserver {
-    multi: MultiProgress,
-    /// Map from effect description to its ProgressBar, created lazily when
-    /// the effect starts executing. Guarded by a Mutex for concurrent access.
-    bars: Mutex<HashMap<String, ProgressBar>>,
+    backend: Backend,
 }
 
 impl CliObserver {
-    /// Create a new observer.
+    /// Create a new observer. Picks `Tty` mode when stdout or stderr is a
+    /// terminal, otherwise `Plain` mode (one line per event, no spinners).
     pub(crate) fn new(_plan: &Plan) -> Self {
-        let multi = MultiProgress::new();
-        if !std::io::stdout().is_terminal() {
-            multi.set_draw_target(indicatif::ProgressDrawTarget::stderr());
-        }
-
-        Self {
-            multi,
-            bars: Mutex::new(HashMap::new()),
-        }
+        let stdout_tty = std::io::stdout().is_terminal();
+        let stderr_tty = std::io::stderr().is_terminal();
+        let backend = if stdout_tty || stderr_tty {
+            let multi = MultiProgress::new();
+            if !stdout_tty {
+                multi.set_draw_target(indicatif::ProgressDrawTarget::stderr());
+            }
+            Backend::Tty {
+                multi,
+                bars: Mutex::new(HashMap::new()),
+            }
+        } else {
+            Backend::Plain
+        };
+        Self { backend }
     }
 }
 
 impl ExecutionObserver for CliObserver {
     fn on_event(&self, event: &ExecutionEvent) {
-        match event {
-            ExecutionEvent::Waiting { .. } => {
-                // Dynamic display: don't show waiting resources.
-                // They will appear when they start executing.
-            }
-            ExecutionEvent::EffectStarted { effect } => {
-                let key = format_effect(effect);
-                let pb = self.multi.add(ProgressBar::new_spinner());
-                pb.set_style(spinner_style());
-                pb.set_message(key.clone());
-                pb.enable_steady_tick(Duration::from_millis(80));
-                self.bars.lock().unwrap().insert(key, pb);
-            }
-            ExecutionEvent::EffectSucceeded {
-                effect,
-                duration,
-                progress,
-                ..
-            } => {
-                let key = format_effect(effect);
-                let timing = format!("[{}]", format_duration(*duration)).dimmed();
-                let counter = format_progress(progress).dimmed();
-                let msg = format!(
-                    "{} {} {} {}",
-                    "✓".green(),
-                    format_effect(effect),
-                    timing,
-                    counter
-                );
-                let mut bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.remove(&key) {
-                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg);
-                } else {
-                    eprintln!("  {msg}");
-                }
-            }
-            ExecutionEvent::EffectFailed {
-                effect,
-                error,
-                duration,
-                progress,
-            } => {
-                let key = format_effect(effect);
-                let timing = format!("[{}]", format_duration(*duration)).dimmed();
-                let counter = format_progress(progress).dimmed();
-                let msg = format!(
-                    "{} {} {} {}\n      {} {}",
-                    "✗".red(),
-                    format_effect(effect),
-                    timing,
-                    counter,
-                    "→".red(),
-                    error.red()
-                );
-                let mut bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.remove(&key) {
-                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg.clone());
-                }
-                // Always print errors to stderr so they're visible even when
-                // indicatif's MultiProgress swallows progress bar output.
+        match &self.backend {
+            Backend::Tty { multi, bars } => handle_tty(multi, bars, event),
+            Backend::Plain => handle_plain(event),
+        }
+    }
+}
+
+fn handle_tty(
+    multi: &MultiProgress,
+    bars: &Mutex<HashMap<String, ProgressBar>>,
+    event: &ExecutionEvent,
+) {
+    match event {
+        ExecutionEvent::Waiting { .. } => {
+            // Dynamic display: don't show waiting resources.
+            // They will appear when they start executing.
+        }
+        ExecutionEvent::EffectStarted { effect } => {
+            let key = format_effect(effect);
+            let pb = multi.add(ProgressBar::new_spinner());
+            pb.set_style(spinner_style());
+            pb.set_message(key.clone());
+            pb.enable_steady_tick(Duration::from_millis(80));
+            bars.lock().unwrap().insert(key, pb);
+        }
+        ExecutionEvent::EffectSucceeded {
+            effect,
+            duration,
+            progress,
+            ..
+        } => {
+            let key = format_effect(effect);
+            let timing = format!("[{}]", format_duration(*duration)).dimmed();
+            let counter = format_progress(progress).dimmed();
+            let msg = format!(
+                "{} {} {} {}",
+                "✓".green(),
+                format_effect(effect),
+                timing,
+                counter
+            );
+            let mut bars = bars.lock().unwrap();
+            if let Some(pb) = bars.remove(&key) {
+                pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                pb.finish_with_message(msg);
+            } else {
                 eprintln!("  {msg}");
             }
-            ExecutionEvent::EffectSkipped {
-                effect,
+        }
+        ExecutionEvent::EffectFailed {
+            effect,
+            error,
+            duration,
+            progress,
+        } => {
+            let key = format_effect(effect);
+            let timing = format!("[{}]", format_duration(*duration)).dimmed();
+            let counter = format_progress(progress).dimmed();
+            let msg = format!(
+                "{} {} {} {}\n      {} {}",
+                "✗".red(),
+                format_effect(effect),
+                timing,
+                counter,
+                "→".red(),
+                error.red()
+            );
+            let mut bars = bars.lock().unwrap();
+            if let Some(pb) = bars.remove(&key) {
+                pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                pb.finish_with_message(msg.clone());
+            }
+            // Always print errors to stderr so they're visible even when
+            // indicatif's MultiProgress swallows progress bar output.
+            eprintln!("  {msg}");
+        }
+        ExecutionEvent::EffectSkipped {
+            effect,
+            reason,
+            progress,
+        } => {
+            let key = format_effect(effect);
+            let counter = format_progress(progress).dimmed();
+            let msg = format!(
+                "{} {} - {} {}",
+                "⊘".yellow(),
+                format_effect(effect),
                 reason,
-                progress,
-            } => {
-                let key = format_effect(effect);
-                let counter = format_progress(progress).dimmed();
-                let msg = format!(
-                    "{} {} - {} {}",
-                    "⊘".yellow(),
-                    format_effect(effect),
-                    reason,
-                    counter
-                );
-                // Skipped effects may not have a spinner (they were never started).
-                let mut bars = self.bars.lock().unwrap();
-                if let Some(pb) = bars.remove(&key) {
-                    pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
-                    pb.finish_with_message(msg);
-                } else {
-                    eprintln!("  {}", msg);
-                }
-            }
-            ExecutionEvent::CascadeUpdateSucceeded { id } => {
-                self.multi
-                    .println(format!("  {} Update {} (cascade)", "✓".green(), id))
-                    .ok();
-            }
-            ExecutionEvent::CascadeUpdateFailed { id, error } => {
-                self.multi
-                    .println(format!("  {} Update {} (cascade)", "✗".red(), id))
-                    .ok();
-                self.multi
-                    .println(format!("      {} {}", "→".red(), error.red()))
-                    .ok();
-            }
-            ExecutionEvent::RenameSucceeded { id, from, to } => {
-                self.multi
-                    .println(format!(
-                        "  {} Rename {} \"{}\" → \"{}\"",
-                        "✓".green(),
-                        id,
-                        from,
-                        to
-                    ))
-                    .ok();
-            }
-            ExecutionEvent::RenameFailed { id, error } => {
-                self.multi
-                    .println(format!("  {} Rename {}", "✗".red(), id))
-                    .ok();
-                self.multi
-                    .println(format!("      {} {}", "→".red(), error.red()))
-                    .ok();
-            }
-            ExecutionEvent::RefreshStarted => {
-                self.multi.println("").ok();
-                self.multi
-                    .println(format!(
-                        "{}",
-                        "Refreshing uncertain resource states...".cyan()
-                    ))
-                    .ok();
-            }
-            ExecutionEvent::RefreshSucceeded { id } => {
-                self.multi
-                    .println(format!("  {} Refresh {}", "✓".green(), id))
-                    .ok();
-            }
-            ExecutionEvent::RefreshFailed { id, error } => {
-                self.multi
-                    .println(format!("  {} Refresh {} - {}", "!".yellow(), id, error))
-                    .ok();
+                counter
+            );
+            // Skipped effects may not have a spinner (they were never started).
+            let mut bars = bars.lock().unwrap();
+            if let Some(pb) = bars.remove(&key) {
+                pb.set_style(ProgressStyle::with_template("  {msg}").unwrap());
+                pb.finish_with_message(msg);
+            } else {
+                eprintln!("  {}", msg);
             }
         }
+        ExecutionEvent::CascadeUpdateSucceeded { id } => {
+            multi
+                .println(format!("  {} Update {} (cascade)", "✓".green(), id))
+                .ok();
+        }
+        ExecutionEvent::CascadeUpdateFailed { id, error } => {
+            multi
+                .println(format!("  {} Update {} (cascade)", "✗".red(), id))
+                .ok();
+            multi
+                .println(format!("      {} {}", "→".red(), error.red()))
+                .ok();
+        }
+        ExecutionEvent::RenameSucceeded { id, from, to } => {
+            multi
+                .println(format!(
+                    "  {} Rename {} \"{}\" → \"{}\"",
+                    "✓".green(),
+                    id,
+                    from,
+                    to
+                ))
+                .ok();
+        }
+        ExecutionEvent::RenameFailed { id, error } => {
+            multi.println(format!("  {} Rename {}", "✗".red(), id)).ok();
+            multi
+                .println(format!("      {} {}", "→".red(), error.red()))
+                .ok();
+        }
+        ExecutionEvent::RefreshStarted => {
+            multi.println("").ok();
+            multi
+                .println(format!(
+                    "{}",
+                    "Refreshing uncertain resource states...".cyan()
+                ))
+                .ok();
+        }
+        ExecutionEvent::RefreshSucceeded { id } => {
+            multi
+                .println(format!("  {} Refresh {}", "✓".green(), id))
+                .ok();
+        }
+        ExecutionEvent::RefreshFailed { id, error } => {
+            multi
+                .println(format!("  {} Refresh {} - {}", "!".yellow(), id, error))
+                .ok();
+        }
+    }
+}
+
+fn handle_plain(event: &ExecutionEvent) {
+    for line in format_plain(event) {
+        println!("{}", line);
+    }
+}
+
+/// Render an `ExecutionEvent` as zero or more plain-mode lines.
+///
+/// Pulled out so the non-TTY rendering can be unit-tested without driving
+/// stdout. `EffectStarted` / `Waiting` produce no lines in plain mode —
+/// they would otherwise duplicate the matching Succeeded / Failed entry.
+fn format_plain(event: &ExecutionEvent) -> Vec<String> {
+    match event {
+        ExecutionEvent::Waiting { .. } | ExecutionEvent::EffectStarted { .. } => Vec::new(),
+        ExecutionEvent::EffectSucceeded {
+            effect,
+            duration,
+            progress,
+            ..
+        } => {
+            let timing = format!("[{}]", format_duration(*duration));
+            let counter = format_progress(progress);
+            vec![format!(
+                "  ✓ {} {} {}",
+                format_effect(effect),
+                timing,
+                counter
+            )]
+        }
+        ExecutionEvent::EffectFailed {
+            effect,
+            error,
+            duration,
+            progress,
+        } => {
+            let timing = format!("[{}]", format_duration(*duration));
+            let counter = format_progress(progress);
+            vec![
+                format!("  ✗ {} {} {}", format_effect(effect), timing, counter),
+                format!("      → {}", error),
+            ]
+        }
+        ExecutionEvent::EffectSkipped {
+            effect,
+            reason,
+            progress,
+        } => {
+            let counter = format_progress(progress);
+            vec![format!(
+                "  ⊘ {} - {} {}",
+                format_effect(effect),
+                reason,
+                counter
+            )]
+        }
+        ExecutionEvent::CascadeUpdateSucceeded { id } => {
+            vec![format!("  ✓ Update {} (cascade)", id)]
+        }
+        ExecutionEvent::CascadeUpdateFailed { id, error } => vec![
+            format!("  ✗ Update {} (cascade)", id),
+            format!("      → {}", error),
+        ],
+        ExecutionEvent::RenameSucceeded { id, from, to } => {
+            vec![format!("  ✓ Rename {} \"{}\" → \"{}\"", id, from, to)]
+        }
+        ExecutionEvent::RenameFailed { id, error } => {
+            vec![format!("  ✗ Rename {}", id), format!("      → {}", error)]
+        }
+        ExecutionEvent::RefreshStarted => vec![
+            String::new(),
+            "Refreshing uncertain resource states...".to_string(),
+        ],
+        ExecutionEvent::RefreshSucceeded { id } => vec![format!("  ✓ Refresh {}", id)],
+        ExecutionEvent::RefreshFailed { id, error } => {
+            vec![format!("  ! Refresh {} - {}", id, error)]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_core::effect::Effect;
+    use carina_core::executor::ProgressInfo;
+    use carina_core::resource::Resource;
+
+    fn dummy_create_effect() -> Effect {
+        Effect::Create(Resource::new("aws.s3.Bucket", "demo"))
+    }
+
+    #[test]
+    fn plain_skips_started_and_waiting() {
+        let effect = dummy_create_effect();
+        assert!(format_plain(&ExecutionEvent::EffectStarted { effect: &effect }).is_empty());
+        assert!(
+            format_plain(&ExecutionEvent::Waiting {
+                effect: &effect,
+                pending_dependencies: vec!["x".into()],
+            })
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn plain_emits_one_line_per_succeeded() {
+        let effect = dummy_create_effect();
+        let lines = format_plain(&ExecutionEvent::EffectSucceeded {
+            effect: &effect,
+            state: None,
+            duration: Duration::from_millis(123),
+            progress: ProgressInfo {
+                completed: 1,
+                total: 3,
+            },
+        });
+        assert_eq!(lines.len(), 1);
+        let line = &lines[0];
+        assert!(line.contains("✓"), "missing check mark: {line}");
+        assert!(line.contains("Create"), "missing verb: {line}");
+        assert!(line.contains("demo"), "missing resource name: {line}");
+        assert!(line.contains("1/3"), "missing counter: {line}");
+    }
+
+    #[test]
+    fn plain_failed_includes_error_on_second_line() {
+        let effect = dummy_create_effect();
+        let lines = format_plain(&ExecutionEvent::EffectFailed {
+            effect: &effect,
+            error: "boom",
+            duration: Duration::from_millis(50),
+            progress: ProgressInfo {
+                completed: 2,
+                total: 3,
+            },
+        });
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("✗"));
+        assert!(lines[1].contains("boom"));
+    }
+
+    #[test]
+    fn plain_skipped_includes_reason() {
+        let effect = dummy_create_effect();
+        let lines = format_plain(&ExecutionEvent::EffectSkipped {
+            effect: &effect,
+            reason: "dependency 'x' failed",
+            progress: ProgressInfo {
+                completed: 3,
+                total: 3,
+            },
+        });
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("dependency 'x' failed"));
     }
 }


### PR DESCRIPTION
## Summary

- Closes #2883.
- `CliObserver` ran every per-effect line through `indicatif::MultiProgress`. `indicatif` suppresses drawing when its target is non-TTY, so in GitHub Actions the apply output went silent between `Applying changes...` and `Apply complete!` even though every effect succeeded.
- Split the observer into a `Tty` backend (unchanged) and a `Plain` backend that bypasses `indicatif` and `println!`s one line per event. Mode is picked once at construction from `stdout/stderr is_terminal()`.

## Test plan

- [x] `cargo nextest run -p carina-cli` (388 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] New unit tests in `carina-cli/src/commands/shared/observer.rs` cover `format_plain` for Started/Waiting (suppressed), Succeeded, Failed (two lines, error on second), and Skipped (with reason).

## Verifying behaviour change

The TTY path is byte-identical to before (same closures, same indicatif calls). The new `Plain` path is taken only when both stdout and stderr are non-TTY — i.e. CI logs and `carina apply ... 2>&1 | cat`. Real-infra apply was not run as part of this PR (no AWS-touching commands initiated locally per repo policy); reviewers can verify by running any apply with stdout+stderr piped and observing per-effect lines now appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
