### PR TITLE
validate: accept ResourceRef in List/Map schema positions

### DIFF
--- a/carina-core/src/schema/mod.rs
+++ b/carina-core/src/schema/mod.rs
@@ -894,6 +894,18 @@ impl AttributeType {
         let AttributeType::List { inner, .. } = self else {
             unreachable!("validate_list called on non-List");
         };
+        // A whole-list `ResourceRef` (e.g. `resource_records =
+        // upstream.nameservers` against a `list(string)` receiver) is
+        // a placeholder that resolves at apply time. The schema layer
+        // can't see the upstream's declared export type, so type
+        // fitness is checked separately by
+        // `check_upstream_state_field_types` (cross-directory) and
+        // `validate_resource_ref_types` (intra-directory). Accept the
+        // ref here, matching how `validate_primitive` already accepts
+        // a `ResourceRef` at a `String` position. Issue #2954.
+        if matches!(value, Value::ResourceRef { .. }) {
+            return Ok(());
+        }
         // `Value::StringList` is the canonicalized form for fields
         // typed as `Union[String, list(String)]` (see #2510). When
         // validated against a `list(String)` member of that Union, it
@@ -934,6 +946,12 @@ impl AttributeType {
         else {
             unreachable!("validate_map called on non-Map");
         };
+        // Whole-map `ResourceRef` mirrors the list case in
+        // `validate_list` — defer to the upstream-aware checker. See
+        // issue #2954.
+        if matches!(value, Value::ResourceRef { .. }) {
+            return Ok(());
+        }
         let Value::Map(map) = value else {
             return Err(TypeError::TypeMismatch {
                 expected: self.type_name(),

--- a/carina-core/src/schema/tests.rs
+++ b/carina-core/src/schema/tests.rs
@@ -857,6 +857,45 @@ fn validate_list_of_struct() {
 }
 
 #[test]
+fn validate_list_accepts_resource_ref() {
+    // A `ResourceRef` standing in for a whole list value (e.g.
+    // `resource_records = registry_dev.nameservers` where the upstream
+    // export is typed `list(string)`) must not be rejected by the
+    // schema-level `validate_list`. Type fitness against the upstream's
+    // declared export type is the upstream-aware checker's job; the
+    // schema layer should treat `ResourceRef` the same way it does for
+    // `String`/`Custom`/`Struct` positions — accept and defer. See
+    // issue #2954.
+    let list_type = AttributeType::list(AttributeType::String);
+    let value = Value::resource_ref(
+        "registry_dev".to_string(),
+        "nameservers".to_string(),
+        vec![],
+    );
+    assert!(
+        list_type.validate(&value).is_ok(),
+        "ResourceRef in List position must not produce an error"
+    );
+}
+
+#[test]
+fn validate_map_accepts_resource_ref() {
+    // Same shape as `validate_list_accepts_resource_ref`, on the map
+    // side: a whole-map `ResourceRef` (e.g. `tags = orgs.tag_map`) must
+    // be accepted by the schema-level `validate_map`. The upstream
+    // checker compares declared export type vs. the receiver.
+    let map_type = AttributeType::Map {
+        key: Box::new(AttributeType::String),
+        value: Box::new(AttributeType::String),
+    };
+    let value = Value::resource_ref("orgs".to_string(), "tag_map".to_string(), vec![]);
+    assert!(
+        map_type.validate(&value).is_ok(),
+        "ResourceRef in Map position must not produce an error"
+    );
+}
+
+#[test]
 fn struct_rejects_block_syntax_single_element() {
     // Block syntax produces Value::List([Value::Map(...)]) which should be rejected
     // for bare Struct attributes

--- a/carina-core/src/validation/tests.rs
+++ b/carina-core/src/validation/tests.rs
@@ -2036,6 +2036,50 @@ fn validate_export_param_ref_types_against_inferred_inputs() {
     assert!(result.is_ok(), "got {:?}", result);
 }
 
+/// Issue #2954. A `Value::ResourceRef` whose receiver is a `List<String>`
+/// attribute (e.g. `resource_records = registry_dev.nameservers` against
+/// `aws.route53.RecordSet.resource_records: List<String>`) must not be
+/// rejected by `validate_resources`. Type fitness against the upstream's
+/// declared export type is the upstream-aware checker's job
+/// (`check_upstream_state_field_types`); the schema-level layer should
+/// defer the same way it already does for scalar / struct positions.
+#[test]
+fn validate_resources_accepts_resource_ref_in_list_position() {
+    let mut schemas = SchemaRegistry::new();
+    schemas.insert(
+        "aws",
+        make_schema(
+            "route53.RecordSet",
+            vec![(
+                "resource_records",
+                AttributeType::list(AttributeType::String),
+            )],
+        ),
+    );
+
+    let record_set = Resource::with_provider("aws", "route53.RecordSet", "ns").with_attribute(
+        "resource_records",
+        Value::resource_ref(
+            "registry_dev".to_string(),
+            "nameservers".to_string(),
+            vec![],
+        ),
+    );
+
+    let mut known = HashSet::new();
+    known.insert("aws".to_string());
+
+    let mut parsed = empty_parsed();
+    parsed.resources.push(record_set); // allow: direct — fixture test inspection
+    let result = validate_resources(&parsed, &schemas, &known, &ProviderContext::default());
+    assert!(
+        result.is_ok(),
+        "ResourceRef in List<String> position must not produce a schema-level \
+         type mismatch (#2954), got: {:?}",
+        result
+    );
+}
+
 /// `validate_resources` must reject a resource whose schema declares an
 /// `exclusive_required` group that is not satisfied — mirrors
 /// `awscc.ec2.Vpc {}` with no cidr_block / ipam pool.


### PR DESCRIPTION
## Summary

`carina validate` rejected `upstream_state.<field>` references at `List<T>` / `Map<K,V>` attribute positions with `Type mismatch: expected List<String>, got ResourceRef(<binding>.<field>)`, even when the upstream's `exports {}` block declared a matching `list(string)` / `map(...)` type. This blocked the registry-dev NS delegation in `carina-rs/infra` (T8).

## Root cause

The schema layer has two type-check tiers:

1. `AttributeType::validate` — generic, no upstream context.
2. `check_upstream_state_field_types` (cross-directory) and `validate_resource_ref_types` (intra-directory) — type-aware, look up the referenced binding's declared type.

For scalar positions (`validate_primitive`) and struct fields (`collect_struct`), tier 1 already accepts `Value::ResourceRef` and defers fitness to tier 2. `validate_list` and `validate_map` were the missing siblings — they returned `TypeMismatch` immediately on any `ResourceRef`, before tier 2 could even run.

## Fix

Add a single-line `Value::ResourceRef` skip arm at the top of `validate_list` and `validate_map`, mirroring the existing scalar/struct treatment.

## Why this is safe

- Unknown-binding / unknown-attribute typos are still flagged by `validate_resource_ref_types`.
- Genuine type mismatches (e.g. `String → List<String>`, `list(int) → list(string)`) are still flagged by `validate_resource_ref_types` and `check_upstream_state_field_types`.
- The differ has no type-check of its own; the resolver already supports list/map exports for plan/apply.
- No snapshot or sibling-repo test pinned the prior error string.

## Test plan

- [x] `cargo nextest run --workspace` (3192 passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] All `scripts/check-*.sh` pass
- [x] New unit test: `validate_list_accepts_resource_ref` (schema layer, list)
- [x] New unit test: `validate_map_accepts_resource_ref` (schema layer, map)
- [x] New integration test: `validate_resources_accepts_resource_ref_in_list_position` (issue scenario shape)

Closes #2954

🤖 Generated with [Claude Code](https://claude.com/claude-code)