### PR TITLE
Migrate the Guides section (Step 4)

### DIFF
--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -8,7 +8,18 @@ const sections = [
       { label: 'Core Concepts', href: '/getting-started/core-concepts/' },
     ],
   },
-  // TODO Step 3+: Guides, Reference, Providers
+  {
+    label: 'Guides',
+    items: [
+      { label: 'Writing Resources',  href: '/guides/writing-resources/' },
+      { label: 'Using Modules',      href: '/guides/using-modules/' },
+      { label: 'State Management',   href: '/guides/state-management/' },
+      { label: 'For/If Expressions', href: '/guides/for-if-expressions/' },
+      { label: 'Functions',          href: '/guides/functions/' },
+      { label: 'LSP Setup',          href: '/guides/lsp-setup/' },
+    ],
+  },
+  // TODO Step 5+: Reference, Providers
 ];
 
 const currentPath = Astro.url.pathname;

--- a/site/src/content/guides/for-if-expressions.md
+++ b/site/src/content/guides/for-if-expressions.md
@@ -1,0 +1,195 @@
+---
+title: "For / If Expressions"
+description: "Learn how to use for loops and if/else expressions in Carina to create multiple resources, iterate over lists and maps, and conditionally include resources."
+---
+
+Carina supports `for` and `if` expressions to dynamically generate resources. This guide shows you how to iterate over collections and conditionally create resources.
+
+## For expressions
+
+A `for` expression creates multiple resources by iterating over a list or map.
+
+### Iterating over a list
+
+The simplest form iterates over a list of values:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpcs = for env in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = '10.0.0.0/16'
+
+    tags = {
+      Name        = "vpc-${env}"
+      Environment = env
+    }
+  }
+}
+```
+
+This creates two VPCs, one for each environment.
+
+### Indexed iteration
+
+Use the `(index, value)` form to access the iteration index:
+
+```crn
+let vpcs = for (i, env) in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
+
+    tags = {
+      Name        = "vpc-${env}"
+      Environment = env
+    }
+  }
+}
+```
+
+The index `i` starts at 0. Here it is used with `cidr_subnet` to assign different CIDR blocks to each VPC.
+
+### Iterating over a map
+
+Use `key, value` binding to iterate over map entries:
+
+```crn
+let cidrs = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+
+let vpcs = for name, cidr in cidrs {
+  awscc.ec2.Vpc {
+    cidr_block = cidr
+
+    tags = {
+      Name        = "vpc-${name}"
+      Environment = name
+    }
+  }
+}
+```
+
+### Accessing for expression results
+
+The result of a `for` expression is a list. You can access individual elements with index syntax:
+
+```crn
+let vpcs = for env in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = '10.0.0.0/16'
+
+    tags = {
+      Name = "vpc-${env}"
+    }
+  }
+}
+
+# Reference the first VPC's attributes
+awscc.ec2.Subnet {
+  vpc_id            = vpcs[0].vpc_id
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
+
+  tags = {
+    Name = 'dev-subnet'
+  }
+}
+```
+
+### Local variables in for body
+
+You can define local `let` bindings inside a `for` body:
+
+```crn
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+let subnets = for (i, az) in ['ap-northeast-1a', 'ap-northeast-1c'] {
+  let cidr = cidr_subnet('10.0.0.0/16', 8, i)
+
+  awscc.ec2.Subnet {
+    vpc_id            = vpc.vpc_id
+    cidr_block        = cidr
+    availability_zone = az
+
+    tags = {
+      Name = "subnet-${az}"
+    }
+  }
+}
+```
+
+### For with modules
+
+You can call modules inside `for` expressions to create multiple instances of a module. See the [Using Modules](/guides/using-modules/#using-modules-with-for-expressions) guide for a full example.
+
+## If expressions
+
+An `if` expression conditionally creates a resource or selects a value.
+
+### Conditional resources
+
+Create a resource only when a condition is true:
+
+```crn
+let enabled = true
+
+let vpc = if enabled {
+  awscc.ec2.Vpc {
+    cidr_block = '10.0.0.0/16'
+
+    tags = {
+      Name = 'conditional-vpc'
+    }
+  }
+}
+```
+
+When `enabled` is `false`, no VPC is created and the `let` binding is empty.
+
+### Conditional values with if/else
+
+Use `if`/`else` as a value expression to choose between two values:
+
+```crn
+let is_production = true
+
+awscc.ec2.Vpc {
+  cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
+
+  tags = {
+    Name = if is_production { 'prod-vpc' } else { 'dev-vpc' }
+  }
+}
+```
+
+This creates a single VPC but uses different CIDR blocks and names depending on the condition.
+
+### Combining for and if
+
+You can use `if` expressions inside `for` bodies and vice versa:
+
+```crn
+let environments = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+  prd = '10.2.0.0/16'
+}
+
+let vpcs = for name, cidr in environments {
+  awscc.ec2.Vpc {
+    cidr_block           = cidr
+    enable_dns_hostnames = if name == 'prd' { true } else { false }
+
+    tags = {
+      Name        = "vpc-${name}"
+      Environment = name
+    }
+  }
+}
+```

--- a/site/src/content/guides/functions.md
+++ b/site/src/content/guides/functions.md
@@ -1,0 +1,198 @@
+---
+title: "Functions"
+description: "Learn how to use built-in functions, define custom functions, and compose them with the pipe operator in Carina."
+---
+
+Carina provides built-in functions for common operations and lets you define your own functions. This guide covers both, along with the pipe and compose operators.
+
+## Built-in functions
+
+### String functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `upper` | `upper(string) -> String` | Converts to uppercase |
+| `lower` | `lower(string) -> String` | Converts to lowercase |
+| `trim` | `trim(string) -> String` | Removes leading/trailing whitespace |
+| `replace` | `replace(search, replacement, string) -> String` | Replaces all occurrences |
+| `split` | `split(separator, string) -> list(String)` | Splits string into a list |
+| `join` | `join(separator, list) -> String` | Joins list elements into a string |
+
+Examples:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = upper('my-vpc')              # 'MY-VPC'
+    Env  = replace('_', '-', 'my_env')  # 'my-env'
+    Id   = join('-', ['vpc', 'prod'])    # 'vpc-prod'
+  }
+}
+```
+
+### Collection functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `length` | `length(list \| map \| String) -> Int` | Returns element/character count |
+| `concat` | `concat(items, base_list) -> list(Any)` | Appends items to a list |
+| `flatten` | `flatten(list) -> list(Any)` | Flattens nested lists by one level |
+| `keys` | `keys(map) -> list(String)` | Returns map keys as a sorted list |
+| `values` | `values(map) -> list(Any)` | Returns map values sorted by key |
+| `lookup` | `lookup(map, key, default) -> Any` | Looks up a key with a fallback |
+| `map` | `map(accessor, collection) -> list(Any) \| map(Any)` | Extracts a field from each element |
+
+Examples:
+
+```crn
+let parts1 = ['web', 'test']
+let parts2 = ['vpc']
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = join('-', concat(parts2, parts1))  # 'web-test-vpc'
+  }
+}
+```
+
+### Numeric functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `min` | `min(a, b) -> Number` | Returns the smaller value |
+| `max` | `max(a, b) -> Number` | Returns the larger value |
+
+### Network functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `cidr_subnet` | `cidr_subnet(prefix, newbits, netnum) -> Ipv4Cidr` | Calculates a subnet CIDR block |
+
+Example:
+
+```crn
+let vpcs = for (i, env) in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
+    # i=0 -> '10.0.0.0/16', i=1 -> '10.1.0.0/16'
+
+    tags = {
+      Name = "vpc-${env}"
+    }
+  }
+}
+```
+
+### Environment and security functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `env` | `env(name) -> string` | Reads an environment variable |
+| `secret` | `secret(value) -> secret` | Marks a value as secret (stored as hash in state) |
+| `decrypt` | `decrypt(ciphertext, key?) -> string` | Decrypts using the provider's encryption service (e.g., AWS KMS) |
+
+## User-defined functions
+
+Define reusable logic with the `fn` keyword:
+
+```crn
+fn tag_name(env: String, service: String): String {
+  join('-', [env, service, 'vpc'])
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = tag_name('production', 'web')  # 'production-web-vpc'
+  }
+}
+```
+
+### Function syntax
+
+```crn
+fn name(param1: type1, param2: type2): return_type {
+  expression
+}
+```
+
+- **Parameters** can have type annotations (`: String`, `: Int`, etc.)
+- **Return type** annotation is optional (`: String`)
+- The function body is a single expression (the return value)
+
+### Local variables in functions
+
+Functions can have local `let` bindings before the final expression:
+
+```crn
+fn subnet_name(env: String, tier: String, index: Int): String {
+  let prefix = join("-", [env, tier])
+  "${prefix}-${index}"
+}
+```
+
+### Default parameter values
+
+Parameters can have default values:
+
+```crn
+fn make_tags(name: String, env: String = 'dev'): map(String) {
+  {
+    Name        = name
+    Environment = env
+  }
+}
+```
+
+## Pipe operator
+
+The pipe operator `|>` passes the result of the left side as the **last** argument to the function on the right (data-last convention):
+
+```crn
+# Without pipe
+let result = join('-', split('_', upper('hello_world')))
+
+# With pipe -- reads left to right
+let result = 'hello_world' |> upper() |> split('_') |> join('-')
+# Result: 'HELLO-WORLD'
+```
+
+The pipe operator is especially useful with collection functions:
+
+```crn
+let names = ['web', 'api', 'worker']
+
+# Extract and transform
+let result = names |> join(', ')
+```
+
+## Compose operator
+
+The compose operator `>>` creates a new function by chaining two partially applied functions (closures). Both sides must be closures:
+
+```crn
+# split('_') is a closure (1 of 2 args provided)
+# join('-') is a closure (1 of 2 args provided)
+let transform = split('_') >> join('-')
+```
+
+The resulting function applies the left function first, then passes the result to the right function.
+
+## Partial application
+
+When you call a built-in function with fewer arguments than it expects, you get a **closure** -- a partially applied function that waits for the remaining arguments:
+
+```crn
+# replace expects 3 args; giving 2 returns a closure
+let dashify = replace('_', '-')
+
+# The closure is called when the last argument arrives (via pipe)
+let result = 'hello_world' |> dashify()  # 'hello-world'
+```
+
+This works naturally with the pipe operator, since the piped value fills in the last argument.

--- a/site/src/content/guides/lsp-setup.md
+++ b/site/src/content/guides/lsp-setup.md
@@ -1,0 +1,148 @@
+---
+title: "LSP Setup"
+description: "Set up the Carina Language Server for editor integration with autocompletion, diagnostics, hover information, semantic highlighting, code actions, and formatting."
+---
+
+Carina includes a Language Server Protocol (LSP) implementation that provides a rich editing experience for `.crn` files. This guide covers how to set it up and what features are available.
+
+## Features
+
+The Carina LSP (`carina-lsp`) provides:
+
+- **Autocompletion** -- resource types, attributes, attribute values, keywords, and built-in function names
+- **Diagnostics** -- parse errors, type validation, unknown resource types, module validation, and cross-directory upstream-reference shape checks
+- **Hover information** -- documentation for resource attributes and types on hover
+- **Semantic tokens** -- syntax highlighting for resource types, regions, and identifiers
+- **Code actions** -- quick fixes for diagnostics (e.g. inserting the canonical enum identifier when an attribute value does not match any variant)
+- **Document formatting** -- automatic formatting of `.crn` files
+
+## Installation
+
+If you installed Carina via Homebrew or GitHub Releases, `carina-lsp` is already included -- no additional installation is needed.
+
+To build from source instead:
+
+```bash
+cargo install --git https://github.com/carina-rs/carina.git carina-lsp
+```
+
+Make sure the `carina-lsp` binary is in your `PATH`.
+
+## VS Code setup
+
+1. Install the **Carina** extension from the VS Code marketplace, or configure a generic LSP client extension (such as [vscode-languageclient](https://github.com/microsoft/vscode-languageserver-node)).
+
+2. If using a generic LSP client, add to your VS Code `settings.json`:
+
+```json
+{
+  "carina.lsp.path": "carina-lsp"
+}
+```
+
+3. Open a `.crn` file. The LSP server starts automatically.
+
+## Neovim setup
+
+### With nvim-lspconfig
+
+Add a custom server configuration:
+
+```lua
+local lspconfig = require('lspconfig')
+local configs = require('lspconfig.configs')
+
+if not configs.carina then
+  configs.carina = {
+    default_config = {
+      cmd = { 'carina-lsp' },
+      filetypes = { 'crn' },
+      root_dir = lspconfig.util.root_pattern('.git', 'main.crn'),
+    },
+  }
+end
+
+lspconfig.carina.setup {}
+```
+
+### File type detection
+
+Add to your Neovim configuration:
+
+```lua
+vim.filetype.add({
+  extension = {
+    crn = 'crn',
+  },
+})
+```
+
+## Autocompletion
+
+The LSP provides context-aware completions:
+
+- **Top-level keywords**: `provider`, `backend`, `let`, `let use`, `import`, `read`, `fn`, `arguments`, `attributes`, `exports`, `moved`, `removed`, `require`, `upstream_state`
+- **Resource types**: Type `awscc.` to see available services, then `awscc.ec2.` to see resource types
+- **Attributes**: Inside a resource block, get completions for all valid attributes
+- **Attribute values**: For enum-typed attributes, get valid value completions
+- **Built-in functions**: Function names with signature information
+
+Completions are triggered by `.`, `=`, and space characters.
+
+## Diagnostics
+
+The LSP reports errors and warnings as you type:
+
+- **Parse errors**: Syntax mistakes detected by the Carina parser
+- **Unknown resource types**: Using a resource type that does not exist in the provider schema
+- **Type validation**: Attribute values that do not match the expected type
+- **Missing required attributes**: Required attributes that are not set
+- **Module validation**: Errors in imported modules, missing module files
+
+## Hover
+
+Hover over a resource attribute to see its documentation, including the expected type and description from the provider schema.
+
+## Code actions
+
+The LSP offers quick fixes for selected diagnostics. Open the code-actions menu (in VS Code: light-bulb / `Ctrl+.`) on a diagnostic to apply one.
+
+- **Insert canonical enum identifier** -- when an attribute's value does not match any variant of its enum type, the LSP offers one code action per candidate that replaces the offending value with the canonical namespaced identifier (e.g. `aws.s3.Bucket.VersioningStatus.enabled`). Both bare-identifier mismatches and quoted string literals are supported.
+
+## Semantic tokens
+
+The LSP emits semantic tokens for richer syntax highlighting beyond what the TextMate grammar can express:
+
+- **Types**: PascalCase resource type segments (e.g. the `Vpc` in `awscc.ec2.Vpc`) and region identifiers
+- **Functions**: Built-in and user-defined function names
+
+DSL keywords (`provider`, `let`, `fn`, `for`, `if`, …) are intentionally **not** emitted as semantic tokens — the bundled TextMate grammar handles them with finer-grained scopes (#1948).
+
+## Document formatting
+
+The LSP supports formatting `.crn` files. In VS Code, use **Format Document** (Shift+Alt+F). The formatter aligns attributes and applies consistent indentation.
+
+You can also format from the CLI:
+
+```bash
+# Format a single file
+carina fmt main.crn
+
+# Format all .crn files in a directory recursively
+carina fmt --recursive .
+
+# Check formatting without modifying files
+carina fmt --check main.crn
+
+# Show diff of formatting changes
+carina fmt --diff main.crn
+```
+
+## Troubleshooting
+
+If the LSP is not working:
+
+1. **Check the binary**: Run `carina-lsp --version` to verify it is installed
+2. **Check your PATH**: The LSP client must be able to find `carina-lsp`
+3. **Check logs**: Set the `RUST_LOG=debug` environment variable and check the LSP output in your editor's log panel
+4. **File type**: Ensure your editor recognizes `.crn` files and routes them to the Carina LSP

--- a/site/src/content/guides/state-management.md
+++ b/site/src/content/guides/state-management.md
@@ -1,0 +1,184 @@
+---
+title: "State Management"
+description: "Learn how Carina tracks infrastructure state, configure an S3 backend, import existing resources, move and remove state entries, and reference upstream state."
+---
+
+Carina uses a state file to track which resources it manages and their current attributes. This guide covers how to configure state storage, manipulate state entries, and share state between projects.
+
+## How state works
+
+When you run `carina apply`, Carina records each managed resource and its attributes in a state file. On subsequent runs, it compares the desired state (your `.crn` files) with the recorded state to determine what needs to change.
+
+By default, state is stored locally as `carina.state.json`. For team usage, configure a remote S3 backend.
+
+## Configuring the S3 backend
+
+Add a `backend` block to your `.crn` file:
+
+```crn
+backend s3 {
+  bucket = 'my-carina-state'
+  key    = 'production/carina.state.json'
+  region = 'ap-northeast-1'
+}
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'my-vpc'
+  }
+}
+```
+
+The S3 backend stores state in the specified bucket and key. It also supports state locking to prevent concurrent modifications.
+
+### Automatic bucket creation
+
+By default, `carina apply` automatically creates the S3 bucket if it doesn't exist. This lets you get started without any manual setup:
+
+```crn
+backend s3 {
+  bucket      = 'my-carina-state'
+  key         = 'production/carina.state.json'
+  region      = 'ap-northeast-1'
+  auto_create = true  # This is the default; can be omitted
+}
+```
+
+When the bucket is auto-created, Carina:
+
+1. Creates the S3 bucket with public access blocked
+2. Appends an `aws.s3.Bucket` resource definition to your `.crn` file
+3. Registers the bucket as a **protected resource** in state, preventing it from being accidentally modified or destroyed
+
+`carina plan` shows the upcoming bucket creation as a bootstrap plan before the main resource plan.
+
+To disable auto-creation and require the bucket to exist beforehand, set `auto_create = false`. If the bucket is missing, `carina plan` and `carina apply` will fail with an error.
+
+To delete an auto-created state bucket, use:
+
+```bash
+carina state bucket-delete <bucket-name> --force
+```
+
+This is a destructive operation that removes the bucket and all state history.
+
+## Importing existing resources
+
+To bring an existing cloud resource under Carina management, use the `import` block:
+
+```crn
+import {
+  to = awscc.ec2.Vpc 'my-vpc'
+  id = 'vpc-0abc123def456'
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'my-vpc'
+  }
+}
+```
+
+- `to` specifies the resource type and the name Carina will use in state
+- `id` is the cloud provider's identifier for the existing resource
+
+Run `carina plan` to verify the import matches the resource definition, then `carina apply` to record it in state.
+
+## Moving resources in state
+
+When you rename a resource or reorganize your code, use the `moved` block to update the state without destroying and recreating the resource:
+
+```crn
+moved {
+  from = awscc.ec2.Vpc 'vpc'
+  to   = awscc.ec2.Vpc 'main_vpc'
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'my-vpc'
+  }
+}
+```
+
+After the move is applied, you can remove the `moved` block from your code.
+
+## Removing resources from state
+
+To stop managing a resource without destroying it in the cloud, use the `removed` block:
+
+```crn
+removed {
+  from = awscc.ec2.Vpc 'main_vpc'
+}
+```
+
+This removes the resource from Carina's state but leaves the actual cloud resource untouched. This is useful when transferring ownership of a resource to another tool or project.
+
+## Referencing upstream state
+
+To read outputs from another Carina project's state, use `upstream_state`:
+
+```crn
+let network = upstream_state {
+  source = "../network"
+}
+
+awscc.ec2.SecurityGroup {
+  group_description = 'Web security group'
+  vpc_id            = network.vpc_id
+
+  tags = {
+    Name = 'web-sg'
+  }
+}
+```
+
+The `upstream_state` expression points at an upstream project's directory. Carina loads that directory's configuration, resolves its backend, reads its state, and exposes the upstream's `exports` through the `let`-bound name. In this example, `network.vpc_id` references the `vpc_id` value published by the `../network` project's `exports` block.
+
+`source` is required and resolved relative to the enclosing `.crn` file's directory. The upstream directory must contain a valid Carina configuration (one or more `.crn` files — no filename is privileged) with an `exports` block that publishes the values consumers need.
+
+## State CLI commands
+
+Carina provides several CLI commands for inspecting and managing state:
+
+```bash
+# List all managed resources
+carina state list
+
+# Show all resources with full attributes
+carina state show
+
+# Look up a specific resource or attribute
+carina state lookup vpc
+carina state lookup vpc.vpc_id
+
+# Refresh state from cloud providers
+carina state refresh
+
+# Force unlock a stuck state lock
+carina force-unlock <lock-id>
+
+# Delete a state bucket (destructive)
+carina state bucket-delete <bucket-name> --force
+```
+
+## State locking
+
+When using the S3 backend, Carina automatically locks state during `apply` and `destroy` operations to prevent concurrent modifications. If a lock gets stuck (for example, after a crash), use `carina force-unlock` to release it.
+
+You can disable locking with the `--lock=false` flag:
+
+```bash
+carina apply --lock=false
+```

--- a/site/src/content/guides/using-modules.md
+++ b/site/src/content/guides/using-modules.md
@@ -1,0 +1,199 @@
+---
+title: "Using Modules"
+description: "Learn how to organize Carina infrastructure code into reusable modules with arguments, attributes, directory modules, and nested module loading."
+---
+
+Modules let you group related resources into reusable units. A module defines its inputs with `arguments`, its outputs with `attributes`, and can be loaded with `use` and called from any `.crn` file.
+
+## Creating a module
+
+A module is a directory containing one or more `.crn` files. Every `.crn` file in the directory is merged together — no filename (including `main.crn`) is privileged. Single-file modules are not supported; always point `use` at a directory.
+
+Create a file at `modules/network/main.crn` (the filename is up to you):
+
+```crn
+arguments {
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = cidr_block
+
+  tags = {
+    Name = 'module-vpc'
+  }
+}
+
+let subnet = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = subnet_cidr
+  availability_zone = az
+
+  tags = {
+    Name = 'module-subnet'
+  }
+}
+
+attributes {
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
+}
+```
+
+### Arguments block
+
+The `arguments` block declares the inputs the module accepts. Each parameter has a name and a type:
+
+```crn
+arguments {
+  cidr_block: String
+  env_name  : String
+}
+```
+
+Supported types include `String`, `Bool`, `Int`, `Float`, `list(String)`, `map(String)`, and resource type references like `awscc.ec2.Vpc`.
+
+### Attributes block
+
+The `attributes` block declares the outputs the module exposes to callers:
+
+```crn
+attributes {
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
+}
+```
+
+Each attribute has a name, an optional type annotation, and a value expression.
+
+## Loading and calling a module
+
+From your root configuration, load the module with `use` and call it with arguments:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let network = use { source = './modules/network' }
+
+network {
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
+}
+```
+
+The `use` expression loads the module from its `source` directory and binds it to a name. You then call the module like a function, passing its arguments as a block.
+
+## Accessing module attributes
+
+To use a module's output attributes, bind the module call with `let`:
+
+```crn
+let network = use { source = './modules/network' }
+
+let net = network {
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
+}
+
+# Use module output to create another resource
+awscc.ec2.RouteTable {
+  vpc_id = net.vpc_id
+  tags   = { Name = 'my-route-table' }
+}
+```
+
+The `net.vpc_id` reference accesses the `vpc_id` attribute declared in the module's `attributes` block.
+
+## Splitting a module across multiple files
+
+Every `.crn` file in a module directory is merged as a peer, so you can split a module across files however you like. A common convention is:
+
+```
+modules/network/
+  main.crn          # resources
+  arguments.crn     # arguments block
+  attributes.crn    # attributes block
+```
+
+The filenames are arbitrary — `main.crn` is a convention, not a requirement. Load the module by pointing `use` at the directory:
+
+```crn
+let network = use { source = './modules/network' }
+```
+
+## Nested modules
+
+A module can load other modules. This lets you compose infrastructure from smaller building blocks.
+
+For example, `modules/network_with_rt/main.crn` can load the network module:
+
+```crn
+let network = use { source = '../network' }
+
+arguments {
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
+}
+
+let net = network {
+  cidr_block  = cidr_block
+  subnet_cidr = subnet_cidr
+  az          = az
+}
+
+let rt = awscc.ec2.RouteTable {
+  vpc_id = net.vpc_id
+
+  tags = {
+    Name = 'nested-module-rt'
+  }
+}
+
+attributes {
+  vpc_id        : awscc.ec2.Vpc = net.vpc_id
+  route_table_id: awscc.ec2.RouteTable = rt.route_table_id
+}
+```
+
+`source` paths are relative to the module file's location.
+
+## Using modules with `for` expressions
+
+Modules can be called inside `for` expressions to create multiple instances:
+
+```crn
+let vpc_mod = use { source = './modules/vpc_only' }
+
+let cidrs = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+
+let networks = for name, cidr in cidrs {
+  vpc_mod {
+    cidr_block = cidr
+    env_name   = name
+  }
+}
+```
+
+This creates one VPC per entry in the `cidrs` map. See the [For / If Expressions](/guides/for-if-expressions/) guide for more details.
+
+## Inspecting modules
+
+Use the CLI to inspect a module's structure:
+
+```bash
+# Show module arguments, attributes, and dependencies
+carina module info modules/network
+
+# List all modules loaded in a configuration
+carina module list
+```

--- a/site/src/content/guides/writing-resources.md
+++ b/site/src/content/guides/writing-resources.md
@@ -1,0 +1,217 @@
+---
+title: "Writing Resources"
+description: "Learn how to define infrastructure resources in Carina using the .crn DSL, including anonymous resources, named bindings, attributes, references, nested blocks, and data sources."
+---
+
+This guide walks you through defining infrastructure resources in Carina's `.crn` files. You will learn the two ways to declare resources, how to set attributes, reference other resources, and use nested blocks.
+
+## Provider configuration
+
+Every `.crn` file that declares resources needs a provider block to specify which cloud provider and region to use:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+```
+
+## Anonymous resources
+
+The simplest way to define a resource is an **anonymous resource**. Use this when no other resource needs to reference it:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block           = '10.0.0.0/16'
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = default
+
+  tags = {
+    Environment = 'production'
+  }
+}
+```
+
+The resource type follows the pattern `<provider>.<service>.<resource_type>`. Carina derives the resource's identity from its `name` tag or other identifying attributes.
+
+## Named resources with `let`
+
+When another resource needs to reference attributes from a resource, use a `let` binding:
+
+```crn
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
+}
+```
+
+The `let` binding gives the resource a name (`vpc`) so you can reference its attributes (like `vpc.vpc_id`) from other resources. Carina automatically determines the dependency order -- the subnet will be created after the VPC.
+
+Use anonymous resources when the binding is unused. Unnecessary `let` bindings add noise.
+
+## Attribute types
+
+Resource attributes support several value types:
+
+```crn
+awscc.ec2.Vpc {
+  # String
+  cidr_block = '10.0.0.0/16'
+
+  # Boolean
+  enable_dns_support = true
+
+  # Integer
+  # (used in some resource attributes)
+
+  # Namespaced enum identifier
+  instance_tenancy = default
+
+  # Map
+  tags = {
+    Name        = 'my-vpc'
+    Environment = 'production'
+  }
+}
+```
+
+### String interpolation
+
+Strings support interpolation with `${}`:
+
+```crn
+let env = 'production'
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = "vpc-${env}"
+  }
+}
+```
+
+## Nested blocks
+
+Some resources have nested configuration blocks. Repeat the block name to add multiple entries:
+
+```crn
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id            = vpc.vpc_id
+  group_description = 'Web server security group'
+
+  security_group_ingress {
+    ip_protocol = 'tcp'
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTP'
+  }
+
+  security_group_ingress {
+    ip_protocol = 'tcp'
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTPS'
+  }
+
+  tags = {
+    Name = 'web-sg'
+  }
+}
+```
+
+## Local `let` bindings inside blocks
+
+You can define local variables inside a resource block with `let`. These are scoped to the block and are **not** sent to the provider:
+
+```crn
+awscc.ec2.Vpc {
+  let env  = 'production'
+  let name = "local-let-${env}"
+
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = name
+    Env  = upper(env)
+  }
+}
+```
+
+## Data sources with `read`
+
+To look up an existing resource without managing it, use the `read` keyword:
+
+```crn
+let caller = read aws.sts.CallerIdentity {}
+```
+
+The `read` expression fetches resource data from the provider at plan/apply time. You can then reference its attributes just like a managed resource.
+
+## Comments
+
+Carina supports line comments with `//` or `#`, and block comments with `/* ... */`:
+
+```crn
+# This is a line comment
+// This is also a line comment
+
+/* This is a
+   block comment */
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'  # inline comment
+}
+```
+
+## Putting it together
+
+Here is a complete example that creates a VPC with a public subnet and a route table:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block           = '10.0.0.0/16'
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = 'my-vpc'
+  }
+}
+
+awscc.ec2.Subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = 'public-subnet'
+  }
+}
+
+awscc.ec2.RouteTable {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = 'public-rt'
+  }
+}
+```
+
+Run `carina plan .` from the directory containing your `.crn` files to preview the changes, and `carina apply .` to create the resources.

--- a/site/src/pages/guides/for-if-expressions.astro
+++ b/site/src/pages/guides/for-if-expressions.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/for-if-expressions.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'For/If Expressions'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/guides/functions.astro
+++ b/site/src/pages/guides/functions.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/functions.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Functions'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/guides/lsp-setup.astro
+++ b/site/src/pages/guides/lsp-setup.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/lsp-setup.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'LSP Setup'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/guides/state-management.astro
+++ b/site/src/pages/guides/state-management.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/state-management.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'State Management'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/guides/using-modules.astro
+++ b/site/src/pages/guides/using-modules.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/using-modules.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Using Modules'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/guides/writing-resources.astro
+++ b/site/src/pages/guides/writing-resources.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../content/guides/writing-resources.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Writing Resources'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>


### PR DESCRIPTION
## Summary
- Bring all six `docs/guides/*.md` files over to `site/`, ride them on the existing `Doc.astro` template, and add a Guides group to the Sidebar with the same Starlight ordering.
- New entries (in order): Writing Resources, Using Modules, State Management, For/If Expressions, Functions, LSP Setup. All linked under `/guides/<slug>/`.
- The six markdown files copy over verbatim (no MDX, no raw HTML).
- No new components, no token edits, and `Doc.astro` / `BaseLayout.astro` are untouched.

## Notes
- Active-link highlighting, multi-language Shiki (bash / json / lua), and nested anchors (e.g. `/guides/state-management/#configuring-the-s3-backend`) all work — confirmed visually in the four screenshots taken via Playwright.
- `.crn` fences continue to fall back to plaintext until the custom Shiki grammar lands later.
- Landing, Getting Started 3 pages, and existing entrypoints are unaffected. Total static pages now 10.

## Test plan
- [ ] `cd site && npm install && npm run build` succeeds (10 pages built).
- [ ] `cd site && npm run dev` serves all 10 URLs on `http://localhost:4321/` with no console errors:
  - `/`, `/getting-started/{installation,quick-start,core-concepts}/`
  - `/guides/{writing-resources,using-modules,state-management,for-if-expressions,functions,lsp-setup}/`
- [ ] Visual: each guide page lights up the matching sidebar entry; Shiki colors `bash` / `json` / `lua` blocks in `lsp-setup`; jumping to `/guides/state-management/#configuring-the-s3-backend` lands at the right heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)