### PR TITLE
ci: rename deploy secret reference to SITE_DEPLOY_TOKEN

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,5 +36,5 @@ jobs:
           external_repository: carina-rs/carina-rs.github.io
           publish_branch: main
           publish_dir: ./site/dist
-          personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          personal_token: ${{ secrets.SITE_DEPLOY_TOKEN }}
           cname: carina-rs.dev


### PR DESCRIPTION
## Summary
- The Pages deploy workflow's secret was named `DOCS_DEPLOY_TOKEN`, matching the old `docs/` tree. After the docs/ → site/ swap, the name is misleading.
- Switch the reference to `SITE_DEPLOY_TOKEN`. The matching repo secret is already registered with a fresh PAT, so deploys resume on merge.

## Background
The previous `DOCS_DEPLOY_TOKEN` PAT was tied to a token shared with `DOCS_PR_TOKEN` (used by the now-removed provider auto-update workflows). Revoking that PAT killed Pages deploys for #2960 / #2961. This PR re-points the workflow at the new `SITE_DEPLOY_TOKEN` secret.

## Test plan
- [x] `gh secret list` shows `SITE_DEPLOY_TOKEN` registered.
- [ ] After merge, the `Deploy Site` workflow runs, builds `site/dist`, and pushes to `carina-rs/carina-rs.github.io` successfully.
- [ ] Confirm the previously stalled changes (#2960 / #2961) reach `carina-rs.dev`.

## Follow-up
- After this lands and the deploy works, delete `DOCS_DEPLOY_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
