### PR TITLE
plan: drop leading comma in all-unchanged list-of-maps element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ plan-list-diff-modified-with-unchanged:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged
 plan-list-diff-modified-with-unchanged-nested:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged_nested
+plan-list-diff-modified-all-unchanged:
+	$(PLAN_FIXTURE) list_diff_modified_all_unchanged
 plan-enum-display:
 	$(PLAN_FIXTURE) enum_display
 plan-no-changes-enum:
@@ -89,6 +91,8 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-modified-with-unchanged
 	@echo "---"
 	@$(MAKE) plan-list-diff-modified-with-unchanged-nested
+	@echo "---"
+	@$(MAKE) plan-list-diff-modified-all-unchanged
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1374,30 +1374,30 @@ fn render_list_of_maps_diff(
             }
             writeln!(out, "{}    }}", attr_prefix).unwrap();
         } else {
+            // `fields` may be empty when state carries an extra
+            // (provider-injected) key not in desired — every desired
+            // key compares equal, so all are absorbed into
+            // `hidden_unchanged_count`. Build the summary as a list so
+            // the comma separator only appears between non-empty
+            // pieces (#2886).
+            let mut parts: Vec<String> = Vec::with_capacity(2);
             let rendered_fields = render_modified_fields(&item.fields);
-            // Append the hidden-fields count after the changed field list
-            // so the summary stays inside the `~ { ... }` block. A paired
-            // modified item always has at least one changed field by
-            // construction (Phase 1 absorbs all-equal pairs as unchanged
-            // before pairing runs), so `rendered_fields` is never empty.
-            debug_assert!(
-                !rendered_fields.is_empty(),
-                "paired modified item must have at least one changed field"
-            );
-            let summary = if item.hidden_unchanged_count > 0 {
-                let s = hidden_unchanged_summary(item.hidden_unchanged_count, "field")
-                    .dimmed()
-                    .to_string();
-                format!("{}, {}", rendered_fields, s)
-            } else {
-                rendered_fields
-            };
+            if !rendered_fields.is_empty() {
+                parts.push(rendered_fields);
+            }
+            if item.hidden_unchanged_count > 0 {
+                parts.push(
+                    hidden_unchanged_summary(item.hidden_unchanged_count, "field")
+                        .dimmed()
+                        .to_string(),
+                );
+            }
             writeln!(
                 out,
                 "{}  {} {{{}}}",
                 attr_prefix,
                 "~".yellow().bold(),
-                summary
+                parts.join(", ")
             )
             .unwrap();
         }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1001,6 +1001,39 @@ fn snapshot_list_diff_modified_with_unchanged_nested() {
     insta::assert_snapshot!(output);
 }
 
+// #2886: a list-of-maps element where state carries an extra
+// (provider-injected) field that desired does not, so Phase 1's
+// `maps_semantically_equal` rejects the pair (lengths differ) and Phase 2
+// pairs them by similarity. Every desired key matches state, so the
+// per-element renderer ends up with `fields = []` and
+// `hidden_unchanged_count > 0`. Pre-fix that produced a leading comma:
+// `~ {, # (N unchanged fields hidden)}`. Post-fix the comma is elided
+// and the summary stands alone inside the braces.
+#[test]
+fn snapshot_list_diff_modified_all_unchanged() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_modified_all_unchanged");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    assert!(
+        !output.contains("{,"),
+        "all-unchanged element must not render a leading comma; got: {}",
+        output
+    );
+    assert!(
+        output.contains("unchanged field"),
+        "expected `# (n unchanged fields hidden)` summary in Full mode; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
 // Mirror of the added-struct test for the removed path.
 #[test]
 fn snapshot_list_diff_removed_struct() {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_all_unchanged.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_modified_all_unchanged.snap
@@ -1,0 +1,13 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      policy_name: "test-inline" → "test-inline-renamed"
+      statement:
+        ~ {# (4 unchanged fields hidden)}
+      # (1 unchanged attribute hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_all_unchanged/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_all_unchanged/carina.state.json
@@ -1,0 +1,34 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-modified-all-unchanged",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*",
+            "spurious_provider_field": "ignored"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_all_unchanged/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_all_unchanged/main.crn
@@ -1,0 +1,29 @@
+# #2886: a list-of-maps element where every key from the desired side
+# matches the state byte-for-byte, but state carries an *extra* key not
+# present in desired. The element is paired (Phase 2 picks it as the
+# best-similarity match), then Phase 3 iterates desired keys — all
+# `field_same` — so `fields` ends up empty while `hidden_unchanged_count`
+# captures every shared key. Pre-fix the renderer emitted
+# `~ {, # (N unchanged fields hidden)}` with a leading comma; post-fix
+# the comma is elided and only the summary remains inside the braces.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline-renamed'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid    = 'AllowS3Read'
+      effect = 'Allow'
+      action = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}


### PR DESCRIPTION
## Summary

After #2881, a list-of-maps element whose only contents are unchanged-and-hidden fields rendered with a leading comma:

```
~ {, # (3 unchanged fields hidden)}
```

This happens when state carries an extra provider-injected key not present in desired (the awscc#206 family — same root as the bucket plan example in the issue body): Phase 1 of the pairing in `compute_list_of_maps_diff_parts` rejects the pair on length mismatch, Phase 2 still pairs them by similarity, and every desired key compares equal — so `fields` ends up empty and `hidden_unchanged_count > 0`. The renderer then joined the (empty) changed-field list and the summary with a hard-coded `, ` separator, leaving the comma exposed.

## Fix

`carina-cli/src/display/mod.rs::render_list_of_maps_diff` — switch the inline `~ { ... }` branch to a `Vec::join(", ")` builder so the separator only appears between non-empty pieces. Result:

```
~ {# (4 unchanged fields hidden)}
```

The previous `debug_assert!("paired modified item must have at least one changed field")` was the original incorrect invariant — removed.

The has_nested branch and the TUI renderer already handled this case correctly; no fix needed there.

## Test plan

- [x] New fixture `list_diff_modified_all_unchanged` reproduces the bug shape: state has `spurious_provider_field` not in desired, `policy_name` is renamed to force an Update so the renderer is reached.
- [x] New snapshot test pins the post-fix output and asserts `!output.contains("{,")`.
- [x] Existing `snapshot_list_diff_modified_with_unchanged` (mixed case — fields + summary) unchanged.
- [x] `cargo nextest run -p carina-cli` (391 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` pass (incl. `check-plan-fixtures.sh` — Makefile target added).

Closes #2886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
