### PR TITLE
Migrate DSL Reference (5 pages) to site/ (Step 5)

### DIFF
--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -19,7 +19,23 @@ const sections = [
       { label: 'LSP Setup',          href: '/guides/lsp-setup/' },
     ],
   },
-  // TODO Step 5+: Reference, Providers
+  {
+    label: 'Reference',
+    subgroups: [
+      {
+        label: 'DSL',
+        items: [
+          { label: 'Syntax',             href: '/reference/dsl/syntax/' },
+          { label: 'Types & Values',     href: '/reference/dsl/types-and-values/' },
+          { label: 'Expressions',        href: '/reference/dsl/expressions/' },
+          { label: 'Built-in Functions', href: '/reference/dsl/built-in-functions/' },
+          { label: 'Modules',            href: '/reference/dsl/modules/' },
+        ],
+      },
+      // TODO Step 6+: CLI subgroup
+    ],
+  },
+  // TODO Step 7+: Providers
 ];
 
 const currentPath = Astro.url.pathname;
@@ -28,19 +44,39 @@ const currentPath = Astro.url.pathname;
   {sections.map(section => (
     <div class="sidebar-section">
       <h3 class="sidebar-section-title">{section.label}</h3>
-      <ul class="sidebar-list">
-        {section.items.map(item => (
-          <li>
-            <a
-              href={item.href}
-              class:list={['sidebar-link', { active: currentPath === item.href }]}
-              aria-current={currentPath === item.href ? 'page' : undefined}
-            >
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ul>
+      {section.items && (
+        <ul class="sidebar-list">
+          {section.items.map(item => (
+            <li>
+              <a
+                href={item.href}
+                class:list={['sidebar-link', { active: currentPath === item.href }]}
+                aria-current={currentPath === item.href ? 'page' : undefined}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+      {section.subgroups && section.subgroups.map(sub => (
+        <div class="sidebar-subgroup">
+          <h4 class="sidebar-subgroup-title">{sub.label}</h4>
+          <ul class="sidebar-list">
+            {sub.items.map(item => (
+              <li>
+                <a
+                  href={item.href}
+                  class:list={['sidebar-link', { active: currentPath === item.href }]}
+                  aria-current={currentPath === item.href ? 'page' : undefined}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   ))}
 </aside>
@@ -91,5 +127,18 @@ const currentPath = Astro.url.pathname;
     color: var(--sidebar-link-active-color);
     background: var(--sidebar-link-active-bg);
     border-left-color: var(--sidebar-link-active-border);
+  }
+
+  .sidebar-subgroup + .sidebar-subgroup { margin-top: var(--space-4); }
+
+  .sidebar-subgroup-title {
+    font-family: var(--font-sans);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--sidebar-group-head-color);
+    opacity: 0.75;
+    margin: var(--space-3) 0 var(--space-2);
   }
 </style>

--- a/site/src/content/reference/dsl/built-in-functions.md
+++ b/site/src/content/reference/dsl/built-in-functions.md
@@ -1,0 +1,327 @@
+---
+title: Built-in Functions
+description: Complete reference for all built-in functions available in the Carina DSL.
+---
+
+Carina provides built-in functions for string manipulation, list operations, map operations, networking, and security. All built-in functions support [partial application](/reference/dsl/expressions/#partial-application) when called with fewer arguments than expected.
+
+## String Functions
+
+### `upper`
+
+Converts a string to uppercase.
+
+```
+upper(string: String) -> String
+```
+
+```crn
+upper('hello')        # => 'HELLO'
+upper('Hello World')  # => 'HELLO WORLD'
+```
+
+### `lower`
+
+Converts a string to lowercase.
+
+```
+lower(string: String) -> String
+```
+
+```crn
+lower('HELLO')        # => 'hello'
+lower('Hello World')  # => 'hello world'
+```
+
+### `trim`
+
+Removes leading and trailing whitespace from a string.
+
+```
+trim(string: String) -> String
+```
+
+```crn
+trim('  hello  ')   # => 'hello'
+trim('\n hello \t')  # => 'hello'
+```
+
+### `replace`
+
+Replaces all occurrences of a search string. Data-last argument order for pipe compatibility.
+
+```
+replace(search: String, replacement: String, string: String) -> String
+```
+
+```crn
+replace('-', '_', 'hello-world')      # => 'hello_world'
+'hello-world' |> replace('-', '_')    # => 'hello_world' (pipe form)
+replace('::', '.', 'foo::bar::baz')   # => 'foo.bar.baz'
+```
+
+### `split`
+
+Splits a string into a list using a separator.
+
+```
+split(separator: String, string: String) -> list(String)
+```
+
+```crn
+split('-', 'a-b-c')      # => ['a', 'b', 'c']
+'a-b-c' |> split('-')    # => ['a', 'b', 'c'] (pipe form)
+split('::', 'a::b::c')   # => ['a', 'b', 'c']
+```
+
+### `join`
+
+Joins list elements into a string using a separator.
+
+```
+join(separator: String, list: list(String)) -> String
+```
+
+```crn
+join('-', ['a', 'b', 'c'])    # => 'a-b-c'
+['a', 'b', 'c'] |> join('-') # => 'a-b-c' (pipe form)
+join(', ', ['hello', 42])     # => 'hello, 42'
+```
+
+## List Functions
+
+### `concat`
+
+Appends items to a list. Data-last argument order for pipe compatibility. The result is `base_list` followed by `items`.
+
+```
+concat(items: list(Any), base_list: list(Any)) -> list(Any)
+```
+
+```crn
+concat([3, 4], [1, 2])          # => [1, 2, 3, 4]
+[1, 2] |> concat([3, 4])        # => [1, 2, 3, 4] (pipe form)
+concat(['c'], ['a', 'b'])        # => ['a', 'b', 'c']
+```
+
+### `flatten`
+
+Flattens nested lists by one level. Non-list elements are kept as-is.
+
+```
+flatten(list: list(Any)) -> list(Any)
+```
+
+```crn
+flatten([[1, 2], [3, 4]])     # => [1, 2, 3, 4]
+flatten([['a', 'b'], ['c']])  # => ['a', 'b', 'c']
+flatten([[1, 2], 3, [4]])     # => [1, 2, 3, 4]
+```
+
+Only one level of nesting is removed:
+
+```crn
+flatten([[1, [2, 3]]])  # => [1, [2, 3]]
+```
+
+### `length`
+
+Returns the number of elements in a list or map, or the number of characters in a string.
+
+```
+length(value: list(Any) | map(Any) | String) -> Int
+```
+
+```crn
+length([1, 2, 3])       # => 3
+length({a = 1, b = 2})  # => 2
+length('hello')         # => 5
+length([])              # => 0
+```
+
+### `map`
+
+Extracts a field from each element of a collection. The accessor must be a dot-prefixed string.
+
+```
+map(accessor: String, collection: list(Any) | map(Any)) -> list(Any) | map(Any)
+```
+
+When applied to a list of maps, returns a list of the extracted values:
+
+```crn
+let subnets = [
+  { name = 'a', subnet_id = 'id-1' },
+  { name = 'b', subnet_id = 'id-2' },
+]
+
+map('.subnet_id', subnets)       # => ['id-1', 'id-2']
+subnets |> map('.subnet_id')     # => ['id-1', 'id-2'] (pipe form)
+```
+
+When applied to a map of maps, returns a map with the same keys and extracted values:
+
+```crn
+let envs = {
+  dev = { cidr = '10.0.0.0/16', name = 'development' }
+  stg = { cidr = '10.1.0.0/16', name = 'staging' }
+}
+
+envs |> map('.cidr')  # => { dev = '10.0.0.0/16', stg = '10.1.0.0/16' }
+```
+
+## Map Functions
+
+### `keys`
+
+Returns the keys of a map as a sorted list of strings.
+
+```
+keys(map: map(Any)) -> list(String)
+```
+
+```crn
+keys({ b = 2, a = 1, c = 3 })  # => ['a', 'b', 'c']
+keys({})                         # => []
+```
+
+### `values`
+
+Returns the values of a map as a list, ordered by sorted keys.
+
+```
+values(map: map(Any)) -> list(Any)
+```
+
+```crn
+values({ b = 2, a = 1, c = 3 })  # => [1, 2, 3]
+values({})                         # => []
+```
+
+### `lookup`
+
+Looks up a key in a map, returning a default value if the key is not found.
+
+```
+lookup(map: map(Any), key: String, default: Any) -> Any
+```
+
+```crn
+lookup({ a = 'one', b = 'two' }, 'a', 'default')  # => 'one'
+lookup({ a = 'one', b = 'two' }, 'c', 'default')  # => 'default'
+```
+
+## Numeric Functions
+
+### `min`
+
+Returns the smaller of two numbers. If both are integers, returns an integer. If either is a float, returns a float.
+
+```
+min(a: Number, b: Number) -> Number
+```
+
+```crn
+min(3, 5)      # => 3
+min(2.5, 1.0)  # => 1.0
+min(1, 2.5)    # => 1.0
+```
+
+### `max`
+
+Returns the larger of two numbers. If both are integers, returns an integer. If either is a float, returns a float.
+
+```
+max(a: Number, b: Number) -> Number
+```
+
+```crn
+max(3, 5)      # => 5
+max(2.5, 1.0)  # => 2.5
+max(1, 2.5)    # => 2.5
+```
+
+## Networking Functions
+
+### `cidr_subnet`
+
+Calculates a subnet CIDR block within a given IP network address prefix.
+
+```
+cidr_subnet(prefix: Ipv4Cidr, newbits: Int, netnum: Int) -> Ipv4Cidr
+```
+
+- `prefix`: base CIDR string (e.g., `"10.0.0.0/16"`)
+- `newbits`: number of additional bits for the subnet mask
+- `netnum`: subnet number within the new address space
+
+```crn
+cidr_subnet('10.0.0.0/16', 8, 0)    # => '10.0.0.0/24'
+cidr_subnet('10.0.0.0/16', 8, 1)    # => '10.0.1.0/24'
+cidr_subnet('10.0.0.0/16', 8, 255)  # => '10.0.255.0/24'
+cidr_subnet('10.0.0.0/8', 8, 10)    # => '10.10.0.0/16'
+```
+
+This is commonly used with `for` expressions to allocate subnets:
+
+```crn
+let vpcs = for (i, env) in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
+  }
+}
+```
+
+## Environment Functions
+
+### `env`
+
+Reads an environment variable. Returns an error if the variable is not set.
+
+```
+env(name: String) -> String
+```
+
+```crn
+let home = env('HOME')
+let db_host = env('DB_HOST')
+```
+
+## Security Functions
+
+### `secret`
+
+Marks a value as secret. The value is sent to the provider but stored only as a SHA256 hash in state. Plan output displays `(secret)` instead of the actual value.
+
+```
+secret(value: Any) -> Secret
+```
+
+```crn
+awscc.rds.DbInstance {
+  master_user_password = secret(env('DB_PASSWORD'))
+}
+```
+
+### `decrypt`
+
+Decrypts ciphertext using the configured provider's encryption service (e.g., AWS KMS). The key argument is optional when the key identifier is embedded in the ciphertext.
+
+```
+decrypt(ciphertext: String, key?: String) -> String
+```
+
+```crn
+# Key embedded in ciphertext (e.g., AWS KMS encrypted blob)
+let password = decrypt('AQICAHh...')
+
+# Explicit key
+let password = decrypt('AQICAHh...', 'alias/my-key')
+
+# Combined with secret() to prevent storing the decrypted value in state
+awscc.rds.DbInstance {
+  master_user_password = secret(decrypt('AQICAHh...'))
+}
+```
+
+Requires a configured provider with encryption support. An error is raised if no provider is configured or credentials are unavailable.

--- a/site/src/content/reference/dsl/expressions.md
+++ b/site/src/content/reference/dsl/expressions.md
@@ -1,0 +1,350 @@
+---
+title: Expressions
+description: For loops, if/else conditionals, let bindings, pipe operator, compose operator, and function definitions in the Carina DSL.
+---
+
+Expressions in the Carina DSL produce values. They can appear as attribute values, function arguments, or in any context where a value is expected.
+
+## For Expression
+
+The `for` expression iterates over a list or map to create multiple resources or values.
+
+### Iterating Over a List
+
+```crn
+let vpcs = for env in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = '10.0.0.0/16'
+
+    tags = {
+      Name        = "vpc-${env}"
+      Environment = env
+    }
+  }
+}
+```
+
+### Indexed Iteration
+
+Use `(index, value)` to access both the index and the element:
+
+```crn
+let vpcs = for (i, env) in ['dev', 'stg'] {
+  awscc.ec2.Vpc {
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
+
+    tags = {
+      Name        = "for-list-test-${env}"
+      Environment = env
+    }
+  }
+}
+```
+
+### Iterating Over a Map
+
+Use `key, value` to iterate over map entries:
+
+```crn
+let cidrs = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+
+let vpcs = for name, cidr in cidrs {
+  awscc.ec2.Vpc {
+    cidr_block = cidr
+
+    tags = {
+      Name        = "vpc-${name}"
+      Environment = name
+    }
+  }
+}
+```
+
+### Local Bindings in For Body
+
+`let` bindings can be used inside a `for` body to compute intermediate values:
+
+```crn
+let networks = for name, cidr in cidrs {
+  let subnet_cidr = cidr_subnet(cidr, 8, 1)
+
+  network {
+    cidr_block  = cidr
+    subnet_cidr = subnet_cidr
+    az          = 'ap-northeast-1a'
+  }
+}
+```
+
+### For with Module Calls
+
+`for` works with module calls to create multiple instances of a module. See [Modules: Modules with For Expressions](/reference/dsl/modules/#modules-with-for-expressions) for a full example.
+
+## If Expression
+
+The `if` expression conditionally produces a resource or value.
+
+### Conditional Resource Creation
+
+```crn
+let is_production = true
+
+if is_production {
+  awscc.ec2.NatGateway {
+    allocation_id = eip.allocation_id
+    subnet_id     = subnet.subnet_id
+  }
+}
+```
+
+### If/Else as a Value
+
+`if`/`else` can be used inline to choose between values:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
+
+  tags = {
+    Name = if is_production { 'prod-vpc' } else { 'dev-vpc' }
+  }
+}
+```
+
+### Local Bindings in If Body
+
+`let` bindings can be used inside `if` and `else` blocks:
+
+```crn
+if is_production {
+  let cidr = '10.0.0.0/16'
+
+  awscc.ec2.Vpc {
+    cidr_block = cidr
+  }
+}
+```
+
+## Let Binding
+
+`let` binds a name to a value. At the top level, it binds resources or values. Inside blocks, it creates scoped variables.
+
+```crn
+# Top-level value binding
+let env = 'prod'
+let zones = ['ap-northeast-1a', 'ap-northeast-1c']
+
+# Top-level resource binding
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+# Module use binding
+let network = use { source = './modules/network' }
+```
+
+Upstream state is bound with `let <binding> = upstream_state { source = "..." }`. See [Upstream State](/reference/dsl/syntax/#upstream-state) for details.
+
+Use `let _ =` (the discard pattern) when you need to evaluate an expression but do not need to reference the result. See [Syntax: Discard Pattern](/reference/dsl/syntax/#discard-pattern) for details.
+
+## Pipe Operator (`|>`)
+
+The pipe operator passes the result of the left expression as the last argument to the function on the right. This enables readable left-to-right data transformations.
+
+```crn
+# Without pipe: nested calls are hard to read
+let result = join('-', concat(['vpc'], ['prod', 'web']))
+
+# With pipe: reads left to right
+let result = ['prod', 'web'] |> concat(['vpc']) |> join('-')
+```
+
+The pipe operator works with any built-in function. The piped value becomes the last argument:
+
+```crn
+# These are equivalent:
+join('-', ['a', 'b', 'c'])
+['a', 'b', 'c'] |> join('-')
+
+# These are equivalent:
+replace('-', '_', 'hello-world')
+'hello-world' |> replace('-', '_')
+
+# These are equivalent:
+split(',', 'a,b,c')
+'a,b,c' |> split(',')
+```
+
+### Chaining Multiple Pipes
+
+Multiple pipe operations can be chained for complex transformations:
+
+```crn
+let result = ['prod', 'web']
+  |> concat(['vpc'])
+  |> join('-')
+  |> upper()
+```
+
+## Compose Operator (`>>`)
+
+The compose operator (`>>`) combines two partially applied functions into a new function. The result of the first function is passed as input to the second. Both sides of `>>` must be closures (partially applied functions).
+
+```crn
+# Compose split and join into a single function
+let transform = split(',') >> join('-')
+
+# Apply the composed function via pipe
+let result = 'a,b,c' |> transform()
+# => 'a-b-c'
+```
+
+Compose works with any partially applied built-in function:
+
+```crn
+# Extract IDs from a list of maps, then join them
+let pipeline = map('.id') >> join(', ')
+let result = [{ id = '1' }, { id = '2' }] |> pipeline()
+# => '1, 2'
+```
+
+Three or more functions can be composed:
+
+```crn
+let transform = split(',') >> join('-') >> split('-')
+```
+
+The compose operator binds tighter than the pipe operator, so `f >> g |> h` means `(f >> g) |> h`.
+
+## Function Calls
+
+Functions are called with parentheses:
+
+```crn
+let len = length(zones)
+let subnet = cidr_subnet('10.0.0.0/16', 8, 1)
+let name = join('-', ['prod', 'web', 'vpc'])
+```
+
+### Partial Application
+
+When a built-in function is called with fewer arguments than it expects, it returns a closure that captures the provided arguments. The closure waits for the remaining arguments before executing.
+
+```crn
+# split expects 2 args: split(separator, string)
+# Providing only 1 creates a closure
+let split_by_comma = split(',')
+
+# The closure can be used with pipe (parentheses are required)
+let parts = 'a,b,c' |> split_by_comma()
+```
+
+This is particularly useful with the pipe operator:
+
+```crn
+let result = 'hello-world' |> replace('-', '_')
+# replace(search, replacement, string) gets '-' and '_' captured,
+# then 'hello-world' is supplied as the third argument via pipe
+```
+
+## User-Defined Functions
+
+Define functions with `fn`. Parameters can have optional type annotations and default values:
+
+```crn
+fn tag_name(env: String, service: String): String {
+  join('-', [env, service, 'vpc'])
+}
+```
+
+### Parameters
+
+Function parameters support:
+- Type annotations: `name: String`
+- Default values: `name: String = "default"`
+- No annotation: `name` (any type accepted)
+
+```crn
+fn make_tags(env: String, service: String, team: String = 'platform') {
+  {
+    Environment = env
+    Service     = service
+    Team        = team
+  }
+}
+```
+
+### Local Bindings in Functions
+
+Functions can contain `let` bindings before the return expression:
+
+```crn
+fn subnet_name(env: String, az: String): String {
+  let short_az = replace('ap-northeast-1', '', az)
+  "${env}-subnet-${short_az}"
+}
+```
+
+### Return Type
+
+The optional return type annotation follows the parameter list with a colon:
+
+```crn
+fn cidr_for_env(env: String): String {
+  lookup({ dev = '10.0.0.0/16', stg = '10.1.0.0/16' }, env, '10.99.0.0/16')
+}
+```
+
+## Validate Expressions
+
+Validate expressions are boolean expressions used in `arguments` blocks for input validation and in `require` statements. They support comparison and logical operators.
+
+### Comparison Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `==` | Equal |
+| `!=` | Not equal |
+| `>` | Greater than |
+| `<` | Less than |
+| `>=` | Greater than or equal |
+| `<=` | Less than or equal |
+
+### Logical Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `&&` | Logical AND |
+| `\|\|` | Logical OR |
+| `!` | Logical NOT |
+
+### Example: Argument Validation
+
+```crn
+arguments {
+  instance_count: Int {
+    description = 'Number of instances to create'
+    default     = 1
+    validation {
+      condition     = instance_count >= 1 && instance_count <= 10
+      error_message = 'Instance count must be between 1 and 10'
+    }
+  }
+}
+```
+
+Function calls can be used in validate expressions:
+
+```crn
+arguments {
+  name: String {
+    validation {
+      condition     = length(name) > 0
+      error_message = 'Name must not be empty'
+    }
+  }
+}
+```

--- a/site/src/content/reference/dsl/modules.md
+++ b/site/src/content/reference/dsl/modules.md
@@ -1,0 +1,281 @@
+---
+title: Modules
+description: Module definition, arguments, attributes, use syntax, directory modules, and module resolution in the Carina DSL.
+---
+
+Modules are reusable units of Carina configuration. A module defines a set of resources along with input parameters (`arguments`) and output values (`attributes`).
+
+## Block Roles at a Glance
+
+A directory of `.crn` files may contain three interface-like blocks. They share a similar surface — `name: Type = expr` — but play different roles, and the `=` part means something different in each:
+
+| Block | Role | `=` expr means | Who consumes it |
+|---|---|---|---|
+| `arguments` | declare inputs | **optional default** for the parameter | callers of the module (`module { name = value }`) |
+| `attributes` | define module outputs | **required value** for the output | callers who bind the module (`let m = module { ... }; m.foo`) |
+| `exports` | define upstream-state outputs | **required value** for the export | other projects referencing this directory via `upstream_state` |
+
+The blocks fall into two groups by role:
+
+- **Declaration side** (`arguments`): the type annotation is required and load-bearing; `= expr` is an optional fallback when the caller omits the argument.
+- **Definition side** (`attributes`, `exports`): the value expression is required and load-bearing; the type annotation is an optional extra.
+
+Because `description` and `validation` are input-side concerns (documenting what callers should pass, and checking what they did pass), they are available on `arguments` entries through the block form but are deliberately absent from `attributes` and `exports`. Outputs are values produced internally from bindings the module already controls, so there is nothing to validate and no caller-facing documentation to attach beyond the type.
+
+`attributes` and `exports` share their body grammar but are intentionally kept separate because their consumers are different: `attributes` is the interface a module presents to its direct caller, while `exports` is the interface a directory presents to other projects through `upstream_state`.
+
+## Module Structure
+
+A module is a directory containing one or more `.crn` files that together declare `arguments` and `attributes` blocks. Carina merges every `.crn` file in the directory as peers; there is no privileged filename like `main.crn`.
+
+```crn
+# modules/network/main.crn  (any filename works — main.crn is just convention)
+
+arguments {
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = cidr_block
+
+  tags = {
+    Name = 'module-test'
+  }
+}
+
+let subnet = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = subnet_cidr
+  availability_zone = az
+
+  tags = {
+    Name = 'module-test-subnet'
+  }
+}
+
+attributes {
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
+}
+```
+
+## Arguments Block
+
+The `arguments` block defines the parameters a module accepts from its caller.
+
+### Basic Parameters
+
+Each parameter has a name and a type:
+
+```crn
+arguments {
+  cidr_block: String
+  count     : Int
+  enabled   : Bool
+}
+```
+
+### Default Values
+
+Parameters can have default values:
+
+```crn
+arguments {
+  cidr_block: String
+  az        : String = 'ap-northeast-1a'
+  enable_dns: Bool   = true
+}
+```
+
+### Block Form with Description and Validation
+
+Parameters can use an expanded block form for description, default values, and validation rules:
+
+```crn
+arguments {
+  instance_count: Int {
+    description = 'Number of instances to create'
+    default     = 1
+    validation {
+      condition     = instance_count >= 1 && instance_count <= 10
+      error_message = 'Instance count must be between 1 and 10'
+    }
+  }
+
+  cidr_block: String {
+    description = 'The CIDR block for the VPC'
+    validation {
+      condition     = length(cidr_block) > 0
+      error_message = 'CIDR block cannot be empty'
+    }
+  }
+}
+```
+
+### Supported Types
+
+Parameter types can be any [type expression](/reference/dsl/types-and-values/#type-expressions):
+
+```crn
+arguments {
+  name       : String
+  count      : Int
+  ratio      : Float
+  enabled    : Bool
+  subnet_ids : list(String)
+  tags       : map(String)
+  cidr_block : Ipv4Cidr
+  role_arn   : Arn
+}
+```
+
+## Attributes Block
+
+The `attributes` block defines the output values that a module exposes to its caller.
+
+Each attribute has a name, an optional type, and a value expression:
+
+```crn
+attributes {
+  vpc_id        : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id     : awscc.ec2.Subnet = subnet.subnet_id
+  route_table_id: awscc.ec2.RouteTable = rt.route_table_id
+}
+```
+
+The type annotation is optional; you can also use the simpler form:
+
+```crn
+attributes {
+  vpc_id = vpc.vpc_id
+}
+```
+
+## Loading Modules
+
+Use `use { source = '...' }` to load a module, then call it by name with arguments:
+
+```crn
+let network = use { source = './modules/network' }
+
+network {
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
+}
+```
+
+### Accessing Module Outputs
+
+When a module call is bound with `let`, its `attributes` values can be accessed with dot notation:
+
+```crn
+let network = use { source = './modules/network' }
+
+let net = network {
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id = net.vpc_id
+}
+```
+
+## Directory Modules
+
+A module is always a **directory** containing one or more `.crn` files. Every
+`.crn` file in that directory is merged into a single module — no file name
+(including `main.crn`) is treated as privileged, so definitions can be split
+across `arguments.crn`, `exports.crn`, `resources.crn`, etc. as naturally as
+you like.
+
+```
+modules/network/
+  main.crn        # optional; just one of the module's .crn files
+  arguments.crn   # merged in as peers
+  exports.crn
+```
+
+Single-file sources (`use { source = "./modules/network.crn" }`) are **not supported**:
+the loader returns `NotADirectory` for any path that is not a directory.
+If your module is currently a single `.crn` file, move it into a directory of
+its own.
+
+## Module Resolution
+
+`source` paths are resolved relative to the file containing the `use`
+statement and must point at a directory:
+
+```crn
+# From project/main.crn, loads every .crn file under project/modules/network/
+let network = use { source = './modules/network' }
+
+# Relative path from current file
+let helper = use { source = '../shared/helper' }
+```
+
+## Nested Modules
+
+Modules can load and use other modules:
+
+```crn
+# modules/network_with_rt/main.crn
+
+let network = use { source = '../network' }
+
+arguments {
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
+}
+
+let net = network {
+  cidr_block  = cidr_block
+  subnet_cidr = subnet_cidr
+  az          = az
+}
+
+let rt = awscc.ec2.RouteTable {
+  vpc_id = net.vpc_id
+
+  tags = {
+    Name = 'nested-module-test-rt'
+  }
+}
+
+attributes {
+  vpc_id        : awscc.ec2.Vpc = net.vpc_id
+  route_table_id: awscc.ec2.RouteTable = rt.route_table_id
+}
+```
+
+## Modules with For Expressions
+
+Modules can be used inside `for` expressions to create multiple instances:
+
+```crn
+let network = use { source = './modules/network' }
+
+let cidrs = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+
+let networks = for name, cidr in cidrs {
+  network {
+    cidr_block  = cidr
+    subnet_cidr = cidr_subnet(cidr, 8, 1)
+    az          = 'ap-northeast-1a'
+  }
+}
+```
+
+This creates a separate set of network resources for each entry in the map. The `name` variable (`dev`, `stg`) is used to distinguish the resources in state.
+
+## Provider Configuration
+
+Modules do not declare their own `provider` blocks. The provider configuration from the root `.crn` file is inherited by all modules. A module only needs to declare `arguments`, `attributes`, and resources.

--- a/site/src/content/reference/dsl/syntax.md
+++ b/site/src/content/reference/dsl/syntax.md
@@ -1,0 +1,362 @@
+---
+title: Syntax
+description: File structure, provider blocks, resource blocks, let bindings, and comments in the Carina DSL.
+---
+
+Carina configuration files use the `.crn` extension. A file consists of a sequence of top-level statements that declare infrastructure resources and their relationships.
+
+## File Structure
+
+A `.crn` file contains zero or more top-level statements in any order:
+
+```crn
+# Provider configuration
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# Backend configuration (optional)
+backend s3 {
+  bucket = 'my-state-bucket'
+  key    = 'infra/carina.state.json'
+  region = 'ap-northeast-1'
+}
+
+# Resource declarations
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'main'
+  }
+}
+
+awscc.ec2.InternetGateway {
+  tags = {
+    Name = 'main'
+  }
+}
+```
+
+## Top-Level Construct Shapes
+
+Carina's top-level constructs come in two shapes, chosen by two independent questions:
+
+1. **Does the block's body schema depend on a kind label?** The attributes valid inside `provider awscc { ... }` differ from those inside `provider aws { ... }`, and similarly for backend kinds. When the schema varies by kind, the construct carries a kind label (`provider <kind>`, `backend <kind>`).
+2. **Does the construct produce a value that other code references by name?** When multiple named instances are useful, the construct is written as an expression on the right-hand side of a `let` binding, and the binding name on the left is how the value is referenced later.
+
+The two questions are orthogonal:
+
+| | kind label needed | kind label not needed |
+|---|---|---|
+| **singleton / not named-referenced** | `provider awscc { ... }`, `backend s3 { ... }` | — |
+| **named reference** | (future: named provider instances) | `let orgs = upstream_state { ... }` |
+
+- `provider` / `backend` carry kind labels because the body schema is kind-specific; they are statements today because one instance per project is sufficient in the common case.
+- `upstream_state` has no kind label because there is only one kind of upstream (a sibling directory); it is an expression because projects typically reference several named upstreams.
+
+When reading an unfamiliar top-level construct, work out which row and column of the table it sits in — that tells you whether to expect a kind label and whether to expect a `let` binding on the left.
+
+## Statements
+
+The following statements are valid at the top level of a `.crn` file:
+
+| Statement | Purpose |
+|-----------|---------|
+| `provider` | Configure a cloud provider |
+| `backend` | Configure remote state storage |
+| `let` | Bind a name to a resource or value |
+| Anonymous resource | Declare a resource without a binding |
+| `import` (state) | Import an existing cloud resource into state |
+| `removed` | Remove a resource from state without deleting it |
+| `moved` | Rename a resource in state |
+| `for` | Iterate to create multiple resources |
+| `if` | Conditionally create resources |
+| `fn` | Define a reusable function |
+| `require` | Assert a condition with an error message |
+| `arguments` | Declare module input parameters |
+| `attributes` | Define module output values (for callers who bind the module with `let`) |
+| `exports` | Define values published to upstream-state consumers |
+| `use` (in `let` RHS) | Load a module from a directory (`let m = use { source = '...' }`) |
+
+## Provider Block
+
+Every `.crn` file that declares resources must configure at least one provider. The provider block specifies which cloud provider to use and its settings.
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+```
+
+Multiple providers can be configured in the same file:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+provider aws {
+  region = aws.Region.ap_northeast_1
+}
+```
+
+## Resource Blocks
+
+Resources represent cloud infrastructure objects. A resource block specifies the provider, service, and resource type using dot notation, followed by a block of attributes.
+
+### Anonymous Resources
+
+When you do not need to reference a resource elsewhere, declare it without a binding:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'main'
+  }
+}
+```
+
+The resource is identified in state by its `name` attribute or a hash of its attributes.
+
+### Named Resources (Let Bindings)
+
+Use `let` to bind a name to a resource so you can reference its attributes:
+
+```crn
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'main'
+  }
+}
+
+let subnet = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
+}
+```
+
+The `let` keyword is also used to bind non-resource values:
+
+```crn
+let cidr = '10.0.0.0/16'
+let environments = ['dev', 'stg', 'prod']
+let config = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+```
+
+### Discard Pattern
+
+Use `let _ =` when you want to evaluate an expression but do not need to reference the result:
+
+```crn
+let _ = awscc.ec2.VpcGatewayAttachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+```
+
+### Data Sources (Read Resources)
+
+Use the `read` keyword to query existing cloud resources without managing them:
+
+```crn
+let identity = read aws.sts.CallerIdentity {}
+```
+
+The returned value can be referenced like any other bound resource:
+
+```crn
+let identity = read aws.sts.CallerIdentity {}
+
+awscc.ec2.IpamPool {
+  source_resource = {
+    resource_owner = identity.account_id
+  }
+}
+```
+
+## Attributes
+
+Attributes are key-value pairs inside a resource block:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block           = '10.0.0.0/16'
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+```
+
+### Nested Blocks
+
+Some resources accept nested blocks for repeated or structured configuration:
+
+```crn
+awscc.ec2.Ipam {
+  tier = advanced
+
+  operating_region {
+    region_name = 'ap-northeast-1'
+  }
+}
+```
+
+### Local Bindings Inside Blocks
+
+Use `let` inside a resource block to create block-scoped variables. These are evaluated during parsing but are not sent to the provider:
+
+```crn
+awscc.ec2.Vpc {
+  let base_cidr = '10.0.0.0/16'
+
+  cidr_block = base_cidr
+
+  tags = {
+    Name = "vpc-${base_cidr}"
+  }
+}
+```
+
+## Backend Block
+
+The `backend` block configures where Carina stores state:
+
+```crn
+backend s3 {
+  bucket = 'my-state-bucket'
+  key    = 'infra/carina.state.json'
+  region = 'ap-northeast-1'
+}
+```
+
+When no backend is configured, state is stored locally in `carina.state.json`.
+
+## State Manipulation
+
+### Import
+
+Import an existing cloud resource into Carina's state:
+
+```crn
+import {
+  to = awscc.ec2.Vpc 'imported_vpc'
+  id = 'vpc-0123456789abcdef0'
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = 'imported'
+  }
+}
+```
+
+### Moved
+
+Rename a resource in state without destroying and recreating it:
+
+```crn
+moved {
+  from = awscc.ec2.Vpc 'old_name'
+  to   = awscc.ec2.Vpc 'new_name'
+}
+```
+
+### Removed
+
+Remove a resource from Carina's state without deleting the actual cloud resource:
+
+```crn
+removed {
+  from = awscc.ec2.Vpc 'old_vpc'
+}
+```
+
+## Upstream State
+
+Reference values exported by another Carina project:
+
+```crn
+let network = upstream_state {
+  source = "../network"
+}
+
+awscc.ec2.SecurityGroup {
+  vpc_id = network.vpc_id
+}
+```
+
+`source` is required and points at the upstream project's directory. The path is resolved relative to the enclosing `.crn` file's directory. Carina loads the upstream's configuration, resolves its backend, reads its state, and exposes the values published by its `exports` block through the declared binding.
+
+## External References at a Glance
+
+Carina has four constructs for pulling data or declarations in from outside the current file. They look different because they do different things; the table below shows the split on *when* the data is fetched, *what* is fetched, and *from where*:
+
+| Construct | When | What | From |
+|---|---|---|---|
+| `let m = use { source = '...' }` | parse time | DSL source (a module) | local directory |
+| `let x = read <type> { }` | plan time | current cloud state | Cloud API (data source) |
+| `import { to = ..., id = ... }` | apply time | an existing cloud resource, adopted into state | Cloud API + state backend |
+| `let x = upstream_state { source = '...' }` | plan time | another Carina project's `exports` | state backend |
+
+The shape differences track these semantic differences:
+
+- `use` and `upstream_state` both name an external location via a `source` attribute and share their shape accordingly.
+- `read` leads with the resource type because the type is the primary piece of information for a live data-source read.
+- `import` is a top-level state-manipulation block parallel to `moved` / `removed`, not a `let`-RHS expression.
+
+## Comments
+
+Carina supports three comment styles:
+
+```crn
+# Hash-style line comment
+// Slash-style line comment
+
+/* Block comment
+   can span multiple lines */
+
+/* Block comments /* can be nested */ like this */
+```
+
+All comments are ignored by the parser.
+
+## User-Defined Functions
+
+Define reusable functions with `fn`:
+
+```crn
+fn tag_name(env: String, service: String): String {
+  join('-', [env, service, 'vpc'])
+}
+
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name = tag_name('prod', 'web')
+  }
+}
+```
+
+See [Expressions](/reference/dsl/expressions/) for details on function definitions.
+
+## Require Statement
+
+Assert conditions that must be true, with a custom error message if they fail:
+
+```crn
+require length(subnets) > 0, 'At least one subnet must be specified'
+require cidr_block != '', 'CIDR block cannot be empty'
+```
+
+The condition is a [validate expression](/reference/dsl/expressions/#validate-expressions) that supports comparison operators (`==`, `!=`, `>`, `<`, `>=`, `<=`) and logical operators (`&&`, `||`, `!`).

--- a/site/src/content/reference/dsl/types-and-values.md
+++ b/site/src/content/reference/dsl/types-and-values.md
@@ -1,0 +1,271 @@
+---
+title: Types & Values
+description: Primitive types, collection types, resource references, enum identifiers, and string interpolation in the Carina DSL.
+---
+
+The Carina DSL is a statically-aware language with the following value types.
+
+## Primitive Types
+
+### String
+
+Strings can be enclosed in either single or double quotes. The two forms have
+different semantics, and the recommended style is to pick the form based on
+whether interpolation is needed.
+
+#### Single-Quoted Strings (Literal)
+
+Single quotes produce a literal string. `${...}` inside single quotes is **not**
+interpreted as interpolation — it is kept verbatim.
+
+```crn
+let name = 'my-vpc'
+let region = 'ap-northeast-1'
+let literal = 'price is ${amount}'   # the six characters ${amount} stay as-is
+```
+
+The only escape sequences recognized inside single quotes are `\'` (single
+quote) and `\\` (backslash).
+
+#### Double-Quoted Strings (Interpolation)
+
+Double quotes support `${...}` interpolation and the full set of escape
+sequences. Use them whenever you need to embed an expression in a string.
+
+```crn
+let env  = 'prod'
+let name = "vpc-${env}"           # => 'vpc-prod'
+let cidr = "${base_cidr}"         # => value of base_cidr
+let tag  = "${env}-${service}"    # => 'prod-web'
+```
+
+Any expression can appear inside `${}`, including function calls:
+
+```crn
+let tag = "vpc-${join('-', ['prod', 'web'])}"
+```
+
+#### Recommended Style
+
+- **Use single quotes** for literal strings that do not need interpolation
+  (the common case).
+- **Use double quotes** only when you need `${...}` interpolation or an
+  escape sequence that is not supported in single quotes.
+
+Both forms are always valid — this is a style guideline, not a correctness
+requirement. A literal written with double quotes (e.g. `"ap-northeast-1"`)
+is accepted and behaves identically to the single-quoted form.
+
+#### Escape Sequences
+
+Double-quoted strings support the following escape sequences:
+
+| Sequence | Meaning |
+|----------|---------|
+| `\"` | Double quote |
+| `\\` | Backslash |
+| `\n` | Newline |
+| `\r` | Carriage return |
+| `\t` | Tab |
+| `\$` | Literal dollar sign (prevents interpolation) |
+
+Single-quoted strings recognize only `\'` and `\\`.
+
+### Int
+
+Integer values, optionally negative:
+
+```crn
+let port = 443
+let offset = -1
+let count = 0
+```
+
+### Float
+
+Floating-point values with a decimal point:
+
+```crn
+let ratio = 0.5
+let threshold = -3.14
+```
+
+### Bool
+
+Boolean values `true` or `false`:
+
+```crn
+let enabled = true
+let public = false
+```
+
+## Collection Types
+
+### List
+
+Ordered sequences enclosed in square brackets:
+
+```crn
+let zones = ['ap-northeast-1a', 'ap-northeast-1c', 'ap-northeast-1d']
+let ports = [80, 443, 8080]
+let empty = []
+```
+
+Lists can contain mixed types and a trailing comma is allowed:
+
+```crn
+let mixed = [
+  'hello',
+  42,
+  true,
+]
+```
+
+### Map
+
+Key-value collections enclosed in curly braces. Keys are identifiers (unquoted), values are expressions:
+
+```crn
+let config = {
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
+}
+```
+
+Maps are also used for resource tags and nested configuration:
+
+```crn
+awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+
+  tags = {
+    Name        = 'main'
+    Environment = 'prod'
+  }
+}
+```
+
+## Namespaced Identifiers
+
+Dot-separated identifiers are used for resource types and enum values. They are not strings and are not quoted.
+
+### Resource Types
+
+Resource types use the format `provider.service.resource_type`:
+
+```crn
+awscc.ec2.Vpc { ... }
+awscc.ec2.Subnet { ... }
+awscc.s3.Bucket { ... }
+```
+
+### Enum Identifiers
+
+Enum values are namespaced identifiers that represent predefined constants:
+
+```crn
+# Provider-level enums
+awscc.Region.ap_northeast_1
+aws.Region.us_east_1
+
+# Resource-level enums
+awscc.ec2.Vpc.InstanceTenancy.default
+```
+
+Enum identifiers are used directly as attribute values without quotes:
+
+```crn
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.Vpc {
+  instance_tenancy = awscc.ec2.Vpc.InstanceTenancy.default
+}
+```
+
+## Resource References
+
+When a resource is bound with `let`, its attributes can be accessed using dot notation:
+
+```crn
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.0.0.0/16'
+}
+
+let subnet = awscc.ec2.Subnet {
+  vpc_id     = vpc.vpc_id      # Reference vpc's vpc_id attribute
+  cidr_block = '10.0.1.0/24'
+}
+```
+
+### Chained Access
+
+Dot notation can be chained for nested access:
+
+```crn
+let sg = network.security_group.group_id
+```
+
+### Index Access
+
+Use square brackets to access list elements or map values:
+
+```crn
+let first_zone = zones[0]
+let dev_cidr = config['dev']
+```
+
+Index and field access can be combined:
+
+```crn
+let subnet_id = subnets[0].subnet_id
+```
+
+## Type Expressions
+
+Type expressions are used in `arguments` and `attributes` blocks in modules, and in function parameters.
+
+### Simple Types
+
+```crn
+arguments {
+  name      : String
+  count     : Int
+  ratio     : Float
+  enabled   : Bool
+  cidr_block: Ipv4Cidr
+  role_arn  : Arn
+}
+```
+
+### Generic Types
+
+`list` and `map` accept a type parameter:
+
+```crn
+arguments {
+  subnet_ids  : list(String)
+  cidr_blocks : list(Ipv4Cidr)
+  tags        : map(String)
+}
+```
+
+### Resource Type References
+
+Resource types can be used as type expressions to indicate a reference:
+
+```crn
+attributes {
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
+}
+```
+
+## Null
+
+The `null` literal represents the absence of a value. It can only appear in [validate expressions](/reference/dsl/expressions/#validate-expressions) such as `require` statements and argument validation:
+
+```crn
+require value != null, 'Value must not be null'
+```

--- a/site/src/pages/reference/dsl/built-in-functions.astro
+++ b/site/src/pages/reference/dsl/built-in-functions.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/dsl/built-in-functions.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Built-in Functions'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/dsl/expressions.astro
+++ b/site/src/pages/reference/dsl/expressions.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/dsl/expressions.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Expressions'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/dsl/modules.astro
+++ b/site/src/pages/reference/dsl/modules.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/dsl/modules.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Modules'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/dsl/syntax.astro
+++ b/site/src/pages/reference/dsl/syntax.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/dsl/syntax.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Syntax'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/dsl/types-and-values.astro
+++ b/site/src/pages/reference/dsl/types-and-values.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/dsl/types-and-values.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'Types & Values'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>


### PR DESCRIPTION
## Summary
- Bring the five DSL reference pages over to `site/` and add a Reference / DSL subgroup to the Sidebar, riding on the existing `Doc.astro` template:
  - `/reference/dsl/syntax/`
  - `/reference/dsl/types-and-values/`
  - `/reference/dsl/expressions/`
  - `/reference/dsl/built-in-functions/`
  - `/reference/dsl/modules/`
- Sidebar now supports an optional `subgroups` array per section, so the Reference group holds a DSL subgroup today and can host a CLI subgroup in Step 6 without restructuring. The subgroup heading reuses the existing `--sidebar-group-*` tokens with a slight opacity drop — no new tokens.

## Notes
- Cross-page anchor links work: jumping to `/reference/dsl/expressions/#partial-application` (linked from `built-in-functions.md`'s opener) lands on the right H3.
- Wide tables in `syntax.md` and `modules.md` rely on `Doc.astro`'s existing `overflow-x: auto`; no per-page max-width tweaks.
- No new hex/hsl colours were introduced. The lone literal hexes that show up in a hex/hsl grep (`Hero.astro` star) are the Step 1 "Canopus warm cream" exception, not part of this PR.
- `.crn` fences continue to fall back to plaintext until the custom Shiki grammar lands later.
- Build now produces 15 static pages (was 10).

## Test plan
- [ ] `cd site && npm install && npm run build` succeeds (15 pages built).
- [ ] `cd site && npm run dev` serves the 5 new URLs on `http://localhost:4321/` with no console errors.
- [ ] Visual: each DSL page lights up its sidebar entry under Reference / DSL; the wide tables don't clip; `partial application` and `pipe |>` cross-links jump to the right anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)