### PR TITLE
Tighten doc heading hierarchy (Step 6 A)

### DIFF
--- a/site/src/layouts/Doc.astro
+++ b/site/src/layouts/Doc.astro
@@ -44,7 +44,9 @@ const { title, description, headings = [] } = Astro.props;
 
   .doc-header h1 {
     font-family: var(--font-display);
-    font-size: var(--text-4xl);
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
     color: var(--page-title-color);
     margin: 0 0 var(--space-3);
   }
@@ -61,9 +63,24 @@ const { title, description, headings = [] } = Astro.props;
   }
 
   .doc-body :global(h2) {
-    margin-top: var(--space-8);
+    position: relative;
+    margin-top: 4rem;
+    padding-top: 1.25rem;
     margin-bottom: var(--space-4);
     scroll-margin-top: var(--space-8);
+    font-size: 1.55rem;
+    font-weight: 700;
+  }
+
+  .doc-body :global(h2::before) {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 3rem;
+    height: 1px;
+    background: var(--accent);
+    opacity: 0.55;
   }
 
   .doc-body :global(h3) {


### PR DESCRIPTION
## Summary
- Tighten the H1 / H2 hierarchy in `Doc.astro` so section breaks are immediately legible against the dark canvas.
  - **H1** → `3rem`, weight 700, tracking `-0.01em` (was `var(--text-4xl)`).
  - **H2** → `1.55rem`, weight 700, `margin-top: 4rem` + `padding-top: 1.25rem`, with a short 3rem gold hairline (`var(--accent)` @ 55% opacity) drawn via `::before` at the top-left of the heading.
- H3 and below, the Sidebar, and the TOC are untouched. No new tokens introduced.

## Notes
- The hairline width is fixed at `3rem` so it visually anchors the heading without dominating it. Opacity `0.55` was preferred over a brighter line during preview.
- Margin-collapse against the lede is non-issue: the header block establishes its own block formatting context.
- Verified locally against pages from each section (Installation, Writing Resources, DSL Syntax, and a temporary preview of the upcoming Step 6 B CLI pages).

## Test plan
- [ ] `cd site && npm install && npm run build` succeeds.
- [ ] `cd site && npm run dev` shows the larger H1 plus the gold hairline above every H2 across all 15 (or 29 with Step 6 B) doc pages.
- [ ] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)