### PR TITLE
core: add ExplicitFields enum (1/13)

### DIFF
--- a/carina-core/src/explicit.rs
+++ b/carina-core/src/explicit.rs
@@ -1,0 +1,83 @@
+//! Per-resource user-authored field tree.
+//!
+//! `ExplicitFields` records which fields the user explicitly wrote in
+//! their `.crn` for a resource. The differ projects the actual-state
+//! through this tree before computing diffs so server-side default
+//! fields the user never authored stop appearing as spurious removals.
+//!
+//! See `docs/specs/2026-05-10-explicit-fields-design.md`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Tree describing which fields the user explicitly wrote in their
+/// `.crn` for this resource. Each variant corresponds to a `Value`
+/// shape:
+///
+/// - `Leaf`: the user wrote this position as a scalar value (or as an
+///   opaque value with no nested authoring information). Treated as
+///   "user wrote the whole thing"; projection keeps the value intact.
+/// - `Struct`: the user wrote a struct here. Only the listed
+///   `children` are user-authored; struct fields not listed are
+///   server-only and are removed by projection.
+/// - `List`: the user wrote a list of structs here. `element` is the
+///   union of authoring across all elements.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum ExplicitFields {
+    #[default]
+    Leaf,
+    Struct {
+        children: HashMap<String, ExplicitFields>,
+    },
+    List {
+        element: Box<ExplicitFields>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaf_is_default() {
+        let e: ExplicitFields = Default::default();
+        assert!(matches!(e, ExplicitFields::Leaf));
+    }
+
+    #[test]
+    fn struct_round_trips_via_serde() {
+        let e = ExplicitFields::Struct {
+            children: HashMap::from([
+                ("a".into(), ExplicitFields::Leaf),
+                (
+                    "b".into(),
+                    ExplicitFields::Struct {
+                        children: HashMap::from([("nested".into(), ExplicitFields::Leaf)]),
+                    },
+                ),
+            ]),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let back: ExplicitFields = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, back);
+    }
+
+    #[test]
+    fn list_round_trips_via_serde() {
+        let e = ExplicitFields::List {
+            element: Box::new(ExplicitFields::Struct {
+                children: HashMap::from([("id".into(), ExplicitFields::Leaf)]),
+            }),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let back: ExplicitFields = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, back);
+    }
+
+    #[test]
+    fn variant_serializes_kebab_case() {
+        let leaf_json = serde_json::to_string(&ExplicitFields::Leaf).unwrap();
+        assert_eq!(leaf_json, r#"{"kind":"leaf"}"#);
+    }
+}

--- a/carina-core/src/lib.rs
+++ b/carina-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod differ;
 pub mod effect;
 pub(crate) mod eval_value;
 pub mod executor;
+pub mod explicit;
 pub mod formatter;
 pub mod heredoc;
 pub mod identifier;


### PR DESCRIPTION
## Summary

Introduces `ExplicitFields`, a recursive enum (`Leaf` / `Struct` / `List`) capturing which fields the user explicitly wrote in their `.crn`. Foundation for the awscc#206 fix series.

Self-contained: no consumer wiring yet. Subsequent tasks build construction (`build_from_value`), projection, state v6 persistence, and differ integration on top.

## Test plan

- [x] `cargo nextest run -p carina-core explicit` (4 new tests pass)
- [x] `cargo nextest run -p carina-core` (1812 tests pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy -p carina-core --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Closes #2895
Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)