### PR TITLE
site: collapse Topbar nav to single Reference link

### DIFF
--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -10,8 +10,7 @@
     </a>
 
     <nav class="topbar-nav" aria-label="Primary">
-      <a href="/getting-started/installation/">Docs</a>
-      <a href="/reference/">Reference</a>
+      <a href="/reference/dsl/syntax/">Reference</a>
       <a href="https://github.com/carina-rs/carina" class="external">GitHub →</a>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- Topbar had "Docs" -> `/getting-started/installation/` and "Reference" -> `/reference/`. The latter 404s (no `/reference/` index in the new site), and the former duplicated the Hero "Get Started" button.
- Drop "Docs" from the Topbar and retarget "Reference" at `/reference/dsl/syntax/`.

After this:

| Place | Label | Target |
|---|---|---|
| Topbar | Reference | `/reference/dsl/syntax/` |
| Hero | Get Started | `/getting-started/installation/` |
| Hero | Documentation | `/reference/dsl/syntax/` |
| Footer | Docs | `/reference/dsl/syntax/` |

Every link works and each surface has one entry per role.

## Test plan
- [x] `cd site && npm run build` — 29 pages built clean.
- [ ] After merge, click each header / hero / footer link on `https://carina-rs.dev/` and confirm none 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)