### PR TITLE
Migrate CLI Reference (14 pages) to site/ (Step 6 B)

### DIFF
--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -32,7 +32,25 @@ const sections = [
           { label: 'Modules',            href: '/reference/dsl/modules/' },
         ],
       },
-      // TODO Step 6+: CLI subgroup
+      {
+        label: 'CLI',
+        items: [
+          { label: 'init',         href: '/reference/cli/init/' },
+          { label: 'validate',     href: '/reference/cli/validate/' },
+          { label: 'plan',         href: '/reference/cli/plan/' },
+          { label: 'apply',        href: '/reference/cli/apply/' },
+          { label: 'destroy',      href: '/reference/cli/destroy/' },
+          { label: 'fmt',          href: '/reference/cli/fmt/' },
+          { label: 'lint',         href: '/reference/cli/lint/' },
+          { label: 'state',        href: '/reference/cli/state/' },
+          { label: 'force-unlock', href: '/reference/cli/force-unlock/' },
+          { label: 'module-info',  href: '/reference/cli/module-info/' },
+          { label: 'export',       href: '/reference/cli/export/' },
+          { label: 'docs',         href: '/reference/cli/docs/' },
+          { label: 'skills',       href: '/reference/cli/skills/' },
+          { label: 'completions',  href: '/reference/cli/completions/' },
+        ],
+      },
     ],
   },
   // TODO Step 7+: Providers

--- a/site/src/content/reference/cli/apply.md
+++ b/site/src/content/reference/cli/apply.md
@@ -1,0 +1,92 @@
+---
+title: apply
+---
+
+Apply changes to reach the desired infrastructure state. Carina generates a plan, displays it for review, and then executes the effects after confirmation.
+
+## Usage
+
+```bash
+carina apply [OPTIONS] [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be either a directory containing one or more `.crn` files, or a saved plan JSON file (any path ending in `.json` is treated as a saved plan).
+
+## Flags
+
+### `--auto-approve`
+
+Skip the interactive confirmation prompt and apply changes immediately. Use with caution.
+
+```bash
+carina apply --auto-approve
+```
+
+### `--lock <BOOL>`
+
+Enable or disable state locking during apply. Defaults to `true`.
+
+When locking is enabled, Carina acquires a lock on the state backend before applying changes. This prevents concurrent modifications from corrupting state.
+
+```bash
+carina apply --lock=false
+```
+
+## Applying a Saved Plan
+
+You can apply a previously saved plan file (created with `carina plan --out`):
+
+```bash
+carina plan --out plan.json
+carina apply plan.json
+```
+
+When applying a saved plan, Carina checks the state lineage and serial number against the current state to detect drift since the plan was created.
+
+## Confirmation Flow
+
+When `--auto-approve` is not set, Carina follows this flow:
+
+1. Refreshes state from the cloud provider for all managed resources
+2. Computes and displays the execution plan
+3. If no changes are needed, prints "No changes needed." and exits
+4. Prompts: "Do you want to perform these actions?"
+5. Waits for the user to type `yes` to confirm (any other input cancels)
+6. Executes the effects concurrently (up to 5 at a time) with progress spinners
+7. Saves the updated state to the backend
+8. Prints a summary of results
+
+## Error Handling
+
+- If an effect fails, Carina refreshes the resource state from the provider to capture any partial changes
+- The state file is always saved after execution, even if some effects failed, to prevent state drift
+- Failed and skipped effects are reported in the summary (e.g., "3 succeeded, 1 failed, 1 skipped")
+- Exit code `1` indicates an error occurred
+
+### State Locking Errors
+
+If the state is already locked by another process, Carina displays the lock holder and lock ID, and suggests using `carina force-unlock` if the lock is stale.
+
+## Bootstrap
+
+When an S3 backend is configured but the bucket does not yet exist, `carina apply` automatically bootstraps the state bucket before applying other changes. The bucket resource can be defined in the `.crn` configuration, or Carina will auto-create it if `auto_create` is enabled (the default).
+
+## Examples
+
+Apply from the current directory:
+
+```bash
+carina apply
+```
+
+Apply with auto-approval (for CI):
+
+```bash
+carina apply --auto-approve
+```
+
+Apply a saved plan:
+
+```bash
+carina apply plan.json
+```

--- a/site/src/content/reference/cli/completions.md
+++ b/site/src/content/reference/cli/completions.md
@@ -1,0 +1,39 @@
+---
+title: completions
+---
+
+Generate shell-completion scripts for the `carina` CLI.
+
+## Usage
+
+```bash
+carina completions <SHELL>
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
+
+The generated script is written to stdout — redirect it into the location your shell expects.
+
+## Examples
+
+### Bash
+
+```bash
+carina completions bash > ~/.local/share/bash-completion/completions/carina
+```
+
+### Zsh
+
+```bash
+mkdir -p ~/.zfunc
+carina completions zsh > ~/.zfunc/_carina
+# Add to .zshrc, then start a new shell:
+#   fpath=(~/.zfunc $fpath)
+#   autoload -Uz compinit; compinit
+```
+
+### Fish
+
+```bash
+carina completions fish > ~/.config/fish/completions/carina.fish
+```

--- a/site/src/content/reference/cli/destroy.md
+++ b/site/src/content/reference/cli/destroy.md
@@ -1,0 +1,55 @@
+---
+title: destroy
+---
+
+Destroy all resources defined in the configuration. Carina computes a destroy plan and, after confirmation, deletes every managed resource recorded in state for the given directory.
+
+## Usage
+
+```bash
+carina destroy [OPTIONS] [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files.
+
+## Flags
+
+### `--auto-approve`
+
+Skip the interactive confirmation prompt and proceed with the destroy immediately.
+
+### `--lock <BOOL>`
+
+Enable or disable state locking during the destroy. Defaults to `true`. Disable only when you know no other process is touching the same state.
+
+### `--refresh <BOOL>`
+
+Refresh state from the cloud provider before computing the destroy plan. Defaults to `true`.
+
+### `--force`
+
+Destroy even resources that have `prevent_destroy = true` in their `directives` block.
+
+### `--reconfigure`
+
+Accept a changed backend configuration and overwrite the local backend lock. Use when the backend block in your configuration has changed since the last apply.
+
+## Examples
+
+Destroy everything in the current directory after confirmation:
+
+```bash
+carina destroy
+```
+
+Destroy without prompting (e.g. in a CI teardown step):
+
+```bash
+carina destroy --auto-approve
+```
+
+Destroy a specific directory and bypass `prevent_destroy`:
+
+```bash
+carina destroy --force path/to/config
+```

--- a/site/src/content/reference/cli/docs.md
+++ b/site/src/content/reference/cli/docs.md
@@ -1,0 +1,86 @@
+---
+title: docs
+---
+
+Display documentation embedded in the Carina binary. This allows AI agents and users to access version-accurate documentation without web search or external files.
+
+## Usage
+
+```bash
+carina docs [OPTIONS] [NAME]
+```
+
+## Flags
+
+### `--list`
+
+List all available embedded documents with their names and titles.
+
+```bash
+carina docs --list
+```
+
+### `--search <QUERY>`
+
+Search all embedded documents for a keyword (case-insensitive). Results show the document name, line number, and matching line.
+
+```bash
+carina docs --search provider
+```
+
+## Arguments
+
+### `[NAME]`
+
+Show a specific document by name. Use `--list` to see available names.
+
+```bash
+carina docs reference/dsl/syntax
+```
+
+If no name or flags are given, the README is displayed.
+
+## Available Documents
+
+Documents are organized by category:
+
+| Category | Documents |
+|----------|-----------|
+| Getting Started | `getting-started/installation`, `getting-started/quick-start`, `getting-started/core-concepts` |
+| Guides | `guides/writing-resources`, `guides/using-modules`, `guides/state-management`, `guides/functions`, `guides/for-if-expressions`, `guides/lsp-setup` |
+| DSL Reference | `reference/dsl/syntax`, `reference/dsl/types-and-values`, `reference/dsl/expressions`, `reference/dsl/modules`, `reference/dsl/built-in-functions` |
+| CLI Reference | `reference/cli/validate`, `reference/cli/plan`, `reference/cli/apply`, `reference/cli/state`, `reference/cli/module-info`, `reference/cli/docs` |
+
+## Examples
+
+Display the README:
+
+```bash
+carina docs
+```
+
+List all documents:
+
+```bash
+carina docs --list
+```
+
+Read the DSL syntax reference:
+
+```bash
+carina docs reference/dsl/syntax
+```
+
+Search for module-related content:
+
+```bash
+carina docs --search module
+```
+
+## Design
+
+All documents are embedded into the binary at compile time using Rust's `include_str!()` macro. This ensures:
+
+- Documentation always matches the installed binary version
+- No network access or external files required
+- AI agents get accurate information instead of stale web search results or training data

--- a/site/src/content/reference/cli/export.md
+++ b/site/src/content/reference/cli/export.md
@@ -1,0 +1,49 @@
+---
+title: export
+---
+
+Print export values from the current state. Exports are values declared in an `exports` block; they are also the values consumed by other projects via `upstream_state`.
+
+## Usage
+
+```bash
+carina export [OPTIONS] [NAME]
+```
+
+**NAME** is optional. When omitted, every export is printed. When set, only the named export is printed.
+
+## Flags
+
+### `--json`
+
+Output as JSON. With a NAME, prints `{"<name>": <value>}`. Without, prints the full export map.
+
+### `--raw`
+
+Output the raw value without the export name or surrounding quotes. Requires a NAME. Useful for piping a single export into another command.
+
+## Examples
+
+Print every export:
+
+```bash
+carina export
+```
+
+Print a single export:
+
+```bash
+carina export vpc_id
+```
+
+Pipe a raw value into another tool:
+
+```bash
+aws ec2 describe-subnets --filters "Name=vpc-id,Values=$(carina export --raw vpc_id)"
+```
+
+Emit the full export map as JSON:
+
+```bash
+carina export --json
+```

--- a/site/src/content/reference/cli/fmt.md
+++ b/site/src/content/reference/cli/fmt.md
@@ -1,0 +1,59 @@
+---
+title: fmt
+---
+
+Format `.crn` files. The formatter aligns attributes within each block and applies consistent indentation, matching the formatting the LSP applies on **Format Document**.
+
+## Usage
+
+```bash
+carina fmt [OPTIONS] [PATH]
+```
+
+**PATH** defaults to `.` (current directory). May be a single `.crn` file or a directory.
+
+## Flags
+
+### `--check`, `-c`
+
+Exit with a non-zero status if any file would be reformatted. Does not modify files. Intended for CI.
+
+### `--diff`
+
+Print the formatting diff to stdout instead of rewriting the file.
+
+### `--recursive`, `-r`
+
+When PATH is a directory, recurse into subdirectories and format every `.crn` file found.
+
+## Examples
+
+Format every `.crn` file in the current directory:
+
+```bash
+carina fmt
+```
+
+Format a single file:
+
+```bash
+carina fmt main.crn
+```
+
+Format every `.crn` under the current tree:
+
+```bash
+carina fmt --recursive .
+```
+
+Show the diff without writing changes:
+
+```bash
+carina fmt --diff main.crn
+```
+
+Verify formatting in CI:
+
+```bash
+carina fmt --check --recursive .
+```

--- a/site/src/content/reference/cli/force-unlock.md
+++ b/site/src/content/reference/cli/force-unlock.md
@@ -1,0 +1,26 @@
+---
+title: force-unlock
+---
+
+Force-release a stuck state lock.
+
+Carina takes a lock on the state backend during `apply` and `destroy` to prevent concurrent writers. If a previous run was killed before it could release the lock, subsequent runs will refuse to proceed. `force-unlock` removes that lock manually.
+
+Only use this when you are certain no other Carina process is currently writing to the same state. Releasing a lock while another process holds it can corrupt state.
+
+## Usage
+
+```bash
+carina force-unlock <LOCK_ID> [PATH]
+```
+
+- **LOCK_ID** -- the ID printed by the failed run (or by the backend's lock metadata).
+- **PATH** -- defaults to `.`. Must be a directory containing the backend configuration.
+
+## Examples
+
+Release the lock identified in a failed run:
+
+```bash
+carina force-unlock 1730000000000-abcd1234 .
+```

--- a/site/src/content/reference/cli/init.md
+++ b/site/src/content/reference/cli/init.md
@@ -1,0 +1,45 @@
+---
+title: init
+---
+
+Resolve and download the provider plugins declared in `providers.crn`. Carina caches WASM plugin binaries locally and writes a lock file so subsequent runs use the same versions.
+
+## Usage
+
+```bash
+carina init [OPTIONS] [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files.
+
+## Flags
+
+### `--upgrade`
+
+Re-resolve all provider versions from the constraints in `providers.crn`, ignoring any pinned versions in the existing lock file. Use when you want to pull in newer provider releases that satisfy your constraints.
+
+### `--locked`
+
+Require the lock file to match `providers.crn` exactly. Errors if any declared provider is missing from the lock file. Intended for CI, similar to `cargo --locked`.
+
+`--upgrade` and `--locked` are mutually exclusive.
+
+## Examples
+
+Download providers for the current directory:
+
+```bash
+carina init
+```
+
+Upgrade all providers to the latest versions allowed by the constraints:
+
+```bash
+carina init --upgrade
+```
+
+Verify the lock file is up to date in CI:
+
+```bash
+carina init --locked
+```

--- a/site/src/content/reference/cli/lint.md
+++ b/site/src/content/reference/cli/lint.md
@@ -1,0 +1,32 @@
+---
+title: lint
+---
+
+Lint `.crn` files for style issues. Lint runs checks that go beyond syntactic validity (which is covered by `validate`) — it surfaces patterns that parse and type-check but are stylistically discouraged.
+
+## Usage
+
+```bash
+carina lint [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files.
+
+## Examples
+
+Lint the current directory:
+
+```bash
+carina lint
+```
+
+Lint a specific directory:
+
+```bash
+carina lint path/to/config
+```
+
+## Related
+
+- [`validate`](/reference/cli/validate/) -- syntactic and type-level checks
+- [`fmt`](/reference/cli/fmt/) -- automatic formatting

--- a/site/src/content/reference/cli/module-info.md
+++ b/site/src/content/reference/cli/module-info.md
@@ -1,0 +1,63 @@
+---
+title: module info
+---
+
+Show the structure of a module, including its arguments, exported attributes, resources, and dependencies.
+
+## Usage
+
+```bash
+carina module info [OPTIONS] <PATH>
+```
+
+**PATH** is a module directory (a directory containing one or more `.crn` files). Single-file paths are rejected.
+
+## Flags
+
+### `--tui`
+
+Display module info in interactive TUI mode.
+
+## Output Format
+
+The output displays the module signature, including:
+
+- **Module name** -- derived from the module's directory name
+- **Arguments** -- parameters the module expects, defined by unresolved references
+- **Attributes** -- values exported by the module for use by the caller
+- **Resources** -- infrastructure resources defined in the module
+- **Dependencies** -- references to other resources or bindings
+
+## Related: `module list`
+
+List all imported modules in a configuration:
+
+```bash
+carina module list [PATH]
+```
+
+**PATH** defaults to `.` (current directory).
+
+Output shows each module's alias and path:
+
+```
+Modules:
+  web_tier    ./modules/web_tier
+  database    ./modules/database
+```
+
+Prints "No modules imported." if no modules are used.
+
+## Examples
+
+Show info for a module:
+
+```bash
+carina module info modules/web_tier/
+```
+
+Show info in TUI mode:
+
+```bash
+carina module info --tui modules/web_tier/
+```

--- a/site/src/content/reference/cli/plan.md
+++ b/site/src/content/reference/cli/plan.md
@@ -1,0 +1,105 @@
+---
+title: plan
+---
+
+Show an execution plan without applying changes. The plan compares the desired state defined in `.crn` files against the current infrastructure state and displays what actions Carina would take.
+
+## Usage
+
+```bash
+carina plan [OPTIONS] [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files — single-file paths are rejected.
+
+## Flags
+
+### `--detail <LEVEL>`
+
+Controls how much detail is shown in plan output.
+
+| Value | Description |
+|-------|-------------|
+| `full` (default) | Show all attributes: user-specified, defaults, read-only, and unchanged (dimmed) |
+| `explicit` | Show only attributes explicitly specified in the `.crn` file |
+| `none` | Show resource names only (no attributes) |
+
+### `--tui`
+
+Display the plan in an interactive TUI (terminal user interface) mode. Allows navigating resources and viewing attribute details in a structured layout.
+
+### `--out <FILE>`
+
+Save the plan to a JSON file for later use with `carina apply`. The saved plan includes the effects, resource definitions, provider configurations, and state metadata for drift detection.
+
+```bash
+carina plan --out plan.json
+carina apply plan.json
+```
+
+### `--detailed-exitcode`
+
+Change the exit code behavior:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No changes needed |
+| `1` | Error occurred |
+| `2` | Changes are present (only with `--detailed-exitcode`) |
+
+This is useful in CI pipelines to detect whether changes exist without parsing output.
+
+### `--refresh <BOOL>`
+
+Refresh state from the cloud provider before planning. Defaults to `true`.
+
+When set to `false`, Carina uses cached state and prints a warning. The plan may not reflect actual infrastructure.
+
+```bash
+carina plan --refresh=false
+```
+
+### `--json`
+
+Output the plan as structured JSON instead of human-readable text. The output uses the same format as `--out` (PlanFile), including effects, resource definitions, and current states. Secrets are redacted.
+
+```bash
+carina plan --json
+```
+
+## Examples
+
+Plan from the current directory:
+
+```bash
+carina plan
+```
+
+Plan a specific directory with compact output:
+
+```bash
+carina plan --detail=none path/to/config
+```
+
+Save a plan for later apply:
+
+```bash
+carina plan --out plan.json
+```
+
+Use in CI to detect drift:
+
+```bash
+carina plan --detailed-exitcode
+```
+
+## Output Format
+
+The plan output shows each resource with its effect type:
+
+- **Create** (`+`) -- new resource to be created
+- **Update** (`~`) -- existing resource with attribute changes
+- **Delete** (`-`) -- resource to be removed
+- **Replace** (`+/-`) -- resource that must be destroyed and recreated
+
+A summary line shows the total count of each effect type.

--- a/site/src/content/reference/cli/skills.md
+++ b/site/src/content/reference/cli/skills.md
@@ -1,0 +1,112 @@
+---
+title: skills
+---
+
+Manage Agent Skills bundled in the Carina binary. Agent Skills are standardized instruction files (`SKILL.md`) that teach AI agents how to use Carina effectively.
+
+Skills are installed to `~/.agents/skills/carina/` following the [Agent Skills standard](https://agentskills.io), making them discoverable by any compatible AI agent client.
+
+## Usage
+
+```bash
+carina skills <COMMAND>
+```
+
+## Commands
+
+### `list`
+
+List embedded skills with their version.
+
+```bash
+carina skills list
+```
+
+### `install`
+
+Install the bundled `SKILL.md` to `~/.agents/skills/carina/`.
+
+```bash
+carina skills install
+```
+
+### `status`
+
+Show install status and compare the installed version against the embedded version.
+
+```bash
+carina skills status
+```
+
+Output when not installed:
+
+```
+Not installed.
+  Embedded version: v0.3.0
+  Run 'carina skills install' to install.
+```
+
+Output when up to date:
+
+```
+Installed at: /Users/you/.agents/skills/carina/SKILL.md
+  Version: v0.3.0 (up to date)
+```
+
+Output when a newer version is available:
+
+```
+Installed at: /Users/you/.agents/skills/carina/SKILL.md
+  Installed version: v0.2.0
+  Embedded version: v0.3.0
+  Run 'carina skills update' to update.
+```
+
+### `update`
+
+Update the installed skill if the embedded version is newer. If not installed, performs an install.
+
+```bash
+carina skills update
+```
+
+### `reinstall`
+
+Force overwrite the installed skill regardless of version.
+
+```bash
+carina skills reinstall
+```
+
+### `uninstall`
+
+Remove the installed skill directory.
+
+```bash
+carina skills uninstall
+```
+
+## Examples
+
+Install skills after upgrading Carina:
+
+```bash
+carina skills update
+```
+
+Check if your installed skills match the current binary:
+
+```bash
+carina skills status
+```
+
+## What is SKILL.md?
+
+The installed `SKILL.md` contains:
+
+- Common Carina workflows (validate, plan, apply)
+- DSL syntax quick reference
+- CLI command reference
+- Best practices for working with Carina via AI agents
+
+AI agents load this file automatically to learn how to operate Carina without relying on web search or training data.

--- a/site/src/content/reference/cli/state.md
+++ b/site/src/content/reference/cli/state.md
@@ -1,0 +1,135 @@
+---
+title: state
+---
+
+State management commands for inspecting, modifying, and maintaining the Carina state file.
+
+## Usage
+
+```bash
+carina state <SUBCOMMAND> [OPTIONS]
+```
+
+## Subcommands
+
+### `list`
+
+List all managed resources from the state file.
+
+```bash
+carina state list [PATH]
+```
+
+Output shows provider, resource type, and binding name (or resource name) for each resource:
+
+```
+aws.s3.Bucket my_bucket
+aws.ec2.Vpc main_vpc
+aws.ec2.Subnet public_subnet
+```
+
+Prints "No resources in state." if the state is empty.
+
+### `show`
+
+Show all managed resources with full attributes.
+
+```bash
+carina state show [OPTIONS] [PATH]
+```
+
+Output groups attributes under each resource:
+
+```
+# aws.s3.Bucket (my_bucket)
+  bucket = "my-bucket-name"
+```
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--tui` | Display state in interactive TUI mode |
+| `--json` | Output full state as JSON |
+
+### `lookup`
+
+Look up resource attributes from the state file.
+
+```bash
+carina state lookup [OPTIONS] <QUERY> [PATH]
+```
+
+**QUERY** can be:
+- `<binding_or_name>` -- returns all attributes as a JSON object
+- `<binding_or_name>.<attribute>` -- returns a single attribute value
+
+The lookup searches by binding name first, then falls back to resource name.
+
+```bash
+# Get all attributes of a resource
+carina state lookup my_bucket
+
+# Get a specific attribute
+carina state lookup my_bucket.bucket
+```
+
+Single attribute values are returned as raw values (no quotes for strings), suitable for shell usage. Use `--json` to always output JSON.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Always output as JSON |
+
+Shell completions are supported for both resource names and attribute names.
+
+### `refresh`
+
+Refresh state from cloud providers without planning or applying. Reads the current state of all managed resources from the providers and updates the state file.
+
+```bash
+carina state refresh [OPTIONS] [PATH]
+```
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--lock <BOOL>` | Enable/disable state locking (default: `true`) |
+
+### `bucket-delete`
+
+Delete the state bucket. This is a destructive operation that removes the bucket and all state history.
+
+```bash
+carina state bucket-delete [OPTIONS] <BUCKET_NAME> [PATH]
+```
+
+The bucket name must match the `bucket` attribute in the backend configuration. Without `--force`, Carina prompts for confirmation by requiring the user to type the bucket name.
+
+#### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Force deletion without confirmation |
+
+## Related Commands
+
+### `force-unlock`
+
+Force unlock a stuck state lock. This is a top-level command, not a state subcommand.
+
+```bash
+carina force-unlock <LOCK_ID> [PATH]
+```
+
+Use this when a previous operation was interrupted and left the state locked. The lock ID is shown in the error message when a lock conflict occurs.
+
+## State File Format
+
+Carina stores state in `carina.state.json` (local backend) or in an S3 bucket (remote backend). The state file tracks:
+
+- **lineage** -- unique identifier for the state, used for drift detection
+- **serial** -- incrementing version number
+- **resources** -- list of managed resources with their provider, type, name, binding, attributes, and dependency bindings

--- a/site/src/content/reference/cli/validate.md
+++ b/site/src/content/reference/cli/validate.md
@@ -1,0 +1,93 @@
+---
+title: validate
+---
+
+Validate the configuration file without communicating with cloud providers. This checks syntax, type correctness, resource schema compliance, and module resolution.
+
+## Usage
+
+```bash
+carina validate [PATH]
+```
+
+**PATH** defaults to `.` (current directory). It must be a directory containing one or more `.crn` files — single-file paths are rejected.
+
+## What It Checks
+
+1. **Syntax** -- Parses all `.crn` files using the Carina grammar. Reports line and column for parse errors.
+2. **Resource types** -- Validates that resource types exist in the provider schema (e.g., `aws.s3.Bucket`).
+3. **Attribute types** -- Checks that attribute values match the expected types defined in the resource schema.
+4. **Module resolution** -- Resolves `import` statements and validates module arguments.
+5. **Unused bindings** -- Warns about `let` bindings that are never referenced. These can be replaced with anonymous resources.
+6. **Duplicate attributes** -- Warns when the same attribute key appears multiple times in a resource block. The last value wins, but this is likely unintentional.
+
+## Output
+
+On success, Carina prints the number of validated resources and lists each resource ID:
+
+```
+Validating...
+✓ 3 resources validated successfully.
+  • aws.s3.Bucket.my-bucket
+  • aws.ec2.Vpc.main
+  • aws.ec2.Subnet.public
+```
+
+Warnings are printed after the success message:
+
+```
+⚠ Unused let binding 'temp'. Consider using an anonymous resource instead.
+⚠ main.crn:Duplicate attribute 'tags' at line 12 (first defined on line 8). The last value will be used.
+```
+
+On failure, Carina prints the error and exits with code `1`.
+
+## Flags
+
+### `--json`
+
+Output results as structured JSON instead of human-readable text.
+
+```bash
+carina validate --json
+```
+
+```json
+{
+  "status": "ok",
+  "resource_count": 3,
+  "resources": [
+    "aws.s3.Bucket.my-bucket",
+    "aws.ec2.Vpc.main",
+    "aws.ec2.Subnet.public"
+  ]
+}
+```
+
+When warnings are present, they are included in the output:
+
+```json
+{
+  "status": "ok",
+  "resource_count": 2,
+  "resources": ["aws.s3.Bucket.my-bucket", "aws.ec2.Vpc.main"],
+  "warnings": [
+    {"type": "unused_binding", "message": "Unused let binding 'temp'"},
+    {"type": "duplicate_attribute", "message": "Duplicate attribute 'tags' at line 12", "file": "main.crn"}
+  ]
+}
+```
+
+## Examples
+
+Validate the current directory:
+
+```bash
+carina validate
+```
+
+Validate a specific directory:
+
+```bash
+carina validate path/to/config
+```

--- a/site/src/pages/reference/cli/apply.astro
+++ b/site/src/pages/reference/cli/apply.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/apply.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina apply'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/completions.astro
+++ b/site/src/pages/reference/cli/completions.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/completions.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina completions'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/destroy.astro
+++ b/site/src/pages/reference/cli/destroy.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/destroy.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina destroy'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/docs.astro
+++ b/site/src/pages/reference/cli/docs.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/docs.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina docs'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/export.astro
+++ b/site/src/pages/reference/cli/export.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/export.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina export'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/fmt.astro
+++ b/site/src/pages/reference/cli/fmt.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/fmt.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina fmt'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/force-unlock.astro
+++ b/site/src/pages/reference/cli/force-unlock.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/force-unlock.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina force-unlock'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/init.astro
+++ b/site/src/pages/reference/cli/init.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/init.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina init'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/lint.astro
+++ b/site/src/pages/reference/cli/lint.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/lint.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina lint'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/module-info.astro
+++ b/site/src/pages/reference/cli/module-info.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/module-info.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina module-info'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/plan.astro
+++ b/site/src/pages/reference/cli/plan.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/plan.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina plan'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/skills.astro
+++ b/site/src/pages/reference/cli/skills.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/skills.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina skills'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/state.astro
+++ b/site/src/pages/reference/cli/state.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/state.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina state'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>

--- a/site/src/pages/reference/cli/validate.astro
+++ b/site/src/pages/reference/cli/validate.astro
@@ -1,0 +1,13 @@
+---
+import Doc from '../../../layouts/Doc.astro';
+import { Content, getHeadings, frontmatter } from '../../../content/reference/cli/validate.md';
+
+const headings = getHeadings();
+---
+<Doc
+  title={frontmatter.title ?? 'carina validate'}
+  description={frontmatter.description}
+  headings={headings}
+>
+  <Content />
+</Doc>


### PR DESCRIPTION
## Summary
- Bring the 14 `carina-cli` command pages over to `site/` and add a Reference / CLI subgroup to the Sidebar — the slot the Step 5 subgroup scaffold was designed for.
- Pages, in Starlight-config order:
  - `init`, `validate`, `plan`, `apply`, `destroy`, `fmt`, `lint`, `state`, `force-unlock`, `module-info`, `export`, `docs`, `skills`, `completions`
- Each page is a verbatim markdown copy + a thin `pages/.../{slug}.astro` that passes `frontmatter`, `getHeadings()`, and `Content` to `Doc.astro`.

## Notes
- `state.md` keeps its **Subcommands** H2 with five H3 subcommand anchors (`list` / `show` / `lookup` / `refresh` / `bucket-delete`) plus a **Related Commands** → `force-unlock` anchor; all six anchors render and `/reference/cli/state/#bucket-delete` jumps correctly.
- No new components or tokens. The Step 5 subgroup template picks up CLI without modification — `Sidebar.astro` only gains the `items` array under the existing Reference subgroups list.
- The `.crn` fences continue to fall back to plaintext until the custom Shiki grammar lands later.
- Build now produces **29 static pages** (was 15).
- This PR is independent of #2944 (Step 6 A heading hierarchy); they don't touch the same files and can ship in either order.

## Test plan
- [ ] `cd site && npm install && npm run build` succeeds (29 pages).
- [ ] `cd site && npm run dev` serves all 14 CLI URLs on `http://localhost:4321/` with no console errors.
- [ ] Visual: each CLI page lights up its sidebar entry under Reference / CLI; `state` page shows the Subcommands H2 with H3 anchors; `state/#bucket-delete` and `state/#force-unlock` jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)