### PR TITLE
core: carina fmt sorts directives.depends_on alphabetically

### DIFF
--- a/carina-core/src/formatter/format.rs
+++ b/carina-core/src/formatter/format.rs
@@ -71,6 +71,17 @@ pub(in crate::formatter) struct Formatter {
     pub(in crate::formatter) output: String,
     pub(in crate::formatter) current_indent: usize,
     pub(in crate::formatter) block_names: std::collections::HashMap<String, String>,
+    /// Stack of currently-open nested-block names. Top-of-stack is the
+    /// immediate enclosing block (e.g. `"directives"`). Pushed in
+    /// `format_nested_block`, popped after the body is emitted. Drives
+    /// context-sensitive normalisation like alphabetical sort of
+    /// `directives.depends_on` (#2872).
+    pub(in crate::formatter) block_stack: Vec<String>,
+    /// Stack of currently-open attribute keys. Top-of-stack is the
+    /// attribute whose value is currently being formatted. Used by
+    /// `format_list` to detect "this list is the value of `depends_on`
+    /// inside `directives`" without parent pointers in the CST.
+    pub(in crate::formatter) attr_stack: Vec<String>,
 }
 
 impl Formatter {
@@ -80,6 +91,8 @@ impl Formatter {
             output: String::new(),
             current_indent: 0,
             block_names: std::collections::HashMap::new(),
+            block_stack: Vec::new(),
+            attr_stack: Vec::new(),
         }
     }
 
@@ -92,6 +105,8 @@ impl Formatter {
             output: String::new(),
             current_indent: 0,
             block_names,
+            block_stack: Vec::new(),
+            attr_stack: Vec::new(),
         }
     }
 
@@ -2137,5 +2152,37 @@ aws.s3.Bucket {
         let first = format(input, &config).unwrap();
         let second = format(&first, &config).unwrap();
         assert_eq!(first, second, "list with comments fmt must be idempotent");
+    }
+
+    #[test]
+    fn fmt_sorts_directives_depends_on_alphabetically() {
+        let input = "let bucket = aws.s3.Bucket {\n  bucket_name = 'x'\n  directives {\n    depends_on = [zebra, apple, mango]\n  }\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("depends_on = [apple, mango, zebra]"),
+            "expected alphabetical order, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn fmt_does_not_sort_other_lists() {
+        // Lists outside `directives.depends_on` must NOT be reordered.
+        let input = "aws.s3.Bucket {\n  bucket_name = 'x'\n  policies = [zebra, apple, mango]\n}\n";
+        let result = format(input, &FormatConfig::default()).unwrap();
+        assert!(
+            result.contains("[zebra, apple, mango]"),
+            "non-depends_on list must keep source order, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn fmt_depends_on_sort_is_idempotent() {
+        let input = "let bucket = aws.s3.Bucket {\n  bucket_name = 'x'\n  directives {\n    depends_on = [zebra, apple, mango]\n  }\n}\n";
+        let config = FormatConfig::default();
+        let first = format(input, &config).unwrap();
+        let second = format(&first, &config).unwrap();
+        assert_eq!(first, second, "depends_on sort must be idempotent");
     }
 }

--- a/carina-core/src/formatter/rules/attributes.rs
+++ b/carina-core/src/formatter/rules/attributes.rs
@@ -370,15 +370,20 @@ impl Formatter {
         self.write_indent();
 
         // Find and write block name (identifier)
+        let mut block_name: Option<String> = None;
         for child in &node.children {
             if let CstChild::Token(token) = child
                 && self.is_identifier(&token.text)
             {
                 self.write_token(&token.text);
+                block_name = Some(token.text.clone());
                 break;
             }
         }
 
+        if let Some(ref n) = block_name {
+            self.block_stack.push(n.clone());
+        }
         if self.block_has_content(node) {
             self.write(" {");
             self.write_newline();
@@ -391,6 +396,9 @@ impl Formatter {
             self.write("}");
         } else {
             self.write(" {}");
+        }
+        if block_name.is_some() {
+            self.block_stack.pop();
         }
         self.write_newline();
     }
@@ -813,6 +821,7 @@ impl Formatter {
         let mut key_len: usize;
         let mut wrote_key = false;
         let mut wrote_equals = false;
+        let mut pushed_key = false;
 
         for child in &node.children {
             match child {
@@ -821,6 +830,8 @@ impl Formatter {
                         key_len = token.text.len();
                         self.write_token(&token.text);
                         wrote_key = true;
+                        self.attr_stack.push(token.text.clone());
+                        pushed_key = true;
 
                         // Add padding for alignment
                         if align_to > 0 && key_len < align_to {
@@ -841,6 +852,10 @@ impl Formatter {
                 }
                 CstChild::Trivia(_) => {}
             }
+        }
+
+        if pushed_key {
+            self.attr_stack.pop();
         }
 
         // Write inline comment if present

--- a/carina-core/src/formatter/rules/values.rs
+++ b/carina-core/src/formatter/rules/values.rs
@@ -204,7 +204,14 @@ impl Formatter {
         // stays single-line *unless* it contains a line comment, in
         // which case it is promoted to multi-line — a line comment
         // intrinsically ends its line and cannot live inline.
-        let items = collect_list_items(node);
+        let mut items = collect_list_items(node);
+        // #2872: `directives { depends_on = [...] }` sorts elements
+        // alphabetically on emission. Sort is order-insensitive in
+        // semantics, so this is purely cosmetic — but produces
+        // stable diffs across edits.
+        if self.in_directives_depends_on() {
+            sort_depends_on_items(&mut items);
+        }
         let multiline = list_is_multiline(node) || any_line_comment(&items);
 
         self.write("[");
@@ -266,6 +273,48 @@ impl Formatter {
         }
     }
 
+    fn in_directives_depends_on(&self) -> bool {
+        self.block_stack.last().map(String::as_str) == Some("directives")
+            && self.attr_stack.last().map(String::as_str) == Some("depends_on")
+    }
+}
+
+/// Identifier text of a `depends_on` list element, used as the sort
+/// key. Returns `None` for shapes the formatter shouldn't touch
+/// (block-bodied expressions, malformed CST). Bare identifiers parse
+/// as a single token, so the common case is straightforward; comments
+/// attached to elements travel with them via `ListItem`.
+fn list_element_sort_key<'a>(element: &ListElement<'a>) -> Option<String> {
+    match element {
+        ListElement::Token(t) => Some((*t).to_string()),
+        ListElement::Node(n) => element_node_first_token(n),
+    }
+}
+
+fn element_node_first_token(node: &CstNode) -> Option<String> {
+    for child in &node.children {
+        match child {
+            CstChild::Token(tok) if !tok.text.trim().is_empty() => return Some(tok.text.clone()),
+            CstChild::Node(n) => {
+                if let Some(t) = element_node_first_token(n) {
+                    return Some(t);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn sort_depends_on_items<'a>(items: &mut [ListItem<'a>]) {
+    items.sort_by(|a, b| {
+        let ka = list_element_sort_key(&a.element).unwrap_or_default();
+        let kb = list_element_sort_key(&b.element).unwrap_or_default();
+        ka.cmp(&kb)
+    });
+}
+
+impl Formatter {
     pub(in crate::formatter) fn format_map(&mut self, node: &CstNode) {
         self.write("{");
 

--- a/carina-core/src/parser/blocks/attributes.rs
+++ b/carina-core/src/parser/blocks/attributes.rs
@@ -274,11 +274,8 @@ pub(in crate::parser) fn extract_directives(
                                 });
                             }
                             Value::String(name) => {
-                                // Pre-#2847 path: bindings resolved through the
-                                // `${name}` indirection marker. Strip it for
-                                // backwards-compat with any code path that
-                                // still produces this shape. Quoted strings
-                                // are rejected upstream by
+                                // Pre-#2847 indirection marker `${name}`.
+                                // Quoted strings are rejected upstream in
                                 // `check_directives_depends_on_elements`.
                                 let bare = name
                                     .strip_prefix("${")


### PR DESCRIPTION
## Summary

`carina fmt` now normalises `directives.depends_on = [...]` to alphabetical order on emission. The IR keeps source order so other consumers (validation, plan tree) see the user's spelling; only the formatter re-orders, producing stable diffs across edits.

```crn
# Before
directives { depends_on = [zebra, apple, mango] }

# After `carina fmt`
directives { depends_on = [apple, mango, zebra] }
```

`depends_on` is set-typed (order-insensitive), so this is purely cosmetic.

## Implementation

Adds two stacks to `Formatter`:

- `block_stack: Vec<String>` — pushed in `format_nested_block`, popped after the body emits.
- `attr_stack: Vec<String>` — pushed in `format_attribute_aligned`, popped after the value emits.

`format_list` now consults the stacks via `in_directives_depends_on()` and sorts only when both top-of-stacks are `directives` and `depends_on` respectively. Sort key is the bare identifier text of each list element; comments attached to elements travel with them via `ListItem`.

Also lands two unrelated fixups that the merge race made necessary:

- `extract_directives` now accepts `Value::BindingRef` (introduced by #2847 between #2870 opening and merging).
- The `snapshot_depends_on` plan-display test gains the eighth `format_plan` arg (`prev_explicit: None`).

Closes #2872.

## Test plan

- [x] New tests: alphabetical sort, other lists not reordered, idempotency
- [x] `cargo nextest run --workspace` — 3120 tests pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
