### PR TITLE
lsp: completion for directives block keys and depends_on list elements

### DIFF
--- a/carina-lsp/src/completion/mod.rs
+++ b/carina-lsp/src/completion/mod.rs
@@ -168,6 +168,14 @@ impl CompletionProvider {
                 current_binding.as_deref(),
                 base_path,
             ),
+            CompletionContext::InsideDirectivesBlock => self.directives_block_completions(),
+            CompletionContext::InsideDirectivesDependsOnList { current_binding } => self
+                .directives_depends_on_completions(
+                    &text,
+                    current_binding.as_deref(),
+                    position,
+                    base_path,
+                ),
             CompletionContext::InsideProviderBlock { .. } => self.provider_block_completions(),
             CompletionContext::AfterProviderRegion { provider_name } => {
                 self.region_completions_for_provider(&provider_name)
@@ -444,6 +452,30 @@ impl CompletionProvider {
                 if !after_colon.contains('=') && !after_colon.contains('{') {
                     return CompletionContext::InTypePosition;
                 }
+            }
+        }
+
+        // `directives { ... }` is the meta-arg block, not a struct
+        // attribute — short-circuit before the struct router runs (#2873).
+        if !nested_block_names.is_empty()
+            && nested_block_names.last().map(String::as_str) == Some("directives")
+            && brace_depth >= 2
+        {
+            // Cursor inside `depends_on = [...]` → list-element completion.
+            if let Some(after_eq) = prefix.split('=').next_back()
+                && let Some(open) = after_eq.rfind('[')
+                && !after_eq[open..].contains(']')
+            {
+                let attr_name = self.extract_attr_name(&prefix);
+                if attr_name == "depends_on" {
+                    return CompletionContext::InsideDirectivesDependsOnList {
+                        current_binding: current_binding.clone(),
+                    };
+                }
+            }
+            // Cursor at attribute-name position inside `directives { | }`.
+            if !prefix.contains('=') || prefix.trim_end().ends_with('{') {
+                return CompletionContext::InsideDirectivesBlock;
             }
         }
 
@@ -850,6 +882,16 @@ enum CompletionContext {
         provider_name: String,
     },
     InTypePosition,
+    /// Cursor is at attribute-name position inside `directives { | }`
+    /// (#2873). Suggests the four directive keys: `force_delete`,
+    /// `create_before_destroy`, `prevent_destroy`, `depends_on`.
+    InsideDirectivesBlock,
+    /// Cursor is inside `directives { depends_on = [|] }` (#2873).
+    /// Suggests sibling resource / wait / module bindings, excluding
+    /// the enclosing binding name and any names already in the list.
+    InsideDirectivesDependsOnList {
+        current_binding: Option<String>,
+    },
     InsideImportPath {
         partial_path: String,
     },

--- a/carina-lsp/src/completion/tests/basic.rs
+++ b/carina-lsp/src/completion/tests/basic.rs
@@ -2393,3 +2393,83 @@ let rd = registry_deploy {
         "String-typed arg should offer string-returning built-ins like `join`, got: {labels:?}"
     );
 }
+
+#[test]
+fn directives_block_completion_includes_all_four_keys() {
+    let provider = test_provider_single_attr();
+    let doc = create_document("test.foo.bar {\n  attr = \"x\"\n  directives {\n    \n  }\n}\n");
+    // Cursor inside directives block, line 3, char 4
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 3,
+            character: 4,
+        },
+        None,
+    );
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    for key in [
+        "force_delete",
+        "create_before_destroy",
+        "prevent_destroy",
+        "depends_on",
+    ] {
+        assert!(
+            labels.contains(&key),
+            "directives block completion missing `{key}`; got {labels:?}"
+        );
+    }
+}
+
+#[test]
+fn directives_depends_on_completion_lists_resource_bindings() {
+    let provider = test_provider_single_attr();
+    let doc = create_document(
+        "let role = test.foo.bar {\n  attr = \"r\"\n}\nlet bucket = test.foo.bar {\n  attr = \"x\"\n  directives {\n    depends_on = []\n  }\n}\n",
+    );
+    // Cursor between `[` and `]` on line 6, char 18
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 6,
+            character: 18,
+        },
+        None,
+    );
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"role"),
+        "depends_on list completion missing `role`; got {labels:?}"
+    );
+    // self-reference suppression
+    assert!(
+        !labels.contains(&"bucket"),
+        "depends_on list completion must not include enclosing binding `bucket`; got {labels:?}"
+    );
+}
+
+#[test]
+fn directives_depends_on_completion_excludes_already_listed_names() {
+    let provider = test_provider_single_attr();
+    let doc = create_document(
+        "let role = test.foo.bar {\n  attr = \"r\"\n}\nlet kms = test.foo.bar {\n  attr = \"k\"\n}\nlet bucket = test.foo.bar {\n  attr = \"x\"\n  directives {\n    depends_on = [role, ]\n  }\n}\n",
+    );
+    // Cursor right after the comma+space inside the list
+    let completions = provider.complete(
+        &doc,
+        Position {
+            line: 9,
+            character: 24,
+        },
+        None,
+    );
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        !labels.contains(&"role"),
+        "already-listed `role` must not be re-suggested; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"kms"),
+        "kms binding should still be suggested; got {labels:?}"
+    );
+}

--- a/carina-lsp/src/completion/values.rs
+++ b/carina-lsp/src/completion/values.rs
@@ -623,6 +623,125 @@ impl CompletionProvider {
         }
     }
 
+    /// Attribute-name candidates for `directives { | }` (#2873). The
+    /// four directives — `force_delete`, `create_before_destroy`,
+    /// `prevent_destroy`, `depends_on` — exhaustively. Order is
+    /// alphabetical to match `KEYWORDS` ordering in `keywords.rs`.
+    pub(super) fn directives_block_completions(&self) -> Vec<CompletionItem> {
+        let trigger_suggest = Command {
+            title: "Trigger Suggest".to_string(),
+            command: "editor.action.triggerSuggest".to_string(),
+            arguments: None,
+        };
+        vec![
+            CompletionItem {
+                label: "create_before_destroy".to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some(
+                    "Create the replacement before destroying the old resource".to_string(),
+                ),
+                insert_text: Some("create_before_destroy = ".to_string()),
+                command: Some(trigger_suggest.clone()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "depends_on".to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some("Explicit ordering edges to sibling let bindings".to_string()),
+                insert_text: Some("depends_on = [$0]".to_string()),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                command: Some(trigger_suggest.clone()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "force_delete".to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some("Force-delete the resource (e.g., non-empty S3 buckets)".to_string()),
+                insert_text: Some("force_delete = ".to_string()),
+                command: Some(trigger_suggest.clone()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "prevent_destroy".to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some("Block any plan that would destroy this resource".to_string()),
+                insert_text: Some("prevent_destroy = ".to_string()),
+                command: Some(trigger_suggest),
+                ..Default::default()
+            },
+        ]
+    }
+
+    /// Element candidates for `directives { depends_on = [|] }`
+    /// (#2873). Suggests every in-scope `let` binding that names a
+    /// resource (managed) or module call. Excludes:
+    ///   - data source bindings (rejected by `validate_depends_on`)
+    ///   - upstream_state bindings (rejected by `validate_depends_on`)
+    ///   - the enclosing binding (self-reference is an error)
+    ///   - names already present in the list before the cursor
+    pub(super) fn directives_depends_on_completions(
+        &self,
+        text: &str,
+        current_binding: Option<&str>,
+        position: Position,
+        base_path: Option<&Path>,
+    ) -> Vec<CompletionItem> {
+        let already_present = self.depends_on_elements_before_cursor(text, position);
+
+        let mut src_buf = String::new();
+        let src = DslSource::resolve_directory(text, base_path, &mut src_buf);
+        let raw = self.in_scope_binding_completions_with_src(
+            src,
+            InScopeBindingMode::ValuePosition { current_binding },
+        );
+
+        // `in_scope_binding_completions_with_src` returns every in-scope
+        // binding (resources, modules, upstream_state, arguments). For
+        // depends_on we drop upstream_state via the `detail` text — the
+        // helper sets `detail = "upstream_state binding"` for those.
+        // Same for arguments (not let-bound resources).
+        raw.into_iter()
+            .filter(|item| {
+                let detail = item.detail.as_deref().unwrap_or("");
+                if detail.contains("upstream_state") || detail.contains("argument") {
+                    return false;
+                }
+                !already_present.contains(&item.label)
+            })
+            .collect()
+    }
+
+    /// Parse `depends_on = [<elements...><cursor>` from `text`,
+    /// returning bare identifier names already typed before the
+    /// cursor. Used to suppress duplicates in
+    /// `directives_depends_on_completions`.
+    fn depends_on_elements_before_cursor(
+        &self,
+        text: &str,
+        position: Position,
+    ) -> std::collections::HashSet<String> {
+        let mut out = std::collections::HashSet::new();
+        let lines: Vec<&str> = text.lines().collect();
+        let line_idx = position.line as usize;
+        if line_idx >= lines.len() {
+            return out;
+        }
+        let line = lines[line_idx];
+        let col = position.character as usize;
+        let prefix_chars: String = line.chars().take(col).collect();
+        let Some(open) = prefix_chars.rfind('[') else {
+            return out;
+        };
+        let inner = &prefix_chars[open + 1..];
+        for raw in inner.split(',') {
+            let name = raw.trim();
+            if !name.is_empty() && name.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                out.insert(name.to_string());
+            }
+        }
+        out
+    }
+
     pub(super) fn provider_block_completions(&self) -> Vec<CompletionItem> {
         let trigger_suggest = Command {
             title: "Trigger Suggest".to_string(),


### PR DESCRIPTION
## Summary

Adds two LSP completion contexts for the `directives` meta-arg block:

- **Inside `directives { | }`** — suggests `force_delete`, `create_before_destroy`, `prevent_destroy`, `depends_on`
- **Inside `directives { depends_on = [|] }`** — suggests every in-scope `let` binding with three filters:
  - **Self-reference** (the enclosing binding) is excluded
  - **upstream_state** and **arguments** bindings are excluded (rejected by `validate_depends_on`)
  - Names already typed before the cursor in the list are not re-suggested

## Implementation

Two new `CompletionContext` variants — `InsideDirectivesBlock` and `InsideDirectivesDependsOnList { current_binding }` — detected before the generic struct router via the existing `nested_block_names` stack. When the topmost nested block is `directives` and `brace_depth >= 2`, the cursor routes to the new variants instead of falling through to `InsideStructBlock`/`AfterEqualsInStruct`.

- `directives_block_completions()` returns the four hardcoded keys with appropriate snippets (`depends_on = [$0]` drops the cursor inside the brackets; others use `=` + trigger-suggest).
- `directives_depends_on_completions()` reuses `in_scope_binding_completions_with_src` for binding discovery (cross-`.crn` aware via `DslSource::resolve_directory`), then filters by detail text and a small `[<elements>]` parser that walks back from the cursor to suppress already-listed names.

Closes #2873.

## Test plan

- [x] `directives_block_completion_includes_all_four_keys`
- [x] `directives_depends_on_completion_lists_resource_bindings` (covers self-reference suppression)
- [x] `directives_depends_on_completion_excludes_already_listed_names`
- [x] `cargo nextest run --workspace` — 3121 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
