### PR TITLE
Add Doc.astro layout and migrate Installation page (Step 2)

### DIFF
--- a/site/src/components/Aside.astro
+++ b/site/src/components/Aside.astro
@@ -1,0 +1,40 @@
+---
+interface Props {
+  type?: 'note' | 'tip' | 'warn' | 'success';
+  title?: string;
+}
+
+const { type = 'note', title } = Astro.props;
+const defaultTitles = { note: 'Note', tip: 'Tip', warn: 'Warning', success: 'Success' };
+const heading = title ?? defaultTitles[type];
+---
+<aside class:list={['aside', `aside-${type}`]} role="note">
+  <p class="aside-title">{heading}</p>
+  <div class="aside-body"><slot /></div>
+</aside>
+
+<style>
+  .aside {
+    border-left: 3px solid var(--aside-accent);
+    background: var(--aside-bg);
+    padding: var(--space-4) var(--space-5);
+    border-radius: 0 var(--radius) var(--radius) 0;
+    margin: var(--space-6) 0;
+  }
+  .aside-tip     { background: var(--aside-tip-bg);     border-left-color: var(--aside-tip-accent); }
+  .aside-warn    { background: var(--aside-warn-bg);    border-left-color: var(--aside-warn-accent); }
+  .aside-success { background: var(--aside-success-bg); border-left-color: var(--aside-success-accent); }
+
+  .aside-title {
+    font-weight: 600;
+    color: var(--aside-title-color);
+    margin: 0 0 var(--space-2);
+  }
+
+  .aside-body {
+    color: var(--aside-body-color);
+    line-height: var(--lh-body);
+  }
+
+  .aside-body :global(:last-child) { margin-bottom: 0; }
+</style>

--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -1,15 +1,84 @@
 ---
-// TODO Step 2+: navigation tree from astro.config or a dedicated config file.
----
+const sections = [
+  {
+    label: 'Getting Started',
+    items: [
+      { label: 'Installation',  href: '/getting-started/installation/' },
+      { label: 'Quick Start',   href: '/getting-started/quick-start/' },
+      { label: 'Core Concepts', href: '/getting-started/core-concepts/' },
+    ],
+  },
+  // TODO Step 3+: Guides, Reference, Providers
+];
 
+const currentPath = Astro.url.pathname;
+---
 <aside class="sidebar">
-  <!-- sidebar items go here in Step 2 -->
+  {sections.map(section => (
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">{section.label}</h3>
+      <ul class="sidebar-list">
+        {section.items.map(item => (
+          <li>
+            <a
+              href={item.href}
+              class:list={['sidebar-link', { active: currentPath === item.href }]}
+              aria-current={currentPath === item.href ? 'page' : undefined}
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ))}
 </aside>
 
 <style>
   .sidebar {
-    padding: var(--space-6) var(--space-4);
-    border-right: 1px solid var(--border);
+    padding: var(--space-2) 0;
     background: var(--sidebar-bg);
+  }
+
+  .sidebar-section + .sidebar-section { margin-top: var(--space-6); }
+
+  .sidebar-section-title {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--sidebar-group-head-color);
+    margin: 0 0 var(--space-3);
+  }
+
+  .sidebar-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .sidebar-link {
+    display: block;
+    padding: var(--space-2) var(--space-3);
+    border-left: 2px solid transparent;
+    color: var(--sidebar-link-color);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    line-height: 1.4;
+    transition: color 0.15s ease, background-color 0.15s ease;
+  }
+
+  .sidebar-link:hover {
+    color: var(--sidebar-link-hover-color);
+  }
+
+  .sidebar-link.active {
+    color: var(--sidebar-link-active-color);
+    background: var(--sidebar-link-active-bg);
+    border-left-color: var(--sidebar-link-active-border);
   }
 </style>

--- a/site/src/components/TOC.astro
+++ b/site/src/components/TOC.astro
@@ -1,0 +1,78 @@
+---
+interface Heading { depth: number; slug: string; text: string; }
+interface Props { headings: Heading[]; }
+
+const { headings } = Astro.props;
+const tocHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
+---
+{tocHeadings.length > 0 && (
+  <nav class="toc" aria-label="On this page">
+    <p class="toc-label">On this page</p>
+    <ul class="toc-list">
+      {tocHeadings.map(h => (
+        <li class:list={['toc-item', `toc-depth-${h.depth}`]}>
+          <a href={`#${h.slug}`} class="toc-link" data-toc-slug={h.slug}>{h.text}</a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}
+
+<style>
+  .toc { font-size: var(--text-sm); }
+
+  .toc-label {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--toc-label-color);
+    margin: 0 0 var(--space-3);
+  }
+
+  .toc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .toc-link {
+    display: block;
+    padding: var(--space-1) 0;
+    color: var(--toc-link-color);
+    text-decoration: none;
+    line-height: 1.4;
+    transition: color 0.15s ease;
+  }
+
+  .toc-link:hover { color: var(--toc-link-hover-color); }
+  .toc-link[data-current="true"] { color: var(--toc-link-current-color); }
+
+  .toc-depth-3 { padding-left: var(--space-4); }
+</style>
+
+<script>
+  const links = document.querySelectorAll<HTMLAnchorElement>('.toc-link');
+  if (links.length) {
+    const bySlug = new Map<string, HTMLAnchorElement>();
+    links.forEach(a => {
+      const slug = a.dataset.tocSlug;
+      if (slug) bySlug.set(slug, a);
+    });
+    const obs = new IntersectionObserver(entries => {
+      for (const e of entries) {
+        const link = bySlug.get(e.target.id);
+        if (!link) continue;
+        if (e.isIntersecting) {
+          links.forEach(l => l.removeAttribute('data-current'));
+          link.setAttribute('data-current', 'true');
+        }
+      }
+    }, { rootMargin: '0px 0px -70% 0px' });
+    document.querySelectorAll('article h2[id], article h3[id]').forEach(h => obs.observe(h));
+  }
+</script>

--- a/site/src/content/getting-started/installation.md
+++ b/site/src/content/getting-started/installation.md
@@ -1,0 +1,105 @@
+---
+title: Installation
+description: How to install Carina and set up provider plugins.
+---
+
+## Homebrew (macOS)
+
+```bash
+brew install carina-rs/tap/carina
+```
+
+This installs both `carina` (CLI) and `carina-lsp` (Language Server).
+
+## GitHub Releases
+
+Download pre-built binaries from [GitHub Releases](https://github.com/carina-rs/carina/releases/latest). Available for macOS (aarch64, x86_64) and Linux (aarch64, x86_64). Each archive contains both `carina` and `carina-lsp`.
+
+```bash
+# macOS (Apple Silicon) — replace <VERSION> with the latest release tag (e.g. 0.5.0)
+curl -LO https://github.com/carina-rs/carina/releases/download/v<VERSION>/carina-<VERSION>-macos-aarch64.tar.gz
+tar xzf carina-<VERSION>-macos-aarch64.tar.gz
+sudo mv carina carina-lsp /usr/local/bin/
+```
+
+## Build from source
+
+Prerequisites:
+- **Rust toolchain** (stable) -- install via [rustup](https://rustup.rs/)
+- **wasm32-wasip2 target** -- required for building provider plugins
+
+```bash
+rustup target add wasm32-wasip2
+```
+
+Clone the repository and build in release mode:
+
+```bash
+git clone https://github.com/carina-rs/carina.git
+cd carina
+cargo build --release
+```
+
+The binary is at `target/release/carina`. Add it to your `PATH` or copy it to a directory already on your `PATH`.
+
+## Provider plugins
+
+Carina uses WASM-based provider plugins. When you specify a `source` and `version` in your `.crn` file, Carina automatically downloads the provider plugin from GitHub Releases on first use:
+
+```crn
+provider awscc {
+    source  = 'github.com/carina-rs/carina-provider-awscc'
+    version = '0.5.0'
+    region  = awscc.Region.ap_northeast_1
+}
+```
+
+The two official providers are:
+
+| Provider | Source |
+|----------|--------|
+| AWSCC (Cloud Control API) | `github.com/carina-rs/carina-provider-awscc` |
+| AWS (native SDK) | `github.com/carina-rs/carina-provider-aws` |
+
+### Building from source (optional)
+
+If you need to build providers from source:
+
+```bash
+git clone https://github.com/carina-rs/carina-provider-awscc.git
+cd carina-provider-awscc
+cargo build -p carina-provider-awscc --target wasm32-wasip2 --release
+```
+
+The WASM component is at `target/wasm32-wasip2/release/carina_provider_awscc.wasm`.
+
+### Building the AWS provider
+
+```bash
+git clone https://github.com/carina-rs/carina-provider-aws.git
+cd carina-provider-aws
+cargo build -p carina-provider-aws --target wasm32-wasip2 --release
+```
+
+The WASM component is at `target/wasm32-wasip2/release/carina_provider_aws.wasm`.
+
+## Shell completions
+
+```bash
+# Bash
+carina completions bash > ~/.local/share/bash-completion/completions/carina
+
+# Zsh
+mkdir -p ~/.zfunc
+carina completions zsh > ~/.zfunc/_carina
+# Add to .zshrc: fpath=(~/.zfunc $fpath); autoload -Uz compinit; compinit
+
+# Fish
+carina completions fish > ~/.config/fish/completions/carina.fish
+```
+
+## Verify the installation
+
+```bash
+carina --help
+```

--- a/site/src/layouts/Doc.astro
+++ b/site/src/layouts/Doc.astro
@@ -1,0 +1,139 @@
+---
+import BaseLayout from '../components/BaseLayout.astro';
+import Sidebar from '../components/Sidebar.astro';
+import TOC from '../components/TOC.astro';
+
+interface Heading { depth: number; slug: string; text: string; }
+interface Props {
+  title: string;
+  description?: string;
+  headings?: Heading[];
+}
+
+const { title, description, headings = [] } = Astro.props;
+---
+<BaseLayout title={title} description={description} showSidebar={false}>
+  <div class="doc-grid">
+    <Sidebar />
+    <article class="doc-main">
+      <header class="doc-header">
+        <h1>{title}</h1>
+        {description && <p class="doc-lede">{description}</p>}
+      </header>
+      <div class="doc-body">
+        <slot />
+      </div>
+    </article>
+    <TOC headings={headings} />
+  </div>
+</BaseLayout>
+
+<style>
+  .doc-grid {
+    display: grid;
+    grid-template-columns: 16rem minmax(0, 1fr) 14rem;
+    gap: var(--space-8);
+    max-width: 80rem;
+    margin: 0 auto;
+    padding: var(--space-8) var(--space-6);
+  }
+
+  .doc-main { min-width: 0; }
+
+  .doc-header { margin-bottom: var(--space-8); }
+
+  .doc-header h1 {
+    font-family: var(--font-display);
+    font-size: var(--text-4xl);
+    color: var(--page-title-color);
+    margin: 0 0 var(--space-3);
+  }
+
+  .doc-lede {
+    font-size: var(--text-lg);
+    color: var(--fg3);
+    margin: 0;
+  }
+
+  .doc-body {
+    color: var(--page-body-color);
+    line-height: var(--lh-body);
+  }
+
+  .doc-body :global(h2) {
+    margin-top: var(--space-8);
+    margin-bottom: var(--space-4);
+    scroll-margin-top: var(--space-8);
+  }
+
+  .doc-body :global(h3) {
+    margin-top: var(--space-6);
+    margin-bottom: var(--space-3);
+    scroll-margin-top: var(--space-8);
+  }
+
+  .doc-body :global(p) { margin: 0 0 var(--space-4); }
+
+  .doc-body :global(ul),
+  .doc-body :global(ol) {
+    margin: 0 0 var(--space-4);
+    padding-left: var(--space-6);
+  }
+
+  .doc-body :global(li) { margin: var(--space-1) 0; }
+
+  .doc-body :global(pre) {
+    background: var(--code-block-bg);
+    border: 1px solid var(--code-block-border);
+    border-radius: var(--radius);
+    padding: var(--space-4);
+    overflow-x: auto;
+    margin: var(--space-4) 0;
+  }
+
+  .doc-body :global(code) {
+    background: var(--code-inline-bg);
+    color: var(--code-inline-color);
+    padding: 0.1em 0.35em;
+    border-radius: var(--radius-sm);
+    font-size: 0.9em;
+  }
+
+  .doc-body :global(pre code) {
+    background: transparent;
+    padding: 0;
+    color: var(--code-block-text);
+  }
+
+  .doc-body :global(table) {
+    border-collapse: collapse;
+    margin: var(--space-4) 0;
+    width: 100%;
+    font-size: var(--text-sm);
+  }
+
+  .doc-body :global(th),
+  .doc-body :global(td) {
+    border: 1px solid var(--border);
+    padding: var(--space-2) var(--space-3);
+    text-align: left;
+  }
+
+  .doc-body :global(th) {
+    background: var(--bg-raise);
+    color: var(--fg1);
+    font-weight: 600;
+  }
+
+  /* 1024px 以下: TOC 落とす */
+  @media (max-width: 64rem) {
+    .doc-grid { grid-template-columns: 14rem minmax(0, 1fr); }
+    .doc-grid > :global(.toc) { display: none; }
+  }
+
+  /* 768px 以下: サイドバーも落とす */
+  @media (max-width: 48rem) {
+    .doc-grid { grid-template-columns: 1fr; }
+    .doc-grid > :global(.sidebar) { display: none; }
+  }
+</style>

--- a/site/src/pages/getting-started/installation.astro
+++ b/site/src/pages/getting-started/installation.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/getting-started/installation.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Installation'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>


### PR DESCRIPTION
## Summary
- Establish the documentation page template at `site/src/layouts/Doc.astro`: 3-column grid (sidebar | main | TOC), with responsive fallbacks to 2 columns below 64rem and 1 column below 48rem.
- New components on the existing design-system tokens:
  - `Sidebar.astro` — dynamic nav with active-link highlight from `Astro.url.pathname`; only the Getting Started section is populated, other sections are stubbed for Step 3+.
  - `TOC.astro` — filters H2/H3, current-position highlight via IntersectionObserver against `article h2[id], article h3[id]`.
  - `Aside.astro` — `note` / `tip` / `warn` / `success` variants on `--aside-*` tokens.
- Migrate `docs/src/content/docs/getting-started/installation.md` to `site/src/content/getting-started/installation.md` and wire it through `Doc` via `pages/getting-started/installation.astro` (`Content` + `getHeadings()` + `frontmatter`). Content collection migration is deferred to Step 3.

## Notes
- The `.crn` code fences fall back to plaintext (`[Shiki] The language "crn" doesn't exist`) until the custom grammar lands in Step 5+. Expected behaviour for this step.
- Sidebar links to `/getting-started/quick-start/` and `/getting-started/core-concepts/` will 404 until Step 3 migrates them.
- Landing (`/`) is unchanged — `Doc` only opts in via `showSidebar={false}` and runs its own grid inside the BaseLayout slot.

## Test plan
- [ ] `cd site && npm install && npm run build` succeeds (2 pages built).
- [ ] `cd site && npm run dev` serves `/getting-started/installation/` and `/` on `http://localhost:4321/` with no console errors.
- [ ] Visual: sidebar shows `Installation` highlighted; TOC lists every H2/H3 and updates as you scroll; landing hero is unchanged.
- [ ] Resize: TOC disappears below 64rem; sidebar disappears below 48rem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)