### PR TITLE
plan: drop paired list-of-maps elements with no displayable diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ plan-list-diff-modified-with-unchanged:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged
 plan-list-diff-modified-with-unchanged-nested:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged_nested
+plan-list-diff-paired-all-unchanged-dropped:
+	$(PLAN_FIXTURE) list_diff_paired_all_unchanged_dropped
 plan-enum-display:
 	$(PLAN_FIXTURE) enum_display
 plan-no-changes-enum:
@@ -89,6 +91,8 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-modified-with-unchanged
 	@echo "---"
 	@$(MAKE) plan-list-diff-modified-with-unchanged-nested
+	@echo "---"
+	@$(MAKE) plan-list-diff-paired-all-unchanged-dropped
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1339,7 +1339,7 @@ fn render_list_of_maps_diff(
             .any(|f| matches!(f, ListOfMapsDiffField::NestedMapChanged { .. }));
         if has_nested {
             writeln!(out, "{}  {} {{", attr_prefix, "~".yellow().bold()).unwrap();
-            for field in &item.fields {
+            for field in item.fields.iter() {
                 match field {
                     ListOfMapsDiffField::Changed { key, old, new } => {
                         writeln!(
@@ -1374,16 +1374,10 @@ fn render_list_of_maps_diff(
             }
             writeln!(out, "{}    }}", attr_prefix).unwrap();
         } else {
-            let rendered_fields = render_modified_fields(&item.fields);
-            // Append the hidden-fields count after the changed field list
-            // so the summary stays inside the `~ { ... }` block. A paired
-            // modified item always has at least one changed field by
-            // construction (Phase 1 absorbs all-equal pairs as unchanged
-            // before pairing runs), so `rendered_fields` is never empty.
-            debug_assert!(
-                !rendered_fields.is_empty(),
-                "paired modified item must have at least one changed field"
-            );
+            // `item.fields` is `NonEmptyVec`, so the changed-field
+            // string is statically non-empty — no need to guard the
+            // separator (#2886).
+            let rendered_fields = render_modified_fields(item.fields.as_slice());
             let summary = if item.hidden_unchanged_count > 0 {
                 let s = hidden_unchanged_summary(item.hidden_unchanged_count, "field")
                     .dimmed()

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1001,6 +1001,26 @@ fn snapshot_list_diff_modified_with_unchanged_nested() {
     insta::assert_snapshot!(output);
 }
 
+// #2886: paired list-of-maps elements whose only "diff" was an
+// upstream-injected key dropped by the IR are absorbed into the
+// trailing `# (n unchanged attributes hidden)` summary. Snapshot
+// pins the resulting per-resource block (no `statement:` row, count
+// includes the absorbed attribute).
+#[test]
+fn snapshot_list_diff_paired_all_unchanged_dropped() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_paired_all_unchanged_dropped");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
 // Mirror of the added-struct test for the removed path.
 #[test]
 fn snapshot_list_diff_removed_struct() {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_paired_all_unchanged_dropped.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_paired_all_unchanged_dropped.snap
@@ -1,0 +1,11 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      policy_name: "test-inline" → "test-inline-renamed"
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
@@ -1,0 +1,34 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-paired-all-unchanged-dropped",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowS3Read",
+            "effect": "Allow",
+            "action": "s3:GetObject",
+            "resource": "arn:aws:s3:::example/*",
+            "provider_default_field": "an-extra-key-the-provider-injected-not-in-desired"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["policy_name", "role_name", "statement"],
+      "binding": "policy",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/main.crn
@@ -1,0 +1,28 @@
+# #2886: state carries an extra `provider_default_field` not in
+# desired (mimics awscc#206-style upstream drift). The paired
+# statement element has zero changed desired keys, so the IR drops
+# it and the statement attribute is absorbed into the trailing
+# unchanged-attributes count. `policy_name` is renamed only to force
+# an Update effect — without it the differ short-circuits before
+# reaching the renderer.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline-renamed'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid    = 'AllowS3Read'
+      effect = 'Allow'
+      action = 's3:GetObject'
+      resource = 'arn:aws:s3:::example/*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -10,6 +10,7 @@ use indexmap::IndexMap;
 
 use crate::diff_helpers::{compute_map_diff, compute_unchanged_count};
 use crate::effect::Effect;
+use crate::non_empty::NonEmptyVec;
 use crate::resource::{ResourceId, Value};
 use crate::schema::SchemaRegistry;
 use crate::value::{format_value, format_value_with_key, is_list_of_maps, map_similarity};
@@ -185,13 +186,15 @@ pub enum ListOfMapsDiffItemKind {
     Removed,
 }
 
-/// A modified item in a list-of-maps diff
+/// A modified item in a list-of-maps diff.
+///
+/// `fields` is `NonEmptyVec`: an item with zero changed fields is by
+/// definition unchanged and the IR builder drops it (#2886) rather
+/// than synthesize a `~ {}` row. Renderers therefore do not need to
+/// guard against an empty `fields` shape.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListOfMapsDiffModified {
-    /// Ordered list of fields. Only changed / nested-changed fields are
-    /// retained — unchanged fields are filtered out at IR build time
-    /// (#2881) and surfaced as a summary count in `hidden_unchanged_count`.
-    pub fields: Vec<ListOfMapsDiffField>,
+    pub fields: NonEmptyVec<ListOfMapsDiffField>,
     /// Number of unchanged fields filtered out of `fields`. Set to a
     /// non-zero value only when the build is in `DetailLevel::Full`,
     /// matching the top-level `# (n unchanged attributes hidden)`
@@ -438,6 +441,13 @@ fn build_update_rows(
         .collect();
     keys.sort();
 
+    // Attributes where `semantically_equal` reported a diff but the
+    // per-shape builder produced no display rows (e.g. list-of-maps
+    // whose only diff was an upstream-injected key dropped by the IR,
+    // #2886). Counted into the trailing unchanged-attributes summary
+    // so the final tally still adds up.
+    let mut effectively_unchanged: usize = 0;
+
     for key in keys {
         let new_value = &to.attributes[key];
         let old_value = from.attributes.get(key);
@@ -450,9 +460,10 @@ fn build_update_rows(
         }
 
         if is_list_of_maps(new_value) {
-            rows.push(build_list_of_maps_diff_row(
-                key, old_value, new_value, detail,
-            ));
+            match build_list_of_maps_diff_row(key, old_value, new_value, detail) {
+                Some(row) => rows.push(row),
+                None => effectively_unchanged += 1,
+            }
         } else if is_both_maps(old_value, new_value) {
             rows.push(build_map_diff_row(key, old_value, new_value, detail));
         } else {
@@ -485,7 +496,8 @@ fn build_update_rows(
     // In Full mode, show count of unchanged attributes hidden
     if detail == DetailLevel::Full {
         let unchanged_count =
-            compute_unchanged_count(&from.attributes, &to.resolved_attributes(), None);
+            compute_unchanged_count(&from.attributes, &to.resolved_attributes(), None)
+                + effectively_unchanged;
         if unchanged_count > 0 {
             rows.push(DetailRow::HiddenUnchanged {
                 count: unchanged_count,
@@ -755,21 +767,30 @@ fn compute_map_diff_entries(
     entries
 }
 
+/// Build the per-attribute list-of-maps diff row, returning `None` when
+/// every section of the diff is empty. The empty result occurs when the
+/// only "difference" was an upstream-injected key that the IR builder
+/// dropped (#2886) — semantically the attribute has no diff to show, so
+/// the caller should treat it as effectively unchanged and let it roll
+/// into the top-level `# (n unchanged attributes hidden)` summary.
 fn build_list_of_maps_diff_row(
     key: &str,
     old_value: Option<&Value>,
     new_value: &Value,
     detail: DetailLevel,
-) -> DetailRow {
+) -> Option<DetailRow> {
     let (unchanged, modified, added, removed) =
         compute_list_of_maps_diff_parts(old_value, new_value, detail);
-    DetailRow::ListOfMapsDiff {
+    if unchanged.is_empty() && modified.is_empty() && added.is_empty() && removed.is_empty() {
+        return None;
+    }
+    Some(DetailRow::ListOfMapsDiff {
         key: key.to_string(),
         unchanged,
         modified,
         added,
         removed,
-    }
+    })
 }
 
 fn compute_list_of_maps_diff_parts(
@@ -909,6 +930,16 @@ fn compute_list_of_maps_diff_parts(
                     });
                 }
             }
+            // #2886: a paired item whose every desired key matched
+            // state (`fields` empty) is semantically unchanged. Drop
+            // it from the modified list rather than synthesizing a
+            // `~ {}` row that would mislead the reader. The driver of
+            // this case is upstream provider drift — state carrying a
+            // key not in desired forces Phase 1 to reject the pair on
+            // length mismatch, but Phase 2 still pairs by similarity.
+            let Some(fields) = NonEmptyVec::from_vec(fields) else {
+                continue;
+            };
             // Only surface the count in Full mode — Explicit / NamesOnly
             // never emit hidden-counts at the top level either.
             let hidden_unchanged_count = if detail == DetailLevel::Full {

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod keywords;
 pub mod lint;
 pub mod module;
 pub mod module_resolver;
+pub(crate) mod non_empty;
 pub mod parser;
 pub mod plan;
 pub mod plan_tree;

--- a/carina-core/src/non_empty.rs
+++ b/carina-core/src/non_empty.rs
@@ -1,0 +1,46 @@
+//! A vector that is statically guaranteed to contain at least one
+//! element. Encoding the invariant in the type lets readers skip
+//! defensive `is_empty` checks and forces empty handling at the
+//! conversion boundary instead of at every read site.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonEmptyVec<T> {
+    // Invariant: never empty. Maintained by every constructor.
+    inner: Vec<T>,
+}
+
+impl<T> NonEmptyVec<T> {
+    pub fn from_vec(v: Vec<T>) -> Option<Self> {
+        if v.is_empty() {
+            None
+        } else {
+            Some(Self { inner: v })
+        }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.inner.iter()
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_vec_empty_returns_none() {
+        assert!(NonEmptyVec::<i32>::from_vec(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn from_vec_preserves_order() {
+        let nev = NonEmptyVec::from_vec(vec![1, 2, 3]).unwrap();
+        let collected: Vec<_> = nev.iter().copied().collect();
+        assert_eq!(collected, vec![1, 2, 3]);
+        assert_eq!(nev.as_slice(), &[1, 2, 3]);
+    }
+}

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -120,7 +120,7 @@ pub(super) fn render_list_of_maps_diff(
     for m in modified {
         let mut spans = vec![Span::raw("    {")];
         let mut emitted = 0usize;
-        for field in &m.fields {
+        for field in m.fields.iter() {
             if emitted > 0 {
                 spans.push(Span::raw(", "));
             }


### PR DESCRIPTION
## Summary

After #2881, a list-of-maps element rendered with a leading comma when its only contents were unchanged-and-hidden fields:

```
~ {, # (3 unchanged fields hidden)}
```

This PR fixes the root cause rather than the symptom (a previous attempt at #2893 patched the renderer; closed in favor of this approach).

## Root cause

`ListOfMapsDiffModified.fields: Vec<...>` allowed "modified but with zero changed fields", a state that is semantically nonsense. The IR builder constructed it whenever Phase 2 paired two map elements by similarity but every desired key compared equal to state — the empty-`fields` case happens when state carries an upstream-injected key not present in desired (Phase 1's `maps_semantically_equal` rejects the pair on length mismatch, so Phase 2 still pairs by similarity). This is the same family as awscc#206.

The renderers (CLI and TUI) each defended against the empty case differently, and a `debug_assert!` encoded the now-disproved invariant.

## Fix

- New `carina-core::non_empty::NonEmptyVec<T>` (pub(crate) module) carries the "at least one element" guarantee in the type system.
- `ListOfMapsDiffModified.fields` retyped to `NonEmptyVec`.
- `compute_list_of_maps_diff_parts` drops paired items whose `fields` end up empty — semantically those are unchanged.
- `build_list_of_maps_diff_row` returns `Option<DetailRow>` and the caller absorbs `None` into the trailing `# (n unchanged attributes hidden)` count via an `effectively_unchanged` counter, so totals still add up.
- CLI and TUI renderers drop their empty-`fields` defensive branches; the `debug_assert!` is gone.

## Display change

Before:
```
~ awscc.iam.RolePolicy policy
    policy_name: "test-inline" → "test-inline-renamed"
    statement:
      ~ {, # (4 unchanged fields hidden)}
    # (1 unchanged attribute hidden)
```

After (paired-all-equal element absorbed into the trailing summary):
```
~ awscc.iam.RolePolicy policy
    policy_name: "test-inline" → "test-inline-renamed"
    # (2 unchanged attributes hidden)
```

## Out of scope

- The Replace path (`DetailRow::ReplaceListOfMapsDiff`) and nested map-of-list-of-maps share `compute_list_of_maps_diff_parts`, so the IR-level drop applies transitively. They still emit a parent header row even when all sections are empty — acceptable for Replace ("everything replaced"), but a follow-up is worth filing for the nested case if reproducible.
- awscc#206 itself (provider returning state with extra fields) is the upstream root; tracked in that repo.
- Real-infra smoke deferred per local policy (don't run real-infra AWS-touching commands myself).

## Test plan

- [x] New fixture `list_diff_paired_all_unchanged_dropped` reproduces the bug shape (state has `provider_default_field` not in desired; `policy_name` renamed only to force an Update so the renderer is reached). Snapshot pins the absorbed-into-summary output.
- [x] Existing `snapshot_list_diff_modified_with_unchanged` (non-empty case — fields + summary, comma preserved) unchanged.
- [x] `cargo nextest run --workspace` (3058 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` pass (incl. `check-plan-fixtures.sh` — Makefile target added).

Closes #2886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
