### PR TITLE
Drop stale exports from state when source removes the exports block

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -280,10 +280,13 @@ pub(crate) async fn finalize_apply(input: FinalizeApplyInput<'_>) -> Result<(), 
         schemas: input.schemas,
     })?;
 
-    // Resolve exports and persist to state
-    if !input.export_params.is_empty() {
-        let exports = resolve_exports(input.export_params, input.sorted_resources, &state)?;
-        state.exports = exports;
+    // `Some([])` is meaningful: the user removed the `exports {}` block,
+    // so stale entries the previous apply persisted must be cleared
+    // (#2932). `None` preserves `state.exports` because the caller has
+    // no source-side view of which exports the user intends — see the
+    // `FinalizeApplyInput::export_params` doc-comment.
+    if let Some(params) = input.export_params {
+        state.exports = resolve_exports(params, input.sorted_resources, &state)?;
     }
 
     if let Some(lock) = input.lock {
@@ -1151,7 +1154,7 @@ async fn run_apply_locked(
         backend,
         lock,
         schemas,
-        export_params: &parsed.export_params,
+        export_params: Some(&parsed.export_params),
     })
     .await?;
 
@@ -1461,7 +1464,11 @@ async fn run_apply_from_plan_locked(
         backend,
         lock,
         schemas: ctx.schemas(),
-        export_params: &[],
+        // Saved plan files do not persist `export_params` today, so
+        // pass `None` to preserve `state.exports` rather than wipe it.
+        // Source-driven `carina apply` reconciles exports from the
+        // `.crn` directly (#2932).
+        export_params: None,
     })
     .await?;
 

--- a/carina-cli/src/commands/shared/state_writeback.rs
+++ b/carina-cli/src/commands/shared/state_writeback.rs
@@ -70,7 +70,15 @@ pub(crate) struct FinalizeApplyInput<'a> {
     pub backend: &'a dyn StateBackend,
     pub lock: Option<&'a LockInfo>,
     pub schemas: &'a SchemaRegistry,
-    pub export_params: &'a [carina_core::parser::InferredExportParam],
+    /// `Some(params)` rebuilds `state.exports` from the source
+    /// configuration's `exports {}` block — empty `params` clears the
+    /// map (#2932). `None` preserves the existing `state.exports` and
+    /// is used by `apply --plan` because saved plan files do not
+    /// persist `export_params` today; with `None` the apply path
+    /// neither resolves nor wipes them, leaving the prior values
+    /// intact for the next source-driven `carina apply` to
+    /// reconcile.
+    pub export_params: Option<&'a [carina_core::parser::InferredExportParam]>,
 }
 
 /// Resolve export expressions using bindings built from applied state.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1397,7 +1397,7 @@ async fn lock_released_on_write_state_failure() {
         backend: &backend,
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
-        export_params: &[],
+        export_params: Some(&[]),
     })
     .await;
 
@@ -1530,7 +1530,7 @@ async fn finalize_apply_uses_write_state_locked() {
         backend: &backend,
         lock: Some(&lock),
         schemas: &SchemaRegistry::new(),
-        export_params: &[],
+        export_params: Some(&[]),
     })
     .await;
 
@@ -2078,7 +2078,7 @@ async fn finalize_apply_without_lock_uses_write_state() {
         backend: &backend,
         lock: None, // No lock
         schemas: &SchemaRegistry::new(),
-        export_params: &[],
+        export_params: Some(&[]),
     })
     .await;
 
@@ -2786,5 +2786,123 @@ async fn persist_exports_only_writes_state_with_new_exports() {
     assert_eq!(
         state.exports.get("account_id"),
         Some(&serde_json::json!("123456789012"))
+    );
+}
+
+/// Regression test for #2932: when the user removes the entire
+/// `exports {}` block (so `parsed.export_params` is empty) but the
+/// plan has resource changes, `finalize_apply` must still drop
+/// stale entries from `state.exports`. Previously a guard
+/// `if !input.export_params.is_empty()` skipped the assignment,
+/// so subsequent plans kept re-emitting the same `- exports`
+/// removal lines and the state never converged.
+#[tokio::test]
+async fn finalize_apply_clears_state_exports_when_params_empty() {
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    // Pre-existing state with exports left over from a previous
+    // apply whose `exports {}` block has since been removed.
+    let mut state_in = StateFile::new();
+    state_in.exports.insert(
+        "zone_id".to_string(),
+        serde_json::json!("Z0788351HTU0H3UKV38I"),
+    );
+    state_in.exports.insert(
+        "nameservers".to_string(),
+        serde_json::json!(["ns-1572.awsdns-04.co.uk"]),
+    );
+
+    let result = ApplyResult {
+        success_count: 0,
+        failure_count: 0,
+        skip_count: 0,
+        applied_states: HashMap::new(),
+        permanent_name_overrides: HashMap::new(),
+        successfully_deleted: HashSet::new(),
+        current_states: HashMap::new(),
+        failed_refreshes: HashSet::new(),
+    };
+
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(state_in),
+        sorted_resources: &[],
+        current_states: &HashMap::new(),
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: Some(&lock),
+        schemas: &SchemaRegistry::new(),
+        export_params: Some(&[]),
+    })
+    .await;
+
+    assert!(op_result.is_ok(), "finalize_apply failed: {:?}", op_result);
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert!(
+        state.exports.is_empty(),
+        "stale exports must be cleared when export_params is empty, got: {:?}",
+        state.exports
+    );
+}
+
+/// `apply --plan plan.json` does not parse the source `.crn`, so it
+/// has no `export_params` to feed `finalize_apply` and passes `None`
+/// instead. In that case `state.exports` must be **preserved** — the
+/// previous source-driven apply already populated them, and clearing
+/// here would silently drop the user's exports on every apply-from-plan
+/// (regression of the #2932 fix). The next source-driven `carina
+/// apply` reconciles them.
+#[tokio::test]
+async fn finalize_apply_preserves_state_exports_when_params_none() {
+    let captured = Arc::new(Mutex::new(None));
+    let backend = CapturingBackend {
+        captured: captured.clone(),
+    };
+    let lock = LockInfo::new("apply");
+
+    let mut state_in = StateFile::new();
+    state_in
+        .exports
+        .insert("vpc_id".to_string(), serde_json::json!("vpc-0abc123"));
+
+    let result = ApplyResult {
+        success_count: 0,
+        failure_count: 0,
+        skip_count: 0,
+        applied_states: HashMap::new(),
+        permanent_name_overrides: HashMap::new(),
+        successfully_deleted: HashSet::new(),
+        current_states: HashMap::new(),
+        failed_refreshes: HashSet::new(),
+    };
+
+    let op_result = finalize_apply(FinalizeApplyInput {
+        result: &result,
+        state_file: Some(state_in),
+        sorted_resources: &[],
+        current_states: &HashMap::new(),
+        plan: &Plan::new(),
+        backend: &backend,
+        lock: Some(&lock),
+        schemas: &SchemaRegistry::new(),
+        export_params: None,
+    })
+    .await;
+
+    assert!(op_result.is_ok(), "finalize_apply failed: {:?}", op_result);
+
+    let written = captured.lock().unwrap();
+    let state = written.as_ref().expect("state should be written");
+    assert_eq!(
+        state.exports.get("vpc_id"),
+        Some(&serde_json::json!("vpc-0abc123")),
+        "state.exports must survive apply-from-plan (export_params: None), got: {:?}",
+        state.exports
     );
 }


### PR DESCRIPTION
## Summary

Fixes #2932. When the user removes the entire `exports {}` block from `.crn`, `finalize_apply` previously skipped writing `state.exports` because `parsed.export_params` was empty. The map loaded from the previous state file was preserved verbatim, so subsequent `carina plan` runs re-emitted the same `- exports` removal lines and state never converged.

## Fix shape

Change `FinalizeApplyInput::export_params` from `&[InferredExportParam]` to `Option<&[InferredExportParam]>`:

- `Some(params)` — source-driven apply: resolve and overwrite. `Some(&[])` clears, which is what the user gets after deleting the `exports {}` block.
- `None` — apply-from-plan: preserve `state.exports`. Saved plan files do not persist `export_params` today, so the apply path has no source-side view of what the user intends. The next source-driven `carina apply` reconciles.

The previous unconditional `&[]` empty-slice meaning was overloaded — it was simultaneously "no exports declared" and "we don't know" — which the bug exploited. Splitting via `Option` makes both intents explicit.

## Tests

- `finalize_apply_clears_state_exports_when_params_empty` reproduces the issue's exact payload (`zone_id`, `nameservers`) and asserts the cleared state.
- `finalize_apply_preserves_state_exports_when_params_none` pins the apply-from-plan invariant against future regression.

## Test plan

- [x] `cargo nextest run -p carina-cli` (395 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] Real-infra smoke test on `carina-rs/infra registry/dev/registry/` — left to issue reporter (requires AWS credentials).

## Follow-up

`apply --plan plan.json` still cannot itself drop a removed `exports {}` block (because `PlanFile` does not carry `export_params`). Source-driven apply reconciles afterwards, so the user-visible effect is bounded, but a follow-up that persists `export_params` into saved plan files would close the gap.

Closes #2932