### PR TITLE
core: Effect.explicit_dependencies accessor + Delete-stored field

### DIFF
--- a/carina-cli/src/commands/destroy.rs
+++ b/carina-cli/src/commands/destroy.rs
@@ -324,12 +324,14 @@ async fn run_destroy_locked(
             .and_then(|s| s.identifier.clone())
             .unwrap_or_default();
         let dependencies = get_resource_dependencies(resource);
+        let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
         destroy_plan.add(Effect::Delete {
             id: resource.id.clone(),
             identifier,
             directives: resource.directives.clone(),
             binding: resource.binding.clone(),
             dependencies,
+            explicit_dependencies,
         });
     }
 
@@ -474,12 +476,14 @@ async fn run_destroy_locked(
                 .and_then(|s| s.identifier.clone())
                 .unwrap_or_default();
             let dependencies = get_resource_dependencies(resource);
+            let explicit_dependencies = resource.directives.depends_on.iter().cloned().collect();
             let effect = Effect::Delete {
                 id: resource.id.clone(),
                 identifier: identifier.clone(),
                 directives: resource.directives.clone(),
                 binding: resource.binding.clone(),
                 dependencies,
+                explicit_dependencies,
             };
             let binding = resource.binding.clone().unwrap_or_else(|| {
                 format!("{}:{}", resource.id.resource_type, resource.id.name_str())

--- a/carina-cli/src/display/tests.rs
+++ b/carina-cli/src/display/tests.rs
@@ -1082,6 +1082,7 @@ fn test_mixed_plan_tree_with_delete_effect() {
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]),
+        explicit_dependencies: std::collections::HashSet::new(),
     };
 
     let mut plan = Plan::new();
@@ -1225,6 +1226,7 @@ fn format_effect_delete_uses_binding_name() {
         directives: Directives::default(),
         binding: Some("my_vpc".to_string()),
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     };
     assert_eq!(format_effect(&effect), "Delete awscc.ec2.Vpc my_vpc");
 }
@@ -1237,6 +1239,7 @@ fn format_effect_delete_falls_back_to_id_name() {
         directives: Directives::default(),
         binding: None,
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     };
     assert_eq!(
         format_effect(&effect),

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -268,6 +268,7 @@ fn plan_file_serde_round_trip() {
         directives: Directives::default(),
         binding: None,
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     let sorted_resources = vec![

--- a/carina-core/src/deps.rs
+++ b/carina-core/src/deps.rs
@@ -474,6 +474,7 @@ mod tests {
             directives: Directives::default(),
             binding: None,
             dependencies: HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
 
         let mut failed = HashSet::new();

--- a/carina-core/src/detail_rows.rs
+++ b/carina-core/src/detail_rows.rs
@@ -1393,6 +1393,7 @@ mod tests {
             directives: crate::resource::Directives::default(),
             binding: None,
             dependencies: HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         let mut delete_attrs: HashMap<ResourceId, HashMap<String, Value>> = HashMap::new();
         delete_attrs.insert(
@@ -1521,6 +1522,7 @@ mod tests {
             directives: crate::resource::Directives::default(),
             binding: None,
             dependencies: HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         let mut tags = IndexMap::new();
         tags.insert("Name".to_string(), Value::String("test".to_string()));

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -298,12 +298,15 @@ pub fn create_plan(
                 let directives = resource.directives.clone();
                 let binding = resource.binding.clone();
                 let dependencies = get_resource_dependencies(resource);
+                let explicit_dependencies =
+                    resource.directives.depends_on.iter().cloned().collect();
                 plan.add(Effect::Delete {
                     id,
                     identifier,
                     directives,
                     binding,
                     dependencies,
+                    explicit_dependencies,
                 });
             }
         }
@@ -356,6 +359,11 @@ pub fn create_plan(
                 directives,
                 binding,
                 dependencies,
+                // Orphan deletes have no source `directives.depends_on`;
+                // the resource is gone from desired state. Carrying an
+                // empty set here is correct and serde-stable for
+                // pre-#2871 state files.
+                explicit_dependencies: std::collections::HashSet::new(),
             });
         }
     }

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -88,9 +88,18 @@ pub enum Effect {
         /// The binding name of the deleted resource (for plan tree display)
         #[serde(default)]
         binding: Option<String>,
-        /// Binding names this resource depended on (for plan tree display)
+        /// Binding names this resource depended on (for plan tree display).
+        /// Includes both value-reference and explicit `directives.depends_on`
+        /// edges — the union the executor needs for ordering.
         #[serde(default)]
         dependencies: HashSet<String>,
+        /// Subset of `dependencies` that came from
+        /// `directives { depends_on = [...] }` rather than value
+        /// references. Captured at Delete construction time because the
+        /// originating Resource is gone by the time the executor runs
+        /// (#2871). Empty for legacy state files.
+        #[serde(default)]
+        explicit_dependencies: HashSet<String>,
     },
 
     /// Import an existing resource into state (via provider read)
@@ -180,6 +189,33 @@ impl Effect {
         }
         self.resource().and_then(|r| r.binding.clone())
     }
+
+    /// Returns the binding names this effect depends on **via explicit
+    /// `directives { depends_on = [...] }` declarations**, as a snapshot
+    /// (cloned).
+    ///
+    /// For variants carrying a `Resource` (Create, Update, Replace,
+    /// Read), the answer is derived live from
+    /// `resource.directives.depends_on`. For Delete the answer comes
+    /// from a stored `explicit_dependencies` set captured by the differ
+    /// at construction time, because the originating Resource is gone
+    /// by the time the executor runs (#2871).
+    ///
+    /// State-only effects (Import, Remove, Move) return an empty set —
+    /// they are scheduling primitives, not resource-state operations.
+    pub fn explicit_dependencies(&self) -> HashSet<String> {
+        if let Some(res) = self.resource() {
+            return res.directives.depends_on.iter().cloned().collect();
+        }
+        if let Effect::Delete {
+            explicit_dependencies,
+            ..
+        } = self
+        {
+            return explicit_dependencies.clone();
+        }
+        HashSet::new()
+    }
 }
 
 #[cfg(test)]
@@ -224,6 +260,7 @@ mod tests {
             directives: Directives::default(),
             binding: None,
             dependencies: HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         assert!(effect.resource().is_none());
     }
@@ -290,6 +327,7 @@ mod tests {
                 directives: Directives::default(),
                 binding: None,
                 dependencies: HashSet::new(),
+                explicit_dependencies: std::collections::HashSet::new(),
             },
         ];
 
@@ -297,6 +335,82 @@ mod tests {
             let json = serde_json::to_string(&effect).unwrap();
             let deserialized: Effect = serde_json::from_str(&json).unwrap();
             assert_eq!(effect, deserialized, "Round-trip failed for {:?}", effect);
+        }
+    }
+
+    #[test]
+    fn explicit_dependencies_derived_from_resource_directives() {
+        use crate::resource::Directives;
+        let mut bucket = Resource::new("s3.Bucket", "b");
+        bucket.directives = Directives {
+            depends_on: vec!["role".to_string(), "kms".to_string()],
+            ..Directives::default()
+        };
+        let create = Effect::Create(bucket.clone());
+        let got = create.explicit_dependencies();
+        assert!(got.contains("role") && got.contains("kms"), "got {:?}", got);
+    }
+
+    #[test]
+    fn explicit_dependencies_for_delete_uses_stored_set() {
+        let effect = Effect::Delete {
+            id: ResourceId::new("s3.Bucket", "b"),
+            identifier: "x".to_string(),
+            directives: Directives::default(),
+            binding: Some("bucket".to_string()),
+            dependencies: HashSet::from(["role".to_string(), "kms".to_string()]),
+            explicit_dependencies: HashSet::from(["role".to_string()]),
+        };
+        let got = effect.explicit_dependencies();
+        assert!(got.contains("role"));
+        assert!(!got.contains("kms"), "kms is value-ref-only; got {:?}", got);
+    }
+
+    #[test]
+    fn explicit_dependencies_empty_for_state_only_effects() {
+        let imp = Effect::Import {
+            id: ResourceId::new("s3.Bucket", "b"),
+            identifier: "x".to_string(),
+        };
+        let rem = Effect::Remove {
+            id: ResourceId::new("s3.Bucket", "b"),
+        };
+        let mov = Effect::Move {
+            from: ResourceId::new("s3.Bucket", "old"),
+            to: ResourceId::new("s3.Bucket", "new"),
+        };
+        for e in [imp, rem, mov] {
+            assert!(
+                e.explicit_dependencies().is_empty(),
+                "expected empty for state-only, got {:?}",
+                e.explicit_dependencies()
+            );
+        }
+    }
+
+    #[test]
+    fn delete_legacy_state_without_explicit_deps_deserialises_to_empty() {
+        // Pre-#2871 state files have no `explicit_dependencies` field.
+        // `#[serde(default)]` must populate it as an empty HashSet so
+        // round-tripping legacy state never fails.
+        let legacy = serde_json::json!({
+            "Delete": {
+                "id": {"provider": "aws", "resource_type": "s3.Bucket", "name": "b"},
+                "identifier": "x",
+                "directives": {},
+                "binding": null,
+                "dependencies": ["role"],
+            }
+        });
+        let effect: Effect = serde_json::from_value(legacy).unwrap();
+        if let Effect::Delete {
+            explicit_dependencies,
+            ..
+        } = &effect
+        {
+            assert!(explicit_dependencies.is_empty());
+        } else {
+            panic!("expected Delete, got {:?}", effect);
         }
     }
 }

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -265,6 +265,7 @@ async fn test_simple_delete() {
         directives: Directives::default(),
         binding: None,
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     provider.push_delete(Ok(()));
@@ -1033,6 +1034,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
         dependencies: HashSet::new(), // vpc has no deps
+        explicit_dependencies: HashSet::new(),
     });
     plan.add(Effect::Delete {
         id: ResourceId::new("ec2.Subnet", "my-subnet"),
@@ -1040,6 +1042,7 @@ fn test_build_dependency_levels_respects_delete_dependencies() {
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]), // subnet depends on vpc
+        explicit_dependencies: HashSet::new(),
     });
 
     let levels = build_dependency_levels(plan.effects(), &HashMap::new());
@@ -1157,6 +1160,7 @@ fn test_build_dependency_map_respects_delete_dependencies() {
         directives: Directives::default(),
         binding: Some("vpc".to_string()),
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
     plan.add(Effect::Delete {
         id: ResourceId::new("ec2.Subnet", "my-subnet"),
@@ -1164,6 +1168,7 @@ fn test_build_dependency_map_respects_delete_dependencies() {
         directives: Directives::default(),
         binding: Some("subnet".to_string()),
         dependencies: HashSet::from(["vpc".to_string()]),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     let deps = build_dependency_map(plan.effects(), &HashMap::new());
@@ -1386,6 +1391,7 @@ async fn test_delete_waits_for_replace_cbd_of_dependent() {
         directives: Default::default(),
         binding: Some("tgw_a".to_string()),
         dependencies: tgw_a_deps,
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     // attachment: Replace (CBD) — from depends on tgw_a
@@ -1475,6 +1481,7 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
         directives: Default::default(),
         binding: None,
         dependencies: tgw_a_deps,
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     // attachment: Replace (CBD)

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -418,6 +418,7 @@ mod tests {
             directives: crate::resource::Directives::default(),
             binding: None,
             dependencies: std::collections::HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         });
 
         let summary = plan.summary();
@@ -572,6 +573,7 @@ mod tests {
             directives: crate::resource::Directives::default(),
             binding: None,
             dependencies: std::collections::HashSet::new(),
+            explicit_dependencies: std::collections::HashSet::new(),
         });
 
         let json = serde_json::to_string(&plan).unwrap();

--- a/carina-core/src/value.rs
+++ b/carina-core/src/value.rs
@@ -720,12 +720,14 @@ pub fn redact_secrets_in_effect(
             directives,
             binding,
             dependencies,
+            explicit_dependencies,
         } => Effect::Delete {
             id: id.clone(),
             identifier: identifier.clone(),
             directives: directives.clone(),
             binding: binding.clone(),
             dependencies: dependencies.clone(),
+            explicit_dependencies: explicit_dependencies.clone(),
         },
         Effect::Import { id, identifier } => Effect::Import {
             id: id.clone(),

--- a/carina-tui/src/app/tests.rs
+++ b/carina-tui/src/app/tests.rs
@@ -20,6 +20,7 @@ fn app_from_plan_with_effects() {
         directives: Directives::default(),
         binding: None,
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
 
     let app = App::new(&plan, &SchemaRegistry::new());

--- a/carina-tui/src/tui_snapshot_tests.rs
+++ b/carina-tui/src/tui_snapshot_tests.rs
@@ -111,6 +111,7 @@ fn build_mixed_operations_plan() -> Plan {
         directives: Directives::default(),
         binding: Some("old_subnet".to_string()),
         dependencies: HashSet::new(),
+        explicit_dependencies: std::collections::HashSet::new(),
     });
     plan
 }


### PR DESCRIPTION
## Summary

Adds `Effect::explicit_dependencies(&self) -> HashSet<String>` so plan-display and future UI code can identify which dependency edges came from an explicit `directives { depends_on = [...] }` declaration rather than a value reference.

## Storage shapes

- For variants carrying a `Resource` (Create / Update / Replace / Read), the answer is **derived live** from `resource.directives.depends_on` — no field added, no constructor sites changed. The Resource is the source of truth.
- For Delete, a new `explicit_dependencies: HashSet<String>` field is captured by the differ at construction time, because the originating Resource is gone by the time the executor runs. Tagged with `#[serde(default)]` so legacy state files without the field deserialise to an empty set (verified by test).

State-only effects (Import / Remove / Move) return an empty set — they are scheduling primitives, not resource-state operations.

## Why not the plan's struct-variant conversion

The original plan called for converting `Effect::Create(Resource)` to a struct variant `Effect::Create { resource, explicit_dependencies }`. That would churn ~120 call sites across the workspace (production, tests, snapshots) for a field that has **no current consumer** — `dependency_bindings` already carries the unioned set, and Phase 6+ of the parent issue (#2823) all read through that.

The accessor approach lets the future plan-tree UI labeling work move forward without locking in that big refactor today. If/when a consumer needs the field on `Create` for performance reasons (avoiding the live derive), the conversion can land as a separate refactor PR.

Closes #2871.

## Test plan

- [x] 4 new tests in `effect.rs::tests`:
  - `explicit_dependencies_derived_from_resource_directives` (Create variant)
  - `explicit_dependencies_for_delete_uses_stored_set` (subset of `dependencies`)
  - `explicit_dependencies_empty_for_state_only_effects` (Import / Remove / Move)
  - `delete_legacy_state_without_explicit_deps_deserialises_to_empty` (serde-default)
- [x] `cargo nextest run --workspace` — 3128 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
