### PR TITLE
core/resource: Phase 1 of Value Concrete/Deferred axis split (RFC #2972)

### DIFF
--- a/carina-cli/tests/state_value_round_trip.rs
+++ b/carina-cli/tests/state_value_round_trip.rs
@@ -1,0 +1,147 @@
+//! Phase 1 of RFC #2972 — `Value` codec round-trip guard.
+//!
+//! State files persist resource attributes as raw JSON; the runtime
+//! lifts them into the rich `Value` enum via `json_to_dsl_value` and
+//! lowers them back via `value_to_json`. When Phase 5 physically
+//! restructures `Value` from the flat 14-variant shape into nested
+//! `Concrete(ConcreteValue) / Deferred(DeferredValue)`, both codec
+//! halves must keep producing/accepting **the same JSON shape** —
+//! end users have on-disk state files in the legacy layout and
+//! cannot be asked to migrate.
+//!
+//! This test exercises every `carina.state.json` fixture in the repo,
+//! pulls each `attributes` JSON value through
+//! `json_to_dsl_value -> value_to_json -> json_to_dsl_value` and
+//! asserts the second pass equals the first via `Value::PartialEq`.
+//! Today (Phase 1, additive only) this passes trivially; the test
+//! fails the moment a Phase-5 codec change re-shapes the JSON
+//! produced by `value_to_json` or interpreted by `json_to_dsl_value`.
+
+use std::path::{Path, PathBuf};
+
+use carina_core::value::{json_to_dsl_value, value_to_json};
+use carina_state::check_and_migrate;
+
+fn find_state_fixtures() -> Vec<PathBuf> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let root = PathBuf::from(manifest_dir).join("tests/fixtures");
+    let mut out = Vec::new();
+    walk(&root, &mut out);
+    out.sort();
+    out
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with('.') {
+            continue;
+        }
+        if path.is_dir() {
+            walk(&path, out);
+        } else if name == "carina.state.json" {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn fixture_attributes_round_trip_through_value_codec() {
+    let fixtures = find_state_fixtures();
+    assert!(
+        !fixtures.is_empty(),
+        "no carina.state.json fixtures found under tests/fixtures — test is a no-op",
+    );
+
+    let mut total_attrs = 0_usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for path in &fixtures {
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        let state = match check_and_migrate(&raw) {
+            Ok(s) => s,
+            Err(e) => {
+                failures.push(format!("{}: deserialize StateFile: {e}", path.display()));
+                continue;
+            }
+        };
+
+        for resource in &state.resources {
+            let resource_id = format!(
+                "{}.{}.{}",
+                resource.provider, resource.resource_type, resource.name,
+            );
+            for (attr_name, json_value) in &resource.attributes {
+                total_attrs += 1;
+
+                // First lift: legacy on-disk JSON → Value.
+                let Some(value_pass1) = json_to_dsl_value(json_value) else {
+                    // `json_to_dsl_value` returns None for JSON null,
+                    // which represents "absent". Skip — there is no
+                    // Value to round-trip.
+                    continue;
+                };
+
+                // Lower: Value → JSON via the production codec.
+                // Some inputs (e.g. a hypothetical `Value::Secret` or
+                // `Value::Unknown` in a fixture) intentionally error
+                // here. None of the in-tree fixtures contain such
+                // values, but if a future fixture adds one, surface
+                // the error rather than swallow it.
+                let json_pass1 = match value_to_json(&value_pass1) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        failures.push(format!(
+                            "{} attr `{}` ({}): value_to_json error: {e}",
+                            path.display(),
+                            attr_name,
+                            resource_id,
+                        ));
+                        continue;
+                    }
+                };
+
+                // Second lift: re-parse the just-emitted JSON.
+                let Some(value_pass2) = json_to_dsl_value(&json_pass1) else {
+                    failures.push(format!(
+                        "{} attr `{}` ({}): pass-2 json_to_dsl_value returned None \
+                         (codec emitted JSON null for a non-null Value)",
+                        path.display(),
+                        attr_name,
+                        resource_id,
+                    ));
+                    continue;
+                };
+
+                // The two `Value`s must be `PartialEq`-equal. This is
+                // the load-bearing assertion: a Phase-5 codec change
+                // that re-shapes the JSON layer would surface here as
+                // `value_pass1 != value_pass2`.
+                if value_pass1 != value_pass2 {
+                    failures.push(format!(
+                        "{} attr `{}` ({}): codec round-trip not idempotent\n  \
+                         pass1: {value_pass1:?}\n  pass2: {value_pass2:?}",
+                        path.display(),
+                        attr_name,
+                        resource_id,
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(total_attrs > 0, "round-trip exercised zero attributes");
+    assert!(
+        failures.is_empty(),
+        "{} attribute(s) failed Value codec round-trip across {} fixture(s):\n{}",
+        failures.len(),
+        fixtures.len(),
+        failures.join("\n"),
+    );
+}

--- a/carina-core/src/resource/mod.rs
+++ b/carina-core/src/resource/mod.rs
@@ -497,6 +497,112 @@ pub enum Value {
     Unknown(UnknownReason),
 }
 
+/// Borrowing projection of [`Value`] restricted to the **concrete** axis
+/// — variants that carry their own runtime type and are safe to type-check
+/// at validate time.
+///
+/// Phase 1 of [RFC #2972](https://github.com/carina-rs/carina/issues/2972).
+/// Sub-systems that only operate on resolved values (`validate`, the
+/// differ, the serializer) take `&ConcreteValueRef<'_>` so the deferred
+/// case is structurally unreachable rather than a runtime `matches!`
+/// guard. Today `Value` is still flat; once every concrete-only path
+/// has migrated to this view, the underlying `Value` enum will be
+/// physically split into `Value { Concrete(ConcreteValue), Deferred(DeferredValue) }`
+/// and this borrow type will become a thin wrapper over the inner
+/// `ConcreteValue`.
+///
+/// Recursive container variants (`List`, `Map`, `StringList`) borrow
+/// from the parent `Value`; the inner element / key types stay
+/// `Value` because lists and maps can mix concrete and deferred
+/// elements (e.g. `["literal", vpc.id]`).
+#[derive(Debug, Clone, Copy)]
+pub enum ConcreteValueRef<'a> {
+    String(&'a str),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Duration(std::time::Duration),
+    List(&'a [Value]),
+    StringList(&'a [String]),
+    Map(&'a IndexMap<String, Value>),
+}
+
+/// Borrowing projection of [`Value`] restricted to the **deferred** axis
+/// — placeholders that resolve later (apply time, upstream load,
+/// function evaluation).
+///
+/// Sub-systems that need to walk only deferred values (e.g.
+/// `check_upstream_state_field_types`, `validate_resource_ref_types`,
+/// dependency analysis) take `&DeferredValueRef<'_>` so they cannot
+/// accidentally consume a concrete value as a placeholder.
+///
+/// Phase 1 of [RFC #2972](https://github.com/carina-rs/carina/issues/2972).
+#[derive(Debug, Clone, Copy)]
+pub enum DeferredValueRef<'a> {
+    ResourceRef { path: &'a AccessPath },
+    BindingRef { binding: &'a str },
+    Interpolation(&'a [InterpolationPart]),
+    FunctionCall { name: &'a str, args: &'a [Value] },
+    Secret(&'a Value),
+    Unknown(&'a UnknownReason),
+}
+
+impl Value {
+    /// If this value is on the concrete axis, return a borrowing
+    /// projection. Returns `None` for deferred-resolution variants
+    /// ([`Value::ResourceRef`], [`Value::BindingRef`],
+    /// [`Value::Interpolation`], [`Value::FunctionCall`],
+    /// [`Value::Secret`], [`Value::Unknown`]).
+    ///
+    /// Concrete-only sub-systems should consume `Value` exclusively
+    /// through this accessor — the returned [`ConcreteValueRef`]
+    /// cannot represent a deferred value, so the "deferred leaked
+    /// into concrete-only path" bug class becomes structurally
+    /// unrepresentable. See RFC #2972.
+    pub fn as_concrete(&self) -> Option<ConcreteValueRef<'_>> {
+        match self {
+            Value::String(s) => Some(ConcreteValueRef::String(s)),
+            Value::Int(n) => Some(ConcreteValueRef::Int(*n)),
+            Value::Float(f) => Some(ConcreteValueRef::Float(*f)),
+            Value::Bool(b) => Some(ConcreteValueRef::Bool(*b)),
+            Value::Duration(d) => Some(ConcreteValueRef::Duration(*d)),
+            Value::List(items) => Some(ConcreteValueRef::List(items)),
+            Value::StringList(items) => Some(ConcreteValueRef::StringList(items)),
+            Value::Map(map) => Some(ConcreteValueRef::Map(map)),
+            Value::ResourceRef { .. }
+            | Value::BindingRef { .. }
+            | Value::Interpolation(_)
+            | Value::FunctionCall { .. }
+            | Value::Secret(_)
+            | Value::Unknown(_) => None,
+        }
+    }
+
+    /// If this value is on the deferred axis, return a borrowing
+    /// projection. Returns `None` for concrete variants. Mirror of
+    /// [`Self::as_concrete`].
+    pub fn as_deferred(&self) -> Option<DeferredValueRef<'_>> {
+        match self {
+            Value::ResourceRef { path } => Some(DeferredValueRef::ResourceRef { path }),
+            Value::BindingRef { binding } => Some(DeferredValueRef::BindingRef { binding }),
+            Value::Interpolation(parts) => Some(DeferredValueRef::Interpolation(parts)),
+            Value::FunctionCall { name, args } => {
+                Some(DeferredValueRef::FunctionCall { name, args })
+            }
+            Value::Secret(inner) => Some(DeferredValueRef::Secret(inner)),
+            Value::Unknown(reason) => Some(DeferredValueRef::Unknown(reason)),
+            Value::String(_)
+            | Value::Int(_)
+            | Value::Float(_)
+            | Value::Bool(_)
+            | Value::Duration(_)
+            | Value::List(_)
+            | Value::StringList(_)
+            | Value::Map(_) => None,
+        }
+    }
+}
+
 /// Why a `Value::Unknown` is unknown. Each variant carries only the
 /// information its own consumer needs — no shared "context" field invites
 /// drift across reasons. See RFC #2371.

--- a/carina-core/src/resource/tests.rs
+++ b/carina-core/src/resource/tests.rs
@@ -1194,3 +1194,105 @@ fn human_display_handles_pending_name() {
     id.name = ResourceName::Pending;
     assert_eq!(format!("{}", id.human()), "awscc.ec2.Vpc ");
 }
+
+// ---------------------------------------------------------------------
+// Phase 1 of RFC #2972 — `Value::as_concrete` / `as_deferred`
+// borrowing projections. The full type-split happens later; for now we
+// only verify the accessors disambiguate the two axes correctly.
+// ---------------------------------------------------------------------
+
+#[test]
+fn as_concrete_returns_projection_for_concrete_variants() {
+    // Sample one variant per concrete arm; the match in `as_concrete`
+    // is exhaustive so this is enough to catch a future variant added
+    // to the wrong axis.
+    let cases: Vec<(Value, &'static str)> = vec![
+        (Value::String("x".into()), "String"),
+        (Value::Int(1), "Int"),
+        (Value::Float(1.5), "Float"),
+        (Value::Bool(true), "Bool"),
+        (
+            Value::Duration(std::time::Duration::from_secs(60)),
+            "Duration",
+        ),
+        (Value::List(vec![]), "List"),
+        (Value::StringList(vec![]), "StringList"),
+        (Value::Map(IndexMap::new()), "Map"),
+    ];
+    for (v, label) in cases {
+        assert!(
+            v.as_concrete().is_some(),
+            "{label} must project to ConcreteValueRef",
+        );
+        assert!(
+            v.as_deferred().is_none(),
+            "{label} must NOT project to DeferredValueRef",
+        );
+    }
+}
+
+#[test]
+fn as_deferred_returns_projection_for_deferred_variants() {
+    let cases: Vec<(Value, &'static str)> = vec![
+        (
+            Value::resource_ref("vpc".to_string(), "id".to_string(), vec![]),
+            "ResourceRef",
+        ),
+        (
+            Value::BindingRef {
+                binding: "bootstrap".to_string(),
+            },
+            "BindingRef",
+        ),
+        (Value::Interpolation(vec![]), "Interpolation"),
+        (
+            Value::FunctionCall {
+                name: "join".to_string(),
+                args: vec![],
+            },
+            "FunctionCall",
+        ),
+        (
+            Value::Secret(Box::new(Value::String("inner".into()))),
+            "Secret",
+        ),
+        (Value::Unknown(UnknownReason::ForKey), "Unknown"),
+    ];
+    for (v, label) in cases {
+        assert!(
+            v.as_deferred().is_some(),
+            "{label} must project to DeferredValueRef",
+        );
+        assert!(
+            v.as_concrete().is_none(),
+            "{label} must NOT project to ConcreteValueRef",
+        );
+    }
+}
+
+#[test]
+fn as_concrete_borrows_inner_string_without_clone() {
+    // The accessor must hand out a &str pointing into the original
+    // value, not a copy. Easy proof: pointer equality on the bytes.
+    let v = Value::String("hello".into());
+    let Some(ConcreteValueRef::String(borrowed)) = v.as_concrete() else {
+        panic!("expected String projection");
+    };
+    let Value::String(ref original) = v else {
+        unreachable!("v constructed as Value::String");
+    };
+    assert_eq!(borrowed.as_ptr(), original.as_str().as_ptr());
+}
+
+#[test]
+fn as_concrete_list_borrows_underlying_slice() {
+    let v = Value::List(vec![Value::Int(1), Value::Int(2)]);
+    let Some(ConcreteValueRef::List(items)) = v.as_concrete() else {
+        panic!("expected List projection");
+    };
+    let Value::List(ref original) = v else {
+        unreachable!("v constructed as Value::List");
+    };
+    assert_eq!(items.as_ptr(), original.as_ptr());
+    assert_eq!(items.len(), 2);
+}


### PR DESCRIPTION
## Summary

**Phase 1 of [RFC #2972](https://github.com/carina-rs/carina/issues/2972).** Purely additive infrastructure for the type-safe `Value` axis split that makes the recurring "deferred Value leaked into concrete-only path" bug class — of which #2954 was the latest instance — structurally unrepresentable.

This PR adds the borrowing projection types and accessors. Subsequent phases will migrate the validate sub-system (Phase 2, closes #2954), then the differ / serializer / plan display / LSP (Phase 3), then the provider repos (Phase 4).

### What changed

- `ConcreteValueRef<'a>` and `DeferredValueRef<'a>` borrowing projection enums next to the existing flat `Value` in `carina-core/src/resource/mod.rs`. Each carries exactly one axis:
  - **Concrete:** String, Int, Float, Bool, Duration, List, StringList, Map
  - **Deferred:** ResourceRef, BindingRef, Interpolation, FunctionCall, Secret, Unknown
- `Value::as_concrete() -> Option<ConcreteValueRef<'_>>` and `Value::as_deferred() -> Option<DeferredValueRef<'_>>` accessors, with exhaustive matches so a future variant added on the wrong axis is a compile error.
- 4 unit tests in `carina-core/src/resource/tests.rs` covering all 14 variants plus pointer-equality proofs that the projections borrow without copying.
- A fixture-driven `Value` codec round-trip test in `carina-cli/tests/state_value_round_trip.rs` that walks every `carina.state.json` in the tree, runs each attribute through `json_to_dsl_value <-> value_to_json` twice, and asserts `Value::PartialEq` equality. This defends the on-disk JSON shape as a stable end-user boundary when Phase 5 physically restructures `Value`.

### What this PR intentionally does NOT change

- No call sites migrated. `validate_*` still takes `&Value`; #2954 is still open until Phase 2.
- No deprecation shims, no lower-case constructor helpers (`Value::string()`, etc.). The RFC body mentions them; deferred to Phase 2 when actually needed by call-site migration.
- No physical restructuring of `Value` itself — that is Phase 5, after every concrete-only consumer has migrated to the borrowing view.

### Why projection rather than physically splitting `Value` now

Splitting `Value` into nested `Value::Concrete(ConcreteValue) / Deferred(DeferredValue)` immediately would force ~900 mechanical pattern rewrites in carina + ~thousands more in `carina-provider-aws` / `carina-provider-awscc`, all in one un-reviewable PR. The borrowing projection lets each sub-system migrate independently in Phase 2-4, with the physical reshape deferred to Phase 5 (or later) once all consumers go through `as_concrete()` / `as_deferred()`. Same end-state, smaller per-phase blast radius. See the implementation note on RFC #2972 for the rationale.

## Test plan

- [x] `cargo nextest run --workspace` — 3194 passed, 74 skipped
- [x] `cargo test --workspace --doc` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `bash scripts/check-*.sh` — all 5 invariant scripts green
- [x] 4 new projection tests (carina-core)
- [x] New fixture round-trip test exercises every `carina.state.json` (30 fixtures, non-zero attributes)
- [x] 5 fresh review rounds — all GO

Refs #2972, #2954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)