### PR TITLE
design: ExplicitFields for nested user-authored tracking (refs awscc#206)

### DIFF
--- a/docs/plans/2026-05-10-explicit-fields.md
+++ b/docs/plans/2026-05-10-explicit-fields.md
@@ -1,0 +1,890 @@
+# Implementation Plan — ExplicitFields
+
+<!-- derived-from ../specs/2026-05-10-explicit-fields-design.md -->
+
+## Goal
+
+Implement `docs/specs/2026-05-10-explicit-fields-design.md`. Final
+acceptance: real-infra `carina plan` against the awscc#206 reproduction
+(`registry/dev/registry`) shows no
+`- transition_default_minimum_object_size: "all_storage_classes_128K"`
+line. All within the carina repo (no WIT or provider repo touch).
+
+## Repo
+
+`carina-rs/carina` only. No upstream submodule changes.
+
+## Task list
+
+Each task corresponds to one GitHub Issue and one PR. Tasks 1–8 are
+sequential dependencies; tasks 9 (display) and 10 (TUI projection
+audit) can begin once 4 lands. Tasks 11–13 (fixture rewrite,
+new fixture, real-infra acceptance) run after the core work is in.
+
+---
+
+### Task 1/13 — `ExplicitFields` enum + serde + unit tests
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-1/13
+**Blocked by:** none
+
+**Goal:** Land the new `ExplicitFields` type as a free-standing module,
+with no consumer wiring yet.
+
+**Files:**
+- Create `carina-core/src/explicit.rs`
+- Modify `carina-core/src/lib.rs` to add `pub mod explicit;`
+
+**Tests (write first):**
+```rust
+// carina-core/src/explicit.rs (#[cfg(test)] mod tests)
+#[test]
+fn leaf_is_default() {
+    let e: ExplicitFields = Default::default();
+    assert!(matches!(e, ExplicitFields::Leaf));
+}
+
+#[test]
+fn struct_round_trips_via_serde() {
+    let e = ExplicitFields::Struct {
+        children: HashMap::from([
+            ("a".into(), ExplicitFields::Leaf),
+            ("b".into(), ExplicitFields::Struct {
+                children: HashMap::from([("nested".into(), ExplicitFields::Leaf)]),
+            }),
+        ]),
+    };
+    let json = serde_json::to_string(&e).unwrap();
+    let back: ExplicitFields = serde_json::from_str(&json).unwrap();
+    assert_eq!(e, back);
+}
+
+#[test]
+fn list_round_trips_via_serde() {
+    let e = ExplicitFields::List {
+        element: Box::new(ExplicitFields::Struct {
+            children: HashMap::from([("id".into(), ExplicitFields::Leaf)]),
+        }),
+    };
+    let json = serde_json::to_string(&e).unwrap();
+    let back: ExplicitFields = serde_json::from_str(&json).unwrap();
+    assert_eq!(e, back);
+}
+
+#[test]
+fn variant_serializes_kebab_case() {
+    let leaf_json = serde_json::to_string(&ExplicitFields::Leaf).unwrap();
+    assert_eq!(leaf_json, r#"{"kind":"leaf"}"#);
+}
+```
+
+**Implementation:**
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ExplicitFields {
+    Leaf,
+    Struct { children: HashMap<String, ExplicitFields> },
+    List { element: Box<ExplicitFields> },
+}
+
+impl Default for ExplicitFields {
+    fn default() -> Self { ExplicitFields::Leaf }
+}
+```
+
+**Verification:**
+```
+cargo nextest run -p carina-core explicit
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- `ExplicitFields` exported from `carina_core::explicit`.
+- Serde round-trip test passes for all three variants.
+- Default is `Leaf`.
+
+---
+
+### Task 2/13 — `build_from_resource` / `build_from_value` / `merge`
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-2/13
+**Blocked by:** Task 1/13
+
+**Goal:** Construct `ExplicitFields` from `Resource` and `Value`.
+
+**Files:**
+- Modify `carina-core/src/explicit.rs`
+
+**Tests (write first):**
+```rust
+#[test]
+fn build_from_value_scalar_is_leaf() {
+    let v = Value::String("x".into());
+    assert_eq!(build_from_value(&v), ExplicitFields::Leaf);
+}
+
+#[test]
+fn build_from_value_struct_collects_children() {
+    let v = Value::Struct {
+        name: "S".into(),
+        fields: vec![
+            ("a".into(), Value::String("x".into())),
+            ("b".into(), Value::Int(1)),
+        ],
+    };
+    let result = build_from_value(&v);
+    let ExplicitFields::Struct { children } = result else { panic!() };
+    assert_eq!(children.len(), 2);
+    assert!(matches!(children["a"], ExplicitFields::Leaf));
+    assert!(matches!(children["b"], ExplicitFields::Leaf));
+}
+
+#[test]
+fn build_from_value_list_unions_element_authoring() {
+    // Element 1 wrote {a, b}; element 2 wrote {b, c}; union = {a, b, c}
+    let v = Value::List(vec![
+        Value::Struct { name: "S".into(), fields: vec![
+            ("a".into(), Value::Int(1)),
+            ("b".into(), Value::Int(1)),
+        ]},
+        Value::Struct { name: "S".into(), fields: vec![
+            ("b".into(), Value::Int(2)),
+            ("c".into(), Value::Int(2)),
+        ]},
+    ]);
+    let result = build_from_value(&v);
+    let ExplicitFields::List { element } = result else { panic!() };
+    let ExplicitFields::Struct { children } = *element else { panic!() };
+    let mut keys: Vec<&str> = children.keys().map(|s| s.as_str()).collect();
+    keys.sort();
+    assert_eq!(keys, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn build_from_resource_skips_underscore_attrs() {
+    let mut r = Resource::with_provider("aws", "s3.bucket", "x");
+    r.set_attr("name".into(), Value::String("hi".into()));
+    r.set_attr("_internal".into(), Value::String("skip".into()));
+    let result = build_from_resource(&r);
+    let ExplicitFields::Struct { children } = result else { panic!() };
+    assert!(children.contains_key("name"));
+    assert!(!children.contains_key("_internal"));
+}
+
+#[test]
+fn merge_struct_into_struct_unions_keys() {
+    let a = ExplicitFields::Struct {
+        children: HashMap::from([("a".into(), ExplicitFields::Leaf)]),
+    };
+    let b = ExplicitFields::Struct {
+        children: HashMap::from([("b".into(), ExplicitFields::Leaf)]),
+    };
+    let result = merge(a, b);
+    let ExplicitFields::Struct { children } = result else { panic!() };
+    assert_eq!(children.len(), 2);
+}
+```
+
+**Implementation:** as in design doc § "Construction".
+
+**Verification:**
+```
+cargo nextest run -p carina-core explicit
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- Construction from `Resource` matches design semantics for scalar,
+  struct, list, list-of-structs (union), underscore filtering.
+
+---
+
+### Task 3/13 — `project` / `project_attributes` (idempotent)
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-3/13
+**Blocked by:** Task 2/13
+
+**Goal:** Add the projection function that strips fields not in the
+authoring tree.
+
+**Files:**
+- Modify `carina-core/src/explicit.rs`
+
+**Tests (write first):**
+```rust
+#[test]
+fn project_struct_drops_unauthored_field() {
+    let value = Value::Struct {
+        name: "S".into(),
+        fields: vec![
+            ("authored".into(), Value::String("keep".into())),
+            ("server_default".into(), Value::String("drop".into())),
+        ],
+    };
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([("authored".into(), ExplicitFields::Leaf)]),
+    };
+    let result = project(value, &explicit);
+    let Value::Struct { fields, .. } = result else { panic!() };
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].0, "authored");
+}
+
+#[test]
+fn project_leaf_keeps_whole_value() {
+    let value = Value::Struct {
+        name: "S".into(),
+        fields: vec![("any".into(), Value::Int(1))],
+    };
+    let result = project(value.clone(), &ExplicitFields::Leaf);
+    assert_eq!(result, value);
+}
+
+#[test]
+fn project_is_idempotent() {
+    let value = Value::Struct {
+        name: "S".into(),
+        fields: vec![
+            ("a".into(), Value::Int(1)),
+            ("b".into(), Value::Int(2)),
+        ],
+    };
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([("a".into(), ExplicitFields::Leaf)]),
+    };
+    let once = project(value.clone(), &explicit);
+    let twice = project(once.clone(), &explicit);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn project_list_recurses_into_each_element() {
+    let value = Value::List(vec![
+        Value::Struct { name: "S".into(), fields: vec![
+            ("authored".into(), Value::Int(1)),
+            ("server".into(), Value::Int(2)),
+        ]},
+        Value::Struct { name: "S".into(), fields: vec![
+            ("authored".into(), Value::Int(3)),
+            ("server".into(), Value::Int(4)),
+        ]},
+    ]);
+    let explicit = ExplicitFields::List {
+        element: Box::new(ExplicitFields::Struct {
+            children: HashMap::from([("authored".into(), ExplicitFields::Leaf)]),
+        }),
+    };
+    let Value::List(items) = project(value, &explicit) else { panic!() };
+    for item in &items {
+        let Value::Struct { fields, .. } = item else { panic!() };
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].0, "authored");
+    }
+}
+
+#[test]
+fn project_mismatched_shape_keeps_value() {
+    // Authoring says Struct, value is a String — keep value as-is
+    let value = Value::String("oops".into());
+    let explicit = ExplicitFields::Struct { children: HashMap::new() };
+    let result = project(value.clone(), &explicit);
+    assert_eq!(result, value);
+}
+
+#[test]
+fn project_attributes_drops_top_level_unauthored() {
+    let attrs = HashMap::from([
+        ("a".into(), Value::Int(1)),
+        ("server_only".into(), Value::Int(99)),
+    ]);
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([("a".into(), ExplicitFields::Leaf)]),
+    };
+    let result = project_attributes(attrs, &explicit);
+    assert_eq!(result.len(), 1);
+    assert!(result.contains_key("a"));
+}
+```
+
+**Implementation:** as in design doc § "Projection".
+
+**Verification:**
+```
+cargo nextest run -p carina-core explicit::tests::project
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- All projection tests pass.
+- Idempotence test passes.
+
+---
+
+### Task 4/13 — `ResourceState.explicit` field + state v6 + v5 read path
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-4/13
+**Blocked by:** Tasks 2/13, 3/13
+
+**Goal:** Replace `desired_keys: Vec<String>` with
+`explicit: ExplicitFields` on `ResourceState`. Bump
+`CURRENT_VERSION` to 6. Add v5→v6 read conversion.
+
+**Files:**
+- Modify `carina-state/src/state/mod.rs`:
+  - `ResourceState`: remove `desired_keys`, add
+    `explicit: ExplicitFields` (with `#[serde(default)]`).
+  - `from_provider_state`: replace
+    ```
+    rs.desired_keys = resource.attributes.keys()...collect();
+    rs.desired_keys.sort();
+    ```
+    with
+    ```
+    rs.explicit = carina_core::explicit::build_from_resource(resource);
+    ```
+  - `build_desired_keys()` → rename to `build_explicit()` returning
+    `HashMap<ResourceId, ExplicitFields>`.
+  - `CURRENT_VERSION = 6`.
+  - In the version-specific reader (around line 380), add a v5
+    branch that converts `desired_keys: Vec<String>` to
+    `ExplicitFields::Struct { children }` with each key mapped to
+    `Leaf`, then drops the `desired_keys` field.
+
+**Tests (write first):**
+```rust
+// carina-state/src/state/tests.rs (additions)
+#[test]
+fn v5_state_read_converts_desired_keys_to_explicit_leaves() {
+    let v5 = r#"{
+        "version": 5,
+        "carina_version": "0.4.0",
+        "resources": [{
+            "resource_type": "s3.Bucket",
+            "name": "x",
+            "provider": "aws",
+            "identifier": null,
+            "attributes": {"name": "x"},
+            "desired_keys": ["name", "tags"]
+        }]
+    }"#;
+    let state = parse_state_file(v5).unwrap();
+    let rs = &state.resources[0];
+    let ExplicitFields::Struct { children } = &rs.explicit else { panic!() };
+    assert_eq!(children.len(), 2);
+    assert!(matches!(children["name"], ExplicitFields::Leaf));
+    assert!(matches!(children["tags"], ExplicitFields::Leaf));
+}
+
+#[test]
+fn v6_state_writes_and_reads_full_explicit_tree() {
+    let mut state = StateFile::new();
+    let mut rs = ResourceState::new("s3.Bucket", "x", "aws");
+    rs.explicit = ExplicitFields::Struct {
+        children: HashMap::from([
+            ("lifecycle_configuration".into(), ExplicitFields::Struct {
+                children: HashMap::from([
+                    ("rules".into(), ExplicitFields::List {
+                        element: Box::new(ExplicitFields::Struct {
+                            children: HashMap::from([
+                                ("id".into(), ExplicitFields::Leaf),
+                            ]),
+                        }),
+                    }),
+                ]),
+            }),
+        ]),
+    };
+    state.upsert_resource(rs);
+    let json = serde_json::to_string(&state).unwrap();
+    let back = parse_state_file(&json).unwrap();
+    assert_eq!(back.resources[0].explicit, state.resources[0].explicit);
+    assert_eq!(back.version, 6);
+}
+```
+
+**Implementation:** as in design doc § "State versioning".
+
+**Verification:**
+```
+cargo nextest run -p carina-state
+cargo test --workspace --doc
+cargo clippy -p carina-state --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- v5→v6 conversion test passes.
+- v6 round-trip test passes.
+- `CURRENT_VERSION == 6` and writes always emit v6.
+
+---
+
+### Task 5/13 — Differ comparison: project current + accept `ExplicitFields`
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-5/13
+**Blocked by:** Task 4/13
+
+**Goal:** Project `current` through `ExplicitFields` at
+`find_changed_attributes` entry. Replace
+`prev_desired_keys: Option<&[String]>` parameter with
+`prev_explicit: Option<&ExplicitFields>`.
+
+**Files:**
+- Modify `carina-core/src/differ/comparison.rs`:
+  - At entry of `find_changed_attributes`, if `prev_explicit` is
+    `Some(e)`, run `let current = project_attributes(current.clone(), e)`.
+  - Lines 382–394: replace
+    `for key in prev_keys` with iteration over the children of
+    `prev_explicit` when it is a `Struct` variant. For each child key
+    not in `desired` but present in `current` (now projected), push
+    to `changed`.
+
+**Tests (write first):**
+```rust
+// carina-core/src/differ/diff_tests.rs (additions)
+#[test]
+fn server_default_struct_field_does_not_appear_in_diff() {
+    let desired = HashMap::from([
+        ("lifecycle_configuration".into(), Value::Struct {
+            name: "LC".into(),
+            fields: vec![
+                ("rules".into(), Value::List(vec![/*...*/])),
+            ],
+        }),
+    ]);
+    let current = HashMap::from([
+        ("lifecycle_configuration".into(), Value::Struct {
+            name: "LC".into(),
+            fields: vec![
+                ("rules".into(), Value::List(vec![/*...*/])),
+                ("transition_default_minimum_object_size".into(),
+                 Value::String("all_storage_classes_128K".into())),
+            ],
+        }),
+    ]);
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([
+            ("lifecycle_configuration".into(), ExplicitFields::Struct {
+                children: HashMap::from([
+                    ("rules".into(), ExplicitFields::Leaf),
+                ]),
+            }),
+        ]),
+    };
+    let changed = find_changed_attributes(
+        &desired, &current, None, Some(&explicit), None, None,
+    );
+    assert!(!changed.iter().any(|k| k == "lifecycle_configuration"),
+        "server-default leaf should not flag the parent attr as changed");
+}
+
+#[test]
+fn explicit_top_level_removal_still_detected() {
+    let desired: HashMap<String, Value> = HashMap::new();
+    let current = HashMap::from([
+        ("tags".into(), Value::Map(IndexMap::from([
+            ("Env".into(), Value::String("prod".into())),
+        ]))),
+    ]);
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([("tags".into(), ExplicitFields::Leaf)]),
+    };
+    let changed = find_changed_attributes(
+        &desired, &current, None, Some(&explicit), None, None,
+    );
+    assert!(changed.contains(&"tags".to_string()),
+        "user-removed top-level attr must still produce a Remove signal");
+}
+```
+
+**Implementation:** signature change + projection at entry +
+removal-detection rewrite that walks `ExplicitFields::Struct`.
+
+**Verification:**
+```
+cargo nextest run -p carina-core differ
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- New tests pass.
+- Existing differ tests pass after parameter type change.
+- All `find_changed_attributes` call sites in carina-core updated.
+
+---
+
+### Task 6/13 — Differ plan + mod: thread `ExplicitFields` through
+
+**Repo:** carina
+**Labels:** refactor, rust, task-6/13
+**Blocked by:** Task 5/13
+
+**Goal:** Update `carina-core/src/differ/plan.rs` and
+`carina-core/src/differ/mod.rs` to take
+`HashMap<ResourceId, ExplicitFields>` and pass it through to
+`find_changed_attributes`.
+
+**Files:**
+- Modify `carina-core/src/differ/plan.rs`:
+  - Function `compute_diff` (around line 144):
+    `prev_desired_keys: &HashMap<ResourceId, Vec<String>>` →
+    `prev_explicit: &HashMap<ResourceId, ExplicitFields>`.
+  - Around line 172: `let prev_keys = prev_desired_keys.get(&resource.id);`
+    → `let prev_explicit = prev_explicit.get(&resource.id);`
+- Modify `carina-core/src/differ/mod.rs`:
+  - `diff` function (line 62, 66, 77): same parameter rename and
+    type change.
+
+**Tests (write first):**
+```rust
+// carina-core/src/differ/plan_tests.rs (replace
+// diff_detects_attribute_removal_with_prev_desired_keys at line 369)
+#[test]
+fn diff_detects_attribute_removal_with_prev_explicit() {
+    let resources = vec![/* ... */];
+    let prev_explicit = HashMap::from([
+        (resources[0].id.clone(), ExplicitFields::Struct {
+            children: HashMap::from([("tags".into(), ExplicitFields::Leaf)]),
+        }),
+    ]);
+    let current_states = HashMap::from([/* ... with tags present ... */]);
+    let plan = compute_diff(&resources, &current_states, &prev_explicit, /* ... */);
+    // Assert plan contains an Update with a Remove patch op for "tags"
+    // ...
+}
+```
+
+**Implementation:** type-driven; cargo will guide each call site.
+
+**Verification:**
+```
+cargo nextest run -p carina-core differ
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- carina-core compiles.
+- Existing differ tests pass.
+
+---
+
+### Task 7/13 — carina-cli: thread `ExplicitFields` through wiring
+
+**Repo:** carina
+**Labels:** refactor, rust, task-7/13
+**Blocked by:** Task 6/13
+
+**Goal:** Update all carina-cli call sites that build
+`prev_desired_keys` to build `prev_explicit` instead.
+
+**Files:**
+- Modify `carina-cli/src/fixture_plan.rs` (line 175): replace
+  `state_file.build_desired_keys()` with `state_file.build_explicit()`.
+- Modify `carina-cli/src/wiring/tests.rs` (lines 172, 180, 197, 257,
+  259, 260, 263, 275, 303): variable type
+  `HashMap<ResourceId, Vec<String>>` →
+  `HashMap<ResourceId, ExplicitFields>`. Constructions:
+  `vec!["tags".to_string()]` → `ExplicitFields::Struct { children: HashMap::from([("tags".into(), ExplicitFields::Leaf)]) }`.
+- Modify `carina-cli/src/tests.rs` (line 1263): same rename to
+  `build_explicit()` and update local variable type.
+- Modify `carina-cli/src/plan_snapshot_tests.rs` (lines 442, 444, 446,
+  457): rename comments and local variables. Behavior of
+  `moved_prev_keys` test stays the same.
+
+**Tests:** existing tests carry the assertions; this task is
+type-driven plumbing.
+
+**Verification:**
+```
+cargo nextest run -p carina-cli
+cargo test --workspace --doc
+cargo clippy -p carina-cli --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- carina-cli compiles.
+- All wiring tests pass with the new type.
+
+---
+
+### Task 8/13 — Display detail_rows: project `from.attributes`
+
+**Repo:** carina
+**Labels:** enhancement, rust, task-8/13
+**Blocked by:** Tasks 4/13, 7/13
+
+**Goal:** Project `from.attributes` (current state) before
+`compute_unchanged_count` so server-default fields don't inflate the
+"N unchanged attributes hidden" count.
+
+**Files:**
+- Modify `carina-core/src/detail_rows.rs`:
+  - `build_update_rows` and `build_replace_rows`: accept an
+    `explicit: &ExplicitFields` parameter (or extract `explicit`
+    from `from` by passing the whole `ResourceState` rather than
+    just `attributes`).
+  - At line 488 area, project `from.attributes` before passing to
+    `compute_unchanged_count`:
+    ```rust
+    let from_projected = project_attributes(
+        from.attributes.clone(),
+        explicit,
+    );
+    let unchanged_count = compute_unchanged_count(
+        &from_projected,
+        &to.resolved_attributes(),
+        None,
+    );
+    ```
+- Update all callers of `build_update_rows` / `build_replace_rows`
+  to pass `explicit`. Cargo will surface them.
+
+**Tests (write first):**
+```rust
+// carina-core/src/detail_rows.rs (#[cfg(test)] additions)
+#[test]
+fn unchanged_count_excludes_server_only_field() {
+    let from_attrs = HashMap::from([
+        ("authored".into(), Value::String("a".into())),
+        ("server_only".into(), Value::String("s".into())),
+    ]);
+    let to = /* ResourceState with authored="a" — unchanged */;
+    let explicit = ExplicitFields::Struct {
+        children: HashMap::from([("authored".into(), ExplicitFields::Leaf)]),
+    };
+    // build update rows; in Full mode the HiddenUnchanged count
+    // should be 1 (just "authored"), not 2 ("authored" + "server_only").
+    let rows = build_update_rows(&state_with(from_attrs), &to, &[], DetailLevel::Full, &explicit);
+    let hidden = rows.iter().find_map(|r| match r {
+        DetailRow::HiddenUnchanged { count } => Some(*count),
+        _ => None,
+    });
+    assert_eq!(hidden, Some(1));
+}
+```
+
+**Verification:**
+```
+cargo nextest run -p carina-core detail_rows
+cargo test --workspace --doc
+cargo clippy -p carina-core --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- Unchanged-count test passes.
+- All `build_*_rows` callers updated.
+
+---
+
+### Task 9/13 — TUI: audit and project `current` reads
+
+**Repo:** carina
+**Labels:** refactor, rust, task-9/13
+**Blocked by:** Task 8/13
+
+**Goal:** Audit `carina-tui/src/ui/detail.rs` and
+`carina-tui/src/ui/diff.rs` for any direct reads of
+`from.attributes` / `current` that bypass the `DetailRow` pipeline.
+If found, project them; if not, no code change beyond a comment
+documenting the audit.
+
+**Files:**
+- Read-only audit of `carina-tui/src/`. Modify only if a direct
+  read is found.
+- If a direct read is found, modify the relevant file to project
+  via `carina_core::explicit::project_attributes`.
+
+**Tests:**
+- If a code change is made, add a TUI snapshot or unit test that
+  asserts a server-default field does not surface.
+- If no code change, no test required; the audit is the deliverable
+  and is recorded in the PR description.
+
+**Verification:**
+```
+cargo nextest run -p carina-tui
+cargo test --workspace --doc
+cargo clippy -p carina-tui --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- Audit recorded in PR body.
+- TUI passes existing tests.
+
+---
+
+### Task 10/13 — Rewrite 19 `plan_display` fixture state files to v6
+
+**Repo:** carina
+**Labels:** test, rust, task-10/13
+**Blocked by:** Task 4/13
+
+**Goal:** Convert all `carina-cli/tests/fixtures/plan_display/*/carina.state.json`
+files from v5 (`desired_keys: [...]`) to v6
+(`explicit: {"kind": "struct", "children": {...}}`).
+
+**Files** (19 fixture state files):
+- `all_create/`, `compact/`, `default_tags/`, `default_values/`,
+  `deferred_for/`, `delete_orphan/`, `destroy_full/`,
+  `destroy_orphans/`, `enum_display/`, `explicit/`, `exports/`,
+  `exports_multifile/`, `list_diff_added_struct/`,
+  `list_diff_modified_with_unchanged/`,
+  `list_diff_modified_with_unchanged_nested/`,
+  `list_diff_removed_struct/`, `map_key_diff/`,
+  `mixed_operations/`, `module_anonymous_resource/`,
+  `moved_prev_keys/`, `moved_pure/`, `moved_with_changes/`,
+  `nested_map_diff/`, `no_changes_enum/`, `no_changes/`,
+  `policy_pretty/`, `policy_pretty_dynamic_key_list/`,
+  `policy_pretty_nested/`, `pretty_long_string_list/`,
+  `pretty_short_string_list/`, `provider_prefix/`,
+  `secret_values/`, `state_blocks/`.
+
+**Implementation:**
+- Write a one-shot conversion script
+  `scripts/convert-fixtures-v5-to-v6.sh` (or Rust binary in
+  `carina-state/src/bin/`) that reads each file, applies the v5→v6
+  conversion logic from Task 4, writes back. The conversion is
+  the same as the in-memory v5 reader: each `desired_keys` entry
+  becomes `ExplicitFields::Leaf` under `explicit.children`.
+- Run the script once, commit the diff.
+- Delete the script after the commit (or leave it under
+  `scripts/` if the team prefers a record).
+
+**Verification:**
+```
+cargo nextest run -p carina-cli plan_snapshot
+cargo insta review  # expected: zero drift; the conversion is
+                    # semantically equivalent for top-level keys
+```
+
+**Acceptance:**
+- All 19 fixture state files declare `"version": 6` and
+  `"explicit": {...}`.
+- `cargo nextest run -p carina-cli plan_snapshot` passes with no
+  snapshot drift.
+
+---
+
+### Task 11/13 — New fixture: `server_default_struct_leaf`
+
+**Repo:** carina
+**Labels:** test, rust, task-11/13
+**Blocked by:** Tasks 5/13, 8/13, 10/13
+
+**Goal:** Add a fixture that reproduces the awscc#206 scenario at
+the carina-cli level (mock provider) and asserts no `-` line for
+the server-default struct leaf.
+
+**Files:**
+- Create
+  `carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/main.crn`:
+  use a mock-provider resource that has a Struct-typed attribute
+  with multiple fields. The `.crn` writes only one of them.
+- Create
+  `carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/carina.state.json`:
+  v6 state where `current.attributes` has both fields, but
+  `explicit.children` has only the user-authored one.
+- Modify `Makefile`: new `plan-server-default-struct-leaf` target
+  per memory rule `feedback_makefile_for_fixtures`.
+- Modify `carina-cli/src/plan_snapshot_tests.rs`: register the
+  fixture.
+
+**Tests:** the snapshot file itself, with assertion that no `-`
+line for the server-default leaf appears in the rendered plan.
+
+**Verification:**
+```
+cargo nextest run -p carina-cli plan_snapshot
+make plan-server-default-struct-leaf
+make plan-fixtures
+bash scripts/check-docs-drift.sh
+```
+
+**Acceptance:**
+- New fixture's snapshot has zero `-` lines for the server-default
+  leaf.
+- All other fixtures' snapshots unchanged.
+- Make target works.
+
+---
+
+### Task 12/13 — LSP audit: `desired_keys` references
+
+**Repo:** carina
+**Labels:** refactor, rust, task-12/13
+**Blocked by:** Task 4/13
+
+**Goal:** Audit `carina-lsp/` for any references to `desired_keys`
+or the old `Vec<String>` parameter. Replace with `ExplicitFields`
+where they exist.
+
+**Files:**
+- Audit: `grep -rn "desired_keys\|prev_desired_keys" carina-lsp/`.
+- Modify any matches; expected scope is small (LSP doesn't run the
+  differ in practice, but may build state for diagnostics).
+
+**Tests:** if changes are made, add an LSP unit test for the
+affected behavior. If no changes, audit is the deliverable.
+
+**Verification:**
+```
+cargo nextest run -p carina-lsp
+cargo clippy -p carina-lsp --all-targets -- -D warnings
+```
+
+**Acceptance:**
+- carina-lsp compiles.
+- LSP tests pass.
+
+---
+
+### Task 13/13 — Real-infra acceptance for awscc#206
+
+**Repo:** carina (validation only)
+**Labels:** test, task-13/13
+**Blocked by:** all of 1–12
+
+**Goal:** Confirm the awscc#206 reproduction is gone against the
+real registry/dev/registry stack.
+
+**Steps (run by user):**
+1. Build carina from the merged main: `cargo build --release -p carina-cli`.
+2. `cd /Users/mizzy/src/github.com/carina-rs/infra`.
+3. `aws-vault exec mizzy -- /path/to/carina plan registry/dev/registry`.
+4. Confirm output does NOT contain
+   `transition_default_minimum_object_size: "all_storage_classes_128K"`.
+5. Inspect the resulting `carina.state.json`: should be `"version": 6`
+   with `explicit` populated as a full tree for the bucket.
+
+**Acceptance:**
+- No spurious `-` line.
+- State file is v6.
+- awscc#206 closed with the real-infra evidence pasted in.
+
+---
+
+## Cross-cutting notes
+
+- **State v6 lock-in**: per memory rule `feedback_no_backward_compat`,
+  no migration docs. Once v6 is written, older binaries can't read.
+- **Snapshot drift policy**: any drift outside the new
+  `server_default_struct_leaf` fixture is a bug in the projection
+  logic, not an "expected update". Investigate before accepting.
+- **No `cargo build` in verify cycle** (CLAUDE.md): use
+  `cargo nextest run` which handles the build.
+- **Repo-specific CI gates**: `bash scripts/check-*.sh` must pass
+  in addition to cargo green (CLAUDE.md / memory
+  `feedback_local_green_is_not_ci_green`).

--- a/docs/specs/2026-05-10-explicit-fields-design.md
+++ b/docs/specs/2026-05-10-explicit-fields-design.md
@@ -1,0 +1,474 @@
+# ExplicitFields — Per-resource user-authored field tree
+
+## Goal
+
+Eliminate spurious diff lines for AWS server-side default values that
+the user never wrote. Concretely close the awscc#206 reproduction in
+which `awscc.s3.Bucket` plans show:
+
+```
+- transition_default_minimum_object_size: "all_storage_classes_128K"
+```
+
+even though no `.crn` source mentions the field.
+
+The fix extends the existing top-level `ResourceState.desired_keys:
+Vec<String>` (state file's user-authored key list, consumed by the
+differ via `prev_desired_keys`) to a **recursive tree** that captures
+authoring information for nested struct fields and list-of-struct
+elements as well. The differ projects the `current` state through this
+tree before comparison, removing fields the user never wrote so they
+do not surface as diffs.
+
+## Non-goals
+
+- Changing the WIT plugin contract. The fix is entirely inside
+  carina-core / carina-state / carina-cli.
+- Distinguishing per-list-element user authoring (different elements
+  may have written different fields). The List variant captures the
+  union across all elements; this is a documented simplification.
+- Touching either provider crate (carina-provider-aws,
+  carina-provider-awscc). The fix lives in core; providers are
+  unaffected.
+
+## Background
+
+`ResourceState.desired_keys: Vec<String>` (carina-state/src/state/mod.rs:459)
+already records the **top-level** attribute keys the user wrote in
+their `.crn`. The differ uses it via `prev_desired_keys`
+(carina-core/src/differ/comparison.rs:382) to detect "user removed
+this attribute" — when a key is in `prev_desired_keys` but not in
+the current desired state, the differ emits a `Remove` op.
+
+The same mechanism is needed inside `Value::Struct` and
+`Value::List` of structs: when AWS Cloud Control returns a struct
+field the user never wrote, that field should not appear in the
+diff. Today's `desired_keys` only tracks top-level keys, so the
+nested case is unhandled and the spurious `- field: value` line
+appears.
+
+## Chosen approach
+
+Replace `desired_keys: Vec<String>` with a recursive **`ExplicitFields`
+tree** that mirrors the structure the user wrote, then **project** the
+current state through the tree before diffing or display.
+
+### Type
+
+```rust
+/// Tree describing which fields the user explicitly wrote in their
+/// `.crn` for this resource. Each variant corresponds to a `Value`
+/// shape:
+///
+/// - `Leaf`: user wrote this position as a scalar value (or as an
+///   opaque value that has no nested authoring information). Treated
+///   as "user wrote the whole thing" — no projection inside.
+/// - `Struct`: user wrote a struct here. Only the listed `children`
+///   are user-authored; struct fields not listed are server-only and
+///   are removed by projection.
+/// - `List`: user wrote a list of structs here. `element` is the
+///   union of authoring across all elements (see "Edge cases").
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ExplicitFields {
+    #[default]
+    Leaf,
+    Struct {
+        children: HashMap<String, ExplicitFields>,
+    },
+    List {
+        element: Box<ExplicitFields>,
+    },
+}
+```
+
+### Storage in state
+
+```rust
+pub struct ResourceState {
+    // ... existing fields ...
+    /// Tree of fields the user explicitly wrote in their `.crn` for this
+    /// resource. Used by the differ to skip "removal" diff lines for
+    /// fields the user never specified (server-side defaults like
+    /// awscc.s3.Bucket.lifecycle_configuration.transition_default_minimum_object_size).
+    /// Replaces the flat `desired_keys: Vec<String>` (state ≤ v5).
+    #[serde(default)]
+    pub explicit: ExplicitFields,
+}
+```
+
+`desired_keys: Vec<String>` is **removed** in state v6.
+
+### Construction
+
+`carina-core/src/explicit.rs` (new module):
+
+```rust
+pub fn build_from_resource(resource: &Resource) -> ExplicitFields {
+    ExplicitFields::Struct {
+        children: resource.attributes.iter()
+            .filter(|(k, _)| !k.starts_with('_'))
+            .map(|(k, v)| (k.clone(), build_from_value(v)))
+            .collect(),
+    }
+}
+
+fn build_from_value(value: &Value) -> ExplicitFields {
+    match value {
+        Value::Struct { fields, .. } => ExplicitFields::Struct {
+            children: fields.iter()
+                .map(|(k, v)| (k.clone(), build_from_value(v)))
+                .collect(),
+        },
+        Value::List(items) => ExplicitFields::List {
+            element: Box::new(
+                items.iter()
+                    .map(build_from_value)
+                    .fold(ExplicitFields::Leaf, merge),
+            ),
+        },
+        _ => ExplicitFields::Leaf,
+    }
+}
+
+fn merge(a: ExplicitFields, b: ExplicitFields) -> ExplicitFields {
+    use ExplicitFields::*;
+    match (a, b) {
+        (Leaf, b) => b,
+        (a, Leaf) => a,
+        (Struct { children: mut a }, Struct { children: b }) => {
+            for (k, v) in b {
+                let merged = match a.remove(&k) {
+                    Some(existing) => merge(existing, v),
+                    None => v,
+                };
+                a.insert(k, merged);
+            }
+            Struct { children: a }
+        }
+        (List { element: a }, List { element: b }) => List {
+            element: Box::new(merge(*a, *b)),
+        },
+        // Mismatched shapes (shouldn't occur for well-typed inputs):
+        // prefer the "richer" structural variant.
+        (a @ Struct { .. }, _) => a,
+        (a @ List { .. }, _) => a,
+    }
+}
+```
+
+### Projection
+
+`carina-core/src/explicit.rs`:
+
+```rust
+/// Strip from `value` everything not listed in `explicit`. Used to
+/// remove server-side defaults from the actual-state side before
+/// diffing. Idempotent: project(project(v)) == project(v).
+pub fn project(value: Value, explicit: &ExplicitFields) -> Value {
+    match (value, explicit) {
+        // user wrote whole leaf: keep entire current value
+        (v, ExplicitFields::Leaf) => v,
+        (Value::Struct { name, fields }, ExplicitFields::Struct { children }) => {
+            Value::Struct {
+                name,
+                fields: fields.into_iter()
+                    .filter_map(|(k, v)| {
+                        children.get(&k).map(|sub| (k, project(v, sub)))
+                    })
+                    .collect(),
+            }
+        }
+        (Value::List(items), ExplicitFields::List { element }) => {
+            Value::List(
+                items.into_iter()
+                    .map(|item| project(item, element))
+                    .collect(),
+            )
+        }
+        // shape mismatch (state inconsistent or schema drift): keep
+        // value as-is to avoid hiding real data
+        (v, _) => v,
+    }
+}
+
+pub fn project_attributes(
+    attrs: HashMap<String, Value>,
+    explicit: &ExplicitFields,
+) -> HashMap<String, Value> {
+    match explicit {
+        ExplicitFields::Struct { children } => attrs.into_iter()
+            .filter_map(|(k, v)| {
+                children.get(&k).map(|sub| (k, project(v, sub)))
+            })
+            .collect(),
+        // top-level being Leaf or List shouldn't occur for a
+        // resource's full attribute set; pass through conservatively
+        _ => attrs,
+    }
+}
+```
+
+### Differ integration
+
+Two changes to `carina-core/src/differ/comparison.rs`:
+
+1. At the entry of `find_changed_attributes`, project the `current`
+   map: `let current = project_attributes(current, explicit)`.
+2. Replace the `prev_desired_keys: Option<&[String]>` parameter
+   with `prev_explicit: Option<&ExplicitFields>`. The "user removed
+   this top-level attribute" detection (lines 382–394) reads
+   `prev_explicit` as a `Struct { children }` and iterates its keys.
+
+Equivalent updates in `carina-core/src/differ/plan.rs` and
+`carina-core/src/differ/mod.rs` to thread the new type instead of
+`Vec<String>`.
+
+### Display integration
+
+`carina-core/src/detail_rows.rs::build_*_rows` calls
+`compute_unchanged_count(&from.attributes, ...)` (line 488). Project
+`from.attributes` (the current state) before counting:
+
+```rust
+let projected = project_attributes(from.attributes.clone(), explicit);
+let unchanged_count = compute_unchanged_count(&projected, ...);
+```
+
+`build_*_rows` signatures gain an `explicit: &ExplicitFields`
+parameter (or accept a pre-projected `from`). Same treatment for any
+other display path that reads `from.attributes` directly. TUI mirrors
+the CLI's row construction, so once `detail_rows.rs` is corrected the
+TUI inherits the fix.
+
+### State versioning (v5 → v6)
+
+State file `version` bumps from 5 to 6.
+
+- v6 is the only writable format.
+- v5 read path constructs `ExplicitFields::Struct { children: ... }`
+  with each `desired_keys` entry mapped to `ExplicitFields::Leaf`:
+
+  ```rust
+  fn convert_v5_resource_state(rs: ResourceStateV5) -> ResourceState {
+      let explicit = ExplicitFields::Struct {
+          children: rs.desired_keys.into_iter()
+              .map(|k| (k, ExplicitFields::Leaf))
+              .collect(),
+      };
+      ResourceState { explicit, /* other fields */ }
+  }
+  ```
+
+- After v5 read, the **first plan** still surfaces nested-field
+  spurious diffs (the v5 file has no nested authoring info). The
+  **first apply** writes back v6 with a fully-built tree from
+  `from_provider_state`, and from then on nested server defaults are
+  hidden. This one-time degradation is acceptable per the project's
+  "No backward compat" policy.
+
+- The v5 reader is retained until the next state version (v7), at
+  which point it is removed in the same PR that introduces v7.
+
+### Test fixtures
+
+All `carina-cli/tests/fixtures/plan_display/*/carina.state.json`
+files are rewritten in v6 form (`explicit` instead of `desired_keys`).
+A new fixture `server_default_struct_leaf/` reproduces the
+awscc#206 scenario: desired state writes
+`lifecycle_configuration { rules = [...] }` without
+`transition_default_minimum_object_size`, current has it; expected
+snapshot has no `- transition_default_minimum_object_size` line.
+
+## Key design decisions
+
+### D1. Replace `desired_keys` outright (not co-exist)
+
+Per memory `feedback_no_backward_compat`, the project does not retain
+deprecated fields. v5 read path performs a one-shot conversion; v6 is
+the only writable format. No "two sources of truth" between
+`desired_keys` and `explicit`.
+
+### D2. Field name `explicit`, type name `ExplicitFields`
+
+Earlier candidate `desired_keys` was rejected as imprecise (`keys`
+implies a flat list; the structure is a tree). `Tracked` /
+`Provenance` were rejected because a previous superseded design
+already used those names. `explicit` matches the IaC literature
+("explicit vs implicit" / "explicit vs server-default") and reads
+naturally for a tree (`state.explicit.children["lifecycle_configuration"]`).
+
+### D3. List of struct uses union semantics, not per-element
+
+A `Value::List` of `Value::Struct` is represented as
+`ExplicitFields::List { element: Box<ExplicitFields> }`. The
+`element` is the **union** of authoring across all list elements —
+if any element wrote a field, that field is considered authored for
+all elements. Rationale:
+
+- Per-element index tracking breaks under reordering, insertion, and
+  deletion. The element identity problem is fundamental.
+- Real `.crn` configurations almost always write the same shape
+  across all elements of a list. The union is virtually never wider
+  than what any single element wrote.
+- If a future requirement genuinely needs per-element provenance,
+  the `ExplicitFields` enum can grow a new variant; the existing
+  `List { element }` form remains a valid restriction.
+
+### D4. Build from `Value`, not from parser AST
+
+`build_from_value` takes a `Value` and walks its structure. The
+parser-level alternative (record authoring during parsing) was
+considered and rejected as over-engineered: `Value`-walking handles
+empty structs/lists correctly via the `match` arms, and avoids
+threading authoring state through the parser.
+
+The corner case "user wrote `lifecycle_configuration {}`" is correctly
+captured: the value is `Value::Struct { fields: [] }`,
+`build_from_value` returns `Struct { children: HashMap::new() }`,
+projection then strips every server-side leaf inside that block. This
+matches the user's intent ("I wrote an empty struct; everything
+inside is server-managed").
+
+### D5. Project both in differ and display, idempotently
+
+The differ projects `current` before computing patch ops; the
+display projects `from.attributes` before counting unchanged. Both
+sites use the same `project_attributes` function, which is idempotent:
+double-projection is a no-op. This yields a defense-in-depth: even
+if a future code path forgets to project, double-projection by an
+intermediate function does not produce wrong output.
+
+A wrapper type `ProjectedAttributes` to enforce projection at the
+type level was considered and rejected as over-engineered.
+Idempotence + a clear naming convention (`current_projected`,
+`from_projected`) is sufficient.
+
+## File touch map
+
+### carina-core
+- `carina-core/src/explicit.rs` (new) — `ExplicitFields` enum,
+  `build_from_resource`, `build_from_value`, `merge`, `project`,
+  `project_attributes`, unit tests.
+- `carina-core/src/lib.rs` — re-export `explicit` module.
+- `carina-core/src/differ/comparison.rs` — replace
+  `prev_desired_keys: Option<&[String]>` parameter with
+  `prev_explicit: Option<&ExplicitFields>`; project `current` at
+  function entry; rewrite the lines 382–394 removal-detection loop
+  to walk `prev_explicit`'s `Struct { children }`.
+- `carina-core/src/differ/plan.rs` — update `prev_desired_keys`
+  parameter type and HashMap value type
+  (`HashMap<ResourceId, ExplicitFields>`).
+- `carina-core/src/differ/mod.rs` — same parameter type update.
+- `carina-core/src/detail_rows.rs` — accept `&ExplicitFields`;
+  project `from.attributes` before passing to
+  `compute_unchanged_count`.
+- `carina-core/src/differ/diff_tests.rs`,
+  `carina-core/src/differ/comparison_tests.rs`,
+  `carina-core/src/differ/plan_tests.rs` — update test fixtures
+  to use `ExplicitFields`; add new tests covering nested struct
+  field projection.
+
+### carina-state
+- `carina-state/src/state/mod.rs`:
+  - Replace `desired_keys: Vec<String>` with
+    `explicit: ExplicitFields` on `ResourceState`.
+  - Bump `CURRENT_VERSION` to 6.
+  - Replace `build_desired_keys()` with `build_explicit()` returning
+    `HashMap<ResourceId, ExplicitFields>`.
+  - In `from_provider_state`, replace `desired_keys` construction
+    with `carina_core::explicit::build_from_resource(resource)`.
+  - Add v5→v6 read path that converts `desired_keys: Vec<String>`
+    into a flat `ExplicitFields::Struct` with `Leaf` children.
+- `carina-state/src/state/tests.rs` — update existing tests; add
+  v5→v6 conversion test.
+
+### carina-cli
+- `carina-cli/src/fixture_plan.rs`,
+  `carina-cli/src/wiring/tests.rs`,
+  `carina-cli/src/tests.rs`,
+  `carina-cli/src/plan_snapshot_tests.rs` — replace
+  `prev_desired_keys` variable type and constructions
+  (`HashMap<ResourceId, Vec<String>>` → `HashMap<ResourceId, ExplicitFields>`).
+- `carina-cli/tests/fixtures/plan_display/*/carina.state.json` —
+  rewrite each fixture from v5 (`desired_keys`) to v6
+  (`explicit`). Use the v5→v6 conversion as a helper one-shot
+  script if desired.
+- `carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/`
+  (new) — `main.crn` and `carina.state.json` reproducing
+  awscc#206. Snapshot asserts no `-` line for the server-default
+  field.
+- `Makefile` — new `plan-server-default-struct-leaf` target per
+  memory rule `feedback_makefile_for_fixtures`.
+
+### carina-tui
+- `carina-tui/src/ui/detail.rs`,
+  `carina-tui/src/ui/diff.rs` — if either reads `from.attributes`
+  directly (rather than going through `DetailRow`), apply
+  projection. Otherwise unchanged.
+
+## Edge cases
+
+- **Empty struct authored** (`lifecycle_configuration {}`):
+  `build_from_value` produces `Struct { children: empty }`;
+  projection strips every nested field. Correct: user explicitly
+  wrote "empty config; everything inside is server-managed".
+
+- **Empty list authored** (`tags = []`): `Value::List([])`;
+  `build_from_value` returns `List { element: Leaf }` (default).
+  Projection of an empty `Value::List([])` is unchanged. If the
+  current side has elements, those elements pass through projection
+  with `element: Leaf` (which keeps the whole element, since Leaf
+  means "user wrote the whole thing"). This correctly surfaces
+  added elements as diffs.
+
+- **State file from before this change** (v5 with
+  `desired_keys`): converted on read to `Struct` with `Leaf`
+  children. First plan after upgrade still shows nested-field
+  spurious diffs; first apply writes v6 with full tree; subsequent
+  plans are clean. Acceptable.
+
+- **`Value::Map` (not Struct, not List)**: maps are treated as
+  Leaf in `build_from_value`. Projection of a Leaf leaves the
+  whole map intact. This means map values are not projected
+  field-by-field — sufficient for current AWS schemas where
+  server-side defaults appear inside Struct fields, not inside
+  user-authored Maps. A future Map variant on `ExplicitFields`
+  can be added if needed.
+
+- **Schema drift** (current has shape that doesn't match
+  authoring tree): the projection's catch-all `(v, _) => v` keeps
+  the value as-is. Conservative: better to over-show than
+  under-show in this rare case.
+
+## Testing
+
+- **Unit tests** in `carina-core/src/explicit.rs`:
+  serde round-trip, `merge` associativity, `project` idempotence,
+  `build_from_value` for each `Value` variant.
+- **Differ tests** in `carina-core/src/differ/diff_tests.rs`:
+  - server-default struct leaf does not produce a `Remove` op
+  - user-removed top-level attribute still produces a `Remove` op
+    (regression guard for the existing `prev_desired_keys` behavior)
+  - server-default in list element does not produce a diff
+- **State tests** in `carina-state/src/state/tests.rs`:
+  v5→v6 conversion preserves top-level keys as `Leaf` children;
+  v6 round-trip preserves full tree.
+- **Snapshot fixture** in
+  `carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/`:
+  full-stack assertion that no `-` line appears for a server-default
+  struct leaf.
+- **Real-infra smoke** (manual, by user): `aws-vault exec mizzy --
+  carina plan` against `carina-rs/infra/.../registry/dev/registry`
+  shows no `- transition_default_minimum_object_size` line.
+
+## Risks
+
+- **State v6 lock-in**: once carina writes v6, older carina
+  binaries fail to read it. Standard for this experimental project.
+- **Test fixture rewrite churn**: every `carina.state.json` in
+  `plan_display/` fixtures is bumped to v6. Mechanical change but
+  large surface; a one-shot script is cheap insurance.
+- **Plan output silently improves**: snapshot fixtures must be
+  reviewed to confirm the *only* changes are server-default lines
+  disappearing; any other delta is a regression.


### PR DESCRIPTION
## Summary

Brainstorming output for `carina-rs/carina-provider-awscc#206`.

Replaces `ResourceState.desired_keys: Vec<String>` (top-level only) with `ResourceState.explicit: ExplicitFields`, a recursive enum capturing user authoring at every nesting level (Struct fields and list-of-struct elements). The differ projects `current` through this tree before diffing so AWS server-side default fields the user never wrote stop appearing as spurious `-` lines.

```rust
pub enum ExplicitFields {
    Leaf,
    Struct { children: HashMap<String, ExplicitFields> },
    List { element: Box<ExplicitFields> },
}
```

State bumps v5 → v6. v5 read converts the flat `desired_keys` to a `Struct` with `Leaf` children (one-time degradation: first plan after upgrade still shows nested-field spurious diffs, first apply rebuilds the full tree).

## Scope

`carina-rs/carina` only. WIT contract unchanged. No provider repo touch. The earlier (rejected) provenance-tracking design that touched WIT + 4 repos was reverted in `carina-rs/carina-provider-awscc#209` after discovery that this repo already has a top-level `desired_keys` mechanism — this PR extends it into nested structs instead of reinventing it.

## Plan

13 tasks. See `docs/plans/2026-05-10-explicit-fields.md`.

| # | Task | Blocked by |
|---|------|------------|
| 1 | `ExplicitFields` enum + serde + tests | — |
| 2 | `build_from_resource` / `build_from_value` / `merge` | 1 |
| 3 | `project` / `project_attributes` (idempotent) | 2 |
| 4 | `ResourceState.explicit` + state v6 + v5→v6 read | 2, 3 |
| 5 | differ comparison: project current + ExplicitFields param | 4 |
| 6 | differ plan + mod: thread `ExplicitFields` through | 5 |
| 7 | carina-cli wiring: type updates | 6 |
| 8 | display detail_rows: project `from.attributes` | 4, 7 |
| 9 | TUI audit + project if direct reads found | 8 |
| 10 | Rewrite 19 `plan_display` fixture state files to v6 | 4 |
| 11 | New fixture `server_default_struct_leaf` + Makefile + snapshot | 5, 8, 10 |
| 12 | LSP audit for `desired_keys` references | 4 |
| 13 | Real-infra acceptance for awscc#206 | 1–12 |

Issues will be created per task immediately after this PR opens.

Refs `carina-rs/carina-provider-awscc#206`

🤖 Generated with [Claude Code](https://claude.com/claude-code)