### PR TITLE
plan: hide unchanged fields inside modified list-of-maps elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ plan-list-diff-added-struct:
 	$(PLAN_FIXTURE) list_diff_added_struct
 plan-list-diff-removed-struct:
 	$(PLAN_FIXTURE) list_diff_removed_struct
+plan-list-diff-modified-with-unchanged:
+	$(PLAN_FIXTURE) list_diff_modified_with_unchanged
+plan-list-diff-modified-with-unchanged-nested:
+	$(PLAN_FIXTURE) list_diff_modified_with_unchanged_nested
 plan-enum-display:
 	$(PLAN_FIXTURE) enum_display
 plan-no-changes-enum:
@@ -81,6 +85,10 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-added-struct
 	@echo "---"
 	@$(MAKE) plan-list-diff-removed-struct
+	@echo "---"
+	@$(MAKE) plan-list-diff-modified-with-unchanged
+	@echo "---"
+	@$(MAKE) plan-list-diff-modified-with-unchanged-nested
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display
@@ -183,6 +191,8 @@ plan-module-anonymous-resource:
 	$(PLAN_FIXTURE) module_anonymous_resource
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
+        plan-list-diff-modified-with-unchanged \
+        plan-list-diff-modified-with-unchanged-nested \
         plan-enum-display plan-destroy-full plan-destroy-orphans plan-read-only-attrs \
         plan-default-values plan-explicit plan-default-tags \
         plan-state-blocks plan-secret-values plan-moved-with-changes plan-moved-prev-keys plan-moved-pure \

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 
 use carina_core::detail_rows::{
     DetailRow, ListOfMapsDiffField, ListOfMapsDiffItem, ListOfMapsDiffItemKind,
-    ListOfMapsDiffModified, MapDiffEntryIR, build_detail_rows,
+    ListOfMapsDiffModified, MapDiffEntryIR, build_detail_rows, hidden_unchanged_summary,
 };
 #[cfg(test)]
 use carina_core::diff_helpers::compute_map_diff;
@@ -1159,16 +1159,11 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
             .unwrap();
         }
         DetailRow::HiddenUnchanged { count } => {
-            let noun = if *count == 1 {
-                "attribute"
-            } else {
-                "attributes"
-            };
             writeln!(
                 out,
                 "{}{}",
                 attr_prefix,
-                format!("# ({} unchanged {} hidden)", count, noun).dimmed()
+                hidden_unchanged_summary(*count, "attribute").dimmed()
             )
             .unwrap();
         }
@@ -1346,9 +1341,6 @@ fn render_list_of_maps_diff(
             writeln!(out, "{}  {} {{", attr_prefix, "~".yellow().bold()).unwrap();
             for field in &item.fields {
                 match field {
-                    ListOfMapsDiffField::Unchanged { key, value } => {
-                        writeln!(out, "{}      {}: {}", attr_prefix, key, value).unwrap();
-                    }
                     ListOfMapsDiffField::Changed { key, old, new } => {
                         writeln!(
                             out,
@@ -1368,15 +1360,44 @@ fn render_list_of_maps_diff(
                     }
                 }
             }
+            // #2881: surface the number of unchanged sibling fields
+            // (only set in Full mode by `compute_list_of_maps_diff_parts`).
+            // Mirrors the top-level `# (n unchanged attributes hidden)` row.
+            if item.hidden_unchanged_count > 0 {
+                writeln!(
+                    out,
+                    "{}      {}",
+                    attr_prefix,
+                    hidden_unchanged_summary(item.hidden_unchanged_count, "field").dimmed()
+                )
+                .unwrap();
+            }
             writeln!(out, "{}    }}", attr_prefix).unwrap();
         } else {
             let rendered_fields = render_modified_fields(&item.fields);
+            // Append the hidden-fields count after the changed field list
+            // so the summary stays inside the `~ { ... }` block. A paired
+            // modified item always has at least one changed field by
+            // construction (Phase 1 absorbs all-equal pairs as unchanged
+            // before pairing runs), so `rendered_fields` is never empty.
+            debug_assert!(
+                !rendered_fields.is_empty(),
+                "paired modified item must have at least one changed field"
+            );
+            let summary = if item.hidden_unchanged_count > 0 {
+                let s = hidden_unchanged_summary(item.hidden_unchanged_count, "field")
+                    .dimmed()
+                    .to_string();
+                format!("{}, {}", rendered_fields, s)
+            } else {
+                rendered_fields
+            };
             writeln!(
                 out,
                 "{}  {} {{{}}}",
                 attr_prefix,
                 "~".yellow().bold(),
-                rendered_fields
+                summary
             )
             .unwrap();
         }
@@ -1444,9 +1465,6 @@ fn render_modified_fields(fields: &[ListOfMapsDiffField]) -> String {
     let mut result_parts = Vec::new();
     for field in fields {
         match field {
-            ListOfMapsDiffField::Unchanged { key, value } => {
-                result_parts.push(format!("{}: {}", key, value));
-            }
             ListOfMapsDiffField::Changed { key, old, new } => {
                 result_parts.push(format!(
                     "{}: {} → {}",

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -936,6 +936,71 @@ fn snapshot_list_diff_added_struct() {
     insta::assert_snapshot!(output);
 }
 
+// #2881 acceptance: when a list-of-maps element is modified (paired with
+// an old element by similarity), unchanged fields inside the `~ { ... }`
+// block should be hidden behind a single `# (n unchanged fields hidden)`
+// summary in Full mode — mirroring the top-level
+// `# (n unchanged attributes hidden)` convention. Pre-fix every sibling
+// field rendered next to the changed one, including a long
+// `action: [...]` list that produced a wide one-line dump.
+#[test]
+fn snapshot_list_diff_modified_with_unchanged() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_modified_with_unchanged");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "modified list-element block should not render a wide unchanged-field line; got: {}",
+        output
+    );
+    assert!(
+        output.contains("unchanged field"),
+        "expected `# (n unchanged fields hidden)` summary in Full mode; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
+// #2881 follow-on: exercises the modified-with-nested branch where the
+// only changed field is a nested Map (`config`). Locks in the
+// `~ { ... }` block-style layout: nested map diff first, then
+// `# (n unchanged fields hidden)` summary inside the block, then the
+// closing `}` on its own line. This is the round-1-review edge case
+// where the inline-spans buffer gets flushed mid-iteration by the
+// `NestedMapChanged` arm.
+#[test]
+fn snapshot_list_diff_modified_with_unchanged_nested() {
+    let (plan, schemas, _moved) =
+        build_plan_from_fixture("list_diff_modified_with_unchanged_nested");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "modified list-element block should not render a wide unchanged-field line; got: {}",
+        output
+    );
+    assert!(
+        output.contains("unchanged field"),
+        "expected `# (n unchanged fields hidden)` summary in Full mode; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
 // Mirror of the added-struct test for the removed path.
 #[test]
 fn snapshot_list_diff_removed_struct() {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_with_unchanged.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_with_unchanged.snap
@@ -1,0 +1,12 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+        ~ {effect: "Allow" → "Deny", # (3 unchanged fields hidden)}
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_with_unchanged_nested.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_with_unchanged_nested.snap
@@ -1,0 +1,17 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+        ~ {
+            config:
+              ~ log_level: "info" → "debug"
+              ~ retention_days: "30" → "90"
+            # (4 unchanged fields hidden)
+          }
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
@@ -1,0 +1,40 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-modified-with-unchanged",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": [
+              "s3:GetObject",
+              "s3:GetObjectTagging",
+              "s3:GetObjectVersion",
+              "s3:GetObjectVersionTagging",
+              "s3:ListBucket",
+              "s3:ListBucketVersions"
+            ],
+            "resource": "arn:aws:s3:::example/*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/main.crn
@@ -1,0 +1,34 @@
+# Update plan that modifies *one* field of a list-of-maps element while
+# leaving its other fields unchanged (issue #2881). Pre-fix, every
+# unchanged sibling field rendered next to the changed one — including
+# a long `action` list that pre-stringified into one ~250-column line.
+# Post-fix, only the `~ effect:` line shows, plus a summary
+# `# (3 unchanged fields hidden)` row in Full mode.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid    = 'AllowS3Read'
+      effect = 'Deny'
+      action = [
+        's3:GetObject',
+        's3:GetObjectTagging',
+        's3:GetObjectVersion',
+        's3:GetObjectVersionTagging',
+        's3:ListBucket',
+        's3:ListBucketVersions',
+      ]
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
@@ -1,0 +1,37 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-modified-with-unchanged-nested",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*",
+            "config": {
+              "log_level": "info",
+              "retention_days": "30"
+            }
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/main.crn
@@ -1,0 +1,30 @@
+# Update plan that modifies a list-of-maps element where the changed
+# field is a nested Map (`config`) and several flat fields stay unchanged.
+# Exercises the modified-with-nested branch in the renderer (CLI block-
+# style `~ { ... }` with the closing brace on its own line, plus the
+# `# (n unchanged fields hidden)` summary attached to that block).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid    = 'AllowS3Read'
+      effect = 'Allow'
+      action = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+      config = {
+        log_level = 'debug'
+        retention_days = '90'
+      }
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -188,15 +188,21 @@ pub enum ListOfMapsDiffItemKind {
 /// A modified item in a list-of-maps diff
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListOfMapsDiffModified {
-    /// Ordered list of fields, each either unchanged or changed
+    /// Ordered list of fields. Only changed / nested-changed fields are
+    /// retained — unchanged fields are filtered out at IR build time
+    /// (#2881) and surfaced as a summary count in `hidden_unchanged_count`.
     pub fields: Vec<ListOfMapsDiffField>,
+    /// Number of unchanged fields filtered out of `fields`. Set to a
+    /// non-zero value only when the build is in `DetailLevel::Full`,
+    /// matching the top-level `# (n unchanged attributes hidden)`
+    /// convention. Zero in `Explicit` / `NamesOnly`. Renderers should
+    /// emit a `# (n unchanged fields hidden)` line when this is > 0.
+    pub hidden_unchanged_count: usize,
 }
 
 /// A single field in a modified list-of-maps item
 #[derive(Debug, Clone, PartialEq)]
 pub enum ListOfMapsDiffField {
-    /// Field value is unchanged
-    Unchanged { key: String, value: String },
     /// Field value changed
     Changed {
         key: String,
@@ -444,9 +450,11 @@ fn build_update_rows(
         }
 
         if is_list_of_maps(new_value) {
-            rows.push(build_list_of_maps_diff_row(key, old_value, new_value));
+            rows.push(build_list_of_maps_diff_row(
+                key, old_value, new_value, detail,
+            ));
         } else if is_both_maps(old_value, new_value) {
-            rows.push(build_map_diff_row(key, old_value, new_value));
+            rows.push(build_map_diff_row(key, old_value, new_value, detail));
         } else {
             let old_str = old_value
                 .map(|v| format_value_with_key(v, Some(key)))
@@ -530,7 +538,7 @@ fn build_replace_rows(
             });
         } else if is_list_of_maps(new_value) {
             let (unchanged, modified, added, removed) =
-                compute_list_of_maps_diff_parts(old_value, new_value);
+                compute_list_of_maps_diff_parts(old_value, new_value, detail);
             rows.push(DetailRow::ReplaceListOfMapsDiff {
                 key: key.to_string(),
                 unchanged,
@@ -539,7 +547,7 @@ fn build_replace_rows(
                 removed,
             });
         } else if is_both_maps(old_value, new_value) {
-            let entries = compute_map_diff_entries(old_value, new_value);
+            let entries = compute_map_diff_entries(old_value, new_value, detail);
             rows.push(DetailRow::ReplaceMapDiff {
                 key: key.to_string(),
                 entries,
@@ -660,15 +668,24 @@ fn build_delete_rows(
     rows
 }
 
-fn build_map_diff_row(key: &str, old_value: Option<&Value>, new_value: &Value) -> DetailRow {
-    let entries = compute_map_diff_entries(old_value, new_value);
+fn build_map_diff_row(
+    key: &str,
+    old_value: Option<&Value>,
+    new_value: &Value,
+    detail: DetailLevel,
+) -> DetailRow {
+    let entries = compute_map_diff_entries(old_value, new_value, detail);
     DetailRow::MapDiff {
         key: key.to_string(),
         entries,
     }
 }
 
-fn compute_map_diff_entries(old_value: Option<&Value>, new_value: &Value) -> Vec<MapDiffEntryIR> {
+fn compute_map_diff_entries(
+    old_value: Option<&Value>,
+    new_value: &Value,
+    detail: DetailLevel,
+) -> Vec<MapDiffEntryIR> {
     let new_map = match new_value {
         Value::Map(m) => m,
         _ => return Vec::new(),
@@ -697,7 +714,7 @@ fn compute_map_diff_entries(old_value: Option<&Value>, new_value: &Value) -> Vec
             crate::diff_helpers::MapDiffItem::Changed(e) => {
                 // If both old and new are maps, recursively diff
                 if matches!(&e.old_value, Value::Map(_)) && matches!(&e.new_value, Value::Map(_)) {
-                    let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value);
+                    let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value, detail);
                     entries.push(MapDiffEntryIR::NestedMapDiff {
                         key: e.key.clone(),
                         entries: nested,
@@ -705,7 +722,7 @@ fn compute_map_diff_entries(old_value: Option<&Value>, new_value: &Value) -> Vec
                 } else if is_list_of_maps(&e.new_value) {
                     // List-of-maps: compute per-item field-level diffs
                     let (_, modified, added, removed) =
-                        compute_list_of_maps_diff_parts(Some(&e.old_value), &e.new_value);
+                        compute_list_of_maps_diff_parts(Some(&e.old_value), &e.new_value, detail);
                     entries.push(MapDiffEntryIR::NestedListOfMapsDiff {
                         key: e.key.clone(),
                         modified,
@@ -742,9 +759,10 @@ fn build_list_of_maps_diff_row(
     key: &str,
     old_value: Option<&Value>,
     new_value: &Value,
+    detail: DetailLevel,
 ) -> DetailRow {
     let (unchanged, modified, added, removed) =
-        compute_list_of_maps_diff_parts(old_value, new_value);
+        compute_list_of_maps_diff_parts(old_value, new_value, detail);
     DetailRow::ListOfMapsDiff {
         key: key.to_string(),
         unchanged,
@@ -757,6 +775,7 @@ fn build_list_of_maps_diff_row(
 fn compute_list_of_maps_diff_parts(
     old_value: Option<&Value>,
     new_value: &Value,
+    detail: DetailLevel,
 ) -> (
     Vec<String>,
     Vec<ListOfMapsDiffModified>,
@@ -858,44 +877,49 @@ fn compute_list_of_maps_diff_parts(
         if let (Value::Map(old_map), Value::Map(new_map)) = (&old_items[oi], &new_items[ni]) {
             let mut keys: Vec<_> = new_map.keys().collect();
             keys.sort();
-            let fields: Vec<ListOfMapsDiffField> = keys
-                .iter()
-                .map(|k| {
-                    let new_v = format_value(&new_map[*k]);
-                    let field_same = old_map
-                        .get(*k)
-                        .map(|ov| ov.semantically_equal(&new_map[*k]))
-                        .unwrap_or(false);
-                    if !field_same {
-                        let old_val = old_map.get(*k);
-                        // If both old and new are maps, show recursive diff
-                        if matches!(old_val, Some(Value::Map(_)))
-                            && matches!(&new_map[*k], Value::Map(_))
-                        {
-                            let nested = compute_map_diff_entries(old_val, &new_map[*k]);
-                            ListOfMapsDiffField::NestedMapChanged {
-                                key: k.to_string(),
-                                entries: nested,
-                            }
-                        } else {
-                            let old_v = old_val
-                                .map(format_value)
-                                .unwrap_or_else(|| "(none)".to_string());
-                            ListOfMapsDiffField::Changed {
-                                key: k.to_string(),
-                                old: old_v,
-                                new: new_v,
-                            }
-                        }
-                    } else {
-                        ListOfMapsDiffField::Unchanged {
-                            key: k.to_string(),
-                            value: new_v,
-                        }
-                    }
-                })
-                .collect();
-            modified.push(ListOfMapsDiffModified { fields });
+            let mut fields: Vec<ListOfMapsDiffField> = Vec::new();
+            let mut unchanged_count: usize = 0;
+            for k in keys {
+                let field_same = old_map
+                    .get(k)
+                    .map(|ov| ov.semantically_equal(&new_map[k]))
+                    .unwrap_or(false);
+                if field_same {
+                    // #2881: drop unchanged fields from the IR; renderers
+                    // surface them as `# (n unchanged fields hidden)`,
+                    // mirroring the top-level `HiddenUnchanged` row.
+                    unchanged_count += 1;
+                    continue;
+                }
+                let old_val = old_map.get(k);
+                if matches!(old_val, Some(Value::Map(_))) && matches!(&new_map[k], Value::Map(_)) {
+                    let nested = compute_map_diff_entries(old_val, &new_map[k], detail);
+                    fields.push(ListOfMapsDiffField::NestedMapChanged {
+                        key: k.to_string(),
+                        entries: nested,
+                    });
+                } else {
+                    let old_v = old_val
+                        .map(format_value)
+                        .unwrap_or_else(|| "(none)".to_string());
+                    fields.push(ListOfMapsDiffField::Changed {
+                        key: k.to_string(),
+                        old: old_v,
+                        new: format_value(&new_map[k]),
+                    });
+                }
+            }
+            // Only surface the count in Full mode — Explicit / NamesOnly
+            // never emit hidden-counts at the top level either.
+            let hidden_unchanged_count = if detail == DetailLevel::Full {
+                unchanged_count
+            } else {
+                0
+            };
+            modified.push(ListOfMapsDiffModified {
+                fields,
+                hidden_unchanged_count,
+            });
         }
     }
 
@@ -903,6 +927,33 @@ fn compute_list_of_maps_diff_parts(
     let removed = collect_added_removed_items(&removed_indices, old_items);
 
     (unchanged, modified, added, removed)
+}
+
+/// Format a `# (n unchanged <noun> hidden)` summary for use under both
+/// the top-level `DetailRow::HiddenUnchanged` row (noun = "attribute")
+/// and the per-element list-of-maps unchanged-fields summary
+/// (noun = "field"). Pluralizes in English (singular / `<noun>s`).
+/// Defined here so CLI and TUI renderers share one source of truth and
+/// don't drift in punctuation or wording.
+///
+/// ```
+/// use carina_core::detail_rows::hidden_unchanged_summary;
+/// assert_eq!(
+///     hidden_unchanged_summary(1, "attribute"),
+///     "# (1 unchanged attribute hidden)"
+/// );
+/// assert_eq!(
+///     hidden_unchanged_summary(3, "field"),
+///     "# (3 unchanged fields hidden)"
+/// );
+/// ```
+pub fn hidden_unchanged_summary(count: usize, noun_singular: &str) -> String {
+    let noun = if count == 1 {
+        noun_singular.to_string()
+    } else {
+        format!("{}s", noun_singular)
+    };
+    format!("# ({} unchanged {} hidden)", count, noun)
 }
 
 /// Build alphabetically-sorted `ListOfMapsDiffItem`s from a list of map

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -1,6 +1,6 @@
 //! Detail-pane drawing and per-row rendering.
 
-use carina_core::detail_rows::DetailRow;
+use carina_core::detail_rows::{DetailRow, hidden_unchanged_summary};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
@@ -235,13 +235,8 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
             lines.push(line);
         }
         DetailRow::HiddenUnchanged { count } => {
-            let noun = if *count == 1 {
-                "attribute"
-            } else {
-                "attributes"
-            };
             let mut line = Line::from(Span::styled(
-                format!("  # ({} unchanged {} hidden)", count, noun),
+                format!("  {}", hidden_unchanged_summary(*count, "attribute")),
                 dim_style,
             ));
             if is_selected {

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -2,7 +2,7 @@
 
 use carina_core::detail_rows::{
     ListOfMapsDiffField, ListOfMapsDiffItem, ListOfMapsDiffItemKind, ListOfMapsDiffModified,
-    MapDiffEntryIR,
+    MapDiffEntryIR, hidden_unchanged_summary,
 };
 use carina_core::value::{PrettyLayout, format_value_pretty, needs_trailing_separator};
 use ratatui::prelude::*;
@@ -119,14 +119,13 @@ pub(super) fn render_list_of_maps_diff(
     }
     for m in modified {
         let mut spans = vec![Span::raw("    {")];
-        for (i, field) in m.fields.iter().enumerate() {
-            if i > 0 {
+        let mut emitted = 0usize;
+        for field in &m.fields {
+            if emitted > 0 {
                 spans.push(Span::raw(", "));
             }
+            emitted += 1;
             match field {
-                ListOfMapsDiffField::Unchanged { key, value } => {
-                    spans.push(Span::raw(format!("{}: {}", key, value)));
-                }
                 ListOfMapsDiffField::Changed { key, old, new } => {
                     spans.push(Span::raw(format!("{}: ", key)));
                     spans.push(Span::styled(
@@ -152,8 +151,37 @@ pub(super) fn render_list_of_maps_diff(
                 }
             }
         }
-        spans.push(Span::raw("}"));
-        lines.push(Line::from(spans));
+        // #2881: surface unchanged-fields summary inside the brace block.
+        // When `spans` is empty here, the previous field was a
+        // `NestedMapChanged` whose recursion flushed the inline buffer
+        // (`std::mem::take` at the arm above). Emit the summary on its
+        // own indented line in that case so we don't produce a stray
+        // `, # (... hidden)}` with no opening `{`.
+        if m.hidden_unchanged_count > 0 {
+            let summary = hidden_unchanged_summary(m.hidden_unchanged_count, "field");
+            // Use the same dim style other TUI paths use for the
+            // sibling top-level `# (n unchanged attributes hidden)`
+            // row (`detail.rs::dim_style`) so both render identically.
+            let dim = Style::default().fg(Color::DarkGray);
+            if spans.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::raw("      "),
+                    Span::styled(summary, dim),
+                ]));
+            } else {
+                if emitted > 0 {
+                    spans.push(Span::raw(", "));
+                }
+                spans.push(Span::styled(summary, dim));
+            }
+        }
+        if !spans.is_empty() {
+            spans.push(Span::raw("}"));
+            lines.push(Line::from(spans));
+        } else {
+            // Closing brace on its own line aligned with the opening.
+            lines.push(Line::from(Span::raw("    }")));
+        }
     }
     for item in added {
         push_added_removed_block(lines, item, ListOfMapsDiffItemKind::Added);


### PR DESCRIPTION
## Summary

- Hide unchanged fields inside a modified list-of-maps element (the `~ { ... }` block emitted when an existing element is paired with a new one by similarity), and surface the count via `# (n unchanged fields hidden)` — same convention used at the top level (`DetailRow::HiddenUnchanged`).
- Pre-fix, every sibling field rendered next to the changed one. A modified IAM `statement` whose only delta was `effect: "Allow" → "Deny"` still printed the entire `action: [...]` list, which collapsed to a ~250-column inline dump because `ListOfMapsDiffField::Unchanged` carried a pre-stringified `value: String` with no indentation context.
- The summary is emitted in `DetailLevel::Full` only — `Explicit` / `NamesOnly` show neither the unchanged fields nor a count, matching how the top-level `HiddenUnchanged` row is gated.

### Before / after

Before:

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {action: ["s3:GetObject", "s3:GetObjectTagging", "s3:GetObjectVersion", "s3:GetObjectVersionTagging", "s3:ListBucket", "s3:ListBucketVersions"], effect: "Allow" → "Deny", resource: "arn:aws:s3:::example/*", sid: "AllowS3Read"}
```

After (inline branch):

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {effect: "Allow" → "Deny", # (3 unchanged fields hidden)}
```

After (block branch, when one of the changed fields is a nested map):

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {
          config:
            ~ log_level: "info" → "debug"
            ~ retention_days: "30" → "90"
          # (4 unchanged fields hidden)
        }
```

## Implementation notes

- **IR.** `ListOfMapsDiffField::Unchanged` removed entirely — `fields` now only carries `Changed` and `NestedMapChanged`. New `hidden_unchanged_count: usize` on `ListOfMapsDiffModified` carries the count.
- **`DetailLevel` threading.** `compute_list_of_maps_diff_parts` and `compute_map_diff_entries` both gained the parameter; the four call sites (`build_update_rows`, `build_replace_rows`, `compute_map_diff_entries::Changed` for `NestedListOfMapsDiff`, `compute_list_of_maps_diff_parts::paired` for `NestedMapChanged`) pass it through. The count is set to 0 outside `Full` so renderers can use the same `if count > 0 { … }` gate everywhere.
- **Shared formatter.** New `pub fn hidden_unchanged_summary(count, noun_singular)` in `carina-core::detail_rows` is now used by all four sites (CLI display + TUI detail.rs for top-level `# (n unchanged attributes hidden)`; CLI display + TUI diff.rs for the new per-element variant), so wording / pluralization can't drift across surfaces.
- **TUI edge case.** The TUI inline `~ {…}` writer flushes its span buffer mid-loop when a field is `NestedMapChanged` (`std::mem::take(&mut spans)`). When the summary then fires, an empty `spans` produces `, # (… hidden)}` with no opening `{`. Guard: when `spans.is_empty()`, emit the summary on its own indented line and put the closing brace on its own line too — matches the CLI block-branch shape.

## Follow-ups (not in this PR)

- TUI inline branch has a pre-existing latent bug when a `Changed` field follows a `NestedMapChanged` (also empty-spans on entry). Same shape as the case above; not exercised by any current fixture, will file as a separate issue.

## Test plan

- [x] New `list_diff_modified_with_unchanged` fixture + snapshot — exercises the inline `~ {field-change, # (… hidden)}` shape; assertion guard `no line > 200 cols` regresses if the wide-line bug returns.
- [x] New `list_diff_modified_with_unchanged_nested` fixture + snapshot — exercises the block shape (nested map diff inside the `~ { ... }` block) and locks in the TUI empty-spans fix.
- [x] Both fixtures wired into Makefile and `plan-fixtures`; `scripts/check-plan-fixtures.sh` passes.
- [x] Doctest on `hidden_unchanged_summary` covers singular + plural.
- [x] `cargo nextest run --workspace`, `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, all `scripts/check-*.sh` — green.

Closes #2881.
