### PR TITLE
core: Replace topological sort respects directives.depends_on edges

### DIFF
--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -60,6 +60,7 @@ fn snapshot_depends_on() {
         &HashMap::new(),
         &[],
         &[],
+        None,
     ));
     insta::assert_snapshot!(output);
 }

--- a/carina-core/src/executor/phased.rs
+++ b/carina-core/src/executor/phased.rs
@@ -28,8 +28,8 @@ pub(super) fn has_interdependent_replaces(effects: &[Effect]) -> bool {
 
     for effect in effects {
         if let Effect::Replace { to, .. } = effect {
-            for dep in &to.dependency_bindings {
-                if replace_bindings.contains(dep) {
+            for dep in get_resource_dependencies(to) {
+                if replace_bindings.contains(&dep) {
                     return true;
                 }
             }
@@ -69,15 +69,16 @@ pub(super) fn topological_sort_replaces(
         }
     }
 
-    // Build adjacency: for each replace effect, find which other replace effects it depends on
+    // Build adjacency: for each replace effect, find which other replace effects it depends on.
+    // Use the unioned `get_resource_dependencies` so explicit
+    // `directives.depends_on` edges participate alongside value refs (#2875).
     let mut deps: HashMap<usize, Vec<usize>> = HashMap::new();
     for &idx in &replace_indices {
         let effect = &effects[idx];
         if let Effect::Replace { to, .. } = effect {
-            let dep_indices: Vec<usize> = to
-                .dependency_bindings
+            let dep_indices: Vec<usize> = get_resource_dependencies(to)
                 .iter()
-                .filter(|b| replace_bindings.contains(*b))
+                .filter(|b| replace_bindings.contains(b.as_str()))
                 .filter_map(|b| binding_to_idx.get(b))
                 .copied()
                 .collect();
@@ -1353,6 +1354,62 @@ mod tests {
             deps_of[&1].contains(&0),
             "caller must depend on Role through two virtual layers (outer → outer.inner → outer.inner.role); got: {:?}",
             deps_of[&1],
+        );
+    }
+
+    /// #2875: Replace topological sort must respect explicit
+    /// `directives.depends_on` edges, not only `dependency_bindings`
+    /// (which is value-ref-only post-#2823).
+    #[test]
+    fn topological_sort_replaces_respects_depends_on() {
+        use crate::resource::{Directives, State};
+
+        let mut role = Resource::with_provider("test", "iam.Role", "role");
+        role.binding = Some("role".to_string());
+        let mut bucket = Resource::with_provider("test", "s3.Bucket", "bucket");
+        bucket.binding = Some("bucket".to_string());
+        bucket.directives = Directives {
+            depends_on: vec!["role".to_string()],
+            ..Directives::default()
+        };
+
+        let role_state = State::not_found(role.id.clone());
+        let bucket_state = State::not_found(bucket.id.clone());
+
+        let role_replace = Effect::Replace {
+            id: role.id.clone(),
+            from: Box::new(role_state),
+            to: role.clone(),
+            directives: Directives::default(),
+            changed_create_only: vec!["role_name".to_string()],
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+        let bucket_replace = Effect::Replace {
+            id: bucket.id.clone(),
+            from: Box::new(bucket_state),
+            to: bucket.clone(),
+            directives: Directives::default(),
+            changed_create_only: vec!["bucket_name".to_string()],
+            cascading_updates: vec![],
+            temporary_name: None,
+            cascade_ref_hints: vec![],
+        };
+
+        let effects = vec![bucket_replace, role_replace];
+        let replace_bindings = collect_replace_bindings(&effects);
+        assert!(
+            has_interdependent_replaces(&effects),
+            "depends_on-only edge between two Replaces should count as interdependent"
+        );
+        let sorted = topological_sort_replaces(&effects, &replace_bindings);
+        let role_pos = sorted.iter().position(|&i| i == 1).unwrap();
+        let bucket_pos = sorted.iter().position(|&i| i == 0).unwrap();
+        assert!(
+            role_pos < bucket_pos,
+            "role Replace must come before bucket Replace; sorted={:?}",
+            sorted
         );
     }
 }

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -255,33 +255,30 @@ pub(in crate::parser) fn extract_directives(
                     let mut names = Vec::with_capacity(items.len());
                     for item in items {
                         match item {
+                            Value::BindingRef { binding } => {
+                                // Bare binding identifier — the canonical
+                                // shape after #2847.
+                                names.push(binding.clone());
+                            }
                             Value::ResourceRef { path } => {
-                                // `a.b` and longer paths are rejected: only bare
-                                // binding identifiers are accepted in MVP. Bare
-                                // identifiers parse as `Value::String` (see
-                                // primary.rs `Rule::variable_ref` with no access
-                                // chain), so a `ResourceRef` here means the user
-                                // wrote `binding.attr`.
-                                if path.attribute().is_empty() && path.field_path().is_empty() {
-                                    names.push(path.binding().to_string());
-                                } else {
-                                    return Err(ParseError::InvalidExpression {
-                                        line: 0,
-                                        message: format!(
-                                            "directives.depends_on: list elements must be \
-                                             bare binding identifiers, not attribute \
-                                             selectors (got `{}`)",
-                                            path.binding()
-                                        ),
-                                    });
-                                }
+                                // `binding.attr` — attribute selectors are
+                                // rejected in MVP (only bare bindings allowed).
+                                return Err(ParseError::InvalidExpression {
+                                    line: 0,
+                                    message: format!(
+                                        "directives.depends_on: list elements must be \
+                                         bare binding identifiers, not attribute \
+                                         selectors (got `{}`)",
+                                        path.binding()
+                                    ),
+                                });
                             }
                             Value::String(name) => {
-                                // Bindings resolve to the indirection marker
-                                // `${name}` (see
-                                // `parse_primary_with_resource_or_module`);
-                                // strip it. Quoted strings are rejected
-                                // upstream by
+                                // Pre-#2847 path: bindings resolved through the
+                                // `${name}` indirection marker. Strip it for
+                                // backwards-compat with any code path that
+                                // still produces this shape. Quoted strings
+                                // are rejected upstream by
                                 // `check_directives_depends_on_elements`.
                                 let bare = name
                                     .strip_prefix("${")


### PR DESCRIPTION
## Summary

`phased.rs::has_interdependent_replaces` and `topological_sort_replaces` were reading `to.dependency_bindings` directly, which is the value-reference snapshot only — `directives.depends_on` is intentionally kept out of that field so the validation pass can detect redundant edges (#2823).

Result: two `Replace` effects whose only ordering came from `directives.depends_on` could run in arbitrary order.

This PR switches both functions to `get_resource_dependencies(to)` so explicit ordering edges participate in the inter-Replace topological sort. The "unioned-deps include depends_on" invariant is what `plan_tree`, the primary `sort_resources_by_dependencies`, and `DepResolver` already rely on.

Also adapts `extract_directives` to accept the new `Value::BindingRef` shape introduced by #2847 (bare binding identifiers in attribute lists became `BindingRef` instead of the `${name}` indirection marker; the merge race made my Phase 2 parser stale on main).

The `snapshot_depends_on` plan-display test gains the eighth `format_plan` argument (`prev_explicit: None`) added by another recent merge.

Closes #2875.

## Test plan

- [x] New test `topological_sort_replaces_respects_depends_on` (RED→GREEN): two Replaces with depends_on-only ordering, asserting role comes before bucket
- [x] `cargo nextest run --workspace` — 3118 tests pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All 5 `bash scripts/check-*.sh` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
