### PR TITLE
plan: render Map<String,String> added from (none) as per-key + lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ plan-compact:
 	$(PLAN_FIXTURE) compact --detail none
 plan-map-diff:
 	$(PLAN_FIXTURE) map_key_diff
+plan-map-added-from-none:
+	$(PLAN_FIXTURE) map_added_from_none
 plan-nested-map-diff:
 	$(PLAN_FIXTURE) nested_map_diff
 plan-list-diff-added-struct:
@@ -82,6 +84,8 @@ plan-fixtures:
 	@echo ""
 	@echo "=== map_key_diff ==="
 	@$(MAKE) plan-map-diff
+	@echo "---"
+	@$(MAKE) plan-map-added-from-none
 	@echo ""
 	@echo "=== nested_map_diff ==="
 	@$(MAKE) plan-nested-map-diff

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -265,6 +265,25 @@ fn snapshot_map_key_diff() {
     insta::assert_snapshot!(output);
 }
 
+/// #2936: a Map<String, String> attribute that goes from absent in
+/// state to a multi-key value must render as per-key `+ key: "value"`
+/// lines, not as a single inline `tags: (none) → {...}` line.
+#[test]
+fn snapshot_map_added_from_none() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("map_added_from_none");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_enum_display() {
     let (plan, schemas, _moved) = build_plan_from_fixture("enum_display");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_added_from_none.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_map_added_from_none.snap
@@ -1,0 +1,16 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.ec2.Vpc vpc
+      tags:
+        + Component: "registry"
+        + Environment: "dev"
+        + ManagedBy: "carina"
+        + Project: "carina-rs"
+        + Repository: "carina-rs/infra"
+      # (1 unchanged attribute hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_moved_with_changes.snap
@@ -5,7 +5,8 @@ expression: output
 Execution Plan:
 
   ~ awscc.ec2.Vpc new_vpc (moved from: old_vpc)
-      tags: (none) → {Name: "updated"}
+      tags:
+        + Name: "updated"
       # (1 unchanged attribute hidden)
         │
         └─ + awscc.ec2.Subnet 

--- a/carina-cli/tests/fixtures/plan_display/map_added_from_none/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/map_added_from_none/carina.state.json
@@ -1,0 +1,32 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-map-added-from-none",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "ec2.Vpc",
+      "name": "vpc",
+      "provider": "awscc",
+      "identifier": "vpc-0123456789abcdef0",
+      "attributes": {
+        "cidr_block": "10.0.0.0/16",
+        "vpc_id": "vpc-0123456789abcdef0"
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "vpc",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "cidr_block": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/map_added_from_none/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/map_added_from_none/main.crn
@@ -1,0 +1,24 @@
+# Update plan: Map<String, String> attribute (tags) added from `(none)`
+# (issue #2936). State has no `tags`; desired has a multi-key map.
+# Expected rendering: per-key `+ key: "value"` lines, not a single
+# inline `tags: (none) → {...}` line.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Component   = 'registry'
+    Environment = 'dev'
+    ManagedBy   = 'carina'
+    Project     = 'carina-rs'
+    Repository  = 'carina-rs/infra'
+  }
+}
+
+exports {
+  cidr_block = vpc.cidr_block
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -547,7 +547,7 @@ fn build_update_rows(
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
             }
-        } else if is_both_maps(old_value, new_value) {
+        } else if should_render_as_map_diff(old_value, new_value) {
             match build_map_diff_row(key, old_value, new_value, detail) {
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
@@ -648,7 +648,7 @@ fn build_replace_rows(
                 added,
                 removed,
             });
-        } else if is_both_maps(old_value, new_value) {
+        } else if should_render_as_map_diff(old_value, new_value) {
             let entries = compute_map_diff_entries(old_value, new_value, detail);
             rows.push(DetailRow::ReplaceMapDiff {
                 key: key.to_string(),
@@ -1122,9 +1122,14 @@ fn collect_added_removed_items(indices: &[usize], items: &[Value]) -> Vec<ListOf
         .collect()
 }
 
-/// Check if both old and new values are `Value::Map`.
-fn is_both_maps(old_value: Option<&Value>, new_value: &Value) -> bool {
-    matches!((old_value, new_value), (Some(Value::Map(_)), Value::Map(_)))
+/// Check whether the diff at this attribute should render via the
+/// per-key `MapDiff` walk. True when `new_value` is a `Value::Map` and
+/// `old_value` is either absent (attribute being added — #2936) or
+/// itself a `Value::Map`. A non-Map old value (type mismatch, e.g.
+/// string → map) keeps the inline `prev → next` form so the prior
+/// scalar stays visible.
+fn should_render_as_map_diff(old_value: Option<&Value>, new_value: &Value) -> bool {
+    matches!(new_value, Value::Map(_)) && matches!(old_value, None | Some(Value::Map(_)))
 }
 
 /// Check whether a Value references the given binding name.

--- a/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_moved_with_changes.snap
+++ b/carina-tui/src/snapshots/carina_tui__tui_snapshot_tests__snapshot_moved_with_changes.snap
@@ -32,9 +32,9 @@ expression: output
 ┌ Details ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │~ ec2.Vpc new_vpc                                                                                                     │
 │                                                                                                                      │
-│  tags: (none) -> {Name: "updated"}                                                                                   │
+│  tags:                                                                                                               │
+│    + Name: "updated"                                                                                                 │
 │  # (1 unchanged attribute hidden)                                                                                    │
-│                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │
 │                                                                                                                      │


### PR DESCRIPTION
## Summary

`~ resource` Update effects with a `Map<String, String>` attribute (most commonly `tags`) that goes from absent in state to populated in desired previously rendered the entire new map inline on one line, overflowing the terminal for real-world `default_tags` sets:

```
~ awscc.s3.Bucket r.bucket
    tags: (none) → {Component: "registry", Environment: "dev", ManagedBy: "carina", Project: "carina-rs", Repository: "carina-rs/infra"}
    # (6 unchanged attributes hidden)
```

The renderer already had a per-key `MapDiff` walk used when both old and new values were `Value::Map`; the predicate gating it (`is_both_maps`) rejected `(None, Map)` and the diff fell through to the inline `Changed` arm.

This PR broadens the predicate (renamed `should_render_as_map_diff`) to accept `(None | Map, Map)`. The downstream `compute_map_diff_entries` already handles `old=None` correctly — every entry becomes `MapDiffEntryIR::Added` and renders as `+ key: \"value\"` under a `tags:` header, matching the shape used elsewhere in the diff series (#2877 etc).

```
~ awscc.s3.Bucket r.bucket
    tags:
      + Component: \"registry\"
      + Environment: \"dev\"
      + ManagedBy: \"carina\"
      + Project: \"carina-rs\"
      + Repository: \"carina-rs/infra\"
    # (6 unchanged attributes hidden)
```

The same predicate gates `build_replace_rows`, so create-only Map attributes get the same fix.

## Test plan

- [x] New fixture + snapshot test `snapshot_map_added_from_none` reproduces the bug and verifies Option B output (per-key `+` lines)
- [x] Existing `snapshot_moved_with_changes` (CLI + TUI) updated — single-key tags map in a moved Update now also uses per-key form
- [x] `cargo nextest run --workspace` (3089 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

## Follow-ups filed

- #2939 — symmetric `Map → (none)` removal still renders inline
- #2940 — empty-map (`tags = {}`) added from `(none)` is now silently rolled into unchanged count

## Design choice

The user picked Option B (per-key `+` lines) over Option A (multi-line struct after the arrow) because it scales naturally to future `~`/`+`/`-` per-entry shapes once the symmetric removal direction (#2939) is handled.

Closes #2936