### PR TITLE
site: fix dead /docs links to point at DSL syntax reference

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -10,7 +10,7 @@ const year = new Date().getFullYear();
       <span class="sep" aria-hidden="true">·</span>
       <a href="https://crates.io/crates/carina">crates.io</a>
       <span class="sep" aria-hidden="true">·</span>
-      <a href="/docs">Docs</a>
+      <a href="/reference/dsl/syntax/">Docs</a>
     </nav>
   </div>
 </footer>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -69,7 +69,7 @@ const planHtml = `<span class="prompt">$</span> carina plan
 
   <div class="hero-actions">
     <a href="/getting-started/installation/" class="hero-btn primary">Get Started</a>
-    <a href="/docs" class="hero-btn secondary">Documentation</a>
+    <a href="/reference/dsl/syntax/" class="hero-btn secondary">Documentation</a>
   </div>
 
   <div class="horizon-line cyan" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- The Hero "Documentation" button and the Footer "Docs" link both pointed at `/docs`, which never existed in the new `site/` tree — they were left over from the old `docs/` Starlight site.
- Repoint both at `/reference/dsl/syntax/` so the buttons work. DSL Syntax best matches the "Documentation" label; from there the sidebar leads to CLI / DSL / guides.

## Test plan
- [x] `cd site && npm run build` — 29 pages built clean.
- [ ] After merge, click both links on `https://carina-rs.dev/` and confirm they no longer 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)