### PR TITLE
core/cli/lsp: wait construct Phase 6+7+8 — LSP + validate + e2e (closes #2825)

### DIFF
--- a/carina-cli/src/commands/mod.rs
+++ b/carina-cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ use crate::wiring::{
     validate_depends_on_with_ctx, validate_module_attribute_param_types, validate_module_calls,
     validate_no_empty_interpolations, validate_provider_region_with_ctx,
     validate_resource_ref_types_with_ctx, validate_resources_with_ctx,
+    validate_wait_bindings_with_ctx,
 };
 
 /// Detect whether the `backend` block in the current configuration has
@@ -317,6 +318,7 @@ pub fn validate_and_resolve_errors_with_factories(
 
         errors.extend(validate_resources_with_ctx(&ctx, parsed, &enriched_context));
         errors.extend(validate_depends_on_with_ctx(parsed));
+        errors.extend(validate_wait_bindings_with_ctx(&ctx, parsed));
         let mut argument_names: HashSet<String> =
             parsed.arguments.iter().map(|a| a.name.clone()).collect();
         // Upstream state bindings are resolved at plan time, skip type validation

--- a/carina-cli/src/wiring/mod.rs
+++ b/carina-cli/src/wiring/mod.rs
@@ -218,6 +218,19 @@ pub fn validate_depends_on_with_ctx<E>(parsed: &carina_core::parser::File<E>) ->
     errors
 }
 
+/// Surface `wait <target> { ... }` diagnostics as `AppError::Validation`.
+/// Shared with the LSP via the underlying
+/// `carina_core::validation::wait::validate_wait_bindings` pass.
+pub fn validate_wait_bindings_with_ctx<E>(
+    ctx: &WiringContext,
+    parsed: &carina_core::parser::File<E>,
+) -> Vec<AppError> {
+    carina_core::validation::wait::validate_wait_bindings(parsed, ctx.schemas())
+        .into_iter()
+        .map(|d| AppError::Validation(d.message))
+        .collect()
+}
+
 pub fn validate_resource_ref_types_with_ctx<E>(
     ctx: &WiringContext,
     parsed: &carina_core::parser::File<E>,

--- a/carina-cli/tests/wait_validate_e2e.rs
+++ b/carina-cli/tests/wait_validate_e2e.rs
@@ -1,0 +1,288 @@
+//! End-to-end validation tests for the `wait` construct (carina#2825).
+//!
+//! Phase 7+8 of the wait construct: assert that `carina validate`
+//! (CLI surface) accepts a well-formed multi-file `.crn` directory
+//! containing a wait declaration, and surfaces the load-bearing
+//! diagnostics for malformed wait blocks (unknown target, unknown
+//! attribute, non-`==` operator).
+//!
+//! Per CLAUDE.md "directory-scoped, never single-file": every fixture
+//! is a multi-file `tempfile::tempdir()` layout — wait, target, and
+//! provider declarations live in separate files so we exercise the
+//! merged-parse path that LSP and CLI share.
+
+use carina_core::provider::{
+    BoxFuture, NoopNormalizer, Provider, ProviderFactory, ProviderNormalizer, ProviderResult,
+};
+use carina_core::resource::{Resource, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Minimal aws provider factory exposing `aws.acm.Certificate` so the
+// validate pipeline sees a real resource type.
+// ---------------------------------------------------------------------------
+
+struct WaitTestFactory;
+
+impl ProviderFactory for WaitTestFactory {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn display_name(&self) -> &str {
+        "AWS (wait-construct test stub)"
+    }
+    fn provider_config_attribute_types(&self) -> HashMap<String, AttributeType> {
+        HashMap::new()
+    }
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        Ok(())
+    }
+    fn validate_custom_type(&self, _type_name: &str, _value: &str) -> Result<(), String> {
+        Ok(())
+    }
+    fn extract_region(&self, _attributes: &IndexMap<String, Value>) -> String {
+        "us-east-1".to_string()
+    }
+    fn create_provider(
+        &self,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, ProviderResult<Box<dyn Provider>>> {
+        Box::pin(async { Ok(Box::new(NoopProvider) as Box<dyn Provider>) })
+    }
+    fn create_normalizer(
+        &self,
+        _attributes: &IndexMap<String, Value>,
+    ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
+        Box::pin(async { Box::new(NoopNormalizer) as Box<dyn ProviderNormalizer> })
+    }
+    fn schemas(&self) -> Vec<ResourceSchema> {
+        vec![cert_schema()]
+    }
+}
+
+fn cert_schema() -> ResourceSchema {
+    ResourceSchema::new("acm.Certificate")
+        .attribute(AttributeSchema::new("domain_name", AttributeType::String))
+        .attribute(AttributeSchema::new(
+            "validation_method",
+            AttributeType::String,
+        ))
+        .attribute(AttributeSchema::new("status", AttributeType::String))
+        .attribute(AttributeSchema::new("arn", AttributeType::String))
+}
+
+struct NoopProvider;
+
+impl Provider for NoopProvider {
+    fn name(&self) -> &str {
+        "aws"
+    }
+    fn read(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: Option<&str>,
+        _request: carina_core::provider::ReadRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::not_found(id)) })
+    }
+    fn read_data_source(
+        &self,
+        resource: &Resource,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = resource.id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn create(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _request: carina_core::provider::CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn update(
+        &self,
+        id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::UpdateRequest,
+    ) -> BoxFuture<'_, ProviderResult<carina_core::resource::State>> {
+        let id = id.clone();
+        Box::pin(async move { Ok(carina_core::resource::State::existing(id, HashMap::new())) })
+    }
+    fn delete(
+        &self,
+        _id: &carina_core::resource::ResourceId,
+        _identifier: &str,
+        _request: carina_core::provider::DeleteRequest,
+    ) -> BoxFuture<'_, ProviderResult<()>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+fn factories() -> Vec<Box<dyn ProviderFactory>> {
+    vec![Box::new(WaitTestFactory) as Box<dyn ProviderFactory>]
+}
+
+fn write_fixture(files: &[(&str, &str)]) -> TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for (name, content) in files {
+        std::fs::write(dir.path().join(name), content).expect("write fixture");
+    }
+    dir
+}
+
+fn cli_validate(fixture: &TempDir) -> Vec<String> {
+    carina_cli::commands::validate::validate_with_factories(fixture.path(), factories())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_accepts_well_formed_wait_multi_file_fixture() {
+    let fixture = write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let cert_issued = wait cert {
+    until   = cert.status == "ISSUED"
+    timeout = 75min
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        !diags.iter().any(|d| d.contains("wait")),
+        "well-formed wait fixture must not produce wait-related errors; got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn validate_flags_wait_unknown_target() {
+    let fixture = write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let waited = wait nonexistent {
+    until = nonexistent.status == "ISSUED"
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        diags.iter().any(|d| d.contains("nonexistent")),
+        "validate must surface unknown wait target; got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn validate_flags_wait_unknown_attribute() {
+    let fixture = write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let waited = wait cert {
+    until = cert.statu == "ISSUED"
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("statu") && d.contains("unknown attribute")),
+        "validate must surface unknown wait attribute; got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn validate_rejects_non_eq_predicate_operator() {
+    // Parser-level rejection — never reaches the differ.
+    let fixture = write_fixture(&[
+        (
+            "providers.crn",
+            r#"provider aws {
+    region = "us-east-1"
+}
+"#,
+        ),
+        (
+            "main.crn",
+            r#"let cert = aws.acm.Certificate {
+    domain_name       = "registry.example.com"
+    validation_method = "DNS"
+}
+"#,
+        ),
+        (
+            "wait.crn",
+            r#"let waited = wait cert {
+    until = cert.status != "FAILED"
+}
+"#,
+        ),
+    ]);
+
+    let diags = cli_validate(&fixture);
+    assert!(
+        diags.iter().any(|d| d.contains("only `==` is supported")),
+        "validate must surface non-`==` operator rejection; got: {:?}",
+        diags
+    );
+}

--- a/carina-core/src/validation/mod.rs
+++ b/carina-core/src/validation/mod.rs
@@ -1,6 +1,7 @@
 //! Validation utilities for resources and modules
 
 pub mod depends_on;
+pub mod wait;
 
 use std::collections::{HashMap, HashSet};
 

--- a/carina-core/src/validation/wait.rs
+++ b/carina-core/src/validation/wait.rs
@@ -1,0 +1,90 @@
+//! Analysis-pass diagnostics for `wait <target> { ... }` declarations.
+//!
+//! Shared by `carina validate` and the LSP. Produces errors for:
+//!
+//! - **target not found**: `wait foo { ... }` where `foo` is not a
+//!   known resource binding in the merged directory parse.
+//! - **attribute not in target schema**: `until = cert.statu == ...`
+//!   where the target's schema has `status` but not `statu`.
+//!
+//! Operator and shape narrowing (non-`==`, boolean combinators, bare
+//! binding LHS) is enforced upstream by `parse_wait_expr`; the parse
+//! error surfaces via the regular parser diagnostic path.
+
+use crate::parser::File;
+use crate::schema::{SchemaKind, SchemaRegistry};
+
+/// A wait-construct diagnostic.
+///
+/// `binding_name` and `target` carry structured location hints so the
+/// LSP can resolve a per-span anchor without re-parsing the message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaitDiagnostic {
+    pub message: String,
+    pub binding_name: String,
+    pub target: String,
+    pub attribute: Option<String>,
+}
+
+/// Run all wait diagnostics against a parsed file + schema registry.
+/// Returns the full list of errors; callers decide how to surface them.
+pub fn validate_wait_bindings<E>(
+    parsed: &File<E>,
+    schemas: &SchemaRegistry,
+) -> Vec<WaitDiagnostic> {
+    if parsed.wait_bindings.is_empty() {
+        return Vec::new();
+    }
+    let mut out: Vec<WaitDiagnostic> = Vec::new();
+
+    // Build binding → (provider, resource_type) lookup once.
+    let mut by_binding: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    for r in &parsed.resources {
+        if let Some(b) = &r.binding {
+            by_binding.insert(
+                b.clone(),
+                (r.id.provider.clone(), r.id.resource_type.clone()),
+            );
+        }
+    }
+
+    for wb in &parsed.wait_bindings {
+        let Some((provider, resource_type)) = by_binding.get(&wb.target) else {
+            out.push(WaitDiagnostic {
+                message: format!(
+                    "wait `{}`: target binding `{}` is not a known resource",
+                    wb.binding, wb.target
+                ),
+                binding_name: wb.binding.clone(),
+                target: wb.target.clone(),
+                attribute: None,
+            });
+            continue;
+        };
+        // Attribute existence check against the target's schema. MVP
+        // supports only top-level attributes; nested struct fields
+        // (`renewal_summary.renewal_status`) are deferred to a follow-up.
+        let Some(attr_name) = wb.until_predicate.lhs_segments.get(1) else {
+            continue;
+        };
+        let Some(schema) = schemas.get(provider, resource_type, SchemaKind::Managed) else {
+            // No schema for this resource type — skip the attr check.
+            // The user already gets a separate "unknown resource type"
+            // diagnostic from the upstream identifier-scope pass.
+            continue;
+        };
+        if !schema.attributes.contains_key(attr_name) {
+            out.push(WaitDiagnostic {
+                message: format!(
+                    "wait `{}`: `until` references unknown attribute `{}.{}` on `{}.{}`",
+                    wb.binding, wb.target, attr_name, provider, resource_type
+                ),
+                binding_name: wb.binding.clone(),
+                target: wb.target.clone(),
+                attribute: Some(attr_name.clone()),
+            });
+        }
+    }
+    out
+}

--- a/carina-lsp/src/completion/tests/extended.rs
+++ b/carina-lsp/src/completion/tests/extended.rs
@@ -836,6 +836,43 @@ fn top_level_completion_suggests_upstream_state() {
 }
 
 #[test]
+fn top_level_completion_suggests_wait() {
+    let provider = test_provider();
+    let completions = provider.top_level_completions(
+        Position {
+            line: 0,
+            character: 0,
+        },
+        "",
+        None,
+    );
+    let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+    assert!(
+        labels.contains(&"wait"),
+        "Top-level completions should include 'wait'. Got: {:?}",
+        labels
+    );
+    let wait_item = completions
+        .iter()
+        .find(|c| c.label == "wait")
+        .expect("wait completion item");
+    let insert = wait_item
+        .insert_text
+        .as_ref()
+        .expect("wait completion has insert_text");
+    assert!(
+        insert.contains("wait ${"),
+        "wait snippet should include the keyword + target placeholder, got: {:?}",
+        insert
+    );
+    assert!(
+        insert.contains("until"),
+        "wait snippet should scaffold the `until` attribute, got: {:?}",
+        insert
+    );
+}
+
+#[test]
 fn upstream_state_block_completes_source_attribute() {
     let provider = test_provider();
     let doc = create_document(

--- a/carina-lsp/src/completion/top_level.rs
+++ b/carina-lsp/src/completion/top_level.rs
@@ -67,6 +67,11 @@ impl CompletionProvider {
         } else {
             "let ${1:binding} = upstream_state {\n    source = '${2:../other-project}'\n}"
         };
+        let wait_snippet = if after_let_binding {
+            "wait ${1:target} {\n    until = ${1:target}.${2:status} == ${3:value}\n}"
+        } else {
+            "let ${1:waited} = wait ${2:target} {\n    until = ${2:target}.${3:status} == ${4:value}\n}"
+        };
 
         let mut completions = vec![
             CompletionItem {
@@ -179,6 +184,16 @@ impl CompletionProvider {
                 insert_text: Some("require ${1:condition}, \"${2:error message}\"".to_string()),
                 insert_text_format: Some(InsertTextFormat::SNIPPET),
                 detail: Some("Cross-argument constraint".to_string()),
+                ..Default::default()
+            },
+            CompletionItem {
+                label: "wait".to_string(),
+                kind: Some(CompletionItemKind::KEYWORD),
+                insert_text: Some(wait_snippet.to_string()),
+                insert_text_format: Some(InsertTextFormat::SNIPPET),
+                detail: Some(
+                    "Block downstream resources until target reaches a condition".to_string(),
+                ),
                 ..Default::default()
             },
         ];

--- a/carina-lsp/src/diagnostics/checks.rs
+++ b/carina-lsp/src/diagnostics/checks.rs
@@ -2000,6 +2000,75 @@ impl DiagnosticEngine {
             })
             .collect()
     }
+
+    /// Lint `wait <target> { ... }` declarations by delegating to the
+    /// shared `carina_core::validation::wait` pass. The diagnostics
+    /// produced here use the same wording as `carina validate`; the
+    /// LSP just adds source anchors via `wait_target_anchor` /
+    /// `wait_until_attr_anchor`.
+    pub(super) fn check_wait_bindings(
+        &self,
+        doc: &Document,
+        parsed: &ParsedFile,
+    ) -> Vec<Diagnostic> {
+        let diags = carina_core::validation::wait::validate_wait_bindings(parsed, &self.schemas);
+        if diags.is_empty() {
+            return Vec::new();
+        }
+        let text = doc.text();
+        diags
+            .into_iter()
+            .map(|d| {
+                let (line, col, end_col) = match d.attribute.as_deref() {
+                    Some(attr) => wait_until_attr_anchor(&text, &d.binding_name, &d.target, attr),
+                    None => wait_target_anchor(&text, &d.binding_name, &d.target),
+                };
+                carina_diagnostic(line, col, end_col, DiagnosticSeverity::ERROR, d.message)
+            })
+            .collect()
+    }
+}
+
+/// Find the source anchor for a wait diagnostic. Returns
+/// `(line, col, end_col)` for the target identifier inside the
+/// `wait <target>` line, falling back to the wait keyword's column when
+/// the target can't be found verbatim.
+fn wait_target_anchor(text: &str, binding: &str, target: &str) -> (u32, u32, u32) {
+    let lines: Vec<&str> = text.lines().collect();
+    // Find `let <binding> =` to scope the forward scan.
+    let start = find_binding_line(&lines, binding).unwrap_or(0);
+    for (i, line) in lines.iter().enumerate().skip(start) {
+        if !line.contains("wait ") {
+            continue;
+        }
+        if let Some((col, end_col)) = find_word_on_line(line, target) {
+            return (i as u32, col, end_col);
+        }
+        // Fall back to the `wait` keyword span.
+        if let Some((col, end_col)) = find_word_on_line(line, "wait") {
+            return (i as u32, col, end_col);
+        }
+    }
+    (0, 0, 0)
+}
+
+/// Find the source anchor for an `until = <target>.<attr> ...`
+/// attribute reference inside a wait block.
+fn wait_until_attr_anchor(text: &str, binding: &str, target: &str, attr: &str) -> (u32, u32, u32) {
+    let lines: Vec<&str> = text.lines().collect();
+    let start = find_binding_line(&lines, binding).unwrap_or(0);
+    let dotted = format!("{}.{}", target, attr);
+    for (i, line) in lines.iter().enumerate().skip(start) {
+        if !line.contains("until") {
+            continue;
+        }
+        if let Some(byte_pos) = line.find(&dotted) {
+            let col = line[..byte_pos].chars().count() as u32;
+            let end_col = col + dotted.chars().count() as u32;
+            return (i as u32, col, end_col);
+        }
+    }
+    wait_target_anchor(text, binding, target)
 }
 
 /// Resolve the source anchor for a depends_on diagnostic.

--- a/carina-lsp/src/diagnostics/mod.rs
+++ b/carina-lsp/src/diagnostics/mod.rs
@@ -151,8 +151,10 @@ impl DiagnosticEngine {
         // resolve; fall back to the buffer-only parse otherwise.
         if let Some(parsed) = merged.as_ref() {
             diagnostics.extend(self.check_depends_on(doc, parsed));
+            diagnostics.extend(self.check_wait_bindings(doc, parsed));
         } else if let Some(parsed) = doc.parsed() {
             diagnostics.extend(self.check_depends_on(doc, parsed));
+            diagnostics.extend(self.check_wait_bindings(doc, parsed));
         }
 
         // Provider-attribute finalize diagnostic (#2717 / #2753): if a

--- a/carina-lsp/src/diagnostics/tests/extended.rs
+++ b/carina-lsp/src/diagnostics/tests/extended.rs
@@ -3743,3 +3743,70 @@ provider awscc {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
     );
 }
+
+#[test]
+fn lsp_flags_wait_unknown_target() {
+    let engine = test_engine_with_wait_target();
+    let src = r#"
+let cert = aws.acm.Certificate {
+    domain_name = "example.com"
+    status = "PENDING"
+}
+let waited = wait nonexistent {
+    until = nonexistent.status == "ISSUED"
+}
+"#;
+    let doc = create_document(src);
+    let diags = engine.analyze(&doc, None);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("nonexistent") && d.message.contains("not a known")),
+        "LSP must surface unknown wait target; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn lsp_flags_wait_unknown_attribute() {
+    let engine = test_engine_with_wait_target();
+    let src = r#"
+let cert = aws.acm.Certificate {
+    domain_name = "example.com"
+    status = "PENDING"
+}
+let waited = wait cert {
+    until = cert.statu == "ISSUED"
+}
+"#;
+    let doc = create_document(src);
+    let diags = engine.analyze(&doc, None);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("statu") && d.message.contains("unknown attribute")),
+        "LSP must surface unknown wait until attribute; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn lsp_accepts_valid_wait_block() {
+    let engine = test_engine_with_wait_target();
+    let src = r#"
+let cert = aws.acm.Certificate {
+    domain_name = "example.com"
+    status = "PENDING"
+}
+let waited = wait cert {
+    until = cert.status == "ISSUED"
+}
+"#;
+    let doc = create_document(src);
+    let diags = engine.analyze(&doc, None);
+    assert!(
+        !diags.iter().any(|d| d.message.contains("wait")),
+        "valid wait block should produce no wait-specific diagnostics; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>(),
+    );
+}

--- a/carina-lsp/src/diagnostics/tests/mod.rs
+++ b/carina-lsp/src/diagnostics/tests/mod.rs
@@ -59,6 +59,18 @@ pub(super) fn test_engine_with_nested_structs() -> DiagnosticEngine {
     )
 }
 
+/// Engine carrying a managed `aws.acm.Certificate` schema with `status`
+/// attribute — the canonical target for `wait` diagnostics tests.
+pub(super) fn test_engine_with_wait_target() -> DiagnosticEngine {
+    use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+    let schema = ResourceSchema::new("acm.Certificate")
+        .attribute(AttributeSchema::new("domain_name", AttributeType::String))
+        .attribute(AttributeSchema::new("status", AttributeType::String));
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert("aws", schema);
+    DiagnosticEngine::new(Arc::new(schemas), vec!["aws".to_string()], Arc::new(vec![]))
+}
+
 pub(super) fn test_engine_with_enum_attr() -> DiagnosticEngine {
     use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 

--- a/carina-lsp/src/semantic_tokens.rs
+++ b/carina-lsp/src/semantic_tokens.rs
@@ -347,6 +347,22 @@ impl SemanticTokensProvider {
                     tokens.push((name_pos as u32, name.len() as u32, 8)); // FUNCTION
                 }
             }
+        } else if trimmed.starts_with("wait ")
+            && let Some(wait_start) = line.find("wait ")
+        {
+            // `wait <target> { ... }` — paint the target binding name as
+            // VARIABLE (same role as a let binding's name) so editor
+            // semantics show it's a reference to a known binding.
+            let after_wait = &line[wait_start + 5..];
+            let leading_spaces = after_wait.len() - after_wait.trim_start().len();
+            let after_wait_trimmed = after_wait.trim_start();
+            if let Some(name_end) = after_wait_trimmed.find([' ', '{']) {
+                let name = &after_wait_trimmed[..name_end];
+                if !name.is_empty() {
+                    let name_pos = wait_start + 5 + leading_spaces;
+                    tokens.push((name_pos as u32, name.len() as u32, 2)); // VARIABLE
+                }
+            }
         }
 
         // Nested block names: "identifier {" without "=" (e.g., "security_group_ingress {")
@@ -368,6 +384,8 @@ impl SemanticTokensProvider {
             && !trimmed.starts_with("removed{")
             && !trimmed.starts_with("moved ")
             && !trimmed.starts_with("moved{")
+            && !trimmed.starts_with("wait ")
+            && !trimmed.starts_with("wait{")
             && !trimmed.starts_with("for ")
             && !trimmed.starts_with("if ")
             && !trimmed.contains('=')


### PR DESCRIPTION
## Summary

3rd and final PR for #2825. Surfaces the `wait` construct through the LSP / `carina validate` editor surfaces and adds the e2e fixture the issue's acceptance criteria require.

- **Phase 1+2+3** (PR #2968, merged): predicate AST + `Effect::Wait` variant + parser + grammar.
- **Phase 4+5** (PR #2969, merged): differ emits `Effect::Wait` + executor polling loop + plan-display fixture.
- **This PR (Phase 6+7+8)**: LSP + `carina validate` + e2e fixture.

## Phase 6 — LSP

### Completion
- New `wait` snippet in `top_level_completions`. Adapts to context: after `let <name> =` the snippet starts at the `wait` keyword; otherwise it scaffolds the full `let <waited> = wait <target> { ... }` shape.
- Snippet placeholders thread the target identifier into both the positional slot and the `until = <target>.<attr> == <value>` LHS so multi-cursor edits keep them in sync.

### Semantic tokens
- `wait <target>` lines emit a VARIABLE token for the target identifier — same role as a `let` binding's name.
- The PROPERTY-detection guard learns `wait`/`wait{` prefixes so it doesn't accidentally tag a `wait <target> {` line.
- The `wait`/`until` keywords stay handled by the TextMate grammar (consistent with `let`/`fn`/`provider`).

### Diagnostics
- New `check_wait_bindings` delegates to the shared `carina_core::validation::wait::validate_wait_bindings` pass and adds source anchors via `wait_target_anchor` / `wait_until_attr_anchor`.
- Wired into the directory-scoped pipeline so cross-file wait declarations work out of the box.

## Phase 7+8 — validate integration + e2e fixture

### `carina_core::validation::wait`
- New shared pass producing `WaitDiagnostic` records for:
  - **target not found**: the wait's target binding is not a known resource in the merged directory parse.
  - **attribute not in target schema**: the `until` LHS's attribute path doesn't exist on the target's schema.
- MVP checks top-level attributes only; nested struct fields (`renewal_summary.renewal_status`) deferred.
- Schema-less resource types are skipped — the user gets a separate "unknown resource type" diagnostic upstream.

### `carina validate`
- New `validate_wait_bindings_with_ctx` wrapper lifts the shared pass into `AppError::Validation` entries.
- Wired into `validate_and_resolve_errors_with_factories` alongside `validate_depends_on_with_ctx` so the CLI surface matches the LSP word for word.

### e2e fixture (`carina-cli/tests/wait_validate_e2e.rs`)
- 4 multi-file `tempfile::tempdir()` fixtures exercising `carina validate` end-to-end:
  - well-formed wait validates with no wait errors,
  - unknown target surfaces the binding name,
  - unknown attribute surfaces the misspelled name,
  - non-`==` operator is rejected with "only `==` is supported".
- Follows the CLAUDE.md "directory-scoped, never single-file" rule: fixtures span `providers.crn` + `main.crn` + `wait.crn`.

## Test plan

- [x] `cargo nextest run --workspace` (3189 tests) green
- [x] `cargo test --workspace --doc` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `cargo fmt --check` green
- [x] `cargo build --release` green
- [x] `bash scripts/check-*.sh` all green
- [x] 8 new tests: LSP completion (1) + LSP diagnostics (3) + CLI validate e2e (4)

Closes #2825

🤖 Generated with [Claude Code](https://claude.com/claude-code)
