### PR TITLE
plan: recursively suppress empty nested Map and list-of-maps section headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ plan-list-diff-modified-with-unchanged-nested:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged_nested
 plan-list-diff-paired-all-unchanged-dropped:
 	$(PLAN_FIXTURE) list_diff_paired_all_unchanged_dropped
+plan-nested-list-of-maps-all-dropped:
+	$(PLAN_FIXTURE) nested_list_of_maps_all_dropped
 plan-enum-display:
 	$(PLAN_FIXTURE) enum_display
 plan-no-changes-enum:
@@ -93,6 +95,8 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-modified-with-unchanged-nested
 	@echo "---"
 	@$(MAKE) plan-list-diff-paired-all-unchanged-dropped
+	@echo "---"
+	@$(MAKE) plan-nested-list-of-maps-all-dropped
 	@echo ""
 	@echo "=== enum_display ==="
 	@$(MAKE) plan-enum-display

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1114,7 +1114,7 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
         }
         DetailRow::MapDiff { key, entries } => {
             writeln!(out, "{}{}:", attr_prefix, key).unwrap();
-            render_map_diff_entries(out, entries, attr_prefix);
+            render_map_diff_entries(out, entries.as_slice(), attr_prefix);
         }
         DetailRow::ListOfMapsDiff {
             key,
@@ -1304,17 +1304,19 @@ fn render_map_diff_entries(out: &mut String, entries: &[MapDiffEntryIR], attr_pr
             MapDiffEntryIR::NestedMapDiff { key, entries } => {
                 writeln!(out, "{}    {}:", attr_prefix, key).unwrap();
                 let nested_prefix = format!("{}    ", attr_prefix);
-                render_map_diff_entries(out, entries, &nested_prefix);
+                render_map_diff_entries(out, entries.as_slice(), &nested_prefix);
             }
-            MapDiffEntryIR::NestedListOfMapsDiff {
-                key,
-                modified,
-                added,
-                removed,
-            } => {
+            MapDiffEntryIR::NestedListOfMapsDiff { key, block } => {
                 writeln!(out, "{}    {}:", attr_prefix, key).unwrap();
                 let nested_prefix = format!("{}    ", attr_prefix);
-                render_list_of_maps_diff(out, &[], modified, added, removed, &nested_prefix);
+                render_list_of_maps_diff(
+                    out,
+                    block.unchanged(),
+                    block.modified(),
+                    block.added(),
+                    block.removed(),
+                    &nested_prefix,
+                );
             }
         }
     }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1021,6 +1021,27 @@ fn snapshot_list_diff_paired_all_unchanged_dropped() {
     insta::assert_snapshot!(output);
 }
 
+// #2910: a Map attribute whose only "diff" is a nested list-of-maps
+// where every paired element is dropped (per #2886). Pre-fix the tree
+// rendered dangling section headers (`config:`, `settings:`, `rules:`)
+// with nothing under them. Post-fix the IR drops the empty sections
+// recursively and the parent Map row is absorbed into the trailing
+// unchanged-attributes count.
+#[test]
+fn snapshot_nested_list_of_maps_all_dropped() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("nested_list_of_maps_all_dropped");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+    ));
+    insta::assert_snapshot!(output);
+}
+
 // Mirror of the added-struct test for the removed path.
 #[test]
 fn snapshot_list_diff_removed_struct() {

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_nested_list_of_maps_all_dropped.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_nested_list_of_maps_all_dropped.snap
@@ -1,0 +1,11 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.ec2.Vpc vpc
+      cidr_block: "10.0.0.0/16" → "10.1.0.0/16"
+      # (1 unchanged attribute hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
@@ -1,0 +1,36 @@
+{
+  "version": 3,
+  "serial": 1,
+  "lineage": "test-lineage-nested-list-of-maps-all-dropped",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.Vpc",
+      "name": "vpc",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0123456789abcdef0",
+        "config": {
+          "settings": {
+            "rules": [
+              {
+                "name": "allow-internal",
+                "action": "allow",
+                "provider_default_field": "an-extra-key-the-provider-injected-not-in-desired"
+              }
+            ]
+          }
+        }
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "desired_keys": ["cidr_block", "config"],
+      "binding": "vpc",
+      "dependency_bindings": []
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/main.crn
@@ -1,0 +1,33 @@
+# #2910: Map attribute whose only "diff" is a nested list-of-maps
+# whose every paired element is dropped per #2886. Pre-fix the
+# rendered tree showed dangling `bucket_encryption:` /
+# `server_side_encryption_configuration:` headers with nothing under
+# them. Post-fix the IR drops the empty sections recursively and the
+# headers vanish; the attribute is absorbed into the trailing
+# unchanged-attributes count.
+#
+# `cidr_block` is renamed to force an Update; `config.settings.rules`
+# is the list-of-maps where every desired key matches state but state
+# carries an extra `provider_default_field` (mimics awscc#206).
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.1.0.0/16'
+  config = {
+    settings = {
+      rules = [
+        {
+          name   = 'allow-internal'
+          action = 'allow'
+        },
+      ]
+    }
+  }
+}
+
+exports {
+  vpc_id = vpc.vpc_id
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -55,10 +55,13 @@ pub enum DetailRow {
         old: String,
         new: String,
     },
-    /// A map attribute with key-level diffs (for Update effects)
+    /// A map attribute with key-level diffs (for Update effects).
+    /// `entries` is `NonEmptyVec`: a Map with no displayable entries
+    /// is dropped at the IR builder (#2910), not rendered as an empty
+    /// header.
     MapDiff {
         key: String,
-        entries: Vec<MapDiffEntryIR>,
+        entries: NonEmptyVec<MapDiffEntryIR>,
     },
     /// A list-of-maps diff (for Update effects)
     ListOfMapsDiff {
@@ -149,18 +152,66 @@ pub enum MapDiffEntryIR {
     },
     /// Nested map diff: when both old and new values are maps,
     /// recursively compute key-level diffs instead of showing as one-liner.
+    /// `entries` is `NonEmptyVec` so renderers do not need to defend
+    /// against an empty container header (#2910).
     NestedMapDiff {
         key: String,
-        entries: Vec<MapDiffEntryIR>,
+        entries: NonEmptyVec<MapDiffEntryIR>,
     },
     /// Nested list-of-maps diff: when both old and new values are lists of maps,
-    /// show per-item field-level diffs instead of one-liner.
+    /// show per-item field-level diffs instead of one-liner. `block`'s
+    /// constructor enforces "at least one of unchanged/modified/added/removed
+    /// is non-empty" (#2910).
     NestedListOfMapsDiff {
         key: String,
+        block: NonEmptyListOfMapsBlock,
+    },
+}
+
+/// A list-of-maps diff bundle whose constructor refuses the
+/// "everything empty" shape (#2910). The IR builder converts via
+/// [`NonEmptyListOfMapsBlock::from_parts`] and only pushes the parent
+/// row when conversion succeeds, so renderers never see a section
+/// header with nothing under it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NonEmptyListOfMapsBlock {
+    unchanged: Vec<String>,
+    modified: Vec<ListOfMapsDiffModified>,
+    added: Vec<ListOfMapsDiffItem>,
+    removed: Vec<ListOfMapsDiffItem>,
+}
+
+impl NonEmptyListOfMapsBlock {
+    pub fn from_parts(
+        unchanged: Vec<String>,
         modified: Vec<ListOfMapsDiffModified>,
         added: Vec<ListOfMapsDiffItem>,
         removed: Vec<ListOfMapsDiffItem>,
-    },
+    ) -> Option<Self> {
+        if unchanged.is_empty() && modified.is_empty() && added.is_empty() && removed.is_empty() {
+            None
+        } else {
+            Some(Self {
+                unchanged,
+                modified,
+                added,
+                removed,
+            })
+        }
+    }
+
+    pub fn unchanged(&self) -> &[String] {
+        &self.unchanged
+    }
+    pub fn modified(&self) -> &[ListOfMapsDiffModified] {
+        &self.modified
+    }
+    pub fn added(&self) -> &[ListOfMapsDiffItem] {
+        &self.added
+    }
+    pub fn removed(&self) -> &[ListOfMapsDiffItem] {
+        &self.removed
+    }
 }
 
 /// A wholly added or removed item in a list-of-maps diff (#2877).
@@ -695,10 +746,7 @@ fn build_map_diff_row(
     new_value: &Value,
     detail: DetailLevel,
 ) -> Option<DetailRow> {
-    let entries = compute_map_diff_entries(old_value, new_value, detail);
-    if entries.is_empty() {
-        return None;
-    }
+    let entries = NonEmptyVec::from_vec(compute_map_diff_entries(old_value, new_value, detail))?;
     Some(DetailRow::MapDiff {
         key: key.to_string(),
         entries,
@@ -739,31 +787,32 @@ fn compute_map_diff_entries(
                 // If both old and new are maps, recursively diff
                 if matches!(&e.old_value, Value::Map(_)) && matches!(&e.new_value, Value::Map(_)) {
                     let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value, detail);
-                    // #2910: drop the parent header when every nested
-                    // entry was suppressed (recursive case of #2886).
-                    if nested.is_empty() {
-                        continue;
+                    // #2910: `from_vec` returns None for the all-empty
+                    // recursive case (every grandchild was itself
+                    // suppressed). Skip pushing so the parent header
+                    // never renders empty.
+                    if let Some(entries_nev) = NonEmptyVec::from_vec(nested) {
+                        entries.push(MapDiffEntryIR::NestedMapDiff {
+                            key: e.key.clone(),
+                            entries: entries_nev,
+                        });
                     }
-                    entries.push(MapDiffEntryIR::NestedMapDiff {
-                        key: e.key.clone(),
-                        entries: nested,
-                    });
                 } else if is_list_of_maps(&e.new_value) {
                     // List-of-maps: compute per-item field-level diffs
                     let (_, modified, added, removed) =
                         compute_list_of_maps_diff_parts(Some(&e.old_value), &e.new_value, detail);
-                    // #2910: drop the parent header when every paired
-                    // element was dropped per #2886 and there are no
-                    // wholly-added / wholly-removed elements either.
-                    if modified.is_empty() && added.is_empty() && removed.is_empty() {
-                        continue;
+                    // #2910: `from_parts` returns None when every
+                    // paired element was dropped per #2886 and there
+                    // are no wholly-added / wholly-removed elements
+                    // either.
+                    if let Some(block) =
+                        NonEmptyListOfMapsBlock::from_parts(Vec::new(), modified, added, removed)
+                    {
+                        entries.push(MapDiffEntryIR::NestedListOfMapsDiff {
+                            key: e.key.clone(),
+                            block,
+                        });
                     }
-                    entries.push(MapDiffEntryIR::NestedListOfMapsDiff {
-                        key: e.key.clone(),
-                        modified,
-                        added,
-                        removed,
-                    });
                 } else {
                     entries.push(MapDiffEntryIR::Changed {
                         key: e.key.clone(),
@@ -1054,6 +1103,27 @@ mod tests {
     use super::*;
     use crate::resource::{Resource, ResourceId, State};
     use std::collections::HashSet;
+
+    #[test]
+    fn non_empty_list_of_maps_block_rejects_all_empty() {
+        assert!(
+            NonEmptyListOfMapsBlock::from_parts(Vec::new(), Vec::new(), Vec::new(), Vec::new())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn non_empty_list_of_maps_block_accepts_any_non_empty_section() {
+        let block = NonEmptyListOfMapsBlock::from_parts(
+            vec!["{ k: v }".to_string()],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("non-empty unchanged section is valid");
+        assert_eq!(block.unchanged().len(), 1);
+        assert!(block.modified().is_empty());
+    }
 
     #[test]
     fn test_names_only_returns_empty() {

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -442,10 +442,12 @@ fn build_update_rows(
     keys.sort();
 
     // Attributes where `semantically_equal` reported a diff but the
-    // per-shape builder produced no display rows (e.g. list-of-maps
-    // whose only diff was an upstream-injected key dropped by the IR,
-    // #2886). Counted into the trailing unchanged-attributes summary
-    // so the final tally still adds up.
+    // per-shape builder produced no display rows. Two shapes today:
+    // list-of-maps whose only diff was an upstream-injected key the IR
+    // dropped (#2886), and Map whose only entries were empty nested
+    // sections recursively suppressed (#2910). Counted into the
+    // trailing unchanged-attributes summary so the final tally still
+    // adds up.
     let mut effectively_unchanged: usize = 0;
 
     for key in keys {
@@ -465,7 +467,10 @@ fn build_update_rows(
                 None => effectively_unchanged += 1,
             }
         } else if is_both_maps(old_value, new_value) {
-            rows.push(build_map_diff_row(key, old_value, new_value, detail));
+            match build_map_diff_row(key, old_value, new_value, detail) {
+                Some(row) => rows.push(row),
+                None => effectively_unchanged += 1,
+            }
         } else {
             let old_str = old_value
                 .map(|v| format_value_with_key(v, Some(key)))
@@ -680,17 +685,24 @@ fn build_delete_rows(
     rows
 }
 
+/// Returns `None` when `compute_map_diff_entries` filters every entry
+/// (#2910), so the caller can fold the attribute into the trailing
+/// `# (n unchanged attributes hidden)` count — same shape as
+/// `build_list_of_maps_diff_row` (#2886).
 fn build_map_diff_row(
     key: &str,
     old_value: Option<&Value>,
     new_value: &Value,
     detail: DetailLevel,
-) -> DetailRow {
+) -> Option<DetailRow> {
     let entries = compute_map_diff_entries(old_value, new_value, detail);
-    DetailRow::MapDiff {
+    if entries.is_empty() {
+        return None;
+    }
+    Some(DetailRow::MapDiff {
         key: key.to_string(),
         entries,
-    }
+    })
 }
 
 fn compute_map_diff_entries(
@@ -727,6 +739,11 @@ fn compute_map_diff_entries(
                 // If both old and new are maps, recursively diff
                 if matches!(&e.old_value, Value::Map(_)) && matches!(&e.new_value, Value::Map(_)) {
                     let nested = compute_map_diff_entries(Some(&e.old_value), &e.new_value, detail);
+                    // #2910: drop the parent header when every nested
+                    // entry was suppressed (recursive case of #2886).
+                    if nested.is_empty() {
+                        continue;
+                    }
                     entries.push(MapDiffEntryIR::NestedMapDiff {
                         key: e.key.clone(),
                         entries: nested,
@@ -735,6 +752,12 @@ fn compute_map_diff_entries(
                     // List-of-maps: compute per-item field-level diffs
                     let (_, modified, added, removed) =
                         compute_list_of_maps_diff_parts(Some(&e.old_value), &e.new_value, detail);
+                    // #2910: drop the parent header when every paired
+                    // element was dropped per #2886 and there are no
+                    // wholly-added / wholly-removed elements either.
+                    if modified.is_empty() && added.is_empty() && removed.is_empty() {
+                        continue;
+                    }
                     entries.push(MapDiffEntryIR::NestedListOfMapsDiff {
                         key: e.key.clone(),
                         modified,

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -183,7 +183,7 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
                 first_line = first_line.style(Style::default().bg(Color::DarkGray));
             }
             lines.push(first_line);
-            render_map_diff_entries(lines, entries);
+            render_map_diff_entries(lines, entries.as_slice());
         }
         DetailRow::ListOfMapsDiff {
             key,

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -63,27 +63,22 @@ pub(super) fn render_map_diff_entries(lines: &mut Vec<Line>, entries: &[MapDiffE
                     Span::raw(format!("{}:", key)),
                 ]));
                 let mut nested_lines = Vec::new();
-                render_map_diff_entries(&mut nested_lines, entries);
+                render_map_diff_entries(&mut nested_lines, entries.as_slice());
                 for line in nested_lines {
                     let mut indented_spans = vec![Span::raw("    ")];
                     indented_spans.extend(line.spans);
                     lines.push(Line::from(indented_spans));
                 }
             }
-            MapDiffEntryIR::NestedListOfMapsDiff {
-                key,
-                modified,
-                added,
-                removed,
-            } => {
+            MapDiffEntryIR::NestedListOfMapsDiff { key, block } => {
                 let mut nested_lines = Vec::new();
                 render_list_of_maps_diff(
                     &mut nested_lines,
                     key,
-                    &[],
-                    modified,
-                    added,
-                    removed,
+                    block.unchanged(),
+                    block.modified(),
+                    block.added(),
+                    block.removed(),
                     false,
                 );
                 for line in nested_lines {


### PR DESCRIPTION
## Summary

Followup to #2886 / #2908. After dropping paired-but-all-equal list-of-maps elements at the IR layer, the surrounding `Map` parent header still rendered with nothing under it:

```
~ awscc.s3.Bucket r.bucket
    bucket_encryption:
        server_side_encryption_configuration:
    lifecycle_configuration:
        rules:
    # (5 unchanged attributes hidden)
```

The headers persisted because `compute_map_diff_entries` pushed `NestedMapDiff` / `NestedListOfMapsDiff` entries unconditionally, even when their inner content was empty.

## Fix

Two commits.

**Commit 1 — runtime suppression:**
- `compute_map_diff_entries`: skip the entry when the recursive nested entries are empty (Map case) or when the list-of-maps's `modified + added + removed` are all empty.
- `build_map_diff_row`: returns `Option<DetailRow>` (None when every entry was filtered), matching `build_list_of_maps_diff_row` from #2908.
- `build_update_rows`: absorbs `None` into the existing `effectively_unchanged` counter introduced by #2886.

**Commit 2 — type-level invariant:** lift the runtime `is_empty` checks into the IR types, same pattern as `NonEmptyVec<ListOfMapsDiffField>` from #2886 (memory rule: type safety over runtime checks).
- `MapDiffEntryIR::NestedMapDiff.entries`: `Vec` → `NonEmptyVec`.
- `MapDiffEntryIR::NestedListOfMapsDiff` now bundles its three sections into a new `NonEmptyListOfMapsBlock` whose `from_parts(...)` constructor returns `None` for the all-empty shape.
- `DetailRow::MapDiff.entries`: `Vec` → `NonEmptyVec`. `build_map_diff_row` uses `NonEmptyVec::from_vec(...)?`.
- IR builder sites use `if let Some(...)` to skip pushing when the constructor refuses, replacing the runtime `is_empty` checks.
- CLI / TUI renderers consume via `.as_slice()` / accessor methods.

Two unit tests cover the `NonEmptyListOfMapsBlock` invariant directly.

Emptiness propagates bottom-up: a deeply nested list-of-maps that collapses to nothing folds the entire ancestor Map chain into the trailing `# (n unchanged attributes hidden)` summary.

## Display change

Fixture (`nested_list_of_maps_all_dropped`): a Vpc with `config.settings.rules` list-of-maps where state has an extra `provider_default_field`.

Before:
```
~ awscc.ec2.Vpc vpc
    cidr_block: "10.0.0.0/16" → "10.1.0.0/16"
    config:
        settings:
            rules:
```

After:
```
~ awscc.ec2.Vpc vpc
    cidr_block: "10.0.0.0/16" → "10.1.0.0/16"
    # (1 unchanged attribute hidden)
```

## Out of scope

- The Replace path (`build_replace_rows` for `ReplaceMapDiff` / `ReplaceListOfMapsDiff`) shares `compute_map_diff_entries` so it benefits from the IR-level filter, but its row constructors still push unconditionally — same dangling-header risk on the Replace path. Tracked in #2909, which I'll update post-merge to scope down to Replace only (the NestedListOfMapsDiff portion of #2909 is resolved by this PR).
- Top-level `DetailRow::ListOfMapsDiff` / `build_list_of_maps_diff_row` still uses 4 separate `Vec` fields with a runtime `is_empty` check (instead of `NonEmptyListOfMapsBlock`). Only the *nested* IR variant uses the bundle; making the top-level symmetric would ripple through both renderer signatures and exceeds #2910 scope.

## Test plan

- [x] New fixture `nested_list_of_maps_all_dropped` (Vpc with `config.settings.rules` where state has an extra `provider_default_field`). Snapshot pins the absorbed-into-summary output.
- [x] New unit tests `non_empty_list_of_maps_block_rejects_all_empty` and `non_empty_list_of_maps_block_accepts_any_non_empty_section`.
- [x] All existing snapshots unchanged (no regression in `nested_map_diff`, `policy_pretty_nested`, `list_diff_*`).
- [x] `cargo nextest run --workspace` (3059 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` pass.

Closes #2910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
