### PR TITLE
tui: audit for ExplicitFields projection — no code change (9/13)

### DIFF
--- a/docs/audits/2026-05-10-tui-explicit-fields.md
+++ b/docs/audits/2026-05-10-tui-explicit-fields.md
@@ -1,0 +1,52 @@
+# TUI ExplicitFields Audit (#2903)
+
+<!-- derived-from ../specs/2026-05-10-explicit-fields-design.md -->
+
+Audit conducted as part of the ExplicitFields series (refs awscc#206)
+to confirm that the TUI does not bypass the projection introduced in
+`build_detail_rows` (PR #2921 / Task 8) by reading `from.attributes`
+or other actual-state values directly.
+
+## Methodology
+
+```bash
+grep -rn "from\.attributes\|state\.attributes\|\.attributes\[" carina-tui/src/
+grep -rn "DetailRow\|build_detail_rows" carina-tui/src/
+grep -rn "Resource\|State\|Effect" carina-tui/src/app/mod.rs
+```
+
+## Findings
+
+1. **`carina-tui/src/ui/` (detail.rs, diff.rs, tree.rs, value_view.rs,
+   help.rs, search.rs, style.rs, mod.rs)**: zero direct accesses to
+   `from.attributes` or any field on `State` / `Resource`. All
+   rendering consumes `DetailRow` values produced upstream.
+
+2. **`carina-tui/src/app/mod.rs::effect_to_node`** is the single
+   bridge from `Effect` to TUI rows. It calls
+   `build_detail_rows(effect, schemas, DetailLevel::Full, None, None)`
+   — passing `prev_explicit: None`, which matches the contract
+   established in PR #2921 (Task 8).
+
+3. **`build_tree_structure`** and **dependency graph builders** in
+   `carina-tui/src/app/mod.rs` walk `Resource.attributes` to discover
+   `ResourceRef` values for navigation. This is not a state-display
+   path — it's structural metadata for the tree view — so projection
+   does not apply.
+
+## Conclusion
+
+No code change required for Task 9.
+
+The TUI inherits the projection contract through `DetailRow`. When
+`prev_explicit` becomes available end-to-end (a follow-up PR will
+thread it through both CLI `format_plan` and TUI `App::new`), the
+TUI will benefit automatically without further changes to the `ui/`
+modules.
+
+## Out of scope
+
+- Threading `prev_explicit` from `App::new` into `effect_to_node` —
+  symmetric to the same change needed in `carina-cli` `format_plan`.
+  Both are tracked separately; both are mechanical once the
+  caller-side state file is in scope.


### PR DESCRIPTION
## Summary

Audit of `carina-tui` for direct reads of `from.attributes` or other actual-state values that would bypass the projection in `build_detail_rows`. Conclusion: no code change required.

- All TUI rendering modules (`ui/detail.rs`, `ui/diff.rs`, `ui/tree.rs`, `ui/value_view.rs`, `ui/help.rs`, `ui/search.rs`, `ui/style.rs`, `ui/mod.rs`) consume `DetailRow` values produced upstream — no direct field access on `State`/`Resource`.
- `app/mod.rs::effect_to_node` already calls `build_detail_rows(effect, schemas, DetailLevel::Full, None, None)`, matching the contract established in #2921 (Task 8).
- `build_tree_structure` walks `Resource.attributes` to discover `ResourceRef` values for navigation — structural metadata for the tree view, not a state-display path.

Audit recorded as `docs/audits/2026-05-10-tui-explicit-fields.md`.

## Test plan

- [x] `cargo nextest run -p carina-tui` — 98 tests pass
- [x] `cargo clippy -p carina-tui --all-targets -- -D warnings`

## Out of scope

Threading `prev_explicit` end-to-end from CLI `format_plan` and TUI `App::new` into `build_detail_rows` is mechanical and tracked separately. The TUI will inherit the projection automatically once the caller-side wiring lands.

Closes #2903
Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)