### PR TITLE
core: wait construct Phase 4+5 — differ emits Effect::Wait + executor polls (#2825)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ plan-default-tags:
 	$(PLAN_FIXTURE) default_tags
 plan-depends-on:
 	$(PLAN_FIXTURE) depends_on
+plan-wait-cert:
+	$(PLAN_FIXTURE) wait_cert
 plan-secret-values:
 	$(PLAN_FIXTURE) secret_values
 plan-moved-with-changes:

--- a/carina-cli/src/commands/apply/mod.rs
+++ b/carina-cli/src/commands/apply/mod.rs
@@ -986,6 +986,7 @@ async fn run_apply_locked(
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
+        &parsed.wait_bindings,
     );
 
     // Populate cascading updates for create_before_destroy Replace effects.

--- a/carina-cli/src/fixture_plan.rs
+++ b/carina-cli/src/fixture_plan.rs
@@ -211,6 +211,7 @@ pub fn build_plan_from_fixture_path(fixture_path: &Path) -> FixturePlan {
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
+        &parsed.wait_bindings,
     );
 
     cascade_dependent_updates(

--- a/carina-cli/src/plan_snapshot_tests.rs
+++ b/carina-cli/src/plan_snapshot_tests.rs
@@ -65,6 +65,31 @@ fn snapshot_depends_on() {
     insta::assert_snapshot!(output);
 }
 
+/// Plan-display gate for the `wait` construct (carina#2825). The
+/// fixture wires ACM Certificate → Route53 validation record → wait
+/// (blocking on `cert.status == ISSUED`). The snapshot pins:
+/// - the `> cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)`
+///   line format (one-character marker `>`, predicate surface form
+///   echoed verbatim from the user source),
+/// - that wait effects are placed in the tree as children of their
+///   target (`cert`) — the tree shape is wired in
+///   `plan_tree::build_dependency_graph`.
+#[test]
+fn snapshot_wait_cert() {
+    let (plan, schemas, _moved) = build_plan_from_fixture("wait_cert");
+    let output = strip_ansi(&format_plan(
+        &plan,
+        DetailLevel::Full,
+        &HashMap::new(),
+        Some(&schemas),
+        &HashMap::new(),
+        &[],
+        &[],
+        None,
+    ));
+    insta::assert_snapshot!(output);
+}
+
 #[test]
 fn snapshot_all_create() {
     let (plan, schemas, _moved) = build_plan_from_fixture("all_create");

--- a/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_wait_cert.snap
+++ b/carina-cli/src/snapshots/carina_cli__plan_snapshot_tests__snapshot_wait_cert.snap
@@ -1,0 +1,19 @@
+---
+source: carina-cli/src/plan_snapshot_tests.rs
+expression: output
+---
+Execution Plan:
+
+  + aws.acm.Certificate cert
+      domain_name: "registry.example.com"
+      validation_method: "DNS"
+        │
+        └─ > cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)
+  + aws.route53.RecordSet validation_record
+      hosted_zone_id: "Z123"
+      name: "_acme.registry.example.com"
+      resource_records: ["validation.example.com"]
+      ttl: 60
+      type: "CNAME"
+
+Plan: 2 to add, 0 to change, 0 to destroy.

--- a/carina-cli/src/tests.rs
+++ b/carina-cli/src/tests.rs
@@ -1272,6 +1272,7 @@ fn orphaned_state_resource_produces_delete_effect() {
         &saved_attrs,
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     // The plan should contain a Delete effect for "removed-bucket"
@@ -2183,6 +2184,7 @@ fn orphaned_resource_deleted_externally_should_not_produce_delete_effect() {
         &saved_attrs,
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     let delete_effects: Vec<_> = plan
@@ -2265,6 +2267,7 @@ fn refresh_false_uses_cached_state_from_state_file() {
         &saved_attrs,
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     // No changes expected since desired matches cached state
@@ -2311,6 +2314,7 @@ fn refresh_false_includes_orphaned_resources_from_state_file() {
         &saved_attrs,
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     // With refresh=false, orphaned resources are assumed to still exist,
@@ -2355,6 +2359,7 @@ fn refresh_false_without_state_file_treats_resources_as_new() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     let create_effects: Vec<_> = plan

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -1360,6 +1360,7 @@ pub async fn create_plan_from_parsed_with_upstream<E>(
         &saved_attrs,
         &prev_explicit,
         &orphan_dependencies,
+        &parsed.wait_bindings,
     );
 
     // Populate cascading updates for Replace effects with create_before_destroy.

--- a/carina-cli/src/wiring/tests.rs
+++ b/carina-cli/src/wiring/tests.rs
@@ -179,6 +179,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &saved_attrs,
         &prev_explicit,
         &orphan_deps,
+        &[],
     );
     assert!(
         !plan_without.is_empty(),
@@ -196,6 +197,7 @@ fn test_normalize_state_prevents_false_enum_diff() {
         &saved_attrs,
         &prev_explicit,
         &orphan_deps,
+        &[],
     );
     assert!(
         plan_with.is_empty(),
@@ -283,6 +285,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &saved_attrs,
         &prev_explicit,
         &orphan_deps,
+        &[],
     );
     assert!(
         !plan_without.is_empty(),
@@ -311,6 +314,7 @@ fn test_merge_default_tags_prevents_false_diff() {
         &saved_attrs,
         &prev_explicit,
         &orphan_deps,
+        &[],
     );
     assert!(
         plan_with.is_empty(),

--- a/carina-cli/tests/fixtures/plan_display/wait_cert/main.crn
+++ b/carina-cli/tests/fixtures/plan_display/wait_cert/main.crn
@@ -1,0 +1,26 @@
+# Plan-display fixture exercising the `wait` construct (carina#2825).
+# `cert_issued` blocks downstream resources until ACM marks the cert
+# ISSUED; the snapshot pins how plan tree renders the wait line.
+
+provider aws {
+    region = "us-east-1"
+}
+
+let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+
+let validation_record = aws.route53.RecordSet {
+    hosted_zone_id   = "Z123"
+    name             = "_acme.registry.example.com"
+    type             = "CNAME"
+    ttl              = 60
+    resource_records = ["validation.example.com"]
+}
+
+let cert_issued = wait cert {
+    until      = cert.status == aws.acm.Certificate.Status.Issued
+    depends_on = [validation_record]
+    timeout    = 75min
+}

--- a/carina-core/Cargo.toml
+++ b/carina-core/Cargo.toml
@@ -18,6 +18,7 @@ argon2 = "0.5"
 thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 indexmap = { version = "2", features = ["serde"] }
+tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/carina-core/src/differ/diff_tests.rs
+++ b/carina-core/src/differ/diff_tests.rs
@@ -73,6 +73,7 @@ fn create_plan_from_resources() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 2);
@@ -98,6 +99,7 @@ fn create_plan_with_read_only_resource() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should have 2 effects: Read for data source, Create for new bucket
@@ -178,6 +180,7 @@ fn create_plan_detects_orphaned_resources_for_deletion() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should have 1 effect: Delete for orphaned-bucket
@@ -224,6 +227,7 @@ fn read_only_resource_always_generates_read_effect() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should still have Read effect, not NoChange
@@ -292,6 +296,7 @@ fn replace_when_create_only_attr_changed() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -342,6 +347,7 @@ fn normal_update_when_non_create_only_attr_changed() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -403,6 +409,7 @@ fn replace_when_schema_force_replace() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -454,6 +461,7 @@ fn replace_when_mix_of_create_only_and_normal_attrs_changed() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -504,6 +512,7 @@ fn replace_carries_create_before_destroy_directives() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -598,6 +607,7 @@ fn replace_with_provider_prefixed_schema_key() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -866,6 +876,7 @@ fn orphan_delete_preserves_binding_and_dependencies() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     let delete_effects: Vec<_> = plan

--- a/carina-core/src/differ/plan.rs
+++ b/carina-core/src/differ/plan.rs
@@ -5,9 +5,13 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use crate::deps::get_resource_dependencies;
 use crate::effect::{CascadingUpdate, Effect, TemporaryName};
 use crate::identifier::generate_random_suffix;
+use crate::parser::WaitBinding;
 use crate::plan::{Plan, PlanError};
 use crate::resource::{Directives, Resource, ResourceId, ResourceKind, State, Value};
-use crate::schema::{ResourceSchema, SchemaKind, SchemaRegistry};
+use crate::schema::{
+    ResourceSchema, SchemaKind, SchemaRegistry, WAIT_DEFAULT_INTERVAL, WAIT_DEFAULT_TIMEOUT,
+};
+use crate::wait::predicate::{AttrPath, WaitPredicate};
 
 use super::{Diff, diff};
 
@@ -137,6 +141,7 @@ fn generate_temporary_name(
 /// the user never wrote, refs awscc#206) and to detect attribute
 /// removals: if a top-level key was previously in the user's desired
 /// state but is now absent, it means the user intentionally removed it.
+#[allow(clippy::too_many_arguments)]
 pub fn create_plan(
     desired: &[Resource],
     current_states: &HashMap<ResourceId, State>,
@@ -145,6 +150,7 @@ pub fn create_plan(
     saved_attrs: &HashMap<ResourceId, HashMap<String, Value>>,
     prev_explicit: &HashMap<ResourceId, crate::explicit::ExplicitFields>,
     orphan_dependencies: &HashMap<ResourceId, BTreeSet<String>>,
+    wait_bindings: &[WaitBinding],
 ) -> Plan {
     let mut plan = Plan::new();
 
@@ -366,6 +372,68 @@ pub fn create_plan(
                 explicit_dependencies: std::collections::HashSet::new(),
             });
         }
+    }
+
+    // Lower each `wait` declaration into an `Effect::Wait`.
+    //
+    // Target resolution: the parser has already pinned the target name;
+    // here we look it up in `desired` (the live resource set after
+    // forward-ref resolution) to recover the resolved `ResourceId`. If
+    // the target is missing — typo, scoped-out binding, etc. — the
+    // wait is skipped with a plan-level error so downstream resources
+    // referencing the wait binding still fail loudly.
+    for wb in wait_bindings {
+        let resolved = desired
+            .iter()
+            .find(|r| r.binding.as_deref() == Some(wb.target.as_str()))
+            .or_else(|| desired.iter().find(|r| r.id.name.as_str() == wb.target));
+        let Some(target_resource) = resolved else {
+            plan.add_error(PlanError {
+                resource_id: ResourceId::new("__wait", &wb.binding),
+                message: format!(
+                    "wait `{}`: target binding `{}` is not a known resource",
+                    wb.binding, wb.target
+                ),
+            });
+            continue;
+        };
+        // `lhs_segments` is guaranteed non-empty and the first segment
+        // equals `wb.target` (enforced by `parse_wait_expr`). The
+        // predicate attribute path is therefore `lhs_segments[1..]`.
+        let attr = AttrPath {
+            segments: wb.until_predicate.lhs_segments[1..].to_vec(),
+        };
+        let until = WaitPredicate::Equals {
+            attr,
+            value: wb.until_predicate.rhs.clone(),
+        };
+        let target_id = target_resource.id.clone();
+        let target_identifier = current_states
+            .get(&target_id)
+            .and_then(|s| s.identifier.clone());
+        let schema = registry.get(
+            &target_id.provider,
+            &target_id.resource_type,
+            SchemaKind::Managed,
+        );
+        let schema_timeout = schema.and_then(|s| s.default_wait_timeout);
+        let schema_interval = schema.and_then(|s| s.default_wait_interval);
+        let timeout = wb
+            .timeout_secs
+            .map(std::time::Duration::from_secs)
+            .or(schema_timeout)
+            .unwrap_or(WAIT_DEFAULT_TIMEOUT);
+        let interval = schema_interval.unwrap_or(WAIT_DEFAULT_INTERVAL);
+        plan.add(Effect::Wait {
+            binding: wb.binding.clone(),
+            target_id,
+            target_identifier,
+            until,
+            until_surface: wb.until_raw.clone(),
+            timeout,
+            interval,
+            explicit_dependencies: wb.depends_on.iter().cloned().collect(),
+        });
     }
 
     plan

--- a/carina-core/src/differ/plan_tests.rs
+++ b/carina-core/src/differ/plan_tests.rs
@@ -60,6 +60,7 @@ fn create_before_destroy_generates_temporary_name_for_name_attribute() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -139,6 +140,7 @@ fn create_before_destroy_generates_temporary_name_with_can_rename() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -196,6 +198,7 @@ fn no_temporary_name_without_create_before_destroy() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -256,6 +259,7 @@ fn no_temporary_name_when_name_prefix_is_used() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -307,6 +311,7 @@ fn no_temporary_name_without_name_attribute_in_schema() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -365,6 +370,7 @@ fn no_temporary_name_when_name_attribute_changes() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -620,6 +626,7 @@ fn create_plan_detects_attribute_removal() {
         &HashMap::new(),
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -685,6 +692,7 @@ fn create_plan_filters_non_removable_attribute_removal() {
         &HashMap::new(),
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     assert_eq!(plan.effects().len(), 1);
@@ -750,6 +758,7 @@ fn create_plan_skips_update_when_only_non_removable_removal() {
         &HashMap::new(),
         &prev_explicit,
         &HashMap::new(),
+        &[],
     );
 
     assert!(
@@ -821,6 +830,7 @@ fn prevent_destroy_blocks_delete_for_orphaned_resource() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should have NO delete effects
@@ -882,6 +892,7 @@ fn prevent_destroy_blocks_replace() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should have NO replace effects
@@ -933,6 +944,7 @@ fn prevent_destroy_does_not_block_update() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should generate an Update effect (not blocked)
@@ -968,6 +980,7 @@ fn prevent_destroy_does_not_block_create() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should generate a Create effect (not blocked)
@@ -1007,6 +1020,7 @@ fn without_prevent_destroy_delete_works_normally() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Should generate a Delete effect
@@ -1068,6 +1082,7 @@ fn prevent_destroy_collects_multiple_errors() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     assert!(plan.effects().is_empty());
@@ -1104,6 +1119,7 @@ fn virtual_resources_are_skipped_in_plan() {
         &HashMap::new(),
         &HashMap::new(),
         &HashMap::new(),
+        &[],
     );
 
     // Only the real resource should generate an effect (Create)
@@ -1111,5 +1127,168 @@ fn virtual_resources_are_skipped_in_plan() {
     assert_eq!(
         plan.effects()[0].resource_id(),
         &ResourceId::new("ec2.SecurityGroup", "sg")
+    );
+}
+
+#[test]
+fn wait_binding_lowers_to_wait_effect() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let resources = vec![cert];
+
+    let wait = WaitBinding {
+        binding: "cert_issued".to_string(),
+        target: "cert".to_string(),
+        until_raw: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::String("aws.acm.Certificate.Status.Issued".to_string()),
+        },
+        timeout_secs: Some(75 * 60),
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+
+    let wait_effect = plan
+        .effects()
+        .iter()
+        .find(|e| matches!(e, Effect::Wait { .. }))
+        .expect("expected Wait effect");
+    let Effect::Wait {
+        binding,
+        target_id,
+        until,
+        until_surface,
+        timeout,
+        ..
+    } = wait_effect
+    else {
+        unreachable!();
+    };
+    assert_eq!(binding, "cert_issued");
+    assert_eq!(target_id.name.as_str(), "cert");
+    assert_eq!(target_id.resource_type, "acm.Certificate");
+    assert_eq!(
+        until,
+        &WaitPredicate::Equals {
+            attr: AttrPath {
+                segments: vec!["status".to_string()],
+            },
+            value: Value::String("aws.acm.Certificate.Status.Issued".to_string()),
+        }
+    );
+    assert_eq!(*timeout, std::time::Duration::from_secs(75 * 60));
+    assert_eq!(
+        until_surface,
+        "cert.status == aws.acm.Certificate.Status.Issued"
+    );
+}
+
+#[test]
+fn wait_uses_schema_default_timeout_when_omitted() {
+    use crate::effect::Effect;
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+    use crate::schema::{AttributeSchema, AttributeType, ResourceSchema};
+
+    let cert = Resource::new("acm.Certificate", "cert").with_binding("cert");
+    let resources = vec![cert];
+
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "",
+        ResourceSchema::new("acm.Certificate")
+            .attribute(AttributeSchema::new("status", AttributeType::String))
+            .with_default_wait_timeout(std::time::Duration::from_secs(99))
+            .with_default_wait_interval(std::time::Duration::from_secs(7)),
+    );
+
+    let wait = WaitBinding {
+        binding: "cert_issued".to_string(),
+        target: "cert".to_string(),
+        until_raw: "cert.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["cert".to_string(), "status".to_string()],
+            rhs: Value::String("ISSUED".to_string()),
+        },
+        timeout_secs: None,
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &HashMap::new(),
+        &HashMap::new(),
+        &schemas,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+    let Effect::Wait {
+        timeout, interval, ..
+    } = plan
+        .effects()
+        .iter()
+        .find(|e| matches!(e, Effect::Wait { .. }))
+        .expect("expected Wait effect")
+    else {
+        unreachable!();
+    };
+    assert_eq!(*timeout, std::time::Duration::from_secs(99));
+    assert_eq!(*interval, std::time::Duration::from_secs(7));
+}
+
+#[test]
+fn wait_with_unknown_target_emits_plan_error() {
+    use crate::parser::{UntilPredicateAst, WaitBinding};
+
+    let resources: Vec<Resource> = vec![];
+
+    let wait = WaitBinding {
+        binding: "cert_issued".to_string(),
+        target: "nonexistent".to_string(),
+        until_raw: "nonexistent.status == ISSUED".to_string(),
+        until_predicate: UntilPredicateAst {
+            lhs_segments: vec!["nonexistent".to_string(), "status".to_string()],
+            rhs: Value::String("ISSUED".to_string()),
+        },
+        timeout_secs: None,
+        depends_on: vec![],
+        line: 1,
+    };
+
+    let plan = create_plan(
+        &resources,
+        &HashMap::new(),
+        &HashMap::new(),
+        &SchemaRegistry::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &[wait],
+    );
+    assert!(
+        !plan.errors().is_empty(),
+        "missing-target wait should surface a plan error"
+    );
+    assert!(
+        plan.errors()[0].message.contains("nonexistent"),
+        "error message should mention the missing target, got: {}",
+        plan.errors()[0].message
     );
 }

--- a/carina-core/src/effect.rs
+++ b/carina-core/src/effect.rs
@@ -158,6 +158,13 @@ pub enum Effect {
         /// schema's default; not user-visible in MVP.
         #[serde(with = "crate::resource::duration_secs")]
         interval: std::time::Duration,
+        /// Additional bindings the wait must wait for before polling,
+        /// declared via `depends_on = [...]` in the wait block. The
+        /// scheduler treats these like `directives.depends_on` on a
+        /// resource — extra ordering edges that aren't expressed via
+        /// value references.
+        #[serde(default)]
+        explicit_dependencies: HashSet<String>,
     },
 }
 
@@ -250,6 +257,13 @@ impl Effect {
             return res.directives.depends_on.iter().cloned().collect();
         }
         if let Effect::Delete {
+            explicit_dependencies,
+            ..
+        } = self
+        {
+            return explicit_dependencies.clone();
+        }
+        if let Effect::Wait {
             explicit_dependencies,
             ..
         } = self
@@ -473,6 +487,7 @@ mod tests {
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(75 * 60),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
     }
 
@@ -493,6 +508,7 @@ mod tests {
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(60),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         assert_eq!(e.binding_name(), Some("cert_issued".to_string()));
     }
@@ -514,6 +530,7 @@ mod tests {
             until_surface: "cert.status == ISSUED".to_string(),
             timeout: Duration::from_secs(60),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         assert!(!e.is_mutating());
         assert_eq!(e.kind(), "wait");
@@ -536,6 +553,7 @@ mod tests {
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(4500),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         let json = serde_json::to_string(&original).expect("serialize");
         // Duration must round-trip as plain integer seconds (matches the

--- a/carina-core/src/executor/mod.rs
+++ b/carina-core/src/executor/mod.rs
@@ -15,6 +15,7 @@ mod basic;
 mod parallel;
 mod phased;
 mod replace;
+pub(crate) mod wait;
 
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;

--- a/carina-core/src/executor/parallel.rs
+++ b/carina-core/src/executor/parallel.rs
@@ -9,7 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use crate::deps::find_failed_dependency;
 use crate::effect::Effect;
 use crate::provider::Provider;
-use crate::resource::{Resource, ResourceId, State};
+use crate::resource::{Resource, ResourceId, State, Value};
 
 use super::basic::{
     ExecutionState, count_actionable_effects, execute_basic_effect, process_basic_result,
@@ -93,6 +93,35 @@ pub(super) fn build_dependency_map(
     }
     for (parent_idx, child_idx) in reverse_deps {
         deps_of.entry(parent_idx).or_default().insert(child_idx);
+    }
+
+    // Wait dependencies: each `Effect::Wait` depends on the effect that
+    // produces its target (Create / Update / Replace on `target_id`) so
+    // the wait does not start polling before the target has been
+    // created. Explicit `depends_on = [...]` entries from the wait
+    // block layer on top.
+    for (idx, effect) in effects.iter().enumerate() {
+        if let Effect::Wait { target_id, .. } = effect {
+            // Edge from the wait to its target's binding-effect (if
+            // present in the plan). The target may already exist (no
+            // Create effect in this plan) — then the wait is free to
+            // start immediately, which is what we want for refresh-only
+            // applies.
+            if let Some(target_binding) = lookup_idx(target_id.name_str()) {
+                deps_of.entry(idx).or_default().insert(target_binding);
+            }
+            // Honour `depends_on = [...]` declared in the wait block.
+            for dep_binding in effect.explicit_dependencies() {
+                if let Some(dep_idx) = lookup_idx(&dep_binding) {
+                    deps_of.entry(idx).or_default().insert(dep_idx);
+                }
+            }
+            // Defensive: ensure the wait has an entry even when it has
+            // no resolved deps (an isolated wait still needs to appear
+            // in deps_of so the scheduler's `&deps_of[&idx]` lookup
+            // doesn't panic).
+            deps_of.entry(idx).or_default();
+        }
     }
 
     deps_of
@@ -323,11 +352,61 @@ pub(super) async fn execute_effects_sequential(
                     Effect::Import { .. } | Effect::Remove { .. } | Effect::Move { .. } => {
                         SingleEffectResult::ReadNoOp
                     }
-                    // Wait effects are dispatched by a follow-up PR (Phase 4
-                    // of carina#2825). Until then, treat them as a planner
-                    // no-op so existing tests stay green; they will not be
-                    // produced by the differ in this PR.
-                    Effect::Wait { .. } => SingleEffectResult::ReadNoOp,
+                    Effect::Wait {
+                        binding,
+                        target_id,
+                        target_identifier,
+                        until,
+                        timeout,
+                        interval,
+                        ..
+                    } => {
+                        let c = completed_ref.fetch_add(1, Ordering::Relaxed) + 1;
+                        let started = Instant::now();
+                        observer.on_event(&ExecutionEvent::EffectStarted { effect });
+                        let progress = ProgressInfo {
+                            completed: c,
+                            total,
+                        };
+                        match super::wait::execute_wait_effect(
+                            provider,
+                            target_id,
+                            target_identifier.as_deref(),
+                            until,
+                            *timeout,
+                            *interval,
+                        )
+                        .await
+                        {
+                            Ok(state) => {
+                                observer.on_event(&ExecutionEvent::EffectSucceeded {
+                                    effect,
+                                    state: Some(&state),
+                                    duration: started.elapsed(),
+                                    progress,
+                                });
+                                SingleEffectResult::Wait {
+                                    success: true,
+                                    binding: binding.clone(),
+                                    target_state: Some(state),
+                                }
+                            }
+                            Err(e) => {
+                                let err_msg = e.to_string();
+                                observer.on_event(&ExecutionEvent::EffectFailed {
+                                    effect,
+                                    error: &err_msg,
+                                    duration: started.elapsed(),
+                                    progress,
+                                });
+                                SingleEffectResult::Wait {
+                                    success: false,
+                                    binding: binding.clone(),
+                                    target_state: None,
+                                }
+                            }
+                        }
+                    }
                 };
                 (idx, result)
             });
@@ -408,6 +487,37 @@ pub(super) async fn execute_effects_sequential(
                 }
             }
             SingleEffectResult::ReadNoOp => {}
+            SingleEffectResult::Wait {
+                success,
+                binding,
+                target_state,
+            } => {
+                if success {
+                    success_count += 1;
+                    if let Some(state) = target_state {
+                        // Register the captured target snapshot under the
+                        // wait's *synthetic* ResourceId so the downstream
+                        // resolution layer can deref `<binding>.<attr>` —
+                        // and under the binding name in `bindings` so
+                        // resolve_refs sees the same attribute map. Wait
+                        // effects do not persist to the state file
+                        // (handled by `state_writeback_should_skip`).
+                        let synthetic = ResourceId::new("__wait", &binding);
+                        let attrs: HashMap<String, Value> = state
+                            .attributes
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone()))
+                            .collect();
+                        input
+                            .bindings
+                            .record_applied(Some(&binding), &attrs, &state);
+                        applied_states.insert(synthetic, state);
+                    }
+                } else {
+                    failure_count += 1;
+                    failed_bindings.insert(binding);
+                }
+            }
         }
     }
 

--- a/carina-core/src/executor/replace.rs
+++ b/carina-core/src/executor/replace.rs
@@ -63,6 +63,15 @@ pub(super) enum SingleEffectResult {
         permanent_overrides: Option<(ResourceId, HashMap<String, String>)>,
     },
     ReadNoOp,
+    /// `Effect::Wait` execution outcome. On success carries the
+    /// captured target state so the parallel scheduler can register it
+    /// under the wait binding for downstream resolution. On failure
+    /// carries the wait binding so dependents can be marked failed.
+    Wait {
+        success: bool,
+        binding: String,
+        target_state: Option<State>,
+    },
 }
 
 /// Context for executing a Replace effect in the parallel path.

--- a/carina-core/src/executor/tests.rs
+++ b/carina-core/src/executor/tests.rs
@@ -1521,3 +1521,147 @@ async fn test_delete_waits_for_replace_cbd_even_when_delete_binding_is_none() {
     // tgw_a delete MUST still come after attachment replace, even though binding is None
     assert_eq!(calls[3], ("delete".to_string(), tgw_a_id.to_string()));
 }
+
+#[tokio::test]
+async fn test_wait_effect_polls_then_unblocks_downstream() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let provider = MockProvider::new();
+
+    // Plan: Create cert → Wait cert_issued (target = cert) → Create dist
+    let cert = make_resource("cert", &[]);
+    let cert_id = cert.id.clone();
+    let mut dist = make_resource("dist", &[]);
+    // `dist` references the wait binding so the scheduler links it.
+    dist.set_attr(
+        "ref_cert_issued".to_string(),
+        Value::resource_ref("cert_issued".to_string(), "arn".to_string(), vec![]),
+    );
+    dist.dependency_bindings = ["cert_issued".to_string()].into_iter().collect();
+    let dist_id = dist.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        target_identifier: None,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::String("ISSUED".to_string()),
+        },
+        until_surface: "cert.status == ISSUED".to_string(),
+        timeout: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+    plan.add(Effect::Create(dist));
+
+    // create cert → state with status PENDING (the Create result; the
+    // wait polls via read for ISSUED).
+    let mut create_attrs = HashMap::new();
+    create_attrs.insert(
+        "status".to_string(),
+        Value::String("PENDING_VALIDATION".to_string()),
+    );
+    provider.push_create(Ok(
+        State::existing(cert_id.clone(), create_attrs).with_identifier("acm-cert-id")
+    ));
+    // wait reads: PENDING → PENDING → ISSUED
+    let mut pending = HashMap::new();
+    pending.insert(
+        "status".to_string(),
+        Value::String("PENDING_VALIDATION".to_string()),
+    );
+    let mut issued = HashMap::new();
+    issued.insert("status".to_string(), Value::String("ISSUED".to_string()));
+    issued.insert(
+        "arn".to_string(),
+        Value::String("arn:aws:acm:...".to_string()),
+    );
+    provider.push_read(Ok(State::existing(cert_id.clone(), pending.clone())));
+    provider.push_read(Ok(State::existing(cert_id.clone(), pending)));
+    provider.push_read(Ok(State::existing(cert_id.clone(), issued)));
+    // create dist → succeeds
+    provider.push_create(Ok(ok_state(&dist_id)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+
+    assert_eq!(
+        result.success_count,
+        3,
+        "expected 3 successful effects (cert create + wait + dist create), got {} (events: {:?})",
+        result.success_count,
+        observer.events()
+    );
+    assert_eq!(result.failure_count, 0);
+
+    let calls = provider.calls();
+    assert_eq!(calls[0], ("create".to_string(), cert_id.to_string()));
+    // Three reads from the wait polling loop.
+    assert_eq!(calls[1], ("read".to_string(), cert_id.to_string()));
+    assert_eq!(calls[2], ("read".to_string(), cert_id.to_string()));
+    assert_eq!(calls[3], ("read".to_string(), cert_id.to_string()));
+    // dist create must follow the wait.
+    assert_eq!(calls[4], ("create".to_string(), dist_id.to_string()));
+}
+
+#[tokio::test]
+async fn test_wait_state_writeback_skips_synthetic_wait_id() {
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+
+    let provider = MockProvider::new();
+    let cert = make_resource("cert", &[]);
+    let cert_id = cert.id.clone();
+
+    let mut plan = Plan::new();
+    plan.add(Effect::Create(cert));
+    plan.add(Effect::Wait {
+        binding: "cert_issued".to_string(),
+        target_id: cert_id.clone(),
+        target_identifier: None,
+        until: WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::String("ISSUED".to_string()),
+        },
+        until_surface: "cert.status == ISSUED".to_string(),
+        timeout: std::time::Duration::from_secs(60),
+        interval: std::time::Duration::from_millis(1),
+        explicit_dependencies: std::collections::HashSet::new(),
+    });
+
+    let mut issued = HashMap::new();
+    issued.insert("status".to_string(), Value::String("ISSUED".to_string()));
+    provider.push_create(Ok(
+        State::existing(cert_id.clone(), issued.clone()).with_identifier("acm-cert-id")
+    ));
+    provider.push_read(Ok(State::existing(cert_id.clone(), issued)));
+
+    let input = ExecutionInput {
+        plan: &plan,
+        unresolved_resources: &HashMap::new(),
+        bindings: ResolvedBindings::default(),
+        current_states: HashMap::new(),
+    };
+
+    let observer = MockObserver::new();
+    let result = execute_plan(&provider, input, &observer).await;
+    assert_eq!(result.success_count, 2);
+    // The wait's captured State is keyed under a synthetic `__wait`
+    // ResourceId. This is what guarantees state writeback never sees
+    // it as a real resource — `sorted_resources` (the writeback input)
+    // does not contain `__wait` IDs.
+    let synthetic = ResourceId::new("__wait", "cert_issued");
+    assert!(
+        result.applied_states.contains_key(&synthetic),
+        "wait should register its captured State under the __wait synthetic id"
+    );
+}

--- a/carina-core/src/executor/wait.rs
+++ b/carina-core/src/executor/wait.rs
@@ -1,0 +1,261 @@
+//! Polling loop for `Effect::Wait`.
+//!
+//! The wait construct (carina#2825) is dispatched by carina-core's
+//! executor — not by the provider — so providers (including WASM
+//! plugins) need no contract change beyond the existing
+//! [`Provider::read`] trait method.
+//!
+//! See `notes/specs/2026-05-09-wait-construct-design.md` §Executor logic.
+
+use std::time::{Duration, Instant};
+
+use crate::provider::{Provider, ProviderError, ProviderResult, ReadRequest};
+use crate::resource::{ResourceId, State};
+use crate::wait::predicate::WaitPredicate;
+
+/// Run the wait polling loop:
+///
+/// 1. `read()` the target's current state.
+/// 2. If the read returns `not_found`, fail immediately with
+///    [`ProviderError::NotFound`] — mid-poll target deletion is a
+///    real divergence the user should see right away.
+/// 3. Evaluate `until` against the returned attribute map.
+/// 4. If true, return the captured state.
+/// 5. Otherwise, if the elapsed time has passed `timeout`, return
+///    [`ProviderError::Timeout`] whose message includes the unmet
+///    predicate, the last observed attribute snapshot, and the
+///    elapsed time.
+/// 6. Otherwise, sleep for `interval` and repeat.
+pub async fn execute_wait_effect(
+    provider: &dyn Provider,
+    target_id: &ResourceId,
+    target_identifier: Option<&str>,
+    until: &WaitPredicate,
+    timeout: Duration,
+    interval: Duration,
+) -> ProviderResult<State> {
+    let start = Instant::now();
+    loop {
+        let state = provider
+            .read(target_id, target_identifier, ReadRequest)
+            .await?;
+        if !state.exists {
+            return Err(ProviderError::not_found(format!(
+                "wait target {} not found (deleted out-of-band?)",
+                target_id
+            ))
+            .for_resource(target_id.clone()));
+        }
+        if until.evaluate(&state.attributes) {
+            return Ok(state);
+        }
+        let elapsed = start.elapsed();
+        if elapsed >= timeout {
+            return Err(ProviderError::timeout(format!(
+                "wait on {} timed out after {:?}; predicate `{:?}` never became true (last observed attributes: {:?})",
+                target_id, timeout, until, state.attributes
+            ))
+            .for_resource(target_id.clone()));
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{BoxFuture, CreateRequest, DeleteRequest, ReadRequest, UpdateRequest};
+    use crate::resource::{Resource, Value};
+    use crate::wait::predicate::{AttrPath, WaitPredicate};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    /// Minimal test provider: returns a queue of pre-canned read
+    /// responses in order, then repeats the last one. Counts every
+    /// `read` call so tests can assert polling behaviour.
+    struct ReadSequenceProvider {
+        responses: Mutex<Vec<State>>,
+        reads: Mutex<usize>,
+    }
+
+    impl ReadSequenceProvider {
+        fn new(responses: Vec<State>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+                reads: Mutex::new(0),
+            }
+        }
+
+        fn read_count(&self) -> usize {
+            *self.reads.lock().unwrap()
+        }
+    }
+
+    impl Provider for ReadSequenceProvider {
+        fn name(&self) -> &str {
+            "mock-wait"
+        }
+
+        fn read(
+            &self,
+            _id: &ResourceId,
+            _identifier: Option<&str>,
+            _request: ReadRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            Box::pin(async move {
+                let mut reads = self.reads.lock().unwrap();
+                *reads += 1;
+                let mut responses = self.responses.lock().unwrap();
+                if responses.len() > 1 {
+                    Ok(responses.remove(0))
+                } else if let Some(last) = responses.last() {
+                    Ok(last.clone())
+                } else {
+                    Err(ProviderError::api_error("no canned response"))
+                }
+            })
+        }
+
+        fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = resource.id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+
+        fn create(
+            &self,
+            id: &ResourceId,
+            _request: CreateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+
+        fn update(
+            &self,
+            id: &ResourceId,
+            _identifier: &str,
+            _request: UpdateRequest,
+        ) -> BoxFuture<'_, ProviderResult<State>> {
+            let id = id.clone();
+            Box::pin(async move { Ok(State::existing(id, HashMap::new())) })
+        }
+
+        fn delete(
+            &self,
+            _id: &ResourceId,
+            _identifier: &str,
+            _request: DeleteRequest,
+        ) -> BoxFuture<'_, ProviderResult<()>> {
+            Box::pin(async move { Ok(()) })
+        }
+    }
+
+    fn state_with_status(status: &str) -> State {
+        let mut attrs = HashMap::new();
+        attrs.insert("status".to_string(), Value::String(status.to_string()));
+        State::existing(ResourceId::new("acm.Certificate", "cert"), attrs)
+    }
+
+    fn equals_status(value: &str) -> WaitPredicate {
+        WaitPredicate::Equals {
+            attr: AttrPath::single("status"),
+            value: Value::String(value.to_string()),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_until_already_true() {
+        let provider = ReadSequenceProvider::new(vec![state_with_status("ISSUED")]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let result = execute_wait_effect(
+            &provider,
+            &target,
+            None,
+            &pred,
+            Duration::from_secs(60),
+            Duration::from_millis(10),
+        )
+        .await;
+        let state = result.expect("wait should succeed");
+        assert_eq!(
+            state.attributes.get("status"),
+            Some(&Value::String("ISSUED".to_string()))
+        );
+        assert_eq!(provider.read_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn wait_polls_until_predicate_becomes_true() {
+        let provider = ReadSequenceProvider::new(vec![
+            state_with_status("PENDING_VALIDATION"),
+            state_with_status("PENDING_VALIDATION"),
+            state_with_status("ISSUED"),
+        ]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let result = execute_wait_effect(
+            &provider,
+            &target,
+            None,
+            &pred,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+        )
+        .await;
+        assert!(result.is_ok(), "wait should succeed after 3 reads");
+        assert_eq!(provider.read_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn wait_returns_timeout_when_predicate_stays_false() {
+        let provider = ReadSequenceProvider::new(vec![state_with_status("PENDING_VALIDATION")]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let result = execute_wait_effect(
+            &provider,
+            &target,
+            None,
+            &pred,
+            Duration::from_millis(10),
+            Duration::from_millis(2),
+        )
+        .await;
+        let err = result.expect_err("should time out");
+        assert!(
+            matches!(err, ProviderError::Timeout(_)),
+            "expected Timeout, got {:?}",
+            err
+        );
+        assert!(
+            err.to_string().contains("PENDING_VALIDATION"),
+            "error message should include last observed value, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_returns_not_found_when_target_disappears() {
+        let provider = ReadSequenceProvider::new(vec![
+            state_with_status("PENDING_VALIDATION"),
+            State::not_found(ResourceId::new("acm.Certificate", "cert")),
+        ]);
+        let pred = equals_status("ISSUED");
+        let target = ResourceId::new("acm.Certificate", "cert");
+        let result = execute_wait_effect(
+            &provider,
+            &target,
+            None,
+            &pred,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+        )
+        .await;
+        let err = result.expect_err("should fail with NotFound");
+        assert!(
+            matches!(err, ProviderError::NotFound(_)),
+            "expected NotFound, got {:?}",
+            err
+        );
+    }
+}

--- a/carina-core/src/parser/ast.rs
+++ b/carina-core/src/parser/ast.rs
@@ -465,12 +465,32 @@ pub struct UpstreamState {
     pub source: std::path::PathBuf,
 }
 
+/// Typed `until` predicate captured at parse time. MVP supports the
+/// `<binding>.<attr-path> == <value>` shape; future operators
+/// (`!=`, `&&`/`||`, comparisons, `in`) will grow new variants here
+/// without breaking existing fields.
+///
+/// `lhs_segments` is the dotted path under the target binding —
+/// `[target, attr]` for `cert.status`, `[target, parent, attr]` for
+/// `cert.renewal_summary.renewal_status`. Always non-empty and the
+/// first segment is the target binding name (enforced by the parser).
+///
+/// `rhs` is the literal value to compare against, captured as a
+/// `Value` so namespaced enums (`aws.acm.Certificate.Status.Issued`),
+/// string literals, integers, booleans, and durations all flow into
+/// the same predicate type.
+#[derive(Debug, Clone)]
+pub struct UntilPredicateAst {
+    pub lhs_segments: Vec<String>,
+    pub rhs: crate::resource::Value,
+}
+
 /// A `wait <target> { ... }` declaration captured during parse.
 ///
-/// Carries the parsed surface form of the `until` predicate so later
-/// phases (differ → executor) can both type-check / lower the predicate
-/// (via `until_ast`) and echo the user-authored expression in plan
-/// display (via `until_raw`). `timeout_secs` is normalised to seconds
+/// Carries the parsed surface form of the `until` predicate so plan
+/// display can echo the user-authored expression verbatim, plus the
+/// structured `until_predicate` for the differ / executor to lower
+/// into `WaitPredicate`. `timeout_secs` is normalised to seconds
 /// because `Duration` from carina#2824 already canonicalises that way.
 ///
 /// See `notes/specs/2026-05-09-wait-construct-design.md`.
@@ -483,10 +503,8 @@ pub struct WaitBinding {
     /// Surface form of the `until` expression as the user wrote it
     /// (e.g. `"cert.status == aws.acm.Certificate.Status.Issued"`).
     pub until_raw: String,
-    /// Parsed `until` predicate. Reuses `validate_expr` so later phases
-    /// can lower to `WaitPredicate` once the supported predicate shape
-    /// (MVP: `<target>.<attr> == <value>`) is enforced.
-    pub until_ast: ValidateExpr,
+    /// Structured predicate for the differ / executor to consume.
+    pub until_predicate: UntilPredicateAst,
     /// Optional user override of the wait timeout, in whole seconds. When
     /// `None` the differ falls back to the target schema's default.
     pub timeout_secs: Option<u64>,

--- a/carina-core/src/parser/expressions/wait_expr.rs
+++ b/carina-core/src/parser/expressions/wait_expr.rs
@@ -4,10 +4,10 @@
 //! design. The grammar piece lives in `carina.pest::wait_expr`.
 
 use super::primary::parse_duration_secs;
-use super::validate_expr::parse_validate_expr;
-use crate::parser::ast::WaitBinding;
+use crate::parser::ast::{UntilPredicateAst, WaitBinding};
 use crate::parser::error::ParseError;
 use crate::parser::{Rule, first_inner};
+use crate::resource::Value;
 use pest::iterators::Pair;
 
 /// Parse a `wait` expression into a [`WaitBinding`].
@@ -19,6 +19,7 @@ use pest::iterators::Pair;
 ///
 /// Semantic rules enforced here:
 /// - `until` is required; absence is an [`ParseError::InvalidExpression`].
+/// - `until` must be `<target-binding>.<attr-path> == <value>` (MVP).
 /// - Each `wait_attr` may appear at most once; duplicates are rejected.
 pub(crate) fn parse_wait_expr(
     pair: Pair<'_, Rule>,
@@ -35,7 +36,7 @@ pub(crate) fn parse_wait_expr(
     let target = target_pair.as_str().to_string();
 
     let mut until_raw: Option<String> = None;
-    let mut until_ast = None;
+    let mut until_predicate: Option<UntilPredicateAst> = None;
     let mut timeout_secs: Option<u64> = None;
     let mut timeout_seen = false;
     let mut depends_on: Vec<String> = Vec::new();
@@ -46,12 +47,13 @@ pub(crate) fn parse_wait_expr(
         let child = first_inner(attr_pair, "wait_attr inner", "wait_expr")?;
         match child.as_rule() {
             Rule::wait_until_attr => {
-                if until_ast.is_some() {
+                if until_predicate.is_some() {
                     return Err(ParseError::InvalidExpression {
                         line,
                         message: format!("duplicate `until` in `wait {}` block", target),
                     });
                 }
+                let attr_line = child.as_span().start_pos().line_col().0;
                 let raw = child.as_str();
                 // Strip leading `until` and `=` so the surface form starts
                 // with the predicate itself (e.g.
@@ -63,9 +65,9 @@ pub(crate) fn parse_wait_expr(
                     .trim()
                     .to_string();
                 let expr_pair = first_inner(child, "validate_expr", "wait_until_attr")?;
-                let ast = parse_validate_expr(expr_pair)?;
+                let predicate = lower_validate_expr_to_until(expr_pair, &target, attr_line)?;
                 until_raw = Some(predicate_text);
-                until_ast = Some(ast);
+                until_predicate = Some(predicate);
             }
             Rule::wait_timeout_attr => {
                 if timeout_seen {
@@ -103,7 +105,7 @@ pub(crate) fn parse_wait_expr(
         }
     }
 
-    let (Some(until_raw), Some(until_ast)) = (until_raw, until_ast) else {
+    let (Some(until_raw), Some(until_predicate)) = (until_raw, until_predicate) else {
         return Err(ParseError::InvalidExpression {
             line,
             message: format!("`wait {}` block requires `until = <predicate>`", target),
@@ -114,11 +116,251 @@ pub(crate) fn parse_wait_expr(
         binding: binding_name.to_string(),
         target,
         until_raw,
-        until_ast,
+        until_predicate,
         timeout_secs,
         depends_on,
         line,
     })
+}
+
+/// Walk a `validate_expr` pest tree and lower it into an
+/// [`UntilPredicateAst`].
+///
+/// MVP narrowing: the only accepted shape is
+/// `<target-binding>.<attr-path> == <value>`. Boolean combinators,
+/// `!=`, `>=`, `<=`, comparisons, `in`, function calls, and bare
+/// variable references all produce a descriptive parse error tied to
+/// the `until` span.
+fn lower_validate_expr_to_until(
+    pair: Pair<'_, Rule>,
+    target_binding: &str,
+    line: usize,
+) -> Result<UntilPredicateAst, ParseError> {
+    let cmp = descend_to_compare(pair, line)?;
+    // `validate_comparison` has shape: validate_primary (compare_op validate_primary)?
+    let mut iter = cmp.into_inner();
+    let lhs_pair = iter.next().ok_or_else(|| ParseError::InvalidExpression {
+        line,
+        message: "`until`: missing LHS of comparison".to_string(),
+    })?;
+    let op_pair = iter.next().ok_or_else(|| ParseError::InvalidExpression {
+        line,
+        message: "`until`: comparison operator required (only `==` is supported)".to_string(),
+    })?;
+    let rhs_pair = iter.next().ok_or_else(|| ParseError::InvalidExpression {
+        line,
+        message: "`until`: missing RHS of comparison".to_string(),
+    })?;
+
+    if op_pair.as_rule() != Rule::compare_op || op_pair.as_str() != "==" {
+        return Err(ParseError::InvalidExpression {
+            line,
+            message: format!(
+                "`until`: only `==` is supported in this version (got `{}`)",
+                op_pair.as_str()
+            ),
+        });
+    }
+
+    let lhs_segments = lower_until_lhs(lhs_pair, target_binding, line)?;
+    let rhs = lower_until_rhs(rhs_pair, line)?;
+
+    Ok(UntilPredicateAst { lhs_segments, rhs })
+}
+
+/// Walk through `validate_expr` → `validate_or_expr` → `validate_and_expr`
+/// → `validate_not_expr` → `validate_comparison`, rejecting any
+/// boolean combinator or negation along the way.
+fn descend_to_compare<'i>(pair: Pair<'i, Rule>, line: usize) -> Result<Pair<'i, Rule>, ParseError> {
+    fn step<'i>(pair: Pair<'i, Rule>, line: usize) -> Result<Pair<'i, Rule>, ParseError> {
+        match pair.as_rule() {
+            Rule::validate_expr
+            | Rule::validate_or_expr
+            | Rule::validate_and_expr
+            | Rule::validate_not_expr => {
+                let mut inner = pair.into_inner();
+                let first = inner.next().ok_or_else(|| ParseError::InvalidExpression {
+                    line,
+                    message: "`until`: empty predicate".to_string(),
+                })?;
+                if inner.next().is_some() {
+                    return Err(ParseError::InvalidExpression {
+                        line,
+                        message: "`until`: boolean combinators (`&&`/`||`) and `!` are not supported in this version"
+                            .to_string(),
+                    });
+                }
+                step(first, line)
+            }
+            Rule::validate_comparison => Ok(pair),
+            _ => Err(ParseError::InvalidExpression {
+                line,
+                message: format!(
+                    "`until`: unexpected predicate shape (rule {:?})",
+                    pair.as_rule()
+                ),
+            }),
+        }
+    }
+    step(pair, line)
+}
+
+/// Extract the dotted segments from the LHS `validate_primary`. The
+/// first segment must equal `target_binding`.
+fn lower_until_lhs(
+    pair: Pair<'_, Rule>,
+    target_binding: &str,
+    line: usize,
+) -> Result<Vec<String>, ParseError> {
+    // validate_primary wraps a single child; descend to it.
+    let primary = first_inner(pair, "validate_primary inner", "until LHS")?;
+    if primary.as_rule() != Rule::variable_ref {
+        return Err(ParseError::InvalidExpression {
+            line,
+            message: format!(
+                "`until`: LHS must be `<target>.<attribute>` (got {:?})",
+                primary.as_rule()
+            ),
+        });
+    }
+    let mut segments: Vec<String> = Vec::new();
+    for child in primary.into_inner() {
+        match child.as_rule() {
+            Rule::identifier => segments.push(child.as_str().to_string()),
+            Rule::field_access => {
+                let id = first_inner(child, "identifier", "field_access")?;
+                segments.push(id.as_str().to_string());
+            }
+            Rule::index_access => {
+                return Err(ParseError::InvalidExpression {
+                    line,
+                    message: "`until`: index access in LHS is not supported".to_string(),
+                });
+            }
+            other => {
+                return Err(ParseError::InternalError {
+                    expected: "identifier | field_access | index_access".to_string(),
+                    context: format!("variable_ref child {:?}", other),
+                });
+            }
+        }
+    }
+    if segments.is_empty() {
+        return Err(ParseError::InvalidExpression {
+            line,
+            message: "`until`: LHS is empty".to_string(),
+        });
+    }
+    if segments.len() < 2 {
+        return Err(ParseError::InvalidExpression {
+            line,
+            message: format!(
+                "`until`: LHS must reference an attribute of `{}` (e.g. `{0}.status`), got bare binding `{}`",
+                target_binding, segments[0]
+            ),
+        });
+    }
+    if segments[0] != target_binding {
+        return Err(ParseError::InvalidExpression {
+            line,
+            message: format!(
+                "`until`: LHS must reference target `{}` (got `{}`); cross-target predicates are not supported",
+                target_binding, segments[0]
+            ),
+        });
+    }
+    Ok(segments)
+}
+
+/// Extract the literal RHS as a `Value`. Supports string, int, float,
+/// bool, duration, and namespaced-id enums (e.g.
+/// `aws.acm.Certificate.Status.Issued`).
+fn lower_until_rhs(pair: Pair<'_, Rule>, line: usize) -> Result<Value, ParseError> {
+    let primary = first_inner(pair, "validate_primary inner", "until RHS")?;
+    match primary.as_rule() {
+        Rule::string => {
+            // Strip surrounding quotes — same convention as
+            // validate_expr's string handling.
+            let raw = primary.as_str();
+            if raw.len() < 2 {
+                return Err(ParseError::InvalidExpression {
+                    line,
+                    message: "`until`: malformed string literal".to_string(),
+                });
+            }
+            Ok(Value::String(raw[1..raw.len() - 1].to_string()))
+        }
+        Rule::number => {
+            let n: i64 = primary
+                .as_str()
+                .parse()
+                .map_err(|e| ParseError::InvalidExpression {
+                    line,
+                    message: format!("`until`: invalid integer: {}", e),
+                })?;
+            Ok(Value::Int(n))
+        }
+        Rule::float => {
+            let f: f64 = primary
+                .as_str()
+                .parse()
+                .map_err(|e| ParseError::InvalidExpression {
+                    line,
+                    message: format!("`until`: invalid float: {}", e),
+                })?;
+            Ok(Value::Float(f))
+        }
+        Rule::boolean => Ok(Value::Bool(primary.as_str() == "true")),
+        Rule::duration_literal => {
+            let secs = parse_duration_secs(primary.as_str(), line)?;
+            Ok(Value::Duration(std::time::Duration::from_secs(secs)))
+        }
+        Rule::variable_ref => {
+            // Treat dotted variable refs as namespaced enum identifiers
+            // (e.g. `aws.acm.Certificate.Status.Issued`). The differ
+            // resolves these to canonical AWS string values at plan
+            // time via the existing enum-conversion machinery.
+            let mut segments: Vec<String> = Vec::new();
+            for child in primary.into_inner() {
+                match child.as_rule() {
+                    Rule::identifier => segments.push(child.as_str().to_string()),
+                    Rule::field_access => {
+                        let id = first_inner(child, "identifier", "field_access")?;
+                        segments.push(id.as_str().to_string());
+                    }
+                    Rule::index_access => {
+                        return Err(ParseError::InvalidExpression {
+                            line,
+                            message: "`until`: index access in RHS is not supported".to_string(),
+                        });
+                    }
+                    other => {
+                        return Err(ParseError::InternalError {
+                            expected: "identifier | field_access | index_access".to_string(),
+                            context: format!("variable_ref child {:?}", other),
+                        });
+                    }
+                }
+            }
+            // Surface form is the dotted identifier exactly as the user
+            // wrote it; the differ's enum-resolution pass converts it to
+            // the AWS canonical value when the target attribute is
+            // declared as an enum.
+            Ok(Value::String(segments.join(".")))
+        }
+        Rule::null_literal => Err(ParseError::InvalidExpression {
+            line,
+            message: "`until`: `null` is not a valid comparison value".to_string(),
+        }),
+        Rule::validate_function_call => Err(ParseError::InvalidExpression {
+            line,
+            message: "`until`: function calls in the RHS are not supported".to_string(),
+        }),
+        other => Err(ParseError::InvalidExpression {
+            line,
+            message: format!("`until`: unsupported RHS shape ({:?})", other),
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -146,8 +388,31 @@ mod tests {
             we.until_raw,
             "cert.status == aws.acm.Certificate.Status.Issued"
         );
+        assert_eq!(we.until_predicate.lhs_segments, vec!["cert", "status"]);
+        assert_eq!(
+            we.until_predicate.rhs,
+            Value::String("aws.acm.Certificate.Status.Issued".to_string())
+        );
         assert!(we.timeout_secs.is_none());
         assert!(we.depends_on.is_empty());
+    }
+
+    #[test]
+    fn parses_string_rhs() {
+        let we = parse_one("wait cert {\n    until = cert.status == \"ISSUED\"\n}");
+        assert_eq!(we.until_predicate.rhs, Value::String("ISSUED".to_string()));
+    }
+
+    #[test]
+    fn parses_int_rhs() {
+        let we = parse_one("wait job {\n    until = job.completed_steps == 10\n}");
+        assert_eq!(we.until_predicate.rhs, Value::Int(10));
+    }
+
+    #[test]
+    fn parses_bool_rhs() {
+        let we = parse_one("wait flag {\n    until = flag.enabled == true\n}");
+        assert_eq!(we.until_predicate.rhs, Value::Bool(true));
     }
 
     #[test]
@@ -163,6 +428,16 @@ mod tests {
             "wait cert {\n    until = cert.status == ISSUED\n    depends_on = [a, b, c]\n}",
         );
         assert_eq!(we.depends_on, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn parses_nested_attr_path() {
+        let we =
+            parse_one("wait cert {\n    until = cert.renewal_summary.renewal_status == SUCCESS\n}");
+        assert_eq!(
+            we.until_predicate.lhs_segments,
+            vec!["cert", "renewal_summary", "renewal_status"]
+        );
     }
 
     #[test]
@@ -190,6 +465,58 @@ mod tests {
         .unwrap();
         let err = parse_wait_expr(pair, "cert_issued").expect_err("duplicate until");
         assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn rejects_lhs_unrelated_to_target() {
+        let pair = CarinaParser::parse(
+            Rule::wait_expr,
+            "wait cert {\n    until = other.status == ISSUED\n}",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let err = parse_wait_expr(pair, "cert_issued").expect_err("cross-target");
+        assert!(err.to_string().contains("must reference target"));
+    }
+
+    #[test]
+    fn rejects_bare_binding_lhs() {
+        let pair = CarinaParser::parse(
+            Rule::wait_expr,
+            "wait cert {\n    until = cert == ISSUED\n}",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let err = parse_wait_expr(pair, "cert_issued").expect_err("bare binding");
+        assert!(err.to_string().contains("attribute"));
+    }
+
+    #[test]
+    fn rejects_non_eq_operator() {
+        let pair = CarinaParser::parse(
+            Rule::wait_expr,
+            "wait cert {\n    until = cert.status != FAILED\n}",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let err = parse_wait_expr(pair, "cert_issued").expect_err("non-eq");
+        assert!(err.to_string().contains("only `==` is supported"));
+    }
+
+    #[test]
+    fn rejects_boolean_combinator() {
+        let pair = CarinaParser::parse(
+            Rule::wait_expr,
+            "wait cert {\n    until = cert.status == A && cert.status == B\n}",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+        let err = parse_wait_expr(pair, "cert_issued").expect_err("&&");
+        assert!(err.to_string().contains("boolean combinators"));
     }
 
     #[test]

--- a/carina-core/src/parser/mod.rs
+++ b/carina-core/src/parser/mod.rs
@@ -20,8 +20,8 @@ pub use ast::{
     ArgumentParameter, AttributeParameter, BackendConfig, DeferredForExpression, ExportParamLike,
     ExportParameter, File, FnParam, InferredExportParam, InferredFile, ModuleCall,
     ParsedExportParam, ParsedFile, ProviderConfig, RequireBlock, ResourceContext, ResourceTypePath,
-    StateBlock, TypeExpr, UpstreamState, UseStatement, UserFunction, UserFunctionBody,
-    ValidateExpr, ValidationBlock, WaitBinding,
+    StateBlock, TypeExpr, UntilPredicateAst, UpstreamState, UseStatement, UserFunction,
+    UserFunctionBody, ValidateExpr, ValidationBlock, WaitBinding,
 };
 pub use config::{DecryptorFn, ProviderContext, ValidatorFn};
 pub(crate) use entry::parse_with_seeded_bindings;

--- a/carina-core/src/plan.rs
+++ b/carina-core/src/plan.rs
@@ -435,6 +435,7 @@ mod tests {
             until_surface: "cert.status == aws.acm.Certificate.Status.Issued".to_string(),
             timeout: Duration::from_secs(75 * 60),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         };
         assert_eq!(
             format_effect_brief(&e),
@@ -461,6 +462,7 @@ mod tests {
             until_surface: "cert.status == ISSUED".to_string(),
             timeout: Duration::from_secs(60),
             interval: Duration::from_secs(5),
+            explicit_dependencies: std::collections::HashSet::new(),
         });
         let summary = plan.summary();
         assert_eq!(summary.create, 1);

--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -1976,7 +1976,27 @@ pub struct ResourceSchema {
     /// (a function pointer), this is plain data and survives the WASM plugin
     /// boundary.
     pub exclusive_required: Vec<Vec<String>>,
+    /// Default total timeout for `wait <target> { ... }` polling against
+    /// this resource type. `None` falls back to
+    /// [`WAIT_DEFAULT_TIMEOUT`].
+    pub default_wait_timeout: Option<std::time::Duration>,
+    /// Default poll cadence between `read()` calls for `wait <target>`
+    /// against this resource type. `None` falls back to
+    /// [`WAIT_DEFAULT_INTERVAL`].
+    pub default_wait_interval: Option<std::time::Duration>,
 }
+
+/// Fallback total timeout when neither the user nor the resource schema
+/// declares one. Conservative — real provider workloads should declare
+/// their own (e.g. ACM Certificate at 75min, EC2 Instance Running at
+/// 5min). Used by the differ when emitting `Effect::Wait`.
+pub const WAIT_DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// Fallback poll cadence when the resource schema declares none. The
+/// executor pauses for this between `read()` calls. AWS API rate limits
+/// drive the lower bound; 5 seconds is the same default Terraform uses
+/// for `aws_acm_certificate_validation`.
+pub const WAIT_DEFAULT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
 impl ResourceSchema {
     pub fn new(resource_type: impl Into<String>) -> Self {
@@ -1990,7 +2010,21 @@ impl ResourceSchema {
             force_replace: false,
             operation_config: None,
             exclusive_required: Vec::new(),
+            default_wait_timeout: None,
+            default_wait_interval: None,
         }
+    }
+
+    /// Set the schema-declared default total timeout for `wait` polling.
+    pub fn with_default_wait_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.default_wait_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the schema-declared default poll interval for `wait` polling.
+    pub fn with_default_wait_interval(mut self, interval: std::time::Duration) -> Self {
+        self.default_wait_interval = Some(interval);
+        self
     }
 
     pub fn attribute(mut self, schema: AttributeSchema) -> Self {

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -786,6 +786,16 @@ pub fn check_unused_bindings<E: crate::parser::ExportParamLike>(
             collect_dot_notation_refs(value, &mut referenced);
         }
     }
+    // Each `wait <target> { ... }` declaration references its target
+    // and every binding in `depends_on = [...]`. The until predicate's
+    // LHS is rooted at the target (enforced by parser), so the target
+    // covers the LHS path too.
+    for wb in &parsed.wait_bindings {
+        referenced.insert(wb.target.clone());
+        for dep in &wb.depends_on {
+            referenced.insert(dep.clone());
+        }
+    }
 
     // Return unused binding names, skipping structurally-required bindings
     // (if/for/read expressions) and for-generated indexed bindings (e.g., vpcs[0])

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -413,6 +413,8 @@ fn make_schema(resource_type: &str, attrs: Vec<(&str, AttributeType)>) -> Resour
         force_replace: false,
         operation_config: None,
         exclusive_required: Vec::new(),
+        default_wait_timeout: None,
+        default_wait_interval: None,
     }
 }
 

--- a/carina-core/tests/wait_directory.rs
+++ b/carina-core/tests/wait_directory.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 use carina_core::config_loader::parse_directory;
 use carina_core::parser::ProviderContext;
+use carina_core::resource::Value;
 
 #[test]
 fn wait_resolves_target_and_depends_on_across_sibling_files() {
@@ -36,6 +37,11 @@ fn wait_resolves_target_and_depends_on_across_sibling_files() {
     );
     assert_eq!(wait.timeout_secs, Some(75 * 60));
     assert_eq!(wait.depends_on, vec!["validation_record"]);
+    assert_eq!(wait.until_predicate.lhs_segments, vec!["cert", "status"]);
+    assert_eq!(
+        wait.until_predicate.rhs,
+        Value::String("aws.acm.Certificate.Status.Issued".to_string())
+    );
 
     // Sanity: the target binding really lives in a sibling file.
     let cert = parsed

--- a/carina-plugin-host/src/wasm_convert.rs
+++ b/carina-plugin-host/src/wasm_convert.rs
@@ -553,6 +553,12 @@ fn proto_schema_to_core(s: &proto::ResourceSchema) -> CoreResourceSchema {
             }
         }),
         exclusive_required: s.exclusive_required.clone(),
+        // Wait defaults are not (yet) carried across the WASM plugin
+        // boundary — providers fall back to the carina-core constants
+        // (`WAIT_DEFAULT_TIMEOUT` / `WAIT_DEFAULT_INTERVAL`) until the
+        // protocol gains explicit fields. See carina-rs/carina#2825.
+        default_wait_timeout: None,
+        default_wait_interval: None,
     }
 }
 


### PR DESCRIPTION
## Summary

2nd of 3 PRs for #2825. Wires the `wait` construct from the parser-side AST (landed in PR #2968) through the differ and executor so `wait` declarations actually do something at plan/apply time.

- **Phase 1+2+3** (PR #2968, merged): predicate AST + `Effect::Wait` variant + parser + grammar.
- **This PR (Phase 4+5)**: differ emits `Effect::Wait` + executor polling loop + plan-display fixture.
- **Phase 6+7+8 follow-up**: LSP + formatter + end-to-end fixture.

## Phase 4 — differ + executor

### Differ (`carina-core/src/differ/plan.rs`)
- `create_plan` gains `wait_bindings: &[WaitBinding]`.
- Each `WaitBinding` is lowered to an `Effect::Wait` carrying the resolved `target_id`, a typed `WaitPredicate::Equals { attr, value }`, the `until_surface` string, `timeout` (user override → schema default → carina-core fallback), `interval` (schema default → fallback), and `explicit_dependencies` from `depends_on = [...]`.
- The until predicate is captured as a structured `UntilPredicateAst { lhs_segments, rhs }` directly at parse time rather than re-walking `ValidateExpr` — `ValidateExpr::Var(String)` drops dotted paths (it stores only the first identifier), so reusing it would have lost `cert.status` → `cert`. Parsing `<binding>.<attr> == <value>` directly off the pest tree surfaces "only `==` is supported" / "must reference target" / "boolean combinators not supported" at the right span.
- A missing target binding produces a `PlanError`.

### Schema (`carina-core/src/schema/mod.rs`)
- `ResourceSchema` gains `default_wait_timeout` / `default_wait_interval`.
- `WAIT_DEFAULT_TIMEOUT = 5min` / `WAIT_DEFAULT_INTERVAL = 5sec` are the fallbacks.
- WIT plugin boundary passes `None` for now — providers fall back to carina-core constants until the protocol gains explicit fields.

### Executor (`carina-core/src/executor/wait.rs`)
- `execute_wait_effect` runs the polling loop on top of `Provider::read`: read → check `until` → sleep on miss → fail with `ProviderError::Timeout` (message includes last observed attrs + unmet predicate + elapsed time) or `ProviderError::NotFound` (target deleted mid-poll).

### Parallel scheduler (`carina-core/src/executor/parallel.rs`)
- `SingleEffectResult::Wait { success, binding, target_state }`.
- On success the captured State is registered under a synthetic `__wait::<binding>` ResourceId in `applied_states` AND under the wait binding in `ResolvedBindings::record_applied`, so downstream effects that reference `<wait>.<attr>` resolve through the same path as `<resource>.<attr>`. The synthetic ResourceId guarantees state writeback can't accidentally persist the wait — sorted resources never contain `__wait` IDs and the writeback effect match falls through `_ => {}` for Wait.
- `build_dependency_map` adds an edge from each Wait to the effect producing its target (when present), plus every `depends_on` binding (via `Effect::explicit_dependencies()`).

### Effect (`carina-core/src/effect.rs`)
- `Effect::Wait` gains `explicit_dependencies: HashSet<String>` (`#[serde(default)]` for legacy state).
- `Effect::explicit_dependencies()` returns the wait's set.

## Phase 5 — plan-display fixture + invariants

- New fixture `carina-cli/tests/fixtures/plan_display/wait_cert/main.crn` exercises the ACM Certificate + Route53 validation + wait pattern.
- `snapshot_wait_cert` pins `> cert_issued (until cert.status == aws.acm.Certificate.Status.Issued)` rendered as a child of cert.
- `Makefile` gains `plan-wait-cert` so `check-plan-fixtures.sh` is satisfied.
- `validation::check_unused_bindings` learns about wait bindings: target + `depends_on = [...]` count as references, so `no_unused_let_bindings_in_fixtures` doesn't trip on the new fixture.

## Test plan

- [x] `cargo nextest run --workspace` (3181 tests) green
- [x] `cargo test --workspace --doc` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo fmt --check` green
- [x] `cargo build --release` green
- [x] `bash scripts/check-*.sh` all green
- [x] 14 new tests: differ (3), executor polling (4), executor end-to-end with parallel dispatch (2), parser `UntilPredicateAst` lowering (5)

Refs #2825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
