### PR TITLE
plan: render List<String> diffs as per-element +/- lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ plan-list-diff-modified-with-unchanged-nested:
 	$(PLAN_FIXTURE) list_diff_modified_with_unchanged_nested
 plan-list-diff-paired-all-unchanged-dropped:
 	$(PLAN_FIXTURE) list_diff_paired_all_unchanged_dropped
+plan-list-diff-string-list-grew:
+	$(PLAN_FIXTURE) list_diff_string_list_grew
 plan-nested-list-of-maps-all-dropped:
 	$(PLAN_FIXTURE) nested_list_of_maps_all_dropped
 plan-enum-display:
@@ -99,6 +101,8 @@ plan-fixtures:
 	@$(MAKE) plan-list-diff-modified-with-unchanged-nested
 	@echo "---"
 	@$(MAKE) plan-list-diff-paired-all-unchanged-dropped
+	@echo "---"
+	@$(MAKE) plan-list-diff-string-list-grew
 	@echo "---"
 	@$(MAKE) plan-nested-list-of-maps-all-dropped
 	@echo ""

--- a/carina-cli/src/display/mod.rs
+++ b/carina-cli/src/display/mod.rs
@@ -1135,6 +1135,15 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
             writeln!(out, "{}{}:", attr_prefix, key).unwrap();
             render_map_diff_entries(out, entries.as_slice(), attr_prefix);
         }
+        DetailRow::StringListDiff {
+            key,
+            unchanged,
+            added,
+            removed,
+        } => {
+            writeln!(out, "{}{}:", attr_prefix, key).unwrap();
+            render_string_list_diff_entries(out, unchanged, added, removed, attr_prefix);
+        }
         DetailRow::ListOfMapsDiff {
             key,
             unchanged,
@@ -1225,6 +1234,16 @@ fn render_detail_row(out: &mut String, row: &DetailRow, effect: &Effect, attr_pr
             let suffix = format!(" {}", "(forces replacement)".magenta());
             writeln!(out, "{}{}:{}", attr_prefix, key, suffix).unwrap();
             render_map_diff_entries(out, entries, attr_prefix);
+        }
+        DetailRow::ReplaceStringListDiff {
+            key,
+            unchanged,
+            added,
+            removed,
+        } => {
+            let suffix = format!(" {}", "(forces replacement)".magenta());
+            writeln!(out, "{}{}:{}", attr_prefix, key, suffix).unwrap();
+            render_string_list_diff_entries(out, unchanged, added, removed, attr_prefix);
         }
         DetailRow::TemporaryNameNote {
             can_rename,
@@ -1341,6 +1360,49 @@ fn render_map_diff_entries(out: &mut String, entries: &[MapDiffEntryIR], attr_pr
     }
 }
 
+/// Render a string-list diff (#2943) with ANSI colors. The
+/// `# (n unchanged elements hidden)` summary trails the diff lines to
+/// match the placement of `# (n unchanged fields hidden)` in
+/// `render_list_of_maps_diff` and `# (n unchanged attributes hidden)`
+/// at the top level.
+fn render_string_list_diff_entries(
+    out: &mut String,
+    unchanged: &[String],
+    added: &[String],
+    removed: &[String],
+    attr_prefix: &str,
+) {
+    for s in removed {
+        writeln!(
+            out,
+            "{}  {} \"{}\"",
+            attr_prefix,
+            "-".red().strikethrough(),
+            s.red().strikethrough()
+        )
+        .unwrap();
+    }
+    for s in added {
+        writeln!(
+            out,
+            "{}  {} {}",
+            attr_prefix,
+            "+".green(),
+            format!("\"{}\"", s).green()
+        )
+        .unwrap();
+    }
+    if !unchanged.is_empty() {
+        writeln!(
+            out,
+            "{}  {}",
+            attr_prefix,
+            hidden_unchanged_summary(unchanged.len(), "element").dimmed()
+        )
+        .unwrap();
+    }
+}
+
 /// Render a list-of-maps diff with ANSI colors.
 fn render_list_of_maps_diff(
     out: &mut String,
@@ -1354,11 +1416,18 @@ fn render_list_of_maps_diff(
         writeln!(out, "{}    {}", attr_prefix, item).unwrap();
     }
     for item in modified {
-        let has_nested = item
-            .fields
-            .iter()
-            .any(|f| matches!(f, ListOfMapsDiffField::NestedMapChanged { .. }));
-        if has_nested {
+        // `StringListChanged` (#2943) forces the block layout for the
+        // same reason `NestedMapChanged` (#2881) does: its rendering
+        // spans multiple lines and cannot fit inside the inline
+        // `~ {field: value, ...}` summary.
+        let has_block_field = item.fields.iter().any(|f| {
+            matches!(
+                f,
+                ListOfMapsDiffField::NestedMapChanged { .. }
+                    | ListOfMapsDiffField::StringListChanged { .. }
+            )
+        });
+        if has_block_field {
             writeln!(out, "{}  {} {{", attr_prefix, "~".yellow().bold()).unwrap();
             for field in item.fields.iter() {
                 match field {
@@ -1378,6 +1447,22 @@ fn render_list_of_maps_diff(
                         writeln!(out, "{}      {}:", attr_prefix, key).unwrap();
                         let nested_prefix = format!("{}      ", attr_prefix);
                         render_map_diff_entries(out, entries, &nested_prefix);
+                    }
+                    ListOfMapsDiffField::StringListChanged {
+                        key,
+                        unchanged,
+                        added,
+                        removed,
+                    } => {
+                        writeln!(out, "{}      {}:", attr_prefix, key).unwrap();
+                        let nested_prefix = format!("{}      ", attr_prefix);
+                        render_string_list_diff_entries(
+                            out,
+                            unchanged,
+                            added,
+                            removed,
+                            &nested_prefix,
+                        );
                     }
                 }
             }
@@ -1490,6 +1575,13 @@ fn render_modified_fields(fields: &[ListOfMapsDiffField]) -> String {
             }
             ListOfMapsDiffField::NestedMapChanged { key, .. } => {
                 result_parts.push(format!("{}: (nested changes)", key));
+            }
+            ListOfMapsDiffField::StringListChanged { .. } => {
+                // `has_block_field` in `render_list_of_maps_diff` keeps
+                // `StringListChanged` out of the inline summary path.
+                unreachable!(
+                    "StringListChanged should be handled by the block layout, not the inline summary"
+                );
             }
         }
     }

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -1022,6 +1022,31 @@ fn snapshot_list_diff_modified_with_unchanged() {
     insta::assert_snapshot!(output);
 }
 
+/// #2943: a List<String> field inside a list-of-maps modified element
+/// that grew by trailing entries must render multi-line with `+` lines
+/// for added entries, not as a single inline `field: [a, b, ...] →
+/// [a, b, ..., c, d]` overflow line.
+#[test]
+fn snapshot_list_diff_string_list_grew() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("list_diff_string_list_grew");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    assert!(
+        !output.lines().any(|l| l.len() > 200),
+        "string-list diff inside a list-of-maps modified element should not render inline; got: {}",
+        output
+    );
+    insta::assert_snapshot!(output);
+}
+
 // #2881 follow-on: exercises the modified-with-nested branch where the
 // only changed field is a nested Map (`config`). Locks in the
 // `~ { ... }` block-style layout: nested map diff first, then

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_string_list_grew.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_list_diff_string_list_grew.snap
@@ -1,0 +1,18 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  ~ awscc.iam.RolePolicy policy
+      statement:
+        ~ {
+            action:
+              + "route53:ListQueryLoggingConfigs"
+              + "route53:GetQueryLoggingConfig"
+              # (11 unchanged elements hidden)
+            # (3 unchanged fields hidden)
+          }
+      # (2 unchanged attributes hidden)
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/carina.state.json
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/carina.state.json
@@ -1,0 +1,58 @@
+{
+  "version": 6,
+  "serial": 1,
+  "lineage": "test-lineage-list-diff-string-list-grew",
+  "carina_version": "0.1.0",
+  "resources": [
+    {
+      "resource_type": "iam.RolePolicy",
+      "name": "policy",
+      "provider": "awscc",
+      "identifier": "test-role|test-inline",
+      "attributes": {
+        "policy_name": "test-inline",
+        "role_name": "test-role",
+        "statement": [
+          {
+            "sid": "AllowRoute53Read",
+            "effect": "Allow",
+            "action": [
+              "route53:CreateHostedZone",
+              "route53:DeleteHostedZone",
+              "route53:GetHostedZone",
+              "route53:ListHostedZones",
+              "route53:ListHostedZonesByName",
+              "route53:UpdateHostedZoneComment",
+              "route53:ChangeTagsForResource",
+              "route53:ListTagsForResource",
+              "route53:ChangeResourceRecordSets",
+              "route53:ListResourceRecordSets",
+              "route53:GetChange"
+            ],
+            "resource": "*"
+          }
+        ]
+      },
+      "protected": false,
+      "directives": {},
+      "prefixes": {},
+      "name_overrides": {},
+      "binding": "policy",
+      "dependency_bindings": [],
+      "explicit": {
+        "kind": "struct",
+        "children": {
+          "policy_name": {
+            "kind": "leaf"
+          },
+          "role_name": {
+            "kind": "leaf"
+          },
+          "statement": {
+            "kind": "leaf"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/list_diff_string_list_grew/main.crn
@@ -1,0 +1,41 @@
+# Update plan: a List<String> field inside a list-of-maps modified
+# element grew by two trailing entries (issue #2943). Pre-fix, the
+# entire `action: [old1, ..., oldN] → [old1, ..., oldN, new1, new2]`
+# pair rendered on one inline line, overflowing the terminal for
+# realistic IAM action lists. Post-fix, the diff is laid out
+# multi-line with `+` lines for added entries.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let policy = awscc.iam.RolePolicy {
+  policy_name = 'test-inline'
+  role_name   = 'test-role'
+  statement = [
+    {
+      sid    = 'AllowRoute53Read'
+      effect = 'Allow'
+      action = [
+        'route53:CreateHostedZone',
+        'route53:DeleteHostedZone',
+        'route53:GetHostedZone',
+        'route53:ListHostedZones',
+        'route53:ListHostedZonesByName',
+        'route53:UpdateHostedZoneComment',
+        'route53:ChangeTagsForResource',
+        'route53:ListTagsForResource',
+        'route53:ChangeResourceRecordSets',
+        'route53:ListResourceRecordSets',
+        'route53:GetChange',
+        'route53:ListQueryLoggingConfigs',
+        'route53:GetQueryLoggingConfig',
+      ]
+      resource = '*'
+    },
+  ]
+}
+
+exports {
+  policy_name = policy.policy_name
+}

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -71,6 +71,13 @@ pub enum DetailRow {
         added: Vec<ListOfMapsDiffItem>,
         removed: Vec<ListOfMapsDiffItem>,
     },
+    /// Per-element `List<String>` diff for Update effects (#2943).
+    StringListDiff {
+        key: String,
+        unchanged: Vec<String>,
+        added: Vec<String>,
+        removed: Vec<String>,
+    },
     /// An attribute that was removed (for Update effects)
     Removed { key: String, old: String },
     /// An attribute with a schema default value (for Create effects in Full mode)
@@ -103,6 +110,13 @@ pub enum DetailRow {
     ReplaceMapDiff {
         key: String,
         entries: Vec<MapDiffEntryIR>,
+    },
+    /// Per-element `List<String>` diff that forces replacement (#2943).
+    ReplaceStringListDiff {
+        key: String,
+        unchanged: Vec<String>,
+        added: Vec<String>,
+        removed: Vec<String>,
     },
     /// Temporary name note for create-before-destroy replacement
     TemporaryNameNote {
@@ -267,6 +281,14 @@ pub enum ListOfMapsDiffField {
     NestedMapChanged {
         key: String,
         entries: Vec<MapDiffEntryIR>,
+    },
+    /// Per-element `List<String>` field diff inside a modified
+    /// list-of-maps element (#2943).
+    StringListChanged {
+        key: String,
+        unchanged: Vec<String>,
+        added: Vec<String>,
+        removed: Vec<String>,
     },
 }
 
@@ -552,6 +574,13 @@ fn build_update_rows(
                 Some(row) => rows.push(row),
                 None => effectively_unchanged += 1,
             }
+        } else if let Some(diff) = compute_string_list_change(old_value, new_value) {
+            rows.push(DetailRow::StringListDiff {
+                key: key.to_string(),
+                unchanged: diff.unchanged,
+                added: diff.added,
+                removed: diff.removed,
+            });
         } else {
             let old_str = old_value
                 .map(|v| format_value_with_key(v, Some(key)))
@@ -653,6 +682,13 @@ fn build_replace_rows(
             rows.push(DetailRow::ReplaceMapDiff {
                 key: key.to_string(),
                 entries,
+            });
+        } else if let Some(diff) = compute_string_list_change(old_value, new_value) {
+            rows.push(DetailRow::ReplaceStringListDiff {
+                key: key.to_string(),
+                unchanged: diff.unchanged,
+                added: diff.added,
+                removed: diff.removed,
             });
         } else {
             let old_str = old_value
@@ -1031,6 +1067,13 @@ fn compute_list_of_maps_diff_parts(
                         key: k.to_string(),
                         entries: nested,
                     });
+                } else if let Some(diff) = compute_string_list_change(old_val, &new_map[k]) {
+                    fields.push(ListOfMapsDiffField::StringListChanged {
+                        key: k.to_string(),
+                        unchanged: diff.unchanged,
+                        added: diff.added,
+                        removed: diff.removed,
+                    });
                 } else {
                     let old_v = old_val
                         .map(format_value)
@@ -1130,6 +1173,30 @@ fn collect_added_removed_items(indices: &[usize], items: &[Value]) -> Vec<ListOf
 /// scalar stays visible.
 fn should_render_as_map_diff(old_value: Option<&Value>, new_value: &Value) -> bool {
     matches!(new_value, Value::Map(_)) && matches!(old_value, None | Some(Value::Map(_)))
+}
+
+/// Compute a string-list diff for a single attribute (#2943).
+///
+/// Returns `Some(diff)` when `new_value` is a string-list shape,
+/// `old_value` is either absent or also a string-list shape, and the
+/// diff has at least one added or removed element. Returns `None`
+/// otherwise — the caller falls through to the inline `Changed` form
+/// so a type mismatch (e.g. string → list) keeps the prior scalar
+/// visible.
+fn compute_string_list_change(
+    old_value: Option<&Value>,
+    new_value: &Value,
+) -> Option<crate::diff_helpers::StringListDiff> {
+    let new_list = crate::value::as_string_list(new_value)?;
+    let old_list = match old_value {
+        Some(ov) => crate::value::as_string_list(ov)?,
+        None => Vec::new(),
+    };
+    let diff = crate::diff_helpers::compute_string_list_diff(&old_list, &new_list);
+    if diff.added.is_empty() && diff.removed.is_empty() {
+        return None;
+    }
+    Some(diff)
 }
 
 /// Check whether a Value references the given binding name.

--- a/carina-core/src/diff_helpers.rs
+++ b/carina-core/src/diff_helpers.rs
@@ -139,6 +139,46 @@ pub fn compute_map_diff(
     }
 }
 
+/// Diff result for two `Vec<String>` slices, partitioned by value
+/// membership. `unchanged` follows new-list order; `added` and
+/// `removed` preserve their source order.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StringListDiff {
+    pub unchanged: Vec<String>,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+/// Diff two `&[String]` slices into `unchanged` / `added` / `removed`.
+/// Set semantics: equality is by value, not position, and duplicate
+/// elements are conflated.
+pub fn compute_string_list_diff(old: &[String], new: &[String]) -> StringListDiff {
+    use std::collections::HashSet;
+    let old_set: HashSet<&str> = old.iter().map(String::as_str).collect();
+    let new_set: HashSet<&str> = new.iter().map(String::as_str).collect();
+
+    let mut unchanged = Vec::new();
+    let mut added = Vec::new();
+    for s in new {
+        if old_set.contains(s.as_str()) {
+            unchanged.push(s.clone());
+        } else {
+            added.push(s.clone());
+        }
+    }
+    let mut removed = Vec::new();
+    for s in old {
+        if !new_set.contains(s.as_str()) {
+            removed.push(s.clone());
+        }
+    }
+    StringListDiff {
+        unchanged,
+        added,
+        removed,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -1006,6 +1006,26 @@ pub fn is_list_of_maps(value: &Value) -> bool {
     }
 }
 
+/// Extract a `Vec<String>` from a `Value::StringList` or a `Value::List`
+/// whose every element is `Value::String`. Returns `None` for other
+/// shapes. Empty lists return `Some(vec![])` so callers can distinguish
+/// "empty string list" from "not a string list" — needed by #2943's
+/// diff path so a list shrinking to empty still routes through
+/// per-element `-` lines instead of the inline `[a, b] → []` form.
+pub fn as_string_list(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::StringList(items) => Some(items.clone()),
+        Value::List(items) => items
+            .iter()
+            .map(|v| match v {
+                Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => None,
+    }
+}
+
 /// Whether `value` renders to a vertical block whose final line sits at
 /// the element's key column, leaving a sibling key visually attached
 /// to the last element. A blank line should follow such a value before

--- a/carina-tui/src/ui/detail.rs
+++ b/carina-tui/src/ui/detail.rs
@@ -6,7 +6,9 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::app::{App, FocusedPanel};
 
-use super::diff::{render_list_of_maps_diff, render_map_diff_entries};
+use super::diff::{
+    render_list_of_maps_diff, render_map_diff_entries, render_string_list_diff_entries,
+};
 use super::style::effect_style;
 use super::value_view::{value_spans, value_spans_dimmed};
 
@@ -185,6 +187,19 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
             lines.push(first_line);
             render_map_diff_entries(lines, entries.as_slice());
         }
+        DetailRow::StringListDiff {
+            key,
+            unchanged,
+            added,
+            removed,
+        } => {
+            let mut first_line = Line::from(Span::raw(format!("  {}:", key)));
+            if is_selected {
+                first_line = first_line.style(Style::default().bg(Color::DarkGray));
+            }
+            lines.push(first_line);
+            render_string_list_diff_entries(lines, unchanged, added, removed);
+        }
         DetailRow::ListOfMapsDiff {
             key,
             unchanged,
@@ -294,6 +309,19 @@ fn render_detail_row_to_lines(lines: &mut Vec<Line>, row: &DetailRow, is_selecte
             }
             lines.push(first_line);
             render_map_diff_entries(lines, entries);
+        }
+        DetailRow::ReplaceStringListDiff {
+            key,
+            unchanged,
+            added,
+            removed,
+        } => {
+            let mut first_line = Line::from(Span::raw(format!("  {}:", key)));
+            if is_selected {
+                first_line = first_line.style(Style::default().bg(Color::DarkGray));
+            }
+            lines.push(first_line);
+            render_string_list_diff_entries(lines, unchanged, added, removed);
         }
         DetailRow::TemporaryNameNote {
             can_rename,

--- a/carina-tui/src/ui/diff.rs
+++ b/carina-tui/src/ui/diff.rs
@@ -7,6 +7,50 @@ use carina_core::detail_rows::{
 use carina_core::value::{PrettyLayout, format_value_pretty, needs_trailing_separator};
 use ratatui::prelude::*;
 
+/// Render string-list diff entries (#2943) into TUI lines. Mirrors
+/// `carina-cli::display::render_string_list_diff_entries` — including
+/// the trailing-summary placement.
+pub(super) fn render_string_list_diff_entries(
+    lines: &mut Vec<Line>,
+    unchanged: &[String],
+    added: &[String],
+    removed: &[String],
+) {
+    for s in removed {
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(
+                "- ",
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::CROSSED_OUT),
+            ),
+            Span::styled(
+                format!("\"{}\"", s),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::CROSSED_OUT),
+            ),
+        ]));
+    }
+    for s in added {
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled("+ ", Style::default().fg(Color::Green)),
+            Span::styled(format!("\"{}\"", s), Style::default().fg(Color::Green)),
+        ]));
+    }
+    if !unchanged.is_empty() {
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(
+                hidden_unchanged_summary(unchanged.len(), "element"),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+}
+
 /// Render map diff entries into TUI lines.
 pub(super) fn render_map_diff_entries(lines: &mut Vec<Line>, entries: &[MapDiffEntryIR]) {
     for entry in entries {
@@ -138,6 +182,22 @@ pub(super) fn render_list_of_maps_diff(
                     lines.push(Line::from(std::mem::take(&mut spans)));
                     let mut nested_lines = Vec::new();
                     render_map_diff_entries(&mut nested_lines, entries);
+                    for line in nested_lines {
+                        let mut indented = vec![Span::raw("      ")];
+                        indented.extend(line.spans);
+                        lines.push(Line::from(indented));
+                    }
+                }
+                ListOfMapsDiffField::StringListChanged {
+                    key,
+                    unchanged,
+                    added,
+                    removed,
+                } => {
+                    spans.push(Span::raw(format!("{}: ", key)));
+                    lines.push(Line::from(std::mem::take(&mut spans)));
+                    let mut nested_lines = Vec::new();
+                    render_string_list_diff_entries(&mut nested_lines, unchanged, added, removed);
                     for line in nested_lines {
                         let mut indented = vec![Span::raw("      ")];
                         indented.extend(line.spans);


### PR DESCRIPTION
## Summary

Sibling fix to #2936. When a `~` Update has a list-of-maps modified element containing a changed `List<String>` field (most commonly IAM policy `action`), the renderer used to dump the entire `prev → next` pair on one inline line:

```
~ awscc.iam.RolePolicy r
    statement:
      ~ {action: ["a", "b", ..., "k"] → ["a", "b", ..., "k", "x", "y"], # (3 unchanged fields hidden)}
```

For real IAM action lists (~13 entries) this routinely produces 700+ character lines that overflow the terminal and bury the actual diff in unchanged context.

This PR mirrors #2936's per-key Map treatment: detect string-list shapes (`Value::StringList` and `Value::List<Value::String>`), partition into `unchanged` / `added` / `removed` by value membership, and route through new IR variants that render multi-line under a `key:` header:

```
~ awscc.iam.RolePolicy policy
    statement:
      ~ {
          action:
            + \"route53:ListQueryLoggingConfigs\"
            + \"route53:GetQueryLoggingConfig\"
            # (11 unchanged elements hidden)
          # (3 unchanged fields hidden)
        }
    # (2 unchanged attributes hidden)
```

The same path covers Replace (create-only) effects via `DetailRow::ReplaceStringListDiff`. Issue #2943 also flags top-level `~ field: List → List` (case 2) as "presumably the same root cause" — the IR variants and renderer wiring are present for it; only fixture coverage is deferred (see Follow-ups).

## Changes

- `carina-core/src/value.rs` — new `as_string_list` accessor (sibling of `is_list_of_maps`).
- `carina-core/src/diff_helpers.rs` — new `compute_string_list_diff` (set-semantic; duplicates conflated).
- `carina-core/src/detail_rows.rs` — three new IR variants (`DetailRow::StringListDiff`, `::ReplaceStringListDiff`, `ListOfMapsDiffField::StringListChanged`); shared private helper `compute_string_list_change` that bails on type mismatch or no-op so the call site falls through to the inline `Changed` form.
- `carina-cli/src/display/mod.rs` — new `render_string_list_diff_entries` plus updated `render_list_of_maps_diff` to force the block layout when any field is `StringListChanged` (alongside the existing `NestedMapChanged` trigger).
- `carina-tui/src/ui/diff.rs` and `ui/detail.rs` — TUI mirror.
- New fixture `list_diff_string_list_grew/` reproduces the IAM Route53 case from issue #2943.

## Test plan

- [x] New snapshot test `snapshot_list_diff_string_list_grew` reproduces the issue's IAM action-list growth and locks in the multi-line layout
- [x] Test asserts no line exceeds 200 cols
- [x] `cargo nextest run --workspace` (3090 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`

## Follow-ups (not in this PR)

- **Top-level fixture for case 2** — issue #2943 mentions a top-level `~ field: List → List` shape; the IR variants and renderer support it but no fixture exercises it yet.
- **Order-only swap** — `compute_string_list_diff` is set-semantic, so a list whose elements were only reordered produces no diff and falls through to the inline form. For string lists where order is semantically meaningless (IAM actions) this is desirable; if order ever matters, a follow-up would be needed.

## Design choice

The user picked Option A (per-element `+`/`-` lines) over Option B (`previous:` / `new:` two-block) because it scales naturally to future `~` per-element shapes and matches the language already used by #2877 / #2936.

Closes #2943