### PR TITLE
differ: project current through ExplicitFields (5+6+7/13)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -787,9 +787,9 @@ async fn run_apply_locked(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
-    let mut prev_desired_keys = state_file
+    let mut prev_explicit = state_file
         .as_ref()
-        .map(|sf| sf.build_desired_keys())
+        .map(|sf| sf.build_explicit())
         .unwrap_or_default();
 
     // Read states for all resources using identifier from state
@@ -896,7 +896,7 @@ async fn run_apply_locked(
     let moved_pairs = {
         let mut pairs = crate::wiring::materialize_moved_states(
             &mut current_states,
-            &mut prev_desired_keys,
+            &mut prev_explicit,
             &mut saved_attrs,
             &parsed.state_blocks,
             &state_file,
@@ -906,7 +906,7 @@ async fn run_apply_locked(
             &sorted_resources,
             &parsed.providers,
             &mut current_states,
-            &mut prev_desired_keys,
+            &mut prev_explicit,
             &mut saved_attrs,
             &state_file,
         ));
@@ -981,7 +981,7 @@ async fn run_apply_locked(
         &directives_map,
         schemas,
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_dependencies,
     );
 

--- a/carina-cli/src/commands/apply/tests.rs
+++ b/carina-cli/src/commands/apply/tests.rs
@@ -279,14 +279,25 @@ fn block_name_attribute_no_diff_when_hydrated() {
     // Saved attrs: same as current (from previous apply)
     let saved: HashMap<String, Value> = current.attributes.clone();
 
-    // Previous desired keys: what was in the resource on first apply
-    let prev_desired_keys = vec!["policies".to_string(), "role_name".to_string()];
+    // Previous explicit tree: what the user wrote on first apply
+    let prev_explicit = carina_core::explicit::ExplicitFields::Struct {
+        children: std::collections::HashMap::from([
+            (
+                "policies".to_string(),
+                carina_core::explicit::ExplicitFields::Leaf,
+            ),
+            (
+                "role_name".to_string(),
+                carina_core::explicit::ExplicitFields::Leaf,
+            ),
+        ]),
+    };
 
     let d = diff(
         &resource,
         &current,
         Some(&saved),
-        Some(&prev_desired_keys),
+        Some(&prev_explicit),
         Some(&schema),
     );
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -177,9 +177,9 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
 
-    let mut prev_desired_keys = state_file
+    let mut prev_explicit = state_file
         .as_ref()
-        .map(|sf| sf.build_desired_keys())
+        .map(|sf| sf.build_explicit())
         .unwrap_or_default();
 
     let orphan_dependencies = if let Some(sf) = state_file.as_ref() {
@@ -192,7 +192,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
 
     let moved_pairs = crate::wiring::materialize_moved_states(
         &mut current_states,
-        &mut prev_desired_keys,
+        &mut prev_explicit,
         &mut saved_attrs,
         &parsed.state_blocks,
         &state_file,
@@ -204,7 +204,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &directives_map,
         wiring.schemas(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_dependencies,
     );
 

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1260,7 +1260,7 @@ fn orphaned_state_resource_produces_delete_effect() {
 
     let directives_map = state_file.build_directives();
     let saved_attrs = state_file.build_saved_attrs();
-    let prev_desired_keys = state_file.build_desired_keys();
+    let prev_explicit = state_file.build_explicit();
 
     let plan = create_plan(
         &desired,
@@ -1268,7 +1268,7 @@ fn orphaned_state_resource_produces_delete_effect() {
         &directives_map,
         &SchemaRegistry::new(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -2171,7 +2171,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
 
     let directives_map = state_file.build_directives();
     let saved_attrs = state_file.build_saved_attrs();
-    let prev_desired_keys = state_file.build_desired_keys();
+    let prev_explicit = state_file.build_explicit();
 
     let plan = create_plan(
         &desired,
@@ -2179,7 +2179,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
         &directives_map,
         &SchemaRegistry::new(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -2253,7 +2253,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
 
     let directives_map = state_file.build_directives();
     let saved_attrs = state_file.build_saved_attrs();
-    let prev_desired_keys = state_file.build_desired_keys();
+    let prev_explicit = state_file.build_explicit();
 
     let plan = create_plan(
         &desired,
@@ -2261,7 +2261,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
         &directives_map,
         &SchemaRegistry::new(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -2299,7 +2299,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
 
     let directives_map = state_file.build_directives();
     let saved_attrs = state_file.build_saved_attrs();
-    let prev_desired_keys = state_file.build_desired_keys();
+    let prev_explicit = state_file.build_explicit();
 
     let plan = create_plan(
         &desired,
@@ -2307,7 +2307,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
         &directives_map,
         &SchemaRegistry::new(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -339,14 +339,14 @@ fn identity_attributes_for_provider(ctx: &WiringContext, name: &str) -> Vec<Stri
 ///
 /// Mirrors `materialize_moved_states` but for synthetic rename pairs produced
 /// by `identifier::detect_anonymous_to_named_renames`. Transfers state,
-/// `prev_desired_keys`, and `saved_attrs` from the old anonymous name to the
+/// `prev_explicit`, and `saved_attrs` from the old anonymous name to the
 /// new binding name so the differ sees the resource under its new identity.
 pub fn apply_anonymous_to_named_renames(
     ctx: &WiringContext,
     resources: &[Resource],
     providers: &[ProviderConfig],
     current_states: &mut HashMap<ResourceId, State>,
-    prev_desired_keys: &mut HashMap<ResourceId, Vec<String>>,
+    prev_explicit: &mut HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
     saved_attrs: &mut HashMap<ResourceId, HashMap<String, Value>>,
     state_file: &Option<StateFile>,
 ) -> Vec<(ResourceId, ResourceId)> {
@@ -395,8 +395,8 @@ pub fn apply_anonymous_to_named_renames(
             state.id = to.clone();
             current_states.insert(to.clone(), state);
         }
-        if let Some(keys) = prev_desired_keys.remove(from) {
-            prev_desired_keys.insert(to.clone(), keys);
+        if let Some(keys) = prev_explicit.remove(from) {
+            prev_explicit.insert(to.clone(), keys);
         }
         if let Some(attrs) = saved_attrs.remove(from) {
             saved_attrs.insert(to.clone(), attrs);
@@ -455,7 +455,7 @@ pub fn reconcile_anonymous_identifiers_with_ctx(
 ///
 /// For each `(old_name, new_name)` pair, find the matching `ResourceState`
 /// in `state_file.resources` and overwrite its `name` field. Downstream maps
-/// (`build_saved_attrs`, `build_desired_keys`, `build_directives`) then key
+/// (`build_saved_attrs`, `build_explicit`, `build_directives`) then key
 /// off the new name, so the differ sees the resource under its updated
 /// identifier instead of an orphan-delete + create pair.
 pub fn apply_provider_prefix_renames(renames: &[(String, String)], state_file: &mut StateFile) {
@@ -1072,9 +1072,9 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         .as_ref()
         .map(|sf| sf.build_saved_attrs())
         .unwrap_or_default();
-    let mut prev_desired_keys = state_file
+    let mut prev_explicit = state_file
         .as_ref()
-        .map(|sf| sf.build_desired_keys())
+        .map(|sf| sf.build_explicit())
         .unwrap_or_default();
     // `moved_pairs` accumulates explicit `moved` block transfers and
     // detected anonymous → let-bound renames. Populated inside the
@@ -1202,7 +1202,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         // an orthogonal edge case that pre-dates this fix.
         moved_pairs.extend(materialize_moved_states(
             &mut current_states,
-            &mut prev_desired_keys,
+            &mut prev_explicit,
             &mut saved_attrs,
             &parsed.state_blocks,
             state_file,
@@ -1212,7 +1212,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
             &sorted_resources,
             &parsed.providers,
             &mut current_states,
-            &mut prev_desired_keys,
+            &mut prev_explicit,
             &mut saved_attrs,
             state_file,
         ));
@@ -1270,7 +1270,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
             provider.hydrate_read_state(&mut current_states, &saved_attrs);
             moved_pairs.extend(materialize_moved_states(
                 &mut current_states,
-                &mut prev_desired_keys,
+                &mut prev_explicit,
                 &mut saved_attrs,
                 &parsed.state_blocks,
                 state_file,
@@ -1280,7 +1280,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
                 &sorted_resources,
                 &parsed.providers,
                 &mut current_states,
-                &mut prev_desired_keys,
+                &mut prev_explicit,
                 &mut saved_attrs,
                 state_file,
             ));
@@ -1338,7 +1338,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         &directives_map,
         ctx.schemas(),
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_dependencies,
     );
 
@@ -1370,20 +1370,20 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
     })
 }
 
-/// Pre-process moved blocks by transferring state, `prev_desired_keys`, and
+/// Pre-process moved blocks by transferring state, `prev_explicit`, and
 /// `saved_attrs` from the old resource name to the new name.
 ///
 /// This must be called BEFORE `create_plan()` so the differ sees the moved
 /// resource's state under its new name and can produce Update/Replace effects
 /// if attributes differ between state and desired. Transferring
-/// `prev_desired_keys` ensures attribute removals are detected; transferring
+/// `prev_explicit` ensures attribute removals are detected; transferring
 /// `saved_attrs` ensures hydrated attributes are found under the new name.
 ///
 /// Returns a list of active Move pairs (from, to) where the `from` resource
 /// existed in state. Callers use this to add Move effects to the plan.
 pub fn materialize_moved_states(
     current_states: &mut HashMap<ResourceId, State>,
-    prev_desired_keys: &mut HashMap<ResourceId, Vec<String>>,
+    prev_explicit: &mut HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
     saved_attrs: &mut HashMap<ResourceId, HashMap<String, Value>>,
     state_blocks: &[StateBlock],
     state_file: &Option<StateFile>,
@@ -1404,10 +1404,10 @@ pub fn materialize_moved_states(
                     current_states.insert(to.clone(), state);
                 }
 
-                // Transfer prev_desired_keys so the differ detects attribute
+                // Transfer prev_explicit so the differ detects attribute
                 // removals under the new resource name.
-                if let Some(keys) = prev_desired_keys.remove(from) {
-                    prev_desired_keys.insert(to.clone(), keys);
+                if let Some(keys) = prev_explicit.remove(from) {
+                    prev_explicit.insert(to.clone(), keys);
                 }
 
                 // Transfer saved_attrs so create_plan can look up saved

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -169,7 +169,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
     let directives_map: HashMap<ResourceId, Directives> = HashMap::new();
     let schemas = SchemaRegistry::new();
     let saved_attrs = HashMap::new();
-    let prev_desired_keys = HashMap::new();
+    let prev_explicit = HashMap::new();
     let orphan_deps = HashMap::new();
     let plan_without = create_plan(
         &resources_without,
@@ -177,7 +177,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &directives_map,
         &schemas,
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_deps,
     );
     assert!(
@@ -194,7 +194,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &directives_map,
         &schemas,
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_deps,
     );
     assert!(
@@ -254,13 +254,22 @@ fn test_merge_default_tags_prevents_false_diff() {
         m
     };
 
-    // Simulate prev_desired_keys from a previous apply that included "tags"
+    // Simulate prev_explicit from a previous apply that included "tags"
     // (because merge_default_tags was called correctly in the plan path).
-    let mut prev_desired_keys = HashMap::new();
-    prev_desired_keys.insert(resource.id.clone(), vec!["tags".to_string()]);
+    let mut prev_explicit: HashMap<ResourceId, carina_core::explicit::ExplicitFields> =
+        HashMap::new();
+    prev_explicit.insert(
+        resource.id.clone(),
+        carina_core::explicit::ExplicitFields::Struct {
+            children: std::collections::HashMap::from([(
+                "tags".to_string(),
+                carina_core::explicit::ExplicitFields::Leaf,
+            )]),
+        },
+    );
 
     // Without merge_default_tags, the desired resource has no tags,
-    // but state has tags and prev_desired_keys says "tags" was previously desired.
+    // but state has tags and prev_explicit says "tags" was previously desired.
     // The differ sees this as attribute removal → false Update diff.
     let resources_without = vec![resource.clone()];
     let directives_map: HashMap<ResourceId, Directives> = HashMap::new();
@@ -272,7 +281,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &directives_map,
         &schemas,
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_deps,
     );
     assert!(
@@ -300,7 +309,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &directives_map,
         &schemas,
         &saved_attrs,
-        &prev_desired_keys,
+        &prev_explicit,
         &orphan_deps,
     );
     assert!(

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
+use crate::explicit::{self, ExplicitFields};
 use crate::resource::{ResourceId, Value, merge_with_saved};
 use crate::schema::{AttributeType, ResourceSchema};
 use crate::value::{SECRET_PREFIX, SecretHashContext, argon2id_hash, value_to_json_with_context};
@@ -314,9 +315,18 @@ fn secret_matches_state(
 /// Find changed attributes between desired and current state.
 /// If `saved` is provided, each desired value is merged with the saved value
 /// before comparison, filling in unmanaged nested fields.
-/// If `prev_desired_keys` is provided, attributes that were previously in the user's
-/// desired state but are now absent from desired (while still present in current)
-/// are detected as removals.
+/// If `prev_explicit` is provided, the actual-state side is **projected**
+/// through its tree before comparison so server-side default fields the
+/// user never wrote do not surface as diffs (refs awscc#206). The
+/// projection is applied per-attribute: each `current[key]` is folded
+/// against the matching `prev_explicit` child shape via
+/// `crate::explicit::project`. Top-level keys absent from
+/// `prev_explicit.children` are treated as the user never having
+/// authored them and excluded from the comparison entirely (so their
+/// presence in `current` does not surface a removal).
+/// `prev_explicit` also drives the explicit-removal detection at the
+/// end of this function: the same set of top-level keys is used to
+/// flag attributes the user *previously* wrote but no longer mentions.
 /// If `schema` is provided, type-aware comparison is used for each attribute.
 /// If `resource_id` is provided, it is used to build context-specific salt for
 /// secret hash comparison.
@@ -324,11 +334,22 @@ pub(super) fn find_changed_attributes(
     desired: &HashMap<String, Value>,
     current: &HashMap<String, Value>,
     saved: Option<&HashMap<String, Value>>,
-    prev_desired_keys: Option<&[String]>,
+    prev_explicit: Option<&ExplicitFields>,
     schema: Option<&ResourceSchema>,
     resource_id: Option<&ResourceId>,
 ) -> Vec<String> {
     let mut changed = Vec::new();
+
+    // Project `current` through `prev_explicit` so server-side defaults
+    // the user never authored disappear before any comparison runs.
+    // The projection is idempotent and shape-preserving for keys the
+    // user did author. When `prev_explicit` is absent (e.g. first-plan,
+    // no saved state) we fall back to the unprojected map — there is
+    // no authoring information to consult yet.
+    let projected_current = match prev_explicit {
+        Some(e) => explicit::project_attributes(current.clone(), e),
+        None => current.clone(),
+    };
 
     for (key, desired_value) in desired {
         // Skip internal attributes (starting with _)
@@ -341,7 +362,7 @@ pub(super) fn find_changed_attributes(
         // absence from state is expected and should not trigger a diff.
         if schema
             .and_then(|s| s.attributes.get(key))
-            .is_some_and(|attr| attr.write_only && !current.contains_key(key))
+            .is_some_and(|attr| attr.write_only && !projected_current.contains_key(key))
         {
             continue;
         }
@@ -357,14 +378,14 @@ pub(super) fn find_changed_attributes(
         let is_equal = match saved.and_then(|s| s.get(key)) {
             Some(saved_value) => {
                 let effective_desired = merge_with_saved(desired_value, saved_value);
-                current
+                projected_current
                     .get(key)
                     .map(|cv| {
                         type_aware_equal(cv, &effective_desired, attr_type, secret_ctx.as_ref())
                     })
                     .unwrap_or(false)
             }
-            None => current
+            None => projected_current
                 .get(key)
                 .map(|cv| type_aware_equal(cv, desired_value, attr_type, secret_ctx.as_ref()))
                 .unwrap_or(false),
@@ -376,18 +397,19 @@ pub(super) fn find_changed_attributes(
     }
 
     // Detect attributes removed from desired but still present in current.
-    // Only flag attributes that were previously in the user's desired state
-    // (from the state file's desired_keys). This prevents false removals for
-    // computed/provider-returned attributes the user never specified.
-    if let Some(prev_keys) = prev_desired_keys {
-        for key in prev_keys {
+    // Only flag attributes that were previously in the user's desired
+    // state (top-level children of `prev_explicit`'s root `Struct`).
+    // This prevents false removals for computed/provider-returned
+    // attributes the user never specified.
+    if let Some(ExplicitFields::Struct { children }) = prev_explicit {
+        for key in children.keys() {
             if key.starts_with('_') {
                 continue;
             }
             if desired.contains_key(key) {
                 continue;
             }
-            if current.contains_key(key) {
+            if projected_current.contains_key(key) {
                 changed.push(key.clone());
             }
         }

--- a/carina-core/src/differ/mod.rs
+++ b/carina-core/src/differ/mod.rs
@@ -55,15 +55,18 @@ impl Diff {
 /// Compare desired state with current state to compute a Diff.
 /// If `saved` is provided, unmanaged nested fields from the saved state are merged
 /// into desired before comparison, preventing false diffs when AWS returns extra fields.
-/// If `prev_desired_keys` is provided, attributes that were previously in the user's
-/// desired state but are now absent are detected as removals.
+/// If `prev_explicit` is provided, the actual-state side is projected through
+/// the authoring tree before comparison so server-side default fields the
+/// user never wrote do not surface as diffs (refs awscc#206). The same
+/// tree drives explicit-removal detection for attributes the user
+/// previously wrote but no longer mentions.
 /// If `schema` is provided, type-aware comparison is used (e.g., Int/Float coercion,
 /// case-insensitive enum matching).
 pub fn diff(
     desired: &Resource,
     current: &State,
     saved: Option<&HashMap<String, Value>>,
-    prev_desired_keys: Option<&[String]>,
+    prev_explicit: Option<&crate::explicit::ExplicitFields>,
     schema: Option<&ResourceSchema>,
 ) -> Diff {
     if !current.exists {
@@ -74,7 +77,7 @@ pub fn diff(
         &desired.resolved_attributes(),
         &current.attributes,
         saved,
-        prev_desired_keys,
+        prev_explicit,
         schema,
         Some(&desired.id),
     );

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -131,17 +131,19 @@ fn generate_temporary_name(
 /// This is used to merge unmanaged nested fields into desired values before comparison,
 /// preventing false diffs when AWS returns extra fields not specified in the .crn file.
 ///
-/// The `prev_desired_keys` map provides the attribute keys that the user explicitly
-/// specified in their .crn file during the last apply. This is used to detect
-/// attribute removal: if a key was previously in the user's desired state but is
-/// now absent, it means the user intentionally removed it.
+/// The `prev_explicit` map provides the per-resource authoring tree that
+/// the user wrote in their `.crn` during the last apply. The differ uses
+/// it both to project the actual-state side (hiding server-side defaults
+/// the user never wrote, refs awscc#206) and to detect attribute
+/// removals: if a top-level key was previously in the user's desired
+/// state but is now absent, it means the user intentionally removed it.
 pub fn create_plan(
     desired: &[Resource],
     current_states: &HashMap<ResourceId, State>,
     directives_map: &HashMap<ResourceId, Directives>,
     registry: &SchemaRegistry,
     saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
-    prev_desired_keys: &HashMap<ResourceId, Vec<String>>,
+    prev_explicit: &HashMap<ResourceId, crate::explicit::ExplicitFields>,
     orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
 ) -> Plan {
     let mut plan = Plan::new();
@@ -169,7 +171,7 @@ pub fn create_plan(
             .unwrap_or_else(|| State::not_found(resource.id.clone()));
 
         let saved = saved_attrs.get(&resource.id);
-        let prev_keys = prev_desired_keys.get(&resource.id);
+        let prev_explicit_for_resource = prev_explicit.get(&resource.id);
         let schema = registry.get(
             &resource.id.provider,
             &resource.id.resource_type,
@@ -179,7 +181,7 @@ pub fn create_plan(
             resource,
             &current,
             saved,
-            prev_keys.map(|v| v.as_slice()),
+            prev_explicit_for_resource,
             schema,
         );
 

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -2,7 +2,21 @@ use super::*;
 
 use indexmap::IndexMap;
 
+use crate::explicit::ExplicitFields;
 use crate::resource::ResourceKind;
+
+/// Build an `ExplicitFields::Struct` whose children are all `Leaf` —
+/// the shape `state v5 → v6` reads produce, and a convenient way to
+/// express "user previously authored these top-level keys" in tests
+/// that pre-date the nested authoring tree.
+fn explicit_top_level(keys: &[&str]) -> ExplicitFields {
+    ExplicitFields::Struct {
+        children: keys
+            .iter()
+            .map(|k| ((*k).to_string(), ExplicitFields::Leaf))
+            .collect(),
+    }
+}
 
 #[test]
 fn create_before_destroy_generates_temporary_name_for_name_attribute() {
@@ -386,9 +400,9 @@ fn diff_detects_attribute_removal_with_prev_desired_keys() {
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
     // Previous desired state had both "region" and "tags"
-    let prev_keys = vec!["region".to_string(), "tags".to_string()];
+    let prev_explicit = explicit_top_level(&["region", "tags"]);
 
-    let result = diff(&desired, &current, None, Some(&prev_keys), None);
+    let result = diff(&desired, &current, None, Some(&prev_explicit), None);
     match result {
         Diff::Update {
             changed_attributes, ..
@@ -421,9 +435,9 @@ fn diff_ignores_attributes_not_in_prev_desired_keys() {
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
     // User previously only specified "region", not "arn"
-    let prev_keys = vec!["region".to_string()];
+    let prev_explicit = explicit_top_level(&["region"]);
 
-    let result = diff(&desired, &current, None, Some(&prev_keys), None);
+    let result = diff(&desired, &current, None, Some(&prev_explicit), None);
     match result {
         Diff::Update {
             changed_attributes, ..
@@ -438,6 +452,102 @@ fn diff_ignores_attributes_not_in_prev_desired_keys() {
             );
         }
         _ => panic!("Expected Update, got {:?}", result),
+    }
+}
+
+#[test]
+fn server_default_struct_field_does_not_appear_in_diff() {
+    // The user wrote `lifecycle_configuration { rules: [...] }` but did
+    // NOT write `transition_default_minimum_object_size`. AWS returns
+    // the latter in `current` as a server-side default. The differ must
+    // project current through `prev_explicit` and skip the server-only
+    // leaf — no `lifecycle_configuration` change should be reported.
+    use indexmap::IndexMap;
+
+    let mut desired_lc = IndexMap::new();
+    desired_lc.insert(
+        "rules".to_string(),
+        Value::List(vec![{
+            let mut rule = IndexMap::new();
+            rule.insert("id".to_string(), Value::String("expire".to_string()));
+            Value::Map(rule)
+        }]),
+    );
+    let desired = Resource::new("s3.Bucket", "test")
+        .with_attribute("lifecycle_configuration", Value::Map(desired_lc.clone()));
+
+    let mut current_lc = desired_lc;
+    current_lc.insert(
+        "transition_default_minimum_object_size".to_string(),
+        Value::String("all_storage_classes_128K".to_string()),
+    );
+    let mut current_attrs = HashMap::new();
+    current_attrs.insert(
+        "lifecycle_configuration".to_string(),
+        Value::Map(current_lc),
+    );
+    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+
+    // prev_explicit reflects what the user wrote: lifecycle_configuration > rules
+    let prev_explicit = ExplicitFields::Struct {
+        children: std::collections::HashMap::from([(
+            "lifecycle_configuration".to_string(),
+            ExplicitFields::Struct {
+                children: std::collections::HashMap::from([(
+                    "rules".to_string(),
+                    ExplicitFields::List {
+                        element: Box::new(ExplicitFields::Struct {
+                            children: std::collections::HashMap::from([(
+                                "id".to_string(),
+                                ExplicitFields::Leaf,
+                            )]),
+                        }),
+                    },
+                )]),
+            },
+        )]),
+    };
+
+    let result = diff(&desired, &current, None, Some(&prev_explicit), None);
+    assert!(
+        matches!(result, Diff::NoChange(_)),
+        "Server-side default struct leaf must not surface in diff, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn explicit_top_level_removal_still_detected() {
+    // Regression guard: removing the *whole* attribute (top-level key
+    // gone from desired but still authored in prev_explicit) must
+    // still produce an Update. This is the existing "explicit unset"
+    // mechanism; the projection logic must not regress it.
+    let desired = Resource::new("s3.Bucket", "test");
+
+    let mut current_attrs = HashMap::new();
+    current_attrs.insert(
+        "tags".to_string(),
+        Value::Map(IndexMap::from([(
+            "Env".to_string(),
+            Value::String("prod".to_string()),
+        )])),
+    );
+    let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
+
+    let prev_explicit = explicit_top_level(&["tags"]);
+    let result = diff(&desired, &current, None, Some(&prev_explicit), None);
+
+    match result {
+        Diff::Update {
+            changed_attributes, ..
+        } => {
+            assert!(
+                changed_attributes.contains(&"tags".to_string()),
+                "Removed top-level attr must still produce Update, got: {:?}",
+                changed_attributes
+            );
+        }
+        _ => panic!("Expected Update for explicit-unset, got {:?}", result),
     }
 }
 
@@ -496,10 +606,10 @@ fn create_plan_detects_attribute_removal() {
         State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
     );
 
-    let mut prev_desired_keys = HashMap::new();
-    prev_desired_keys.insert(
+    let mut prev_explicit = HashMap::new();
+    prev_explicit.insert(
         ResourceId::new("s3.Bucket", "test"),
-        vec!["region".to_string(), "tags".to_string()],
+        explicit_top_level(&["region", "tags"]),
     );
 
     let plan = create_plan(
@@ -508,7 +618,7 @@ fn create_plan_detects_attribute_removal() {
         &HashMap::new(),
         &SchemaRegistry::new(),
         &HashMap::new(),
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -548,10 +658,10 @@ fn create_plan_filters_non_removable_attribute_removal() {
         State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
     );
 
-    let mut prev_desired_keys = HashMap::new();
-    prev_desired_keys.insert(
+    let mut prev_explicit = HashMap::new();
+    prev_explicit.insert(
         ResourceId::new("s3.Bucket", "test"),
-        vec!["region".to_string(), "tags".to_string()],
+        explicit_top_level(&["region", "tags"]),
     );
 
     // Schema: tags is auto-removable (optional, not create-only),
@@ -573,7 +683,7 @@ fn create_plan_filters_non_removable_attribute_removal() {
         &HashMap::new(),
         &schemas,
         &HashMap::new(),
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -617,10 +727,10 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
         State::existing(ResourceId::new("s3.Bucket", "test"), attrs),
     );
 
-    let mut prev_desired_keys = HashMap::new();
-    prev_desired_keys.insert(
+    let mut prev_explicit = HashMap::new();
+    prev_explicit.insert(
         ResourceId::new("s3.Bucket", "test"),
-        vec!["bucket".to_string(), "region".to_string()],
+        explicit_top_level(&["bucket", "region"]),
     );
 
     // Schema: region is explicitly non-removable, bucket is required
@@ -638,7 +748,7 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
         &HashMap::new(),
         &schemas,
         &HashMap::new(),
-        &prev_desired_keys,
+        &prev_explicit,
         &HashMap::new(),
     );
 
@@ -666,9 +776,9 @@ fn diff_skips_internal_attributes_in_removal_detection() {
     );
     let current = State::existing(ResourceId::new("s3.Bucket", "test"), current_attrs);
 
-    let prev_keys = vec!["region".to_string(), "_internal".to_string()];
+    let prev_explicit = explicit_top_level(&["region", "_internal"]);
 
-    let result = diff(&desired, &current, None, Some(&prev_keys), None);
+    let result = diff(&desired, &current, None, Some(&prev_explicit), None);
     assert!(
         matches!(result, Diff::NoChange(_)),
         "Should skip internal attributes starting with '_', got {:?}",

--- a/carina-state/src/state/mod.rs
+++ b/carina-state/src/state/mod.rs
@@ -211,31 +211,6 @@ impl StateFile {
         result
     }
 
-    /// Backwards-compatible shim that flattens the per-resource
-    /// `ExplicitFields` tree to a sorted list of its top-level keys
-    /// — the shape callers used before the v6 schema change.
-    ///
-    /// Retained only so the differ entry points (which still take
-    /// `prev_desired_keys: Option<&[String]>`) keep compiling while
-    /// the differ-side rewrite (#2899 / #2900) lands. Once those land,
-    /// this method is deleted in #2901.
-    pub fn build_desired_keys(&self) -> HashMap<ResourceId, Vec<String>> {
-        let mut result = HashMap::new();
-        for rs in &self.resources {
-            let ExplicitFields::Struct { children } = &rs.explicit else {
-                continue;
-            };
-            if children.is_empty() {
-                continue;
-            }
-            let mut keys: Vec<String> = children.keys().cloned().collect();
-            keys.sort();
-            let id = ResourceId::with_provider(&rs.provider, &rs.resource_type, &rs.name);
-            result.insert(id, keys);
-        }
-        result
-    }
-
     /// Build a `State` for a resource from the state file data.
     /// Returns a non-existing state if the resource is not found in the state file.
     pub fn build_state_for_resource(&self, resource: &Resource) -> State {


### PR DESCRIPTION
## Summary

Replaces the `prev_desired_keys: Option<&[String]>` parameter on `find_changed_attributes` / `diff` / `create_plan` with `prev_explicit: Option<&ExplicitFields>`. At `find_changed_attributes` entry, `current` attributes are projected through `prev_explicit` via `project_attributes` so server-side default fields the user never authored disappear before any comparison runs. Top-level removal detection now walks the root `Struct`'s children instead of a flat `Vec<String>`.

## Why three issues in one PR

The parameter rename and type change cascade through every call site in carina-core, carina-state, and carina-cli simultaneously. Splitting them across PRs leaves the workspace uncompilable on intermediate commits, which would break CI on the bridging branches. The original plan acknowledged this risk; rolling Tasks 5/6/7 together is the cleaner shape.

## Changes

- `carina-core/src/differ/comparison.rs`: project current; walk Struct children for removal detection
- `carina-core/src/differ/mod.rs`: `diff()` signature
- `carina-core/src/differ/plan.rs`: `create_plan()` signature, `prev_desired_keys` map type
- `carina-cli/`: rename variable + type updates throughout (apply, fixture_plan, wiring, tests)
- `carina-state`: drop the temporary `build_desired_keys()` shim added in #2919

## Test plan

- [x] `cargo nextest run --workspace` — 3084 tests pass (2 new differ tests)
  - `server_default_struct_field_does_not_appear_in_diff`
  - `explicit_top_level_removal_still_detected`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Closes #2899
Closes #2900
Closes #2901
Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)