### PR TITLE
test: server_default_struct_leaf fixture (11/13)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,8 @@ plan-provider-prefix:
 	$(PLAN_FIXTURE) provider_prefix
 plan-module-anonymous-resource:
 	$(PLAN_FIXTURE) module_anonymous_resource
+plan-server-default-struct-leaf:
+	$(PLAN_FIXTURE) server_default_struct_leaf
 .PHONY: plan-all-create plan-no-changes plan-no-changes-enum plan-mixed plan-delete plan-compact \
         plan-map-diff plan-list-diff-added-struct plan-list-diff-removed-struct \
         plan-list-diff-modified-with-unchanged \
@@ -209,7 +211,7 @@ plan-module-anonymous-resource:
         plan-deferred-for plan-exports plan-exports-multifile plan-policy-pretty \
         plan-policy-pretty-nested plan-policy-pretty-dynamic-key-list \
         plan-pretty-long-string-list plan-pretty-short-string-list plan-provider-prefix \
-        plan-module-anonymous-resource \
+        plan-module-anonymous-resource plan-server-default-struct-leaf \
         plan-map-diff-tui plan-all-create-tui plan-mixed-tui plan-delete-tui \
         plan-moved-with-changes-tui plan-moved-pure-tui plan-fixtures
 

--- a/carina-cli/examples/plan-fixture.rs
+++ b/carina-cli/examples/plan-fixture.rs
@@ -111,6 +111,7 @@ fn main() -> ExitCode {
             &fp.moved_origins,
             &[],
             &fp.deferred_for_expressions,
+            Some(&fp.prev_explicit),
         );
     }
 

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1038,6 +1038,7 @@ async fn run_apply_locked(
             &HashMap::new(),
             &export_changes,
             &parsed.deferred_for_expressions,
+            None,
         );
 
         let stdin = tokio::io::BufReader::new(tokio::io::stdin());
@@ -1106,6 +1107,7 @@ async fn run_apply_locked(
         &moved_origins,
         &export_changes,
         &parsed.deferred_for_expressions,
+        Some(&prev_explicit),
     );
 
     let stdin = tokio::io::BufReader::new(tokio::io::stdin());
@@ -1396,6 +1398,7 @@ async fn run_apply_from_plan_locked(
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 
     let stdin = tokio::io::BufReader::new(tokio::io::stdin());

--- a/carina-cli/src/commands/plan.rs
+++ b/carina-cli/src/commands/plan.rs
@@ -375,6 +375,7 @@ pub async fn run_plan(
             &ctx.moved_origins,
             &export_changes,
             &parsed.deferred_for_expressions,
+            Some(&ctx.prev_explicit),
         );
     }
 

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -198,6 +198,7 @@ fn format_export_change(change: &crate::commands::plan::ExportChange) -> String 
     out
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn print_plan(
     plan: &Plan,
     detail: DetailLevel,
@@ -206,6 +207,7 @@ pub fn print_plan(
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
+    prev_explicit: Option<&HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
 ) {
     print!(
         "{}",
@@ -217,6 +219,7 @@ pub fn print_plan(
             moved_origins,
             export_changes,
             deferred_for_expressions,
+            prev_explicit,
         )
     );
 }
@@ -225,6 +228,12 @@ pub fn print_plan(
 ///
 /// This is the core formatting logic used by `print_plan`. Returning a `String`
 /// enables snapshot testing and other programmatic uses of the plan output.
+///
+/// When `prev_explicit` is provided, the actual-state side of each effect
+/// is projected through the per-resource authoring tree before
+/// unchanged-attribute counting (refs awscc#206), so server-side default
+/// fields the user never wrote do not inflate the plan output.
+#[allow(clippy::too_many_arguments)]
 pub fn format_plan(
     plan: &Plan,
     detail: DetailLevel,
@@ -233,6 +242,7 @@ pub fn format_plan(
     moved_origins: &HashMap<ResourceId, ResourceId>,
     export_changes: &[crate::commands::plan::ExportChange],
     deferred_for_expressions: &[carina_core::parser::DeferredForExpression],
+    prev_explicit: Option<&HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
 ) -> String {
     let mut out = String::new();
 
@@ -260,6 +270,7 @@ pub fn format_plan(
         attrs,
         schemas,
         moved_origins,
+        prev_explicit,
     ));
 
     // Show deferred for-expressions
@@ -374,6 +385,7 @@ pub fn format_destroy_plan(
         Some(delete_attributes),
         None,
         &HashMap::new(),
+        None,
     ));
 
     out
@@ -749,12 +761,13 @@ impl<'a> TreeRenderContext<'a> {
 ///
 /// `delete_attributes` optionally provides current state attributes for Delete
 /// effects, allowing the display to show what will be deleted.
-fn format_plan_tree(
+fn format_plan_tree<'a>(
     plan: &Plan,
     detail: DetailLevel,
-    delete_attributes: Option<&HashMap<ResourceId, HashMap<String, Value>>>,
-    schemas: Option<&SchemaRegistry>,
-    moved_origins: &HashMap<ResourceId, ResourceId>,
+    delete_attributes: Option<&'a HashMap<ResourceId, HashMap<String, Value>>>,
+    schemas: Option<&'a SchemaRegistry>,
+    moved_origins: &'a HashMap<ResourceId, ResourceId>,
+    prev_explicit: Option<&'a HashMap<ResourceId, carina_core::explicit::ExplicitFields>>,
 ) -> String {
     // Build dependency graph from effects
     let graph = build_dependency_graph(plan);
@@ -781,7 +794,7 @@ fn format_plan_tree(
         delete_attributes,
         schemas,
         moved_origins,
-        prev_explicit: None,
+        prev_explicit,
         update_or_replace_targets,
     };
 

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -37,6 +37,7 @@ fn test_print_plan_with_external_dependency_does_not_panic() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 }
 
@@ -59,6 +60,7 @@ fn test_print_plan_with_internal_dependency_does_not_panic() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 }
 
@@ -582,6 +584,7 @@ fn test_print_plan_compact_does_not_panic() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 }
 
@@ -611,6 +614,7 @@ fn test_print_plan_compact_with_anonymous_resources() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 }
 
@@ -763,6 +767,7 @@ fn test_cascading_update_shows_attribute_diffs() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     );
 }
 

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -34,6 +34,11 @@ pub struct FixturePlan {
     pub moved_origins: HashMap<ResourceId, ResourceId>,
     pub deferred_for_expressions: Vec<carina_core::parser::DeferredForExpression>,
     pub export_params: Vec<carina_core::parser::InferredExportParam>,
+    /// Per-resource user-authoring trees lifted from the fixture's
+    /// `carina.state.json`. Forwarded to `format_plan` so server-side
+    /// default fields the user never wrote do not surface in plan
+    /// output (refs awscc#206).
+    pub prev_explicit: HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
 }
 
 /// Build a plan from a fixture directory name (e.g. "all_create"). Resolves
@@ -235,6 +240,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         moved_origins,
         deferred_for_expressions: parsed.deferred_for_expressions,
         export_params: parsed.export_params,
+        prev_explicit,
     }
 }
 

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -57,6 +57,7 @@ fn snapshot_all_create() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -78,6 +79,7 @@ fn snapshot_module_anonymous_resource() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -93,6 +95,7 @@ fn snapshot_policy_pretty() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -108,6 +111,7 @@ fn snapshot_policy_pretty_nested() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -129,6 +133,7 @@ fn snapshot_policy_pretty_dynamic_key_list() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -144,6 +149,7 @@ fn snapshot_pretty_long_string_list() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -159,6 +165,7 @@ fn snapshot_pretty_short_string_list() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -174,6 +181,7 @@ fn snapshot_no_changes() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -189,6 +197,7 @@ fn snapshot_mixed_operations() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -219,6 +228,7 @@ fn snapshot_delete_orphan() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -234,6 +244,7 @@ fn snapshot_compact() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -249,6 +260,7 @@ fn snapshot_map_key_diff() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -264,6 +276,7 @@ fn snapshot_enum_display() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -279,6 +292,7 @@ fn snapshot_no_changes_enum() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -330,6 +344,7 @@ fn snapshot_default_values() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -345,6 +360,7 @@ fn snapshot_read_only_attrs() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -360,6 +376,7 @@ fn snapshot_explicit() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -375,6 +392,7 @@ fn snapshot_default_tags() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -390,6 +408,7 @@ fn snapshot_state_blocks() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -420,6 +439,7 @@ fn snapshot_secret_values() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -435,6 +455,7 @@ fn snapshot_moved_with_changes() {
         &moved_origins,
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -464,6 +485,7 @@ fn snapshot_moved_prev_keys() {
         &moved_origins,
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -499,6 +521,7 @@ fn snapshot_moved_pure() {
         &moved_origins,
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -522,6 +545,7 @@ fn snapshot_moved_with_changes_compact() {
         &moved_origins,
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -649,6 +673,7 @@ fn plan_snapshot_upstream_state() {
         &moved_origins,
         &[],
         &[],
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -668,6 +693,7 @@ fn plan_snapshot_upstream_state_unresolved() {
         &moved_origins,
         &[],
         &[],
+        None,
     );
     let stripped = strip_ansi(&output);
     assert!(
@@ -694,6 +720,7 @@ fn plan_snapshot_upstream_state_empty_exports() {
         &moved_origins,
         &[],
         &[],
+        None,
     );
     let stripped = strip_ansi(&output);
     assert!(
@@ -719,6 +746,7 @@ fn plan_snapshot_upstream_state_map_subscript() {
         &moved_origins,
         &[],
         &[],
+        None,
     );
     let stripped = strip_ansi(&output);
     // Both subscript forms — bare attribute value and inside `${...}`
@@ -765,6 +793,7 @@ fn plan_snapshot_upstream_state_map_dot_notation() {
         &moved_origins,
         &[],
         &[],
+        None,
     );
     let stripped = strip_ansi(&output);
     // Both dot-notation forms — bare attribute value and inside `${...}`
@@ -821,6 +850,7 @@ fn plan_snapshot_exports() {
         &moved_origins,
         &export_changes,
         &[],
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -856,6 +886,7 @@ fn plan_snapshot_exports_multifile() {
         &fp.moved_origins,
         &export_changes,
         &[],
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -892,6 +923,7 @@ fn plan_snapshot_export_changes_mixed() {
         &moved_origins,
         &export_changes,
         &[],
+        None,
     );
     insta::assert_snapshot!(strip_ansi(&output));
 }
@@ -907,6 +939,7 @@ fn snapshot_nested_map_diff() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -927,6 +960,7 @@ fn snapshot_list_diff_added_struct() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     assert!(
         !output.lines().any(|l| l.len() > 200),
@@ -954,6 +988,7 @@ fn snapshot_list_diff_modified_with_unchanged() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     assert!(
         !output.lines().any(|l| l.len() > 200),
@@ -987,6 +1022,7 @@ fn snapshot_list_diff_modified_with_unchanged_nested() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     assert!(
         !output.lines().any(|l| l.len() > 200),
@@ -1017,6 +1053,7 @@ fn snapshot_list_diff_paired_all_unchanged_dropped() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -1038,6 +1075,7 @@ fn snapshot_nested_list_of_maps_all_dropped() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }
@@ -1054,6 +1092,7 @@ fn snapshot_list_diff_removed_struct() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     assert!(
         !output.lines().any(|l| l.len() > 200),
@@ -1079,6 +1118,7 @@ fn snapshot_deferred_for() {
         &HashMap::new(),
         &[],
         &fp.deferred_for_expressions,
+        Some(&fp.prev_explicit),
     ));
     insta::assert_snapshot!(output);
 }
@@ -1098,6 +1138,38 @@ fn snapshot_provider_prefix() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
+}
+
+/// Refs awscc#206. The user wrote `tags = { Env = 'prod' }`; the
+/// saved state's actual `tags` value carries an additional `Name`
+/// leaf the user never authored. With prev_explicit threaded into
+/// the differ + display, projection through the authoring tree
+/// strips the unauthored `Name` leaf before comparison — there
+/// must be no Update effect for the Vpc and no `- Name: ...` line
+/// in the rendered plan.
+#[test]
+fn snapshot_server_default_struct_leaf() {
+    let fp = build_plan_from_fixture_name("server_default_struct_leaf");
+    let output = strip_ansi(&format_plan(
+        &fp.plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&fp.schemas),
+        &fp.moved_origins,
+        &[],
+        &[],
+        Some(&fp.prev_explicit),
+    ));
+    insta::assert_snapshot!(output);
+
+    // Acceptance: no `Name` line should appear in the rendered plan,
+    // since `Name` is a server-side default the user never authored.
+    assert!(
+        !output.contains("Name"),
+        "rendered plan must not surface the unauthored 'Name' leaf, got:\n{}",
+        output
+    );
 }

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_server_default_struct_leaf.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_server_default_struct_leaf.snap
@@ -1,0 +1,5 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+No changes. Infrastructure is up-to-date.

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -45,6 +45,10 @@ pub struct PlanContext {
     /// cascade re-resolution. Empty when the configuration declares no
     /// `upstream_state` blocks.
     pub upstream_snapshot: HashMap<String, HashMap<String, carina_core::resource::Value>>,
+    /// Per-resource user-authoring trees lifted from the saved state.
+    /// Forwarded to the display layer so server-side default fields the
+    /// user never wrote do not surface in plan output (refs awscc#206).
+    pub prev_explicit: HashMap<ResourceId, carina_core::explicit::ExplicitFields>,
 }
 
 /// Cached provider factories and schemas, constructed once per CLI invocation.
@@ -1367,6 +1371,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         current_states,
         moved_origins,
         upstream_snapshot: remote_bindings.clone(),
+        prev_explicit,
     })
 }
 

--- a/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/carina.state.json
@@ -1,0 +1,44 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-server-default-struct-leaf",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.Vpc",
+      "name": "",
+      "provider": "awscc",
+      "identifier": "vpc-0000000000000abcd",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0000000000000abcd",
+        "tags": {
+          "Env": "prod",
+          "Name": "auto-generated-by-server"
+        }
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": null,
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          },
+          "tags": {
+            "kind": "struct",
+            "children": {
+              "Env": {
+                "kind": "leaf"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/server_default_struct_leaf/main.crn
@@ -1,0 +1,23 @@
+# server_default_struct_leaf — refs awscc#206
+#
+# Reproduces the awscc.s3.Bucket scenario in which a server-side
+# default leaf (e.g. transition_default_minimum_object_size) appears
+# inside a user-authored Struct attribute. The user wrote only
+# `tags = { Env = 'prod' }`; the saved state's actual current value
+# carries an additional `Name` leaf the user never authored.
+#
+# Expected plan output: no `- Name: ...` line for the unauthored
+# leaf, no Update effect — the projection through ExplicitFields
+# strips the server-default leaf before diffing.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Env = 'prod'
+  }
+}

--- a/carina-core/src/differ/comparison.rs
+++ b/carina-core/src/differ/comparison.rs
@@ -346,10 +346,19 @@ pub(super) fn find_changed_attributes(
     // user did author. When `prev_explicit` is absent (e.g. first-plan,
     // no saved state) we fall back to the unprojected map — there is
     // no authoring information to consult yet.
+    //
+    // `saved` undergoes the same projection so the saved-merge fallback
+    // doesn't smuggle server-only fields back into `effective_desired`
+    // (refs awscc#206).
     let projected_current = match prev_explicit {
         Some(e) => explicit::project_attributes(current.clone(), e),
         None => current.clone(),
     };
+    let projected_saved = match (saved, prev_explicit) {
+        (Some(s), Some(e)) => Some(explicit::project_attributes(s.clone(), e)),
+        _ => None,
+    };
+    let saved = projected_saved.as_ref().or(saved);
 
     for (key, desired_value) in desired {
         // Skip internal attributes (starting with _)


### PR DESCRIPTION
## Summary

Adds the canonical fixture that reproduces the awscc#206 scenario at the carina-cli level: a Vpc resource whose user-authored `tags` map has `Env = 'prod'`; the saved state's `current` carries an extra `Name` leaf the user never authored.

Expected snapshot: `No changes. Infrastructure is up-to-date.` — projection through `ExplicitFields` strips the unauthored `Name` leaf before the differ runs.

Threads `prev_explicit` end-to-end through the display layer:
- `print_plan` / `format_plan` / `format_plan_tree` gain a `prev_explicit` parameter (`Option<&HashMap<ResourceId, ExplicitFields>>`).
- `PlanContext` / `FixturePlan` expose `prev_explicit` so callers can forward the per-resource authoring trees.
- carina-cli `plan` command, `fixture_plan` loader, and `apply` paths now feed `prev_explicit` into `print_plan`.
- `comparison.find_changed_attributes` also projects `saved` so the saved-merge fallback doesn't smuggle server-only fields back into `effective_desired`.

## Test plan

- [x] New fixture's snapshot test (`snapshot_server_default_struct_leaf`) passes — output is "No changes" thanks to projection.
- [x] `cargo nextest run --workspace` — 3086 tests pass, no other snapshot drift.
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

Closes #2905
Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)