### PR TITLE
fix: project display old_value + state-writeback uses merged resources (closes awscc#206)

### DIFF
--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -1145,10 +1145,15 @@ async fn run_apply_locked(
     // Execute remove and move effects (state-only, logged for user feedback)
     execute_state_only_effects(&plan, &mut result);
 
+    // Use `resources_for_plan` (post-default_tags merge, post-canonicalize)
+    // for state writeback so the per-resource `explicit` tree includes
+    // provider-level default tags. Otherwise the next plan projects the
+    // tags out of `current` and surfaces a spurious `tags: (none) → ...`
+    // diff (refs awscc#206).
     finalize_apply(FinalizeApplyInput {
         result: &result,
         state_file,
-        sorted_resources: &sorted_resources,
+        sorted_resources: &resources_for_plan,
         current_states: &current_states,
         plan: &plan,
         backend,

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -527,7 +527,13 @@ fn build_update_rows(
 
     for key in keys {
         let new_value = &to.attributes[key];
-        let old_value = from.attributes.get(key);
+        // Look up `old_value` from the projected map so MapDiff /
+        // ListOfMapsDiff rows don't surface server-side default leaves
+        // the user never authored (refs awscc#206). The same value the
+        // unchanged-count computation below uses, kept consistent so a
+        // field that's "unchanged after projection" is also "unchanged
+        // for display".
+        let old_value = from_attrs_projected.get(key);
         let is_same = old_value
             .map(|ov| ov.semantically_equal(new_value))
             .unwrap_or(false);
@@ -558,14 +564,16 @@ fn build_update_rows(
         }
     }
 
-    // Show removed attributes (in changed_attributes but not in to)
+    // Show removed attributes (in changed_attributes but not in to).
+    // Use the projected map so we don't surface unauthored leaves as
+    // removals (refs awscc#206).
     let mut removed_keys: Vec<_> = changed_attributes
         .iter()
         .filter(|k| !to.attributes.contains_key(k.as_str()))
         .collect();
     removed_keys.sort();
     for key in removed_keys {
-        if let Some(old_value) = from.attributes.get(key.as_str()) {
+        if let Some(old_value) = from_attrs_projected.get(key.as_str()) {
             rows.push(DetailRow::Removed {
                 key: key.to_string(),
                 old: format_value_with_key(old_value, Some(key)),


### PR DESCRIPTION
## Summary

Fixes the awscc#206 reproduction confirmed in production after the ExplicitFields series (#2916–#2930) merged. Two bugs blocked the projection from reaching plan output:

### 1. display-side: `build_update_rows` looked up `old_value` from unprojected `from.attributes`

`build_detail_rows` projects `from.attributes` for the unchanged-attribute count, but the per-key MapDiff / ListOfMapsDiff loop still looked up `old_value` from the raw `from.attributes`. Server-side default leaves the differ correctly excluded from `changed` still surfaced as MapDiff entries when display walked `to.attributes` and re-determined `is_same` via `semantically_equal`.

Fix: `let old_value = from_attrs_projected.get(key)` — same map the unchanged count uses.

### 2. apply-side: state writeback got the pre-default_tags resources

The apply path passes `sorted_resources` (pre `merge_default_tags`, pre `canonicalize_resources_with_schemas`) to `build_state_after_apply`. So `build_from_resource` saw the user's pre-merge attributes — without the provider-injected default tags. The resulting `explicit` tree had no `tags` child, projection stripped tags from `current` on the next plan, and `is_equal` returned `false` because `projected_current.get("tags") == None`.

Fix: `sorted_resources: &resources_for_plan` (post-merge, post-canonicalize).

## Real-infra confirmation

```
$ aws-vault exec carina-registry-dev -- carina plan
Using awscc (region: ap-northeast-1, source: github.com/carina-rs/carina-provider-awscc)
Refreshing state...
No changes. Infrastructure is up-to-date.
```

Closes #2933 (the carina#2933 placeholder for this work) and finally puts awscc#206 to bed end-to-end.

## Test plan

- [x] `cargo nextest run --workspace` — 3088 tests pass, no snapshot drift
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [x] Real-infra `carina plan` against `registry/dev/registry` returns "No changes" after `apply`

Refs carina-rs/carina-provider-awscc#206

🤖 Generated with [Claude Code](https://claude.com/claude-code)