### PR TITLE
test: migrate plan_display fixtures to v6 explicit (10/13)

### DIFF
--- a/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/delete_orphan/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-delete-orphan",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "ec2_vpc_fb75c929",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -34,15 +52,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "my_subnet",
-      "dependency_bindings": ["ec2_vpc_fb75c929"]
+      "dependency_bindings": [
+        "ec2_vpc_fb75c929"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_full/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-destroy-full",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "ec2_vpc_fb75c929",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -34,15 +52,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "ec2_subnet_f5269366",
-      "dependency_bindings": ["ec2_vpc_fb75c929"]
+      "dependency_bindings": [
+        "ec2_vpc_fb75c929"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/destroy_orphans/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-destroy-orphans",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "my_vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -34,15 +52,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "my_subnet",
-      "dependency_bindings": ["my_vpc"]
+      "dependency_bindings": [
+        "my_vpc"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/explicit/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/explicit/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 2,
   "lineage": "test-lineage-mixed",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -34,15 +52,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "my_subnet",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_added_struct/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-list-diff-added-struct",
   "carina_version": "0.1.0",
@@ -25,9 +25,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["policy_name", "role_name", "statement"],
       "binding": "policy",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-list-diff-modified-with-unchanged",
   "carina_version": "0.1.0",
@@ -32,9 +32,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["policy_name", "role_name", "statement"],
       "binding": "policy",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_modified_with_unchanged_nested/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-list-diff-modified-with-unchanged-nested",
   "carina_version": "0.1.0",
@@ -29,9 +29,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["policy_name", "role_name", "statement"],
       "binding": "policy",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_paired_all_unchanged_dropped/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-list-diff-paired-all-unchanged-dropped",
   "carina_version": "0.1.0",
@@ -26,9 +26,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["policy_name", "role_name", "statement"],
       "binding": "policy",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_removed_struct/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-list-diff-removed-struct",
   "carina_version": "0.1.0",
@@ -31,7 +31,9 @@
               "cloudformation:ListResources",
               "cloudformation:UpdateResource"
             ],
-            "resource": ["*"]
+            "resource": [
+              "*"
+            ]
           }
         ]
       },
@@ -39,9 +41,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["policy_name", "role_name", "statement"],
       "binding": "policy",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_key_diff/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-map-diff",
   "carina_version": "0.1.0",
@@ -14,15 +14,35 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "main", "Environment": "staging", "OldTag": "remove-me" }
+        "tags": {
+          "Name": "main",
+          "Environment": "staging",
+          "OldTag": "remove-me"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "ec2_vpc_fb75c929",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/mixed_operations/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/mixed_operations/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 2,
   "lineage": "test-lineage-mixed",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -34,15 +52,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "my_subnet",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/moved_prev_keys/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_prev_keys/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 6,
   "serial": 1,
   "lineage": "test-moved-prev-keys",
   "carina_version": "0.1.0",
@@ -13,16 +13,32 @@
         "vpc_id": "vpc-old123",
         "cidr_block": "10.0.0.0/16",
         "tags": [
-          { "key": "Name", "value": "old" }
+          {
+            "key": "Name",
+            "value": "old"
+          }
         ]
       },
       "protected": false,
-      "directives": { "force_delete": false, "create_before_destroy": false },
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "tags"],
       "binding": "old_vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/moved_pure/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_pure/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 6,
   "serial": 1,
   "lineage": "test-moved-pure",
   "carina_version": "0.1.0",
@@ -14,12 +14,22 @@
         "cidr_block": "10.0.0.0/16"
       },
       "protected": false,
-      "directives": { "force_delete": false, "create_before_destroy": false },
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block"],
       "binding": "old_vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/moved_with_changes/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 6,
   "serial": 1,
   "lineage": "test-moved-with-changes",
   "carina_version": "0.1.0",
@@ -14,12 +14,22 @@
         "cidr_block": "10.0.0.0/16"
       },
       "protected": false,
-      "directives": { "force_delete": false, "create_before_destroy": false },
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block"],
       "binding": "old_vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_list_of_maps_all_dropped/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-nested-list-of-maps-all-dropped",
   "carina_version": "0.1.0",
@@ -28,9 +28,19 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "config"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "config": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/nested_map_diff/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-nested-map-diff",
   "carina_version": "0.1.0",
@@ -23,9 +23,19 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "config"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "config": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-no-changes",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -33,15 +51,32 @@
         "vpc_id": "vpc-0123456789abcdef0",
         "cidr_block": "10.0.1.0/24",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "tags"],
       "binding": "ec2_subnet_aac7c86b",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/no_changes_enum/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-no-changes-enum",
   "carina_version": "0.1.0",
@@ -13,15 +13,30 @@
         "cidr_block": "10.0.0.0/16",
         "instance_tenancy": "default",
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "test-vpc" }
+        "tags": {
+          "Name": "test-vpc"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "instance_tenancy", "tags"],
       "binding": "vpc",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "instance_tenancy": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -33,15 +48,35 @@
         "cidr_block": "10.0.1.0/24",
         "availability_zone": "ap-northeast-1a",
         "subnet_id": "subnet-0123456789abcdef0",
-        "tags": { "Name": "test-subnet" }
+        "tags": {
+          "Name": "test-subnet"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "availability_zone", "tags"],
       "binding": "ec2_subnet_f5269366",
-      "dependency_bindings": ["vpc"]
+      "dependency_bindings": [
+        "vpc"
+      ],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "availability_zone": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/provider_prefix/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-provider-prefix",
   "carina_version": "0.1.0",
@@ -14,15 +14,33 @@
         "enable_dns_support": true,
         "enable_dns_hostnames": true,
         "vpc_id": "vpc-0123456789abcdef0",
-        "tags": { "Name": "provider-prefix-fixture" }
+        "tags": {
+          "Name": "provider-prefix-fixture"
+        }
       },
       "protected": false,
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "enable_dns_support", "enable_dns_hostnames", "tags"],
       "binding": "awscc_ec2_vpc_fb75c929",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "enable_dns_support": {
+            "kind": "leaf"
+          },
+          "enable_dns_hostnames": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/secret_values/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "serial": 1,
   "lineage": "test-lineage-secret",
   "carina_version": "0.1.0",
@@ -21,9 +21,19 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["cidr_block", "tags"],
       "binding": null,
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     },
     {
       "resource_type": "ec2.Subnet",
@@ -43,9 +53,22 @@
       "directives": {},
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": ["vpc_id", "cidr_block", "tags"],
       "binding": null,
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "vpc_id": {
+            "kind": "leaf"
+          },
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "leaf"
+          }
+        }
+      }
     }
   ]
 }

--- a/carina-cli/tests/fixtures/plan_display/state_blocks/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/state_blocks/carina.state.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 6,
   "serial": 1,
   "lineage": "test-state-blocks",
   "carina_version": "0.1.0",
@@ -15,12 +15,17 @@
         "cidr_block": "10.0.1.0/24"
       },
       "protected": false,
-      "directives": { "force_delete": false, "create_before_destroy": false },
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": [],
       "binding": "legacy_subnet",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "leaf"
+      }
     },
     {
       "resource_type": "ec2.SecurityGroup",
@@ -32,12 +37,17 @@
         "group_description": "Old security group"
       },
       "protected": false,
-      "directives": { "force_delete": false, "create_before_destroy": false },
+      "directives": {
+        "force_delete": false,
+        "create_before_destroy": false
+      },
       "prefixes": {},
       "name_overrides": {},
-      "desired_keys": [],
       "binding": "old_sg",
-      "dependency_bindings": []
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "leaf"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Rewrites all 21 `carina-cli/tests/fixtures/plan_display/*/carina.state.json` files from v5 (`desired_keys: [...]`) to v6 (`explicit: ExplicitFields::Struct`). The v5→v6 read migration in `check_and_migrate` (added in #2919) was already lifting these on read, but canonicalizing the on-disk format locks in v6 as the only writable shape and avoids keeping the migration path warm forever just for fixture testing.

Conversion is the same logic as the v5 reader: each `desired_keys` entry becomes a `Leaf` child of the root `Struct`.

## Test plan

- [x] `cargo nextest run -p carina-cli plan_snapshot` — 45 tests pass, zero snapshot drift
- [x] `cargo nextest run --workspace` — 3085 tests pass
- [x] `bash scripts/check-*.sh`

Closes #2904
Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)